### PR TITLE
Async ui team delete

### DIFF
--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -84,8 +84,8 @@ class TeamDetailsEndpoint(Endpoint):
 
         team.update(status=TeamStatus.PENDING_DELETION)
 
-        # TODO(dcramer): set status to pending deletion
         # we delay the task for 5 minutes so we can implement an undo
-        delete_team.delay(object_id=team.id, countdown=60 * 5)
+        kwargs = {'object_id': team.id}
+        delete_team.apply_async(kwargs=kwargs, countdown=60 * 5)
 
         return Response(status=204)

--- a/src/sentry/manager.py
+++ b/src/sentry/manager.py
@@ -143,7 +143,7 @@ class TeamManager(BaseManager):
         Each <Team> returned has an ``access_type`` attribute which holds the
         MEMBER_TYPE value.
         """
-        from sentry.models import TeamMember, AccessGroup, Project
+        from sentry.models import TeamMember, TeamStatus, AccessGroup, Project
 
         results = SortedDict()
 
@@ -160,8 +160,9 @@ class TeamManager(BaseManager):
 
         for tm in qs:
             team = tm.team
-            team.access_type = tm.type
-            all_teams.add(team)
+            if team.status == TeamStatus.VISIBLE:
+                team.access_type = tm.type
+                all_teams.add(team)
 
         if access_groups:
             qs = AccessGroup.objects.filter(

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -89,8 +89,8 @@ class TeamDeleteTest(APITestCase):
         assert team.status == TeamStatus.PENDING_DELETION
 
         assert response.status_code == 204
-        delete_team.delay.assert_called_once_with(
-            object_id=team.id,
+        delete_team.apply_async.assert_called_once_with(
+            kwargs={"object_id": team.id},
             countdown=60 * 5,
         )
 


### PR DESCRIPTION
These commits fix a couple small items around async team deletion, then convert's remove_team() to async.
