### PR TITLE
Add timestamp info to templates.

### DIFF
--- a/sentry/templates/sentry/group/details.html
+++ b/sentry/templates/sentry/group/details.html
@@ -25,9 +25,9 @@
         <dt>{% trans "Status:" %}</dt>
         <dd>{{ group.get_status_display|title }}</dd>
         <dt>{% trans "First Seen:" %}</dt>
-        <dd>{{ group.first_seen|timesince }}</dd>
+        <dd title="{{ group.first_seen }}">{{ group.first_seen|timesince }}</dd>
         <dt>{% trans "Last Seen:" %}</dt>
-        <dd>{{ group.last_seen|timesince }}</dd>
+        <dd title="{{ group.first_seen }}">{{ group.last_seen|timesince }}</dd>
     </dl>
     
     {% for html in group|get_widgets:request %}
@@ -40,7 +40,7 @@
         <li class="{% cycle 'row1' 'row2' %} level-{{ group.level }} active" id="group_{{ group.pk }}" data-sentry-count="{{ group.times_seen }}">
             <span class="count count-digits-{{ group.times_seen|num_digits }}">{{ group.times_seen }}</span>
             <h3>{% if group.view %}{{ group.view }}{% else %}{{ group.message_top|truncatechars:100 }}{% endif %}</h3>
-            <span class="last_seen">{{ group.last_seen|timesince }}</span>
+            <span class="last_seen" title="{{ group.last_seen }}">{{ group.last_seen|timesince }}</span>
             <span class="status status-{{ group.status }}">{{ group.get_status_display }}</span>
             <p class="message">
                 <span class="tag tag-level">{{ group.get_level_display }}</span> 

--- a/sentry/templates/sentry/group/message.html
+++ b/sentry/templates/sentry/group/message.html
@@ -26,7 +26,7 @@
                         <span class="tag tag-version">{{ version.0 }} {{ version.1 }}</span> 
                     {% endif %}
                 {% endwith %}
-                <span class="last_seen">{{ message.datetime|timesince }}</span>
+                <span class="last_seen" title="{{ message.datetime }}">{{ message.datetime|timesince }}</span>
             </p>
         </li>
     </ul>


### PR DESCRIPTION
Normal behaviour in Sentry is to show the "timesince" a log entry was created. 
This is easy to read, but often we need to know the exact time when the log entry was created - for example, to match up against the log files of other systems/applications.
In order to keep the display uncluttered, I've changed the templates so that when the user hovers over the "timesince" of a log entry, it will show the exact time of that entry.
