### PR TITLE
Clean up an old index in sentry_groupedmessage

### DIFF
--- a/src/sentry/migrations/0063_remove_bad_groupedmessage_index.py
+++ b/src/sentry/migrations/0063_remove_bad_groupedmessage_index.py
@@ -1,0 +1,15 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'GroupedMessage', fields ['logger', 'view', 'checksum']
+        db.delete_unique('sentry_groupedmessage', ['logger', 'view', 'checksum'])
+
+    def backwards(self, orm):
+        # Adding unique constraint on 'GroupedMessage', fields ['logger', 'view', 'checksum']
+        db.create_unique('sentry_groupedmessage', ['logger', 'view', 'checksum'])


### PR DESCRIPTION
The original migration version 0015 was supposed to remove this, but the
ordering of the index fields in the migration script didn't match the
actual index.

0015 has:

  db.delete_unique('sentry_groupedmessage', ['checksum', 'logger', 'view'])

but the order should be:

  db.delete_unique('sentry_groupedmessage', ['logger', 'view', 'checksum'])

This old index prevents a message group from existing in multiple
projects. There is a new index already added by 0015 that includes the
project id and should replace this index.
