### PR TITLE
Quietly upgrade

### DIFF
--- a/sentry/management/commands/start.py
+++ b/sentry/management/commands/start.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
 
         # Ensure we perform an upgrade before starting any service
         print "Performing upgrade before service startup..."
-        call_command('upgrade', verbosity=0)
+        call_command('upgrade', verbosity=0, noinput=True)
 
         try:
             service_class = services[service_name]


### PR DESCRIPTION
Initial install start prompts for superuser, etc.

noinput on call_command('upgrade') allows puppet/chef install, which I wished for.

Also, I think it would be good to have an explicit flag to skip upgrade since there's some overhead to it and it slows bounces.  If you agree w/ that (or prefer it instead of this), then I could do a different pull req.
