### PR TITLE
Add php raw interface (fixes #1805)

### DIFF
--- a/tests/js/spec/components/interfaces/rawStacktraceContent.spec.jsx
+++ b/tests/js/spec/components/interfaces/rawStacktraceContent.spec.jsx
@@ -3,7 +3,7 @@ var React = require("react/addons");
 var Cookies = require("js-cookie");
 
 var api = require("app/api");
-import {getJavaFrame} from "app/components/interfaces/rawStacktraceContent";
+import {getJavaFrame, getPHPFrame, getPHPException} from "app/components/interfaces/rawStacktraceContent";
 
 var TestUtils = React.addons.TestUtils;
 
@@ -29,6 +29,45 @@ describe("RawStacktraceContent", function() {
         module: 'org.mortbay.thread.QueuedThreadPool$PoolThread',
         function: 'run'
       })).to.eql('    at org.mortbay.thread.QueuedThreadPool$PoolThread.run');
+    });
+  });
+
+  describe('getPHPFrame()', function () {
+    it('should render PHP frames', function () {
+      expect(getPHPFrame({
+        module: 'Raven_Client',
+        function: 'capture',
+        filename: '/raven-php/lib/Raven/Client.php',
+        lineNo: 302
+      }, 0)).to.eql('#0 /raven-php/lib/Raven/Client.php(302): Raven_Client->capture()');
+
+      // without line number
+      expect(getPHPFrame({
+        module: 'Raven_Client',
+        function: 'capture',
+        filename: '/raven-php/lib/Raven/Client.php'
+      }, 0)).to.eql('#0 /raven-php/lib/Raven/Client.php: Raven_Client->capture()');
+
+      // without line number and filename
+      expect(getPHPFrame({
+        module: 'Raven_Client',
+        function: 'capture',
+      }, 0)).to.eql('#0 Raven_Client->capture()');
+    });
+  });
+
+  describe('getPHPException()', function () {
+    it('should render PHP exception', function () {
+      expect(getPHPException({
+        type: 'Exception',
+        value: 'something bad happened',
+        module: '/raven-php/lib/Raven/Client.php:302' // module contains path + lineno for PHP
+      })).to.eql('Exception: something bad happened in /raven-php/lib/Raven/Client.php:302\nStack trace:');
+
+      expect(getPHPException({
+        type: 'Exception',
+        value: 'something bad happened'
+      })).to.eql('Exception: something bad happened\nStack trace:');
     });
   });
 });


### PR DESCRIPTION
Note this doesn't handle the final, trailing line:

```
#1 {main}
  thrown in /Users/benvinegar/Projects/test.php on line 4
```

I need to compare some more sample data to figure out how this works, 'cause it doesn't seem to be present in the captured exception we're working with.
