### PR TITLE
Add event attribute rule condition

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -200,6 +200,7 @@ SENTRY_RULES = (
     'sentry.rules.conditions.regression_event.RegressionEventCondition',
     'sentry.rules.conditions.tagged_event.TaggedEventCondition',
     'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
+    'sentry.rules.conditions.event_attribute.EventAttributeCondition',
 )
 
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -1,0 +1,215 @@
+"""
+sentry.rules.conditions.tagged_event
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from collections import OrderedDict
+from django import forms
+
+from sentry.rules.conditions.base import EventCondition
+
+
+class MatchType(object):
+    EQUAL = 'eq'
+    NOT_EQUAL = 'ne'
+    STARTS_WITH = 'sw'
+    ENDS_WITH = 'ew'
+    CONTAINS = 'co'
+    NOT_CONTAINS = 'nc'
+    IS_SET = 'is'
+    NOT_SET = 'ns'
+
+
+MATCH_CHOICES = OrderedDict([
+    (MatchType.EQUAL, 'equals'),
+    (MatchType.NOT_EQUAL, 'does not equal'),
+    (MatchType.STARTS_WITH, 'starts with'),
+    (MatchType.ENDS_WITH, 'ends with'),
+    (MatchType.CONTAINS, 'contains'),
+    (MatchType.NOT_CONTAINS, 'does not contain'),
+    (MatchType.IS_SET, 'is set'),
+    (MatchType.NOT_SET, 'is not set'),
+])
+
+
+class EventAttributeForm(forms.Form):
+    attribute = forms.CharField(widget=forms.TextInput(
+        attrs={'placeholder': 'i.e. exception.type'},
+    ))
+    match = forms.ChoiceField(MATCH_CHOICES.items())
+    value = forms.CharField(widget=forms.TextInput(
+        attrs={'placeholder': 'value'},
+    ), required=False)
+
+
+class EventAttributeCondition(EventCondition):
+    """
+    Attributes are a mapping of <logical-key>.<property>.
+
+    For example:
+
+    - message
+    - platform
+    - exception.{type,value}
+    - user.{id,ip_address,email,FIELD}
+    - http.{method,url}
+    - stacktrace.{code,module,filename}
+    - extra.{FIELD}
+    """
+    # TODO(dcramer): add support for stacktrace.vars.[name]
+
+    form_cls = EventAttributeForm
+    label = 'An events {attribute} value {match} {value}'
+
+    def _get_attribute_values(self, event, attr):
+        # TODO(dcramer): we should validate attributes (when we can) before
+
+        path = attr.split('.')
+
+        if path[0] in ('message', 'platform'):
+            if len(path) != 1:
+                return []
+            return [getattr(event, path[0])]
+
+        elif len(path) == 1:
+            return []
+
+        elif path[0] == 'extra':
+            path.pop(0)
+            value = event.data['extra']
+            while path:
+                bit = path.pop(0)
+                value = value.get(bit)
+                if not value:
+                    return []
+
+            if isinstance(value, (list, tuple)):
+                return value
+            return [value]
+
+        elif len(path) != 2:
+            return []
+
+        elif path[0] == 'exception':
+            if path[1] not in ('type', 'value'):
+                return []
+
+            return [
+                getattr(e, path[1])
+                for e in event.interfaces['sentry.interfaces.Exception'].values
+            ]
+
+        elif path[0] == 'user':
+            if path[1] in ('id', 'ip_address', 'email', 'username'):
+                return [
+                    getattr(event.interfaces['sentry.interfaces.User'], path[1])
+                ]
+            return [
+                getattr(event.interfaces['sentry.interfaces.User'].data, path[1])
+            ]
+
+        elif path[0] == 'http':
+            if path[1] not in ('url', 'method'):
+                return []
+
+            return [
+                getattr(event.interfaces['sentry.interfaces.Http'], path[1])
+            ]
+
+        elif path[0] == 'stacktrace':
+            stacks = event.interfaces.get('sentry.interfaces.Stacktrace')
+            if stacks:
+                stacks = [stacks]
+            else:
+                stacks = [
+                    e.stacktrace
+                    for e in event.interfaces['sentry.interfaces.Exception'].values
+                ]
+
+            result = []
+            for st in stacks:
+                for frame in st.frames:
+                    if path[1] in ('filename', 'module'):
+                        result.append(getattr(frame, path[1]))
+                    elif path[1] == 'code':
+                        if frame.pre_context:
+                            result.extend(frame.pre_context)
+                        if frame.context_line:
+                            result.append(frame.context_line)
+                        if frame.post_context:
+                            result.extend(frame.post_context)
+            return result
+        return []
+
+    def render_label(self):
+        data = {
+            'attribute': self.data['attribute'],
+            'value': self.data['value'],
+            'match': MATCH_CHOICES[self.data['match']],
+        }
+        return self.label.format(**data)
+
+    def passes(self, event, state, **kwargs):
+        attr = self.get_option('attribute')
+        match = self.get_option('match')
+        value = self.get_option('value')
+
+        if not (attr and match and value):
+            return False
+
+        value = value.lower()
+        attr = attr.lower()
+
+        try:
+            attribute_values = self._get_attribute_values(event, attr)
+        except KeyError:
+            attribute_values = []
+
+        attribute_values = [v.lower() for v in attribute_values]
+
+        if match == MatchType.EQUAL:
+            for a_value in attribute_values:
+                if a_value == value:
+                    return True
+            return False
+
+        elif match == MatchType.NOT_EQUAL:
+            for a_value in attribute_values:
+                if a_value == value:
+                    return False
+            return True
+
+        elif match == MatchType.STARTS_WITH:
+            for a_value in attribute_values:
+                if a_value.startswith(value):
+                    return True
+            return False
+
+        elif match == MatchType.ENDS_WITH:
+            for a_value in attribute_values:
+                if a_value.endswith(value):
+                    return True
+            return False
+
+        elif match == MatchType.CONTAINS:
+            for a_value in attribute_values:
+                if value in a_value:
+                    return True
+            return False
+
+        elif match == MatchType.NOT_CONTAINS:
+            for a_value in attribute_values:
+                if value in a_value:
+                    return False
+            return True
+
+        elif match == MatchType.IS_SET:
+            return bool(attribute_values)
+
+        elif match == MatchType.NOT_SET:
+            return not attribute_values

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -1,0 +1,389 @@
+from __future__ import absolute_import
+
+from sentry.testutils.cases import RuleTestCase
+from sentry.rules.conditions.event_attribute import (
+    EventAttributeCondition, MatchType
+)
+
+
+class EventAttributeConditionTest(RuleTestCase):
+    rule_cls = EventAttributeCondition
+
+    def get_event(self):
+        event = self.create_event(
+            message='hello world',
+            platform='php',
+            data={
+                'sentry.interfaces.Http': {
+                    'method': 'GET',
+                    'url': 'http://example.com',
+                },
+                'sentry.interfaces.User': {
+                    'id': '1',
+                    'ip_address': '127.0.0.1',
+                    'email': 'foo@example.com',
+                    'username': 'foo',
+                },
+                'sentry.interfaces.Exception': {
+                    'values': [
+                        {
+                            'type': 'SyntaxError',
+                            'value': 'hello world',
+                            'stacktrace': {
+                                'frames': [
+                                    {
+                                        'filename': 'example.php',
+                                        'module': 'example',
+                                        'context_line': 'echo "hello";',
+                                    }
+                                ]
+                            }
+                        },
+                    ],
+                },
+                'extra': {
+                    'foo': {
+                        'bar': 'baz',
+                    },
+                    'biz': ['baz'],
+                    'bar': 'foo',
+                }
+            },
+        )
+        return event
+
+    def test_equals(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'platform',
+            'value': 'php',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'platform',
+            'value': 'python',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_does_not_equal(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.NOT_EQUAL,
+            'attribute': 'platform',
+            'value': 'php',
+        })
+        self.assertDoesNotPass(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.NOT_EQUAL,
+            'attribute': 'platform',
+            'value': 'python',
+        })
+        self.assertPasses(rule, event)
+
+    def test_starts_with(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.STARTS_WITH,
+            'attribute': 'platform',
+            'value': 'ph',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.STARTS_WITH,
+            'attribute': 'platform',
+            'value': 'py',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_ends_with(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.ENDS_WITH,
+            'attribute': 'platform',
+            'value': 'hp',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.ENDS_WITH,
+            'attribute': 'platform',
+            'value': 'thon',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_contains(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.CONTAINS,
+            'attribute': 'platform',
+            'value': 'p',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.CONTAINS,
+            'attribute': 'platform',
+            'value': 'z',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_does_not_contain(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.NOT_CONTAINS,
+            'attribute': 'platform',
+            'value': 'p',
+        })
+        self.assertDoesNotPass(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.NOT_CONTAINS,
+            'attribute': 'platform',
+            'value': 'z',
+        })
+        self.assertPasses(rule, event)
+
+    def test_message(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'message',
+            'value': 'hello world',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'message',
+            'value': 'php',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_http_method(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'http.method',
+            'value': 'get',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'http.method',
+            'value': 'post',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_http_url(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'http.url',
+            'value': 'http://example.com',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'http.url',
+            'value': 'http://foo.com',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_user_id(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.id',
+            'value': '1',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.id',
+            'value': '2',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_user_ip_address(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.ip_address',
+            'value': '127.0.0.1',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.ip_address',
+            'value': '2',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_user_email(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.email',
+            'value': 'foo@example.com',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.email',
+            'value': '2',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_user_username(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.username',
+            'value': 'foo',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'user.username',
+            'value': '2',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_exception_type(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.type',
+            'value': 'SyntaxError',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.type',
+            'value': 'TypeError',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_exception_value(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.value',
+            'value': 'hello world',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.value',
+            'value': 'foo bar',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_stacktrace_filename(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.filename',
+            'value': 'example.php',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.filename',
+            'value': 'foo.php',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_stacktrace_module(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.module',
+            'value': 'example',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.module',
+            'value': 'foo',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_stacktrace_code(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.code',
+            'value': 'echo "hello";',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.code',
+            'value': 'foo',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_extra_simple_value(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.bar',
+            'value': 'foo',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.bar',
+            'value': 'bar',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_extra_nested_value(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.foo.bar',
+            'value': 'baz',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.foo.bar',
+            'value': 'bar',
+        })
+        self.assertDoesNotPass(rule, event)
+
+    def test_extra_nested_list(self):
+        event = self.get_event()
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.biz',
+            'value': 'baz',
+        })
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.biz',
+            'value': 'bar',
+        })
+        self.assertDoesNotPass(rule, event)


### PR DESCRIPTION
This adds a rule condition which allows you to check against attributes in the event's data.

Attributes supported are:
- message
- platform
- exception.{type,value}
- user.{id,ip_address,email,FIELD}
- http.{method,url}
- stacktrace.{code,module,filename}
- extra.{FIELD}

We handle most of the common cases. We'll need to add a fancy autocomplete widget similar to the new design's search bar (i.e. it gives hints on what you can put in here).

Additionally the "is set" and "is not set" parameters suck. We need to inject some JS to hide the value option in that situation.
