### PR TITLE
Fix bug: check_all expects an iterable.

### DIFF
--- a/src/sentry/status_checks/celery_ping.py
+++ b/src/sentry/status_checks/celery_ping.py
@@ -11,8 +11,7 @@ class CeleryPingCheck(StatusCheck):
     def check(self):
         last_ping = options.get('sentry:last_worker_ping') or 0
         if last_ping >= time() - 300:
-            return
-
+            return []
         return [
             Problem("Background workers haven't checked in recently. This can mean an issue with your configuration or a serious backlog in tasks."),
         ]


### PR DESCRIPTION
Otherwise you may get a:

```
[2015-07-22 21:09:53 +0000] [20813] [ERROR] Error handling request
Traceback (most recent call last):
  .... lots of stuff ...
  File "sentry/templatetags/sentry_status.py", line 12, in show_system_status
problems = status_checks.check_all()
  File "sentry/status_checks/__init__.py", line 16, in check_all
problems.extend(cls().check())
TypeError: 'NoneType' object is not iterable
```
