### PR TITLE
Handle Dictionary keys

### DIFF
--- a/sentry/utils/__init__.py
+++ b/sentry/utils/__init__.py
@@ -124,7 +124,8 @@ def transform(value, stack=[], context=None):
     elif isinstance(value, uuid.UUID):
         ret = repr(value)
     elif isinstance(value, dict):
-        ret = dict((str(k), transform_rec(v)) for k, v in value.iteritems())
+        ret = dict((k if isinstance(k, str) or isinstance(k, unicode) else repr(k),
+                    transform_rec(v)) for k, v in value.iteritems())
     elif isinstance(value, unicode):
         ret = to_unicode(value)
     elif isinstance(value, str):


### PR DESCRIPTION
https://github.com/bbangert/zilch/pull/1
As discussed, attempt to ensure that dictionary keys in the transform()'d frame locals are safe for json encoding.

Attempt to make dictionary keys safe for dumpsing.
