### PR TITLE
Remove unused project attribute

### DIFF
--- a/docs/developer/client/index.rst
+++ b/docs/developer/client/index.rst
@@ -404,7 +404,6 @@ The request body should then somewhat resemble the following::
         sentry_secret=b7d80b520139450f903720eb7991bf3d
 
     {
-        "project": "project-id",
         "event_id": "fc6d8c0c43fc4630ad850ee518f1b9d0",
         "culprit": "my.module.function_name",
         "timestamp": "2011-05-02T17:41:36",


### PR DESCRIPTION
In client dev docs, an example shows a `"project"` attribute in the
JSON packet.

There's no mention of it anywhere else, and everything works
brilliantly without it, so I figured it's probably worth nuking.
