### PR TITLE
Expose a hook for IssueTrackingPlugin.get_issue_annotation_html

### DIFF
--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -214,14 +214,22 @@ class IssueTrackingPlugin(Plugin):
         if not issue_id:
             return tag_list
 
-        tag_list.append(format_html('<a href="{}">{}</a>',
-            self.get_issue_url(group=group, issue_id=issue_id),
-            self.get_issue_label(group=group, issue_id=issue_id),
-        ))
+        tag_list.append(self.get_issue_annotation_html(group=group, issue_id=issue_id))
 
         return tag_list
 
     def get_issue_doc_html(self, **kwargs):
         return ""
+
+    def get_issue_annotation_html(self, group, issue_id, **kwargs):
+        """
+        Given an issue_id (string) return a string representing the entire
+        HTML for the issue annotation.
+        """
+        return format_html(
+            '<a href="{}">{}</a>{}',
+            self.get_issue_url(group=group, issue_id=issue_id),
+            self.get_issue_label(group=group, issue_id=issue_id),
+        )
 
 IssuePlugin = IssueTrackingPlugin


### PR DESCRIPTION
This will allow a plugin to override the HTML snippet that comes out
for the issue's annotation. This will allow potentially a plugin to
inject some JavaScript to check the status of the issue.

I'd want to first shove this in for the GitHub plugin so that we can show the
state of the issue and make the request purely client side.

Something like:

``` javascript
$.ajax('https://api.github.com/repos/getsentry/sentry/issues/1889').done(function(data){
  console.log(data.state)
})
```

Will need to get injected.

:+1: :-1: ?
