### PR TITLE
Added sentry-seachbutton plugin to the documentation

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -57,6 +57,7 @@ The following extensions are available and maintained by members of the Sentry c
 * `sentry-phabricator <https://github.com/getsentry/sentry-phabricator>`_
 * `sentry-pivotal <https://github.com/getsentry/sentry-pivotal>`_
 * `sentry-pushover <https://github.com/dz0ny/sentry-pushover>`_
+* `sentry-searchbutton <https://github.com/timmyomahony/sentry-searchbutton>`_
 * `sentry-sprintly <https://github.com/mattrobenolt/sentry-sprintly>`_
 * `sentry-trello <https://github.com/DamianZaremba/sentry-trello>`_
 * `sentry-webhooks <https://github.com/getsentry/sentry-webhooks>`_


### PR DESCRIPTION
I've [created a simple plugin](https://github.com/timmyomahony/sentry-searchbutton) that adds an input/button to the sidebar allowing users to easily launch a Google search for the error:

![Screenshot](https://github.com/timmyomahony/sentry-searchbutton/blob/master/screenshot.png?raw=true)
