### PR TITLE
Updated docs for Connect: no need in NODE_ENV

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/connect.html
+++ b/src/sentry/templates/sentry/partial/client_config/connect.html
@@ -17,10 +17,6 @@
   raven.middleware.connect('{% if dsn %}{{ dsn }}{% else %}<strong>SENTRY_DSN</strong>{% endif %}'),
 ).listen(3000);</pre>
 
-	<p>{% trans "Ensure Node is run with <code>NODE_ENV=production</code>:" %}</p>
-
-	<pre>NODE_ENV=production node script.js</pre>
-
 	<p>{% trans "That's it! Raven automatically installs an error handling hook to pipe all uncaught exceptions to Sentry." %}</p>
 
 	<p>{% blocktrans with 'https://github.com/mattrobenolt/raven-node' as link %}For more information on other uses of Raven with Node.js, please see the <a href="{{ link }}">official documentation for raven-node</a>.{% endblocktrans %}</p>


### PR DESCRIPTION
raven-node documentation (https://github.com/mattrobenolt/raven-node) now says:

> We don't infer this from NODE_ENV automatically anymore. It's up to you to implement whatever logic you'd like.

Therefore sentry docs do not need to mention NODE_ENV configuration anymore.
