### PR TITLE
Add limit_request_line to the config template.

### DIFF
--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -115,6 +115,7 @@ SENTRY_WEB_HOST = '0.0.0.0'
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
     'workers': 3,  # the number of gunicorn workers
+    'limit_request_line': 0,  # required for raven-js
     'secure_scheme_headers': {'X-FORWARDED-PROTO': 'https'},
 }
 


### PR DESCRIPTION
This is needed because SENTRY_WEB_OPTIONS from sentry/conf/server.py
gets clobbered by the config generated here.

See #874 for the original issue this solves.
