### PR TITLE
user email tag plugin for email aggregation

### DIFF
--- a/sentry/conf/server.py
+++ b/sentry/conf/server.py
@@ -136,6 +136,7 @@ INSTALLED_APPS = (
     'sentry.plugins.sentry_servers',
     'sentry.plugins.sentry_sites',
     'sentry.plugins.sentry_urls',
+    'sentry.plugins.sentry_user_emails',
     'sentry.plugins.sentry_useragents',
     'south',
 )

--- a/sentry/plugins/sentry_user_emails/__init__.py
+++ b/sentry/plugins/sentry_user_emails/__init__.py
@@ -1,0 +1,7 @@
+"""
+sentry.plugins.sentry_user_emails
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""

--- a/sentry/plugins/sentry_user_emails/models.py
+++ b/sentry/plugins/sentry_user_emails/models.py
@@ -1,0 +1,39 @@
+"""
+sentry.plugins.sentry_user_emails.models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+import sentry
+
+from django.utils.translation import ugettext_lazy as _
+
+from sentry.plugins import register
+from sentry.plugins.bases.tag import TagPlugin
+
+
+class UserEmailsPlugin(TagPlugin):
+    """
+    Adds additional support for showing information about users including:
+
+    * A panel which shows all users a message was created by.
+    * A sidebar module which shows the users most actively seeing event.
+    """
+    slug = 'user-emails'
+    title = _('User Emails')
+    version = sentry.VERSION
+    author = "Sentry Team"
+    author_url = "https://github.com/dcramer/sentry"
+    tag = 'user_email'
+    tag_label = _('User Email')
+
+    def get_tag_values(self, event):
+        user = event.interfaces.get('sentry.interfaces.User')
+        if not user:
+            return []
+        if not user.email:
+            return []
+        return [user.email]
+
+register(UserEmailsPlugin)


### PR DESCRIPTION
For smaller deployments, it's good to know what users have been affected by issues.  I think this plugin is small/useful enough that it makes sense in core sentry, but that's my opinion.

If not, I can surely create a plugin and maintain it separately.
