### PR TITLE
Replace string.split with a regex split for carriage returns

### DIFF
--- a/src/sentry/web/forms/__init__.py
+++ b/src/sentry/web/forms/__init__.py
@@ -5,6 +5,7 @@ sentry.web.forms
 :copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
+import re
 from django import forms
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
@@ -24,7 +25,7 @@ class ReplayForm(forms.Form):
         if not value:
             return
 
-        return dict(line.split(': ') for line in value.split('\n'))
+        return dict(line.split(': ') for line in re.split(r'\r\n|\n', value))
 
 
 class BaseUserForm(forms.ModelForm):


### PR DESCRIPTION
`sentry.web.forms.ReplayForm` wasn't building the header dict correctly because it was leaving junk `\r` at the each of each header field.  Some web servers will return 400 Bad Request for these requests.

It also should be noted that the spec for HTTP Headers does allow for field values to have carriage return characters if it is followed by a tab or space.  That might be something to look into later.
