### PR TITLE
make error message <pre> so newlines are visible

### DIFF
--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block inner %}
-    <p>{{ event.message }}</p>
+    <p><pre>{{ event.message }}</pre></p>
 
     <p><a href="{{ link }}">{{ link }}</a></p>
 


### PR DESCRIPTION
The alternative would be to embed <br> tags in our message sends, but in lieu of that, I think it would be easier to just force the text to be <pre>...
