### PR TITLE
Make "Create a new user" button on Admin users page visible

### DIFF
--- a/src/sentry/templates/sentry/admin/users/list.html
+++ b/src/sentry/templates/sentry/admin/users/list.html
@@ -7,11 +7,6 @@
 
 {% block admin-nav-users %} class="active"{% endblock %}
 
-{% block page_header %}
-    <a href="{% url 'sentry-admin-new-user' %}" class="btn pull-right btn-primary">{% trans "Create a new user" %}</a>
-    {{ block.super }}
-{% endblock %}
-
 {% block inner %}
     {% paginator user_list from request as user_list per_page 50 %}
 
@@ -74,6 +69,7 @@
     {% endif %}
 
     <div class="btn-toolbar">
+        <a href="{% url 'sentry-admin-new-user' %}" class="btn btn-primary">{% trans "Create a new user" %}</a>
         <div class="btn-group pull-right">
             <a class="btn prev{% if not user_list.paginator.has_previous %} disabled{% else %}" href="?{{ user_list.query_string|escape }}&amp;p={{ user_list.paginator.previous_page }}{% endif %}"><span>{% trans "Previous" %}</span></a>
             <a class="btn next{% if not user_list.paginator.has_next %} disabled{% else %}" href="?{{ user_list.query_string|escape }}&amp;p={{ user_list.paginator.next_page }}{% endif %}"><span>{% trans "Next" %}</span></a>


### PR DESCRIPTION
The list.html template extends admin.html which overrides
the 'page_header_block' (from layout.html) with:

```
{% block page_header_block %}
    <section id="page-header" class="toolbar" style="height:5px;">
    </section>
{% endblock %}
```

Thus there is no 'page_header' into which list.html can insert
the button. Move the button into the lower button toolbar so
that it appears.
