### PR TITLE
Add search box to releases page (fixes #1733)

### DIFF
--- a/src/sentry/static/sentry/app/views/projectReleases.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases.jsx
@@ -11,6 +11,7 @@ import RouteMixin from "../mixins/routeMixin";
 import TimeSince from "../components/timeSince";
 import utils from "../utils";
 import Version from "../components/version";
+import SearchBar from "../views/stream/searchBar.jsx";
 
 var ReleaseList = React.createClass({
   contextTypes: {
@@ -56,6 +57,12 @@ var ProjectReleases = React.createClass({
     RouteMixin
   ],
 
+  getDefaultProps() {
+    return {
+      defaultQuery: ""
+    };
+  },
+
   contextTypes: {
     router: React.PropTypes.func
   },
@@ -68,8 +75,19 @@ var ProjectReleases = React.createClass({
     return {
       releaseList: [],
       loading: true,
-      error: false
+      error: false,
+      query: this.props.defaultQuery
     };
+  },
+
+  onQueryChange(query, callback) {
+    this.setState({
+      query: query
+    }, callback);
+  },
+
+  onSearch(query) {
+    this.fetchData();
   },
 
   componentWillMount() {
@@ -108,8 +126,9 @@ var ProjectReleases = React.createClass({
   getProjectReleasesEndpoint() {
     var router = this.context.router;
     var params = router.getCurrentParams();
-    var queryParams = router.getCurrentQuery();
+    var queryParams = $.extend({}, router.getCurrentQuery());
     queryParams.limit = 50;
+    queryParams.query = this.state.query;
 
     return '/projects/' + params.orgId + '/' + params.projectId + '/releases/?' + jQuery.param(queryParams);
   },
@@ -117,7 +136,7 @@ var ProjectReleases = React.createClass({
   onPage(cursor) {
     var router = this.context.router;
     var params = router.getCurrentParams();
-    var queryParams = router.getCurrentQuery();
+    var queryParams = $.extend({}, router.getCurrentQuery());
     queryParams.cursor = cursor;
 
     router.transitionTo('projectReleases', params, queryParams);
@@ -142,7 +161,19 @@ var ProjectReleases = React.createClass({
           <LoadingError onRetry={this.fetchData} />
         :
           <div>
-            <h3>Releases</h3>
+            <div className="row">
+              <div className="col-sm-7">
+                <h3>Releases</h3>
+              </div>
+              <div className="col-sm-5">
+                <SearchBar defaultQuery=""
+                  placeholder="Search for a release."
+                  query={this.state.query}
+                  onQueryChange={this.onQueryChange}
+                  onSearch={this.onSearch}
+                />
+              </div>
+            </div>
             <div className="release-header">
               <div className="row">
                 <div className="col-sm-8 col-xs-6">Version</div>
@@ -172,4 +203,3 @@ var ProjectReleases = React.createClass({
 });
 
 export default ProjectReleases;
-

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -5,6 +5,7 @@ var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
 import DateSelector from "./dateSelector";
 import FilterSelectLink from "./filterSelectLink";
 import SearchBar from "./searchBar";
+import SearchDropdown from "./searchDropdown";
 import utils from "../../utils";
 import SortOptions from "./sortOptions";
 
@@ -90,9 +91,12 @@ var StreamFilters = React.createClass({
           </div>
           <div className="col-sm-5">
             <SearchBar defaultQuery={this.props.defaultQuery}
+              placeholder="Search for events, users, tags, and everything else."
               query={this.props.query}
               onQueryChange={this.props.onQueryChange}
-              onSearch={this.props.onSearch} />
+              onSearch={this.props.onSearch}>
+              <SearchDropdown dropdownVisible={this.state.dropdownVisible} />
+            </SearchBar>
           </div>
         </div>
       </div>
@@ -101,4 +105,3 @@ var StreamFilters = React.createClass({
 });
 
 export default StreamFilters;
-

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -63,12 +63,16 @@ var SearchBar = React.createClass({
   },
 
   render() {
+    var dropdownStyle = {
+      display: this.state.dropdownVisible ? 'block' : 'none'
+    };
+
     return (
       <div className="search">
         <form className="form-horizontal" ref="searchForm" onSubmit={this.onSubmit}>
           <div>
             <input type="text" className="search-input form-control"
-              placeholder="Search for events, users, tags, and everything else."
+              placeholder={this.props.placeholder}
               name="query"
               ref="searchInput"
               autoComplete="off"
@@ -86,7 +90,12 @@ var SearchBar = React.createClass({
               </div>
             }
           </div>
-          <SearchDropdown dropdownVisible={this.state.dropdownVisible} />
+
+          {function() {
+            if (this.props.children) {
+              return <div style={dropdownStyle}>{this.props.children}</div>;
+            }
+          }.call(this)}
         </form>
       </div>
     );

--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -4,23 +4,9 @@ var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
 var SearchDropdown = React.createClass({
   mixins: [PureRenderMixin],
 
-  propTypes: {
-    dropdownVisible: React.PropTypes.bool
-  },
-
-  getDefaultProps() {
-    return {
-      dropdownVisible: false
-    };
-  },
-
   render() {
-    var style = {
-      display: this.props.dropdownVisible ? 'block' : 'none'
-    };
-
     return (
-      <div className="search-dropdown" style={style}>
+      <div className="search-dropdown">
         <ul className="search-helper search-autocomplete-list">
           <li className="search-autocomplete-item">
             <span className="icon icon-tag"></span>
@@ -71,4 +57,3 @@ var SearchDropdown = React.createClass({
 });
 
 export default SearchDropdown;
-


### PR DESCRIPTION
A couple polish TODOs left, but I thought I'd put this PR up since it works and we can start playing with it.

Notes: 
- Makes the `SearchBar` component more generic / no longer stream-specific. I'll follow up and move it to `/components` later.
- Fixed a handful of places where the router's `state.query` was being mutated.
- `SearchDropdown` no longer hides/shows itself, and is now just content. `SearchBar` instead shows/hides the parent container. I did this so a parent component can specify its own dropdown content.
- If no release matches your query, the status / error message says "There don't seem to be any releases yet." We need a more accurate message like "There are no releases matching that query" for this case.
