### PR TITLE
Corrected example of Raven PHP client

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/php.html
+++ b/src/sentry/templates/sentry/partial/client_config/php.html
@@ -22,7 +22,7 @@ try {
     throw new Exception('Uh oh!');
 }
 catch ($e) {
-    $client->captureException($e);
+    $client->captureException(Exception $e);
 }</pre>
 
 <p>{% trans "You can also optionally install a default error handler to catch all exceptions:" %}</p>

--- a/src/sentry/templates/sentry/partial/client_config/php.html
+++ b/src/sentry/templates/sentry/partial/client_config/php.html
@@ -21,8 +21,8 @@ $client->captureMessage('hello world!');
 try {
     throw new Exception('Uh oh!');
 }
-catch ($e) {
-    $client->captureException(Exception $e);
+catch (Exception $e) {
+    $client->captureException($e);
 }</pre>
 
 <p>{% trans "You can also optionally install a default error handler to catch all exceptions:" %}</p>


### PR DESCRIPTION
Was missing 'Exception' in the example, causing invalid PHP and producing errors.

Verified from the PHP Docs: http://php.net/manual/en/language.exceptions.php
