### PR TITLE
Fix for Issue #178

### DIFF
--- a/sentry/utils/__init__.py
+++ b/sentry/utils/__init__.py
@@ -82,7 +82,6 @@ def has_sentry_metadata(value):
 def transform(value, stack=[], context=None):
     # TODO: make this extendable
     # TODO: include some sane defaults, like UUID
-    # TODO: dont coerce strings to unicode, leave them as strings
     if context is None:
         context = {}
 
@@ -105,7 +104,7 @@ def transform(value, stack=[], context=None):
         ret = to_unicode(value)
     elif isinstance(value, str):
         try:
-            ret = str(value)
+            ret = unicode(value)
         except:
             ret = to_unicode(value)
     elif not isinstance(value, (ClassType, TypeType)) and \


### PR DESCRIPTION
It may make more sense to always call to_unicode() instead of even doing the try/except.  Let me know if you want it that way and I can submit a different patch.

Cheers,

Keith.
