### PR TITLE
add sentry-zabbix to the list of 3rd party plugins

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -65,6 +65,7 @@ The following extensions are available and maintained by members of the Sentry c
 * `sentry-xmpp <https://github.com/chroto/sentry-xmpp>`_
 * `sentry-youtrack <https://github.com/bogdal/sentry-youtrack>`_
 * `sentry-slack <https://github.com/getsentry/sentry-slack>`_
+* `sentry-zabbix <https://github.com/m0n5t3r/sentry-zabbix>`_
 
 Have an extension that should be listed here? Submit a `pull request <https://github.com/getsentry/sentry>`_ and we'll
 get it added.


### PR DESCRIPTION
proposing it just in case the hack I use is not _that_ ugly to the team...
