### PR TITLE
GET -> POST

### DIFF
--- a/sentry/client/base.py
+++ b/sentry/client/base.py
@@ -50,7 +50,7 @@ class SentryClient(object):
                     'key': conf.KEY,
                 }
                 try:
-                    urlread(url, GET=data, timeout=conf.REMOTE_TIMEOUT)
+                    urlread(url, POST=data, timeout=conf.REMOTE_TIMEOUT)
                 except urllib2.URLError, e:
                     logger.error('Unable to reach Sentry log server: %s' % (e,), exc_info=sys.exc_info(), extra={'remote_url': url})
                     logger.log(kwargs.pop('level', None) or logging.ERROR, kwargs.pop('message', None))

--- a/sentry/models.py
+++ b/sentry/models.py
@@ -167,7 +167,7 @@ class GroupedMessage(MessageBase):
 
         obj_request = message.request
 
-        subject = 'Error (%s IP): %s' % ((obj_request.META.get('REMOTE_ADDR') in settings.INTERNAL_IPS and 'internal' or 'EXTERNAL'), obj_request.path)
+        subject = '[%s] Error (%s IP): %s' % (message.site, (obj_request.META.get('REMOTE_ADDR') in settings.INTERNAL_IPS and 'internal' or 'EXTERNAL'), obj_request.path)
         try:
             request_repr = repr(obj_request)
         except:
@@ -186,7 +186,7 @@ class GroupedMessage(MessageBase):
             'link': link,
         })
         
-        send_mail(settings.EMAIL_SUBJECT_PREFIX + subject, body,
+        send_mail(subject, body,
                   settings.SERVER_EMAIL, conf.ADMINS,
                   fail_silently=fail_silently)
     


### PR DESCRIPTION
The server is expecting a POST request to /sentry/store/ but the included client is sending a GET request so it fails when trying to find the key in request.POST to compare to conf.KEY. 

In other words, multi-site setup is broken out of the box. 

This patch simply gets the client to send a POST request instead of GET. 
