### PR TITLE
Line too long is sidebar break layout

### DIFF
--- a/src/sentry.less
+++ b/src/sentry.less
@@ -285,6 +285,7 @@ h3 {
     float: left;
     padding: 18px 20px;
     margin-right: -300px;
+    overflow: hidden;
 
     h6 {
       display: block;


### PR DESCRIPTION
When you checkout an error, it happen that there's a line to long to fit inside the sidebar, and this break the layout.

Just added an `overflow: hidden` to prevent this from happening. Adding a `title` attributes to those links could help too.
