### PR TITLE
Fix plugin site option getter/setter code path

### DIFF
--- a/src/sentry/plugins/helpers.py
+++ b/src/sentry/plugins/helpers.py
@@ -7,6 +7,7 @@ sentry.plugins.helpers
 """
 from __future__ import absolute_import
 
+from sentry import options
 from sentry.models import ProjectOption, UserOption
 
 __all__ = ('set_option', 'get_option', 'unset_option')
@@ -40,7 +41,7 @@ def get_option(key, project=None, user=None):
     elif project:
         result = ProjectOption.objects.get_value(project, key, None)
     else:
-        raise NotImplementedError
+        result = options.get(key)
 
     return result
 

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -212,7 +212,7 @@ def plugin_config(plugin, project, request):
                 if project:
                     ProjectOption.objects.set_value(project, key, value)
                 else:
-                    Option.objects.set_value(key, value)
+                    options.set(key, value)
 
             return ('redirect', None)
 


### PR DESCRIPTION
Apparently the plugin site_conf_form has never been used
as the underlying code to get and set the options was
broken/missing.
