### PR TITLE
Update RiakNodeStore to use our own lightweight client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ tests_require = [
     'pytest-timeout',
     'python-coveralls',
     'responses',
-    'riak',
 ]
 
 
@@ -111,7 +110,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'South==1.0.1',
     'toronado>=0.0.4,<0.1.0',
-    'urllib3>=1.7.1,<1.8.0',
+    'urllib3>=1.11,<1.12',
     'rb',
 ]
 

--- a/src/sentry/nodestore/riak/backend.py
+++ b/src/sentry/nodestore/riak/backend.py
@@ -2,115 +2,75 @@
 sentry.nodestore.riak.backend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 
 from __future__ import absolute_import
 
-import riak
-import riak.resolver
 import six
-
-# XXX(dcramer): I realize this is a private function. We lock in versions, so
-# we're going to treat it as a public API as it's better than re-implementing
-# the function using the other public APIs.
-from riak.client.transport import _is_retryable
-from time import sleep
+import json
 
 from sentry.nodestore.base import NodeStorage
-from sentry.utils.cache import memoize
+from .client import RiakClient
 
 
-# Riak commonly has timeouts or non-200 HTTP errors. Being that almost
-# always our messages are immutable, it's safe to simply retry in many
-# cases
-def retry(attempts, func, *args, **kwargs):
-    for _ in range(attempts):
-        try:
-            return func(*args, **kwargs)
-        except Exception as err:
-            if _is_retryable(err):
-                sleep(0.01)
-            raise
-    raise
-
-
-# TODO(dcramer): ideally we would use Nydus here, but we need to confirm that
-# the Riak backend is in good shape. This would resolve some issues we see with
-# riak-python, and Nydus is a much more lean codebase that removes a lot of the
-# complexities (and thus, things features dont want or plan to use)
 class RiakNodeStorage(NodeStorage):
     """
     A Riak-based backend for storing node data.
 
-    >>> RiakNodeStorage(nodes=[{'host':'127.0.0.1','http_port':8098}])
-
-    Due to issues with riak-python, we implement our own retry strategy for the
-    get_multi behavior.
+    >>> RiakNodeStorage(nodes=[{'host':'127.0.0.1','port':8098}])
     """
-    def __init__(self, nodes, bucket='nodes',
-                 resolver=riak.resolver.last_written_resolver,
-                 protocol='http',
-                 max_retries=3):
-        self._client_options = {
-            'nodes': nodes,
-            'resolver': resolver,
-            'protocol': protocol,
-            'retries': 0,
-        }
-        self._bucket_name = bucket
-        self.max_retries = max_retries
-
-    @memoize
-    def conn(self):
-        return riak.RiakClient(**self._client_options)
-
-    @memoize
-    def bucket(self):
-        return self.conn.bucket(self._bucket_name)
-
-    def create(self, data):
-        node_id = self.generate_id()
-        obj = self.bucket.new(data=data, key=node_id)
-        retry(self.max_retries, obj.store)
-        return obj.key
-
-    def delete(self, id):
-        obj = self.bucket.new(key=id)
-        retry(self.max_retries, obj.delete)
-
-    def get(self, id):
-        # just fetch it from a random backend, we're not aiming for consistency
-        obj = retry(self.max_retries, self.bucket.get, key=id, r=1)
-        if not obj:
-            return None
-        return obj.data
-
-    def get_multi(self, id_list):
-        attempt_num = 0
-        results = {}
-        while id_list and attempt_num < self.max_retries:
-            attempt_num += 1
-            result = self.bucket.multiget(id_list, r=1)
-            id_list = []
-            for obj in result:
-                # errors return a tuple of (bucket, key, err)
-                if isinstance(obj, tuple):
-                    err = obj[3]
-                    if attempt_num == self.max_retries:
-                        six.reraise(type(err), err)
-                    elif _is_retryable(err):
-                        id_list.append(obj[2])
-                    else:
-                        six.reraise(type(err), err)
-                else:
-                    results[obj.key] = obj.data
-        return results
+    def __init__(self, nodes, bucket='nodes', timeout=1, cooldown=5,
+                 max_retries=3, multiget_pool_size=5, tcp_keepalive=True,
+                 protocol=None):
+        # protocol being defined is useless, but is needed for backwards
+        # compatability and leveraged as an opportunity to yell at the user
+        if protocol == 'pbc':
+            raise ValueError("'pbc' protocol is no longer supported")
+        if protocol is not None:
+            import warnings
+            warnings.warn("'protocol' has been deprecated",
+                          DeprecationWarning)
+        self.bucket = bucket
+        self.conn = RiakClient(**dict(
+            hosts=nodes,
+            max_retries=max_retries,
+            multiget_pool_size=multiget_pool_size,
+            cooldown=cooldown,
+            tcp_keepalive=tcp_keepalive,
+        ))
 
     def set(self, id, data):
-        obj = self.bucket.new(key=id, data=data)
-        retry(self.max_retries, obj.store)
+        data = json.dumps(data, separators=(',', ':'))
+        self.conn.put(self.bucket, id, data, returnbody='false')
+
+    def delete(self, id):
+        self.conn.delete(self.bucket, id)
+
+    def get(self, id):
+        rv = self.conn.get(self.bucket, id, r=1)
+        if rv.status != 200:
+            return None
+        return json.loads(rv.data)
+
+    def get_multi(self, id_list):
+        # shortcut for just one id since this is a common
+        # case for us from EventManager.bind_nodes
+        if len(id_list) == 1:
+            id = id_list[0]
+            return {id: self.get(id)}
+
+        rv = self.conn.multiget(self.bucket, id_list, r=1)
+        results = {}
+        for key, value in rv.iteritems():
+            if isinstance(value, Exception):
+                six.reraise(type(value), value)
+            if value.status != 200:
+                results[key] = None
+            else:
+                results[key] = json.loads(value.data)
+        return results
 
     def cleanup(self, cutoff_timestamp):
         # TODO(dcramer): we should either index timestamps or have this run

--- a/src/sentry/nodestore/riak/client.py
+++ b/src/sentry/nodestore/riak/client.py
@@ -1,0 +1,275 @@
+"""
+sentry.nodestore.riak.client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+import socket
+from random import shuffle
+from time import time
+from threading import Lock, Thread, Event
+from Queue import Queue
+
+# utilize the ca_certs path from requests since we already depend on it
+# and they bundle a ca cert.
+from requests.certs import where as ca_certs
+from urllib import urlencode, quote_plus
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.connection import HTTPConnection
+from urllib3.exceptions import HTTPError
+
+
+DEFAULT_NODES = (
+    {'host': '127.0.0.1', 'port': 8098},
+)
+
+
+class RiakClient(object):
+    """
+    A thread-safe simple light-weight riak client that does only
+    the bare minimum.
+    """
+    def __init__(self, multiget_pool_size=5, **kwargs):
+        self.manager = ConnectionManager(**kwargs)
+        self.queue = Queue()
+
+        # TODO: maybe start this lazily? Probably not valuable though
+        # since we definitely will need it.
+        self._start(multiget_pool_size)
+
+    def _start(self, size):
+        assert size > 0
+        for _ in xrange(size):
+            t = Thread(target=self._target)
+            t.setDaemon(True)
+            t.start()
+
+    def _target(self):
+        q = self.queue
+        while True:
+            func, args, kwargs, cb = q.get()
+            try:
+                rv = func(*args, **kwargs)
+            except Exception as e:
+                rv = e
+            finally:
+                cb(rv)
+                q.task_done()
+
+    def build_url(self, bucket, key, qs):
+        url = '/buckets/%s/keys/%s' % tuple(map(quote_plus, (bucket, key)))
+        if qs:
+            url += '?' + urlencode(qs)
+        return url
+
+    def put(self, bucket, key, data, headers=None, **kwargs):
+        if headers is None:
+            headers = {}
+        headers['content-type'] = 'application/json'
+
+        return self.manager.urlopen(
+            'PUT', self.build_url(bucket, key, kwargs),
+            headers=headers,
+            body=data,
+        )
+
+    def delete(self, bucket, key, headers=None, **kwargs):
+        return self.manager.urlopen(
+            'DELETE', self.build_url(bucket, key, kwargs),
+            headers=headers,
+        )
+
+    def get(self, bucket, key, headers=None, **kwargs):
+        return self.manager.urlopen(
+            'GET', self.build_url(bucket, key, kwargs),
+            headers=headers,
+        )
+
+    def multiget(self, bucket, keys, headers=None, **kwargs):
+        """
+        Thread-safe multiget implementation that shares the same thread pool
+        for all requests.
+        """
+        # Each request is paired with a thread.Event to signal when it is finished
+        requests = [
+            (key, self.build_url(bucket, key, {'foo': 'bar'}), Event())
+            for key in keys
+        ]
+
+        results = {}
+        for key, url, event in requests:
+            def callback(rv, key=key, event=event):
+                results[key] = rv
+                # Signal that this request is finished
+                event.set()
+
+            self.queue.put((
+                self.manager.urlopen,  # func
+                ('GET', url),  # args
+                {'headers': headers},  # kwargs
+                callback,  # callback
+            ))
+
+        # Now we wait for all of the callbacks to be finished
+        for _, _, event in requests:
+            event.wait()
+
+        return results
+
+    def close(self):
+        self.manager.close()
+
+
+class RoundRobinStrategy(object):
+    def __init__(self):
+        self.i = -1
+
+    def next(self, connections):
+        self.i += 1
+        return connections[self.i % len(connections)]
+
+
+class ConnectionManager(object):
+    """
+    A thread-safe multi-host http connection manager.
+    """
+    def __init__(self, hosts=DEFAULT_NODES, strategy=RoundRobinStrategy, randomize=True,
+                 timeout=1, cooldown=5, max_retries=3, tcp_keepalive=True):
+        assert hosts
+        self.strategy = strategy()
+        self.dead_connections = []
+        self.timeout = timeout
+        self.cooldown = cooldown
+        self.max_retries = max_retries
+        self.tcp_keepalive = tcp_keepalive
+
+        self.connections = map(self.create_pool, hosts)
+        # Shuffle up the order to prevent stampeding the same hosts
+        if randomize:
+            shuffle(self.connections)
+
+        # Lock needed when mutating the alive/dead list of connections
+        self._lock = Lock()
+
+    def create_pool(self, host):
+        """
+        Create a new HTTP(S)ConnectionPool for a (host, port) tuple
+        """
+        options = {
+            'timeout': self.timeout,
+            'strict': True,
+            # We don't need urllib3's retries, since we'll retry
+            # on a different host ourselves
+            'retries': False,
+            # Max of 5 connections open per host
+            # this is arbitrary. The # of connections can burst
+            # above 5 if needed becuase we're also setting
+            # block=False
+            'maxsize': 5,
+            'block': False,
+        }
+        if self.tcp_keepalive:
+            options['socket_options'] = HTTPConnection.default_socket_options + [
+                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            ]
+
+        # Support backwards compatibility with `http_port`
+        if 'http_port' in host:
+            import warnings
+            warnings.warn("'http_port' has been deprecated. Use 'port'.",
+                          DeprecationWarning)
+            host['port'] = host.pop('http_port')
+
+        addr = host.get('host', '127.0.0.1')
+        port = int(host.get('port', 8098))
+        secure = host.get('secure', False)
+        if not secure:
+            connection_cls = HTTPConnectionPool
+        else:
+            connection_cls = HTTPSConnectionPool
+            verify_ssl = host.get('verify_ssl', False)
+            if verify_ssl:
+                options.extend({
+                    'cert_reqs': host.get('cert_reqs', 'CERT_REQUIRED'),
+                    'ca_certs': host.get('ca_certs', ca_certs())
+                })
+        return connection_cls(addr, port, **options)
+
+    def urlopen(self, method, path, **kwargs):
+        """
+        Make a request using the next server according to the connection
+        strategy, and retries up to max_retries attempts. Ultimately,
+        if the request still failed, we reraise the HTTPError from
+        urllib3. If at the start of the request, there are no known
+        available hosts, we revive all dead connections and forcefully
+        attempt to reconnect.
+        """
+        # If we're trying to initiate a new connection, and
+        # all connections are already dead, then we should flail
+        # and attempt to connect to one of them
+        if len(self.connections) == 0:
+            self.force_revive()
+
+        print method, path
+        try:
+            for _ in xrange(self.max_retries):
+                conn = self.strategy.next(self.connections)
+                try:
+                    return conn.urlopen(method, path, **kwargs)
+                except HTTPError as e:
+                    self.mark_dead(conn)
+
+                    if len(self.connections) == 0:
+                        raise
+        finally:
+            self.cleanup_dead()
+
+    def mark_dead(self, conn):
+        """
+        Mark a connection as dead.
+        """
+        timeout = time() + self.cooldown
+        with self._lock:
+            self.dead_connections.append((conn, timeout))
+            self.connections.remove(conn)
+
+    def force_revive(self):
+        """
+        Forcefully revive all dead connections
+        """
+        with self._lock:
+            for conn, _ in self.dead_connections:
+                self.connections.append(conn)
+            self.dead_connections = []
+
+    def cleanup_dead(self):
+        """
+        Check dead connections and see if any timeouts have expired
+        """
+        if not self.dead_connections:
+            return
+
+        now = time()
+        for conn, timeout in self.dead_connections[:]:
+            if timeout > now:
+                # Can exit fast here on the first non-expired
+                # since dead_connections is ordered
+                return
+
+            # timeout has expired, so move from dead to alive pool
+            with self._lock:
+                self.connections.append(conn)
+                self.dead_connections.remove((conn, timeout))
+
+    def close(self):
+        """
+        Close all connections to all servers
+        """
+        self.force_revive()
+
+        for conn in self.connections:
+            conn.close()


### PR DESCRIPTION
/cc @dcramer @mitsuhiko @tkaemming 

Refs GH-1823

:fire:

Some non-scientific benchmarks show that `RiakLightNodeStorage` is significantly faster, especially with `get_multi`:

```
$ python -m timeit -s 'from sentry.utils.runner import configure;configure();from sentry.nodestore.riak.backend import RiakNodeStorage; store=RiakNodeStorage(nodes=[{"host":"127.0.0.1","http_port":8098}])' 'store.get_multi(["foo","bar","baz","thing"])'
100 loops, best of 3: 10.6 msec per loop
$ python -m timeit -s 'from sentry.utils.runner import configure;configure();from sentry.nodestore.riak_light.backend import RiakLightNodeStorage; store=RiakLightNodeStorage(addrs=[("127.0.0.1",8098)])' 'store.get_multi(["foo","bar","baz","thing"])'
100 loops, best of 3: 3.6 msec per loop
$ python -m timeit -s 'from sentry.utils.runner import configure;configure();from sentry.nodestore.riak.backend import RiakNodeStorage; store=RiakNodeStorage(nodes=[{"host":"127.0.0.1","http_port":8098}])' 'store.get("foo")'
1000 loops, best of 3: 1.72 msec per loop
$ python -m timeit -s 'from sentry.utils.runner import configure;configure();from sentry.nodestore.riak_light.backend import RiakLightNodeStorage; store=RiakLightNodeStorage(addrs=[("127.0.0.1",8098)])' 'store.get("foo")'
1000 loops, best of 3: 1.26 msec per loop
```
- [x] TLS
- [x] replace RiakNodeStore
