### PR TITLE
Cache all groupmeta

### DIFF
--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -6,6 +6,8 @@ sentry.models.groupmeta
 :license: BSD, see LICENSE for more details.
 """
 
+from celery.signals import task_postrun
+from django.core.signals import request_finished
 from django.db import models
 
 from sentry.db.models import Model, sane_repr
@@ -13,28 +15,47 @@ from sentry.db.models.manager import BaseManager
 
 
 class GroupMetaManager(BaseManager):
-    def get_value_bulk(self, instances, key):
-        instance_map = dict((i.id, i) for i in instances)
-        queryset = self.filter(
-            group__in=instances,
-            key=key,
+    def __init__(self, *args, **kwargs):
+        super(GroupMetaManager, self).__init__(*args, **kwargs)
+        task_postrun.connect(self.clear_local_cache)
+        request_finished.connect(self.clear_local_cache)
+        self.__cache = {}
+
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('_GroupMetaManager__cache', None)
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.__cache = {}
+
+    def clear_local_cache(self, **kwargs):
+        self.__cache = {}
+
+    def populate_cache(self, instance_list):
+        results = self.filter(
+            group__in=instance_list,
+        ).values_list('group', 'key', 'value')
+        for group_id, key, value in results:
+            self.__cache.setdefault(group_id, {})
+            self.__cache[group_id][key] = value
+
+    def get_value_bulk(self, instance_list, key):
+        return dict(
+            (i, self.__cache.get(i.id, {}).get(key))
+            for i in instance_list
         )
-        result = dict((i, None) for i in instances)
-        for obj in queryset:
-            result[instance_map[obj.group_id]] = obj.value
-        return result
 
     def get_value(self, instance, key, default=None):
-        try:
-            return self.get(
-                group=instance,
-                key=key,
-            ).value
-        except self.model.DoesNotExist:
-            return default
+        return self.__cache.get(instance.id, {}).get(key, default)
 
     def unset_value(self, instance, key):
         self.filter(group=instance, key=key).delete()
+        try:
+            del self.__cache[instance.id][key]
+        except KeyError:
+            pass
 
     def set_value(self, instance, key, value):
         self.create_or_update(
@@ -44,6 +65,8 @@ class GroupMetaManager(BaseManager):
                 'value': value,
             },
         )
+        self.__cache.setdefault(instance.id, {})
+        self.__cache[instance.id][key] = value
 
 
 class GroupMeta(Model):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -29,7 +29,7 @@ from nydus.db import create_cluster
 from rest_framework.test import APITestCase as BaseAPITestCase
 
 from sentry.constants import MODULE_ROOT
-from sentry.models import ProjectOption
+from sentry.models import GroupMeta, ProjectOption
 from sentry.rules import EventState
 from sentry.utils import json
 
@@ -105,6 +105,7 @@ class BaseTestCase(Fixtures, Exam):
     def _pre_setup(self):
         cache.clear()
         ProjectOption.objects.clear_local_cache()
+        GroupMeta.objects.clear_local_cache()
         super(BaseTestCase, self)._pre_setup()
 
     def _post_teardown(self):

--- a/src/sentry/web/frontend/groups.py
+++ b/src/sentry/web/frontend/groups.py
@@ -25,7 +25,7 @@ from sentry.constants import (
 )
 from sentry.db.models import create_or_update
 from sentry.models import (
-    Project, Group, Event, Activity, EventMapping, TagKey, GroupSeen
+    Project, Group, GroupMeta, Event, Activity, EventMapping, TagKey, GroupSeen
 )
 from sentry.permissions import (
     can_admin_group, can_remove_group, can_create_projects
@@ -256,6 +256,8 @@ def group_list(request, team, project):
         del query_dict['p']
     pageless_query_string = query_dict.urlencode()
 
+    GroupMeta.objects.populate_cache(response['event_list'])
+
     return render_to_response('sentry/groups/group_list.html', {
         'team': project.team,
         'project': project,
@@ -284,6 +286,7 @@ def group(request, team, project, group, event_id=None):
         event = group.get_latest_event() or Event()
 
     Event.objects.bind_nodes([event], 'data')
+    GroupMeta.objects.populate_cache([group])
 
     # bind params to group in case they get hit
     event.group = group

--- a/tests/sentry/models/test_groupmeta.py
+++ b/tests/sentry/models/test_groupmeta.py
@@ -19,6 +19,10 @@ class GroupMetaManagerTest(TestCase):
         GroupMeta.objects.create(
             group=self.group, key='foo', value='bar')
         result = GroupMeta.objects.get_value(self.group, 'foo')
+        assert result is None
+
+        GroupMeta.objects.populate_cache([self.group])
+        result = GroupMeta.objects.get_value(self.group, 'foo')
         assert result == 'bar'
 
     def test_unset_value(self):
@@ -35,5 +39,9 @@ class GroupMetaManagerTest(TestCase):
 
         GroupMeta.objects.create(
             group=self.group, key='foo', value='bar')
+        result = GroupMeta.objects.get_value_bulk([self.group], 'foo')
+        assert result == {self.group: None}
+
+        GroupMeta.objects.populate_cache([self.group])
         result = GroupMeta.objects.get_value_bulk([self.group], 'foo')
         assert result == {self.group: 'bar'}


### PR DESCRIPTION
This will ensure we only query these once per load, and it will fetch them all in bulk.
