### PR TITLE
django admin url added to front of urlpatterns

### DIFF
--- a/sentry/conf/urls.py
+++ b/sentry/conf/urls.py
@@ -38,10 +38,10 @@ def handler500(request):
     t = loader.get_template('sentry/500.html')
     return HttpResponseServerError(t.render(Context(context)))
 
-urlpatterns += patterns('',
+urlpatterns = patterns('',
     (r'^i18n/', include('django.conf.urls.i18n')),
     (r'^admin/', include(admin.site.urls)),
     url(r'^_admin_media/(?P<path>.*)$', generic.static_media,
         kwargs={'root': admin_media_dir},
         name='admin-media'),
-)
+) + urlpatterns


### PR DESCRIPTION
Add django.contrib.admin.site.urls to position 0 of urlpatterns
to avoid shadowing from sentry.web.urls.

Fixes https://github.com/dcramer/sentry/issues/432.
