### PR TITLE
Suppress chart js error

### DIFF
--- a/sentry/static/scripts/global.js
+++ b/sentry/static/scripts/global.js
@@ -191,6 +191,11 @@ if (Sentry === undefined) {
     Sentry.charts = {};
     Sentry.charts.render = function(el, project_id, group_id, grid){
         var $sparkline = $(el);
+
+        if ($sparkline.length < 1) {
+            return; // Supress an empty chart
+        }
+
         $.ajax({
             url: Sentry.options.urlPrefix + '/api/' + project_id + '/chart/',
             type: 'get',


### PR DESCRIPTION
In the group details template, the chart display is conditional based on
group|has_charts. This change causes the JavaScript to gracefully handle
being called when the #chart container element wasn't actually rendered.
