### PR TITLE
Preserve whitespace in traceback text

### DIFF
--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -1356,6 +1356,7 @@ ul.traceback {
   color: #666;
   font-size: 0.9em;
   margin-left: 15px;
+  white-space: pre;
 }
 .traceback > .traceback {
   margin-top: 10px;


### PR DESCRIPTION
Exception messages sometimes contain detail information in separate lines, for readability in log/console output; this change preserves that readability in Sentry layout.

Example:

![image](https://cloud.githubusercontent.com/assets/153580/4318782/03c923e0-3f23-11e4-8e8b-db90ae0865ff.png)

becomes:

![image](https://cloud.githubusercontent.com/assets/153580/4318802/32c4d536-3f23-11e4-8c62-f9d49eca0931.png)

I've made this layout tweak locally for some time; haven't yet encountered a case in which there was a downside to it.
