### PR TITLE
'//' for javascript comments (not '#') :)

### DIFF
--- a/src/sentry/templates/sentry/partial/client_config/javascript.html
+++ b/src/sentry/templates/sentry/partial/client_config/javascript.html
@@ -14,7 +14,7 @@
 
 <pre>&lt;script&gt;
 Raven.config('{% if dsn_public %}{{ dsn_public }}{% else %}<strong>SENTRY_DSN</strong>{% endif %}', {
-    # we highly recommend restricting exceptions to a domain in order to filter out clutter
+    // we highly recommend restricting exceptions to a domain in order to filter out clutter
     whitelistUrls: ['example.com/scripts/']
 }).install();
 &lt;/script&gt;</pre>


### PR DESCRIPTION
The example-code in "Configuring Javascript" uses '#' as a comment. Not very critical, but would have saved me a minute of head-scratching :). 
