### PR TITLE
Fix React.addons.classSet deprecation notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "bootstrap": "^3.3.4",
+    "classnames": "^2.1.3",
     "crypto-js": "^3.1.2-5",
     "gulp": "^3.8.11",
     "gulp-clean": "^0.3.1",

--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -1,5 +1,5 @@
 import joinClasses from "react/lib/joinClasses";
-import classSet from "react/lib/cx";
+import classNames from "classnames";
 import React from "react";
 import $ from "jquery";
 
@@ -38,12 +38,12 @@ var DropdownLink = React.createClass({
   },
 
   render() {
-    var className = classSet({
+    var className = classNames({
       "dropdown-toggle": true,
       "disabled": this.props.disabled,
     });
 
-    var topLevelClasses = classSet({
+    var topLevelClasses = classNames({
       "dropdown" : true,
     });
 

--- a/src/sentry/static/sentry/app/components/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/interfaces/exception.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import classSet from "react/lib/cx";
 import GroupEventDataSection from "../eventDataSection";
 import PropTypes from "../../proptypes";
 import RawStacktraceContent from "./rawStacktraceContent";

--- a/src/sentry/static/sentry/app/components/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/interfaces/frame.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import classSet from "react/lib/cx";
+import classNames from "classnames";
 import {defined} from "../../utils";
 import PropTypes from "../../proptypes";
 import ContextData from "../contextData";
@@ -65,7 +65,7 @@ var Frame = React.createClass({
   render() {
     var data = this.props.data;
 
-    var className = classSet({
+    var className = classNames({
       "frame": true,
       "system-frame": !data.inApp,
       "frame-errors": data.errors,

--- a/src/sentry/static/sentry/app/components/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/interfaces/stacktrace.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import classSet from "react/lib/cx";
 import GroupEventDataSection from "../eventDataSection";
 import PropTypes from "../../proptypes";
 import RawStacktraceContent from "./rawStacktraceContent";

--- a/src/sentry/static/sentry/app/components/listLink.jsx
+++ b/src/sentry/static/sentry/app/components/listLink.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Router from "react-router";
-import classSet from 'react/lib/cx';
+import classNames from 'classnames';
 
 var ListLink = React.createClass({
   displayName: 'ListLink',
@@ -24,15 +24,15 @@ var ListLink = React.createClass({
   },
 
   getClassName() {
-    var classNames = {};
+    var _classNames = {};
 
     if (this.props.className)
-      classNames[this.props.className] = true;
+      _classNames[this.props.className] = true;
 
     if (this.context.router.isActive(this.props.to, this.props.params, this.props.query))
-      classNames[this.props.activeClassName] = true;
+      _classNames[this.props.activeClassName] = true;
 
-    return classSet(classNames);
+    return classNames(_classNames);
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/loadingIndicator.jsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.jsx
@@ -1,5 +1,5 @@
 import joinClasses from "react/lib/joinClasses";
-import classSet from "react/lib/cx";
+import classNames from "classnames";
 import React from "react";
 
 var LoadingIndicator = React.createClass({
@@ -13,7 +13,7 @@ var LoadingIndicator = React.createClass({
   },
 
   render() {
-    var className = classSet({
+    var className = classNames({
       "loading": true,
       "mini": this.props.mini,
       "global": this.props.global,

--- a/src/sentry/static/sentry/app/components/menuItem.jsx
+++ b/src/sentry/static/sentry/app/components/menuItem.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Router from "react-router";
 import joinClasses from "react/lib/joinClasses";
-import classSet from "react/lib/cx";
+import classNames from "classnames";
 
 var MenuItem = React.createClass({
   propTypes: {
@@ -70,7 +70,7 @@ var MenuItem = React.createClass({
 
     return (
       <li {...this.props} role="presentation" title={null} href={null}
-        className={joinClasses(this.props.className, classSet(classes))}>
+        className={joinClasses(this.props.className, classNames(classes))}>
         {children}
       </li>
     );


### PR DESCRIPTION
Fixed by using the [classnames library](https://github.com/JedWatson/classnames), as recommended in the React docs.

> This module now exists independently at JedWatson/classnames and is React-agnostic. The add-on here will thus be removed in the future.

http://facebook.github.io/react/docs/class-name-manipulation.html
