### PR TITLE
change custom email headers from all-caps to mixed-case

### DIFF
--- a/sentry/plugins/sentry_mail/models.py
+++ b/sentry/plugins/sentry_mail/models.py
@@ -142,10 +142,10 @@ class MailProcessor(NotifyPlugin):
             'interfaces': interface_list,
         })).run()
         headers = {
-            'X-SENTRY-LOGGER': event.logger,
-            'X-SENTRY-LOGGER-LEVEL': event.get_level_display(),
-            'X-SENTRY-PROJECT': project.name,
-            'X-SENTRY-SERVER': event.server_name,
+            'X-Sentry-Logger': event.logger,
+            'X-Sentry-Logger-Level': event.get_level_display(),
+            'X-Sentry-Project': project.name,
+            'X-Sentry-Server': event.server_name,
         }
 
         self._send_mail(


### PR DESCRIPTION
A colleague pointed out that custom email headers tend to be mixed case, not all caps.  Eg: "X-Mailer", "X-BeenThere".  This change updates the custom headers that I had previously added to now be mixed-case.

See examples of other headers at: http://rajshekhar.net/my-writings-mainmenu-26/7-programming/35-x-headers-in-spam.html#sec5
