### PR TITLE
Fix Interface.__setstate__

### DIFF
--- a/sentry/interfaces.py
+++ b/sentry/interfaces.py
@@ -67,7 +67,9 @@ class Interface(object):
         self.__dict__.update(kwargs)
 
     def __setstate__(self, data):
-        self.__dict__.update(self.unserialize(data))
+        kwargs = self.unserialize(data)
+        self.attrs = kwargs.keys()
+        self.__dict__.update(kwargs)
 
     def __getstate__(self):
         return self.serialize()

--- a/tests/sentry/interfaces/tests.py
+++ b/tests/sentry/interfaces/tests.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import pickle
+
+from sentry.interfaces import Interface
+
+from tests.base import TestCase
+
+
+class InterfaceTests(TestCase):
+
+    def test_init_sets_attrs(self):
+        obj = Interface(foo=1)
+        self.assertEqual(obj.attrs, ['foo'])
+
+    def test_setstate_sets_attrs(self):
+        data = pickle.dumps(Interface(foo=1))
+        obj = pickle.loads(data)
+        self.assertEqual(obj.attrs, ['foo'])


### PR DESCRIPTION
**setstate**() is called when deserializing objects with pickle.
Since this path is never invoking **init**() args would be left unset.
