### PR TITLE
__name__ is not always assured

### DIFF
--- a/sentry/client/base.py
+++ b/sentry/client/base.py
@@ -163,7 +163,10 @@ class SentryClient(object):
             best_guess = None
             view = None
             for frame in iter_tb_frames(exc_traceback):
-                view = '.'.join([frame.f_globals['__name__'], frame.f_code.co_name])
+                try:
+                    view = '.'.join([frame.f_globals['__name__'], frame.f_code.co_name])
+                except:
+                    continue
                 if contains(modules, view):
                     if not (contains(conf.EXCLUDE_PATHS, view) and best_guess):
                         best_guess = view


### PR DESCRIPTION
I'm not sure why this happens, but I've reached my debugging limit and must move on. **name** is not always present when trying to determine the name of the thing the exception originated from.

I am using Sentry with Piston, and from what I could tell this happened with a decorator or a lambda. Sorry, the python traceback objects are mysterious. 

I'm not saying this is the best approach to solving this either, just a start. I'm not sure what you want to do but for a routine that is supposed to guess a graceful failure to guess would be best.

Trey
