### PR TITLE
avoid UnicodeEncodeError when token is not ascii

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -9,6 +9,7 @@ sentry.buffer.redis
 from __future__ import with_statement
 
 from django.db import models
+from django.utils.encoding import smart_str
 from hashlib import md5
 from nydus.db import create_cluster
 from sentry.buffer import Buffer
@@ -42,12 +43,12 @@ class RedisBuffer(Buffer):
         Returns a Redis-compatible key for the model given filters.
         """
         return '%s:%s:%s' % (model._meta,
-            md5('&'.join('%s=%s' % (k, self._map_column(model, k, v)) for k, v in sorted(filters.iteritems()))).hexdigest(),
+            md5(smart_str('&'.join('%s=%s' % (k, self._map_column(model, k, v)) for k, v in sorted(filters.iteritems())))).hexdigest(),
             column)
 
     def _make_extra_key(self, model, filters):
         return '%s:extra:%s' % (model._meta,
-            md5('&'.join('%s=%s' % (k, self._map_column(model, k, v)) for k, v in sorted(filters.iteritems()))).hexdigest())
+            md5(smart_str('&'.join('%s=%s' % (k, self._map_column(model, k, v)) for k, v in sorted(filters.iteritems())))).hexdigest())
 
     def incr(self, model, columns, filters, extra=None):
         with self.conn.map() as conn:


### PR DESCRIPTION
error log:

UnicodeEncodeError: 'ascii' codec can't encode characters in position 29-49: ordinal not in range(128)
[2013-02-19 06:20:46,992: ERROR/MainProcess] Task sentry.tasks.index.index_event[4de195fe-e607-440c-8b56-b8f23f79d7a1] raised exception: UnicodeEncodeError('ascii', u'document=6&field=text&token=\u9875\u9762\u91cd\u590d\u9012\u4ea4', 28, 34, 'ordinal not in range(128)')
Traceback (most recent call last):
  File "/aa/sentry/lib/python2.7/site-packages/celery/task/trace.py", line 228, in trace_task
    R = retval = fun(_args, *_kwargs)
  File "/aa/sentry/lib/python2.7/site-packages/celery/task/trace.py", line 415, in **protected_call**
    return self.run(_args, *_kwargs)
  File "/aa/sentry/lib/python2.7/site-packages/sentry/tasks/index.py", line 16, in index_event
    SearchDocument.objects.index(event)
  File "/aa/sentry/lib/python2.7/site-packages/sentry/manager.py", line 1084, in index
    'field': field,
  File "/aa/sentry/lib/python2.7/site-packages/sentry/buffer/redis.py", line 55, in incr
    key = self._make_key(model, filters, column)
  File "/aa/sentry/lib/python2.7/site-packages/sentry/buffer/redis.py", line 45, in _make_key
    md5('&'.join('%s=%s' % (k, self._map_column(model, k, v)) for k, v in sorted(filters.iteritems()))).hexdigest(),
UnicodeEncodeError: 'ascii' codec can't encode characters in position 28-33: ordinal not in range(128)
