### PR TITLE
Save user language in UserOption and load setting on logon

### DIFF
--- a/src/sentry/models.py
+++ b/src/sentry/models.py
@@ -19,7 +19,6 @@ from indexer.models import BaseIndex
 from picklefield.fields import PickledObjectField
 
 from django.contrib.auth.models import User
-from django.contrib.auth.signals import user_logged_in
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import F
@@ -894,7 +893,12 @@ pre_delete.connect(
     dispatch_uid="remove_key_for_team_member",
     weak=False,
 )
-user_logged_in.connect(set_language_on_logon)
+# Only available in Django >= 1.3
+try:
+    from django.contrib.auth.signals import user_logged_in
+    user_logged_in.connect(set_language_on_logon)
+except:
+    pass
 
 try:
     import south

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -76,4 +76,13 @@ class AccountSettingsForm(forms.Form):
         self.user.email = self.cleaned_data['email']
         if commit:
             self.user.save()
+
+        # Save user language
+        UserOption.objects.set_value(
+            user=self.user,
+            project=None,
+            key='language',
+            value=self.cleaned_data['language'],
+        )
+
         return self.user


### PR DESCRIPTION
- Changing AccountSettingsForm to save language in UserOption.
- Adding 'user_logged_in' signal to set user language on logon.
