### PR TITLE
Change behavior of sourcemap discovery so last pragma found wins

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -160,15 +160,16 @@ def discover_sourcemap(result):
         # are generous and assume it's somewhere either in the first or last 5 lines.
         # If it's somewhere else in the document, you're probably doing it wrong.
         if len(parsed_body) > 10:
-            possibilities = set(parsed_body[:5] + parsed_body[-5:])
+            possibilities = parsed_body[:5] + parsed_body[-5:]
         else:
-            possibilities = set(parsed_body)
+            possibilities = parsed_body
 
+        # We want to scan each line sequentially, and the last one found wins
+        # This behavior is undocumented, but matches what Chrome and Firefox do.
         for line in possibilities:
-            if line.startswith('//@ sourceMappingURL=') or line.startswith('//# sourceMappingURL='):
+            if line[:21] in ('//# sourceMappingURL=', '//@ sourceMappingURL='):
                 # We want everything AFTER the indicator, which is 21 chars long
                 sourcemap = line[21:].rstrip()
-                break
 
     if sourcemap:
         # fix url so its absolute

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -99,6 +99,9 @@ class DiscoverSourcemapTest(TestCase):
         result = UrlResult('http://example.com', {}, 'console.log(true)\n//# sourceMappingURL=http://example.com/source.map.js')
         assert discover_sourcemap(result) == 'http://example.com/source.map.js'
 
+        result = UrlResult('http://example.com', {}, 'console.log(true)\n//# sourceMappingURL=http://example.com/source.map.js\n//# sourceMappingURL=http://example.com/source2.map.js')
+        assert discover_sourcemap(result) == 'http://example.com/source2.map.js'
+
 
 class GenerateModuleTest(TestCase):
     def test_simple(self):


### PR DESCRIPTION
Currently, we treat all lines the same, and the first one found, we bail and assume that's the one to use.

Turns out, there are several cases where there exist multiple pragmas defined causing ambiguous behavior. This behavior is also blurry and undefined, so we match what browsers do. Both Chrome and Firefox use the last one found while scanning the document sequentially, so we'll do the same.
