### PR TITLE
Format IssueTrackingPlugin labels with format_html

### DIFF
--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 
 from django import forms
 from django.conf import settings
-from django.utils.html import escape
+from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 from social_auth.models import UserSocialAuth
 
@@ -215,10 +215,10 @@ class IssueTrackingPlugin(Plugin):
         if not issue_id:
             return tag_list
 
-        tag_list.append(mark_safe('<a href="%s">%s</a>' % (
+        tag_list.append(format_html('<a href="{}">{}</a>',
             self.get_issue_url(group=group, issue_id=issue_id),
-            escape(self.get_issue_label(group=group, issue_id=issue_id)),
-        )))
+            self.get_issue_label(group=group, issue_id=issue_id),
+        ))
 
         return tag_list
 


### PR DESCRIPTION
This tiny fix allows plugin developers to use either plaintext or marked as safe HTML in label text. 

For instance, I use it to show the github icon next to the issue title when I connect Sentry group to GitHub issue: https://github.com/imankulov/sentry-github/commit/da7120cc8b8214f06cf250ee753a1360f6d3ae8f#diff-6b2638722bc17be62a096a5287822227R103
