### PR TITLE
Improve test performance by using the md5 hasher for tests.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -39,3 +39,7 @@ def pytest_configure(config):
     )
     settings.SENTRY_KEY = base64.b64encode(os.urandom(40))
     settings.SENTRY_PUBLIC = False
+    # This speeds up the tests considerably, pbkdf2 is by design, slow.
+    settings.PASSWORD_HASHERS = [
+        'django.contrib.auth.hashers.MD5PasswordHasher',
+    ]


### PR DESCRIPTION
This isover a 2x speed, from ~45 seconds to ~18 on my laptop.
