### PR TITLE
Fixes typo in default configuration

### DIFF
--- a/sentry/utils/runner.py
+++ b/sentry/utils/runner.py
@@ -79,7 +79,7 @@ GOOGLE_OAUTH2_CLIENT_SECRET = ''
 
 # https://github.com/settings/applications/new
 GITHUB_APP_ID = ''
-GITHUB_APP_SECRET = ''
+GITHUB_API_SECRET = ''
 """
 
 

--- a/sentry/utils/runner.py
+++ b/sentry/utils/runner.py
@@ -79,7 +79,7 @@ GOOGLE_OAUTH2_CLIENT_SECRET = ''
 
 # https://github.com/settings/applications/new
 GITHUB_APP_ID = ''
-GITHUB_API_SECRET = ''
+GITHUB_APP_SECRET = ''
 """
 
 

--- a/sentry/web/frontend/accounts.py
+++ b/sentry/web/frontend/accounts.py
@@ -22,7 +22,7 @@ from sentry.utils.safe import safe_execute
 AUTH_ENGINES = {
     'twitter': ('TWITTER_CONSUMER_KEY', 'TWITTER_CONSUMER_SECRET'),
     'facebook': ('FACEBOOK_APP_ID', 'FACEBOOK_API_SECRET'),
-    'github': ('GITHUB_APP_ID', 'GITHUB_APP_SECRET'),
+    'github': ('GITHUB_APP_ID', 'GITHUB_API_SECRET'),
     'google': ('GOOGLE_OAUTH2_CLIENT_ID', 'GOOGLE_OAUTH2_CLIENT_SECRET'),
 }
 


### PR DESCRIPTION
This fixes the typo in the default configuration which causes the Github backend not to work.
