### PR TITLE
Fix Remove button on "Access Groups" page

### DIFF
--- a/src/sentry/templates/sentry/teams/groups/list.html
+++ b/src/sentry/templates/sentry/teams/groups/list.html
@@ -36,7 +36,7 @@
                     <tr>
                         <td><a href="{% url 'sentry-edit-access-group' team.slug group.id %}">{{ group.name }}</a>{% if group.managed %} ({% trans "automatically managed" %}){% endif %}</td>
                         <td style="text-align:center">{{ group.get_type_display }}</td>
-                        <td style="text-align:center"><a href="#" class="btn">{% trans "Remove" %}</a></td>
+                        <td style="text-align:center"><a href="{% url 'sentry-remove-access-group' team.slug group.id %}" class="btn btn-danger">{% trans "Remove" %}</a></td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
The URL was missing, and the class should include btn-danger.
