### PR TITLE
fix test runner

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -61,6 +61,7 @@ if not settings.configured:
         HAYSTACK_SITECONF='sentry.search_indexes',
         HAYSTACK_SEARCH_ENGINE='whoosh',
         SENTRY_SEARCH_ENGINE='whoosh',
+        HAYSTACK_WHOOSH_PATH=join(dirname(__file__), 'sentry_test_index'),
         SENTRY_SEARCH_OPTIONS={
             'path': join(dirname(__file__), 'sentry_test_index'),
         },

--- a/sentry/search_indexes.py
+++ b/sentry/search_indexes.py
@@ -14,7 +14,8 @@ if settings.SEARCH_ENGINE:
     class SentrySearchSite(SearchSite): pass
 
     site = SentrySearchSite()
-    site.backend = backend.SearchBackend(site, **settings.SEARCH_OPTIONS)
+    haystack.site = site
+    site.backend = backend.SearchBackend(site)
 
     class GroupedMessageIndex(RealTimeSearchIndex):
         text = CharField(document=True, stored=False)


### PR DESCRIPTION
hi dcramer,

I found the sentry test runner is broken:
  File "/Users/xyb/github/django-sentry/sentry/search_indexes.py", line 18, in <module>
    site.backend = backend.SearchBackend(site, **settings.SEARCH_OPTIONS)
TypeError: **init**() got an unexpected keyword argument 'path'

So I fix it, please take a look.
