### PR TITLE
Fix tag_name variable ref in per-group tag list

### DIFF
--- a/src/sentry/templates/sentry/plugins/bases/tag/index.html
+++ b/src/sentry/templates/sentry/plugins/bases/tag/index.html
@@ -27,7 +27,7 @@
             <tbody>
                 {% for tag_value, times_seen, first_seen, last_seen in tag_list.objects %}
                     <tr>
-                        <td><a href="{% url 'sentry-stream' group.team.slug group.project.slug %}?{{ tag }}={{ tag_value }}">{{ tag_value }}</a></td>
+                        <td><a href="{% url 'sentry-stream' group.team.slug group.project.slug %}?{{ tag_name }}={{ tag_value }}">{{ tag_value }}</a></td>
                         <td style="text-align:center">{{ times_seen|small_count }}</td>
                         <td style="text-align:center">{% if first_seen %}{{ first_seen|timesince }}{% else %}<em>n/a</em>{% endif %}</td>
                         <td style="text-align:center">{% if last_seen %}{{ last_seen|timesince }}{% else %}<em>n/a</em>{% endif %}</td>


### PR DESCRIPTION
Calling code is in groups.group_tag_details.
