### PR TITLE
Fixed CSRF problem with AJAX POST requests

### DIFF
--- a/sentry/media/scripts/global.js
+++ b/sentry/media/scripts/global.js
@@ -169,4 +169,28 @@ $(document).ready(function(){
             });
        }
     });
+
+    // Ensure that the CSRF token is sent with AJAX POSTs sent by jQuery
+    // Taken from the documentation: http://docs.djangoproject.com/en/dev/ref/contrib/csrf/
+    $('html').ajaxSend(function(event, xhr, settings) {
+        function getCookie(name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie != '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = jQuery.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+        if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
+            // Only send the token to relative URLs i.e. locally.
+            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+        }
+    });
 });


### PR DESCRIPTION
After [the new security release](http://www.djangoproject.com/weblog/2011/feb/08/security/), Django now requires that CSRF tokens be sent in _all_ POST requests, even AJAX ones.

This commit uses the [example jQuery code in the documentation](http://docs.djangoproject.com/en/dev/ref/contrib/csrf/) to add the CSRF token to all jQuery AJAX requests.

This fixes issue #93.

Previously Django excluded AJAX requests from CSRF checks so this is not a problem for older versions of Django (before February 2011).
