### PR TITLE
Add word-break:break-all to error result anchors to prevent long URLs from flowing into sidebar.

### DIFF
--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -500,10 +500,12 @@ h3 {
     padding: 25px 30px 10px;
     min-width: 786px;
 
+    a {
+      word-break: break-all;
+    }
     .select2-drop {
       .box-shadow(0 0 0 2px #c3c8ce);
     }
-
     .select2-container {
       margin-left: 2px;
     }

--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -809,7 +809,7 @@ a.icon-share {
 .progressbar {
   position: relative;
   border: 1px solid lighten(@linkColor, 30%);
-  height: 1.5em;
+  min-height: 1.5em;
   line-height: 1.5em;
 
   > a,
@@ -824,6 +824,10 @@ a.icon-share {
 
   > a {
     left: 5px;
+    position: relative;
+    z-index: 1;
+    padding-right: 60px;
+    display: block;
 
     span {
       position: absolute;
@@ -834,6 +838,7 @@ a.icon-share {
   > div {
     background-color: lighten(@linkColor, 40%);
     text-indent: -100000em;
+    z-index: 0;
   }
 }
 

--- a/src/sentry/static/sentry/styles/global.min.css
+++ b/src/sentry/static/sentry/styles/global.min.css
@@ -6994,6 +6994,9 @@ h3 {
   padding: 25px 30px 10px;
   min-width: 786px;
 }
+#content section.body a {
+  word-break: break-all;
+}
 #content section.body .select2-drop {
   -webkit-box-shadow: 0 0 0 2px #c3c8ce;
   -moz-box-shadow: 0 0 0 2px #c3c8ce;

--- a/src/sentry/static/sentry/styles/global.min.css
+++ b/src/sentry/static/sentry/styles/global.min.css
@@ -7333,7 +7333,7 @@ a.icon-share:hover {
 .progressbar {
   position: relative;
   border: 1px solid #c7def5;
-  height: 1.5em;
+  min-height: 1.5em;
   line-height: 1.5em;
 }
 .progressbar > a,
@@ -7347,6 +7347,10 @@ a.icon-share:hover {
 }
 .progressbar > a {
   left: 5px;
+  position: relative;
+  z-index: 1;
+  padding-right: 60px;
+  display: block;
 }
 .progressbar > a span {
   position: absolute;
@@ -7355,6 +7359,7 @@ a.icon-share:hover {
 .progressbar > div {
   background-color: #f2f8fd;
   text-indent: -100000em;
+  z-index: 0;
 }
 .sparkline {
   position: relative;


### PR DESCRIPTION
When a URL is too long it throws off the page's formatting, like so:

![overflow](http://i.imgur.com/EfZuKxU.png)
