### PR TITLE
Fix stream polling casting of cursor as date string on sqlite to fix bug originally reported in #961

### DIFF
--- a/src/sentry/static/sentry/scripts/views.js
+++ b/src/sentry/static/sentry/scripts/views.js
@@ -475,6 +475,8 @@
 
             data = app.utils.getQueryParams();
             data.cursor = this.cursor || undefined;
+            // Fix sqlite bug where cursor comes down as a date string.
+            if (typeof data.cursor === "string") data.cursor = new Date(data.cursor).valueOf();
 
             $.ajax({
                 url: this.options.pollUrl,


### PR DESCRIPTION
While it seems that the right fix would be replacing: 

``` python
SQLITE_SORT_CLAUSES.update({
    'date': 'sentry_groupedmessage.last_seen',
    'new': 'sentry_groupedmessage.first_seen',
})
```

with 

``` python
SQLITE_SORT_CLAUSES.update({
    'date': "strftime('%s', sentry_groupedmessage.last_seen)",
    'new': "strftime('%s', sentry_groupedmessage.first_seen)",
})
```

, that throws a mysterious error I can't seem to trace back. What's up with error reporting? I get a stack, but no root cause. 

So this works around it by parsing the date string as an integer in the javascript when the poll occurs.
