### PR TITLE
Fixed sidebar markup

### DIFF
--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -1736,15 +1736,22 @@ div.pastebin textarea { padding: 10px; background: #f9f9f9; border-color: #ddd; 
 
 dl.flat {
     margin-bottom: 1em;
-}
-dl.flat dt {
-    float: left;
-    clear: left;
-    width: 90px;
-    padding-bottom: 5px;
-}
-dl.flat dd {
-    padding-bottom: 5px;
+
+    dt {
+        float: left;
+        width: 90px;
+        padding-bottom: 5px;
+    }
+
+    dd {
+        padding-bottom: 5px;
+
+        &::after {
+            clear: both;
+            content: " ";
+            display: block;
+        }
+    }
 }
 
 #full-message {


### PR DESCRIPTION
With some localization (Russian, for example) sidebar on event page looks some unaligned.
![wrong sidebar dl](https://cloud.githubusercontent.com/assets/4144213/9346021/0e5df74a-4620-11e5-8863-87b950361e37.png)

After fix:

![corrected sidebar dl](https://cloud.githubusercontent.com/assets/4144213/9346028/1fa22260-4620-11e5-99d4-54a53fd4792b.png)
