### PR TITLE
Docs (client config -> Python): Fix exception type in example

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/python.html
+++ b/src/sentry/templates/sentry/partial/client_config/python.html
@@ -17,7 +17,7 @@ client.captureMessage('hello world!')
 # {% trans "capture an exception" %}
 try:
     1 / 0
-except DivisionError:
+except ZeroDivisionError:
     client.captureException()</pre>
 
 	<p>{% trans "If you want to wrap a WSGI app to record uncaught exceptions, Raven provides a middleware for that:" %}</p>


### PR DESCRIPTION
Again, a minor fix, but the example doesn't work when you copy & paste it. 
