### PR TITLE
support --noinput mode for syncdb

### DIFF
--- a/sentry/management/commands/upgrade.py
+++ b/sentry/management/commands/upgrade.py
@@ -7,10 +7,19 @@ sentry.management.commands.upgrade
 """
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
+from optparse import make_option
 
 
 class Command(BaseCommand):
     help = 'Performs any pending database migrations and upgrades'
 
+    option_list = BaseCommand.option_list + (
+            make_option('--noinput',
+                action='store_true',
+                dest='noinput',
+                default=False,
+                help='Tells Django to NOT prompt the user for input of any kind.'),
+            )
+
     def handle(self, **options):
-        call_command('syncdb', migrate=True)
+        call_command('syncdb', migrate=True, interactive=(not options['noinput']))


### PR DESCRIPTION
... script the use of sentry upgrade without needing pexpect
