### PR TITLE
Format javascript stackstraces after submission

### DIFF
--- a/src/sentry/tasks/fetch_source.py
+++ b/src/sentry/tasks/fetch_source.py
@@ -493,7 +493,10 @@ def format_firefox_safari_stacktrace(value):
 def extract_location(value):
     locationParts = value.split(':')
     lastNumber = locationParts.pop()
-    possibleNumber = float(locationParts[-1]) if len(locationParts) > 0 else float('NaN')
+    try:
+        possibleNumber = float(locationParts[-1])
+    except:
+        possibleNumber = float('NaN')
 
     if not math.isnan(possibleNumber) and not math.isinf(possibleNumber):
         lineNumber = locationParts.pop()


### PR DESCRIPTION
Raven.js goes through numerous hoops to standardize browser stack traces prior to sending to Sentry. The downfall of this method is that the source code needed is rather large.

This PR allows passing the unformatted stack property on an JS error object as an extra and allowing Sentry to format the stacktrace. This allows the client code to be significantly reduced in size.
