### PR TITLE
Add sentry-irc plugin

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -60,6 +60,7 @@ These extensions are officially recognized and support the current Sentry protoc
 * `sentry-phabricator <https://github.com/dcramer/sentry-phabricator>`_
 * `sentry-hipchat <https://github.com/linovia/sentry-hipchat>`_
 * `sentry-groveio <https://github.com/mattrobenolt/sentry-groveio>`_
+* `sentry-irc <https://github.com/gisce/sentry-irc>`_
 
 Have an extension that should be listed here? Submit a `pull request <https://github.com/dcramer/sentry>`_ and we'll
 get it added.


### PR DESCRIPTION
It's possible to add [sentry-irc](https://github.com/gisce/sentry-irc) plugin to the 3rd party plugins?
