### PR TITLE
Add sentry-ldap-auth extension

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -50,6 +50,7 @@ The following extensions are available and maintained by members of the Sentry c
 * `sentry-irc <https://github.com/gisce/sentry-irc>`_
 * `sentry-irccat <https://github.com/russss/sentry-irccat>`_
 * `sentry-jira <https://github.com/thurloat/sentry-jira>`_
+* `sentry-ldap-auth <https://github.com/banno/getsentry-ldap-auth>`_
 * `sentry-lighthouse <https://github.com/gthb/sentry-lighthouse>`_
 * `sentry-notifico <https://github.com/lukegb/sentry-notifico>`_
 * `sentry-phabricator <https://github.com/getsentry/sentry-phabricator>`_


### PR DESCRIPTION
Add new extension to the list. Makes the django ldap plugin work better with Sentry.
