### PR TITLE
Add redis host options

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -186,6 +186,8 @@ That said, if you're running a small install you can probably get away with just
             0: {
                 'host': '127.0.0.1',
                 'port': 6379,
+                'timeout': 3,
+                #'password': 'redis auth password'
             }
         }
     }


### PR DESCRIPTION
Add examples for redis timeout and redis auth ('password', as it relies on nydus)
