### PR TITLE
Django 1.5 support: ExpressionNode's AND/OR are now BITAND/BITOR

### DIFF
--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -42,9 +42,15 @@ EXPRESSION_NODE_CALLBACKS = {
     ExpressionNode.MUL: operator.mul,
     ExpressionNode.DIV: operator.div,
     ExpressionNode.MOD: operator.mod,
-    ExpressionNode.AND: operator.and_,
-    ExpressionNode.OR: operator.or_,
 }
+try:
+    EXPRESSION_NODE_CALLBACKS[ExpressionNode.AND] = operator.and_
+except AttributeError:
+    EXPRESSION_NODE_CALLBACKS[ExpressionNode.BITAND] = operator.and_
+try:
+    EXPRESSION_NODE_CALLBACKS[ExpressionNode.OR] = operator.or_
+except AttributeError:
+    EXPRESSION_NODE_CALLBACKS[ExpressionNode.BITOR] = operator.or_
 
 
 class CannotResolve(Exception):


### PR DESCRIPTION
As mentioned in the [1.5 release notes](https://docs.djangoproject.com/en/dev/releases/1.5/#miscellaneous):

> The F() expressions supported bitwise operators by & and |. These operators are now available using .bitand() and .bitor() instead. The removal of & and | was done to be consistent with Q() expressions and QuerySet combining where the operators are used as boolean AND and OR operators.

Along with this change, `ExpressionNode.AND` has become `ExpressionNode.BITAND` and `ExpressionNode.OR` has become `ExpressionNode.BITOR`, breaking `sentry/utils/db.py`.
