### PR TITLE
Switch to using nameservers closer to build servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,13 @@ env:
     # - S3_CREDENTIALS=
     - secure: pZ7DtkEu2q/pGINfVT9S+iPRE5ck6mBQmuHTQz3PVXF/UJmpM1LCbC7aqrw4GXWuUhYc50QCnMZJL1yoBORVEfY4nfXHLRc3HMoWE6Srqf0IBDywi6T+UUdLeOYe13EDb4p8WIpnRGlV4WI1WaPXuFlMEdj5tAjlC9ZotLxyVaI=
 
-# These need to be here and not in the env hash because they need to be
-# evaluated after the virtualenv has been setup
 before_install:
+  # Use closer nameservers
+  - printf "nameserver 199.91.168.70\nnameserver 199.91.168.71\n" | sudo tee /etc/resolv.conf
+
+  # These need to be here and not in the env hash because they need to be
+  # evaluated after the virtualenv has been setup
+  - mkdir -p $PIP_DOWNLOAD_CACHE
   - export WAD_ENVIRONMENT_VARIABLES="TRAVIS_PYTHON_VERSION,TRAVIS_NODE_VERSION,WAD_CACHE_PATH"
   - export WAD_CACHE_PATH="node_modules,$PIP_DOWNLOAD_CACHE,$VIRTUAL_ENV"
 

--- a/script/wad
+++ b/script/wad
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Generated on: 15-09-2013 at 01:09
+# Generated on: 20-09-2013 at 12:38
 
 require 'time'
 require 'net/http'
@@ -10,7 +10,7 @@ require 'digest/sha1'
 require 'fileutils'
 require 'openssl'
 require 'base64'
-
+require 'cgi'
 class Presss
   # Computes the Authorization header for a AWS request based on a message,
   # the access key ID and secret access key.
@@ -102,13 +102,13 @@ class Presss
       canonical_path = canonicalized_resource(path)
       signature      = [ verb.to_s.upcase, nil, nil, expires, [ headers, canonical_path ].flatten.compact ].flatten.join("\n")
       signed         = authorization.sign(signature)
-      "#{url_prefix}#{path}?Signature=#{signed}&Expires=#{expires}&AWSAccessKeyId=#{authorization.access_key_id}"
+      "#{url_prefix}#{path}?Signature=#{CGI.escape(signed)}&Expires=#{expires}&AWSAccessKeyId=#{CGI.escape(authorization.access_key_id)}"
     end
 
     def download(path, destination)
       url = signed_url(:get, Time.now.to_i + 600, nil, path)
       Presss.log "signed_url=#{url}"
-      system 'curl', '-f', '-o', destination, url
+      system 'curl', '-f', '-S', '-o', destination, url
       $?.success?
     end
 
@@ -118,7 +118,7 @@ class Presss
       header = 'x-amz-storage-class:REDUCED_REDUNDANCY'
       url = signed_url(:put, Time.now.to_i + 600, header, path)
       Presss.log "signed_url=#{url}"
-      system 'curl', '-f', '-H', header, '-T', file, url
+      system 'curl', '-f', '-S', '-H', header, '-T', file, url
       $?.success?
     end
   end


### PR DESCRIPTION
This causes closer S3 hosts to be used.

It also fixes a bug in how the signature is generated for downloading files.
