### PR TITLE
Fix ini syntax in getting started guide

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -356,8 +356,8 @@ folder and you're good to go.
   autostart=true
   autorestart=true
   redirect_stderr=true
-  stdout_logfile syslog
-  stderr_logfile syslog
+  stdout_logfile=syslog
+  stderr_logfile=syslog
 
   [program:sentry-worker]
   directory=/www/sentry/
@@ -365,8 +365,8 @@ folder and you're good to go.
   autostart=true
   autorestart=true
   redirect_stderr=true
-  stdout_logfile syslog
-  stderr_logfile syslog
+  stdout_logfile=syslog
+  stderr_logfile=syslog
 
 
 Removing Old Data


### PR DESCRIPTION
This makes it work on supervisor 3.0 (from EPEL7).
