### PR TITLE
fix: alert mail display invalid url (subpath in the SENTRY_URL_PREFIX was dropped)

### DIFF
--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -14,7 +14,7 @@ from django.conf import settings
 def absolute_uri(url=None):
     if not url:
         return settings.SENTRY_URL_PREFIX
-    return urljoin(settings.SENTRY_URL_PREFIX, url)
+    return urljoin(settings.SENTRY_URL_PREFIX, url.lstrip('/'))
 
 
 def safe_urlencode(params, doseq=0):

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -14,7 +14,7 @@ from django.conf import settings
 def absolute_uri(url=None):
     if not url:
         return settings.SENTRY_URL_PREFIX
-    return urljoin(settings.SENTRY_URL_PREFIX, url.lstrip('/'))
+    return urljoin(settings.SENTRY_URL_PREFIX.rstrip('/') + '/', url.lstrip('/'))
 
 
 def safe_urlencode(params, doseq=0):


### PR DESCRIPTION
for example::

```
>>> settings.SENTRY_URL_PREFIX='http://example.com/sentry'
>>> url='/team/project/1/'  #generated by django.core.urlresolvers.reverse
>>> urljoin(settings.SENTRY_URL_PREFIX, url)
'http://example.com/team/project/1/'
```
