### PR TITLE
C# configuration example is invalid.

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/csharp.html
+++ b/src/sentry/templates/sentry/partial/client_config/csharp.html
@@ -4,7 +4,7 @@
 
 <p>{% blocktrans %}Initialize the client:{% endblocktrans %}</p>
 
-<pre>ravenClient = new RavenClient('{% if dsn %}{{ dsn }}{% else %}<strong>SENTRY_DSN</strong>{% endif %}');</pre>
+<pre>ravenClient = new RavenClient("{% if dsn %}{{ dsn }}{% else %}<strong>SENTRY_DSN</strong>{% endif %}");</pre>
 
 <p>{% blocktrans %}To capture errors, you'll need to wrap your code in a simple try/catch block:{% endblocktrans %}</p>
 


### PR DESCRIPTION
C# strings require double quotes. Updated the example to reflect this. 
