### PR TITLE
Pass $http_host as Host header in sample nginx config.

### DIFF
--- a/docs/quickstart/nginx.rst
+++ b/docs/quickstart/nginx.rst
@@ -21,7 +21,7 @@ limits:
       server {
         listen   80;
 
-        proxy_set_header   Host                 $host;
+        proxy_set_header   Host                 $http_host;
         proxy_set_header   X-Real-IP            $remote_addr;
         proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto    $scheme;


### PR DESCRIPTION
$http_host includes the port that the server is running on.  $host does not.

If your server is listening on 8080, Sentry generates redirects like "http://<server>/path/to/thing" if you pass Host = $http.  Passing Host = $http_server causes Sentry to generate correct redirects, including the port if necessary.
