### PR TITLE
"PUBLIC" setting is not documented

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -291,3 +291,8 @@ SENTRY_MAX_LENGTH_STRING
 
 The maximum characters of a string that should be stored. Defaults to 200.
 
+########################
+SENTRY_PUBLIC
+########################
+
+Should Sentry be protected by a username and password (using @login_required) or be publicly accessible. Defaults to False (password protection).


### PR DESCRIPTION
Was trying to figure out the best way of not making people login with yet another password and discovered there is already a "PUBLIC" setting to turn off authentication.

Attached commit adds documentation. Our deployment and my fork are before recent code reorganization, so please update as appropriate.
