### PR TITLE
Removed error prone gravatar ssl-detection.

### DIFF
--- a/sentry/templatetags/sentry_helpers.py
+++ b/sentry/templatetags/sentry_helpers.py
@@ -301,11 +301,7 @@ def get_project_dsn(context, user, project, asvar):
                 Optional([Constant('size'), Variable('sizevar')]),
                 Optional([Constant('default'), Variable('defaultvar')])])
 def gravatar_url(context, email, sizevar=None, defaultvar='mm'):
-    # XXX - use request.is_secure() in django 1.4
-    if context['request'].META['wsgi.url_scheme'] == 'https':
-        base = 'https://secure.gravatar.com'
-    else:
-        base = 'http://www.gravatar.com'
+    base = 'https://secure.gravatar.com'
 
     gravatar_url = "%s/avatar/%s" % (base, hashlib.md5(email.lower()).hexdigest())
 


### PR DESCRIPTION
Removed gravatar ssl detection as it's neer impossible to get right in every deployment scenario, and doesn't really add any overhead.

For example, running sentry (as preposed by the docs) in a gevent proxy behind apache with ssl, the check will fail and include resources over http.

The solution I propose is to always use https with the thought, that it's better to be safe than ...
