### PR TITLE
Updated docs for Express: no need in NODE_ENV

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/express.html
+++ b/src/sentry/templates/sentry/partial/client_config/express.html
@@ -12,11 +12,7 @@
 
 	<pre>var app = require('express').createServer();
 
-app.error(raven.middleware.express('{% if dsn %}{{ dsn }}{% else %}<strong>SENTRY_DSN</strong>{% endif %}'));</pre>
-
-	<p>{% trans "Ensure Node is run with <code>NODE_ENV=production</code>:" %}</p>
-
-	<pre>NODE_ENV=production node script.js</pre>
+app.use(raven.middleware.express('{% if dsn %}{{ dsn }}{% else %}<strong>SENTRY_DSN</strong>{% endif %}'));</pre>
 
 	<p>{% trans "That's it! Raven automatically installs an error handling hook to pipe all uncaught exceptions to Sentry." %}</p>
 


### PR DESCRIPTION
raven-node documentation (https://github.com/mattrobenolt/raven-node) now says:

> We don't infer this from NODE_ENV automatically anymore. It's up to you to implement whatever logic you'd like.

Therefore sentry docs do not need to mention NODE_ENV configuration anymore.

Also `app.error` doesn't seem to work now, it should be `app.use`.
