### PR TITLE
Make a query more performant on mysql

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -21,6 +21,7 @@ SORT_OPTIONS = SortedDict((
     ('accel_15', _('Trending: %(minutes)d minutes' % {'minutes': 15})),
     ('accel_60', _('Trending: %(minutes)d minutes' % {'minutes': 60})),
 ))
+
 SORT_CLAUSES = {
     'priority': 'sentry_groupedmessage.score',
     'date': 'EXTRACT(EPOCH FROM sentry_groupedmessage.last_seen)',
@@ -30,12 +31,14 @@ SORT_CLAUSES = {
     'avgtime': '(sentry_groupedmessage.time_spent_total / sentry_groupedmessage.time_spent_count)',
 }
 FILTER_CLAUSES = SORT_CLAUSES.copy()
+
 SQLITE_SORT_CLAUSES = SORT_CLAUSES.copy()
 SQLITE_SORT_CLAUSES.update({
     'date': 'sentry_groupedmessage.last_seen',
     'new': 'sentry_groupedmessage.first_seen',
 })
-SQLITE_FILTER_CLAUSES = FILTER_CLAUSES
+SQLITE_FILTER_CLAUSES = SQLITE_SORT_CLAUSES.copy()
+
 MYSQL_SORT_CLAUSES = SORT_CLAUSES.copy()
 MYSQL_SORT_CLAUSES.update({
     'date': 'sentry_groupedmessage.last_seen',
@@ -46,6 +49,7 @@ MYSQL_FILTER_CLAUSES.update({
     'date': 'UNIX_TIMESTAMP(sentry_groupedmessage.last_seen)',
     'new': 'UNIX_TIMESTAMP(sentry_groupedmessage.first_seen)',
 })
+
 SEARCH_SORT_OPTIONS = SortedDict((
     ('score', _('Score')),
     ('date', _('Last Seen')),

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -29,13 +29,20 @@ SORT_CLAUSES = {
     'tottime': 'sentry_groupedmessage.time_spent_total',
     'avgtime': '(sentry_groupedmessage.time_spent_total / sentry_groupedmessage.time_spent_count)',
 }
+FILTER_CLAUSES = SORT_CLAUSES.copy()
 SQLITE_SORT_CLAUSES = SORT_CLAUSES.copy()
 SQLITE_SORT_CLAUSES.update({
     'date': 'sentry_groupedmessage.last_seen',
     'new': 'sentry_groupedmessage.first_seen',
 })
+SQLITE_FILTER_CLAUSES = FILTER_CLAUSES
 MYSQL_SORT_CLAUSES = SORT_CLAUSES.copy()
 MYSQL_SORT_CLAUSES.update({
+    'date': 'sentry_groupedmessage.last_seen',
+    'new': 'sentry_groupedmessage.first_seen',
+})
+MYSQL_FILTER_CLAUSES = FILTER_CLAUSES.copy()
+MYSQL_FILTER_CLAUSES.update({
     'date': 'UNIX_TIMESTAMP(sentry_groupedmessage.last_seen)',
     'new': 'UNIX_TIMESTAMP(sentry_groupedmessage.first_seen)',
 })

--- a/src/sentry/web/frontend/groups.py
+++ b/src/sentry/web/frontend/groups.py
@@ -134,7 +134,6 @@ def _get_group_list(request, project, view=None):
         event_list = event_list.extra(
             select={
                 'cursor_sort_value': sort_clause,
-                'cursor_filter_value': filter_clause,
             },
         ).order_by('-cursor_sort_value', '-last_seen')
         cursor = request.GET.get('cursor')

--- a/src/sentry/web/frontend/groups.py
+++ b/src/sentry/web/frontend/groups.py
@@ -132,10 +132,8 @@ def _get_group_list(request, project, view=None):
 
     if sort_clause:
         event_list = event_list.extra(
-            select={
-                'cursor_sort_value': sort_clause,
-            },
-        ).order_by('-cursor_sort_value', '-last_seen')
+            select={'sort_value': sort_clause},
+        ).order_by('-sort_value', '-last_seen')
         cursor = request.GET.get('cursor')
         if cursor:
             event_list = event_list.extra(

--- a/src/sentry/web/frontend/groups.py
+++ b/src/sentry/web/frontend/groups.py
@@ -11,15 +11,15 @@ import logging
 import re
 
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, \
-  HttpResponseRedirect, Http404
+from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
 from sentry.conf import settings
-from sentry.constants import SORT_OPTIONS, SEARCH_SORT_OPTIONS, \
-  SORT_CLAUSES, MYSQL_SORT_CLAUSES, SQLITE_SORT_CLAUSES, MEMBER_USER
+from sentry.constants import (SORT_OPTIONS, SEARCH_SORT_OPTIONS,
+    SORT_CLAUSES, MYSQL_SORT_CLAUSES, SQLITE_SORT_CLAUSES, MEMBER_USER,
+    FILTER_CLAUSES, MYSQL_FILTER_CLAUSES, SQLITE_FILTER_CLAUSES)
 from sentry.filters import get_filters
 from sentry.models import Group, Event, View, SearchDocument
 from sentry.permissions import can_admin_group
@@ -114,10 +114,13 @@ def _get_group_list(request, project, view=None):
     engine = get_db_engine('default')
     if engine.startswith('sqlite'):
         sort_clause = SQLITE_SORT_CLAUSES.get(sort)
+        filter_clause = SQLITE_FILTER_CLAUSES.get(sort)
     elif engine.startswith('mysql'):
         sort_clause = MYSQL_SORT_CLAUSES.get(sort)
+        filter_clause = MYSQL_FILTER_CLAUSES.get(sort)
     else:
         sort_clause = SORT_CLAUSES.get(sort)
+        filter_clause = FILTER_CLAUSES.get(sort)
 
     # All filters must already be applied once we reach this point
     if sort == 'tottime':
@@ -129,12 +132,15 @@ def _get_group_list(request, project, view=None):
 
     if sort_clause:
         event_list = event_list.extra(
-            select={'sort_value': sort_clause},
-        ).order_by('-sort_value', '-last_seen')
+            select={
+                'cursor_sort_value': sort_clause,
+                'cursor_filter_value': filter_clause,
+            },
+        ).order_by('-cursor_sort_value', '-last_seen')
         cursor = request.GET.get('cursor')
         if cursor:
             event_list = event_list.extra(
-                where=['%s > %%s' % sort_clause],
+                where=['%s > %%s' % filter_clause],
                 params=[cursor],
             )
 


### PR DESCRIPTION
MySQL doesn't like ORDER BY UNIX_TIMESTAMP; this is because mysql is a terrible excuse for a database
