### PR TITLE
Improve compatibility with logbook

### DIFF
--- a/bootstrap/sentry.less
+++ b/bootstrap/sentry.less
@@ -393,11 +393,11 @@ footer {
       position: absolute;
     }
 
-    &.level-10 .count {}
-    &.level-20 .count { background: #ffa101; }
-    &.level-30 .count { background: #ffa101; }
-    &.level-40 .count { background: #f0431c; }
-    &.level-50 .count { background: #f0431c; }
+    &.level-debug .count {}
+    &.level-info .count { background: #ffa101; }
+    &.level-warning .count { background: #ffa101; }
+    &.level-error .count { background: #f0431c; }
+    &.level-fatal .count { background: #f0431c; }
 
     &.resolved {
       h3 {

--- a/sentry/static/styles/global.css
+++ b/sentry/static/styles/global.css
@@ -3802,16 +3802,16 @@ footer a {
   height: 100%;
   position: absolute;
 }
-.events .event.level-20 .count {
+.events .event.level-info .count {
   background: #ffa101;
 }
-.events .event.level-30 .count {
+.events .event.level-warning .count {
   background: #ffa101;
 }
-.events .event.level-40 .count {
+.events .event.level-error .count {
   background: #f0431c;
 }
-.events .event.level-50 .count {
+.events .event.level-fatal .count {
   background: #f0431c;
 }
 .events .event.resolved h3 {

--- a/sentry/static/styles/global.min.css
+++ b/sentry/static/styles/global.min.css
@@ -658,10 +658,10 @@ footer a{color:#fff;font-weight:bold;}
 .events .event .actions{position:absolute;right:15px;top:20px;list-style-type:none;margin:0;padding:0;}.events .event .actions li{margin-bottom:12px;font-size:14px;line-height:18px;}.events .event .actions li .checked{color:orange;}
 .events .event .actions li .disabled{color:#6d757e;}
 .events .event .row_link{top:0;left:0;width:100%;height:100%;position:absolute;}
-.events .event.level-20 .count{background:#ffa101;}
-.events .event.level-30 .count{background:#ffa101;}
-.events .event.level-40 .count{background:#f0431c;}
-.events .event.level-50 .count{background:#f0431c;}
+.events .event.level-info .count{background:#ffa101;}
+.events .event.level-warning .count{background:#ffa101;}
+.events .event.level-error .count{background:#f0431c;}
+.events .event.level-fatal .count{background:#f0431c;}
 .events .event.resolved h3{text-decoration:line-through;}
 .events .event.resolved .count{opacity:0.5;filter:alpha(opacity=50);}
 label{font-weight:bold;}

--- a/sentry/templates/sentry/emails/error.html
+++ b/sentry/templates/sentry/emails/error.html
@@ -54,11 +54,11 @@
             font-weight: 400;
             font-family: "proxima nova", "proxima-nova", "heletica-neue", sans-serif;
         }
-        .level-10 .count {}
-        .level-20 .count { background: #ffa101; }
-        .level-30 .count { background: #ffa101; }
-        .level-40 .count { background: #f0431c; }
-        .level-50 .count { background: #f0431c; }
+        .level-debug .count {}
+        .level-info .count { background: #ffa101; }
+        .level-warning .count { background: #ffa101; }
+        .level-error .count { background: #f0431c; }
+        .level-fatal .count { background: #f0431c; }
         .header h1 {
             float: left;
             font-size: 22px;
@@ -99,7 +99,7 @@
         </style>
     </head>
     <body>
-        <table class="main level-{{ event.level }}">
+        <table class="main level-{{ event.get_level_display }}">
             <tr>
                 <td>
                     <div class="body">

--- a/sentry/templates/sentry/groups/details.html
+++ b/sentry/templates/sentry/groups/details.html
@@ -40,7 +40,7 @@
 {% block main %}
     {% handle_before_events request group %}
     <ul class="events" id="event_list">
-        <li class="event level-{{ group.level }}{% if group.status == 1 %} resolved{% endif %}" id="group_{{ group.pk|safe }}" data-count="{{ group.times_seen }}" data-score="{{ group.sort_value }}">
+        <li class="event level-{{ group.get_level_display }}{% if group.status == 1 %} resolved{% endif %}" id="group_{{ group.pk|safe }}" data-count="{{ group.times_seen }}" data-score="{{ group.sort_value }}">
             <div class="count"><span>{{ group.times_seen|small_count }}</span></div>
             <div class="details">
                 <h3>

--- a/sentry/templates/sentry/partial/_event.html
+++ b/sentry/templates/sentry/partial/_event.html
@@ -1,6 +1,6 @@
 {% load sentry_helpers %}
 
-<li class="event level-{{ event.level }}" id="message_{{ event.pk|safe }}">
+<li class="event level-{{ event.get_level_display }}" id="message_{{ event.pk|safe }}">
     <div class="details">
         <h3>
             <a href="{% url sentry-group-event event.project_id event.group_id event.pk %}">

--- a/sentry/templates/sentry/partial/_group.html
+++ b/sentry/templates/sentry/partial/_group.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load sentry_helpers %}
 
-<li class="event level-{{ group.level }}{% if group.status == 1 %} resolved{% endif %}" id="group_{{ group.pk|safe }}" data-count="{{ group.times_seen }}" data-score="{{ group.sort_value }}">
+<li class="event level-{{ group.get_level_display }}{% if group.status == 1 %} resolved{% endif %}" id="group_{{ group.pk|safe }}" data-count="{{ group.times_seen }}" data-score="{{ group.sort_value }}">
     <div class="count"><span>{{ group.times_seen|small_count }}</span></div>
     <div class="details">
         <h3>


### PR DESCRIPTION
I'm trying to use logbook instead of logging to send log entries to Sentry. But logging and logbook use different integer log levels:

```
>>> import logging
>>> logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.FATAL
(10, 20, 30, 40, 50)
>>> 
>>> import logbook
>>> logbook.DEBUG, logbook.INFO, logbook.NOTICE, logbook.WARNING, logbook.ERROR, logbook.CRITICAL
(1, 2, 3, 4, 5, 6)
```

Adding new entries works but there are some glitches in presentation. Using SENTRY_LOG_LEVELS fixes the "Level: " field in "AGGREGATE DETAILS" but the css classes for the colored circles with the count are wrong because they embed the log level.

This change does not use the log level directly in the css classes but rather the log level name. With this change, one should use SENTRY_LOG_LEVELS as follows to work with logbook.

```
SENTRY_LOG_LEVELS = (
    (logbook.DEBUG, 'debug'),
    (logbook.INFO, 'info'),
    (logbook.NOTICE, 'info'),
    (logbook.WARNING, 'warning'),
    (logbook.ERROR, 'error'),
    (logbook.CRITICAL, 'fatal'),
)
```

Notice that logbook has an extra level called NOTICE which I clobber onto INFO here. You could even use both logging and logbook if you add the same list to SENTRY_LOG_LEVELS for the log levels of logging.

By the way: we use logbook because with logging, if the Sentry server is unavailable, the raven client hangs, presumably waiting for a TCP timeout, bringing our app to a crawl. With logbook you can use the ZeroMQ or MultiProcessing handlers to offload the logging logic to a different thread or process. This way your main app runs more or less independently from the logging process.
