### PR TITLE
Removed usage of names that don't exist on py3k

### DIFF
--- a/src/sentry/api/endpoints/team_stats.py
+++ b/src/sentry/api/endpoints/team_stats.py
@@ -1,5 +1,7 @@
 from rest_framework.response import Response
 
+from six.moves import range
+
 from sentry.app import tsdb
 from sentry.api.base import BaseStatsEndpoint
 from sentry.api.permissions import assert_perm
@@ -24,7 +26,7 @@ class TeamStatsEndpoint(BaseStatsEndpoint):
         ).values()
 
         summarized = []
-        for n in xrange(len(data[0])):
+        for n in range(len(data[0])):
             total = sum(d[n][1] for d in data)
             summarized.append((data[0][n][0], total))
 

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -13,11 +13,13 @@ import base64
 import logging
 import uuid
 import zlib
+from gzip import GzipFile
 
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.utils.encoding import smart_str
-from gzip import GzipFile
+
+import six
 
 from sentry.app import env
 from sentry.constants import (
@@ -262,7 +264,7 @@ def validate_data(project, data, client=None):
 
     if not data.get('message'):
         data['message'] = '<no message value>'
-    elif not isinstance(data['message'], basestring):
+    elif not isinstance(data['message'], six.string_types):
         raise APIError('Invalid value for message')
     elif len(data['message']) > settings.SENTRY_MAX_MESSAGE_LENGTH:
         logger.info(
@@ -272,7 +274,7 @@ def validate_data(project, data, client=None):
             data['message'], settings.SENTRY_MAX_MESSAGE_LENGTH)
 
     if data.get('culprit'):
-        if not isinstance(data['culprit'], basestring):
+        if not isinstance(data['culprit'], six.string_types):
             raise APIError('Invalid value for culprit')
         logger.info(
             'Truncated value for culprit due to length (%d chars)',
@@ -281,7 +283,7 @@ def validate_data(project, data, client=None):
 
     if not data.get('event_id'):
         data['event_id'] = uuid.uuid4().hex
-    elif not isinstance(data['event_id'], basestring):
+    elif not isinstance(data['event_id'], six.string_types):
         raise APIError('Invalid value for event_id')
     if len(data['event_id']) > 32:
         logger.info(
@@ -331,17 +333,17 @@ def validate_data(project, data, client=None):
                             pair, **client_metadata(client, project))
                 continue
 
-            if not isinstance(k, basestring):
+            if not isinstance(k, six.string_types):
                 try:
-                    k = unicode(k)
+                    k = six.text_type(k)
                 except Exception:
                     logger.info('Discarded invalid tag key: %r',
                                 type(k), **client_metadata(client, project))
                     continue
 
-            if not isinstance(v, basestring):
+            if not isinstance(v, six.string_types):
                 try:
-                    v = unicode(v)
+                    v = six.text_type(v)
                 except Exception:
                     logger.info('Discarded invalid tag value: %s=%r',
                                 k, type(v), **client_metadata(client, project))
@@ -401,7 +403,7 @@ def validate_data(project, data, client=None):
                 **client_metadata(client, project, exception=e, extra={'value': value}))
 
     level = data.get('level') or DEFAULT_LOG_LEVEL
-    if isinstance(level, basestring) and not level.isdigit():
+    if isinstance(level, six.string_types) and not level.isdigit():
         # assume it's something like 'warning'
         try:
             data['level'] = LOG_LEVEL_REVERSE_MAP[level]

--- a/src/sentry/db/models/fields/gzippeddict.py
+++ b/src/sentry/db/models/fields/gzippeddict.py
@@ -12,6 +12,8 @@ import logging
 
 from django.db import models
 
+import six
+
 from sentry.utils.compat import pickle
 from sentry.utils.strings import decompress, compress
 
@@ -28,7 +30,7 @@ class GzippedDictField(models.TextField):
     __metaclass__ = models.SubfieldBase
 
     def to_python(self, value):
-        if isinstance(value, basestring) and value:
+        if isinstance(value, six.string_types) and value:
             try:
                 value = pickle.loads(decompress(value))
             except Exception as e:
@@ -44,7 +46,7 @@ class GzippedDictField(models.TextField):
             return None
         # enforce unicode strings to guarantee consistency
         if isinstance(value, str):
-            value = unicode(value)
+            value = six.text_type(value)
         return compress(pickle.dumps(value))
 
     def value_to_string(self, obj):

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -15,6 +15,8 @@ import warnings
 from django.db import models
 from django.db.models.signals import post_delete
 
+import six
+
 from sentry.utils.cache import memoize
 from sentry.utils.compat import pickle
 from sentry.utils.strings import decompress, compress
@@ -94,7 +96,7 @@ class NodeField(GzippedDictField):
         app.nodestore.delete(value.id)
 
     def to_python(self, value):
-        if isinstance(value, basestring) and value:
+        if isinstance(value, six.string_types) and value:
             try:
                 value = pickle.loads(decompress(value))
             except Exception as e:

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -20,6 +20,8 @@ from django.db.models.signals import (
     post_save, post_delete, post_init, class_prepared)
 from django.utils.encoding import smart_str
 
+import six
+
 from sentry.utils.cache import cache
 
 from .query import create_or_update
@@ -43,7 +45,7 @@ def __prep_value(model, key, value):
     if isinstance(value, Model):
         value = value.pk
     else:
-        value = unicode(value)
+        value = six.text_type(value)
     return value
 
 

--- a/src/sentry/filters/widgets.py
+++ b/src/sentry/filters/widgets.py
@@ -12,6 +12,8 @@ __all__ = ('Widget', 'TextWidget', 'ChoiceWidget')
 from django.utils.safestring import mark_safe
 from django.utils.html import escape
 
+import six
+
 
 class Widget(object):
     def __init__(self, filter, request):
@@ -59,7 +61,7 @@ class ChoiceWidget(TextWidget):
                 column=column,
             ))
         for key, val in choices:
-            key = unicode(key)
+            key = six.text_type(key)
             output.append(u'<option%(active)s value="%(key)s">%(value)s</option>' % dict(
                 active=value == key and ' selected="selected"' or '',
                 column=column,

--- a/src/sentry/interfaces.py
+++ b/src/sentry/interfaces.py
@@ -13,17 +13,18 @@ import itertools
 import re
 import urlparse
 import warnings
+from urllib import urlencode
 
 from pygments import highlight
-# from pygments.lexers import get_lexer_for_filename, TextLexer, ClassNotFound
 from pygments.lexers import TextLexer
 from pygments.formatters import HtmlFormatter
-from urllib import urlencode
 
 from django.http import QueryDict
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
+
+import six
 
 from sentry.app import env
 from sentry.models import UserOption
@@ -1062,7 +1063,7 @@ class Http(Interface):
         #  a=b&c=d
         # and
         #  a=b; c=d
-        if isinstance(self.cookies, basestring):
+        if isinstance(self.cookies, six.string_types):
             self.cookies = dict(urlparse.parse_qsl(self.cookies, keep_blank_values=True))
         # if cookies were [also] included in headers we
         # strip them out

--- a/src/sentry/manager.py
+++ b/src/sentry/manager.py
@@ -19,6 +19,8 @@ from django.db import transaction, IntegrityError
 from django.utils import timezone
 from django.utils.datastructures import SortedDict
 
+import six
+
 from raven.utils.encoding import to_string
 
 from sentry import app
@@ -109,7 +111,7 @@ class GroupManager(BaseManager):
     def normalize_event_data(self, data):
         # TODO(dcramer): store http.env.REMOTE_ADDR as user.ip
         # First we pull out our top-level (non-data attr) kwargs
-        if not isinstance(data.get('level'), (basestring, int)):
+        if not isinstance(data.get('level'), (six.string_types, int)):
             data['level'] = logging.ERROR
         elif data['level'] not in LOG_LEVELS:
             data['level'] = logging.ERROR
@@ -487,7 +489,7 @@ class GroupManager(BaseManager):
             if not value:
                 continue
 
-            value = unicode(value)
+            value = six.text_type(value)
             if len(value) > MAX_TAG_LENGTH:
                 continue
 

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -10,6 +10,8 @@ from django.utils import timezone
 from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext_lazy as _
 
+import six
+
 from sentry.db.models import (
     Model, NodeField, BoundedIntegerField, BoundedPositiveIntegerField,
     BaseManager, sane_repr
@@ -176,7 +178,7 @@ class Event(Model):
 
     @property
     def size(self):
-        return len(unicode(vars(self)))
+        return len(six.text_type(vars(self)))
 
     # XXX(dcramer): compatibility with plugins
     def get_level_display(self):

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -16,6 +16,8 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
+import six
+
 from sentry.constants import (
     LOG_LEVELS, STATUS_LEVELS, MAX_CULPRIT_LENGTH, STATUS_RESOLVED,
     STATUS_UNRESOLVED, STATUS_MUTED
@@ -204,6 +206,6 @@ class Group(Model):
         return '[%s %s] %s: %s' % (
             self.team.name.encode('utf-8'),
             self.project.name.encode('utf-8'),
-            unicode(self.get_level_display()).upper().encode('utf-8'),
+            six.text_type(self.get_level_display()).upper().encode('utf-8'),
             self.message_short.encode('utf-8')
         )

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -14,6 +14,8 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+import six
+
 from sentry.db.models import (
     Model, BaseManager, sane_repr
 )
@@ -48,7 +50,7 @@ class ProjectKey(Model):
     __repr__ = sane_repr('project_id', 'user_id', 'public_key')
 
     def __unicode__(self):
-        return unicode(self.public_key)
+        return six.text_type(self.public_key)
 
     @classmethod
     def generate_api_key(cls):

--- a/src/sentry/nodestore/multi/backend.py
+++ b/src/sentry/nodestore/multi/backend.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 
 import random
 
+import six
+
 from sentry.nodestore.base import NodeStorage
 from sentry.utils.imports import import_string
 
@@ -32,7 +34,7 @@ class MultiNodeStorage(NodeStorage):
 
         self.backends = []
         for backend, backend_options in backends:
-            if isinstance(backend, basestring):
+            if isinstance(backend, six.string_types):
                 backend = import_string(backend)
             self.backends.append(backend(**backend_options))
         self.read_selector = read_selector

--- a/src/sentry/nodestore/riak/backend.py
+++ b/src/sentry/nodestore/riak/backend.py
@@ -23,7 +23,7 @@ from sentry.utils.cache import memoize
 # always our messages are immutable, it's safe to simply retry in many
 # cases
 def retry(attempts, func, *args, **kwargs):
-    for _ in xrange(attempts):
+    for _ in range(attempts):
         try:
             return func(*args, **kwargs)
         except Exception:

--- a/src/sentry/permissions.py
+++ b/src/sentry/permissions.py
@@ -6,7 +6,11 @@ sentry.permissions
 :license: BSD, see LICENSE for more details.
 """
 from functools import wraps
+
 from django.conf import settings
+
+import six
+
 from sentry.constants import MEMBER_OWNER
 from sentry.plugins import plugins
 from sentry.utils.cache import cached_for_request
@@ -21,7 +25,7 @@ class Permission(object):
         return self.name
 
     def __eq__(self, other):
-        return unicode(self) == unicode(other)
+        return six.text_type(self) == six.text_type(other)
 
 
 class Permissions(object):

--- a/src/sentry/search/solr/client.py
+++ b/src/sentry/search/solr/client.py
@@ -28,6 +28,8 @@ from urlparse import urljoin
 
 from nydus.db.backends import BaseConnection
 
+import six
+
 # Using two-tuples to preserve order.
 REPLACEMENTS = (
     # Nuke nasty control characters.
@@ -64,7 +66,7 @@ REPLACEMENTS = (
 
 
 def sanitize(data):
-    if isinstance(data, unicode):
+    if isinstance(data, six.text_type):
         data = data.encode('utf-8')
 
     for bad, good in REPLACEMENTS:
@@ -125,7 +127,7 @@ class SolrClient(object):
         if not any(key.lower() == 'content-type' for key in headers.iterkeys()):
             headers['Content-Type'] = 'application/xml; charset=UTF-8'
 
-        if isinstance(body, unicode):
+        if isinstance(body, six.text_type):
             body = body.encode('utf-8')
 
         resp = self.http.urlopen(
@@ -138,7 +140,7 @@ class SolrClient(object):
 
     def _extract_error(self, response):
         if not response.headers.get('content-type', '').startswith('application/xml'):
-            return unicode(response.status)
+            return six.text_type(response.status)
 
         dom_tree = ET.fromstring(response.data)
         reason_node = dom_tree.find('response/lst/str')
@@ -150,7 +152,7 @@ class SolrClient(object):
         if value is None:
             return True
 
-        if isinstance(value, basestring) and len(value) == 0:
+        if isinstance(value, six.string_types) and len(value) == 0:
             return True
 
         return False
@@ -199,7 +201,7 @@ class SolrClient(object):
                 value = u'false'
         else:
             if isinstance(value, str):
-                value = unicode(value, errors='replace')
+                value = six.text_type(value, errors='replace')
 
             value = u"{0}".format(value)
 

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -28,6 +28,9 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
+import six
+from six.moves import range
+
 from sentry.constants import STATUS_MUTED, EVENTS_PER_PAGE, MEMBER_OWNER
 from sentry.models import Team, Option, GroupTagValue
 from sentry.web.helpers import group_is_public
@@ -63,13 +66,13 @@ def pprint(value, break_after=10):
 
     value = to_unicode(value)
     return mark_safe(u'<span></span>'.join(
-        [escape(value[i:(i + break_after)]) for i in xrange(0, len(value), break_after)]
+        [escape(value[i:(i + break_after)]) for i in range(0, len(value), break_after)]
     ))
 
 
 @register.filter
 def is_url(value):
-    if not isinstance(value, basestring):
+    if not isinstance(value, six.string_tyeps):
         return False
     if not value.startswith(('http://', 'https://')):
         return False

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -72,7 +72,7 @@ def pprint(value, break_after=10):
 
 @register.filter
 def is_url(value):
-    if not isinstance(value, six.string_tyeps):
+    if not isinstance(value, six.string_types):
         return False
     if not value.startswith(('http://', 'https://')):
         return False

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -7,13 +7,18 @@ sentry.testutils.fixtures
 """
 from __future__ import unicode_literals
 
-from exam import fixture
 from uuid import uuid4
+
+from exam import fixture
+
+from django.utils.text import slugify
+
+import six
 
 from sentry.models import Activity, Event, Group, Project, Team, User
 from sentry.utils.compat import pickle
 from sentry.utils.strings import decompress
-from django.utils.text import slugify
+
 
 # an example data blog from Sentry 5.4.1 (db level)
 LEGACY_DATA = pickle.loads(decompress("""eJy9WW1v20YS/q5fwfqLpECluMvXFSzjgKK9BrikByR3XwyDXpFLmjVFsnxxbAT57zczS0rUS+LGrU8IYu3s2+yzM8/MrGZxxSYfpo0q2vrJzIpW1YmMVGO+U00jUzWdVHwyiysbBm13IgdaH++yxoB/0mhV0xp9p5GqQtWyVbHRNVmRGre3tXxQBQ26vYW57qT5MK1kLbcNtLzJLK/8SQOyVqYoCVAicJB6bGsJEmahBoz0fGpMWacPKOU4kKFiy/80qm6WcQSLqnppPmR128lcFQ/NUp9sucmKJSmCM52JhO1AIWy42Lhr26pZLZdqE9luYtuKucyxWCJiJSPXEcIPNrFkbJXYjmUnAVOMKyfijnB47FpuYgXehkcy/oesKjNVbQ9oVG6XDHfxJhJOlJcylg8pCnzSPpj8YpnC9yzf4SzwQRdoB4FtW5YfMN63bVsEjo29sEYHZ8UFBBy8PzFekkUYbsu4yxXCyBmCxjmMGs7NESvbZCazseXQjNOb/xWwwH6XFvBgTlSW95le1SdhgNfT1TlKUA+ED9F7lNsqV3hq6LEtHHWnZAyXg23SyOZ0tQVeoW2TxEHJH52qn8KmrcFosMuFZafYEcsWjcD2aKyPoq1q78oYhQGM+ufPH/Gr+MpxPrQyugdDishwyZQcNKUEoUO9HDIkh3Rx0LKTrojarETIHFRj02V5HG4b1MvxUAG5acJKtnco8P+cAebZZlk9gd4FN/1lk7XqxwoUA5dptGEuN7JRZvWEaxK+Va3CqISDPKKdOgK1dC2CBSzWGH0QIrOr4I+afUYXYzDiwjj6fBublfH5AmbyczNpdo/XCjy8hXuCiWFWJOVMyxc42T5WbPzJs6YNt/IxBFjS9m7dqDwxj4QLVN4hM3+QZDQuWaGLVlh1mzyLwnuFELn+5D3aEQDXhu1ThZfrBoOxmyQfk5hLjBJ1eVVnCKdn7cY2UZ1VMLjuioJ8yWOTPR15fLRRhkbnoRu5Ikg2TNierXzHVVGwUZ7nKm8jg2DDNhzHkV3ffwK+ooXoJJ53QKQeWM/FC6kUEPfIUHJQDl3RQ1fkFnzzNRvcT5+hdh9Ommp69fkkZWjL1weEtDAO+IiaAx3d4Ao2riDwFAMZgV7+wC15gmPQiS412GTkP+UZKGWUm99V1BqyNaxHZjm28BNmXeEEcrI226qwqWAkivR9o4ljC28av+MYc/gy4xazFwZfGMyBP9bC8BaGDRLHF47P5jiRzOBOFnFOVx1Ye9UObeZIOztRG19rF5B51KrpctQsoPgY2JMUuPbi8+5yV8YL73VhDOFxZVzffAE4Aw0nUCbu5E7Sv2g2gXcQgwO6drzNIKCNdtQYoEVd9guW9YAJkFfdU4AeOkIpsVxCSVgj8hZE/QKDUV6mKUEvbDyDhp5iMSgm4KApBB7EEcMLYHgmtABAfQSAfmR/xEi4OPW1bkAAYilyxsV50sAhOoshWPB4weStxUZBGWViRzroB5TaEExJBvwHQJKEDYNGEYFZFDarEuhyHxMAcMoiLIxax3z7ZUEj3GNO/jInuYfy6Zjts+SZEGFkBYWa1QUu4B8vDPOJ07MiyrtYUYBsVrRZQJSeFSFkRyQQAA6dvD9MmGcFnZ5ZZ44yfHR2cBJETsR0QkZuiusWJbX55C1Hq5SUTIK/UnCPZNV2td4bre814jljaJw6gjPmHYdwAK4o2x68JgRL2OQqns0JO3aCc61AYcpjIX2UR2vh/RhrvdYub5ntw+SCRtD/8H1PsWQswOOySXXIZZBRpt+KqIzvgwfjL4sejJ8NH4xy0/S74wYmzOCmGLFTChip15/F+8ucySD1hfV2IZZhEgzbBLiN5jcGuXB6jtYYpsIv5DVms9ckNob5+DPMxiBPh6PuGC09w2OYxKdf4S7bpT7NVfaJ+WsfVkU8e/MGjZO81/ZP+EnbvTHDMdf7hOxGm/T1NLpT0X3Tbac3c1J6cA7cu+eb9Dy/UKG5MIi6wSkg8VvjfwvjzRudvmmVBC0ANOJAjqppBOqJAxoZuYfDXotNHL5nE8cenefi4oL6nTG8P9UKDAIspTAIMyOpyy0YRm8yt7cmzXFP8L66ujIi8jjz8HSz6bunfq3fOzC+O2B1sLv4hykB73jj7Qed/BG1QH1D7vjiNwTm4F18Pz+4aAM9J0CRhOyFfjWU5eAUf56+wJeoFAdnHKiLHMrlmoM+TN+XOqa5SHJAEXorSn9g0ogiFucCL5XhUJV9F2GcXendjjb+fgqB5lBU7c50xCAaFeQHgeHkY91pVNxDPoUarznPLa7/dW6BCLXnFleMuSVWidEb7s+PkaqwpJ8h2SzA4SMqXtd4RSM3p4gLZHhqvx573qewNWxETuXxr1HQMakRB/bKzs5H3MVwQ+v+70hvRNizB3pyvSHLgRJU09NWZpQxeO7fSkr9TS/1TfdX4nl7eiIvH85KdeoaPQDsynz7/pffKOvwgoNogCS8RiPRnWLcSdRcom0RP9M72sFtEZOvP1PHySPI4K/Vpxif6KpPXRbPyga/K/w6n19bN/iQwaAY3rOVjxQLNt+/u/mYbF+CEiQyf6Pr/jd1Q4IM6heRGnGPxS3NPT49fNZlSZm7j2HwcsDiX8QKJ8QVSE/0k+ndq6/nIzCa/hmE+fQC0D8xMF+jHlA432UfASHxym+ctBGnPD9uyNYCe/J/eFgN6JVFxylqf3dQwGp4yOCgFD6fwWFl/NIMLhCvmsEJ6/kMTuhKFF2H3o5Rm8v/yrzb1+5oq9HGwiBBVfvK0OSoH8J068sVLWYfJYEnL2hMHKeDZ5lCjBND4Y2oQhevYlf7zCkDE4f1DtRNfX4CXtcqM87iMJFZ3ldOQowJAEIUWMFU1XVZ/4CYgF9+i5iJMPaJgaaJvj2bL2gBNjAuPgkh4XIo0zXhXuqi/4qe5u3vIN3xDxXccnZUyi1cNttWZQ2l4hM9xusinmJPdZ+GtWrKroaIb/TDUN2Qlg2rMiP/4NY+sQb8whCfHcLQWK+NaRhimAjD6YpOt6Nl/NFFPWbtjOaPakRO2XQYYqHZAvfBVPzhATOd/vzGvhc6jRl9/zEr5mhInNGjRhji80c/9wU/53Dm6GX64NSv5NKDYY8UFt17nVB4oouvF6nVH10GSPar7Arg9Xr/ywmjV8Rz6HJ6Txx+QDi5gN07mXK4p4h+OGd6Y30RJOGEan8ZKLD1kLiMeoEDh+td8GCgu3O7A4S4t3c0zoeYPKeu4FtecHyA2REYmP6VRVPC/fUejiK973yGeQnnu7IJvsimMf8Hr5plBQ=="""))
@@ -63,7 +68,7 @@ class Fixtures(object):
     def create_team(self, **kwargs):
         kwargs.setdefault('name', 'foo')
         if not kwargs.get('slug'):
-            kwargs['slug'] = slugify(unicode(kwargs['name']))
+            kwargs['slug'] = slugify(six.text_type(kwargs['name']))
         if not kwargs.get('owner'):
             kwargs['owner'] = self.user
 
@@ -72,7 +77,7 @@ class Fixtures(object):
     def create_project(self, **kwargs):
         kwargs.setdefault('name', 'Bar')
         if not kwargs.get('slug'):
-            kwargs['slug'] = slugify(unicode(kwargs['name']))
+            kwargs['slug'] = slugify(six.text_type(kwargs['name']))
         if not kwargs.get('team'):
             kwargs['team'] = self.team
         if not kwargs.get('owner'):

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -10,10 +10,14 @@ from __future__ import absolute_import
 from binascii import crc32
 from collections import defaultdict
 from datetime import timedelta
+from hashlib import md5
+
 from django.conf import settings
 from django.utils import timezone
-from hashlib import md5
+
 from nydus.db import create_cluster
+
+import six
 
 from sentry.tsdb.base import BaseTSDB
 
@@ -65,7 +69,7 @@ class RedisTSDB(BaseTSDB):
         super(RedisTSDB, self).__init__(**kwargs)
 
     def make_key(self, model, epoch, model_key):
-        if isinstance(model_key, (int, long)):
+        if isinstance(model_key, six.integer_types):
             vnode = model_key % self.vnodes
         else:
             vnode = crc32(model_key) % self.vnodes
@@ -76,7 +80,7 @@ class RedisTSDB(BaseTSDB):
         # We specialize integers so that a pure int-map can be optimized by
         # Redis, whereas long strings (say tag values) will store in a more
         # efficient hashed format.
-        if not isinstance(key, (int, long)):
+        if not isinstance(key, six.integer_types):
             return md5(repr(key)).hexdigest()
         return key
 

--- a/src/sentry/utils/__init__.py
+++ b/src/sentry/utils/__init__.py
@@ -8,10 +8,12 @@ sentry.utils
 
 from django.utils.encoding import force_unicode
 
+import six
+
 
 def to_unicode(value):
     try:
-        value = unicode(force_unicode(value))
+        value = six.text_type(force_unicode(value))
     except (UnicodeEncodeError, UnicodeDecodeError):
         value = '(Error decoding value)'
     except Exception:  # in some cases we get a different exception

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -10,6 +10,8 @@ from urlparse import urlparse, urljoin
 
 from django.conf import settings
 
+import six
+
 
 def absolute_uri(url=None):
     if not url:
@@ -34,12 +36,12 @@ def safe_urlencode(params, doseq=0):
     for k, v in params:
         k = k.encode("utf-8")
 
-        if isinstance(v, basestring):
+        if isinstance(v, six.string_types):
             new_params.append((k, v.encode("utf-8")))
         elif isinstance(v, (list, tuple)):
             new_params.append((k, [i.encode("utf-8") for i in v]))
         else:
-            new_params.append((k, unicode(v)))
+            new_params.append((k, six.text_type(v)))
 
     return urllib.urlencode(new_params, doseq)
 

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -13,6 +13,9 @@ from django.db import transaction
 
 from sentry.utils.strings import truncatechars
 
+import six
+from six.moves import range
+
 
 def safe_execute(func, *args, **kwargs):
     try:
@@ -55,7 +58,7 @@ def trim(value, max_size=settings.SENTRY_MAX_VARIABLE_SIZE, max_depth=3,
         for k, v in value.iteritems():
             trim_v = trim(v, _size=_size, **options)
             result[k] = trim_v
-            _size += len(unicode(trim_v)) + 1
+            _size += len(six.text_type(trim_v)) + 1
             if _size >= max_size:
                 break
 
@@ -65,11 +68,11 @@ def trim(value, max_size=settings.SENTRY_MAX_VARIABLE_SIZE, max_depth=3,
         for v in value:
             trim_v = trim(v, _size=_size, **options)
             result.append(trim_v)
-            _size += len(unicode(trim_v))
+            _size += len(six.text_type(trim_v))
             if _size >= max_size:
                 break
 
-    elif isinstance(value, basestring):
+    elif isinstance(value, six.string_types):
         result = truncatechars(value, max_size - _size)
 
     else:
@@ -99,5 +102,5 @@ def trim_frames(stacktrace, max_frames=settings.SENTRY_MAX_STACKTRACE_FRAMES):
 
     stacktrace['frames_omitted'] = (half_max, frames_len - half_max)
 
-    for n in xrange(half_max, frames_len - half_max):
+    for n in range(half_max, frames_len - half_max):
         del frames[half_max]

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -10,6 +10,8 @@ import zlib
 
 from django.utils.encoding import smart_unicode
 
+import six
+
 
 def truncatechars(value, arg):
     """
@@ -41,6 +43,6 @@ def gunzip(value):
 def strip(value):
     if not value:
         return ''
-    if not isinstance(value, basestring):
+    if not isinstance(value, six.string_types):
         return smart_unicode(value)  # fuck it
     return smart_unicode(value).strip()

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -23,6 +23,8 @@ from django.views.decorators.cache import never_cache, cache_control
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View as BaseView
 
+import six
+
 from raven.contrib.django.models import client as Raven
 
 from sentry import app
@@ -199,7 +201,7 @@ class APIView(BaseView):
             try:
                 project_, user = project_from_auth_vars(auth_vars)
             except APIError as error:
-                return HttpResponse(unicode(error.msg), status=error.http_status)
+                return HttpResponse(six.text_type(error.msg), status=error.http_status)
             else:
                 if user:
                     request.user = user
@@ -234,7 +236,7 @@ class APIView(BaseView):
                 response = super(APIView, self).dispatch(request, project=project, auth=auth, **kwargs)
 
             except APIError as error:
-                response = HttpResponse(unicode(error.msg), content_type='text/plain', status=error.http_status)
+                response = HttpResponse(six.text_type(error.msg), content_type='text/plain', status=error.http_status)
                 if isinstance(error, APIRateLimited) and error.retry_after is not None:
                     response['Retry-After'] = str(error.retry_after)
 
@@ -331,7 +333,7 @@ class StoreView(APIView):
             # mutates data
             validate_data(project, data, auth.client)
         except InvalidData as e:
-            raise APIError(u'Invalid data: %s (%s)' % (unicode(e), type(e)))
+            raise APIError(u'Invalid data: %s (%s)' % (six.text_type(e), type(e)))
 
         # mutates data
         Group.objects.normalize_event_data(data)

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -14,6 +14,8 @@ from django import forms
 from django.contrib.auth.forms import AuthenticationForm as AuthenticationForm_
 from django.utils.translation import ugettext_lazy as _
 
+from six.moves import range
+
 from sentry.constants import LANGUAGES
 from sentry.models import UserOption, User
 from sentry.utils.auth import find_users
@@ -27,7 +29,7 @@ def _get_timezone_choices():
         results.append((int(offset), tz, '(GMT%s) %s' % (offset, tz)))
     results.sort()
 
-    for i in xrange(len(results)):
+    for i in range(len(results)):
         results[i] = results[i][1:]
     return results
 

--- a/src/sentry/web/forms/fields.py
+++ b/src/sentry/web/forms/fields.py
@@ -12,6 +12,8 @@ from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
+import six
+
 from sentry.models import User
 
 # Special case origins that don't fit the normal regex pattern, but are valid
@@ -40,7 +42,7 @@ class UserField(CharField):
                 attrs = {}
             if 'placeholder' not in attrs:
                 attrs['placeholder'] = 'username'
-            if isinstance(value, (int, long)):
+            if isinstance(value, six.integer_types):
                 value = User.objects.get(id=value).username
             return super(UserField.widget, self).render(name, value, attrs)
 

--- a/src/sentry/web/frontend/admin.py
+++ b/src/sentry/web/frontend/admin.py
@@ -21,6 +21,8 @@ from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_protect
 
+import six
+
 from sentry.app import env
 from sentry.models import Team, Project, User
 from sentry.plugins import plugins
@@ -335,7 +337,7 @@ def status_mail(request):
                 fail_silently=False
             )
         except Exception as e:
-            form.errors['__all__'] = [unicode(e)]
+            form.errors['__all__'] = [six.text_type(e)]
 
     return render_to_response('sentry/admin/status/mail.html', {
         'form': form,


### PR DESCRIPTION
Some of the semantics will probably need adjustment, but for now this is the best we can do. flake8 now runs clean under py3k, we have to wait for all the dependencies to be ported at this point.
