### PR TITLE
suggestion: show _latest_ message on group

### DIFF
--- a/src/sentry/manager.py
+++ b/src/sentry/manager.py
@@ -536,6 +536,7 @@ class GroupManager(BaseManager, ChartMixin):
                 'score': ScoreClause(group),
             }
 
+            #
             message = kwargs.get('message')
             if message:
                 group.update(message=message)

--- a/src/sentry/manager.py
+++ b/src/sentry/manager.py
@@ -535,6 +535,11 @@ class GroupManager(BaseManager, ChartMixin):
                 'last_seen': max(event.datetime, group.last_seen),
                 'score': ScoreClause(group),
             }
+
+            message = kwargs.get('message')
+            if message:
+                group.update(message=message)
+
             if group.status == STATUS_RESOLVED:
                 # Group has changed from resolved -> unresolved
                 is_new = True


### PR DESCRIPTION
set group message to that of _latest_ event rather than that of the first event (which may even be resolved at
this point). 

This is mainly proof of concept, and may not be the best way to achieve this effect.
