### PR TITLE
Fix for a typo rendering the message list

### DIFF
--- a/sentry/models.py
+++ b/sentry/models.py
@@ -98,7 +98,7 @@ class MessageBase(Model):
             if self.class_name:
                 return "%s: %s" % (self.class_name, message)
         else:
-            self.message = self.class_name or ''
+            message = self.class_name or ''
         return message
     error.short_description = _('error')
 


### PR DESCRIPTION
MessageBase.error didn't always define `message` before returning it.
