### PR TITLE
Poll with Current Active Filters

### DIFF
--- a/src/sentry/static/sentry/app/utils/cursorPoller.jsx
+++ b/src/sentry/static/sentry/app/utils/cursorPoller.jsx
@@ -17,6 +17,10 @@ class CursorPoller {
     return Math.min(delay, this._maxDelay);
   }
 
+  setEndpoint(url) {
+    this._pollingEndpoint = url;
+  }
+
   enable(){
     this._active = true;
     if (!this._timeoutId) {
@@ -51,7 +55,6 @@ class CursorPoller {
         }
 
         var links = parseLinkHeader(jqXHR.getResponseHeader('Link'));
-
         this._pollingEndpoint = links.previous.href;
 
         this.options.success(data, jqXHR.getResponseHeader('Link'));

--- a/src/sentry/static/sentry/app/utils/streamManager.jsx
+++ b/src/sentry/static/sentry/app/utils/streamManager.jsx
@@ -24,6 +24,8 @@ class StreamManager {
     items = [].concat(items);
     if (items.length === 0) return this;
 
+    items = items.filter((item) => item.hasOwnProperty("id"));
+
     items.forEach((item) => removeFromList(item.id, this.idList));
     var ids = items.map((item) => item.id);
     this.idList = [].concat(this.idList, ids);

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -124,7 +124,9 @@ var Stream = React.createClass({
       error: false
     });
 
-    api.request(this.getGroupListEndpoint(), {
+    var url = this.getGroupListEndpoint();
+
+    api.request(url, {
       success: (data, _, jqXHR) => {
         this._streamManager.push(data);
 
@@ -142,6 +144,7 @@ var Stream = React.createClass({
       },
       complete: () => {
         if (this.state.realtimeActive) {
+          this._poller.setEndpoint(url);
           this._poller.enable();
         }
       }

--- a/tests/js/spec/views/stream/filterSelectLink.spec.js
+++ b/tests/js/spec/views/stream/filterSelectLink.spec.js
@@ -11,39 +11,38 @@ describe("FilterSelectLink", function() {
 
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
-    this.wrapper = TestUtils.renderIntoDocument(<FilterSelectLink />);
   });
 
   afterEach(function() {
     this.sandbox.restore();
+    React.unmountComponentAtNode(document.body);
   });
 
   describe("render()", function() {
 
     it("shows a button", function(){
-      var expected = findWithClass(this.wrapper, "btn");
+      var wrapper = React.render(<FilterSelectLink />, document.body);
+      var expected = findWithClass(wrapper, "btn");
       expect(expected).to.be.ok;
     });
 
     it("shows active state when passed isActive=true", function(){
-      this.wrapper = TestUtils.renderIntoDocument(<FilterSelectLink isActive={true} />);
-      var expected = findWithClass(this.wrapper, "active");
+      var wrapper = React.render(<FilterSelectLink isActive={true} />, document.body);
+      var expected = findWithClass(wrapper, "active");
       expect(expected).to.be.ok;
     });
 
     it("doesn't show active state when passed isActive=false", function(){
-      var wrapper = TestUtils.renderIntoDocument(<FilterSelectLink isActive={false} />);
-      function findActive() {
-        findWithClass(wrapper, "active");
-      }
-      expect(findActive).to.throw();
+      var wrapper = React.render(<FilterSelectLink isActive={false} />, document.body);
+      expect(() => findWithClass(wrapper, "active")).to.throw();
     });
 
 
     it("calls onSelect() when clicked", function(){
       var onSelect = this.sandbox.spy();
-      this.wrapper = TestUtils.renderIntoDocument(<FilterSelectLink onSelect={onSelect} />);
-      TestUtils.Simulate.click(this.wrapper.getDOMNode());
+      var wrapper = React.render(<FilterSelectLink onSelect={onSelect} />, document.body);
+
+      TestUtils.Simulate.click(wrapper.getDOMNode());
 
       expect(onSelect.called).to.be.true;
     });

--- a/tests/js/spec/views/stream/searchBar.spec.js
+++ b/tests/js/spec/views/stream/searchBar.spec.js
@@ -17,28 +17,35 @@ describe("SearchBar", function() {
 
   afterEach(function() {
     this.sandbox.restore();
+    React.unmountComponentAtNode(document.body);
   });
 
   describe("clearSearch()", function() {
 
     it("clears the query", function() {
-      var stubbedOnQueryChange = this.sandbox.spy();
-      var wrapper = TestUtils.renderIntoDocument(<SearchBar query={"is:unresolved"} onQueryChange={stubbedOnQueryChange} />);
+      var props = {
+        query: "is:unresolved",
+        onQueryChange: this.sandbox.spy()
+      };
+      var wrapper = React.render(<SearchBar {...props} />, document.body);
+
       wrapper.clearSearch();
-      expect(stubbedOnQueryChange.calledWith("")).to.be.true;
+
+      expect(props.onQueryChange.calledWith("")).to.be.true;
     });
 
     it("calls onSearch()", function(done) {
       var props = {
         query: "is:unresolved",
         onSearch: this.sandbox.spy(),
-        onQueryChange: (query, callback) => callback()
+        onQueryChange: this.sandbox.spy()
       };
-      var wrapper = TestUtils.renderIntoDocument(<SearchBar {...props} />);
+      var wrapper = React.render(<SearchBar {...props} />, document.body);
+
       wrapper.clearSearch();
 
       setTimeout(() => {
-        expect(props.onSearch.called).to.be.true;
+        expect(props.onQueryChange.calledWith("", props.onSearch)).to.be.true;
         done();
       });
     });
@@ -48,9 +55,11 @@ describe("SearchBar", function() {
   describe("onQueryFocus()", function() {
 
     it("displays the drop down", function() {
-      var wrapper = TestUtils.renderIntoDocument(<SearchBar />);
+      var wrapper = React.render(<SearchBar />, document.body);
       expect(wrapper.state.dropdownVisible).to.be.false;
+
       wrapper.onQueryFocus();
+
       expect(wrapper.state.dropdownVisible).to.be.true;
     });
 
@@ -59,10 +68,11 @@ describe("SearchBar", function() {
   describe("onQueryBlur()", function() {
 
     it("hides the drop down", function() {
-      var wrapper = TestUtils.renderIntoDocument(<SearchBar />);
+      var wrapper = React.render(<SearchBar />, document.body);
       wrapper.state.dropdownVisible = true;
 
       wrapper.onQueryBlur();
+
       expect(wrapper.state.dropdownVisible).to.be.false;
     });
 
@@ -71,12 +81,12 @@ describe("SearchBar", function() {
   describe("render()", function() {
 
     it("invokes onSearch() when submitting the form", function() {
-      var stubOnSearch = this.sandbox.spy();
-      var wrapper = TestUtils.renderIntoDocument(<SearchBar onSearch={stubOnSearch} />);
+      var stubbedOnSearch = this.sandbox.spy();
+      var wrapper = React.render(<SearchBar onSearch={stubbedOnSearch} />, document.body);
 
       TestUtils.Simulate.submit(wrapper.refs.searchForm, { preventDefault() {} });
 
-      expect(stubOnSearch.called).to.be.true;
+      expect(stubbedOnSearch.called).to.be.true;
     });
 
     it("invokes onSearch() when search is cleared", function(done) {
@@ -85,13 +95,12 @@ describe("SearchBar", function() {
         onSearch: this.sandbox.spy(),
         onQueryChange: this.sandbox.spy()
       };
-      var wrapper = TestUtils.renderIntoDocument(<SearchBar {...props} />);
+      var wrapper = React.render(<SearchBar {...props} />, document.body);
 
       var cancelButton = findWithClass(wrapper, "search-clear-form");
       TestUtils.Simulate.click(cancelButton);
 
       setTimeout(() => {
-        // expect(props.onSearch.called).to.be.true;
         expect(props.onQueryChange.calledWith("", props.onSearch)).to.be.true;
         done();
       });


### PR DESCRIPTION
#### What's this PR do?

This PR fixes the use of `CursorPoller` in `Stream` so that it's updated with the current active filters. Previously, the poller locked in whatever filters were present on page load.

This fixes "Switching the active filter does not prevent old results from loading" on issue #1585.

Change summary:
- StreamManager: Don't add items unless they have an id
- Stream: sync state with url on mount
- CursorPoller: add `setEndpoint` method to update internal url
- Unmount React components after each test
#### Where should the reviewer start?

`src/sentry/static/sentry/app/views/stream.jsx`
`src/sentry/static/sentry/app/utils/cursorPoller.jsx`
#### How should this be manually tested?

Run `make test-js`

You can also start the Sentry server, navigate to the stream page, and select one of the filters (i.e., "Bookmarks", "Assigned") before the poller has a chance to complete its first poll. If the filtered data remains the same after the first poll has completed then the changes have fixed the issue.
#### Any background context you want to provide?

This PR builds upon #1602.
#### What gif best describes this PR or how it makes you feel?

![cheers](http://media.giphy.com/media/QMkPpxPDYY0fu/giphy.gif)
