### PR TITLE
Submitting changes for allowing sentry to submit to multiple servers

### DIFF
--- a/sentry/models.py
+++ b/sentry/models.py
@@ -135,7 +135,7 @@ class GroupedMessage(MessageBase):
         if engine.startswith('postgresql'):
             return 'times_seen / (pow((floor(extract(epoch from now() - last_seen) / 3600) + 2), 1.25) + 1)'
         if engine.startswith('mysql'):
-            return 'times_seen / (pow((floor(unix_timestamp(now() - last_seen) / 3600) + 2), 1.25) + 1)'
+            return 'times_seen / (pow((floor((unix_timestamp(now()) - unix_timestamp(last_seen)) / 3600) + 2), 1.25) + 1)'
         return 'times_seen'
 
     def mail_admins(self, request=None, fail_silently=True):

--- a/sentry/tests/tests.py
+++ b/sentry/tests/tests.py
@@ -566,7 +566,7 @@ class RemoteSentryTest(TestCase):
     
     def setUp(self):
         self.server_thread = None
-        settings.REMOTE_URL = 'http://localhost:8000%s' % reverse('sentry-store')
+        settings.REMOTE_URL = ['http://localhost:8000%s' % reverse('sentry-store')]
         logger = logging.getLogger('sentry')
         for h in logger.handlers:
             logger.removeHandler(h)
@@ -770,3 +770,4 @@ class SentryClientTest(TestCase):
         self.assertEquals(_foo[''].getMessage(), 'view exception')
         self.assertEquals(_foo[''].levelno, client.default_level)
         self.assertEquals(_foo[''].class_name, 'Exception')
+


### PR DESCRIPTION
sentry/client/base.py -- Modified SentryClient.send() to expect a list of servers.
from REMOTE_URL. If REMOTE_URL is not a list, a ValueError will be raised.

senty/models.py -- Fixed MySQL-related bug in GroupedMessage.get_score_clause()
related to the way date math was being done.
