### PR TITLE
Improvements to Releases search, search bar ... (fixes #1776)

### DIFF
--- a/src/sentry/static/sentry/app/views/projectReleases.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases.jsx
@@ -80,14 +80,8 @@ var ProjectReleases = React.createClass({
     };
   },
 
-  onQueryChange(query, callback) {
-    this.setState({
-      query: query
-    }, callback);
-  },
-
   onSearch(query) {
-    this.fetchData();
+    this.setState({ query: query }, this.fetchData);
   },
 
   componentWillMount() {
@@ -156,19 +150,30 @@ var ProjectReleases = React.createClass({
       body = this.renderLoading();
     else if (this.state.error)
       body = <LoadingError onRetry={this.fetchData} />;
-    else if (this.state.releaseList.length > 0) {
+    else if (this.state.releaseList.length > 0)
       body = <ReleaseList releaseList={this.state.releaseList} />;
-    } else {
+    else if (this.state.query && this.state.query !== this.props.defaultQuery)
+      body = this.renderNoQueryResults();
+    else
       body = this.renderEmpty();
-    }
 
     return body;
   },
+
 
   renderLoading() {
     return (
       <div className="box">
         <LoadingIndicator />
+      </div>
+    );
+  },
+
+  renderNoQueryResults() {
+    return (
+      <div className="box empty-stream">
+        <span className="icon icon-exclamation" />
+        <p>Sorry, no releases match your filters.</p>
       </div>
     );
   },

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -236,14 +236,10 @@ var Stream = React.createClass({
     router.transitionTo('stream', params, queryParams);
   },
 
-  onSearch() {
-    this.transitionTo();
-  },
-
-  onQueryChange(query, callback) {
+  onSearch(query) {
     this.setState({
       query: query
-    }, callback);
+    }, this.transitionTo);
   },
 
   onSortChange(sort) {
@@ -330,7 +326,6 @@ var Stream = React.createClass({
       <div>
         <StreamFilters query={this.state.query}
           defaultQuery={this.props.defaultQuery}
-          onQueryChange={this.onQueryChange}
           onSortChange={this.onSortChange}
           onFilterChange={this.onFilterChange}
           onSearch={this.onSearch} />

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -22,7 +22,6 @@ var StreamFilters = React.createClass({
       query: "",
       onFilterChange: function() {},
       onSortChange: function() {},
-      onQueryChange: function() {},
       onSearch: function() {}
     };
   },
@@ -97,7 +96,6 @@ var StreamFilters = React.createClass({
             <SearchBar defaultQuery={this.props.defaultQuery}
               placeholder="Search for events, users, tags, and everything else."
               query={this.props.query}
-              onQueryChange={this.props.onQueryChange}
               onSearch={this.props.onSearch}>
               <SearchDropdown dropdownVisible={this.state.dropdownVisible} />
             </SearchBar>

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -21,6 +21,7 @@ var SearchBar = React.createClass({
 
   getInitialState() {
     return {
+      query: this.props.query || this.props.defaultQuery,
       dropdownVisible: false
     };
   },
@@ -32,11 +33,14 @@ var SearchBar = React.createClass({
   onSubmit(event) {
     event.preventDefault();
     this.blur();
-    this.props.onSearch();
+    this.props.onSearch(this.state.query);
   },
 
   clearSearch() {
-    this.props.onQueryChange(this.props.defaultQuery, this.props.onSearch);
+    this.setState(
+      { query: this.props.defaultQuery },
+      () => this.props.onSearch(this.state.query)
+    );
   },
 
   onQueryFocus() {
@@ -52,7 +56,10 @@ var SearchBar = React.createClass({
   },
 
   onQueryChange(event) {
-    this.props.onQueryChange(event.target.value);
+    this.setState(
+      { query: event.target.value },
+      () => this.props.onQueryChange(this.state.query)
+    );
   },
 
   onKeyUp(event) {
@@ -76,13 +83,13 @@ var SearchBar = React.createClass({
               name="query"
               ref="searchInput"
               autoComplete="off"
-              value={this.props.query}
+              value={this.state.query}
               onFocus={this.onQueryFocus}
               onBlur={this.onQueryBlur}
               onKeyUp={this.onKeyUp}
               onChange={this.onQueryChange} />
             <span className="icon-search" />
-            {this.props.query !== this.props.defaultQuery &&
+            {this.state.query !== this.props.defaultQuery &&
               <div>
                 <a className="search-clear-form" onClick={this.clearSearch}>
                   <span className="icon-circle-cross" />

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -25,28 +25,28 @@ describe("SearchBar", function() {
 
     it("clears the query", function() {
       var props = {
-        query: "is:unresolved",
-        onQueryChange: this.sandbox.spy()
+        query: "is:unresolved ruby",
+        defaultQuery: "is:unresolved"
       };
       var wrapper = React.render(<SearchBar {...props} />, document.body);
 
       wrapper.clearSearch();
 
-      expect(props.onQueryChange.calledWith("")).to.be.true;
+      expect(wrapper.state.query).to.equal("is:unresolved");
     });
 
     it("calls onSearch()", function(done) {
       var props = {
-        query: "is:unresolved",
-        onSearch: this.sandbox.spy(),
-        onQueryChange: this.sandbox.spy()
+        query: "is:unresolved ruby",
+        defaultQuery: "is:unresolved",
+        onSearch: this.sandbox.spy()
       };
       var wrapper = React.render(<SearchBar {...props} />, document.body);
 
       wrapper.clearSearch();
 
       setTimeout(() => {
-        expect(props.onQueryChange.calledWith("", props.onSearch)).to.be.true;
+        expect(props.onSearch.calledWith("is:unresolved")).to.be.true;
         done();
       });
     });
@@ -112,8 +112,7 @@ describe("SearchBar", function() {
     it("invokes onSearch() when search is cleared", function(done) {
       var props = {
         query: "is:unresolved",
-        onSearch: this.sandbox.spy(),
-        onQueryChange: this.sandbox.spy()
+        onSearch: this.sandbox.spy()
       };
       var wrapper = React.render(<SearchBar {...props} />, document.body);
 
@@ -121,7 +120,7 @@ describe("SearchBar", function() {
       TestUtils.Simulate.click(cancelButton);
 
       setTimeout(() => {
-        expect(props.onQueryChange.calledWith("", props.onSearch)).to.be.true;
+        expect(props.onSearch.calledWith("")).to.be.true;
         done();
       });
     });


### PR DESCRIPTION
- Search bar now maintains its own query state
- Stream, Project Releases listen only to submitted queries (or clears)
- "No results" on releases search when query present / no results
