### PR TITLE
Fixed up a small number of errant apostrophes in the documentation

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -139,7 +139,7 @@ Authentication
 .. data:: sentry.conf.USE_JS_CLIENT
     :noindex:
 
-    Instructs Sentry to install it's JavaScript error handler to catch internal errors in the
+    Instructs Sentry to install its JavaScript error handler to catch internal errors in the
     Sentry client-side code.
 
     Defaults to ``False``.

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -40,7 +40,7 @@ Running the Test Suite
 ----------------------
 
 The test suite is also powered off of setuptools, and can be run in two fashions. The
-easiest is to simply use setuptools and it's ``test`` command. This will handle installing
+easiest is to simply use setuptools and its ``test`` command. This will handle installing
 any dependancies you're missing automatically.
 
 ::

--- a/docs/developer/client/index.rst
+++ b/docs/developer/client/index.rst
@@ -438,7 +438,7 @@ Tags are key/value pairs that describe an event. They should be configurable in 
 * Thread (block-level)
 * Event (as part of capture)
 
-Each of these should inherit it's parent. So for example, if you configure your client as so::
+Each of these should inherit its parent. So for example, if you configure your client as so::
 
     client = Client(..., {
         'tags': {'foo': 'bar'},

--- a/docs/developer/interfaces/index.rst
+++ b/docs/developer/interfaces/index.rst
@@ -1,7 +1,7 @@
 Interfaces
 ==========
 
-Sentry implements data interfaces for storing structured data. At it's core, an interface describes what it's storing, and optionally how it's data should be rendered.
+Sentry implements data interfaces for storing structured data. At its core, an interface describes what it's storing, and optionally how its data should be rendered.
 
 Within the client, interfaces are referenced by their full Python module path. For example, if you were sending data
 for the ``sentry.interfaces.Message`` class, it would look like this in your JSON packet::


### PR DESCRIPTION
Sorry to be a pedant, but the docs have a number of apostrophes in the wrong place (using it's instead of its).
