### PR TITLE
Middleware to make the request available to the `LogHandler`

### DIFF
--- a/sentry/client/handlers.py
+++ b/sentry/client/handlers.py
@@ -4,6 +4,10 @@ import sys
 class SentryHandler(logging.Handler):
     def emit(self, record):
         from sentry.client.models import get_client
+        from sentry.client.middleware import SentryLogMiddleware
+
+        # Fetch the request from a threadlocal variable, if available
+        request = getattr(SentryLogMiddleware.thread, 'request', None)
 
         # Avoid typical config issues by overriding loggers behavior
         if record.name == 'sentry.errors':
@@ -11,7 +15,7 @@ class SentryHandler(logging.Handler):
             print >> sys.stderr, record.message
             return
 
-        get_client().create_from_record(record)
+        get_client().create_from_record(record,request=request)
 
 try:
     import logbook
@@ -38,3 +42,4 @@ else:
             if record.exc_info:
                 return client.create_from_exception(record.exc_info, **kwargs)
             return client.create_from_text(**kwargs)
+

--- a/sentry/client/middleware.py
+++ b/sentry/client/middleware.py
@@ -1,5 +1,5 @@
 from sentry.client.models import get_client
-
+import threading
 import logging
 
 class Sentry404CatchMiddleware(object):
@@ -24,3 +24,11 @@ class SentryResponseErrorIdMiddleware(object):
             return response
         response['X-Sentry-ID'] = request.sentry['id']
         return response
+
+class SentryLogMiddleware(object):
+    # Create a threadlocal variable to store the session in for logging
+    thread = threading.local()
+
+    def process_request(self, request):
+        self.thread.request = request
+


### PR DESCRIPTION
Simple log messages without any context seem only rarely useful to me so I wrote this patch to automatically add the request to a threadlocal variable so the `LogHandler` can automatically fetch it.

This way log messages will automatically get the url and request data if available.
