### PR TITLE
Fixing a warning: HttpRequest.raw_post_data has been deprecated

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -284,7 +284,7 @@ class StoreView(APIView):
 
     """
     def post(self, request, project, auth, **kwargs):
-        data = request.raw_post_data
+        data = request.body
         response_or_event_id = self.process(request, project, auth, data, **kwargs)
         if isinstance(response_or_event_id, HttpResponse):
             return response_or_event_id


### PR DESCRIPTION
django/http/request.py:193: DeprecationWarning: HttpRequest.raw_post_data has been deprecated. Use HttpRequest.body instead.
  warnings.warn('HttpRequest.raw_post_data has been deprecated. Use HttpRequest.body instead.', DeprecationWarning)
