### PR TITLE
Add FontAwesome to sentry.css

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "moment": "~2.8.4",
     "simple-slider": "https://github.com/loopj/jquery-simple-slider.git",
     "platformicons": "1.0.2",
-    "raven-js": "~1.1.16"
+    "raven-js": "~1.1.16",
+    "fontawesome": "~4.3.0"
   },
   "resolutions": {
     "bootstrap": "~2.3.2",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,7 +115,7 @@ function buildCssCompileTask(name, fileList) {
     gulp.src(fileList)
     .pipe(gp_cached('css-' + name))
     .pipe(gp_less({
-        paths: [vendorFile("bootstrap/less")]
+        paths: [vendorFile("bootstrap/less"), vendorFile("fontawesome/less")]
     }))
     .pipe(gp_concat(name))
     .pipe(gulp.dest(distPath))

--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -1,4 +1,5 @@
 @import url("../vendor/bootstrap/less/bootstrap.less");
+@import url("../vendor/fontawesome/less/font-awesome.less");
 @import url("fonts.less");
 @import url("datepicker.less");
 @import url("github.less");
@@ -16,6 +17,7 @@
 
 @iconSpritePath:          "../vendor/bootstrap/img/glyphicons-halflings.png";
 @iconWhiteSpritePath:     "../vendor/bootstrap/img/glyphicons-halflings-white.png";
+@fa-font-path:            "../vendor/fontawesome/fonts";
 
 @red: #ff2e46;
 @blue: #1791F8;


### PR DESCRIPTION
I'm not sure if it's a good idea for the upstream or not, but I would definitely love to see more meaningful icons in my Sentry interface. FontAwesome has icon of all types, distributed under a [liberal license](http://fontawesome.io/license/), and in general looks like a great fit for Sentry.

This is my tiny use case: 

![FontAwesome example](http://i.imgur.com/qCj9MTj.png)

Adding in a huge icon set just for one icon may look like an overkill, but for me it would be a nice feature allowing plugin developers to improve the UI of their apps with minimal efforts. 
