### PR TITLE
Updated setup.py: http to https for getsentry website's url.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
     version='6.3.2',
     author='David Cramer',
     author_email='dcramer@gmail.com',
-    url='http://www.getsentry.com',
+    url='https://www.getsentry.com',
     description='A realtime logging and aggregation server.',
     long_description=open('README.rst').read(),
     package_dir={'': 'src'},


### PR DESCRIPTION
SSL since #903.
