### PR TITLE
Make setup.py exclude the example_project package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email='dcramer@gmail.com',
     url='http://github.com/dcramer/django-sentry',
     description = 'Exception Logging to a Database in Django',
-    packages=find_packages(exclude="example_project"),
+    packages=find_packages(exclude=("example_project",)),
     zip_safe=False,
     install_requires=install_requires,
     dependency_links=[


### PR DESCRIPTION
Previously setup.py was using the exclude keyword incorrectly for find_packages, which caused it to not exclude any packages.
