### PR TITLE
Reinstate count from emails.

### DIFF
--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -12,6 +12,7 @@
             {% trans "Regression" %}
         {% endif %}
     </small></h1>
+    <span class="count">{{ group.times_seen }}</span>
 {% endblock %}
 
 {% block inner %}


### PR DESCRIPTION
Any reason it was removed?  We found it incredibly useful.
