### PR TITLE
Only add template information for loaded templates

### DIFF
--- a/sentry/client/base.py
+++ b/sentry/client/base.py
@@ -13,6 +13,7 @@ import uuid
 
 from django.core.cache import cache
 from django.template import TemplateSyntaxError
+from django.template.loader import LoaderOrigin
 from django.views.debug import ExceptionReporter
 
 from sentry import conf
@@ -255,7 +256,8 @@ class SentryClient(object):
             'exc': map(transform, [exc_module, exc_value.args, frames]),
         }
 
-        if isinstance(exc_value, TemplateSyntaxError) and hasattr(exc_value, 'source'):
+        if (isinstance(exc_value, TemplateSyntaxError) and
+            hasattr(exc_value, 'source') and isinstance(exc_value.source, LoaderOrigin)):
             origin, (start, end) = exc_value.source
             data['__sentry__'].update({
                 'template': (origin.reload(), start, end, origin.name),


### PR DESCRIPTION
When templates are loaded from storage using `render_to_response` or a similar method, a `django.template.loader.LoaderOrigin` object is used.

When templates are loaded from raw strings, a `django.template.StringOrigin` object is used.  `StringOrigin` objects do not have a `loadname` attribute so this section of code throws an error if an error is raised in one of these templates and caught by sentry.

This additional conditional check allows errors in `StringOrigin` templates to bubble up properly.
