### PR TITLE
Add sentry-notifico to plugin list

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -54,6 +54,7 @@ The following extensions are available and maintained by members of the Sentry c
 * `sentry-irc <https://github.com/gisce/sentry-irc>`_
 * `sentry-irccat <https://github.com/russss/sentry-irccat>`_
 * `sentry-jira <https://github.com/thurloat/sentry-jira>`_
+* `sentry-notifico <https://github.com/lukegb/sentry-notifico>`_
 * `sentry-phabricator <https://github.com/getsentry/sentry-phabricator>`_
 * `sentry-pivotal <https://github.com/getsentry/sentry-pivotal>`_
 * `sentry-pushover <https://github.com/dz0ny/sentry-pushover>`_


### PR DESCRIPTION
Add sentry-notifico to the list of plugins in the documentation.
