### PR TITLE
Fix empty slug problem causeing 500 error when project name is all Chinese

### DIFF
--- a/src/sentry/models.py
+++ b/src/sentry/models.py
@@ -55,6 +55,8 @@ __all__ = ('Event', 'Group', 'Project', 'SearchDocument')
 
 def slugify_instance(inst, label, **kwargs):
     base_slug = slugify(label)
+    if not base_slug:
+        base_slug = 'default_%s' % (uuid.uuid4())
     manager = type(inst).objects
     inst.slug = base_slug
     n = 0


### PR DESCRIPTION
When project name is all Chinese, django's slugify() will return empty string. It will cause 500 error like this:

```
Internal Server Error: /account/teams/tech/projects/new/
Traceback (most recent call last):
  File "/home/env/sentry/lib/python2.6/site-packages/Django-1.4.5-py2.6.egg/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/home/env/sentry/lib/python2.6/site-packages/Django-1.4.5-py2.6.egg/django/utils/decorators.py", line 91, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/home/env/sentry/lib/python2.6/site-packages/sentry-5.4.4-py2.6.egg/sentry/web/decorators.py", line 110, in _wrapped
    return func(request, *args, **kwargs)
  File "/home/env/sentry/lib/python2.6/site-packages/sentry-5.4.4-py2.6.egg/sentry/web/frontend/teams.py", line 455, in create_new_team_project
    return HttpResponseRedirect(reverse('sentry-docs-client', args=[project.team.slug, project.slug, project.platform]))
  File "/home/env/sentry/lib/python2.6/site-packages/Django-1.4.5-py2.6.egg/django/core/urlresolvers.py", line 476, in reverse
    return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
  File "/home/env/sentry/lib/python2.6/site-packages/Django-1.4.5-py2.6.egg/django/core/urlresolvers.py", line 396, in _reverse_with_prefix
    "arguments '%s' not found." % (lookup_view_s, args, kwargs))
NoReverseMatch: Reverse for 'sentry-docs-client' with arguments '(u'tech', u'', u'flask')' and keyword arguments '{}' not found.
```

So a default slug should be provided when base_slug is empty.
