### PR TITLE
Update documentation with instructions for subpath hosting.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Sentry'
-copyright = u'2010-2014, the Sentry Team'
+copyright = u'2010-2015, the Sentry Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -19,6 +19,8 @@ configurations:
 - Set ``maxmemory 1gb`` to a reasonable allowance.
 
 
+.. _performance-web-server:
+
 Web Server
 ----------
 

--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -178,6 +178,10 @@ SENTRY_URL_PREFIX = 'http://sentry.example.com'  # No trailing slash!
 # SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # SESSION_COOKIE_SECURE = True
 
+# If you're not hosting at the root of your web server, and not using uWSGI,
+# you need to uncomment and set it to the path where Sentry is hosted.
+# FORCE_SCRIPT_NAME = '/sentry'
+
 SENTRY_WEB_HOST = '0.0.0.0'
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {


### PR DESCRIPTION
This commit adds configuration instructions for users who wish to host
sentry at a subpath, such as /sentry. It includes how to achieve this
with the default web server, and using uWSGI. This seems to be a
frequently asked question online and I have run both setups at some
point in time.
