### PR TITLE
Pretty format for list data values

### DIFF
--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -371,6 +371,10 @@ def github_button(user, repo):
 
 @register.inclusion_tag('sentry/partial/data_values.html')
 def render_values(value, threshold=5, collapse_to=3):
+    
+    if isinstance(value, list):
+        value = { "[%04d]" % (idx+1): val for idx, val in enumerate(value) }
+    
     is_dict = isinstance(value, dict)
     context = {
         'is_dict': is_dict,


### PR DESCRIPTION
Right now Additional Data section is pretty smart about displaying dictionaries, however lists are simply dumped as their string representations. This could be quite unreadable in case of complex / nested objects.

My patch simply converts a list into a dictionary keyed by formatted list index before rendering. This approach takes advantage of all the existing dictionary output machinery.
