### PR TITLE
Added a default process name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ install_requires = [
     'httpagentparser>=1.0.5',
     'django-social-auth>=0.7.1,<1.0',
     'django-social-auth-trello>=1.0.2',
+    'setproctitle>=1.1.7',
 ]
 
 setup(

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -37,6 +37,7 @@ class SentryHTTPServer(Service):
         options.setdefault('bind', '%s:%s' % (self.host, self.port))
         options.setdefault('daemon', False)
         options.setdefault('timeout', 30)
+        options.setdefault('proc_name', 'Sentry')
         if workers:
             options['workers'] = workers
 


### PR DESCRIPTION
Prior to this, when a sentry server was started, the process names would be:
gunicorn: worker [gunicorn]
gunicorn: master [gunicorn].
This changes the default process names to:
gunicorn worker [Sentry]
gunicorn master [Sentry]
