### PR TITLE
Add option so gunicorn works with raven-js

### DIFF
--- a/src/sentry/conf/defaults.py
+++ b/src/sentry/conf/defaults.py
@@ -82,6 +82,7 @@ WEB_HOST = 'localhost'
 WEB_PORT = 9000
 WEB_OPTIONS = {
     'workers': 3,
+    'limit_request_line': 1024*16,
 }
 
 # UDP Service


### PR DESCRIPTION
Feel free to make the default bigger or smaller, but this seems sane-ish.
