### PR TITLE
Add support for dumping multiple events as JSON, not just one

### DIFF
--- a/sentry/conf/defaults.py
+++ b/sentry/conf/defaults.py
@@ -158,3 +158,6 @@ USE_JS_CLIENT = False
 
 # The alias for the cache backend (MUST be a compatible backend string for < 1.3)
 CACHE_BACKEND = 'dummy://'
+
+# The maximum number of events which can be requested as JSON
+MAX_JSON_RESULTS=1000

--- a/sentry/models.py
+++ b/sentry/models.py
@@ -533,6 +533,19 @@ class Event(MessageBase):
         module = self.data['__sentry__'].get('module', 'ver')
         return module, self.data['__sentry__']['version']
 
+    def as_dict(self):
+        # We use a SortedDict to keep elements ordered for a potential JSON serializer
+        data = SortedDict()
+        data['id'] = self.event_id
+        data['checksum'] = self.checksum
+        data['project'] = self.project.slug
+        data['logger'] = self.logger
+        data['level'] = self.get_level_display()
+        data['culprit'] = self.culprit
+        for k, v in sorted(self.data.iteritems()):
+            data[k] = v
+        return data
+
 
 class GroupBookmark(Model):
     """

--- a/sentry/templates/sentry/groups/details.html
+++ b/sentry/templates/sentry/groups/details.html
@@ -98,8 +98,11 @@
                 <a class="dropdown-toggle" href="#" data-toggle="dropdown">{% trans "Actions" %} <span class="caret"></span></a>
                 <ul class="dropdown-menu">
                     <li><a href="{% url sentry-api-remove-group project_id=project.slug group_id=group.pk %}">{% trans "Remove Event" %}</a></li>
-                    <li><a href="{% url sentry-group-json project_id=project.slug group_id=group.pk %}">{% trans "Raw JSON Data" %}</a></li>
-                    <li><a href="{% url sentry-group-json-multi project_id=project.slug group_id=group.pk how_many=10 %}">{% trans "Mutli-event JSON Data" %}</a></li>
+                    <li><a {% ifequal page 'event_list' %}{% if event %}
+                    href="{% url sentry-group-event-json project_id=project.slug group_id=group.pk event_id_or_latest=event.pk %}"{% else %}
+                    href="{% url sentry-group-event-json project_id=project.slug group_id=group.pk event_id_or_latest="latest" %}"{% endif %}{% else %}
+                    href="{% url sentry-group-events-json project_id=project.slug group_id=group.pk %}"{% endifequal %}
+                    >{% trans "Raw JSON Data" %}</a></li>
                     {% for label, link, is_active in group|get_actions:request %}
                         {% if forloop.first %}
                             <li class="divider"></li>

--- a/sentry/templates/sentry/groups/details.html
+++ b/sentry/templates/sentry/groups/details.html
@@ -99,6 +99,7 @@
                 <ul class="dropdown-menu">
                     <li><a href="{% url sentry-api-remove-group project_id=project.slug group_id=group.pk %}">{% trans "Remove Event" %}</a></li>
                     <li><a href="{% url sentry-group-json project_id=project.slug group_id=group.pk %}">{% trans "Raw JSON Data" %}</a></li>
+                    <li><a href="{% url sentry-group-json-multi project_id=project.slug group_id=group.pk how_many=10 %}">{% trans "Mutli-event JSON Data" %}</a></li>
                     {% for label, link, is_active in group|get_actions:request %}
                         {% if forloop.first %}
                             <li class="divider"></li>

--- a/sentry/web/frontend/groups.py
+++ b/sentry/web/frontend/groups.py
@@ -14,7 +14,6 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse, \
   HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404
-from django.utils.datastructures import SortedDict
 from django.utils.safestring import mark_safe
 
 from sentry.conf import settings
@@ -242,36 +241,6 @@ def group_list(request, project, view_id=None):
 
 @login_required
 @has_access
-def group_json(request, project, group_id):
-    group = get_object_or_404(Group, pk=group_id)
-
-    if group.project and group.project != project:
-        return HttpResponse(status=404)
-
-    # It's possible that a message would not be created under certain
-    # circumstances (such as a post_save signal failing)
-    event = group.get_latest_event() or Event()
-
-    return HttpResponse(json.dumps(event.as_dict()), mimetype='application/json')
-
-@login_required
-@has_access
-def group_json_multi(request, project, group_id, how_many):
-    group = get_object_or_404(Group, pk=group_id)
-
-    if group.project and group.project != project:
-        return HttpResponse(status=404)
-    how_many = int(how_many)
-    if how_many > settings.MAX_JSON_RESULTS:
-        return HttpResponse("too many objects requested", mimetype='text/plain', status=400)
-
-    events = group.event_set.order_by('-id')[:how_many]
-
-    return HttpResponse(json.dumps(list(event.as_dict() for event in events)), mimetype='application/json')
-
-
-@login_required
-@has_access
 def group(request, project, group_id):
     group = get_object_or_404(Group, pk=group_id)
 
@@ -313,6 +282,27 @@ def group_event_list(request, project, group_id):
 
 @login_required
 @has_access
+def group_event_list_json(request, project, group_id):
+    group = get_object_or_404(Group, pk=group_id)
+
+    if group.project and group.project != project:
+        return HttpResponse(status=404)
+
+    limit = request.GET.get('limit', settings.MAX_JSON_RESULTS)
+    try:
+        limit = int(limit)
+    except ValueError:
+        return HttpResponse('non numeric limit', status=400, mimetype='text/plain')
+    if limit > settings.MAX_JSON_RESULTS:
+        return HttpResponse("too many objects requested", mimetype='text/plain', status=400)
+
+    events = group.event_set.order_by('-id')[:limit]
+
+    return HttpResponse(json.dumps(list(event.as_dict() for event in events)), mimetype='application/json')
+
+
+@login_required
+@has_access
 def group_event_details(request, project, group_id, event_id):
     group = get_object_or_404(Group, pk=group_id)
 
@@ -330,6 +320,24 @@ def group_event_details(request, project, group_id, event_id):
         'json_data': event.data.get('extra', {}),
         'version_data': event.data.get('modules', None),
     }, request)
+
+
+@login_required
+@has_access
+def group_event_details_json(request, project, group_id, event_id_or_latest):
+    group = get_object_or_404(Group, pk=group_id)
+
+    if group.project and group.project != project:
+        return HttpResponse(status=404)
+
+    if event_id_or_latest == 'latest':
+        # It's possible that a message would not be created under certain
+        # circumstances (such as a post_save signal failing)
+        event = group.get_latest_event() or Event()
+    else:
+        event = get_object_or_404(group.event_set, pk=event_id_or_latest)
+
+    return HttpResponse(json.dumps(event.as_dict()), mimetype='application/json')
 
 
 @login_required

--- a/sentry/web/urls.py
+++ b/sentry/web/urls.py
@@ -124,10 +124,10 @@ urlpatterns = patterns('',
     # Project specific
 
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/$', groups.group, name='sentry-group'),
-    url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/json/$', groups.group_json, name='sentry-group-json'),
-    url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/json/(?P<how_many>\d+)/$', groups.group_json_multi, name='sentry-group-json-multi'),
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/events/$', groups.group_event_list, name='sentry-group-events'),
+    url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/events/json/$', groups.group_event_list_json, name='sentry-group-events-json'),
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/events/(?P<event_id>\d+)/$', groups.group_event_details, name='sentry-group-event'),
+    url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/events/(?P<event_id_or_latest>(\d+|latest))/json/$', groups.group_event_details_json, name='sentry-group-event-json'),
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/actions/(?P<slug>[\w_-]+)/', groups.group_plugin_action, name='sentry-group-plugin-action'),
 
     url(r'^(?P<project_id>[\w_-]+)/events/$', events.event_list, name='sentry-events'),

--- a/sentry/web/urls.py
+++ b/sentry/web/urls.py
@@ -125,6 +125,7 @@ urlpatterns = patterns('',
 
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/$', groups.group, name='sentry-group'),
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/json/$', groups.group_json, name='sentry-group-json'),
+    url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/json/(?P<how_many>\d+)/$', groups.group_json_multi, name='sentry-group-json-multi'),
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/events/$', groups.group_event_list, name='sentry-group-events'),
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/events/(?P<event_id>\d+)/$', groups.group_event_details, name='sentry-group-event'),
     url(r'^(?P<project_id>[\w_-]+)/group/(?P<group_id>\d+)/actions/(?P<slug>[\w_-]+)/', groups.group_plugin_action, name='sentry-group-plugin-action'),

--- a/tests/sentry/web/frontend/tests.py
+++ b/tests/sentry/web/frontend/tests.py
@@ -96,21 +96,23 @@ class SentryViewsTest(TestCase):
         group = Group.objects.get(pk=2)
         self.assertEquals(resp.context['group'], group)
 
-    def test_group_json(self):
-        self.client.login(username='admin', password='admin')
-        resp = self.client.get(reverse('sentry-group-json', kwargs={'project_id': 1, 'group_id': 2}))
-        self.assertEquals(resp.status_code, 200)
-        self.assertEquals(resp['Content-Type'], 'application/json')
-        self.assertEquals(json.loads(resp.content)['level'], 'error')
-
     def test_group_json_multi(self):
         self.client.login(username='admin', password='admin')
-        resp = self.client.get(reverse('sentry-group-json-multi', kwargs={'project_id': 1, 'group_id': 2, 'how_many': 1}))
+        resp = self.client.get(reverse('sentry-group-events-json', kwargs={'project_id': 1, 'group_id': 2}))
         self.assertEquals(resp.status_code, 200)
         self.assertEquals(resp['Content-Type'], 'application/json')
         self.assertEquals(json.loads(resp.content)[0]['level'], 'error')
-        resp = self.client.get(reverse('sentry-group-json-multi', kwargs={'project_id': 1, 'group_id': 2, 'how_many': settings.MAX_JSON_RESULTS+1}))
+        resp = self.client.get(reverse('sentry-group-events-json', kwargs={'project_id': 1, 'group_id': 2}), {'limit': 1})
+        self.assertEquals(resp.status_code, 200)
+        resp = self.client.get(reverse('sentry-group-events-json', kwargs={'project_id': 1, 'group_id': 2}), {'limit': settings.MAX_JSON_RESULTS+1})
         self.assertEquals(resp.status_code, 400)
+
+    def test_group_events_details_json(self):
+        self.client.login(username='admin', password='admin')
+        resp = self.client.get(reverse('sentry-group-event-json', kwargs={'project_id': 1, 'group_id': 2, 'event_id_or_latest': 'latest'}))
+        self.assertEquals(resp.status_code, 200)
+        self.assertEquals(resp['Content-Type'], 'application/json')
+        self.assertEquals(json.loads(resp.content)['level'], 'error')
 
     def test_status_env(self):
         self.client.login(username='admin', password='admin')


### PR DESCRIPTION
When looking at a group of events, I often want to get some statistical overview from some (or even all) the events - like were they all made from the same user-agent or even the same user. This commit enables quick and easy awesomeness like:

```
$ curl -s http://localhost:9000/default/group/2/json/10/ |
> json -a '["sentry.interfaces.Exception"]'.type '["sentry.interfaces.Stacktrace"]'.frames.0.context_line
ZeroDivisionError     2/0
ZeroDivisionError     1/0
ZeroDivisionError     1/0
$ 
```

(`json` is [trentm/json](https://github.com/trentm/json), of course)

A future commit should probably add an optional security hash to this view, so that if your project is private but you still want to get the JSON without fumbling with cookies in `curl`, you could still do so (just copy the link with the hash from your browser and paste it to the command line).
