### PR TITLE
Break long links in sidebar

### DIFF
--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -607,6 +607,7 @@ h3 {
             display: inline;
             padding: 0;
             margin: 0;
+            word-break: break-all;
           }
           .count {
             padding-right: 5px;


### PR DESCRIPTION
break long links to multiline in sidebar (prevent cropping them)
