### PR TITLE
Add a couple new source map features

### DIFF
--- a/src/sentry/tasks/fetch_source.py
+++ b/src/sentry/tasks/fetch_source.py
@@ -261,14 +261,18 @@ def expand_javascript_source(data, **kwargs):
             continue
 
         sourcemap = discover_sourcemap(result)
+
+        # TODO: we're currently running splitlines twice
+        if not sourcemap:
+            source_code[filename] = (result.body.splitlines(), None)
+            continue
+        else:
+            logger.debug('Found sourcemap %r for minified script %r', sourcemap[:256], result.url)
+
         sourcemap_key = hashlib.md5(sourcemap).hexdigest()
         source_code[filename] = (result.body.splitlines(), sourcemap_key)
 
-        # TODO: we're currently running splitlines twice
-        if sourcemap:
-            logger.debug('Found sourcemap %r for minified script %r', sourcemap, result.url)
-
-        if sourcemap in sourmap_idxs or not sourcemap:
+        if sourcemap in sourmap_idxs:
             continue
 
         # pull down sourcemap

--- a/src/sentry/tasks/fetch_source.py
+++ b/src/sentry/tasks/fetch_source.py
@@ -28,6 +28,7 @@ BAD_SOURCE = -1
 LINES_OF_CONTEXT = 5
 CHARSET_RE = re.compile(r'charset=(\S+)')
 DEFAULT_ENCODING = 'utf-8'
+BASE64_SOURCEMAP_PREAMBLE = 'data:application/json;base64,'
 
 UrlResult = namedtuple('UrlResult', ['url', 'headers', 'body'])
 
@@ -162,8 +163,8 @@ def fetch_url(url):
 
 
 def fetch_sourcemap(url):
-    if url.startswith('data:application/json;base64,'):
-        body = base64.b64decode(url[29:])
+    if url.startswith(BASE64_SOURCEMAP_PREAMBLE):
+        body = base64.b64decode(url[len(BASE64_SOURCEMAP_PREAMBLE):])
     else:
         result = fetch_url(url)
         if result == BAD_SOURCE:

--- a/src/sentry/utils/sourcemaps.py
+++ b/src/sentry/utils/sourcemaps.py
@@ -61,9 +61,8 @@ def parse_vlq(segment):
 
 def parse_sourcemap(smap):
     """
-    Given a file-like object, yield SourceMap objects as they are read from it.
+    Given a sourcemap json object, yield SourceMap objects as they are read from it.
     """
-
     sources = smap['sources']
     sourceRoot = smap.get('sourceRoot')
     names = smap['names']
@@ -114,7 +113,7 @@ def sourcemap_to_index(sourcemap):
     src_list = set()
     content = None
 
-    if(smap['sourcesContent']):
+    if 'sourcesContent' in smap:
         content = {}
         for idx, source in enumerate(smap['sources']):
             if smap['sourcesContent'][idx]:

--- a/src/sentry/utils/sourcemaps.py
+++ b/src/sentry/utils/sourcemaps.py
@@ -17,7 +17,7 @@ from sentry.utils import json
 
 
 SourceMap = namedtuple('SourceMap', ['dst_line', 'dst_col', 'src', 'src_line', 'src_col', 'name'])
-SourceMapIndex = namedtuple('SourceMapIndex', ['states', 'keys', 'sources'])
+SourceMapIndex = namedtuple('SourceMapIndex', ['states', 'keys', 'sources', 'content'])
 
 # Mapping of base64 letter -> integer value.
 B64 = dict(
@@ -59,12 +59,11 @@ def parse_vlq(segment):
     return values
 
 
-def parse_sourcemap(sourcemap):
+def parse_sourcemap(smap):
     """
     Given a file-like object, yield SourceMap objects as they are read from it.
     """
 
-    smap = json.loads(sourcemap)
     sources = smap['sources']
     sourceRoot = smap.get('sourceRoot')
     names = smap['names']
@@ -108,16 +107,27 @@ def parse_sourcemap(sourcemap):
 
 
 def sourcemap_to_index(sourcemap):
+    smap = json.loads(sourcemap)
+
     state_list = []
     key_list = []
     src_list = set()
+    content = None
 
-    for state in parse_sourcemap(sourcemap):
+    if(smap['sourcesContent']):
+        content = {}
+        for idx, source in enumerate(smap['sources']):
+            if smap['sourcesContent'][idx]:
+                content[source] = smap['sourcesContent'][idx].splitlines()
+            else:
+                content[source] = []
+
+    for state in parse_sourcemap(smap):
         state_list.append(state)
         key_list.append((state.dst_line, state.dst_col))
         src_list.add(state.src)
 
-    return SourceMapIndex(state_list, key_list, src_list)
+    return SourceMapIndex(state_list, key_list, src_list, content)
 
 
 def find_source(indexed_sourcemap, lineno, colno):

--- a/tests/sentry/tasks/fetch_source/tests.py
+++ b/tests/sentry/tasks/fetch_source/tests.py
@@ -3,9 +3,10 @@
 from __future__ import absolute_import
 
 import mock
+import base64
 
 from sentry.tasks.fetch_source import (
-    UrlResult, expand_javascript_source, discover_sourcemap)
+    UrlResult, expand_javascript_source, discover_sourcemap, fetch_sourcemap)
 from sentry.testutils import TestCase
 
 
@@ -82,3 +83,12 @@ class ExpandJavascriptSourceTest(TestCase):
         assert frame['pre_context'] == []
         assert frame['context_line'] == 'h'
         assert frame['post_context'] == ['e', 'l', 'l', 'o', ' ']
+
+
+class FetchBase64SourcemapTest(TestCase):
+    @mock.patch('sentry.utils.sourcemaps.sourcemap_to_index')
+    def test_simple(self, sourcemap_to_index):
+        sourcemap_to_index.return_value = None
+        url = 'data:application/json;base64,' + base64.b64encode('hello, World!')
+        fetch_sourcemap(url)
+        sourcemap_to_index.assert_called_once_with('hello, World!')

--- a/tests/sentry/tasks/fetch_source/tests.py
+++ b/tests/sentry/tasks/fetch_source/tests.py
@@ -45,7 +45,8 @@ class ExpandJavascriptSourceTest(TestCase):
     @mock.patch('sentry.models.Event.update')
     @mock.patch('sentry.tasks.fetch_source.fetch_url')
     @mock.patch('sentry.tasks.fetch_source.fetch_sourcemap')
-    def test_simple(self, fetch_sourcemap, fetch_url, update):
+    @mock.patch('sentry.tasks.fetch_source.discover_sourcemap')
+    def test_simple(self, discover_sourcemap, fetch_sourcemap, fetch_url, update):
         data = {
             'sentry.interfaces.Exception': {
                 'values': [{
@@ -68,6 +69,7 @@ class ExpandJavascriptSourceTest(TestCase):
                 }],
             }
         }
+        discover_sourcemap.return_value = None
         fetch_sourcemap.return_value = None
         fetch_url.return_value.body = '\n'.join('hello world')
 

--- a/tests/sentry/utils/sourcemaps/tests.py
+++ b/tests/sentry/utils/sourcemaps/tests.py
@@ -6,6 +6,8 @@ from sentry.utils.sourcemaps import (SourceMap, parse_vlq, parse_sourcemap, sour
     find_source)
 from sentry.testutils import TestCase
 
+from sentry.utils import json
+
 
 sourcemap = """{"version":3,"file":"file.min.js","sources":["file1.js","file2.js"],"names":["add","a","b","multiply","divide","c","e","Raven","captureException"],"mappings":"AAAA,QAASA,KAAIC,EAAGC,GACf,YACA,OAAOD,GAAIC,ECFZ,QAASC,UAASF,EAAGC,GACpB,YACA,OAAOD,GAAIC,EAEZ,QAASE,QAAOH,EAAGC,GAClB,YACA,KACC,MAAOC,UAASH,IAAIC,EAAGC,GAAID,EAAGC,GAAKG,EAClC,MAAOC,GACRC,MAAMC,iBAAiBF"}"""
 
@@ -30,7 +32,8 @@ class FindSourceTest(TestCase):
 
 class ParseSourcemapTest(TestCase):
     def test_basic(self):
-        states = list(parse_sourcemap(sourcemap))
+        smap = json.loads(sourcemap)
+        states = list(parse_sourcemap(smap))
 
         assert states == [
             SourceMap(dst_line=0, dst_col=0, src='file1.js', src_line=0, src_col=0, name=None),


### PR DESCRIPTION
This adds 2 sourcemaps features that will allow Sentry to work with the source maps generated by browserify:
1. Loading data URI source maps.  The allows you to include your source map as a base64 data uri inside you generated source to avoid having to have a publicly available source map in a seperate file: mdn.io/data-URIs
2. Parsing inlined source content.  The v3 spec for source maps adds the `sourcesContent` field, which can contain an array of strings which contain the contents of the original source files in the sources field. see line 6 of https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#heading=h.qz3o9nc69um5

I have not been able to run the test on my machine, so this PR is still a work in progress, and I am submitting it more to start the feedback process than as a final product.
