### PR TITLE
Allow setting config path in configure call

### DIFF
--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -317,9 +317,10 @@ def skip_migration_if_applied(settings, app_name, table_name,
         skip_if_table_exists(migration.forwards), migration)
 
 
-def configure():
+def configure(config_path=None):
     configure_app(
         project='sentry',
+        config_path=config_path,
         default_config_path='~/.sentry/sentry.conf.py',
         default_settings='sentry.conf.server',
         settings_initializer=generate_settings,


### PR DESCRIPTION
This way when configuring programmatically (like in the example [here](http://sentry.readthedocs.org/en/latest/faq/index.html#how-do-i)):

``` python
from sentry.utils.runner import configure
configure()
```

You can set the config file path:

``` python
from sentry.utils.runner import configure
configure('path/to/config')
```
