### PR TITLE
Replace urllib2 with python-requests, support SNI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ install_requires = [
     'ndg-httpsclient>=0.3.2',
     'pyOpenSSL>=0.14',
     'pyasn1>=0.1.7',
-    'requests>=2.4.3',
+    'requests>=2.4.3,<2.5.0',
 ]
 
 postgres_requires = [

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,10 @@ install_requires = [
     'toronado>=0.0.4,<0.1.0',
     'ua-parser>=0.3.5',
     'urllib3>=1.7.1,<1.8.0',
+    'ndg-httpsclient>=0.3.2',
+    'pyOpenSSL>=0.14',
+    'pyasn1>=0.1.7',
+    'requests>=2.4.3',
 ]
 
 postgres_requires = [


### PR DESCRIPTION
Hello,

I came across a very naughty bug when trying to access to an SNI (Server Name Indication) HTTPS website, which is the case for every Amazon Cloudfront-enabled website as a default, for instance, and will increasingly happen in the future.

Here is a dump of what happens on the Sentry server:

``` python
[05/Nov/2014 10:31:46] "GET /api/xxx/yyy/poll/?cursor=1415030294 HTTP/1.0" 200 1461
Fetching remote source u'https://dashboard.locarise.com/index.html'
Disabling sources to dashboard.locarise.com for 300s
Traceback (most recent call last):
  File "/home/sentry/env/local/lib/python2.7/site-packages/sentry/tasks/fetch_source.py", line 167, in fetch_url
    timeout=settings.SENTRY_SOURCE_FETCH_TIMEOUT)
  File "/home/sentry/env/local/lib/python2.7/site-packages/sentry/http.py", line 83, in safe_urlopen
    return opener.open(req, timeout=timeout)
  File "/usr/lib/python2.7/urllib2.py", line 401, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 419, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 379, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1219, in https_open
    return self.do_open(httplib.HTTPSConnection, req)
  File "/usr/lib/python2.7/urllib2.py", line 1181, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 1] _ssl.c:504: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure>
```

Well, the error is easy to reproduce: any urllib2.urlopen will fail when trying to do this.

And that's entirely normal, urllib2 does not support SNI in python 2.7.8.
It's planned to be backported for the next release (2.7.9), CF http://legacy.python.org/dev/peps/pep-0466/

Still, using requests, pyopenssl, ndg-httpsclient and pyasn1, we can support it, and that's what's explained in this PEP466.

Here is the SO thread that explains how to fix the issue:
https://stackoverflow.com/questions/18578439/using-requests-with-tls-doesnt-give-sni-support/18579484#18579484

This simple patch replaces urllib2 with python-requests, which also simplifies the code. The tests are all passing.

Now, do we wait for Python 2.7.9 instead, that's the question.
