### PR TITLE
Client '2012-06-07T13:11:06.%fZ' passed an invalid value for timestamp 'raven-python/1.9.2' errors

### DIFF
--- a/sentry/coreapi.py
+++ b/sentry/coreapi.py
@@ -291,8 +291,8 @@ def validate_data(project, data, client=None):
         except InvalidTimestamp:
             # Log the error, remove the timestamp, and continue
             logger.error('Client %r passed an invalid value for timestamp %r' % (
-                data['timestamp'],
                 client or '<unknown client>',
+                data['timestamp'],
             ))
             del data['timestamp']
 


### PR DESCRIPTION
Attached pull request fixes formatting in this error message (parameter order was swapped).

We see a few of these messages in our logs, such as:

```
New event from client 'raven-python/1.9.2' (id=7f8fc65fa4d84e6c93a7a83bd4a89a1c)
New event from client 'raven-python/1.9.2' (id=3287a4be5f984aafb5e011200798c631)
Client '2012-06-07T13:11:06.%fZ' passed an invalid value for timestamp 'raven-python/1.9.2'
New event from client 'raven-python/1.9.2' (id=a57db0aae40141b2a7ed1cec8bdf0d8f)
Client '2012-06-07T13:11:48.%fZ' passed an invalid value for timestamp 'raven-python/1.7.5'
Client '2012-06-07T13:11:48.%fZ' passed an invalid value for timestamp 'raven-python/1.7.5'
Client '2012-06-07T13:11:48.%fZ' passed an invalid value for timestamp 'raven-python/1.7.5'
```

I just upgraded Raven from 1.7.5 to 1.9.2 so we have servers running both.  There is "return obj.strftime('%Y-%m-%dT%H:%M:%S.%fZ')" in raven/utils/json.py which is where I presume this is coming from.

We are running Python 2.5
