### PR TITLE
Fixed JavaScript-powered Resolve buttons

### DIFF
--- a/sentry/templates/sentry/partial/_group.html
+++ b/sentry/templates/sentry/partial/_group.html
@@ -18,6 +18,6 @@
     </p>
     <a href="{% url sentry-group group.pk %}" class="row_link"></a>
     {% if group.status == 0 %}
-        <a href="{% url sentry-ajax %}?op=resolve&amp;gid={{ group.pk }}" onclick="sentryResolve({{ group.pk }});returnfalse;" class="button resolve_button hidden">&#10003;</a>
+        <a href="{% url sentry-ajax %}?op=resolve&amp;gid={{ group.pk }}" onclick="sentryResolve({{ group.pk }});return false;" class="button resolve_button hidden">&#10003;</a>
     {% endif %}
 </li>


### PR DESCRIPTION
I changed `returnfalse` to `return false` so that the Resolve links would properly override the default link functionality once again.

Without this override, the resolve link actually attempts to resolve twice: once by AJAX request and then again by activating the link and changing the page.
