### PR TITLE
Allows custom raven js server

### DIFF
--- a/src/sentry/conf/defaults.py
+++ b/src/sentry/conf/defaults.py
@@ -161,3 +161,5 @@ AUTH_PROVIDERS = {
 # Default alerting threshold values
 DEFAULT_ALERT_PROJECT_THRESHOLD = (500, 100)  # 500%, 100 events
 DEFAULT_ALERT_GROUP_THRESHOLD = (1000, 100)  # 1000%, 100 events
+
+RAVEN_JS_URL = 'd3nslu0hdya83q.cloudfront.net/dist/1.0/raven.min.js'

--- a/src/sentry/templates/sentry/partial/client_config/javascript.html
+++ b/src/sentry/templates/sentry/partial/client_config/javascript.html
@@ -5,7 +5,7 @@
 
 <p>{% blocktrans with 'https://github.com/getsentry/raven-js' as link %}Start by installing <a href="{{ link }}">raven-js</a>.{% endblocktrans %}</p>
 
-<pre>&lt;script src="//d3nslu0hdya83q.cloudfront.net/dist/1.0/raven.min.js"&gt;&lt;/script&gt;</pre>
+<pre>&lt;script src="//{{ raven_js_url }}"&gt;&lt;/script&gt;</pre>
 
 <p>{% blocktrans %}Add the any URLs which will be logging errors in your project's settings under <a href="{{ project_link }}#client-security">Client Security</a>:{% endblocktrans %}</p>
 

--- a/src/sentry/web/frontend/docs.py
+++ b/src/sentry/web/frontend/docs.py
@@ -13,7 +13,7 @@ from sentry.constants import (MEMBER_OWNER, PLATFORM_LIST, PLATFORM_TITLES,
     PLATFORM_ROOTS)
 from sentry.models import ProjectKey
 from sentry.web.decorators import has_access
-from sentry.web.helpers import render_to_response, render_to_string
+from sentry.web.helpers import render_to_response, render_to_string, get_raven_js_url
 
 
 def can_see_global_keys(user, project):
@@ -52,6 +52,7 @@ def get_key_context(user, project):
         'key': key,
         'dsn': dsn,
         'dsn_public': dsn_public,
+        'raven_js_url': get_raven_js_url(),
     }
 
 

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -207,3 +207,7 @@ def plugin_config(plugin, project, request):
         'plugin': plugin,
         'plugin_description': plugin.get_description() or '',
     }, context_instance=RequestContext(request))))
+
+
+def get_raven_js_url():
+    return settings.RAVEN_JS_URL

--- a/tests/sentry/web/helpers/tests.py
+++ b/tests/sentry/web/helpers/tests.py
@@ -6,7 +6,7 @@ import mock
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
-from sentry.web.helpers import get_login_url, group_is_public
+from sentry.web.helpers import get_login_url, group_is_public, get_raven_js_url
 from sentry.testutils import TestCase
 
 
@@ -71,3 +71,13 @@ class GroupIsPublicTest(TestCase):
         self.group.is_public = True
         result = group_is_public(self.group, AnonymousUser())
         assert result is True
+
+
+class GetRavenJsUrl(TestCase):
+    def test_with_custom_raven_js_url(self):
+        url = 'my.cdn/1.0/raven.min.js'
+        with self.Settings(SENTRY_RAVEN_JS_URL=url):
+            self.assertEquals(get_raven_js_url(), url)
+
+    def test_with_default_raven_js_url(self):
+        self.assertEquals(get_raven_js_url(), 'd3nslu0hdya83q.cloudfront.net/dist/1.0/raven.min.js')


### PR DESCRIPTION
Hey,
we're using the raven_js file through our own CDN, and for that I've added a Setting that changes the location of this file and it shows on the 'Client configuration' page.

If you don't set anything it still uses the default.

```
RAVEN_JS_URL = 'my.cdn.com/dist/1.0/raven.min.js'
```
