### PR TITLE
Have _health/full return the checks it is calling and not just the problems.

### DIFF
--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -36,12 +36,11 @@ handler500 = Error500View.as_view()
 def handler_healthcheck(request):
     if request.GET.get('full'):
 
-        problems = status_checks.check_all()
-        if problems:
-            return HttpResponse(json.dumps({
-                'problems': map(unicode, problems),
-            }), content_type='application/json', status=500)
-    return HttpResponse('ok')
+        problems, checks = status_checks.check_all()
+        return HttpResponse(json.dumps({
+            'problems': map(unicode, problems),
+            'healthy': checks,
+        }), content_type='application/json', status=(500 if problems else 200))
 
 
 urlpatterns = patterns('',

--- a/src/sentry/status_checks/__init__.py
+++ b/src/sentry/status_checks/__init__.py
@@ -5,13 +5,17 @@ __all__ = ('check_all', 'Problem', 'StatusCheck')
 from .base import Problem, StatusCheck  # NOQA
 from .celery_ping import CeleryPingCheck
 
-checks = [
+check_classes = [
     CeleryPingCheck,
 ]
 
 
 def check_all():
+    checks = {}
     problems = []
-    for cls in checks:
-        problems.extend(cls().check())
-    return problems
+    for cls in check_classes:
+        problem = cls().check()
+        problems.extend(problem)
+        checks[cls.__name__] = not bool(problem)
+
+    return problems, checks

--- a/src/sentry/templatetags/sentry_status.py
+++ b/src/sentry/templatetags/sentry_status.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 @register.inclusion_tag('sentry/partial/system-status.html', takes_context=True)
 def show_system_status(context):
-    problems = status_checks.check_all()
+    problems, _ = status_checks.check_all()
 
     return {
         'problems': problems,


### PR DESCRIPTION
POC for returning check names and health status along with the problems.

Super open to suggestions/discussion. Possibly mapping problems to their respective check. This really is just a suggestion to take it a step further than a generic set of what could be wrong with a self-hosted installation.

Example:

```
bash-3.2$ curl -ik https://vm/_health/?full=1
HTTP/1.1 500 INTERNAL SERVER ERROR
Server: nginx/1.6.3
Date: Thu, 23 Jul 2015 17:20:03 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: close
Vary: Accept-Language, Cookie
Content-Language: en

{
    "healthy": {
        "CeleryPingCheck": false
    },
    "problems": [
        "Background workers haven't checked in recently. This can mean an issue with your configuration or a serious backlog in tasks."
    ]
}
```
