### PR TITLE
Make sending email invites configurable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -596,6 +596,9 @@ SENTRY_ALLOW_ORIGIN = None
 # Enable scraping of javascript context for source code
 SENTRY_SCRAPE_JAVASCRIPT_CONTEXT = True
 
+# Enable email invites
+SENTRY_ENABLE_INVITES = True
+
 # Redis connection information (see Nydus documentation)
 SENTRY_REDIS_OPTIONS = {}
 

--- a/src/sentry/templates/sentry/teams/members/new.html
+++ b/src/sentry/templates/sentry/teams/members/new.html
@@ -11,6 +11,7 @@
 {% endblock %}
 
 {% block inner %}
+{% if invite_form %}
     <ul class="nav nav-tabs">
         <li class="active"><a href="#invite" data-toggle="tab">{% trans "Invite a new user" %}</a></li>
         <li><a href="#add" data-toggle="tab">{% trans "Add an existing user" %}</a></li>
@@ -19,16 +20,20 @@
         <div class="tab-pane active" id="invite">
             <p>{% trans "Invite a member to join this team via their email address. If they do not already have an account, they will first be asked to create one." %}</p>
             {% with invite_form as form %}
+                {% trans "Send Invite" as submit_label %}
                 {% include "sentry/partial/_form.html" %}
             {% endwith %}
         </div>
         <div class="tab-pane" id="add">
+{% endif %}
             <p>{% trans "You may add a user by their username if they already have an account." %}</p>
             {% with add_form as form %}
                 {% include "sentry/partial/_form.html" %}
             {% endwith %}
+{% if invite_form %}
         </div>
     </div>
+{% endif %}
 
     <script type="text/javascript">
     new app.AddTeamMemberPage();


### PR DESCRIPTION
Introduce "SENTRY_ENABLE_INVITES" setting to enable/disable the
ability to send email invites per discussion in #1249.

And while we're touching the new.html template, change the submit
button text for sending an invite from "Save Changes" to
"Send Invite".
