### PR TITLE
SortOptions no longer comms w/ router, uses callbacks (fixes #1713)

### DIFF
--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -32,6 +32,7 @@ var Stream = React.createClass({
   getDefaultProps() {
     return {
       defaultQuery: "is:unresolved",
+      defaultSort: "date",
       defaultStatsPeriod: "24h",
       maxItems: 25
     };
@@ -239,12 +240,16 @@ var Stream = React.createClass({
     }, callback);
   },
 
+  onSortChange(sort) {
+    this.setState({
+      sort: sort
+    }, this.transitionTo);
+  },
+
   onFilterChange(filter) {
     this.setState({
       filter: filter
-    }, function() {
-      this.transitionTo();
-    });
+    }, this.transitionTo);
   },
 
   transitionTo() {
@@ -257,6 +262,10 @@ var Stream = React.createClass({
 
     if (this.state.query !== this.props.defaultQuery) {
       queryParams.query = this.state.query;
+    }
+
+    if (this.state.sort !== this.props.defaultSort) {
+      queryParams.sort = this.state.sort;
     }
 
     if (this.state.statsPeriod !== this.props.defaultStatsPeriod) {
@@ -316,6 +325,7 @@ var Stream = React.createClass({
         <StreamFilters query={this.state.query}
           defaultQuery={this.props.defaultQuery}
           onQueryChange={this.onQueryChange}
+          onSortChange={this.onSortChange}
           onFilterChange={this.onFilterChange}
           onSearch={this.onSearch} />
         <div className="group-header">

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -17,9 +17,11 @@ var StreamFilters = React.createClass({
   getDefaultProps() {
     return {
       defaultQuery: "",
+      sort: "",
       filter: "",
       query: "",
       onFilterChange: function() {},
+      onSortChange: function() {},
       onQueryChange: function() {},
       onSearch: function() {}
     };
@@ -85,7 +87,9 @@ var StreamFilters = React.createClass({
                 extraClass="btn-assigned" />
               <li className="divider" />
               <li className="highlight">
-                <SortOptions />
+                <SortOptions
+                  sort={this.props.sort}
+                  onSelect={this.props.onSortChange} />
               </li>
             </ul>
           </div>

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -4,41 +4,27 @@ import DropdownLink from "../../components/dropdownLink";
 import MenuItem from "../../components/menuItem";
 
 var SortOptions = React.createClass({
-  contextTypes: {
-    router: React.PropTypes.func
-  },
-
   mixins: [PureRenderMixin],
 
   getInitialState() {
-    var router = this.context.router;
-    var queryParams = router.getCurrentQuery();
-
     return {
-      sortKey: queryParams.sort || 'date'
+      sortKey: this.props.sort || 'date'
     };
   },
 
   getMenuItem(key) {
-    var router = this.context.router;
-    var queryParams = $.extend({}, router.getCurrentQuery());
-    var params = router.getCurrentParams();
-
-    queryParams.sort = key;
-
     return (
-      <MenuItem to="stream" params={params} query={queryParams}
-                isActive={this.state.sortKey === key}>
+      <MenuItem onSelect={this.onSelect} eventKey={key} isActive={this.state.sortKey === key}>
         {this.getSortLabel(key)}
       </MenuItem>
     );
   },
 
-  componentWillReceiveProps(nextProps) {
-    var router = this.context.router;
-    this.setState({
-      sortKey: router.getCurrentQuery().sort || 'date'
-    });
+  onSelect(sort) {
+    this.setState({sortKey: sort});
+    if (this.props.onSelect) {
+      this.props.onSelect(sort);
+    }
   },
 
   getSortLabel(key) {


### PR DESCRIPTION
This fixes a bunch of state mismatch issues caused by `SortOptions` and `Stream` manipulating the query string separately, and without knowledge of each other.

After this patch, `Stream` becomes the single source of truth re: the stream query, and is the only component that manipulates the router.
