### PR TITLE
Add organization to project bootstrap FAQ answer

### DIFF
--- a/docs/faq/index.rst
+++ b/docs/faq/index.rst
@@ -27,7 +27,7 @@ How do I
      configure()
 
      # Do something crazy
-     from sentry.models import Team, Project, ProjectKey, User
+     from sentry.models import Team, Project, ProjectKey, User, Organization
 
      user = User()
      user.username = 'admin'
@@ -36,14 +36,21 @@ How do I
      user.set_password('admin')
      user.save()
 
+     organization = Organization()
+     organization.name = 'MyOrg'
+     organization.owner = user
+     organization.save()
+
      team = Team()
      team.name = 'Sentry'
+     team.organization = organization
      team.owner = user
      team.save()
 
      project = Project()
      project.team = team
      project.name = 'Default'
+     project.organization = organization
      project.save()
 
      key = ProjectKey.objects.filter(project=project)[0]


### PR DESCRIPTION
The current code example in the [How do I... section](http://sentry.readthedocs.org/en/latest/faq/index.html#how-do-i) results in an `organization.DoesNotExist: Team has no organization` exception (tested on 7.0.1); the patch creates an organization and links it to the project and the team.
