### PR TITLE
Custom AuthenticationForm to override the username label

### DIFF
--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from django import forms
 from django.contrib.auth import authenticate
+from django.contrib.auth.forms import AuthenticationForm as AuthenticationForm_
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.constants import EMPTY_PASSWORD_VALUES, LANGUAGES
@@ -31,6 +32,11 @@ def _get_timezone_choices():
     return results
 
 TIMEZONE_CHOICES = _get_timezone_choices()
+
+
+class AuthenticationForm(AuthenticationForm_):
+    username = forms.CharField(
+        label=_('Username or email'), max_length=128)
 
 
 class RegistrationForm(forms.ModelForm):

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -24,7 +24,7 @@ from sentry.web.decorators import login_required
 from sentry.web.forms.accounts import (
     AccountSettingsForm, NotificationSettingsForm, AppearanceSettingsForm,
     RegistrationForm, RecoverPasswordForm, ChangePasswordRecoverForm,
-    ProjectEmailOptionsForm)
+    ProjectEmailOptionsForm, AuthenticationForm)
 from sentry.web.helpers import render_to_response
 from sentry.utils.auth import get_auth_providers
 from sentry.utils.safe import safe_execute
@@ -34,7 +34,6 @@ from sentry.utils.safe import safe_execute
 @never_cache
 def login(request):
     from django.conf import settings
-    from django.contrib.auth.forms import AuthenticationForm
 
     if request.user.is_authenticated():
         return login_redirect(request)


### PR DESCRIPTION
Hopefully this helps avoid some confusion since we accept both username and email address for logging in.
