### PR TITLE
Add Beacon

### DIFF
--- a/docs/beacon.rst
+++ b/docs/beacon.rst
@@ -1,0 +1,24 @@
+Beacon
+======
+
+Sentry will periodically communicate with a remote beacon server. This is utilized for a couple of things, primarily:
+
+- Getting information about the current version of Sentry
+- Retrieving important system notices
+
+The remote server is operated by the Sentry team (getsentry.com), and the information reported follows the company's `privacy policy <https://www.getsentry.com/privacy/>`_.
+
+The following information is reported:
+
+- A unique installation ID
+- The version of Sentry
+- A technical contact email (``SENTRY_ADMIN_EMAIL``)
+- General anonymous statistics on the data pattern (such as the number of users)
+
+Note: The contact email is utilized for security announcements, and will never be used outside of such.
+
+The data reported is minimal and it greatly helps the development team behind Sentry. With that said, you can disable the beacon with the following setting:
+
+.. code-block:: python
+
+	SENTRY_BEACON = False

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -424,6 +424,13 @@ CELERYBEAT_SCHEDULE = {
             'expires': 3600,
         },
     },
+    'send-beacon': {
+        'task': 'sentry.tasks.send_beacon',
+        'schedule': timedelta(hours=1),
+        'options': {
+            'expires': 3600,
+        },
+    },
     'flush-buffers': {
         'task': 'sentry.tasks.process_buffer.process_pending',
         'schedule': timedelta(seconds=10),
@@ -534,6 +541,12 @@ SENTRY_IGNORE_EXCEPTIONS = (
 
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 SENTRY_URL_PREFIX = ''
+
+# Should we send the beacon to the upstream server?
+SENTRY_BEACON = True
+
+# The administrative contact for this installation
+SENTRY_ADMIN_EMAIL = ''
 
 # Allow access to Sentry without authentication.
 SENTRY_PUBLIC = False

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -1,0 +1,75 @@
+"""
+sentry.tasks.beacon
+~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import, print_function
+
+import logging
+import sentry
+
+from django.conf import settings
+from hashlib import sha1
+from uuid import uuid4
+
+from sentry.http import safe_urlopen, safe_urlread
+from sentry.tasks.base import instrumented_task
+
+BEACON_URL = 'https://www.getsentry.com/remote/beacon/'
+
+logger = logging.getLogger('beacon')
+
+
+@instrumented_task(name='sentry.tasks.beacon', queue='update')
+def send_beacon():
+    """
+    Send a Beacon to a remote server operated by the Sentry team.
+
+    See the documentation for more details.
+    """
+    from sentry import options
+    from sentry.models import Organization, Project, Team, User
+
+    if not settings.SENTRY_BEACON:
+        logger.info('Not sending beacon (disabled)')
+        return
+
+    # TODO(dcramer): move version code off of PyPi and into beacon
+    install_id = options.get('sentry:install-id')
+    if not install_id:
+        logger.info('Generated installation ID: %s', install_id)
+        install_id = sha1(uuid4().hex).hexdigest()
+        options.set('sentry:install-id', install_id)
+
+    internal_project_ids = filter(bool, [
+        settings.SENTRY_PROJECT, settings.SENTRY_FRONTEND_PROJECT,
+    ])
+    platform_list = list(set(Project.objects.exclude(
+        id__in=internal_project_ids,
+    ).values_list('platform', flat=True)))
+
+    payload = {
+        'install_id': install_id,
+        'version': sentry.get_version(),
+        'admin_email': settings.SENTRY_ADMIN_EMAIL,
+        'data': {
+            # TODO(dcramer): we'd also like to get an idea about the throughput
+            # of the system (i.e. events in 24h)
+            'platforms': platform_list,
+            'users': User.objects.count(),
+            'projects': Project.objects.count(),
+            'teams': Team.objects.count(),
+            'organizations': Organization.objects.count(),
+        }
+    }
+
+    # TODO(dcramer): relay the response 'notices' as admin broadcasts
+    try:
+        request = safe_urlopen(BEACON_URL, json=payload)
+        response = safe_urlread(request)
+    except Exception:
+        logger.warning('Failed sending beacon', exc_info=True)
+        return

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -68,7 +68,7 @@ def send_beacon():
 
     # TODO(dcramer): relay the response 'notices' as admin broadcasts
     try:
-        request = safe_urlopen(BEACON_URL, json=payload)
+        request = safe_urlopen(BEACON_URL, json=payload, timeout=5)
         response = safe_urlread(request)
     except Exception:
         logger.warning('Failed sending beacon', exc_info=True)

--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -53,6 +53,15 @@ SENTRY_USE_BIG_INTS = True
 # If you're expecting any kind of real traffic on Sentry, we highly recommend
 # configuring the CACHES and Redis settings
 
+#############
+## General ##
+#############
+
+# The administrative email for this installation.
+# Note: This will be reported back to getsentry.com as the point of contact. See
+# the beacon documentation for more information.
+SENTRY_ADMIN_EMAIL = 'your.name@example.com'
+
 ###########
 ## Redis ##
 ###########
@@ -327,6 +336,13 @@ def apply_legacy_settings(config):
         warnings.warn('SENTRY_USE_QUEUE is deprecated. Please use CELERY_ALWAYS_EAGER instead. '
                       'See http://sentry.readthedocs.org/en/latest/queue/index.html for more information.', DeprecationWarning)
         settings.CELERY_ALWAYS_EAGER = (not settings.SENTRY_USE_QUEUE)
+
+    if not settings.SENTRY_ADMIN_EMAIL:
+        print('')
+        print('\033[91m!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\033[0m')
+        print('\033[91m!! SENTRY_ADMIN_EMAIL is not configured !!\033[0m')
+        print('\033[91m!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\033[0m')
+        print('')
 
     if settings.SENTRY_URL_PREFIX in ('', 'http://sentry.example.com') and not settings.DEBUG:
         # Maybe also point to a piece of documentation for more information?

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import, print_function
+
+import json
+import sentry
+
+from mock import patch
+
+from sentry import options
+from sentry.testutils import TestCase
+from sentry.tasks.beacon import BEACON_URL, send_beacon
+
+
+class SendBeaconTest(TestCase):
+    @patch('sentry.tasks.beacon.safe_urlopen')
+    @patch('sentry.tasks.beacon.safe_urlread')
+    def test_simple(self, safe_urlread, safe_urlopen):
+        self.create_project(platform='java')
+
+        safe_urlread.return_value = json.dumps({
+            'notices': [],
+        })
+
+        with self.settings(SENTRY_ADMIN_EMAIL='foo@example.com'):
+            send_beacon()
+
+        install_id = options.get('sentry:install-id')
+        assert install_id and len(install_id) == 40
+
+        safe_urlopen.assert_called_once_with(BEACON_URL, json={
+            'install_id': install_id,
+            'version': sentry.get_version(),
+            'data': {
+                'platforms': ['java'],
+                'organizations': 2,
+                'users': 2,
+                'projects': 2,
+                'teams': 2,
+            },
+            'admin_email': 'foo@example.com',
+        })
+        safe_urlread.assert_called_once_with(safe_urlopen.return_value)

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -37,5 +37,5 @@ class SendBeaconTest(TestCase):
                 'teams': 2,
             },
             'admin_email': 'foo@example.com',
-        })
+        }, timeout=5)
         safe_urlread.assert_called_once_with(safe_urlopen.return_value)


### PR DESCRIPTION
To quote the docs I wrote:

Sentry will periodically communicate with a remote beacon server. This is utilized for a couple of things, primarily:
- Getting information about the current version of Sentry
- Retrieving important system notices

The remote server is operated by the Sentry team (getsentry.com), and the information reported follows the company's [privacy policy](https://www.getsentry.com/privacy/).

The following information is reported:
- A unique installation ID
- The version of Sentry
- A technical contact email (`SENTRY_ADMIN_EMAIL`)
- General anonymous statistics on the data pattern (such as the number of users)

Note: The contact email is utilized for security announcements, and will never be used outside of such.
