### PR TITLE
Allow to overwrite the server name on a per-client basis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,10 @@ Sentry also allows you to support high availability by pushing to multiple serve
 
 	SENTRY_REMOTE_URL = ['http://server1/sentry/store', 'http://server2/sentry/store']
 
+If not configured otherwise, Sentry will use the host name as server name. To overwrite this, use::
+
+	SENTRY_CLIENT_NAME = 'example.com'
+
 ===========================
 Other configuration options
 ===========================

--- a/sentry/client/base.py
+++ b/sentry/client/base.py
@@ -29,7 +29,7 @@ class SentryClient(object):
             kwargs = filter_(None).process(kwargs) or kwargs
 
         kwargs.setdefault('level', logging.ERROR)
-        kwargs.setdefault('server_name', socket.gethostname())
+        kwargs.setdefault('server_name', settings.CLIENT_NAME or socket.gethostname())
 
         checksum = construct_checksum(**kwargs)
 

--- a/sentry/settings.py
+++ b/sentry/settings.py
@@ -33,13 +33,12 @@ LOG_LEVELS = (
 
 # This should be the full URL to sentries store view
 REMOTE_URL = getattr(settings, 'SENTRY_REMOTE_URL', None)
-
 if REMOTE_URL:
     if isinstance(REMOTE_URL, basestring):
         REMOTE_URL = [REMOTE_URL]
     elif not isinstance(REMOTE_URL, (list, tuple)):
         raise ValueError("SENTRY_REMOTE_URL must be of type list.")
-
+CLIENT_NAME = getattr(settings, 'SENTRY_CLIENT_NAME', None)
 REMOTE_TIMEOUT = getattr(settings, 'SENTRY_REMOTE_TIMEOUT', 5)
 
 ADMINS = getattr(settings, 'SENTRY_ADMINS', [])


### PR DESCRIPTION
I run sentry clients with multiple apps on a single server, so all the errors have the same server name, independent of the app. This change allows the server name to be customized on a per-client basis
