### PR TITLE
Make the Max Http Body Size configurable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -612,6 +612,9 @@ SENTRY_MAX_VARIABLE_SIZE = 512
 # characters
 SENTRY_MAX_EXTRA_VARIABLE_SIZE = 4096
 
+# For changing the amount of data seen in Http Response Body part.
+SENTRY_MAX_HTTP_BODY_SIZE = 2048
+
 # For various attributes we don't limit the entire attribute on size, but the
 # individual item. In those cases we also want to limit the maximum number of
 # keys

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 __all__ = ('Http',)
 
 from Cookie import SmartCookie
+from django.conf import settings
 from django.utils.translation import ugettext as _
 from pipes import quote
 from urllib import urlencode
@@ -132,7 +133,7 @@ class Http(Interface):
         elif isinstance(body, dict):
             body = trim_dict(body)
         elif body:
-            body = trim(body, 2048)
+            body = trim(body, settings.SENTRY_MAX_HTTP_BODY_SIZE)
             if headers.get('Content-Type') == cls.FORM_TYPE and '=' in body:
                 body = dict(parse_qsl(body))
 


### PR DESCRIPTION
In case of need, the representation of the body in events can be changed via this commit.

We are using sentry for our company, and in some of the errors we catch, we needed to see the body part of the response, which was truncated to 2048 chars. Because our response is a json dump, It isn't considered as a dict, but a string. With this commit, one can change the Max Http Body Size via sentry.conf settings. 

Any suggestions are welcome. 

Thanks and keep up the good work \o/
