### PR TITLE
Allow Plugins to override config form rendering

### DIFF
--- a/src/sentry/plugins/base.py
+++ b/src/sentry/plugins/base.py
@@ -144,6 +144,7 @@ class IPlugin(local):
     conf_title = None
 
     project_conf_form = None
+    project_conf_form_template = 'sentry/partial/_form.html'
     project_conf_template = 'sentry/plugins/project_configuration.html'
 
     site_conf_form = None

--- a/src/sentry/templates/sentry/plugins/project_configuration.html
+++ b/src/sentry/templates/sentry/plugins/project_configuration.html
@@ -10,7 +10,7 @@
             </div>
         {% endif %}
 
-        {% include "sentry/partial/_form.html" %}
+        {% include form_template %}
     </div>
     <div class="span4">
         <div class="well plugin-meta">

--- a/src/sentry/templates/sentry/plugins/site_configuration.html
+++ b/src/sentry/templates/sentry/plugins/site_configuration.html
@@ -7,4 +7,4 @@
     </div>
 {% endif %}
 
-{% include "sentry/partial/_form.html" %}
+{% include form_template %}

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -151,9 +151,11 @@ def plugin_config(plugin, project, request):
     plugin_key = plugin.get_conf_key()
     if project:
         form_class = plugin.project_conf_form
+        form_template = plugin.project_conf_form_template
         template = plugin.project_conf_template
     else:
         form_class = plugin.site_conf_form
+        form_template =  "sentry/partial/_form.html"
         template = plugin.site_conf_template
 
     initials = plugin.get_form_initial(project)
@@ -187,4 +189,5 @@ def plugin_config(plugin, project, request):
             'request': request,
             'plugin': plugin,
             'plugin_description': plugin.get_description() or '',
+            'form_template': form_template
         }, context_instance=RequestContext(request))))


### PR DESCRIPTION
Add project form template overrides into the base `IPlugin` class to allow for plugins which require a different / custom form rendering than the default form partial without having to recreate everything in the `project_configuration.html`

note: backward compatibility with existing plugins is maintained (tested with github and mail plugins) 
