### PR TITLE
Docs: change UDP config to specify UDP_PORT instead of WEB_PORT

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -294,7 +294,7 @@ The following settings are available for the built-in UDP API server:
 
         SENTRY_UDP_HOST = '0.0.0.0'  # bind to all addresses
 
-.. data:: sentry.conf.WEB_PORT
+.. data:: sentry.conf.UDP_PORT
     :noindex:
 
     The port which the udp server should listen on.


### PR DESCRIPTION
Currently http://sentry.readthedocs.org/en/latest/config/index.html#udp-server shows WEB_PORT under the UDP section as well.
