### PR TITLE
Updated Apache proxy instructions to include the all-important trailing /

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -122,8 +122,8 @@ Proxying with Apache
 
 Apache requires the use of mod_proxy for forwarding requests::
 
-    ProxyPass / http://localhost:9000
-    ProxyPassReverse / http://localhost:9000
+    ProxyPass / http://localhost:9000/
+    ProxyPassReverse / http://localhost:9000/
 
 Proxying with Nginx
 ```````````````````


### PR DESCRIPTION
The install instructions require a slight modification to avoid mod_proxy errors
