### PR TITLE
make sure log record is formatted

### DIFF
--- a/sentry/client/handlers.py
+++ b/sentry/client/handlers.py
@@ -15,6 +15,7 @@ class SentryHandler(logging.Handler):
             print >> sys.stderr, record.message
             return
 
+        self.format(record)
         get_client().create_from_record(record, request=request)
 
 try:


### PR DESCRIPTION
without this, or another handler in the chain doing the formatting, this gives an error: "AttributeError: LogRecord instance has no attribute 'message'"
