### PR TITLE
Adding documentation in the contrib. section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ dev-mysql:
 	pip install -q "file://`pwd`#egg=sentry[mysql]" --use-mirrors
 	pip install -q -e . --use-mirrors
 
+dev-docs:
+	pip install -q -r docs/requirements.txt --use-mirrors
+
 build: locale
 
 clean:

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -5,6 +5,39 @@ Want to contribute back to Sentry? This page describes the general development f
 our philosophy, the test suite, and issue tracking.
 
 
+Documentation
+-------------
+
+If you're looking to help document Sentry, you can get set up with Sphinx, our documentation tool,
+but first you will want to make sure you have a few things on your local system:
+
+* python-dev (if you're on OS X, you already have this)
+* pip
+* virtualenvwrapper
+
+Once you've got all that, the rest is simple:
+
+::
+
+    # If you have a fork, you'll want to clone it instead
+    git clone git://github.com/getsentry/sentry.git
+
+    # Create a python virtualenv
+    mkvirtualenv sentry
+
+    # Make the magic happen
+    make dev-docs
+
+Running ``make dev-docs`` will install the basic requirements to get Sphinx running.
+
+
+Building Documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+Inside the ``docs`` directory, you can run ``make`` to build the documentation.  
+See ``make help`` for available options and the `Sphinx Documentation <http://sphinx-doc.org/contents.html>`_ for more information.
+
+
 Localization
 ------------
 
@@ -42,6 +75,10 @@ Running ``make`` will do several things, including:
 * Setting up any submodules (including Bootstrap)
 * Installing Python requirements
 * Installing NPM requirements
+
+.. note::
+    You will want to store your virtualenv out of the ``sentry`` directory you cloned above,
+    otherwise ``make`` will fail.
 
 Create a default Sentry configation just as if this were a production instance:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+Jinja2>=2.3
+Pygments>=1.2
+Sphinx==1.2b1
+docutils>=0.7
+markupsafe


### PR DESCRIPTION
Adding documentation in the contributing section on how to contribute documentation, as well as a warning about putting your virtualenv in the `sentry` directory.

`make` would fail when running `pip install` with errors like: http://dpaste.com/1272161/plain/
