### PR TITLE
Change group sharing/public link logic

### DIFF
--- a/src/sentry/models.py
+++ b/src/sentry/models.py
@@ -462,12 +462,10 @@ class Group(MessageBase):
         ).order_by('-times_seen')
 
     def can_be_shared(self):
-        return settings.PUBLIC
+        return (settings.PUBLIC and not self.project.public)
 
     def has_been_shared(self):
-        if not self.can_be_shared():
-            return False
-        return self.project.public or self.is_public
+        return settings.PUBLIC and (self.project.public or self.is_public)
 
 
 class GroupMeta(Model):

--- a/src/sentry/models.py
+++ b/src/sentry/models.py
@@ -461,6 +461,14 @@ class Group(MessageBase):
             'last_seen',
         ).order_by('-times_seen')
 
+    def can_be_shared(self):
+        return settings.PUBLIC
+
+    def has_been_shared(self):
+        if not self.can_be_shared():
+            return False
+        return self.project.public or self.is_public
+
 
 class GroupMeta(Model):
     """

--- a/src/sentry/templates/sentry/groups/details.html
+++ b/src/sentry/templates/sentry/groups/details.html
@@ -15,20 +15,20 @@
 {% block sidebar %}
     <!--- there is probably a less terrible way to do things like this -->
     <p id="public-status"><small>
-        <span data-public="true"{% if not group.project.public and not group.is_public %} style="display: none;"{% endif %}>
+        <span data-public="true"{% if not group.has_been_shared %} style="display: none;"{% endif %}>
             {% trans "This event is <strong>publicly visible</strong>." %}
         </span>
-        <span data-public="false"{% if group.project.public or group.is_public %} style="display: none;"{% endif %}>
+        <span data-public="false"{% if group.has_been_shared %} style="display: none;"{% endif %}>
             {% trans "This event is <strong>not publicly visible</strong>." %}
         </span>
-        <span data-public="true"{% if not group.project.public and not group.is_public %} style="display: none;"{% endif %}>
-            <a href="{% url sentry-group group.project.slug group.id %}">{% trans "Link" %}</a>{% if can_admin_event and not group.project.public %} | {% endif %}
+        <span data-public="true"{% if not group.has_been_shared %} style="display: none;"{% endif %}>
+            <a href="{% url sentry-group group.project.slug group.id %}">{% trans "Link" %}</a>{% if can_admin_event and group.can_be_shared %} | {% endif %}
         </span>
-        {% if can_admin_event and not group.project.public %}
-            <span data-public="true"{% if not group.is_public %} style="display: none;"{% endif %}>
+        {% if can_admin_event and group.can_be_shared %}
+            <span data-public="true"{% if not group.has_been_shared %} style="display: none;"{% endif %}>
                 <a href="javascript:void(0)" data-api-url="{% url sentry-api-set-group-private group.project.slug group.id %}" class="action">{% trans "Change" %}</a>
             </span>
-            <span data-public="false"{% if group.is_public %} style="display: none;"{% endif %}>
+            <span data-public="false"{% if group.has_been_shared %} style="display: none;"{% endif %}>
                 <a href="javascript:void(0)" data-api-url="{% url sentry-api-set-group-public group.project.slug group.id %}" class="action">{% trans "Change" %}</a>
             </span>
         {% endif %}

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -108,14 +108,14 @@ class EventSharingTest(TestCase):
             self.project.update(public=True)
             self.assertFalse(self.group.can_be_shared())
 
-    def test_can_be_shared_only_if_setting_is_true(self):
+    def test_can_be_shared_only_if_setting_is_true_and_project_is_private(self):
         with self.Settings(SENTRY_PUBLIC=True):
             self.project.update(public=False)
             self.group.update(is_public=False)
             self.assertTrue(self.group.can_be_shared())
             self.project.update(public=True)
             self.group = self.project.group_set.all()[0]
-            self.assertTrue(self.group.can_be_shared())
+            self.assertFalse(self.group.can_be_shared())
 
     def test_has_been_shared_is_false_if_it_cant_be(self):
         with self.Settings(SENTRY_PUBLIC=False):


### PR DESCRIPTION
Re #634, this is a test that describes the current behaviour - I'm not sure that 200 in the middle is expected behaviour when SENTRY_PUBLIC = False, given that in the third case the link requires login.

[edit] This pull request will change SENTRY_PUBLIC=False into a kill switch that prevents groups from being viewed by anonymous users.
