### PR TITLE
Correct deletion of unique index on sentry_groupedmessage and update

### DIFF
--- a/sentry/manager.py
+++ b/sentry/manager.py
@@ -633,8 +633,8 @@ class GroupManager(BaseManager, ChartMixin):
                 'last_seen': date,
             })
 
-    def get_by_natural_key(self, logger, culprit, checksum):
-        return self.get(logger=logger, view=culprit, checksum=checksum)
+    def get_by_natural_key(self, project, logger, culprit, checksum):
+        return self.get(project=project, logger=logger, view=culprit, checksum=checksum)
 
     def get_accelerated(self, queryset=None, minutes=15):
         # mintues should

--- a/sentry/migrations/0062_correct_del_index_sentry_groupedmessage_logger__view__checksum.py
+++ b/sentry/migrations/0062_correct_del_index_sentry_groupedmessage_logger__view__checksum.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'GroupedMessage', fields ['logger', 'view', 'checksum']
+        # FIXES 0015
+        db.delete_unique('sentry_groupedmessage', ['logger', 'view', 'checksum'])
+
+    def backwards(self, orm):
+        # Adding unique constraint on 'GroupedMessage', fields ['checksum', 'logger', 'view']
+        #FIXES 0015
+        db.create_unique('sentry_groupedmessage', ['checksum', 'logger', 'view'])
+
+    complete_apps = ['sentry']

--- a/sentry/models.py
+++ b/sentry/models.py
@@ -429,7 +429,7 @@ class Group(MessageBase):
         return '#'
 
     def natural_key(self):
-        return (self.logger, self.culprit, self.checksum)
+        return (self.project, self.logger, self.culprit, self.checksum)
 
     def get_score(self):
         return int(math.log(self.times_seen) * 600 + float(time.mktime(self.last_seen.timetuple())))


### PR DESCRIPTION
natural_key

I believe this fixes #510 as well. I dealt with a very similar issue when deploying with multiple projects today. The ordering of column names was not correct in the migration 0015. This is a correction.
