### PR TITLE
Include distribute_setup.py in the MANIFEST

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+
+1.8.6.1
+
+* Include distribute_setup.py in the MANIFEST to ship it in sdists.
+
 1.8.6
 
 * Corrected an issue which was causing certain settings (like WEB_HOST) to

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include setup.py README.rst MANIFEST.in LICENSE
+include setup.py README.rst MANIFEST.in LICENSE distribute_setup.py
 recursive-include sentry/templates *
 recursive-include sentry/static *
 recursive-include sentry/plugins/*/templates *

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except ImportError:
 
 setup(
     name='django-sentry',
-    version='1.8.6',
+    version='1.8.6.1',
     author='David Cramer',
     author_email='dcramer@gmail.com',
     url='http://github.com/dcramer/django-sentry',


### PR DESCRIPTION
Right now, sdists (including the package on PyPI) fail with "ImportError: No module named distribute_setup" when installed into a clean venv. This fixes that.
