### PR TITLE
Added instructions to install libpq-dev dependency for PostgreSQL.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -116,6 +116,7 @@ of meta packages to make things easier:
 ::
 
     # install sentry and its postgresql dependencies
+    apt get libpq-dev
     pip install -U sentry[postgres]
 
     # or if you choose, mysql


### PR DESCRIPTION
As part of 'pip install sentry[postgres]', psycopg is being installed. On a clean install of Ubuntu 14.04 this fails since psycopg requires libpq-dev (which has already been mentioned in #1399 and #834, but not added to the docs as far as I could see).
