### PR TITLE
generalize the seemingly incorrect number of required packages

### DIFF
--- a/docs/buffer/index.rst
+++ b/docs/buffer/index.rst
@@ -32,7 +32,7 @@ The Redis Backend
 Configuring the Redis backend **requires the queue** or you won't see any gains (in fact you'll just negatively
 impact your performance).
 
-The first thing you will need to do is install two additional required packages:
+The first thing you will need to do is install a few additional required packages:
 
 ::
 


### PR DESCRIPTION
I didn't mean to alter the newline status of the last line, I just used github.com's editor and I guess it does this automatically?
