### PR TITLE
Add new "remove_event" permission

### DIFF
--- a/src/sentry/permissions.py
+++ b/src/sentry/permissions.py
@@ -177,7 +177,7 @@ def can_remove_project(user, project):
 
 
 @requires_login
-def can_admin_group(user, group):
+def can_admin_group(user, group, is_remove=False):
     from sentry.models import Team
 
     if user.is_superuser:
@@ -189,11 +189,23 @@ def can_admin_group(user, group):
     except KeyError:
         return False
 
+    # The "remove_event" permission was added after "admin_event".
+    # First check the new "remove_event" permission, then fall back
+    # to the "admin_event" permission.
+    if is_remove:
+        result = plugins.first('has_perm', user, 'remove_event', group)
+        if result is False:
+            return False
+
     result = plugins.first('has_perm', user, 'admin_event', group)
     if result is False:
         return False
 
     return True
+
+
+def can_remove_group(user, group):
+    return can_admin_group(user, group, is_remove=True)
 
 
 @requires_login

--- a/src/sentry/plugins/base.py
+++ b/src/sentry/plugins/base.py
@@ -313,7 +313,7 @@ class IPlugin(local):
 
     def get_view_response(self, request, group):
         from sentry.models import Event
-        from sentry.permissions import can_admin_group
+        from sentry.permissions import can_admin_group, can_remove_group
 
         self.selected = request.path == self.get_url(group)
 
@@ -340,6 +340,7 @@ class IPlugin(local):
             'group': group,
             'event': event,
             'can_admin_event': can_admin_group(request.user, group),
+            'can_remove_event': can_remove_group(request.user, group),
         })
 
     def view(self, request, group, **kwargs):

--- a/src/sentry/templates/sentry/groups/details.html
+++ b/src/sentry/templates/sentry/groups/details.html
@@ -145,7 +145,7 @@
         href="{% url 'sentry-group-event-json' group.team.slug project.slug group.id event.id %}"{% else %}
         href="{% url 'sentry-group-event-json' group.team.slug project.slug group.id 'latest' %}"{% endif %}
         >{% trans "Raw JSON Data" %}</a></li>
-        {% if can_admin_event %}
+        {% if can_remove_event %}
             <li><a href="{% url 'sentry-api-remove-group' group.team.slug project.slug group.id %}"
                    onclick="return confirm('{% trans "Are you sure you wish to delete all data for this event?" %}');">{% trans "Remove Event Data" %}</a></li>
         {% endif %}

--- a/src/sentry/web/frontend/groups.py
+++ b/src/sentry/web/frontend/groups.py
@@ -27,7 +27,9 @@ from sentry.db.models import create_or_update
 from sentry.models import (
     Project, Group, Event, Activity, EventMapping, TagKey, GroupSeen
 )
-from sentry.permissions import can_admin_group, can_create_projects
+from sentry.permissions import (
+    can_admin_group, can_remove_group, can_create_projects
+)
 from sentry.plugins import plugins
 from sentry.utils import json
 from sentry.utils.dates import parse_date
@@ -132,6 +134,7 @@ def render_with_group_context(group, template, context, request=None,
         'project': group.project,
         'group': group,
         'can_admin_event': can_admin_group(request.user, group),
+        'can_remove_event': can_remove_group(request.user, group),
     })
 
     if event:


### PR DESCRIPTION
This permission may be used to disallow event removal, without
disallowing the other event actions (Mute, Share, etc). Since
this is a new permission, we fall back to "admin_event" if
"remove_event" is not False.
