### PR TITLE
Fix issue with showing configuration options when viewing help pages

### DIFF
--- a/src/sentry/web/frontend/help_platform_base.py
+++ b/src/sentry/web/frontend/help_platform_base.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db.models import Q
 from itertools import groupby
 
-from sentry.models import Project, ProjectKey
+from sentry.models import OrganizationMemberTeam, Project, ProjectKey
 from sentry.web.frontend.base import BaseView
 
 
@@ -15,8 +15,11 @@ class HelpPlatformBaseView(BaseView):
             Q(organization__member_set__has_global_access=True, organization__member_set__user=user)
             | Q(team__organizationmember__user=user)
         ).exclude(
-            team__organizationmemberteam__is_active=False,
-        ).select_related('team', 'organization').order_by('organization', 'team').distinct())
+            team__id__in=OrganizationMemberTeam.objects.filter(
+                organizationmember__user=user,
+                is_active=False
+            ).values('team_id')
+        ).select_related('team', 'organization').order_by('organization__name', 'team__name', 'name').distinct())
 
     def group_project_list(self, project_list):
         results = []

--- a/tests/sentry/web/frontend/test_help_platform_index.py
+++ b/tests/sentry/web/frontend/test_help_platform_index.py
@@ -45,3 +45,100 @@ class HelpPlatformIndexTest(TestCase):
         assert len(team_results[1]) == 2
         assert project1 in team_results[1]
         assert project2 in team_results[1]
+
+    # https://github.com/getsentry/sentry/issues/1673
+    def test_correct_project_list_as_global_active(self):
+        org = self.create_organization(owner=self.user)
+        team1 = self.create_team(name='foo', organization=org)
+        project1 = self.create_project(name='foo', team=team1)
+        project2 = self.create_project(name='bar', team=team1)
+        team2 = self.create_team(name='bar', organization=org)
+        project3 = self.create_project(name='baz', team=team2)
+
+        # Our other user
+        other_user = self.create_user('other@localhost', is_superuser=True)
+
+        member = OrganizationMember.objects.get(
+            organization=org,
+            user=self.user,
+        )
+        OrganizationMemberTeam.objects.create(
+            organizationmember=member,
+            team=team2,
+            is_active=False,
+        )
+
+        other_member = OrganizationMember.objects.create(
+            organization=org,
+            user=other_user,
+        )
+        OrganizationMemberTeam.objects.create(
+            organizationmember=other_member,
+            team=team1,
+            is_active=False,
+        )
+
+        path = reverse('sentry-help-platform-list')
+
+        self.login_as(self.user)
+        resp = self.client.get(path)
+        assert resp.status_code == 200
+        assert len(resp.context['org_results']) == 1
+        org_results = resp.context['org_results'][0]
+        assert org_results[0] == org
+        assert len(org_results[1]) == 1
+        team_results = org_results[1][0]
+        assert team_results[0] == team1
+        assert len(team_results[1]) == 2
+        assert project1 in team_results[1]
+        assert project2 in team_results[1]
+
+    def test_correct_project_list_not_global_active(self):
+        org = self.create_organization(owner=self.user)
+        team1 = self.create_team(name='foo', organization=org)
+        project1 = self.create_project(name='foo', team=team1)
+        project2 = self.create_project(name='bar', team=team1)
+        team2 = self.create_team(name='bar', organization=org)
+        project3 = self.create_project(name='baz', team=team2)
+
+        # Our other user
+        other_user = self.create_user('other@localhost', is_superuser=False)
+
+        member = OrganizationMember.objects.get(
+            organization=org,
+            user=self.user,
+        )
+        OrganizationMemberTeam.objects.create(
+            organizationmember=member,
+            team=team2,
+            is_active=False,
+        )
+
+        other_member = OrganizationMember.objects.create(
+            organization=org,
+            user=other_user,
+        )
+        OrganizationMemberTeam.objects.create(
+            organizationmember=other_member,
+            team=team1,
+            is_active=False,
+        )
+        OrganizationMemberTeam.objects.create(
+            organizationmember=other_member,
+            team=team2,
+            is_active=True,
+        )
+
+        path = reverse('sentry-help-platform-list')
+
+        self.login_as(other_user)
+        resp = self.client.get(path)
+        assert resp.status_code == 200
+        assert len(resp.context['org_results']) == 1
+        org_results = resp.context['org_results'][0]
+        assert org_results[0] == org
+        assert len(org_results[1]) == 1
+        team_results = org_results[1][0]
+        assert team_results[0] == team2
+        assert len(team_results[1]) == 1
+        assert project3 in team_results[1]


### PR DESCRIPTION
Fixes #1673, also sorted the list.

The sub-select was better than using a double join on the `organizationmember` and `organizationmember_teams`.
