### PR TITLE
CORS Support

### DIFF
--- a/bootstrap/sentry.less
+++ b/bootstrap/sentry.less
@@ -622,6 +622,10 @@ small {
   padding-top: 5px; // has to be padding because margin collaspes
 }
 
+legend {
+  margin-bottom: 18px;
+}
+
 
 .modal-header small {
   font-size: 0.65em;

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -197,3 +197,23 @@ folder and you're good to go.
   autostart=true
   autorestart=true
   redirect_stderr=true
+
+Additional Utilities
+--------------------
+
+If you're familiar with Python you'll quickly find yourself at home, and even more so if you've used Django. The
+``sentry`` command is just a simple wrapper around Django's ``django-admin.py``, which means you get all of the
+power and flexibility that goes with it.
+
+Some of those which you'll likely find useful are::
+
+createsuperuser
+~~~~~~~~~~~~~~~
+
+Quick and easy creation of superusers. These users have full access to the entirety of the Sentry server.
+
+runserver
+~~~~~~~~~
+
+Testing Sentry locally? Spin up Django's builtin runserver (or ``pip install django-devserver`` for something
+slightly better).

--- a/sentry/migrations/0055_auto__del_projectdomain__del_unique_projectdomain_project_domain.py
+++ b/sentry/migrations/0055_auto__del_projectdomain__del_unique_projectdomain_project_domain.py
@@ -1,0 +1,246 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Removing unique constraint on 'ProjectDomain', fields ['project', 'domain']
+        db.delete_unique('sentry_projectdomain', ['project_id', 'domain'])
+
+        # Deleting model 'ProjectDomain'
+        db.delete_table('sentry_projectdomain')
+
+
+    def backwards(self, orm):
+        
+        # Adding model 'ProjectDomain'
+        db.create_table('sentry_projectdomain', (
+            ('project', self.gf('django.db.models.fields.related.ForeignKey')(related_name='domain_set', to=orm['sentry.Project'])),
+            ('domain', self.gf('django.db.models.fields.CharField')(max_length=128)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('sentry', ['ProjectDomain'])
+
+        # Adding unique constraint on 'ProjectDomain', fields ['project', 'domain']
+        db.create_unique('sentry_projectdomain', ['project_id', 'domain'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'sentry.event': {
+            'Meta': {'unique_together': "(('project', 'event_id'),)", 'object_name': 'Event', 'db_table': "'sentry_message'"},
+            'checksum': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'culprit': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'db_column': "'view'", 'blank': 'True'}),
+            'data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'db_column': "'message_id'"}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'event_set'", 'null': 'True', 'to': "orm['sentry.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'default': '40', 'db_index': 'True', 'blank': 'True'}),
+            'logger': ('django.db.models.fields.CharField', [], {'default': "'root'", 'max_length': '64', 'db_index': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'server_name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'site': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'time_spent': ('django.db.models.fields.FloatField', [], {'null': 'True'})
+        },
+        'sentry.filtervalue': {
+            'Meta': {'unique_together': "(('project', 'key', 'value'),)", 'object_name': 'FilterValue'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        'sentry.group': {
+            'Meta': {'unique_together': "(('project', 'logger', 'culprit', 'checksum'),)", 'object_name': 'Group', 'db_table': "'sentry_groupedmessage'"},
+            'checksum': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'culprit': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'db_column': "'view'", 'blank': 'True'}),
+            'data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'default': '40', 'db_index': 'True', 'blank': 'True'}),
+            'logger': ('django.db.models.fields.CharField', [], {'default': "'root'", 'max_length': '64', 'db_index': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'score': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'status': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'time_spent_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'time_spent_total': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'times_seen': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1', 'db_index': 'True'}),
+            'views': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.View']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'sentry.groupbookmark': {
+            'Meta': {'unique_together': "(('project', 'user', 'group'),)", 'object_name': 'GroupBookmark'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'bookmark_set'", 'to': "orm['sentry.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'bookmark_set'", 'to': "orm['sentry.Project']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sentry_bookmark_set'", 'to': "orm['auth.User']"})
+        },
+        'sentry.groupmeta': {
+            'Meta': {'unique_together': "(('group', 'key'),)", 'object_name': 'GroupMeta'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'sentry.messagecountbyminute': {
+            'Meta': {'unique_together': "(('project', 'group', 'date'),)", 'object_name': 'MessageCountByMinute'},
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'time_spent_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'time_spent_total': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'times_seen': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.messagefiltervalue': {
+            'Meta': {'unique_together': "(('project', 'key', 'value', 'group'),)", 'object_name': 'MessageFilterValue'},
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'times_seen': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        'sentry.messageindex': {
+            'Meta': {'unique_together': "(('column', 'value', 'object_id'),)", 'object_name': 'MessageIndex'},
+            'column': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'sentry.option': {
+            'Meta': {'object_name': 'Option'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'value': ('picklefield.fields.PickledObjectField', [], {})
+        },
+        'sentry.pendingteammember': {
+            'Meta': {'unique_together': "(('team', 'email'),)", 'object_name': 'PendingTeamMember'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pending_member_set'", 'to': "orm['sentry.Team']"}),
+            'type': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'sentry.project': {
+            'Meta': {'object_name': 'Project'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sentry_owned_project_set'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'db_index': 'True'}),
+            'status': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Team']", 'null': 'True'})
+        },
+        'sentry.projectcountbyminute': {
+            'Meta': {'unique_together': "(('project', 'date'),)", 'object_name': 'ProjectCountByMinute'},
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'time_spent_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'time_spent_total': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'times_seen': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.projectkey': {
+            'Meta': {'object_name': 'ProjectKey'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'key_set'", 'to': "orm['sentry.Project']"}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'unique': 'True', 'null': 'True'}),
+            'secret_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'unique': 'True', 'null': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True'})
+        },
+        'sentry.projectoption': {
+            'Meta': {'unique_together': "(('project', 'key'),)", 'object_name': 'ProjectOption', 'db_table': "'sentry_projectoptions'"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'value': ('picklefield.fields.PickledObjectField', [], {})
+        },
+        'sentry.searchdocument': {
+            'Meta': {'unique_together': "(('project', 'group'),)", 'object_name': 'SearchDocument'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_changed': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'status': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'total_events': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        'sentry.searchtoken': {
+            'Meta': {'unique_together': "(('document', 'field', 'token'),)", 'object_name': 'SearchToken'},
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'token_set'", 'to': "orm['sentry.SearchDocument']"}),
+            'field': ('django.db.models.fields.CharField', [], {'default': "'text'", 'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'times_seen': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'token': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'sentry.team': {
+            'Meta': {'object_name': 'Team'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'db_index': 'True'})
+        },
+        'sentry.teammember': {
+            'Meta': {'unique_together': "(('team', 'user'),)", 'object_name': 'TeamMember'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'member_set'", 'to': "orm['sentry.Team']"}),
+            'type': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sentry_teammember_set'", 'to': "orm['auth.User']"})
+        },
+        'sentry.view': {
+            'Meta': {'object_name': 'View'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'verbose_name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'verbose_name_plural': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'})
+        }
+    }
+
+    complete_apps = ['sentry']

--- a/sentry/models.py
+++ b/sentry/models.py
@@ -316,45 +316,6 @@ class PendingTeamMember(Model):
             logger.exception(e)
 
 
-class ProjectDomain(Model):
-    """
-    Currently unused. Planned for 'trusted domains' for JS apis.
-    """
-    project = models.ForeignKey(Project, related_name="domain_set")
-    domain = models.CharField(max_length=128)
-
-    objects = BaseManager()
-
-    class Meta:
-        unique_together = (('project', 'domain'),)
-
-    def __unicode__(self):
-        return u'project=%s, domain=%s' % (self.project_id, self.domain)
-
-    @classmethod
-    def test(cls, project, url, strict=False):
-        """
-        Tests whether the ``url`` is a trusted domain for the given project.
-        """
-        if not url:
-            return False
-        url = urlparse.urlsplit(url).hostname
-        if not url:
-            # If we fail to parse the referral url
-            return False
-        if url in ('127.0.0.1', 'localhost'):
-            return True
-        if url.endswith('.local'):
-            return True
-        url = url.split('.')
-        domains = ProjectDomain.objects.filter(project=project).values_list('domain', flat=True)
-        for d in domains:
-            d = d.split('.')
-            if url[-len(d):] == d:
-                return True
-        return False
-
-
 class View(Model):
     """
     A view ties directly to a view extension and simply

--- a/sentry/static/styles/global.css
+++ b/sentry/static/styles/global.css
@@ -4056,6 +4056,9 @@ small {
 .controls > .inputs-list label:first-child, .controls > .inputs-list label:first-child {
   padding-top: 5px;
 }
+legend {
+  margin-bottom: 18px;
+}
 .modal-header small {
   font-size: 0.65em;
 }

--- a/sentry/static/styles/global.min.css
+++ b/sentry/static/styles/global.min.css
@@ -714,6 +714,7 @@ small{font-size:0.9em;}
 .inputs-list label{padding-left:18px;}
 .inputs-list label input[type="radio"],.inputs-list label input[type="checkbox"]{float:left;margin-left:-18px;}
 .controls>.inputs-list label:first-child,.controls>.inputs-list label:first-child{padding-top:5px;}
+legend{margin-bottom:18px;}
 .modal-header small{font-size:0.65em;}
 .btn-primary{background-color:#56afe8;background-image:-moz-linear-gradient(top, #61c1ef, #4593de);background-image:-ms-linear-gradient(top, #61c1ef, #4593de);background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#61c1ef), to(#4593de));background-image:-webkit-linear-gradient(top, #61c1ef, #4593de);background-image:-o-linear-gradient(top, #61c1ef, #4593de);background-image:linear-gradient(top, #61c1ef, #4593de);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#61c1ef', endColorstr='#4593de', GradientType=0);border-color:#4593de #4593de #206db6;border-color:rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);font-weight:bold;}.btn-primary:hover,.btn-primary:active,.btn-primary.active,.btn-primary.disabled,.btn-primary[disabled]{background-color:#4593de;}
 .btn-primary:active,.btn-primary.active{background-color:#247acc \9;}

--- a/sentry/templates/sentry/partial/_form_field.html
+++ b/sentry/templates/sentry/partial/_form_field.html
@@ -1,4 +1,4 @@
-<fieldset class="control-group{% if field.errors %} error{% endif %}">
+<div class="control-group{% if field.errors %} error{% endif %}">
     {{ field.label_tag }}
     <div class="controls">
         {{ field }}
@@ -11,4 +11,4 @@
             {% endfor %}
         {% endif %}
     </div>
-</fieldset>
+</div>

--- a/sentry/templates/sentry/projects/manage.html
+++ b/sentry/templates/sentry/projects/manage.html
@@ -44,17 +44,37 @@
                 {% csrf_token %}
                 <fieldset>
                     {% for field in form %}
-                        {% include "sentry/partial/_form_field.html" %}
+                        {% if field.name != 'origins' %}
+                            {% include "sentry/partial/_form_field.html" %}
+                        {% endif %}
                     {% endfor %}
                 </fieldset>
-                <fieldset class="form-actions">
+                <fieldset>
+                    <div><legend>Client Security</legend></div>
+                    {% with form.origins as field %}
+                        <p>{% blocktrans with 'https://github.com/lincolnloop/raven-js' as link %}Configure origin URLs which Sentry should accept events from. This is used for communication with client's like <a href="{{ link }}">raven-js</a>.{% endblocktrans %}
+                        <p>{% blocktrans with 'http://en.wikipedia.org/wiki/Cross-origin_resource_sharing' as link' %}For more information check out the <a href="{{ link }}">Wikipedia page on CORS</a>.{% endblocktrans %}</p>
+                        <div class="control-group{% if field.errors %} error{% endif %}">
+                            <div class="controls">
+                                <div class="help-block">{% trans "List one URL per line." %}</div>
+                                {{ field }}
+                                {% if field.errors %}
+                                    {% for error in field.errors %}
+                                        <div class="help-block error">{{ error }}</div>
+                                    {% endfor %}
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% endwith %}
+                </fieldset>
+                <div class="form-actions">
                     <button type="submit" class="btn btn-primary">{% trans "Save Changes" %}</button>
                     {% if PROJECT_ID != project.pk %}
                         <a href="{% url sentry-remove-project project.slug %}" class="btn btn-danger">{% trans "Remove Project" %}</a>
                     {% else %}
                         <a href="#" class="btn disabled btn-danger">{% trans "Cannot remove default project" %}</a>
                     {% endif %}
-                </fieldset>
+                </div>
             </form>
             <div class="page-header">
                 {% if can_add_member %}

--- a/sentry/utils/http.py
+++ b/sentry/utils/http.py
@@ -56,7 +56,7 @@ def apply_access_control_headers(response, project=None):
     https://developer.mozilla.org/En/HTTP_access_control#Simple_requests
     """
     origin = settings.ALLOW_ORIGIN or ''
-    if project:
+    if project and origin is not '*':
         optval = get_option('sentry:origins', project)
         if optval:
             origin = ('%s %s' % (origin, ' '.join(optval))).strip()

--- a/sentry/utils/http.py
+++ b/sentry/utils/http.py
@@ -9,6 +9,7 @@ import urllib
 from urlparse import urlparse
 
 from sentry.conf import settings
+from sentry.plugins.helpers import get_option
 
 
 def safe_urlencode(params, doseq=0):
@@ -48,14 +49,21 @@ def is_same_domain(url1, url2):
     return url1.netloc == url2.netloc
 
 
-def apply_access_control_headers(response):
+def apply_access_control_headers(response, project=None):
     """
     Provides the Access-Control headers to enable cross-site HTTP requests. You
     can find more information about these headers here:
     https://developer.mozilla.org/En/HTTP_access_control#Simple_requests
     """
-    if settings.ALLOW_ORIGIN:
-        response['Access-Control-Allow-Origin'] = settings.ALLOW_ORIGIN
+    origin = settings.ALLOW_ORIGIN or ''
+    if project:
+        optval = get_option('sentry:origins', project)
+        if optval:
+            origin = ('%s %s' % (origin, ' '.join(optval))).strip()
+
+    if origin:
+        response['Access-Control-Allow-Origin'] = origin
         response['Access-Control-Allow-Headers'] = 'X-Sentry-Auth'
         response['Access-Control-Allow-Methods'] = 'POST'
+
     return response

--- a/sentry/web/api.py
+++ b/sentry/web/api.py
@@ -46,12 +46,12 @@ def store(request, project_id=None):
        require an authentication header which is signed using with the project
        member's secret key.
 
-    2. Explicit trusted requests
+    2. CORS Secured Requests
 
        Generally used for communications with client-side platforms (such as
-       JavaScript in the browser), they require the GET variables public_key
-       and project_id, as well as an HTTP_REFERER to be set from a trusted
-       domain.
+       JavaScript in the browser), they require a standard header, excluding
+       the signature and timestamp requirements, and must be listed in the
+       origins for the given project (or the global origins).
 
     3. Implicit trusted requests
 

--- a/sentry/web/api.py
+++ b/sentry/web/api.py
@@ -100,7 +100,7 @@ def store(request, project_id=None):
                 origin = request.META.get('HTTP_ORIGIN')
 
                 project_ = project_from_auth_vars(auth_vars, data,
-                    require_signature=bool(origin))
+                    require_signature=bool(not origin))
 
                 if project_ != project:
                     raise APIError('Project ID mismatch')

--- a/sentry/web/api.py
+++ b/sentry/web/api.py
@@ -99,12 +99,18 @@ def store(request, project_id=None):
                 # (this is restricted via the CORS headers)
                 origin = request.META.get('HTTP_ORIGIN')
 
-                project = project_from_auth_vars(auth_vars, data,
+                project_ = project_from_auth_vars(auth_vars, data,
                     require_signature=bool(origin))
+
+                if project_ != project:
+                    raise APIError('Project ID mismatch')
 
             elif request.user.is_authenticated() and is_same_domain(request.build_absolute_uri(), referrer):
                 # authenticated users are simply trusted to provide the right id
-                project = project_from_id(request)
+                project_ = project_from_id(request)
+
+                if project_ != project:
+                    raise APIError('Project ID mismatch')
 
             else:
                 raise APIUnauthorized()

--- a/sentry/web/decorators.py
+++ b/sentry/web/decorators.py
@@ -30,6 +30,11 @@ def has_access(group_or_func=None):
     def wrapped(func):
         @wraps(func)
         def _wrapped(request, project_id=None, *args, **kwargs):
+            # If we're asking for anything other than implied access, the user
+            # must be authenticated
+            if group_or_func and not request.user.is_authenticated():
+                return HttpResponseRedirect(get_login_url())
+
             # XXX: if project_id isn't set, should we only allow superuser?
             if project_id.isdigit():
                 lookup_kwargs = {'id': int(project_id)}

--- a/sentry/web/urls.py
+++ b/sentry/web/urls.py
@@ -109,6 +109,7 @@ urlpatterns = patterns('',
 
     url(r'^api/store/$', api.store, name='sentry-api-store'),
     url(r'^api/notification/$', api.notification, name='sentry-api-notification'),
+    url(r'^api/(?P<project_id>[\w_-]+)/store/$', api.store, name='sentry-api-store'),
     url(r'^api/(?P<project_id>[\w_-]+)/poll/$', api.poll, name='sentry-api-poll'),
     url(r'^api/(?P<project_id>[\w_-]+)/resolve/$', api.resolve, name='sentry-api-resolve'),
     url(r'^api/(?P<project_id>[\w_-]+)/bookmark/$', api.bookmark, name='sentry-api-bookmark'),

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,6 +18,8 @@ from django.db import DEFAULT_DB_ALIAS
 from django.test import TestCase, TransactionTestCase
 from django.test.client import Client
 
+from sentry.models import ProjectOption, Option
+
 
 class Settings(object):
     """
@@ -63,6 +65,8 @@ class BaseTestCase(object):
 
     def _pre_setup(self):
         cache.clear()
+        ProjectOption.objects.clear_cache()
+        Option.objects.clear_cache()
         super(BaseTestCase, self)._pre_setup()
 
     def _postWithKey(self, data, key=None):


### PR DESCRIPTION
This adds support for configuring origin URLs via the Project settings page, as well as removing support for implicit authentication using ProjectDomain.

Additionally this opens up the store API so that clients may pass the project_id as part of the URL. This will be required of raven-js in order to get the project_id in the OPTIONS request without duplicating headers/excess parsing.

The options page now looks like this:

<img src="http://cramer.io/1I2a1d1J0B0u0J2G2d0W/by%20default%202012-05-01%20at%201.41.36%20AM.png">
