### PR TITLE
Fixes 'str' object has no attribute 'META' error in message list view

### DIFF
--- a/sentry/web/views.py
+++ b/sentry/web/views.py
@@ -338,6 +338,7 @@ def group_message_list(request, group_id):
         'group': group,
         'message_list': message_list,
         'page': 'messages',
+        'request' : request
     })
 
 @login_required


### PR DESCRIPTION
Fixes 'str' object has no attribute 'META' error in message list view when django is running in DEBUG mode.
