### PR TITLE
Fixes blank link in members page

### DIFF
--- a/src/sentry/templates/sentry/teams/members/index.html
+++ b/src/sentry/templates/sentry/teams/members/index.html
@@ -8,7 +8,7 @@
 
 {% block sidebar %}
     <h6>{% trans "About Memberships" %}</h6>
-    {% url 'sentry-manage-team-access-groups' team.slug as link %}
+    {% url 'sentry-manage-access-groups' team.slug as link %}
     <p>{% blocktrans %}This page lists team-wide memberships whom have access to all projects owned by this team. If you wish to add memberships bound to individual projects, you can do so with <a href="{{ link }}">Access Groups</a>.{% endblocktrans %}</p>
 {% endblock %}
 


### PR DESCRIPTION
I found that clicking in "Access groups" link simply reload the page. This is caused by its link, that is blank, caused by the fact that the name of the view is incorrect when compared to the correct page in urls.py file.

This commit fixes that problem. =)
