### PR TITLE
Reduce database hits for solving database blocking problem.

### DIFF
--- a/sentry/conf/server.py
+++ b/sentry/conf/server.py
@@ -148,6 +148,13 @@ CELERY_SEND_EVENTS = False
 CELERY_RESULT_BACKEND = None
 CELERY_TASK_RESULT_EXPIRES = 1
 
+from datetime import timedelta
+CELERYBEAT_SCHEDULE = {
+    "runs-every-10-seconds": {
+        "task": "sentry.tasks.store.process_data",
+        "schedule": timedelta(seconds=10)
+        },
+    }
 
 # Sentry and Raven configuration
 

--- a/sentry/tasks/store.py
+++ b/sentry/tasks/store.py
@@ -6,7 +6,15 @@ sentry.tasks.store
 :license: BSD, see LICENSE for more details.
 """
 
+from datetime import datetime
+from simplejson import dumps, loads
+
+from kombu.compat import Publisher, Consumer
 from celery.task import task
+from celery.messaging import establish_connection
+
+from django.db.models import F
+from django.core.serializers.json import DjangoJSONEncoder
 
 
 @task(ignore_result=True)
@@ -14,6 +22,48 @@ def store_event(data, **kwargs):
     """
     Saves an event to the database.
     """
-    from sentry.models import Group
+    send_increment_data(data)
 
-    Group.objects.from_kwargs(**data)
+def send_increment_data(data):
+    connection = establish_connection()
+    publisher = Publisher(connection=connection,
+                          exchange="data",
+                          routing_key="increment_data",
+                          exchange_type="direct")
+
+    data = dumps(data, cls=DjangoJSONEncoder)
+    publisher.send(data)
+
+    publisher.close()
+    connection.close()
+
+def merge_data(data):
+    return sorted(data, key=lambda x:datetime.strptime(x['timestamp'], '%Y-%m-%d %H:%M:%S'), reverse=True)[0]
+
+@task
+def process_data():
+    connection = establish_connection()
+    consumer = Consumer(connection=connection,
+                        queue="data",
+                        exchange="data",
+                        routing_key="increment_data",
+                        exchange_type="direct")
+
+    data_to_save = {}
+    for message in consumer.iterqueue():
+        data = message.body
+        data = loads(data)
+        checksum = data['checksum']
+        data_to_save.setdefault(checksum, []).append(data)
+
+    from sentry.models import Group
+    for checksum in data_to_save:
+        data = data_to_save[checksum]
+        merged_times_seen = len(data)
+        data = merge_data(data)
+        data['timestamp'] = datetime.strptime(data['timestamp'], '%Y-%m-%d %H:%M:%S')
+        event = Group.objects.from_kwargs(**data)
+        event.group.update(times_seen=F('times_seen') + merged_times_seen - 1)
+    
+    consumer.close()
+    connection.close()


### PR DESCRIPTION
We @qingfeng @cnborn and I are trying to solve the database blocking problem.

The plan is:
Every time get the data from api, just send data to queue but not store to database at this time.
Set a periodic task to process all data aggregated in queue, merging data with same checksum key into one data and update the 'times_seen' field.
This could reduce the quantity of database hits, for the same errors or messages will only store one time and the count still be correct.

Please review the code and give us suggestion, thanks.
