### PR TITLE
RichHttpContent should attempt JSON parsing, even w/ bad Content-Type

### DIFF
--- a/src/sentry/static/sentry/app/components/interfaces/richHttpContent.jsx
+++ b/src/sentry/static/sentry/app/components/interfaces/richHttpContent.jsx
@@ -34,16 +34,24 @@ var RichHttpContent = React.createClass({
     contentType = contentType && contentType[1];
 
     switch (contentType) {
-      case 'application/json':
-        try {
-          // Sentry API abbreviates long JSON strings, which cannot be parsed ...
-          return <ContextData data={JSON.parse(data.data)} />;
-        } catch (e) { /* do nothing */ }
-        return <pre>{data.data}</pre>
       case 'application/x-www-form-urlencoded':
         return <DefinitionList data={this.objectToTupleArray(queryString.parse(data.data))}/>
+      case 'application/json':
+        // falls through
       default:
-        return <pre>{data.data}</pre>;
+        // Even if Content-Type isn't JSON, attempt to serialize it as JSON
+        // anyways. Many HTTP requests contains JSON bodies, despite not having
+        // matching Content-Type.
+        return this.getJsonOrRaw(data.data);
+    }
+  },
+
+  getJsonOrRaw(data) {
+    try {
+      // Sentry API abbreviates long JSON strings, which cannot be parsed ...
+      return <ContextData data={JSON.parse(data)} />;
+    } catch (e) {
+      return <pre>{data}</pre>
     }
   },
 

--- a/tests/js/spec/components/interfaces/richHttpContent.spec.jsx
+++ b/tests/js/spec/components/interfaces/richHttpContent.spec.jsx
@@ -50,7 +50,7 @@ describe("RichHttpContent", function () {
   });
 
   describe("getBodySection", function () {
-    it("should return plain-text when unrecognized Content-Type", function () {
+    it("should return plain-text when unrecognized Content-Type and not parsable as JSON", function () {
       let out = this.elem.getBodySection({
         headers: [], // no content-type header,
         data: 'helloworld'
@@ -92,7 +92,22 @@ describe("RichHttpContent", function () {
       });
     });
 
-    it("should return plain-text when JSON is not parseable", function () {
+    it("should return a ContextData element when content is JSON, ignoring Content-Type", function () {
+      var out = this.elem.getBodySection({
+        headers: [
+          ['Content-Type', 'text/plain']
+        ], // no content-type header,
+        data: JSON.stringify({foo: 'bar'})
+      });
+
+      // NOTE: ContextData is stubbed in tests; instead returns <div className="ContextData"/>
+      expect(out.props.className).to.eql('ContextData');
+      expect(out.props.data).to.eql({
+        foo: 'bar'
+      });
+    });
+
+    it("should return plain-text when JSON is not parsable", function () {
       let out = this.elem.getBodySection({
         headers: [
           ['lol' , 'no'],


### PR DESCRIPTION
Seems like there's not much harm in doing this ... as it try/catches back to plaintext. Thoughts @dcramer?
