### PR TITLE
Fixed doc for cleanup crontab

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -372,7 +372,7 @@ One of the most important things you're going to need to be aware of is storage 
 .. code-block:: bash
 
   $ crontab -e
-  * 3 * * * sentry cleanup --days=30
+  0 3 * * * sentry cleanup --days=30
 
 
 Additional Utilities


### PR DESCRIPTION
I copied the crontab suggestion of the doc without checking too closely, it turns out that it runs 60 times instead of just one...
