### PR TITLE
Fix for KeyErrors in group and message views

### DIFF
--- a/sentry/views.py
+++ b/sentry/views.py
@@ -280,7 +280,7 @@ def group_message_details(request, group_id, message_id):
 
     message = get_object_or_404(group.message_set, pk=message_id)
     
-    if '__sentry__' in message.data:
+    if '__sentry__' in message.data and 'exc' in message.data['__sentry__']:
         module, args, frames = message.data['__sentry__']['exc']
         message.class_name = str(message.class_name)
         # We fake the exception class due to many issues with imports/builtins/etc

--- a/sentry/views.py
+++ b/sentry/views.py
@@ -235,7 +235,7 @@ def group(request, group_id):
     group = get_object_or_404(GroupedMessage, pk=group_id)
 
     obj = group.message_set.all().order_by('-id')[0]
-    if '__sentry__' in obj.data:
+    if '__sentry__' in obj.data and 'exc' in obj.data['__sentry__']:
         module, args, frames = obj.data['__sentry__']['exc']
         obj.class_name = str(obj.class_name)
         # We fake the exception class due to many issues with imports/builtins/etc


### PR DESCRIPTION
The problem in #70 is that data['**sentry**']['versions'] is now set -- for instance for messages from the logging handler -- without  data['**sentry**']['exc']. But the views still assume that anytime data['**sentry**'] is present, data['**sentry**']['exc'] is too. This diff fixes that by making the views more defensive.
