### PR TITLE
Improve Queue Use

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -234,6 +234,7 @@ SOCIAL_AUTH_DEFAULT_USERNAME = lambda: random.choice(['Darth Vader', 'Obi-Wan Ke
 SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email']
 
 # Queue configuration
+from kombu import Queue
 
 BROKER_URL = "django://"
 
@@ -241,6 +242,20 @@ CELERY_IGNORE_RESULT = True
 CELERY_SEND_EVENTS = False
 CELERY_RESULT_BACKEND = None
 CELERY_TASK_RESULT_EXPIRES = 1
+CELERY_DEFAULT_QUEUE = "default"
+CELERY_DEFAULT_EXCHANGE = "default"
+CELERY_DEFAULT_EXCHANGE_TYPE = "direct"
+CELERY_DEFAULT_ROUTING_KEY = "default"
+CELERY_QUEUES = (
+    Queue('alerts', routing_key='alerts'),
+    Queue('cleanup', routing_key='cleanup'),
+    Queue('sourcemaps', routing_key='sourcemaps'),
+    Queue('search', routing_key='search'),
+    Queue('counters', routing_key='counters'),
+    Queue('events', routing_key='events'),
+    Queue('triggers', routing_key='triggers'),
+)
+
 
 # Sentry and Raven configuration
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -247,6 +247,7 @@ CELERY_DEFAULT_EXCHANGE = "default"
 CELERY_DEFAULT_EXCHANGE_TYPE = "direct"
 CELERY_DEFAULT_ROUTING_KEY = "default"
 CELERY_QUEUES = (
+    Queue('default', routing_key='default'),
     Queue('alerts', routing_key='alerts'),
     Queue('cleanup', routing_key='cleanup'),
     Queue('sourcemaps', routing_key='sourcemaps'),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -246,6 +246,7 @@ CELERY_DEFAULT_QUEUE = "default"
 CELERY_DEFAULT_EXCHANGE = "default"
 CELERY_DEFAULT_EXCHANGE_TYPE = "direct"
 CELERY_DEFAULT_ROUTING_KEY = "default"
+CELERY_CREATE_MISSING_QUEUES = True
 CELERY_QUEUES = (
     Queue('default', routing_key='default'),
     Queue('alerts', routing_key='alerts'),

--- a/src/sentry/tasks/check_alerts.py
+++ b/src/sentry/tasks/check_alerts.py
@@ -48,7 +48,7 @@ def fsteps(start, stop, steps):
         start += step
 
 
-@periodic_task(ignore_result=True, run_every=crontab(minute='*'))
+@periodic_task(run_every=crontab(minute='*'), queue='alerts')
 def check_alerts(**kwargs):
     """
     Iterates all current keys and fires additional tasks to check each individual
@@ -79,7 +79,7 @@ def check_alerts(**kwargs):
         )
 
 
-@task(ignore_result=True)
+@task(queue='alerts')
 def check_project_alerts(project_id, when, count, **kwargs):
     """
     Given 'when' and 'count', which should signify recent times we compare it to historical data for this project

--- a/src/sentry/tasks/check_alerts.py
+++ b/src/sentry/tasks/check_alerts.py
@@ -48,7 +48,9 @@ def fsteps(start, stop, steps):
         start += step
 
 
-@periodic_task(run_every=crontab(minute='*'), queue='alerts')
+@periodic_task(
+    name='sentry.tasks.check_alerts',
+    run_every=crontab(minute='*'), queue='alerts')
 def check_alerts(**kwargs):
     """
     Iterates all current keys and fires additional tasks to check each individual
@@ -79,7 +81,7 @@ def check_alerts(**kwargs):
         )
 
 
-@task(queue='alerts')
+@task(name='sentry.tasks.check_alerts.check_project_alerts', queue='alerts')
 def check_project_alerts(project_id, when, count, **kwargs):
     """
     Given 'when' and 'count', which should signify recent times we compare it to historical data for this project

--- a/src/sentry/tasks/cleanup.py
+++ b/src/sentry/tasks/cleanup.py
@@ -9,7 +9,7 @@ sentry.tasks.cleanup
 from celery.task import task
 
 
-@task(queue='cleanup')
+@task(name='sentry.tasks.cleanup.cleanup', queue='cleanup')
 def cleanup(days=30, project=None, **kwargs):
     """
     Deletes a portion of the trailing data in Sentry based on

--- a/src/sentry/tasks/cleanup.py
+++ b/src/sentry/tasks/cleanup.py
@@ -9,7 +9,7 @@ sentry.tasks.cleanup
 from celery.task import task
 
 
-@task(ignore_result=True)
+@task(queue='cleanup')
 def cleanup(days=30, project=None, **kwargs):
     """
     Deletes a portion of the trailing data in Sentry based on

--- a/src/sentry/tasks/fetch_source.py
+++ b/src/sentry/tasks/fetch_source.py
@@ -128,7 +128,7 @@ def fetch_url(url, logger=None):
     return result
 
 
-@task(ignore_result=True)
+@task(queue='sourcemaps')
 def fetch_javascript_source(event, **kwargs):
     """
     Attempt to fetch source code for javascript frames.

--- a/src/sentry/tasks/fetch_source.py
+++ b/src/sentry/tasks/fetch_source.py
@@ -128,7 +128,9 @@ def fetch_url(url, logger=None):
     return result
 
 
-@task(queue='sourcemaps')
+@task(
+    name='sentry.tasks.fetch_source.fetch_javascript_source',
+    queue='sourcemaps')
 def fetch_javascript_source(event, **kwargs):
     """
     Attempt to fetch source code for javascript frames.

--- a/src/sentry/tasks/index.py
+++ b/src/sentry/tasks/index.py
@@ -9,7 +9,7 @@ sentry.tasks.index
 from celery.task import task
 
 
-@task(ignore_result=True)
+@task(queue='search')
 def index_event(event, **kwargs):
     from sentry.models import SearchDocument
 

--- a/src/sentry/tasks/index.py
+++ b/src/sentry/tasks/index.py
@@ -9,7 +9,7 @@ sentry.tasks.index
 from celery.task import task
 
 
-@task(queue='search')
+@task(name='sentry.tasks.index.index_event', queue='search')
 def index_event(event, **kwargs):
     from sentry.models import SearchDocument
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -12,7 +12,7 @@ from sentry.utils.safe import safe_execute
 from sentry.utils.queue import maybe_delay
 
 
-@task(ignore_result=True)
+@task(queue='triggers')
 def post_process_group(group, **kwargs):
     """
     Fires post processing hooks for a group.
@@ -23,7 +23,7 @@ def post_process_group(group, **kwargs):
                 plugin.slug, group=group, **kwargs)
 
 
-@task(ignore_result=True)
+@task(queue='triggers')
 def plugin_post_process_group(plugin_slug, group, **kwargs):
     """
     Fires post processing hooks for a group.

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -12,7 +12,7 @@ from sentry.utils.safe import safe_execute
 from sentry.utils.queue import maybe_delay
 
 
-@task(queue='triggers')
+@task(name='sentry.tasks.post_process.post_process_group', queue='triggers')
 def post_process_group(group, **kwargs):
     """
     Fires post processing hooks for a group.
@@ -23,7 +23,9 @@ def post_process_group(group, **kwargs):
                 plugin.slug, group=group, **kwargs)
 
 
-@task(queue='triggers')
+@task(
+    name='sentry.tasks.post_process.plugin_post_process_group',
+    queue='triggers')
 def plugin_post_process_group(plugin_slug, group, **kwargs):
     """
     Fires post processing hooks for a group.

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -9,7 +9,7 @@ sentry.tasks.process_buffer
 from celery.task import task
 
 
-@task(queue='counters')
+@task(name='sentry.tasks.process_buffer.process_incr', queue='counters')
 def process_incr(**kwargs):
     """
     Processes a buffer event.

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -9,7 +9,7 @@ sentry.tasks.process_buffer
 from celery.task import task
 
 
-@task(ignore_result=True)
+@task(queue='counters')
 def process_incr(**kwargs):
     """
     Processes a buffer event.

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -9,7 +9,7 @@ sentry.tasks.store
 from celery.task import task
 
 
-@task(queue='events')
+@task(name='sentry.tasks.store.store_event', queue='events')
 def store_event(data, **kwargs):
     """
     Saves an event to the database.

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -9,7 +9,7 @@ sentry.tasks.store
 from celery.task import task
 
 
-@task(ignore_result=True)
+@task(queue='events')
 def store_event(data, **kwargs):
     """
     Saves an event to the database.


### PR DESCRIPTION
This changes all tasks to run within explicit queues and to have fixed names.

Reasoning:
- Named queues provide more insight and easier control of importance
- Fixed names provide compatibility when code changes
