### PR TITLE
Fix word-wrap

### DIFF
--- a/src/sentry/static/sentry/styles/sentry.css
+++ b/src/sentry/static/sentry/styles/sentry.css
@@ -7939,6 +7939,7 @@ ul.traceback {
   color: #474747;
   font-size: 0.9em;
   white-space: pre-wrap;
+  word-wrap: break-word;
   background: #F8F8F8;
   padding: 10px;
   border-radius: 4px;


### PR DESCRIPTION
Is a fix for this:

Before:
![before](https://cloud.githubusercontent.com/assets/202559/6168080/f4f0c1ee-b28f-11e4-806a-b8d7bb5363d6.png)

After:
![after](https://cloud.githubusercontent.com/assets/202559/6168090/00769f02-b290-11e4-9df0-3577d9388711.png)
