### PR TITLE
remove LAN IP addresses from blacklist

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -729,7 +729,6 @@ SENTRY_SOURCE_FETCH_TIMEOUT = 5
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses
 SENTRY_DISALLOWED_IPS = (
     '0.0.0.0/8',
-    '10.0.0.0/8',
     '100.64.0.0/10',
     '127.0.0.0/8',
     '169.254.0.0/16',


### PR DESCRIPTION
For your consideration! :)

This PR removes `10.0.0.0/8` from `SENTRY_DISALLOWED_IPS`.

The reasoning is that `10.0.0.0/8` is "Used for local communications within a private network as specified by RFC 1918." and Sentry should be able to make requests to resources within a private network.  I encountered this need when setting up [sentry-jira](https://github.com/thurloat/sentry-jira), because the Jira instance lives at an IP under `10.0.0.0/8`.

I'm happy to remove `10.0.0.0/8` in my own Sentry config, but I thought I'd send this PR in case you all think this might be a good change for others as well.
