### PR TITLE
Fix #81: logging: __sentry__ isn't always callable

### DIFF
--- a/sentry/helpers.py
+++ b/sentry/helpers.py
@@ -76,7 +76,7 @@ def transform(value):
             return str(value)
         except:
             return to_unicode(value)
-    elif hasattr(value, '__sentry__'):
+    elif callable(getattr(value, '__sentry__', None)):
         return value.__sentry__()
     elif not isinstance(value, (int, bool)) and value is not None:
         # XXX: we could do transform(repr(value)) here


### PR DESCRIPTION
This avoids an unhandled exception when using sentry for logging
