### PR TITLE
Highlight substrings in stream search

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -65,6 +65,7 @@ var SearchBar = React.createClass({
     return {
       query: this.props.query || this.props.defaultQuery,
 
+      searchTerm: '',
       searchItems: [],
       activeSearchItem: 0,
 
@@ -215,7 +216,7 @@ var SearchBar = React.createClass({
       method: "GET",
       success: (values) => {
         this.setState({ loading: false });
-        callback(values.map(v => '"' + v.value + '"'), tag.key);
+        callback(values.map(v => '"' + v.value + '"'), tag.key, query);
       }
     });
   }, 300),
@@ -267,6 +268,7 @@ var SearchBar = React.createClass({
     {
       // show default "help" search terms
       return void this.setState({
+        searchTerm: '',
         searchItems: this.props.defaultSearchItems,
         activeSearchItem: 0
       });
@@ -282,13 +284,17 @@ var SearchBar = React.createClass({
       matchValue = last;
       autoCompleteItems = this.getTagKeys(matchValue);
 
+      this.setState({searchTerm: matchValue});
       this.updateAutoCompleteState(autoCompleteItems, matchValue);
     } else {
       [tagName, query] = last.split(':');
+      this.setState({searchTerm: query});
 
       let tag = this.getTag(tagName);
       if (!tag)
-        return void this.setState({ searchItems: [] });
+        return void this.setState({
+          searchItems: []
+        });
 
       return void (
         tag.predefined
@@ -442,6 +448,7 @@ var SearchBar = React.createClass({
                 items={this.state.searchItems}
                 onClick={this.onAutoComplete}
                 loading={this.state.loading}
+                searchSubstring={this.state.searchTerm}
                 />
             </div>
           }

--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -8,12 +8,35 @@ var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
 var SearchDropdown = React.createClass({
   mixins: [PureRenderMixin],
 
-  defaultProps: {
-    onClick: function () {}
+  getDefaultProps() {
+    return {
+      searchSubstring: '',
+      onClick: function () {}
+    };
   },
 
   onClick(itemValue) {
     this.props.onClick(itemValue);
+  },
+
+  renderDescription(item) {
+    let searchSubstring = this.props.searchSubstring;
+    if (!searchSubstring)
+      return item.desc;
+
+    let text = item.desc;
+    let idx = text.toLowerCase().indexOf(searchSubstring.toLowerCase());
+
+    if (idx === -1)
+      return item.desc;
+
+    return (
+      <span>
+        {text.substr(0, idx)}
+        <strong>{text.substr(idx, searchSubstring.length)}</strong>
+        {text.substr(idx + searchSubstring.length)}
+      </span>
+    );
   },
 
   render() {
@@ -26,7 +49,7 @@ var SearchDropdown = React.createClass({
               return (
                 <li key={item.value || item.desc} className={classNames("search-autocomplete-item", item.active && 'active')} onClick={this.onClick.bind(this, item.value)}>
                   <span className={classNames("icon", item.className)}></span>
-                  <h4>{ item.title && item.title + ' - '}<span className="search-description">{item.desc}</span></h4>
+                  <h4>{ item.title && item.title + ' - '}<span className="search-description">{this.renderDescription(item)}</span></h4>
                   {item.example ?
                     <p className="search-example">{item.example}</p> : ''
                   }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -842,6 +842,12 @@ table.integrations {
   z-index: 100;
   overflow: hidden;
 
+  strong { /* highlight */
+    font-weight: normal;
+    background: lighten(@yellow, 15);
+    color: @gray-dark;
+  }
+
   .nav-tabs {
     border-bottom: 1px solid lighten(@trim, 6);
     margin: 0;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2153/9856260/70244cc4-5ac8-11e5-8917-1031d6faadbf.png)

One known issue: right now, predefined terms can be autocompleted by any substring, whereas tag values autocomplete using `startswith` (but the highlight presumes any substring). This will probably confuse people.
