### PR TITLE
Always populate self.__cache when reloading

### DIFF
--- a/src/sentry/models/projectoption.py
+++ b/src/sentry/models/projectoption.py
@@ -90,8 +90,7 @@ class ProjectOptionManager(BaseManager):
             for i in self.filter(project=project_id)
         )
         cache.set(cache_key, result)
-        if project_id in self.__cache:
-            self.__cache[project_id] = result
+        self.__cache[project_id] = result
         return result
 
     def post_save(self, instance, **kwargs):


### PR DESCRIPTION
On a cache miss, `self.__cache` never gets populated. Inside `get_all_values`, it's being conditionally populated, and if `self.__cache[project_id]` never exists in the first place, we're fucked.

This was broken locally for me, which is why I didn't just push this to master since I'm not sure why this isn't broken in production, or maybe it is and we always get cache hits or something.

But this seems problematic.
