### PR TITLE
Add basic reference integrity checks to NodeStore

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -388,6 +388,10 @@ class EventManager(object):
         using = group._state.db
 
         event.group = group
+        # store a reference to the group id to guarantee validation of isolation
+        # TODO(dcramer): ideally NodeField would do this itself, but it's unable
+        # to
+        event.data.bind_ref(group)
 
         try:
             with transaction.atomic():


### PR DESCRIPTION
This will add a new 'ref' concept to NodeField. The ref is bound to the primary key of the instance, and is then validated when its pulled out.
