### PR TITLE
More fixes for https://github.com/dcramer/django-sentry/pull/143

### DIFF
--- a/sentry/client/handlers.py
+++ b/sentry/client/handlers.py
@@ -1,14 +1,21 @@
 import logging
 import sys
 
+def _safe_dump(record):
+    print >> sys.stderr, "Recursive log message sent to SentryHandler"
+    try:
+        print >> sys.stderr, record.message
+    except Exception, e:
+        print >> sys.stderr, e
+
+
 class SentryHandler(logging.Handler):
     def emit(self, record):
         from sentry.client.models import get_client
 
         # Avoid typical config issues by overriding loggers behavior
         if record.name == 'sentry.errors':
-            print >> sys.stderr, "Recursive log message sent to SentryHandler"
-            print >> sys.stderr, record.message
+            _safe_dump(record)
             return
 
         get_client().create_from_record(record)
@@ -24,8 +31,7 @@ else:
 
             # Avoid typical config issues by overriding loggers behavior
             if record.name == 'sentry.errors':
-                print >> sys.stderr, "Recursive log message sent to SentryHandler"
-                print >> sys.stderr, record.message
+                _safe_dump(record)
                 return
 
             kwargs = dict(


### PR DESCRIPTION
Hi David,

I'm using django-sentry with celery client and log celery exceptions to sentry. So an exception in logging causes infinite loop and server eats all the CPU. 

The fix in https://github.com/dcramer/django-sentry/pull/143 is not full because record.message can be accessed earlier. The patch should fix this.
