### PR TITLE
Add instance methods for javascript processor so they can be extended

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -535,7 +535,7 @@ class SourceProcessor(object):
             cache.add(filename, result.body.splitlines())
             cache.alias(result.url, filename)
 
-            sourcemap_url = discover_sourcemap(result)
+            sourcemap_url = self.discover_sourcemap(result)
             if not sourcemap_url:
                 continue
 
@@ -552,7 +552,7 @@ class SourceProcessor(object):
 
             # pull down sourcemap
             try:
-                sourcemap_idx = fetch_sourcemap(
+                sourcemap_idx = self.fetch_sourcemap(
                     sourcemap_url,
                     project=project,
                     release=release,
@@ -572,3 +572,9 @@ class SourceProcessor(object):
                         done_file_list.add(next_filename)
                     else:
                         pending_file_list.add(next_filename)
+
+    def discover_sourcemap(self, result):
+        return discover_sourcemap(result)
+
+    def fetch_sourcemap(self, url, project=None, release=None):
+        return fetch_sourcemap(url, project, release)

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -552,7 +552,7 @@ class SourceProcessor(object):
 
             # pull down sourcemap
             try:
-                sourcemap_idx = self.fetch_sourcemap(
+                sourcemap_idx = fetch_sourcemap(
                     sourcemap_url,
                     project=project,
                     release=release,
@@ -574,7 +574,5 @@ class SourceProcessor(object):
                         pending_file_list.add(next_filename)
 
     def discover_sourcemap(self, result):
+        global discover_sourcemap
         return discover_sourcemap(result)
-
-    def fetch_sourcemap(self, url, project=None, release=None):
-        return fetch_sourcemap(url, project, release)

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -8,8 +8,8 @@ import responses
 from requests.exceptions import RequestException
 
 from sentry.lang.javascript.processor import (
-    BadSource, discover_sourcemap, fetch_sourcemap, fetch_url, generate_module,
-    trim_line, UrlResult
+    BadSource, fetch_url, generate_module,
+    SourceProcessor, trim_line, UrlResult
 )
 from sentry.lang.javascript.sourcemaps import SourceMap, SourceMapIndex
 from sentry.testutils import TestCase
@@ -75,29 +75,30 @@ class DiscoverSourcemapTest(TestCase):
     # discover_sourcemap(result)
     def test_simple(self):
         result = UrlResult('http://example.com', {}, '')
-        assert discover_sourcemap(result) is None
+        processor = SourceProcessor()
+        assert processor.discover_sourcemap(result) is None
 
         result = UrlResult('http://example.com', {
             'x-sourcemap': 'http://example.com/source.map.js'
         }, '')
-        assert discover_sourcemap(result) == 'http://example.com/source.map.js'
+        assert processor.discover_sourcemap(result) == 'http://example.com/source.map.js'
 
         result = UrlResult('http://example.com', {
             'sourcemap': 'http://example.com/source.map.js'
         }, '')
-        assert discover_sourcemap(result) == 'http://example.com/source.map.js'
+        assert processor.discover_sourcemap(result) == 'http://example.com/source.map.js'
 
         result = UrlResult('http://example.com', {}, '//@ sourceMappingURL=http://example.com/source.map.js\nconsole.log(true)')
-        assert discover_sourcemap(result) == 'http://example.com/source.map.js'
+        assert processor.discover_sourcemap(result) == 'http://example.com/source.map.js'
 
         result = UrlResult('http://example.com', {}, '//# sourceMappingURL=http://example.com/source.map.js\nconsole.log(true)')
-        assert discover_sourcemap(result) == 'http://example.com/source.map.js'
+        assert processor.discover_sourcemap(result) == 'http://example.com/source.map.js'
 
         result = UrlResult('http://example.com', {}, 'console.log(true)\n//@ sourceMappingURL=http://example.com/source.map.js')
-        assert discover_sourcemap(result) == 'http://example.com/source.map.js'
+        assert processor.discover_sourcemap(result) == 'http://example.com/source.map.js'
 
         result = UrlResult('http://example.com', {}, 'console.log(true)\n//# sourceMappingURL=http://example.com/source.map.js')
-        assert discover_sourcemap(result) == 'http://example.com/source.map.js'
+        assert processor.discover_sourcemap(result) == 'http://example.com/source.map.js'
 
 
 class GenerateModuleTest(TestCase):
@@ -125,7 +126,8 @@ class GenerateModuleTest(TestCase):
 
 class FetchBase64SourcemapTest(TestCase):
     def test_simple(self):
-        index = fetch_sourcemap(base64_sourcemap)
+        processor = SourceProcessor()
+        index = processor.fetch_sourcemap(base64_sourcemap)
         states = [SourceMap(1, 0, '/test.js', 0, 0, None)]
         sources = set(['/test.js'])
         keys = [(1, 0)]

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -8,7 +8,7 @@ import responses
 from requests.exceptions import RequestException
 
 from sentry.lang.javascript.processor import (
-    BadSource, fetch_url, generate_module,
+    BadSource, fetch_sourcemap, fetch_url, generate_module,
     SourceProcessor, trim_line, UrlResult
 )
 from sentry.lang.javascript.sourcemaps import SourceMap, SourceMapIndex
@@ -127,7 +127,7 @@ class GenerateModuleTest(TestCase):
 class FetchBase64SourcemapTest(TestCase):
     def test_simple(self):
         processor = SourceProcessor()
-        index = processor.fetch_sourcemap(base64_sourcemap)
+        index = fetch_sourcemap(base64_sourcemap)
         states = [SourceMap(1, 0, '/test.js', 0, 0, None)]
         sources = set(['/test.js'])
         keys = [(1, 0)]


### PR DESCRIPTION
I'm developing a plugin to obtain JS sourcemaps from private sources which require authentication (like S3). I need to override the implementation of both `discover_sourcemap` and `fetch_sourcemap`.
