### PR TITLE
Sentry main view has minor styling breakage

### DIFF
--- a/sentry/media/styles/global.css
+++ b/sentry/media/styles/global.css
@@ -435,6 +435,9 @@ dl.flat dd {
 }
 
 .no-messages { font-size: 1.1em; padding: 10px 0; }
+#message_list {
+    clear: left;
+}
 
 .paging-wrap {
     display: inline;


### PR DESCRIPTION
Fixed by clear: left on the message list; there may be other approaches. Without this, the first message entry pops off to the right of the controls (on Safari).

J
