### PR TITLE
Calculate composite hash from all interfaces plus message

### DIFF
--- a/src/sentry/manager.py
+++ b/src/sentry/manager.py
@@ -54,15 +54,14 @@ LOG_LEVELS_DICT = dict(settings.LOG_LEVELS)
 
 
 def get_checksum_from_event(event):
-    interfaces = event.interfaces
-    for interface in interfaces.itervalues():
+    hash = hashlib.md5()
+    for interface in event.interfaces.itervalues():
         result = interface.get_composite_hash(interfaces=event.interfaces)
         if result:
-            hash = hashlib.md5()
             for r in result:
                 hash.update(to_string(r))
-            return hash.hexdigest()
-    return hashlib.md5(to_string(event.message)).hexdigest()
+    hash.update(to_string(event.message))
+    return hash.hexdigest()
 
 
 class BaseManager(models.Manager):


### PR DESCRIPTION
I made a patch to solve one of the problems noted here: https://github.com/getsentry/sentry/issues/889

The problem with the old behavior is that only one interface (or the message, if no interfaces have a hash) determines the hash of the event. That behavior is very dangerous because the order of interface iteration is not guaranteed and it is not always desirable to have any interface nullify the impact of the message on the hash.

For example we have a requirement where multiple loggers representing different customers could generate the same stacktrace (same interface hash) which we would nonetheless want to be grouped into different groups per customer (which are identified in the message contents).

The solution is trivial, make sure every interface along with the message contributes to the hash.

This has been tested & deployed internally, so should be safe to merge.
