### PR TITLE
Avoid re-reading raw_post_data

### DIFF
--- a/sentry/client/base.py
+++ b/sentry/client/base.py
@@ -105,9 +105,9 @@ class SentryClient(object):
 
         request = kwargs.pop('request', None)
         if isinstance(request, HttpRequest):
-            if not request.POST and request.raw_post_data:
-                post_data = request.raw_post_data
-            else:
+            try:
+                post_data = not request.POST and request.raw_post_data or request.POST
+            except:
                 post_data = request.POST
 
             kwargs['data'].update(dict(


### PR DESCRIPTION
In some cases (uploading a file and getting an exception), you'll have no `request.POST` but you're already read `request.raw_post_data`, so this causes an exception to be thrown which drops the exception from sentry. This patch just catches the exception and ignores it should there be one.

Here's a stack trace of the error:

```
2011-10-17_15:47:32.56318 Traceback (most recent call last):
2011-10-17_15:47:32.56319   File "/data/www/shared/env/lib/python2.6/site-packages/sentry/client/handlers.py", line 31, in emit
2011-10-17_15:47:32.56320     get_client().create_from_record(record, request=request)
2011-10-17_15:47:32.56320   File "/data/www/shared/env/lib/python2.6/site-packages/sentry/client/base.py", line 305, in create_from_record
2011-10-17_15:47:32.56321     return self.create_from_exception(record.exc_info, **kwargs)
2011-10-17_15:47:32.56322   File "/data/www/shared/env/lib/python2.6/site-packages/sentry/client/base.py", line 382, in create_from_exception
2011-10-17_15:47:32.56323     **kwargs
2011-10-17_15:47:32.56323   File "/data/www/shared/env/lib/python2.6/site-packages/sentry/client/base.py", line 105, in process
2011-10-17_15:47:32.56324     if not request.POST and request.raw_post_data:
2011-10-17_15:47:32.56325   File "/data/www/shared/env/lib/python2.6/site-packages/django/http/__init__.py", line 240, in _get_raw_post_data
2011-10-17_15:47:32.56326     raise Exception("You cannot access raw_post_data after reading from request's data stream")
2011-10-17_15:47:32.56326 Exception: You cannot access raw_post_data after reading from request's data stream
```
