### PR TITLE
Respect Django's IGNORABLE_404_* Settings in Sentry404CatchMiddleware

### DIFF
--- a/sentry/client/middleware.py
+++ b/sentry/client/middleware.py
@@ -1,10 +1,11 @@
+from django.middleware.common import _is_ignorable_404
 from sentry.client.models import get_client
 import threading
 import logging
 
 class Sentry404CatchMiddleware(object):
     def process_response(self, request, response):
-        if response.status_code != 404:
+        if response.status_code != 404 or _is_ignorable_404(request.get_full_path()):
             return response
         message_id = get_client().create_from_text('Http 404', request=request, level=logging.INFO, logger='http404')
         request.sentry = {


### PR DESCRIPTION
Django supports the ability to ignore certain strings from the path of 404 errors. The settings are `IGNORABLE_404_ENDS` and `IGNORABLE_404_STARTS`. Sentry should read those and not record them in `sentry.client.middleware.Sentry404CatchMiddleware`.

For reference, the docs on the settings are [here](https://docs.djangoproject.com/en/1.3/ref/settings/#ignorable-404-ends).
