### PR TITLE
Normalize styling of Create a New Project on Team Pages

### DIFF
--- a/src/sentry/templates/sentry/bases/team.html
+++ b/src/sentry/templates/sentry/bases/team.html
@@ -20,7 +20,7 @@
             <a href="{% url 'sentry-manage-access-groups' team.slug %}">{% trans "Access Groups" %}</a>
         </li>
         <li class="pull-right{% if SUBSECTION == 'new_project' %} active{% endif %}">
-            <a href="{% url 'sentry-new-project' team.slug %}">{% trans "Create a New Project" %}</a>
+            <a class="btn btn-primary" href="{% url 'sentry-new-project' team.slug %}">{% trans "Create a New Project" %}</a>
         </li>
     </ul>
 {% endblock %}


### PR DESCRIPTION
Create a New Project is a btn-primary everywhere else. Make it so on Team pages too.
