### PR TITLE
Add some basic docs for using the UDP server.

### DIFF
--- a/docs/udp_server/index.rst
+++ b/docs/udp_server/index.rst
@@ -1,0 +1,23 @@
+Utilizing the UDP Server
+========================
+
+The UDP server requires the :mod:`eventlet` module.
+
+::
+
+    pip install eventlet
+
+To start the server:
+
+::
+
+    sentry start udp
+
+
+Configuration
+-------------
+
+There are a few settings that you can tweak::
+
+    SENTRY_UDP_HOST = '0.0.0.0'
+    SENTRY_UDP_PORT = 9001


### PR DESCRIPTION
Note that I didn't test this, because for some reason I couldn't get Sphinx to recognize sentry installed via `pip install -e .` or `python setup.py develop`.
