### PR TITLE
Add the Django admin to the Sentry-provided web server

### DIFF
--- a/sentry/conf/server.py
+++ b/sentry/conf/server.py
@@ -86,7 +86,7 @@ MIDDLEWARE_CLASSES = (
     # 'django.contrib.messages.middleware.MessageMiddleware',
 )
 
-ROOT_URLCONF = 'sentry.web.urls'
+ROOT_URLCONF = 'sentry.conf.urls'
 
 TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
@@ -117,3 +117,5 @@ logging.basicConfig(level=logging.WARNING)
 
 SENTRY_PUBLIC = True
 SENTRY_PROJECT = 1
+
+ADMIN_MEDIA_PREFIX = '/_admin_media/'

--- a/sentry/conf/urls.py
+++ b/sentry/conf/urls.py
@@ -1,0 +1,26 @@
+"""
+sentry.conf.urls
+~~~~~~~~~~~~~~~~
+
+These are additional urls used by the Sentry-provided web server
+
+:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+import os
+
+from django.contrib import admin
+
+from sentry.web.urls import *
+
+
+admin.autodiscover()
+admin_media_dir = os.path.join(os.path.dirname(admin.__file__), 'media')
+
+urlpatterns += patterns('',
+    (r'^admin/', include(admin.site.urls)),
+    url(r'^_admin_media/(?P<path>.*)$', generic.static_media,
+        kwargs={'root': admin_media_dir},
+        name='admin-media'),
+)

--- a/sentry/web/frontend/generic.py
+++ b/sentry/web/frontend/generic.py
@@ -92,7 +92,7 @@ def status(request):
     }, request)
 
 
-def static_media(request, path):
+def static_media(request, path, root=None):
     """
     Serve static files below a given point in the directory structure.
     """
@@ -104,7 +104,7 @@ def static_media(request, path):
     import stat
     import urllib
 
-    document_root = os.path.join(settings.ROOT, 'static')
+    document_root = root or os.path.join(settings.ROOT, 'static')
 
     path = posixpath.normpath(urllib.unquote(path))
     path = path.lstrip('/')


### PR DESCRIPTION
Points the ROOT_URLCONF of sentry.conf.server to sentry.conf.urls, which extends sentry.web.urls.

Adds an additional optional kwarg to sentry.web.frontend.generic.static_media that overrides the root - used to strap on the admin media in sentry.conf.urls.
