### PR TITLE
You can't md5 a unicode

### DIFF
--- a/src/sentry/filters/base.py
+++ b/src/sentry/filters/base.py
@@ -61,7 +61,7 @@ class Filter(object):
         return '?' + query_dict.urlencode()
 
     def get_choices(self):
-        key = 'filters:%s:%s' % (self.project.id, hashlib.md5(self.column).hexdigest())
+        key = 'filters:%s:%s' % (self.project.id, hashlib.md5(self.column.encode('utf8')).hexdigest())
         result = cache.get(key)
         if result is None:
             result = list(TagValue.objects.filter(


### PR DESCRIPTION
Fixes https://app.getsentry.com/sentry/sentry/group/6511458/

``` python
>>> hashlib.md5(u'ü').hexdigest()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 0: ordinal not in range(128)
>>> hashlib.md5(u'ü'.encode('utf8')).hexdigest()
'c03410a5204b21cd8229ff754688d743'
```
