### PR TITLE
change cssutils version to fix py2.7 install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ tests_require = [
 
 
 install_requires = [
-    'cssutils>=0.9.9,<0.10.0',
+    'cssutils>=0.9.9,<0.9.10',
     'BeautifulSoup>=3.2.1,<3.3.0',
     'django-celery>=3.0.11,<3.1.0',
     'celery>=3.0.15,<3.1.0',


### PR DESCRIPTION
Currently on py2.7 Sentry will install, but when you do `sentry upgrade` or `sentry start` it will complain like this and not work:

```
File "/home/ronald/sentry/local/lib/python2.7/site-packages/cssutils-0.9.10-py2.7.egg/cssutils/helper.py", line 9, in <module>
    import urllib.request, urllib.parse, urllib.error
ImportError: No module named request
```

This is related to this bug: https://bitbucket.org/cthedot/cssutils/issue/29/python-27-release-egg-for-0910-has-python

Fixing the version of cssutils to <0.9.10 will install 0.9.10b1 which is not affected by the issue.
