### PR TITLE
including URL path to sentry in DSN

### DIFF
--- a/sentry/models.py
+++ b/sentry/models.py
@@ -265,7 +265,7 @@ class ProjectMember(Model):
             urlparts.scheme,
             self.public_key,
             self.secret_key,
-            urlparts.netloc,
+            urlparts.netloc + urlparts.path,
             self.project_id,
         )
 


### PR DESCRIPTION
I am hosting a sentry server on example.org/sentry but DSN strings on project/user pages would be set to http://foo:bar@example.org/1 instead of http://foo:bar@example.org/sentry/1

This patch includes the path to sentry in the DSN.
