### PR TITLE
Set Real-Time Streaming From Cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-core": "^5.6.15",
     "babel-loader": "^5.2.2",
     "chai": "^3.0.0",
+    "js-cookie": "^2.0.2",
     "karma-chai": "^0.1.0",
     "karma-sinon": "^1.0.4",
     "karma-webpack": "^1.5.1",

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -1,6 +1,7 @@
 var React = require("react");
 var Reflux = require("reflux");
 var $ = require("jquery");
+var Cookies = require("js-cookie");
 
 var api = require("../api");
 var GroupActions = require("../actions/groupActions");
@@ -55,6 +56,14 @@ var Stream = React.createClass({
       endpoint: this.getGroupListEndpoint()
     });
     this._poller.enable();
+
+    var realtime = Cookies.get("realtimeActive");
+
+    if (realtime) {
+      this.setState({
+        realtimeActive: realtime === "true"
+      });
+    }
 
     this.fetchData();
   },
@@ -121,9 +130,10 @@ var Stream = React.createClass({
     return '/projects/' + params.orgId + '/' + params.projectId + '/groups/?' + querystring;
   },
 
-  handleRealtimeChange(event) {
+  onRealtimeChange(realtime) {
+    Cookies.set("realtimeActive", realtime.toString());
     this.setState({
-      realtimeActive: !this.state.realtimeActive
+      realtimeActive: realtime
     });
   },
 
@@ -215,7 +225,7 @@ var Stream = React.createClass({
             orgId={params.orgId}
             projectId={params.projectId}
             onSelectStatsPeriod={this.handleSelectStatsPeriod}
-            onRealtimeChange={this.handleRealtimeChange}
+            onRealtimeChange={this.onRealtimeChange}
             realtimeActive={this.state.realtimeActive}
             statsPeriod={this.state.statsPeriod}
             groupIds={this.state.groupIds} />

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -342,9 +342,11 @@ var StreamActions = React.createClass({
       multiSelected: false,
     };
   },
+
   selectStatsPeriod(period) {
     return this.props.onSelectStatsPeriod(period);
   },
+
   actionSelectedGroups(actionType, callback, data) {
     var selectedIds;
 
@@ -363,6 +365,7 @@ var StreamActions = React.createClass({
 
     SelectedGroupStore.clearAll();
   },
+
   onResolve(event, actionType) {
     this.actionSelectedGroups(actionType, (itemIds) => {
       var loadingIndicator = IndicatorStore.add('Saving changes..');
@@ -381,6 +384,7 @@ var StreamActions = React.createClass({
       });
     });
   },
+
   onBookmark(event, actionType) {
     this.actionSelectedGroups(actionType, (itemIds) => {
       var loadingIndicator = IndicatorStore.add('Saving changes..');
@@ -399,6 +403,7 @@ var StreamActions = React.createClass({
       });
     });
   },
+
   onRemoveBookmark(event, actionType) {
     var loadingIndicator = IndicatorStore.add('Saving changes..');
 
@@ -417,6 +422,7 @@ var StreamActions = React.createClass({
       });
     });
   },
+
   onDelete(event, actionType) {
     var loadingIndicator = IndicatorStore.add('Removing events..');
 
@@ -432,6 +438,7 @@ var StreamActions = React.createClass({
       });
     });
   },
+
   onMerge(event, actionType) {
     var loadingIndicator = IndicatorStore.add('Merging events..');
 
@@ -447,6 +454,7 @@ var StreamActions = React.createClass({
       });
     });
   },
+
   onSelectedGroupChange() {
     this.setState({
       selectAllActive: SelectedGroupStore.allSelected(),
@@ -454,9 +462,15 @@ var StreamActions = React.createClass({
       anySelected: SelectedGroupStore.anySelected()
     });
   },
+
   onSelectAll() {
     SelectedGroupStore.toggleSelectAll();
   },
+
+  onRealtimeChange(event) {
+    this.props.onRealtimeChange(!this.props.realtimeActive);
+  },
+
   render() {
     return (
       <div className="stream-actions row">
@@ -542,7 +556,7 @@ var StreamActions = React.createClass({
 
           <div className="btn-group">
             <a className="btn btn-default btn-sm hidden-xs realtime-control"
-               onClick={this.props.onRealtimeChange}>
+               onClick={this.onRealtimeChange}>
               {(this.props.realtimeActive ?
                 <span className="icon icon-pause"></span>
                 :

--- a/tests/js/spec/views/stream.spec.js
+++ b/tests/js/spec/views/stream.spec.js
@@ -1,4 +1,5 @@
 var React = require("react/addons");
+var Cookies = require("js-cookie");
 
 var Api = require("app/api");
 var LoadingError = require("app/components/loadingError");
@@ -20,6 +21,22 @@ describe("Stream", function() {
     this.sandbox.stub(Api, "request");
     this.sandbox.stub(Stream.prototype, "fetchData");
     stubReactComponents(this.sandbox, [StreamGroup]);
+
+    this.Element = stubRouterContext(Stream, {
+      setProjectNavSection() {}
+    }, {
+      getCurrentParams() {
+        return {
+          orgId: "123",
+          projectId: "456"
+        };
+      },
+      getCurrentQuery() {
+        return {
+          limit: 0
+        };
+      }
+    });
   });
 
   afterEach(function() {
@@ -29,22 +46,7 @@ describe("Stream", function() {
   describe("render()", function() {
 
     beforeEach(function() {
-      var Element = stubRouterContext(Stream, {
-        setProjectNavSection() {}
-      }, {
-        getCurrentParams() {
-          return {
-            orgId: "123",
-            projectId: "456"
-          };
-        },
-        getCurrentQuery() {
-          return {
-            limit: 0
-          };
-        }
-      });
-      this.wrapper = TestUtils.renderIntoDocument(<Element />);
+      this.wrapper = TestUtils.renderIntoDocument(<this.Element />);
     });
 
     it("displays a loading indicator when component is loading", function() {
@@ -80,6 +82,70 @@ describe("Stream", function() {
       });
       var expected = findWithClass(this.wrapper, "empty-stream");
       expect(expected).to.be.ok;
+    });
+
+  });
+
+  describe("componentWillMount()", function() {
+
+    afterEach(function() {
+      Cookies.remove("realtimeActive");
+    });
+
+    it("reads the realtimeActive state from a cookie", function() {
+      Cookies.set("realtimeActive", "false");
+      this.wrapper = TestUtils.renderIntoDocument(<this.Element />);
+      var expected = findWithClass(this.wrapper, "icon-play");
+      expect(expected).to.be.ok;
+    });
+
+    it("reads the true realtimeActive state from a cookie", function() {
+      Cookies.set("realtimeActive", "true");
+      this.wrapper = TestUtils.renderIntoDocument(<this.Element />);
+      var expected = findWithClass(this.wrapper, "icon-pause");
+      expect(expected).to.be.ok;
+    });
+
+  });
+
+  describe("onRealtimeChange", function() {
+
+    it("sets the realtimeActive state", function() {
+      this.wrapper = TestUtils.renderIntoDocument(<this.Element />);
+
+      this.wrapper.refs.stub.state.realtimeActive = false;
+      this.wrapper.refs.stub.onRealtimeChange(true);
+      expect(this.wrapper.refs.stub.state.realtimeActive).to.eql(true);
+      expect(Cookies.get("realtimeActive")).to.eql("true");
+
+      this.wrapper.refs.stub.onRealtimeChange(false);
+      expect(this.wrapper.refs.stub.state.realtimeActive).to.eql(false);
+      expect(Cookies.get("realtimeActive")).to.eql("false");
+    });
+
+  });
+
+  describe("getInitialState", function() {
+
+    it("sets the right defaults", function() {
+      this.wrapper = TestUtils.renderIntoDocument(<this.Element />);
+
+      var expected = {
+        groupIds: [],
+        selectAllActive: false,
+        multiSelected: false,
+        anySelected: false,
+        statsPeriod: '24h',
+        realtimeActive: true,
+        pageLinks: '',
+        loading: true,
+        error: false
+      }
+      var actual = this.wrapper.refs.stub.getInitialState();
+
+      for (var property in expected) {
+        expect(actual[property]).to.eql(expected[property]);
+      }
     });
 
   });


### PR DESCRIPTION
#### What's this PR do?

This PR changes the real-time streaming feature to be enabled or disabled via a cookie. Previously the state was defaulted to `true` and toggling the state didn't persist between page loads. Now the state is saved to a cookie and is persisted.

This fixes "Cookie needed for remembering if stream is paused or not" on issue #1585.
#### Where should the reviewer start?

`tests/js/spec/views/stream.spec.js` and `src/sentry/static/sentry/app/views/stream.jsx`
#### How should this be manually tested?

Run `make test-js`

You can also start the Sentry server, navigate to the stream page, toggle the "pause / play" button, and navigate to different pages to see it persisted.
#### Any background context you want to provide?

The [js-cookie](https://www.npmjs.com/package/js-cookie) library was added to help with setting and retrieving cookies.
#### What gif best describes this PR or how it makes you feel?

![coooookie](http://i.giphy.com/1ngQorBCDcUFy.gif)
