### PR TITLE
Distribute 0.6.16 is higher than the version of distribute (0.6.15) in virtualenv

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -46,7 +46,7 @@ except ImportError:
             args = [quote(arg) for arg in args]
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
-DEFAULT_VERSION = "0.6.16"
+DEFAULT_VERSION = "0.6.15"
 DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 


### PR DESCRIPTION
Distribute 0.6.16 is higher than the version of distribute (0.6.15) installed by the latest pypi available virtualenv (0.6.1) with the `--distribute` flag. Perhaps we can get someone at @pypa to update there?
