### PR TITLE
Fix TypeErrors caused by escaped interpolations (ex. %%s) in log statements

### DIFF
--- a/sentry/utils/safe.py
+++ b/sentry/utils/safe.py
@@ -22,7 +22,7 @@ def safe_execute(func, *args, **kwargs):
         else:
             cls = func.__class__
         logger = logging.getLogger('sentry.plugins')
-        logger.error('Error processing %r on %%r: %%s', func.__name__, cls.__name__, e, extra={
+        logger.error('Error processing %r on %r: %s', func.__name__, cls.__name__, e, extra={
             'func_module': cls.__module__,
             'func_args': args,
             'func_kwargs': kwargs,

--- a/sentry/web/api.py
+++ b/sentry/web/api.py
@@ -177,7 +177,7 @@ def store(request, project=None):
             }, exc_info=True)
             response = HttpResponse(unicode(error.msg), status=error.http_status)
         else:
-            logger.info('New event from client %r (id=%%s)', client, data['event_id'])
+            logger.info('New event from client %r (id=%s)', client, data['event_id'])
 
     return response
 


### PR DESCRIPTION
When commit a157229ca97 deferred interpolation of internal logs,
several interpolations which were already deferred by escaping
were not updated. These statements caused TypeErrors when not all
of the log arguments were consumed.
