### PR TITLE
Add feature abstraction

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+Version 7.4.0
+-------------
+
+- A new features subsystem was added, and many optional features are now run through it.
+- The 'add_organization' permission is no longer used.
+- SENTRY_ALLOW_REGISTRATION is deprecated in favor of SENTRY_FEATURES['auth:register'].
+- SOCIAL_AUTH_CREATE_USERS is deprecated in favor of SENTRY_FEATURES['social-auth:register'].
+
 Version 7.3.2
 -------------
 

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -19,7 +19,7 @@ Authentication
 --------------
 
 
-.. data:: SENTRY_ALLOW_REGISTRATION
+.. data:: SENTRY_FEATURES['auth:register']
     :noindex:
 
     Should Sentry allow users to create new accounts?
@@ -28,7 +28,7 @@ Authentication
 
     ::
 
-        SENTRY_ALLOW_REGISTRATION = False
+        SENTRY_FEATURES['auth:register'] = True
 
 .. data:: SENTRY_PUBLIC
     :noindex:

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -409,7 +409,9 @@ want to disable account creation, simply set the following value:
 
 .. code-block:: python
 
-  SOCIAL_AUTH_CREATE_USERS = False
+  SENTRY_FEATURES = {
+    'social-auth:register': False,
+  }
 
 
 Google

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -534,6 +534,7 @@ SENTRY_CACHE_BACKEND = 'default'
 SENTRY_FEATURES = {
     'auth:register': True,
     'social-auth:register': True,
+    'organizations:create': True,
 }
 
 SENTRY_FILTERS = (

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -334,8 +334,6 @@ SOCIAL_AUTH_PIPELINE = (
     'social_auth.backends.pipeline.misc.save_status_to_session',
 )
 
-SOCIAL_AUTH_CREATE_USERS = True
-
 INITIAL_CUSTOM_USER_MIGRATION = '0108_fix_user'
 
 # Auth engines and the settings required for them to be listed
@@ -532,6 +530,11 @@ SENTRY_CLIENT = 'sentry.utils.raven.SentryInternalClient'
 SENTRY_FRONTEND_PROJECT = None
 
 SENTRY_CACHE_BACKEND = 'default'
+
+SENTRY_FEATURES = {
+    'auth:register': True,
+    'social-auth:register': True,
+}
 
 SENTRY_FILTERS = (
     'sentry.filters.StatusFilter',

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from .base import *  # NOQA
+from .manager import *  # NOQA
+
+
+default_manager = FeatureManager()
+default_manager.add('auth:register')
+default_manager.add('social-auth:register')
+
+# expose public api
+add = default_manager.add
+get = default_manager.get
+has = default_manager.has

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -7,6 +7,7 @@ from .manager import *  # NOQA
 default_manager = FeatureManager()
 default_manager.add('auth:register')
 default_manager.add('social-auth:register')
+default_manager.add('organizations:create')
 
 # expose public api
 add = default_manager.add

--- a/src/sentry/features/base.py
+++ b/src/sentry/features/base.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+__all__ = ['Feature', 'OrganizationFeature']
+
+
+class Feature(object):
+    def __init__(self, name):
+        self.name = name
+
+    def has(self, actor):
+        """
+        A feature may return one of three values:
+
+        - True: the feature is enabled for actor
+        - False: the feature is not enabled for actor
+        - None: defer
+        """
+        return None
+
+
+class OrganizationFeature(object):
+    def __init__(self, name, organization):
+        self.name = name
+        self.organization = organization

--- a/src/sentry/features/exceptions.py
+++ b/src/sentry/features/exceptions.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+__all__ = ['FeatureNotRegistered']
+
+
+class FeatureNotRegistered(Exception):
+    pass

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+
+__all__ = ['FeatureManager']
+
+from django.conf import settings
+
+from sentry.plugins import plugins
+from sentry.utils.safe import safe_execute
+
+from .base import Feature
+from .exceptions import FeatureNotRegistered
+
+
+class FeatureManager(object):
+    def __init__(self):
+        self._registry = {}
+
+    def add(self, name, cls=Feature):
+        self._registry[name] = cls
+
+    def get(self, name, *args, **kwargs):
+        try:
+            cls = self._registry[name]
+        except KeyError:
+            raise FeatureNotRegistered(name)
+        return cls(name, *args, **kwargs)
+
+    def has(self, name, *args, **kwargs):
+        """
+        >>> FeatureManager.has('my:feature', actor=request.user)
+        """
+        actor = kwargs.pop('actor', None)
+        feature = self.get(name, *args, **kwargs)
+        rv = self._get_plugin_value(feature, actor)
+        if rv is None:
+            rv = feature.has(actor=actor)
+        if rv is None:
+            rv = self._get_default_value(feature)
+        return rv
+
+    def _get_default_value(self, feature):
+        return settings.SENTRY_FEATURES.get(feature.name, False)
+
+    def _get_plugin_value(self, feature, actor):
+        for plugin in plugins.all(version=2):
+            for handler in (safe_execute(plugin.get_feature_hooks) or ()):
+                rv = handler(feature, actor)
+                if rv is not None:
+                    return rv
+        return None

--- a/src/sentry/permissions.py
+++ b/src/sentry/permissions.py
@@ -69,23 +69,6 @@ def is_project_admin(user, project):
 
 @cached_for_request
 @requires_login
-def can_create_organizations(user):
-    """
-    Returns a boolean describing whether a user has the ability to
-    create new organizations.
-    """
-    if user.is_superuser:
-        return True
-
-    result = plugins.first('has_perm', user, 'add_organization')
-    if result is False:
-        return result
-
-    return True
-
-
-@cached_for_request
-@requires_login
 def can_create_teams(user, organization):
     """
     Returns a boolean describing whether a user has the ability to

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -291,6 +291,17 @@ class IPlugin2(local):
         """
         return []
 
+    def get_feature_hooks(self, **kwargs):
+        """
+        Return a list of callables to check for feature status.
+
+        >>> def get_feature_hooks(self, **kwargs):
+        >>>     def no_features(feature, actor):
+        >>>         return False
+        >>>     return [no_features]
+        """
+        return []
+
 
 class Plugin2(IPlugin2):
     """

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load sentry_features %}
 {% load sentry_helpers %}
 {% load sentry_permissions %}
 {% get_sentry_version %}
@@ -122,9 +123,9 @@
                                             <span class="caret"></span>
                                           </a>
                                           <ul class="dropdown-menu">
-                                            {% if request.user|can_create_organizations %}
+                                            {% feature organizations:create %}
                                               <li><h6><a href="{% url 'sentry-create-organization' %}" class="new pull-right"><span class="icon-plus"></span></a>{% trans "Organizations" %}</h6></li>
-                                            {% endif %}
+                                            {% endfeature %}
                                             {% for o in request.user|list_organizations %}
                                                 <li{% if o == organization %} class="active"{% endif %}>
                                                     <a href="{% url 'sentry-organization-home' o.slug %}">{{ o.name }}</a>

--- a/src/sentry/templatetags/sentry_features.py
+++ b/src/sentry/templatetags/sentry_features.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+
+from django import template
+
+from sentry import features
+
+register = template.Library()
+
+
+@register.tag
+def feature(parser, token):
+    bits = token.split_contents()
+    if len(bits) < 2:
+        raise template.TemplateSyntaxError("%r tag requires an argument" % token.contents.split()[0])
+
+    name = bits[1]
+    params = bits[2:]
+
+    nodelist_true = parser.parse(('else', 'endfeature'))
+    token = parser.next_token()
+
+    if token.contents == 'else':
+        nodelist_false = parser.parse(('endfeature',))
+        parser.delete_first_token()
+    else:
+        nodelist_false = template.NodeList()
+
+    return FeatureNode(nodelist_true, nodelist_false, name, params)
+
+
+class FeatureNode(template.Node):
+    def __init__(self, nodelist_true, nodelist_false, name, params):
+        self.nodelist_true = nodelist_true
+        self.nodelist_false = nodelist_false
+        self.name = name
+        self.params = [template.Variable(i) for i in params]
+
+    def render(self, context):
+        params = [i.resolve(context) for i in self.params]
+        if 'request' in context:
+            user = context['request'].user
+        else:
+            user = None
+
+        if not features.has(self.name, actor=user, *params):
+            return self.nodelist_false.render(context)
+
+        return self.nodelist_true.render(context)

--- a/src/sentry/templatetags/sentry_permissions.py
+++ b/src/sentry/templatetags/sentry_permissions.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 from django import template
 
 from sentry.permissions import (
-    can_create_organizations, can_create_teams, can_create_projects,
+    can_create_teams, can_create_projects,
     can_remove_project, can_manage_project, can_manage_team, can_manage_org
 )
 
@@ -18,7 +18,6 @@ register = template.Library()
 
 # TODO: Django doesn't seem to introspect function args correctly for filters
 # so we can't just register.filter(can_add_team_member)
-register.filter('can_create_organizations')(lambda a: can_create_organizations(a))
 register.filter('can_create_teams')(lambda a, b: can_create_teams(a, b))
 register.filter('can_create_projects')(lambda a, b: can_create_projects(a, b))
 register.filter('can_manage_team')(lambda a, b: can_manage_team(a, b))

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -33,7 +33,7 @@ from sentry.rules import EventState
 from sentry.utils import json
 
 from .fixtures import Fixtures
-from .helpers import get_auth_header
+from .helpers import Feature, get_auth_header
 
 
 def create_redis_conn():
@@ -67,6 +67,13 @@ class BaseTestCase(Fixtures, Exam):
         session.save()
 
         self.session = session
+
+    def feature(self, name, active=True):
+        """
+        >>> with self.feature('feature:name')
+        >>>     # ...
+        """
+        return Feature(name, active)
 
     def save_session(self):
         self.session.save()

--- a/src/sentry/testutils/helpers/__init__.py
+++ b/src/sentry/testutils/helpers/__init__.py
@@ -8,4 +8,5 @@ sentry.testutils.helpers
 from __future__ import absolute_import
 
 from .auth_header import *  # NOQA
+from .features import *  # NOQA
 from .link_header import *  # NOQA

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+
+__all__ = ['Feature']
+
+from contextlib import contextmanager
+from mock import patch
+
+
+@contextmanager
+def Feature(name, active=True):
+    with patch('sentry.features.has') as features_has:
+        features_has.side_effect = lambda x, *a, **k: active and x == name
+        yield

--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -364,8 +364,16 @@ def apply_legacy_settings(config):
             settings.ALLOWED_HOSTS = (urlbits.hostname,)
 
     if not settings.SERVER_EMAIL and hasattr(settings, 'SENTRY_SERVER_EMAIL'):
-        warnings.warn('SENTRY_SERVER_EMAIL is deprecated. Please use SERVER_EMAIL instead.', DeprecationWarning)
+        warnings.warn('SENTRY_SERVER_EMAIL is deprecated. Use SERVER_EMAIL instead.', DeprecationWarning)
         settings.SERVER_EMAIL = settings.SENTRY_SERVER_EMAIL
+
+    if hasattr(settings, 'SENTRY_ALLOW_REGISTRATION'):
+        warnings.warn('SENTRY_ALLOW_REGISTRATION is deprecated. Use SENTRY_FEATURES instead.', DeprecationWarning)
+        settings.SENTRY_FEATURES['auth:register'] = settings.SENTRY_ALLOW_REGISTRATION
+
+    if hasattr(settings, 'SOCIAL_AUTH_CREATE_USERS'):
+        warnings.warn('SOCIAL_AUTH_CREATE_USERS is deprecated. Use SENTRY_FEATURES instead.', DeprecationWarning)
+        settings.SENTRY_FEATURES['social-auth:register'] = settings.SOCIAL_AUTH_CREATE_USERS
 
 
 def skip_migration_if_applied(settings, app_name, table_name,

--- a/src/sentry/utils/social_auth.py
+++ b/src/sentry/utils/social_auth.py
@@ -7,10 +7,10 @@ sentry.utils.social_auth
 """
 from __future__ import absolute_import
 
-from django.conf import settings
-
 from social_auth.backends.pipeline.user import create_user
 from social_auth.exceptions import SocialAuthBaseException
+
+from sentry import features
 
 
 class AuthNotAllowed(SocialAuthBaseException):
@@ -22,7 +22,7 @@ def create_user_if_enabled(*args, **kwargs):
     A pipeline step for django-social-auth
     Create user. Depends on get_username pipeline.
     """
-    if not settings.SOCIAL_AUTH_CREATE_USERS and not kwargs.get('user'):
+    if not features.has('social-auth:register') and not kwargs.get('user'):
         raise AuthNotAllowed('You must create an account before associating an identity.')
 
     backend = kwargs.pop('backend')

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -20,6 +20,7 @@ from django.views.decorators.csrf import csrf_protect
 from django.utils import timezone
 from sudo.decorators import sudo_required
 
+from sentry import features
 from sentry.models import (
     LostPasswordHash, Organization, Project, Team, UserOption
 )
@@ -68,7 +69,7 @@ def register(request):
     return render_to_response('sentry/register.html', {
         'form': form,
         'AUTH_PROVIDERS': get_auth_providers(),
-        'SOCIAL_AUTH_CREATE_USERS': settings.SOCIAL_AUTH_CREATE_USERS,
+        'SOCIAL_AUTH_CREATE_USERS': features.has('social-auth:register'),
     }, request)
 
 

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, print_function
 
 from django.contrib.auth import login
-from django.conf import settings
 
+from sentry import features
 from sentry.web.forms.accounts import AuthenticationForm
 from sentry.web.frontend.base import BaseView
 from sentry.utils.auth import get_auth_providers, get_login_redirect
@@ -34,8 +34,8 @@ class AuthLoginView(BaseView):
         context = {
             'form': form,
             'next': request.session.get('_next'),
-            'CAN_REGISTER': settings.SENTRY_ALLOW_REGISTRATION or request.session.get('can_register'),
+            'CAN_REGISTER': features.has('auth:register') or request.session.get('can_register'),
             'AUTH_PROVIDERS': get_auth_providers(),
-            'SOCIAL_AUTH_CREATE_USERS': settings.SOCIAL_AUTH_CREATE_USERS,
+            'SOCIAL_AUTH_CREATE_USERS': features.has('social-auth:register'),
         }
         return self.respond('sentry/login.html', context)

--- a/src/sentry/web/frontend/create_organization.py
+++ b/src/sentry/web/frontend/create_organization.py
@@ -5,10 +5,10 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 
+from sentry import features
 from sentry.models import (
     AuditLogEntry, AuditLogEntryEvent, Organization
 )
-from sentry.permissions import can_create_organizations
 from sentry.web.frontend.base import BaseView
 
 
@@ -26,9 +26,7 @@ class CreateOrganizationView(BaseView):
         return NewOrganizationForm(request.POST or None)
 
     def has_permission(self, request):
-        if not can_create_organizations(request.user):
-            return False
-        return True
+        return features.has('organizations:create', actor=request.user)
 
     def handle(self, request):
         form = self.get_form(request)

--- a/tests/sentry/templatetags/test_sentry_features.py
+++ b/tests/sentry/templatetags/test_sentry_features.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from django.template import Context, Template
+from mock import Mock
+
+from sentry.testutils import TestCase
+
+
+class FeaturesTest(TestCase):
+    TEMPLATE = Template("""
+        {% load sentry_features %}
+        {% feature auth:register %}
+            <span>register</span>
+        {% else %}
+            <span>nope</span>
+        {% endfeature %}
+    """)
+
+    def test_enabled(self):
+        with self.feature('auth:register'):
+            result = self.TEMPLATE.render(Context({
+                'request': Mock(),
+            }))
+
+        assert '<span>register</span>' in result
+
+    def test_disabled(self):
+        with self.feature('auth:register', False):
+            result = self.TEMPLATE.render(Context({
+                'request': Mock(),
+            }))
+
+        assert '<span>nope</span>' in result


### PR DESCRIPTION
This adds a new abstraction for determining if a feature is enabled. This will slowly expand to encompass a number of things, and will provide a second layer hook to permissions.

For example, getsentry.com might want to say "this organization cannot create teams". That's not so much permission related (and the permission system isn't great). This also makes it much simpler to provide a layer that would abstract this into something like Gargoyle.

As a future example, this will be used to gate SSO:

```
features.add('organization:sso', OrganizationFeature)
if features.has('organization:sso', organization, actor=request.user):
   # ...
```
