### PR TITLE
Fix documentation syntax error and two warnings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -673,7 +673,7 @@ Version 2.3.0
 Version 2.2.5
 -------------
 
-* The |date filter now forces things to UTC (it assumes local time).
+* The \|date filter now forces things to UTC (it assumes local time).
 * Event templates have been updated to resemble groups.
 
 Version 2.2.4

--- a/docs/developer/client/index.rst
+++ b/docs/developer/client/index.rst
@@ -543,7 +543,7 @@ The client should send the following upstream for ``tags``::
 
 You should also provide relevant contextual interfaces. These should last for the lifecycle of a request, and the general interface is "bind some kind of context", and then at the end of a request lifecycle, clear any present context.
 
-This interface consists of *_context methods, as well as a "clear context" method. The following is an example API which is implemented in most clients:
+This interface consists of \*_context methods, as well as a "clear context" method. The following is an example API which is implemented in most clients:
 
 ::
 

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -179,7 +179,7 @@ enable more aggressive/optimized LRU.
 
 That said, if you're running a small install you can probably get away with just setting up the defaults:
 
-.. code-block::
+::
 
     SENTRY_REDIS_OPTIONS = {
         'hosts': {


### PR DESCRIPTION
This fixes a syntax error in the documentation which caused the SENTRY_REDIS_OPTIONS example to disappear. I also saw two sphinx warnings about missing escaping which I also fixed.
