### PR TITLE
Allow promoting a user to admin via the manage users page.

### DIFF
--- a/src/sentry/web/forms/__init__.py
+++ b/src/sentry/web/forms/__init__.py
@@ -44,8 +44,11 @@ class NewUserForm(BaseUserForm):
 
 
 class ChangeUserForm(BaseUserForm):
+    is_staff = forms.BooleanField(required=False, label=_('Admin'),
+        help_text=_("Designates whether this user can perform administrative functions."))
+
     class Meta:
-        fields = ('first_name', 'username', 'email', 'is_active')
+        fields = ('first_name', 'username', 'email', 'is_active', 'is_staff')
         model = User
 
 


### PR DESCRIPTION
Sometimes (such as if you're using ldap for authentication), the primary admin of the install won't be that of the initial superuser.

Using the initial superuser, you should be able to promote any other user to be an admin - via the is_staff flag.

This patch allows this promotion, by extending the ChangeUserForm, currently used to administratively modify users.
