### PR TITLE
Added new setting "SENTRY_TESTING"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,16 @@ You can also use the ``exc_info`` and ``extra=dict(url=foo)`` arguments on your 
 
 	logging.error('There was some crazy error', exc_info=sys.exc_info(), extra={'url': request.build_absolute_uri()})
 
+##############
+SENTRY_TESTING
+##############
+
+Enabling this setting allows the testing of Sentry exception handler even if Django DEBUG is enabled.
+
+Default value is ``False``
+
+.. note:: Normally when Django DEBUG is enabled the Sentry exception handler is immediately skipped
+
 =====
 Usage
 =====

--- a/sentry/client/models.py
+++ b/sentry/client/models.py
@@ -3,7 +3,6 @@ import traceback
 import logging
 import warnings
 
-from django.conf import settings as dj_settings
 from django.core.signals import got_request_exception
 from django.db import  transaction
 from django.http import Http404
@@ -23,7 +22,7 @@ def sentry_exception_handler(sender, request=None, **kwargs):
                 and issubclass(exc_type, Http404):
             return
 
-        if dj_settings.DEBUG or getattr(exc_type, 'skip_sentry', False):
+        if settings.DEBUG or getattr(exc_type, 'skip_sentry', False):
             return
 
         if transaction.is_dirty():

--- a/sentry/settings.py
+++ b/sentry/settings.py
@@ -4,6 +4,9 @@ from django.utils.translation import ugettext_lazy as _
 
 import logging
 
+# Allow local testing of Sentry even if DEBUG is enabled
+DEBUG = getattr(settings, 'DEBUG', False) and not getattr(settings, 'SENTRY_TESTING', False)
+
 CATCH_404_ERRORS = getattr(settings, 'SENTRY_CATCH_404_ERRORS', False)
 
 DATABASE_USING = getattr(settings, 'SENTRY_DATABASE_USING', None)
@@ -34,3 +37,4 @@ LOG_LEVELS = (
 REMOTE_URL = getattr(settings, 'SENTRY_REMOTE_URL', None)
 
 REMOTE_TIMEOUT = getattr(settings, 'SENTRY_REMOTE_TIMEOUT', 5)
+


### PR DESCRIPTION
This allows the Sentry exception handler to still handle exceptions even if dj_settings.DEBUG is enabled. 
