### PR TITLE
Amended raven package path on the sentry.client warning

### DIFF
--- a/sentry/client/__init__.py
+++ b/sentry/client/__init__.py
@@ -8,4 +8,4 @@ sentry.client
 
 import warnings
 
-warnings.warn('sentry.client will be removed in version 1.14.0. You should switch to raven.client.django', DeprecationWarning)
+warnings.warn('sentry.client will be removed in version 1.14.0. You should switch to raven.contrib.django', DeprecationWarning)


### PR DESCRIPTION
Hey,

I amended the warning to reflect the right package for using it along django.

Cheers,

Alfredo
