### PR TITLE
Fix filename formatting for java stack frames

### DIFF
--- a/src/sentry/templates/sentry/partial/frames/java.txt
+++ b/src/sentry/templates/sentry/partial/frames/java.txt
@@ -1,4 +1,4 @@
 {% load sentry_helpers %}{% autoescape off %}
-    at {% if filename %}{{ filename }}{% elif module %}{{ module }}{% else %}?{% endif %}{% if function %}.{{ function }}{% endif %}({% if filename %}{{ filename|basename }}{% endif %}{% if lineno != None %}:{{ lineno }}{% endif %}{% if context_line %}
+    at {% if filename %}{{ filename }}{% elif module %}{{ module }}{% else %}?{% endif %}{% if function %}.{{ function }}{% endif %}{% if filename %}({{ filename|basename }}{% if lineno != None %}:{{ lineno }}{% endif %}){% endif %}{% if context_line %}
     {{ context_line.strip }}{% endif %}
 {% endautoescape %}


### PR DESCRIPTION
Only shows the line number of the filename exists
