### PR TITLE
Add project name to group and event list page titles

### DIFF
--- a/sentry/templates/sentry/events/event_list.html
+++ b/sentry/templates/sentry/events/event_list.html
@@ -3,6 +3,8 @@
 {% load i18n %}
 {% load sentry_helpers %}
 
+{% block title %}{% blocktrans with project.name as name %}{{ name }} events{% endblocktrans %} | {{ block.super }}{% endblock %}
+
 {% block breadcrumb %}
     {{ block.super }}
     <li class="divider">/</li>

--- a/sentry/templates/sentry/groups/group_list.html
+++ b/sentry/templates/sentry/groups/group_list.html
@@ -4,6 +4,8 @@
 {% load sentry_helpers %}
 {% load sentry_plugins %}
 
+{% block title %}{{ project.name }} | {{ block.super }}{% endblock %}
+
 {% block meta %}
     {{ block.super }}
     <script>


### PR DESCRIPTION
This is handy when you have multiple browser tabs open
