### PR TITLE
Catch the real Exception in interfaces.py

### DIFF
--- a/sentry/interfaces.py
+++ b/sentry/interfaces.py
@@ -372,7 +372,7 @@ class Http(Interface):
         if self.headers.get('Content-Type') == 'application/x-www-form-urlencoded':
             try:
                 data = QueryDict(data)
-            except Exception:
+            except:
                 pass
             else:
                 data_is_dict = True
@@ -383,7 +383,7 @@ class Http(Interface):
         if not cookies_is_dict:
             try:
                 cookies = QueryDict(cookies)
-            except Exception:
+            except:
                 pass
             else:
                 cookies_is_dict = True


### PR DESCRIPTION
Exception is redefined as an interface, so can't catch it.
Rather use a wildcard except clause instead. I thought wildcard looks better than going **builtins**.Exception
