### PR TITLE
Compatibility fix for Oracle's mysql-connector-python

### DIFF
--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -20,6 +20,8 @@ def get_db_engine(alias='default'):
     else:
         assert alias == 'default', 'You cannot fetch a database engine other than the default on Django < 1.2'
         value = settings.DATABASE_ENGINE
+    if value == 'mysql.connector.django':
+        return 'mysql'
     return value.rsplit('.', 1)[-1]
 
 


### PR DESCRIPTION
The name of this engine is mysql.connector.django.
Make get_db_engine() return 'mysql', not 'django'.
