### PR TITLE
Avoid logging if request.method == 'OPTIONS' for javascript logging

### DIFF
--- a/sentry/web/api.py
+++ b/sentry/web/api.py
@@ -111,7 +111,8 @@ def store(request):
         logging.error('Client %r raised API error: %s' % (client, error), exc_info=True)
         response = HttpResponse(unicode(error.msg), status=error.http_status)
     else:
-        logging.info('New event from client %r (id=%%s)' % client, data['event_id'])
+        if request.method == 'POST':
+            logging.info('New event from client %r (id=%%s)' % client, data['event_id'])
         response = HttpResponse('')
     return apply_access_control_headers(response)
 


### PR DESCRIPTION
When you send a request using ALLOW_ORIGIN, data goes through OPTIONS, then `data` from the try wasn't defined yet and raises an error in the else.

Didn't find a reason to notify/log about the OPTIONS call, then just ignored it.
