### PR TITLE
Google is deprecating OpenID logins starting April 20th, 2015.  Move to OAuth2 based logins.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -296,6 +296,7 @@ AUTHENTICATION_BACKENDS = (
 
 # URL should be: https://[domainname]/account/settings/social/complete/google-oauth2/
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = True  # redirect_uri for OAuth2 should be https://
+SOCIAL_AUTH_SESSION_EXPIRATION = False  # don't use Google's short-lived token to determine session length
 
 SOCIAL_AUTH_USER_MODEL = AUTH_USER_MODEL = 'sentry.User'
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -287,13 +287,15 @@ else:
 AUTHENTICATION_BACKENDS = (
     'social_auth.backends.twitter.TwitterBackend',
     'social_auth.backends.facebook.FacebookBackend',
-    # TODO: migrate to GoogleOAuth2Backend
-    'social_auth.backends.google.GoogleBackend',
+    'social_auth.backends.google.GoogleOAuth2Backend',
     'social_auth.backends.contrib.github.GithubBackend',
     'social_auth.backends.contrib.bitbucket.BitbucketBackend',
     'social_auth.backends.contrib.trello.TrelloBackend',
     'sentry.utils.auth.EmailAuthBackend',
 )
+
+# URL should be: https://[domainname]/account/settings/social/complete/google-oauth2/
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = True  # redirect_uri for OAuth2 should be https://
 
 SOCIAL_AUTH_USER_MODEL = AUTH_USER_MODEL = 'sentry.User'
 
@@ -341,7 +343,7 @@ AUTH_PROVIDERS = {
     'twitter': ('TWITTER_CONSUMER_KEY', 'TWITTER_CONSUMER_SECRET'),
     'facebook': ('FACEBOOK_APP_ID', 'FACEBOOK_API_SECRET'),
     'github': ('GITHUB_APP_ID', 'GITHUB_API_SECRET'),
-    'google': ('GOOGLE_OAUTH2_CLIENT_ID', 'GOOGLE_OAUTH2_CLIENT_SECRET'),
+    'google-auth2': ('GOOGLE_OAUTH2_CLIENT_ID', 'GOOGLE_OAUTH2_CLIENT_SECRET'),
     'trello': ('TRELLO_API_KEY', 'TRELLO_API_SECRET'),
     'bitbucket': ('BITBUCKET_CONSUMER_KEY', 'BITBUCKET_CONSUMER_SECRET'),
 }


### PR DESCRIPTION
Changes that must be made:
1. Create a project at: https://console.developers.google.com
2. Select the project.
3. Navigate to `APIs & auth` -> `Credentials`.
4. Create a new Client ID.
5. Get the client ID and client secret and specify as `GOOGLE_OAUTH2_CLIENT_ID` and `GOOGLE_OAUTH2_CLIENT_SECRET`.
6. Add to authorized redirect URI's:

https://[sentry.yourdomain.com]/account/settings/social/complete/google-oauth2/
