### PR TITLE
Trust client's timestamp in signature

### DIFF
--- a/sentry/web/api.py
+++ b/sentry/web/api.py
@@ -66,11 +66,11 @@ def store(request):
         # Signed data packet
         if signature and timestamp:
             try:
-                timestamp = float(timestamp)
+                timestamp_float = float(timestamp)
             except ValueError:
                 return HttpResponseBadRequest('Invalid timestamp')
 
-            if timestamp < time.time() - 3600: # 1 hour
+            if timestamp_float < time.time() - 3600: # 1 hour
                 return HttpResponseGone('Message has expired')
 
             sig_hmac = get_signature(data, timestamp, secret_key)


### PR DESCRIPTION
The parsed timestamp shouldn't be used in comparison with the signature. A parsed timestamp is subject to float precision errors causing the signature to be invalid. Trust the client's exact timestamp
sent.

I came across this issue when writing a version of Raven in Node.js. Javascript and Python's float precision is calculated a bit differently and I was having issues with signatures not being validated all of the time.

e.g., the timestamp 1322533180.139

In Javascript:

``` javascript
> parseFloat('1322533180.139')+''
'1322533180.139'
```

In Python:

``` python
>>> str(float('1322533180.139'))
'1322533180.14'
```
