### PR TITLE
Quick bug fix for clean_origins() in EditProjectForm

### DIFF
--- a/sentry/web/forms/__init__.py
+++ b/sentry/web/forms/__init__.py
@@ -110,10 +110,12 @@ class EditProjectForm(forms.ModelForm):
 
     def clean_origins(self):
         value = self.cleaned_data.get('origins')
-        if value:
-            values = filter(bool, (v.strip() for v in value.split('\n')))
-            for value in values:
-                self._url_validator(value)
+        if not value:
+            return
+            
+        values = filter(bool, (v.strip() for v in value.split('\n')))
+        for value in values:
+            self._url_validator(value)
         return values
 
 


### PR DESCRIPTION
Just noticed this small bug, where Django form validation raises "UnboundLocalError: local variable 'values' referenced before assignment" at sentry/web/forms/**init**.py in clean_origins, line 117. 

Hope this helps!

Best,
Chris Adams
