### PR TITLE
generate module for files without source maps

### DIFF
--- a/src/sentry/tasks/fetch_source.py
+++ b/src/sentry/tasks/fetch_source.py
@@ -273,6 +273,9 @@ def expand_javascript_source(data, **kwargs):
         # TODO: we're currently running splitlines twice
         if not sourcemap:
             source_code[filename] = (result.body.splitlines(), None)
+            for f in frames:
+                if f.abs_path == filename:
+                    f.module = generate_module(filename)
             continue
         else:
             logger.debug('Found sourcemap %r for minified script %r', sourcemap[:256], result.url)


### PR DESCRIPTION
When javascript files are loaded in the browser directly without concatenation and source maps, the displayed module name is the full URL of the script. This commit fixes it and generates a proper module name for such files as well.

Fixes #1108
