### PR TITLE
Remove remaining unused versions code

### DIFF
--- a/src/sentry/static/sentry/scripts/models.js
+++ b/src/sentry/static/sentry/scripts/models.js
@@ -10,7 +10,6 @@
             version: 0,
             annotations: [],
             tags: [],
-            versions: [],
             hasSeen: false,
             isBookmarked: false,
             historicalData: []

--- a/src/sentry/static/sentry/scripts/templates.js
+++ b/src/sentry/static/sentry/scripts/templates.js
@@ -28,9 +28,6 @@
                     '<span class="tag tag-logger">' +
                         '<a href="<%= loggerUrl %>"><%= logger %></a>' +
                     '</span>' +
-                    '<% _.each(versions, function(version){ %> ' +
-                        '<span class="tag tag-version"><%= version %></span>' +
-                    '<% }) %>' +
                     '<% _.each(tags, function(tag){ %> ' +
                         '<span class="tag"><%= tag %></span>' +
                     '<% }) %>' +

--- a/src/sentry/utils/javascript.py
+++ b/src/sentry/utils/javascript.py
@@ -166,7 +166,6 @@ class GroupTransformer(Transformer):
             'levelName': escape(obj.get_level_display()),
             'logger': escape(obj.logger),
             'permalink': absolute_uri(reverse('sentry-group', args=[obj.team.slug, obj.project.slug, obj.id])),
-            'versions': list(obj.get_version() or []),
             'firstSeen': self.localize_datetime(obj.first_seen, request=request),
             'lastSeen': self.localize_datetime(obj.last_seen, request=request),
             'timeSpent': obj.avg_time_spent,


### PR DESCRIPTION
All of this relies on Group.data["version"] which nothing appears
to populate anymore, and is being replaced in the future by a more
robust "releases" concept anyway.

Oops, bug in b7aa984767. Either revert that change or pull this in too.
Sorry about that.
