### PR TITLE
make external request using href="//host.com/path" which matches protocol

### DIFF
--- a/sentry/templates/sentry/layout.html
+++ b/sentry/templates/sentry/layout.html
@@ -6,7 +6,7 @@
     <head> 
         <meta http-equiv="content-type" content="text/html; charset=utf-8"> 
         <meta name="robots" content="NONE,NOARCHIVE">
-        <link href="http{% if request.is_secure %}s{% endif %}://fonts.googleapis.com/css?family=Yanone+Kaffeesatz:light,regular&amp;subset=latin" rel="stylesheet" type="text/css">
+        <link href="//fonts.googleapis.com/css?family=Yanone+Kaffeesatz:light,regular&amp;subset=latin" rel="stylesheet" type="text/css">
         <link href="{% url sentry-media "styles/global.css" %}" rel="stylesheet" type="text/css"/>
         <link href="{% url sentry-media "images/sentry.png" %}" rel="shortcut icon"/>
         <title>{% block title %}Sentry{% endblock %}</title> 


### PR DESCRIPTION
make external request using href="//host.com/path" which matches protocol

couldn't figure out how to get request.is_secure to work when using nginx+gunicorn, but then remembered this nice solution
