### PR TITLE
Added required apache modules to quick start guides.

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -229,6 +229,8 @@ Apache requires the use of mod_proxy for forwarding requests::
     ProxyPreserveHost On
     RequestHeader set X-Forwarded-Proto "https" env=HTTPS
 
+You will need to enable ``headers``, ``proxy``, and ``proxy_http`` apache modules to use these settings.
+
 Proxying with Nginx
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I had some difficulties to setup apache reverse proxy, so updated the quickstart guide and added extra needed modules (mod_headers, mod_proxy and mod_proxy_http). 
