### PR TITLE
Fixed root logger configuration.

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -23,6 +23,10 @@ Django 1.3
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': True,
+        'root': {
+            'level': 'WARNING',
+            'handlers': ['sentry'],
+        },
         'handlers': {
             'sentry': {
                 'level': 'DEBUG',
@@ -36,10 +40,6 @@ Django 1.3
             }
         },
         'loggers': {
-            '()': {
-                'level': 'WARNING',
-                'handlers': ['sentry'],
-            },
             'sentry.errors': {
                 'level': 'DEBUG',
                 'handlers': ['console'],


### PR DESCRIPTION
After scratching the itch and delving into logging documentation, i've finally stumbled upon this post: http://www.calazan.com/how-to-configure-the-logging-module-using-dictionaries-in-python-2-6/ which enlighten the root logger configuration.
Looks like the root logger is a special case, so the '()' hack doesn't apply here - especially when disable_existing_loggers=True.
Finally, i can now do something like :

```
import logging
logger = logging.getLogger(__name__)
logger.error('A naughty error', exc_info=True)
```

...that logs a record into sentry.
Great !
