### PR TITLE
Hack to prevent stupid "TypeError: 'NoneType' object is not callable"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ any application.
 :copyright: (c) 2011-2012 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
+
 from setuptools import setup, find_packages
+
+import multiprocessing
 
 
 tests_require = [


### PR DESCRIPTION
error in multiprocessing/util.py _exit_function when running `python
setup.py test` (see
http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
