### PR TITLE
The right scheme for ZMQ transport is `zmq+tcp`

### DIFF
--- a/docs/developer/client/index.rst
+++ b/docs/developer/client/index.rst
@@ -141,7 +141,7 @@ transports are available on top of HTTP:
 
 * ``gevent+http``
 * ``threaded+http``
-* ``zmq+http``
+* ``zmq+tcp``
 
 Building the JSON Packet
 ------------------------


### PR DESCRIPTION
The scheme name is written in `raven-python` is `zmq+tcp`
https://github.com/getsentry/raven-python/blob/master/raven/contrib/transports/zeromq/raven_zmq.py

Also, please update the docs and add something like "not tested" to ZMQ transport, if it isn't really tested and supported.
