### PR TITLE
Fix example configuration such that it includes all needed apps; fix readme so it indicates how to set up

### DIFF
--- a/example/README.rst
+++ b/example/README.rst
@@ -4,15 +4,17 @@ To run this app you will need raven client installed::
 
     pip install raven
 
-Edit :file:`settings.py` and change `SENTRY_DSN` so that it matches your Sentry server.
+Edit :file:`settings.py` in your project and change `SENTRY_DSN` so that it matches your Sentry server.
 
 Then do::
 
-    python manage.py syncdb
+    python manage.py syncdb --all
+    python manage.py migrate --fake
     python manage.py runserver
 
 And visit these URLS:
 
+- http://localhost:8000/sentry/
 - http://localhost:8000/captureMessage/
 - http://localhost:8000/captureException/
 - http://localhost:8000/loggingError/

--- a/example/settings.py
+++ b/example/settings.py
@@ -128,6 +128,9 @@ INSTALLED_APPS = (
     # 'django.contrib.admindocs',
     'sentry',
     'raven.contrib.django',
+    'crispy_forms',
+    'static_compiler',
+    'south',
 )
 
 # DSN of your Sentry server
@@ -165,3 +168,5 @@ LOGGING = {
         },
     }
 }
+
+SOCIAL_AUTH_CREATE_USERS = False


### PR DESCRIPTION
The configuration included in sentry in the `example` folder does not work.

This patch fixes the issues relating to it:
- Missing some `INSTALLED_APPS` needed to give Sentry all the template tags it requires.
- Updates the README such that it indicates the use of South to run Sentry's migrations for initial database creation.
