### PR TITLE
Fix minor typo for empty events in dashboard

### DIFF
--- a/src/sentry/static/sentry/scripts/app.js
+++ b/src/sentry/static/sentry/scripts/app.js
@@ -62,7 +62,7 @@
 
         makeDefaultView: function(id){
             return new app.GroupListView({
-                emptyMessage: '<p>There are now events to show.</p>',
+                emptyMessage: '<p>There are no events to show.</p>',
                 className: 'group-list small',
                 id: id,
                 maxItems: 5,


### PR DESCRIPTION
I stumbled upon a minor typo when there are no events to show in the dashboard.
