### PR TITLE
Docs: remove stale redis `maxclients 0` stanza

### DIFF
--- a/docs/performance/index.rst
+++ b/docs/performance/index.rst
@@ -14,7 +14,6 @@ All Redis usage in Sentry is temporal, which means the append-log/fsync models i
 With that in mind, we recommend the following changes to (some) default configurations:
 
 - Disable saving by removing all ``save XXXX`` lines.
-- Set ``maxclients 0`` to remove connection limitations.
 - Set ``maxmemory-policy allkeys-lru`` to aggressively prune all keys.
 - Set ``maxmemory 1gb`` to a reasonable allowance.
 


### PR DESCRIPTION
Setting `maxclients 0` in the redis configuration is no longer valid and will cause a fatal error when the server starts:

https://github.com/antirez/redis/commit/a5f8341245aeebd22a2474e92c4ed497eae01545
