### PR TITLE
Fix invalid URL in admin/projects/list.html.

### DIFF
--- a/src/sentry/templates/sentry/admin/projects/list.html
+++ b/src/sentry/templates/sentry/admin/projects/list.html
@@ -45,8 +45,12 @@
                     {% for project, avg_events in project_list.paginator.objects|with_event_counts %}
                         <tr>
                             <td>
-                                <a href="{% url 'sentry-manage-project' project.team.slug project.slug %}"><strong>{{ project.team.slug }}/{{ project.slug }}</strong></a>
-                                <a href="{% url 'sentry-stream' project.team.slug project.slug %}">[stream]</a><br/>
+                                {% if project.team %}
+                                    <a href="{% url 'sentry-manage-project' project.team.slug project.slug %}"><strong>{{ project.team.slug }}/{{ project.slug }}</strong></a>
+                                    <a href="{% url 'sentry-stream' project.team.slug project.slug %}">[stream]</a><br/>
+                                {% else %}
+                                    <strong>{{ project.slug }}</strong>
+                                {% endif %}
                                 {% if project.owner %}
                                     <small>Owned by <a href="{% url 'sentry-admin-edit-user' project.owner.pk %}">
                                         {% if project.owner.email %}


### PR DESCRIPTION
If the `project_list` contains a project that is not associated with a team (such as "Sentry (Internal)"), then URL generation for the _sentry-stream_ and _sentry-manage-project_ URLs breaks.  The "fix" is to not emit the URLs that we cannot possibly generate without a team slug.
