### PR TITLE
Allow http service daemon mode configuration in SENTRY_WEB_OPTIONS

### DIFF
--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -35,7 +35,7 @@ class SentryHTTPServer(Service):
         options = (settings.WEB_OPTIONS or {}).copy()
         options['bind'] = '%s:%s' % (self.host, self.port)
         options['debug'] = debug
-        options.setdefault('daemon', 30)
+        options.setdefault('daemon', False)
         options.setdefault('timeout', 30)
         if workers:
             options['workers'] = workers

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -35,7 +35,7 @@ class SentryHTTPServer(Service):
         options = (settings.WEB_OPTIONS or {}).copy()
         options['bind'] = '%s:%s' % (self.host, self.port)
         options['debug'] = debug
-        options['daemon'] = False
+        options.setdefault('daemon', 30)
         options.setdefault('timeout', 30)
         if workers:
             options['workers'] = workers


### PR DESCRIPTION
Allow setting gunicorn "daemon" setting through SENTRY_WEB_OPTIONS
