### PR TITLE
Configurable Bind Address

### DIFF
--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -33,8 +33,8 @@ class SentryHTTPServer(Service):
         #     worker.init_process = profiling_init_process.__get__(worker)
 
         options = (settings.WEB_OPTIONS or {}).copy()
-        options['bind'] = '%s:%s' % (self.host, self.port)
         options['debug'] = debug
+        options.setdefault('bind', '%s:%s' % (self.host, self.port))
         options.setdefault('daemon', False)
         options.setdefault('timeout', 30)
         if workers:


### PR DESCRIPTION
I run sentry on a machine with several other internal web services running under gunicorn and to avoid having to deal with knowing which apps are running on which ports it's much easier to have gunicorn listen on a unix socket. The HTTP service wasn't set up to allow the `bind` option to be configured through `SENTRY_WEB_OPTIONS`. This changes that.
