### PR TITLE
Add Rails 4 as an Ruby project option

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -114,6 +114,7 @@ PLATFORM_LIST = (
     'r',
     'ruby',
     'rails3',
+    'rails4',
     'sidekiq',
     'sinatra',
     'tornado',
@@ -121,6 +122,7 @@ PLATFORM_LIST = (
 
 PLATFORM_ROOTS = {
     'rails3': 'ruby',
+    'rails4': 'ruby',
     'sinatra': 'ruby',
     'sidekiq': 'ruby',
     'django': 'python',
@@ -136,6 +138,7 @@ PLATFORM_ROOTS = {
 
 PLATFORM_TITLES = {
     'rails3': 'Rails 3 (Ruby)',
+    'rails4': 'Rails 4 (Ruby)',
     'php': 'PHP',
     'ios': 'iOS',
     'express': 'Express (Node.js)',

--- a/src/sentry/templates/sentry/partial/_client_config.html
+++ b/src/sentry/templates/sentry/partial/_client_config.html
@@ -109,6 +109,12 @@
         </a>
     </li>
     <li>
+        <a href="{% url 'sentry-docs-client' project.team.slug project.slug 'rails4' %}">
+            <span><img src="{% url 'sentry-media' "sentry" "images/platforms/rails48x48.png" %}"></span>
+            <strong>Rails 4</strong>
+        </a>
+    </li>
+    <li>
         <a href="{% url 'sentry-docs-client' project.team.slug project.slug 'django' %}">
             <span><img src="{% url 'sentry-media' "sentry" "images/platforms/django48x48.png" %}"></span>
             <strong>Django</strong>

--- a/src/sentry/templates/sentry/partial/client_config/rails4.html
+++ b/src/sentry/templates/sentry/partial/client_config/rails4.html
@@ -1,0 +1,19 @@
+{% extends "sentry/partial/client_config/ruby_base.html" %}
+
+{% load i18n %}
+
+{% block inner %}
+  <p>{% trans "Add a <code>config/initializers/raven.rb</code> containing:" %}</p>
+
+  <pre>require 'raven'
+
+Raven.configure do |config|
+  config.dsn = '{% if dsn %}{{ dsn }}{% else %}<strong>SENTRY_DSN</strong>{% endif %}'
+end</pre>
+
+  <p>{% trans "That's it! Raven automatically installs an error handling hook to pipe all uncaught exceptions to Sentry." %}</p>
+
+  <p>{% trans "If you wish to test your connection to the server, you can use the raven test command:" %}</p>
+
+  <pre>rake raven:test</pre>
+{% endblock %}

--- a/src/sentry/templates/sentry/partial/client_config/ruby_base.html
+++ b/src/sentry/templates/sentry/partial/client_config/ruby_base.html
@@ -8,8 +8,9 @@
 <ul class="nav nav-tabs">
 	<li{% if platform == 'ruby' %} class="active"{% endif %}><a href="{% url 'sentry-docs-client' project.team.slug project.slug 'ruby' %}">Ruby</a></li>
 	<li{% if platform == 'rails3' %} class="active"{% endif %}><a href="{% url 'sentry-docs-client' project.team.slug project.slug 'rails3' %}">Rails 3</a></li>
-    <li{% if platform == 'sinatra' %} class="active"{% endif %}><a href="{% url 'sentry-docs-client' project.team.slug project.slug 'sinatra' %}">Sinatra</a></li>
-    <li{% if platform == 'sidekiq' %} class="active"{% endif %}><a href="{% url 'sentry-docs-client' project.team.slug project.slug 'sidekiq' %}">Sidekiq</a></li>
+  <li{% if platform == 'rails4' %} class="active"{% endif %}><a href="{% url 'sentry-docs-client' project.team.slug project.slug 'rails4' %}">Rails 4</a></li>
+  <li{% if platform == 'sinatra' %} class="active"{% endif %}><a href="{% url 'sentry-docs-client' project.team.slug project.slug 'sinatra' %}">Sinatra</a></li>
+  <li{% if platform == 'sidekiq' %} class="active"{% endif %}><a href="{% url 'sentry-docs-client' project.team.slug project.slug 'sidekiq' %}">Sidekiq</a></li>
 </ul>
 
 


### PR DESCRIPTION
With the release of Rails 4, making it available as a Ruby project option. The other option I could see is writing a migration to move projects from 'rails3' to a more generic 'rails'. I don't see there would be a functional difference with Sentry between Rails 3 and Rails 4, so feel free to punt this if necessary.
