### PR TITLE
Explicitly mention minimum required Redis version

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -15,7 +15,7 @@ Some basic prerequisites which you'll need in order to run Sentry:
 * Python 2.7
 * python-setuptools, python-pip, python-dev, libxslt1-dev, libxml2-dev, libz-dev, libffi-dev, libssl-dev
 * A real database (PostgreSQL is preferred, MySQL also works with caveats)
-* Redis
+* Redis (2.4 or newer)
 * Nginx (with RealIP, i.e. nginx-full)
 * A dedicated domain to host Sentry on (i.e. sentry.yourcompany.com).
 

--- a/docs/upgrading/index.rst
+++ b/docs/upgrading/index.rst
@@ -23,7 +23,7 @@ Upgrading to 7.x
 
 An extremely large amount of changes happened between the 6.x and 7.x series. Many of them are backwards incompatible so you should review the setup guide again.
 
-- Redis is now a requirement
+- Redis (at least version 2.4) is now a requirement
 - The queue and buffer systems are no longer optional for production systems
 - Time series data (graphs) have been moved to a new system (there is no data migration)
 - The default sentry.conf.py has greatly changed


### PR DESCRIPTION
Ubuntu 12.04 LTS has Redis 2.2 which will not work (you'll get thousands
of ResponseErrors in the sentry-internal project, something about
"wrong number of arguments for 'zrem' command").
