### PR TITLE
Support pagination in /api/<team>/<project>/poll

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -357,8 +357,12 @@ class StoreView(APIView):
 @never_cache
 @api
 def poll(request, team, project):
-    offset = 0
     limit = EVENTS_PER_PAGE
+    try:
+        page = int(request.REQUEST.get('p', '1'))
+    except ValueError:
+        page = 1
+    offset = limit * (page - 1)
 
     response = _get_group_list(
         request=request,


### PR DESCRIPTION
The web interface calls this API, parameterized with `?p=$p` where `$p`, so I assume pagination is the expected behavior.

Our specific use-case is enumerating the event groups in a project; that obviously doesn't work without this change.

If my assumption is wrong and returning unpaginated data is the requirement then please close the PR. In that case a hint on how to get the number of event groups in a project would be most welcome.
