### PR TITLE
Update Nginx quickstart guide

### DIFF
--- a/docs/quickstart/nginx.rst
+++ b/docs/quickstart/nginx.rst
@@ -24,8 +24,8 @@ limits:
         proxy_set_header   Host                 $host;
         proxy_set_header   X-Real-IP            $remote_addr;
         proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto    $http_x_forwarded_proto;
-        proxy_redirect    off;
+        proxy_set_header   X-Forwarded-Proto    $scheme;
+        proxy_redirect     off;
 
         location / {
           proxy_pass        http://localhost:9000;


### PR DESCRIPTION
As referenced in the main quickstart guide, the proxy header `X-Forwarded-Proto` needs to be set to `$scheme`, not
`$http_x_forwarded_proto`
