### PR TITLE
Add Gravatar to Navbar and "Account Settings" page

### DIFF
--- a/bootstrap/sentry.less
+++ b/bootstrap/sentry.less
@@ -158,7 +158,7 @@ p {
 
       &:last-child > a {
         color: @grayDark;
-      }    
+      }
 
       .action {
         .btn;
@@ -793,4 +793,9 @@ legend {
 
 #daterange {
   display: none;
+}
+
+.avatar {
+  vertical-align: middle;
+  border-radius: 3px;
 }

--- a/sentry/templates/sentry/account/settings.html
+++ b/sentry/templates/sentry/account/settings.html
@@ -1,6 +1,7 @@
 {% extends "sentry/layout.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block title %}{% trans "Account Settings" %} | {{ block.super }}{% endblock %}
 
@@ -49,6 +50,13 @@
             {% with form.language as field %}
                 {% include "sentry/partial/_form_field.html" %}
             {% endwith %}
+            <fieldset class="control-group">
+                <label>Avatar</label>
+                <div class="controls">
+                    <img class="avatar" src="{% gravatar_url user.email size 32 %}">
+                    <a href="http://gravatar.com/">Change your avatar at Gravatar.com</a>
+                </div>
+            </fieldset>
             <hr>
             <p>{% trans "You may also optionally change your password." %}</p>
             {% with form.new_password1 as field %}

--- a/sentry/templates/sentry/header.html
+++ b/sentry/templates/sentry/header.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load sentry_helpers %}
 
 <header id="header">
     <div class="navbar">
@@ -39,7 +40,7 @@
                                 </li>
                             {% endif %}
                             <li class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans "Account" %} <span class="caret"></span></a>
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><img class="avatar" src="{% gravatar_url user.email size 20 %}"> {{ user.username}} <span class="caret"></span></a>
                                 <ul class="dropdown-menu">
                                     <li><a href="{% url sentry-project-list %}">{% trans "Projects" %}</a></li>
                                     <li><a href="{% url sentry-team-list %}">{% trans "Teams" %}</a></li>


### PR DESCRIPTION
**Screenshots**
- Navbar: http://img.ly/iZZh
- Account Settings: http://img.ly/j04p

**Testing Done:**
- Tested on Firefox 12 and Chrome 19
- Tested with both HTTP and HTTPS
- Tested for users with a gravatar and w/o a gravatar

**Potential Issues**
- HTTPS detecting code in the templatetag worked on my box w/secured nginx & gunicorn, but Django 1.4 has better support for this.
- Was I supposed to check in the less-compiled CSS as well?
