### PR TITLE
Only show users notification options for projects they can access

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -13,6 +13,7 @@ from sentry.plugins import Plugin
 from sentry.models import UserOption
 from sentry.utils.cache import cache
 from sentry.web.helpers import get_project_list
+from sentry.constants import MEMBER_USER
 
 
 class NotificationConfigurationForm(forms.Form):
@@ -44,7 +45,7 @@ class NotificationUserOptionsForm(BaseNotificationUserOptionsForm):
     def __init__(self, *args, **kwargs):
         super(NotificationUserOptionsForm, self).__init__(*args, **kwargs)
         user = self.user
-        self.project_list = get_project_list(user, key='slug')
+        self.project_list = get_project_list(user, access=MEMBER_USER, key='slug')
         project_list = sorted(self.project_list.items())
         self.fields['projects'].choices = project_list
         self.fields['projects'].widget.choices = self.fields['projects'].choices


### PR DESCRIPTION
We had some confusion internally where registered users, when browsing /account/settings/notifications/, thought they were opting in for email notifications for a project when in fact they weren't a member of that project's team, so the notifications never came through. This changes the form to show only projects you're a member of.
