### PR TITLE
Stacktrace: don't clobber filename if it was explicitly provided

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -140,10 +140,13 @@ class Frame(Interface):
         if not abs_path:
             abs_path = filename
 
-        if not filename:
+        if filename:
+            have_filename = True
+        else:
+            have_filename = False
             filename = abs_path
 
-        if abs_path and is_url(abs_path):
+        if not have_filename and abs_path and is_url(abs_path):
             urlparts = urlparse(abs_path)
             if urlparts.path:
                 filename = urlparts.path


### PR DESCRIPTION
I'm using the abs_path to provide a URL to github... so it makes things look ugly when Sentry clobbers the filename I send it. e.g.:

```
        {
          "function": "main",
          "abs_path": "https://github.com/org/repo/blob/da39a3ee5e6b4b0d3255bfef95601890afd80709/path/to/main.m#L16",
          "in_app": true,
          "lineno": 16,
          "filename": "/org/repo/blob/da39a3ee5e6b4b0d3255bfef95601890afd80709/path/to/main.m"
        },
```

So yeah, I'd rather Sentry retain the filename that was sent in with the event (which was just "main.m").
