### PR TITLE
Set environment variables after virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
   global:
     - PIP_DOWNLOAD_CACHE=".pip_download_cache"
     - WAD_FILES="package.json,Makefile,setup.py"
-    - WAD_ENVIRONMENT_VARIABLES="TRAVIS_PYTHON_VERSION,TRAVIS_NODE_VERSION"
-    - WAD_CACHE_PATH="node_modules,$PIP_DOWNLOAD_CACHE,$VIRTUAL_ENV"
     - WAD_INSTALL_COMMAND="make develop dev-postgres dev-mysql"
 
     # This should be specified with:
@@ -19,6 +17,12 @@ env:
     # - S3_BUCKET_NAME=
     # - S3_CREDENTIALS=
     - secure: pZ7DtkEu2q/pGINfVT9S+iPRE5ck6mBQmuHTQz3PVXF/UJmpM1LCbC7aqrw4GXWuUhYc50QCnMZJL1yoBORVEfY4nfXHLRc3HMoWE6Srqf0IBDywi6T+UUdLeOYe13EDb4p8WIpnRGlV4WI1WaPXuFlMEdj5tAjlC9ZotLxyVaI=
+
+# These need to be here and not in the env hash because they need to be
+# evaluated after the virtualenv has been setup
+before_install:
+  - export WAD_ENVIRONMENT_VARIABLES="TRAVIS_PYTHON_VERSION,TRAVIS_NODE_VERSION,WAD_CACHE_PATH"
+  - export WAD_CACHE_PATH="node_modules,$PIP_DOWNLOAD_CACHE,$VIRTUAL_ENV"
 
 install:
   - time script/wad


### PR DESCRIPTION
This ensures that the virtualenv variables are set before defining the ones we depend on.

Hopefully this will be the last fix. :)
