### PR TITLE
update transifex url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,4 +35,4 @@ Resources
 * `Code <http://github.com/getsentry/sentry>`_
 * `Mailing List <https://groups.google.com/group/getsentry>`_
 * `IRC <irc://irc.freenode.net/sentry>`_  (irc.freenode.net, #sentry)
-* `Transifex <https://www.transifex.net/projects/p/sentry/>`_ (Translate Sentry!)
+* `Transifex <https://www.transifex.com/projects/p/sentry/>`_ (Translate Sentry!)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Reference
 Resources
 ---------
 
-* `Transifex <https://www.transifex.net/projects/p/sentry/>`_ (Translate Sentry!)
+* `Transifex <https://www.transifex.com/projects/p/sentry/>`_ (Translate Sentry!)
 * `Bug Tracker <http://github.com/getsentry/sentry/issues>`_
 * `Code <http://github.com/getsentry/sentry>`_
 * `Mailing List <https://groups.google.com/group/getsentry>`_


### PR DESCRIPTION
transifex.net's ssl cert has expired. according to transifex/transifex#226 .com is the one to use
