### PR TITLE
display projects, teams, and team members sorted alphabetically

### DIFF
--- a/sentry/web/frontend/teams.py
+++ b/sentry/web/frontend/teams.py
@@ -71,8 +71,8 @@ def manage_team(request, team):
 
         return HttpResponseRedirect(request.path + '?success=1')
 
-    member_list = [(pm, pm.user) for pm in team.member_set.select_related('user')]
-    pending_member_list = [(pm, pm.email) for pm in team.pending_member_set.all()]
+    member_list = [(pm, pm.user) for pm in team.member_set.select_related('user').order_by('user__username')]
+    pending_member_list = [(pm, pm.email) for pm in team.pending_member_set.all().order_by('email')]
 
     project_list = list(team.project_set.all())
 


### PR DESCRIPTION
When a Sentry instance has numerous projects, teams, or team members, it can be difficult to quickly find an item in a listing that one is looking for.  Ex: the "Dashboard" drop-down, the team listing when adding a new project, etc.

This change sorts such listings alphabetically (case-sensitive).
