### PR TITLE
Do not remove non-slash first character of module

### DIFF
--- a/src/sentry/tasks/fetch_source.py
+++ b/src/sentry/tasks/fetch_source.py
@@ -31,7 +31,7 @@ CHARSET_RE = re.compile(r'charset=(\S+)')
 DEFAULT_ENCODING = 'utf-8'
 BASE64_SOURCEMAP_PREAMBLE = 'data:application/json;base64,'
 BASE64_PREAMBLE_LENGTH = len(BASE64_SOURCEMAP_PREAMBLE)
-CLEAN_MODULE_RE = re.compile(r"""^(?:(?:
+CLEAN_MODULE_RE = re.compile(r"""^(?:/|(?:
     (?:java)?scripts?|js|build|static|[_\.].*?|  # common folder prefixes
     v?(?:\d+\.)*\d+|   # version numbers, v1, 1.0.0
     [a-f0-9]{7,8}|     # short sha
@@ -380,7 +380,7 @@ def generate_module(src):
 
     e.g. http://google.com/js/v1.0/foo/bar/baz.js -> foo/bar/baz
     """
-    return CLEAN_MODULE_RE.sub('', splitext(urlsplit(src).path[1:])[0])
+    return CLEAN_MODULE_RE.sub('', splitext(urlsplit(src).path)[0])
 
 
 def generate_culprit(frame):


### PR DESCRIPTION
The removal of initial slash in the path was error-prone and always removed first character from the string, even if it's not a slash. I replaced that with a small improvement to the cleaning regex.

Fixes #1106
