### PR TITLE
Updated docs for node.js: no need in NODE_ENV

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/node.js.html
+++ b/src/sentry/templates/sentry/partial/client_config/node.js.html
@@ -18,10 +18,6 @@ var client = new raven.Client('{% if dsn %}{{ dsn }}{% else %}<strong>SENTRY_DSN
 
 	<pre>client.patchGlobal();</pre>
 
-	<p>{% trans "Ensure Node is run with <code>NODE_ENV=production</code>:" %}</p>
-
-	<pre>NODE_ENV=production node script.js</pre>
-
 	<p>{% trans "Now call out to the raven client to capture events:" %}</p>
 
 	<pre>// {% trans "record a simple message" %}


### PR DESCRIPTION
raven-node documentation (https://github.com/mattrobenolt/raven-node) now says:

> We don't infer this from NODE_ENV automatically anymore. It's up to you to implement whatever logic you'd like.

Therefore sentry docs do not need to mention NODE_ENV configuration anymore.
