### PR TITLE
Remove the bookmarks filter if anon user #398

### DIFF
--- a/sentry/templates/sentry/groups/group_list.html
+++ b/sentry/templates/sentry/groups/group_list.html
@@ -34,10 +34,13 @@
 {% block sidebar %}
     {% querystring from request without bookmarks as bookmark_querystring %}
     <h6>{% trans "Bookmarks" %}</h6>
-    <form>
     <ul class="nav nav-tabs nav-stacked filter-list">
+        {% if request.user.is_anonymous %}
+        <li class="active"><a href="?">{% trans "All Events" %}</a></li>
+        {% else %}
         <li{% if not request.GET.bookmarks %} class="active"{% endif %}><a href="?{{ bookmark_querystring }}">{% trans "All Events" %}</a></li>
         <li{% if request.GET.bookmarks %} class="active"{% endif %}><a href="?{{ bookmark_querystring }}&amp;bookmarks=1">{% trans "Only Bookmarks" %}</a></li>
+        {% endif %}
     </ul>
 
     {% for filter in filters %}

--- a/sentry/web/frontend/groups.py
+++ b/sentry/web/frontend/groups.py
@@ -58,10 +58,12 @@ def _get_group_list(request, project, view=None):
 
     event_list = Group.objects
     if request.GET.get('bookmarks'):
-        event_list = event_list.filter(
-            bookmark_set__project=project,
-            bookmark_set__user=request.user,
-        )
+        # Ignore this filter if anon user
+        if not request.user.is_anonymous():
+            event_list = event_list.filter(
+                bookmark_set__project=project,
+                bookmark_set__user=request.user,
+            )
     else:
         event_list = event_list.filter(project=project)
 


### PR DESCRIPTION
Attempting to filter by bookmarks when not logged in currently fails hard (see #398)

This patch removes the "Only Bookmarks" link from the sidebar, and ignores `?bookmarks=1` if the user is anonymous.

I'm not convinced removing the link makes for a good UX. Perhaps disabling it in some way is a better option. Let me know what you guys prefer and I'll modify accordingly.
