### PR TITLE
Add a context line to the ruby frame

### DIFF
--- a/src/sentry/templates/sentry/partial/frames/ruby.txt
+++ b/src/sentry/templates/sentry/partial/frames/ruby.txt
@@ -1,3 +1,4 @@
 {% autoescape off %}
-  {{ filename }}{% if lineno %}:{{ lineno }}{% endif %}:in `{{ function }}'
+  {{ filename }}{% if lineno %}:{{ lineno }}{% endif %}:in `{{ function }}'{% if context_line %}
+    {{ context_line.strip }}{% endif %}
 {% endautoescape %}


### PR DESCRIPTION
I didn't notice that I had missed the context line.
