### PR TITLE
remove short timeout when replaying requests

### DIFF
--- a/src/sentry/replays.py
+++ b/src/sentry/replays.py
@@ -24,7 +24,7 @@ class Replayer(object):
         if isinstance(data, dict):
             data = urlencode(data)
 
-        conn = conn_cls(urlparts.netloc, timeout=5)
+        conn = conn_cls(urlparts.netloc)
         try:
             conn.request(self.method, urlparts.path, data, self.headers or {})
 


### PR DESCRIPTION
The 5 second timeout is too short for some requests. Unless there's a reason to keep it this low, should we just use the default?
