### PR TITLE
Fix group_by query in SearchDocumentManager

### DIFF
--- a/src/sentry/manager.py
+++ b/src/sentry/manager.py
@@ -1015,7 +1015,7 @@ class SearchDocumentManager(BaseManager):
                 ON st.document_id = sd.id
             WHERE %s
                 sd.project_id = %s
-            GROUP BY sd.id, sd.group_id, sd.total_events, sd.date_changed, sd.date_added
+            GROUP BY sd.id, sd.group_id, sd.total_events, sd.date_changed, sd.date_added, sd.project_id, sd.status
             ORDER BY %s
             LIMIT %d OFFSET %d
         """ % (


### PR DESCRIPTION
SearchDocumentManger has a raw group_by sql query for search.
sd.project_id and sd.status was missing from the group_by clause.

This is due to the sd.\* in the SELECT.
