### PR TITLE
Remove dead "get_version" code

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -141,16 +141,6 @@ class Event(Model):
 
         return SortedDict((k, v) for k, v in sorted(result, key=lambda x: x[1].get_score(), reverse=True))
 
-    def get_version(self):
-        if not self.data:
-            return
-        if '__sentry__' not in self.data:
-            return
-        if 'version' not in self.data['__sentry__']:
-            return
-        module = self.data['__sentry__'].get('module', 'ver')
-        return module, self.data['__sentry__']['version']
-
     def get_tags(self):
         try:
             return [

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -138,14 +138,6 @@ class Group(Model):
                 self._latest_event = None
         return self._latest_event
 
-    def get_version(self):
-        if not self.data:
-            return
-        if 'version' not in self.data:
-            return
-        module = self.data.get('module', 'ver')
-        return module, self.data['version']
-
     def get_unique_tags(self, tag, since=None, order_by='-times_seen'):
         # TODO(dcramer): this has zero test coverage and is a critical path
         from sentry.models import GroupTagValue

--- a/src/sentry/templates/sentry/emails/new_note.html
+++ b/src/sentry/templates/sentry/emails/new_note.html
@@ -33,11 +33,6 @@
                 <span class="tag">
                     <a href="{% absolute_uri project_link %}">{{ group.project.name }}</a>
                 </span>
-                {% with group.get_version as version %}
-                    {% if version %}
-                        <span class="tag tag-version">{{ version.0 }} {{ version.1 }}</span>
-                    {% endif %}
-                {% endwith %}
             </div>
         </div>
     </div>

--- a/src/sentry/templates/sentry/partial/_group.html
+++ b/src/sentry/templates/sentry/partial/_group.html
@@ -13,11 +13,6 @@
         </h3>
         <p class="message" title="{{ group.message }}">
             <a href="{% url 'sentry-stream' group.team.slug group.project.slug %}?logger={{ group.logger }}" class="tag tag-logger">{{ group.logger }}</a>
-            {% with group.get_version as version %}
-                {% if version %}
-                    <span class="tag tag-version">{{ version.0 }} {{ version.1 }}</span>
-                {% endif %}
-            {% endwith %}
             {% for tag in group|get_tags:request %}<span class="tag">{{ tag }}</span> {% endfor %}
             {{ group.error }}
         </p>


### PR DESCRIPTION
This code dates back to 2aa95f5662 (Display appropriate 'best guess'
version for executing application, 2011-01-03) and is AFAICT completely
unused since at least 75ef8739fe (Move validation logic into coreapi
and remove support for legacy data, 2012-04-08).

I'm pretty sure this code is unused... I don't see anything that populates
this information in the database. I hope I'm not missing anything.
