### PR TITLE
Pass missing keyword arguments to post_process_group

### DIFF
--- a/sentry/processors/base.py
+++ b/sentry/processors/base.py
@@ -14,4 +14,4 @@ __all__ = ('send_group_processors',)
 
 
 def send_group_processors(group, **kwargs):
-    maybe_delay(post_process_group, group=group)
+    maybe_delay(post_process_group, group=group, **kwargs)


### PR DESCRIPTION
This change restores the post processor arguments dropped by 6a6afba, and prevents errors due to missing parameters from occurring during post processing. This issue was especially devious if celery was disabled:
the resulting errors would cause logs of their own to be generated, generating more errors as post processing failed, and so on.
