### PR TITLE
Make interfaces.Template.to_string work.

### DIFF
--- a/sentry/interfaces.py
+++ b/sentry/interfaces.py
@@ -433,9 +433,10 @@ class Template(Interface):
         return [self.filename, self.context_line]
 
     def to_string(self, event):
+        context = get_context(self.lineno, self.context_line, self.pre_context, self.post_context)
         result = [
             'Stacktrace (most recent call last):', '',
-            self.get_traceback()
+            self.get_traceback(event, context)
         ]
 
         return '\n'.join(result)


### PR DESCRIPTION
interfaces.Template.to_string couldn't work like it did; I cobbled the context = get_context call like the to_html below it.
