### PR TITLE
Fix name of SENTRY_CONF file in Nginx quickstart docs

### DIFF
--- a/docs/quickstart/nginx.rst
+++ b/docs/quickstart/nginx.rst
@@ -68,7 +68,7 @@ as well the ``sentry.wsgi`` module:
 ::
 
     [uwsgi]
-    env = SENTRY_CONF=/etc/sentry.conf
+    env = SENTRY_CONF=/etc/sentry.conf.py
     module = sentry.wsgi
 
     ; spawn the master and 4 processes


### PR DESCRIPTION
Fix name of SENTRY_CONF file, so that it is consistent with the filename used in quickstart documentation
