### PR TITLE
Documentation typos

### DIFF
--- a/docs/developer/client/index.rst
+++ b/docs/developer/client/index.rst
@@ -81,12 +81,12 @@ The following attributes are required for all events:
 
 .. data:: project
 
-    Integer value representing the project ID
+    String value representing the project
 
     ::
 
         {
-            "project": "3"
+            "project": "default"
         }
 
 .. data:: event_id

--- a/docs/developer/client/index.rst
+++ b/docs/developer/client/index.rst
@@ -1,9 +1,9 @@
 Writing a Client
 ================
 
-A client at it's core is simply a set of utilities for capturing various
+A client at its core is simply a set of utilities for capturing various
 logging parameters. Given these parameters, it then builds a JSON payload
-which it will send to a the Sentry server, using some sort of authentication
+which it will send to a Sentry server using some sort of authentication
 method.
 
 Generally, a client consists of three steps to the end user, which should look
@@ -59,7 +59,7 @@ that they've misconfigured the client.
 Building the JSON Packet
 ------------------------
 
-The body of the post is a string representation of a JSON object. It is also preferabblly gzipped encoding,
+The body of the post is a string representation of a JSON object. It is also preferably gzipped encoding,
 which also means its expected to be base64-encoded.
 
 For example, with an included Exception event, a basic JSON body might resemble the following::
@@ -86,7 +86,7 @@ The following attributes are required for all events:
     ::
 
         {
-            "project": "default"
+            "project": "3"
         }
 
 .. data:: event_id
@@ -131,7 +131,7 @@ The following attributes are required for all events:
 
     Defaults to ``logging.ERROR``.
 
-    The value can either be the integar value or the string label
+    The value can either be the integer value or the string label
     as specified in ``SENTRY_LOG_LEVELS``.
 
     ::
@@ -224,7 +224,7 @@ An authentication header is expected to be sent along with the message body, whi
 
 .. data:: sentry_client
 
-    An arbitrary string which identifies your client, including it's version.
+    An arbitrary string which identifies your client, including its version.
 
     For example, the Python client might send this as "raven-python/1.0"
 

--- a/docs/developer/plugins/permissions.rst
+++ b/docs/developer/plugins/permissions.rst
@@ -6,7 +6,7 @@ As described in the plugin interface, Sentry provides a large suite of permissio
 
 In most cases, a superuser (that is, if User.is_superuser is ``True``), will be granted implicit permissions
 on everything. Additionally, several cases provide overrides via Django's standard permission system. All
-permissions are also bound to some level of inherint permission logic, such as projects only being editable
+permissions are also bound to some level of inherent permission logic, such as projects only being editable
 by someone who has some level of control on that project.
 
 This page attempts to describe those permissions, and the contextual objects along with them.


### PR DESCRIPTION
Fixed a few typos in the documentation.
