### PR TITLE
Stop Event.request throwing a KeyError

### DIFF
--- a/src/sentry/models.py
+++ b/src/sentry/models.py
@@ -612,7 +612,7 @@ class Event(EventBase):
             return MockDjangoRequest()
 
         fake_request = MockDjangoRequest(**kwargs)
-        if kwargs['url']:
+        if 'url' in kwargs and kwargs['url']:
             fake_request.path_info = '/' + kwargs['url'].split('/', 3)[-1]
         else:
             fake_request.path_info = ''


### PR DESCRIPTION
It's bad behaviour for accessing an attribute to throw an Exception in my opinion, so let's stop Event.request from doing it (for one specific instance, at least).
