### PR TITLE
sentry.helpers.transform doesn't transform lazy strings

### DIFF
--- a/sentry/helpers.py
+++ b/sentry/helpers.py
@@ -5,7 +5,7 @@ import uuid
 
 import django
 from django.conf import settings
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import force_unicode
 from django.utils.hashcompat import md5_constructor
 
 from sentry import conf
@@ -69,24 +69,24 @@ def transform(value):
     elif isinstance(value, dict):
         return dict((k, transform(v)) for k, v in value.iteritems())
     elif isinstance(value, unicode):
-        return force_unicode(value)
+        return to_unicode(value)
     elif isinstance(value, str):
         try:
             return str(value)
         except:
-            return force_unicode(value)
+            return to_unicode(value)
     elif not isinstance(value, (int, bool)) and value is not None:
         # XXX: we could do transform(repr(value)) here
-        return force_unicode(value)
+        return to_unicode(value)
     return value
 
-def force_unicode(value):
+def to_unicode(value):
     try:
-        value = smart_unicode(value)
+        value = force_unicode(value)
     except (UnicodeEncodeError, UnicodeDecodeError):
         value = '(Error decoding value)'
     except Exception: # in some cases we get a different exception
-        value = smart_unicode(type(value))
+        value = force_unicode(type(value))
     return value
 
 def get_installed_apps():

--- a/sentry/tests/tests.py
+++ b/sentry/tests/tests.py
@@ -24,7 +24,7 @@ from django.template import TemplateSyntaxError
 from django.utils.encoding import smart_unicode
 
 from sentry import conf
-from sentry.helpers import transform, force_unicode
+from sentry.helpers import transform
 from sentry.models import Message, GroupedMessage
 from sentry.client.base import SentryClient
 from sentry.client.handlers import SentryHandler
@@ -900,6 +900,18 @@ class SentryHelpersTest(TestCase):
         
         settings.DATABASES = _databases
         settings.DATABASE_ENGINE = _engine
+
+    def test_transform_handles_gettext_lazy(self):
+        from sentry.helpers import transform
+        from django.utils.functional import lazy
+
+        def fake_gettext(to_translate):
+            return u'Igpay Atinlay'
+        fake_gettext_lazy = lazy(fake_gettext, str)
+        self.assertEquals(
+            pickle.loads(pickle.dumps(
+                    transform(fake_gettext_lazy("something")))),
+            u'Igpay Atinlay')
 
 class SentryClientTest(TestCase):
     urls = 'sentry.tests.urls'


### PR DESCRIPTION
This diff fixes an issue with sentry.helpers.transform: lazy strings (like those returned by django's gettext_lazy) pass through django's smart_unicode without being transformed. This means that sentry winds up trying to pass functions to pickle, which has unfortunate results. This diff changes sentry.helpers to use django's force_unicode instead, which resolves the lazy strings.
