### PR TITLE
Fix for issue #509

### DIFF
--- a/sentry/manager.py
+++ b/sentry/manager.py
@@ -837,6 +837,12 @@ class SearchDocumentManager(BaseManager):
         else:
             raise ValueError('sort_by: %r' % sort_by)
 
+        if tokens:
+            token_sql = ' st.token IN (%s) AND ' % \
+                ', '.join('%s' for i in range(len(tokens)))
+        else:
+            token_sql = ' '
+
         sql = """
             SELECT sd.id AS id,
                    sd.group_id AS group_id,
@@ -846,13 +852,13 @@ class SearchDocumentManager(BaseManager):
             FROM sentry_searchdocument as sd
             INNER JOIN sentry_searchtoken as st
                 ON st.document_id = sd.id
-            WHERE st.token IN (%s)
-                AND sd.project_id = %s
+            WHERE %s
+                sd.project_id = %s
             GROUP BY sd.id, sd.group_id, sd.total_events, sd.date_changed, sd.date_added
             ORDER BY %s
             LIMIT %d OFFSET %d
         """ % (
-            ', '.join('%s' for i in range(len(tokens))),
+            token_sql,
             project.id,
             order_by,
             limit,


### PR DESCRIPTION
Searching on MySQL where tokens is empty, results in an invalid query. This solves that, and should still work on other databases.
