### PR TITLE
Hide account identities tab if there are no auth providers

### DIFF
--- a/src/sentry/templates/sentry/bases/account.html
+++ b/src/sentry/templates/sentry/bases/account.html
@@ -31,6 +31,8 @@
         <li{% if page == 'settings' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings' %}">{% trans "Account" %}</a></li>
         <li{% if page == 'appearance' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-appearance' %}">{% trans "Appearance" %}</a></li>
         <li{% if page == 'notifications' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-notifications' %}">{% trans "Notifications" %}</a></li>
+    {% if AUTH_PROVIDERS %}
         <li{% if page == 'identities' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-identities' %}">{% trans "Identities" %}</a></li>
+    {% endif %}
     </ul>
 {% endblock %}

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -217,6 +217,7 @@ def settings(request):
     context.update({
         'form': form,
         'page': 'settings',
+        'AUTH_PROVIDERS': get_auth_providers(),
     })
     return render_to_response('sentry/account/settings.html', context, request)
 
@@ -245,6 +246,7 @@ def appearance_settings(request):
     context.update({
         'form': form,
         'page': 'appearance',
+        'AUTH_PROVIDERS': get_auth_providers(),
     })
     return render_to_response('sentry/account/appearance.html', context, request)
 
@@ -291,6 +293,7 @@ def notification_settings(request):
         'project_forms': project_forms,
         'ext_forms': ext_forms,
         'page': 'notifications',
+        'AUTH_PROVIDERS': get_auth_providers(),
     })
     return render_to_response('sentry/account/notifications.html', context, request)
 


### PR DESCRIPTION
If there's no configured auth providers, there's not much reason
to show this tab.

Just a minor UI tweak. I could go either way with this one. :-)
