### PR TITLE
Fix a typo in java logback config documentation template.

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/java_logback.html
+++ b/src/sentry/templates/sentry/partial/client_config/java_logback.html
@@ -12,7 +12,7 @@
         &lt;/dsn&gt;
     &lt;/appender&gt;
 
-    &lt;root &lt;"error"&gt;
+    &lt;root level="error"&gt;
         &lt;appender-ref ref="Sentry"/&gt;
     &lt;/root&gt;
 &lt;/configuration&gt;</pre>


### PR DESCRIPTION
The original template renders to

``` html
<root <"error">
    <appender-ref ref="Sentry"/>
</root>
```

It should be

``` html
<root level="error">
    <appender-ref ref="Sentry"/>
</root>
```
