### PR TITLE
GET /health/ should work without ?full=1

### DIFF
--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -34,13 +34,17 @@ handler500 = Error500View.as_view()
 
 
 def handler_healthcheck(request):
-    if request.GET.get('full'):
+    problems, checks = status_checks.check_all()
 
-        problems, checks = status_checks.check_all()
+    if request.GET.get('full'):
         return HttpResponse(json.dumps({
             'problems': map(unicode, problems),
             'healthy': checks,
         }), content_type='application/json', status=(500 if problems else 200))
+    elif problems:
+        return handler500(request)
+    else:
+        return HttpResponse('ok')
 
 
 urlpatterns = patterns('',


### PR DESCRIPTION
Currently you get the following:

```
[ERROR] Internal Server Error: /_health/
Traceback (most recent call last):
  File "/home/sentry/sentry/env/local/lib/python2.7/site-packages/Django-1.6.11-py2.7.egg/django/core/handlers/base.py", line 130, in get_response
    raise ValueError("The view %s.%s didn't return an HttpResponse object." % (callback.__module__, view_name))
ValueError: The view sentry.conf.urls.handler_healthcheck didn't return an HttpResponse object.
```
