### PR TITLE
Fix word-wrap

### DIFF
--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -1462,6 +1462,7 @@ ul.traceback {
   color: #474747;
   font-size: 0.9em;
   white-space: pre-wrap;
+  word-wrap: break-word;
   background: #F8F8F8;
   padding: 10px;
   border-radius: 4px;


### PR DESCRIPTION
Add the change from 486d51a975c29dcd337d664107b860fb88978de6 into the less file.

Can we remove the `src/sentry/static/sentry/styles/sentry.css` to avoid confusions?
