### PR TITLE
Fix for when no exceptions are being processed

### DIFF
--- a/sentry/client/base.py
+++ b/sentry/client/base.py
@@ -92,7 +92,10 @@ class SentryClient(object):
             'level': record.levelno,
             'message': record.getMessage(),
         })
-        if record.exc_info:
+        
+        # If there's no exception being processed, exc_info may be a 3-tuple of None
+        # http://docs.python.org/library/sys.html#sys.exc_info
+        if record.exc_info and all(record.exc_info):
             return self.create_from_exception(record.exc_info, **kwargs)
 
         return self.process(

--- a/sentry/tests/tests.py
+++ b/sentry/tests/tests.py
@@ -554,6 +554,23 @@ class SentryTestCase(TestCase):
         
         self.assertEquals(last.view, 'sentry.tests.views.logging_request_exc')
         self.assertEquals(last.data['url'], 'http://testserver' + reverse('sentry-log-request-exc'))
+        
+    def testCreateFromRecordNoneExcInfo(self):
+        # sys.exc_info can return (None, None, None) if no exception is being
+        # handled anywhere on the stack. See:
+        #  http://docs.python.org/library/sys.html#sys.exc_info
+        client = get_client()
+        record = logging.LogRecord(
+            'foo', 
+            logging.INFO, 
+            pathname=None,
+            lineno=None,
+            msg='test',
+            args=(),
+            exc_info=(None, None, None),
+        )
+        message = client.create_from_record(record)
+        self.assertEquals('test', message.message)
 
 
 class SentryViewsTest(TestCase):


### PR DESCRIPTION
Hi,

I came across an AttributeError when sentry was trying to send out a record that originated with a logging.info() call. exc_info wound up having a 3-tuple (None, None, None) in it (see the Python docs referred to in the patch) which caused sentry to incorrectly think it was processing an exception rather than a log message.

Thought you might be interested in the patch.

Cheers,
Dan
