### PR TITLE
Modify references to PATH_INFO to accomodate installation at a non-root path

### DIFF
--- a/sentry/plugins/__init__.py
+++ b/sentry/plugins/__init__.py
@@ -38,7 +38,7 @@ class ActionProvider:
         self.url = reverse('sentry-plugin-action', args=(self.slug,))
 
     def __call__(self, request):
-        self.selected = request.META['PATH_INFO'] == self.url
+        self.selected = request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == self.url
         if not self.selected:
             return
 
@@ -59,7 +59,7 @@ class GroupActionProvider:
         self.url = self.__class__.get_url(group_id)
 
     def __call__(self, request, group):
-        self.selected = request.META['PATH_INFO'] == self.url
+        self.selected = request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == self.url
         if not self.selected:
             return
         return self.view(request, group)

--- a/sentry/plugins/__init__.py
+++ b/sentry/plugins/__init__.py
@@ -38,7 +38,7 @@ class ActionProvider:
         self.url = reverse('sentry-plugin-action', args=(self.slug,))
 
     def __call__(self, request):
-        self.selected = request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == self.url
+        self.selected = request.path == self.url
         if not self.selected:
             return
 
@@ -59,7 +59,7 @@ class GroupActionProvider:
         self.url = self.__class__.get_url(group_id)
 
     def __call__(self, request, group):
-        self.selected = request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == self.url
+        self.selected = request.path == self.url
         if not self.selected:
             return
         return self.view(request, group)

--- a/sentry/templatetags/sentry_helpers.py
+++ b/sentry/templatetags/sentry_helpers.py
@@ -96,7 +96,7 @@ def get_actions(group, request):
         inst = cls(group.pk)
         action_list = inst.actions(request, action_list, group)
     for action in action_list:
-        yield action[0], action[1], request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == action[1]
+        yield action[0], action[1], request.path == action[1]
 
 @register.filter
 def get_panels(group, request):
@@ -105,7 +105,7 @@ def get_panels(group, request):
         inst = cls(group.pk)
         panel_list = inst.panels(request, panel_list, group)
     for panel in panel_list:
-        yield panel[0], panel[1], request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == panel[1]
+        yield panel[0], panel[1], request.path == panel[1]
 
 @register.filter
 def get_widgets(group, request):

--- a/sentry/templatetags/sentry_helpers.py
+++ b/sentry/templatetags/sentry_helpers.py
@@ -96,7 +96,7 @@ def get_actions(group, request):
         inst = cls(group.pk)
         action_list = inst.actions(request, action_list, group)
     for action in action_list:
-        yield action[0], action[1], request.META['PATH_INFO'] == action[1]
+        yield action[0], action[1], request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == action[1]
 
 @register.filter
 def get_panels(group, request):
@@ -105,7 +105,7 @@ def get_panels(group, request):
         inst = cls(group.pk)
         panel_list = inst.panels(request, panel_list, group)
     for panel in panel_list:
-        yield panel[0], panel[1], request.META['PATH_INFO'] == panel[1]
+        yield panel[0], panel[1], request.META.get('SCRIPT_NAME', '') + request.META['PATH_INFO'] == panel[1]
 
 @register.filter
 def get_widgets(group, request):


### PR DESCRIPTION
I've installed sentry at a non-root URL path, which was causing the resolution of plugin requests to fail.  In this case, request.META["PATH_INFO"] contains just the fragment of the URL beneath the installation root, so comparisons to the full expected URL fail.

One solution is to prepend the contents of SCRIPT_NAME to PATH_INFO, but at dcramer's suggestion, I changed the comparison's to use request.path, which sidesteps the issue completely.
