### PR TITLE
style fix for firefox messages display

### DIFF
--- a/sentry/media/styles/global.css
+++ b/sentry/media/styles/global.css
@@ -340,7 +340,7 @@ dl.flat dd {
 
 .messages .tag { display: inline-block; padding: 2px 5px; background: #eaeaea; margin-right: 5px;}
 .messages .traceback { display: none; }
-.messages li { padding: 8px; position: relative; padding-right: 50px; overflow: hidden;}
+.messages li { clear: both; padding: 8px; position: relative; padding-right: 50px; overflow: hidden; }
 .messages .row1 { background: #f9f9f9; }
 .messages .hidden {
     position: absolute;


### PR DESCRIPTION
This fixes issue #79.  In my repository I am not seeing the extra blank line that github seems to insist is there (the second change in the file).  I am relatively new to git and I'm not sure how to remove it from the pull request -- sorry about that. The first change is the only intended one.
