### PR TITLE
Disable serve static files in DEBUG

### DIFF
--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -46,7 +46,7 @@ def static_media(request, **kwargs):
     if module:
         path = '%s/%s' % (module, path)
 
-    return serve(request, path, insecure=True)
+    return serve(request, path)
 
 
 def missing_perm(request, perm, **kwargs):


### PR DESCRIPTION
From [staticfiles documentation](https://docs.djangoproject.com/en/1.5/ref/contrib/staticfiles/#django.contrib.staticfiles.views.serve):

> This view will only work if DEBUG is True.
> 
> That’s because this view is grossly inefficient and probably insecure. This is only intended for local development, and should never be used in production.
