### PR TITLE
Don't include function if it doesn't exist

### DIFF
--- a/src/sentry/templates/sentry/partial/frames/ruby.txt
+++ b/src/sentry/templates/sentry/partial/frames/ruby.txt
@@ -1,4 +1,4 @@
 {% autoescape off %}
-  {{ filename }}{% if lineno %}:{{ lineno }}{% endif %}:in `{{ function }}'{% if context_line %}
+  {{ filename }}{% if lineno %}:{{ lineno }}{% endif %}:{% if function %}in `{{ function }}'{% endif %}{% if context_line %}
     {{ context_line.strip }}{% endif %}
 {% endautoescape %}


### PR DESCRIPTION
Only include the ruby function if it is present.
