### PR TITLE
Fixed iterating by NoneType object

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -167,7 +167,7 @@ class NotificationPlugin(Plugin):
             tags = event.data.get('tags', ())
             if not tags:
                 return False
-            if not any(v in allowed_tags.get(k) for k, v in tags):
+            if not any(v in allowed_tags.get(k, ()) for k, v in tags):
                 return False
         return True
 

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -165,6 +165,8 @@ class NotificationPlugin(Plugin):
         allowed_tags = project.get_option('notifcation:tags', {})
         if allowed_tags:
             tags = event.data.get('tags', ())
+            if not tags:
+                return False
             if not any(v in allowed_tags.get(k) for k, v in tags):
                 return False
         return True


### PR DESCRIPTION
I got this error while processing log request:

```
Traceback (most recent call last):
  File "/home/sentry/envs/sentry/lib/python2.7/site-packages/sentry/utils/safe.py", line 16, in safe_execute
    result = func(*args, **kwargs)
  File "/home/sentry/envs/sentry/lib/python2.7/site-packages/sentry/plugins/bases/notify.py", line 184, in post_process
    if not self.should_notify(group, event):
  File "/home/sentry/envs/sentry/lib/python2.7/site-packages/sentry/plugins/bases/notify.py", line 168, in should_notify
    if not any(v in allowed_tags.get(k) for k, v in tags):
  File "/home/sentry/envs/sentry/lib/python2.7/site-packages/sentry/plugins/bases/notify.py", line 168, in <genexpr>
    if not any(v in allowed_tags.get(k) for k, v in tags):
TypeError: argument of type 'NoneType' is not iterable
Error processing 'post_process' on 'MailProcessor': argument of type 'NoneType' is not iterable
```

`allowed_tags.get(k)`

can return None
