### PR TITLE
Support fingerprint in API

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -213,6 +213,7 @@ CLIENT_RESERVED_ATTRS = (
     'message',
     'checksum',
     'culprit',
+    'fingerprint',
     'level',
     'time_spent',
     'logger',


### PR DESCRIPTION
This adds support for the 'fingerprint' attribute in the client spec.

Fingerprint must be a list of strings. If the string is {{ default }} the
default behavior will be implemented, thus allowing you to both extend
and replace it.

Fixes GH-1657
