### PR TITLE
Fix for loaddata

### DIFF
--- a/src/sentry/models.py
+++ b/src/sentry/models.py
@@ -794,7 +794,7 @@ def create_team_and_keys_for_project(instance, created, **kwargs):
     if not instance.owner:
         return
 
-    if not instance.team:
+    if not instance.team_id:
         update(instance, team=Team.objects.create(
             owner=instance.owner,
             name=instance.name,


### PR DESCRIPTION
This will now work when a project refers to a team that doesn't exist yet (this can occur during load data).
