### PR TITLE
Removed mention of "sentry start worker" in documentation.

### DIFF
--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -31,7 +31,7 @@ Builtin Commands
 
     ::
 
-        sentry start worker
+        sentry start udp
 
 .. data:: upgrade
 


### PR DESCRIPTION
http://sentry.readthedocs.org/en/latest/cli/index.html
