### PR TITLE
Add basic account removal feature (fixes GH-1938)

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
@@ -138,6 +140,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
 
         if organization.is_default:
             return Response({'detail': ERR_DEFAULT_ORG}, status=400)
+
+        logging.getLogger('sentry.deletions').info(
+            'Organization %s (id=%s) removal requested by user (id=%s)',
+            organization.slug, organization.id, request.user.id)
 
         updated = Organization.objects.filter(
             id=organization.id,

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
@@ -169,6 +171,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if project.is_internal_project():
             return Response('{"error": "Cannot remove projects internally used by Sentry."}',
                             status=status.HTTP_403_FORBIDDEN)
+
+        logging.getLogger('sentry.deletions').info(
+            'Project %s/%s (id=%s) removal requested by user (id=%s)',
+            project.organization.slug, project.slug, project.id, request.user.id)
 
         updated = Project.objects.filter(
             id=project.id,

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
@@ -113,6 +115,10 @@ class TeamDetailsEndpoint(TeamEndpoint):
         immediate.  However once deletion has begun the state of a project
         changes and will be hidden from most public views.
         """
+        logging.getLogger('sentry.deletions').info(
+            'Team %s/%s (id=%s) removal requested by user (id=%s)',
+            team.organization.slug, team.slug, team.id, request.user.id)
+
         updated = Team.objects.filter(
             id=team.id,
             status=TeamStatus.VISIBLE,

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -161,6 +161,16 @@ class Organization(Model):
             sentry_orgmember_set__organization=self,
         )[0]
 
+    def has_single_owner(self):
+        from sentry.models import OrganizationMember, OrganizationMemberType
+        count = OrganizationMember.objects.filter(
+            organization=self,
+            type=OrganizationMemberType.OWNER,
+            has_global_access=True,
+            user__isnull=False,
+        ).count()
+        return count == 1
+
     def merge_to(from_org, to_org):
         from sentry.models import (
             ApiKey, AuditLogEntry, OrganizationMember, OrganizationMemberTeam,

--- a/src/sentry/templates/sentry/bases/account.html
+++ b/src/sentry/templates/sentry/bases/account.html
@@ -13,6 +13,14 @@
 <div class="box">
     <div class="box-content with-padding">
       {% block nav %}
+        <div class="dropdown pull-right anchor-right">
+          <a class="dropdown-toggle" data-toggle="dropdown">
+            More <i class="icon-arrow-down"></i>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-right">
+            <li><a href="{% url 'sentry-remove-account' %}">{% trans "Close Account" %}</a></li>
+          </ul>
+        </div>
         <ul class="nav nav-tabs border-bottom">
           <li{% if page == 'settings' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings' %}">{% trans "Account" %}</a></li>
           <li{% if page == 'appearance' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-appearance' %}">{% trans "Appearance" %}</a></li>

--- a/src/sentry/templates/sentry/post-remove-account.html
+++ b/src/sentry/templates/sentry/post-remove-account.html
@@ -1,0 +1,16 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Remove Account" %}{% endblock %}
+
+{% block main %}
+  <section class="body">
+    <div class="page-header">
+      <h2>{% trans "Scheduled for Removal" %}</h2>
+    </div>
+
+    <p>{% trans "Your account has been deactivated and scheduled for removal." %}</p>
+    <p>{% trans "Thanks for using Sentry! We hope to see you again soon!"}
+  </section>
+{% endblock %}

--- a/src/sentry/templates/sentry/remove-account.html
+++ b/src/sentry/templates/sentry/remove-account.html
@@ -1,0 +1,52 @@
+{% extends "sentry/bases/account.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% load sentry_helpers %}
+
+{% block title %}{% trans "Close Account" %}{% endblock %}
+
+{% block main %}
+  <h3>Close Account</h3>
+
+  <form class="form-stacked" action="" method="post">
+    {% csrf_token %}
+
+    <p>{% trans "This will permanently remove all associated data for your user." %}</p>
+
+    <p><strong>{% trans "Closing your account is permanent and cannot be undone!" %}</strong></p>
+
+    {% if organization_results %}
+      <p>{% trans "If you continue, the following organizations will be removed:" %}</p>
+
+      <div class="control-group">
+        <ul class="inputs-list">
+          {% for result in organization_results %}
+            <li>
+              <label class="checkbox">
+                <input type="checkbox" value="{{ result.organization.slug }}"
+                  name="oID" checked="checked"
+                  {% if result.single_owner %} disabled="disabled"{% endif %}/>
+                {{ result.organization.name }} ({{ result.organization.slug }})
+              </label>
+            </li>
+          {% endfor %}
+        </ul>
+        <div class="help-block">
+          Ownership will remain with other members if an organization is not deleted.<br />
+          Disabled boxes mean that there is no other owner within the organization so no one else can take ownership.
+        </div>
+      </div>
+    {% endif %}
+
+    {{ form|as_crispy_errors }}
+
+    {% for field in form %}
+        {{ field|as_crispy_field }}
+    {% endfor %}
+
+    <fieldset class="form-actions">
+      <button type="submit" class="btn btn-danger">{% trans "Close Account" %}</button>
+      <a href="{% url 'sentry-account-settings' %}" class="btn btn-default">{% trans "Cancel" %}</a>
+    </fieldset>
+{% endblock %}

--- a/src/sentry/web/frontend/remove_account.py
+++ b/src/sentry/web/frontend/remove_account.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from django import forms
 from django.contrib.auth import logout
 
@@ -47,6 +49,10 @@ class RemoveAccountView(BaseView):
             for result in org_results:
                 if result['single_owner']:
                     orgs_to_remove.add(result['organization'].slug)
+
+            logging.getLogger('sentry.deletions').info(
+                'User (id=%s) removal requested by self',
+                request.user.id)
 
             for org_slug in orgs_to_remove:
                 client.delete('/organizations/{}/'.format(org_slug),

--- a/src/sentry/web/frontend/remove_account.py
+++ b/src/sentry/web/frontend/remove_account.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+
+from django import forms
+from django.contrib.auth import logout
+
+from sentry.api import client
+from sentry.models import (
+    Organization, OrganizationMember, OrganizationMemberType, User
+)
+from sentry.web.frontend.base import BaseView
+
+
+class RemoveAccountForm(forms.Form):
+    pass
+
+
+class RemoveAccountView(BaseView):
+    sudo_required = True
+
+    def get_form(self, request):
+        if request.method == 'POST':
+            return RemoveAccountForm(request.POST)
+        return RemoveAccountForm()
+
+    def handle(self, request):
+        org_list = Organization.objects.filter(
+            member_set__type=OrganizationMemberType.OWNER,
+            member_set__user=request.user,
+            member_set__has_global_access=True,
+        )
+        org_results = []
+        for org in sorted(org_list, key=lambda x: x.name):
+            # O(N) query
+            org_results.append({
+                'organization': org,
+                'single_owner': org.has_single_owner(),
+            })
+
+        form = self.get_form(request)
+        if form.is_valid():
+            avail_org_slugs = set([
+                o['organization'].slug for o in org_results
+            ])
+            orgs_to_remove = set(
+                request.POST.getlist('oID')
+            ).intersection(avail_org_slugs)
+            for result in org_results:
+                if result['single_owner']:
+                    orgs_to_remove.add(result['organization'].slug)
+
+            for org_slug in orgs_to_remove:
+                client.delete('/organizations/{}/'.format(org_slug),
+                              request.user, is_sudo=True)
+
+            OrganizationMember.objects.filter(
+                organization__in=[
+                    o.id for o in org_list
+                    if o.slug in avail_org_slugs.difference(orgs_to_remove)
+                ],
+                user=request.user,
+            ).delete()
+
+            User.objects.filter(
+                id=request.user.id,
+            ).update(
+                is_active=False,
+            )
+
+            logout(request)
+
+            return self.respond('sentry/post-remove-account.html')
+
+        context = {
+            'form': form,
+            'organization_results': org_results,
+        }
+
+        return self.respond('sentry/remove-account.html', context)

--- a/src/sentry/web/frontend/remove_account.py
+++ b/src/sentry/web/frontend/remove_account.py
@@ -58,13 +58,16 @@ class RemoveAccountView(BaseView):
                 client.delete('/organizations/{}/'.format(org_slug),
                               request.user, is_sudo=True)
 
-            OrganizationMember.objects.filter(
-                organization__in=[
-                    o.id for o in org_list
-                    if o.slug in avail_org_slugs.difference(orgs_to_remove)
-                ],
-                user=request.user,
-            ).delete()
+            remaining_org_ids = [
+                o.id for o in org_list
+                if o.slug in avail_org_slugs.difference(orgs_to_remove)
+            ]
+
+            if remaining_org_ids:
+                OrganizationMember.objects.filter(
+                    organization__in=remaining_org_ids,
+                    user=request.user,
+                ).delete()
 
             User.objects.filter(
                 id=request.user.id,

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -51,6 +51,7 @@ from sentry.web.frontend.project_release_tracking import ProjectReleaseTrackingV
 from sentry.web.frontend.project_settings import ProjectSettingsView
 from sentry.web.frontend.react_page import GenericReactPageView, ReactPageView
 from sentry.web.frontend.release_webhook import ReleaseWebhookView
+from sentry.web.frontend.remove_account import RemoveAccountView
 from sentry.web.frontend.remove_organization import RemoveOrganizationView
 from sentry.web.frontend.remove_project import RemoveProjectView
 from sentry.web.frontend.remove_team import RemoveTeamView
@@ -153,6 +154,8 @@ urlpatterns += patterns(
         name='sentry-account-settings-identities'),
     url(r'^account/settings/notifications/$', accounts.notification_settings,
         name='sentry-account-settings-notifications'),
+    url(r'^account/remove/$', RemoveAccountView.as_view(),
+        name='sentry-remove-account'),
     url(r'^account/settings/social/', include('social_auth.urls')),
 
     # Admin

--- a/tests/sentry/web/frontend/test_remove_account.py
+++ b/tests/sentry/web/frontend/test_remove_account.py
@@ -101,23 +101,3 @@ class RemoveAccountTest(TestCase):
         assert Organization.objects.get(
             id=self.organization3.id,
         ).status == OrganizationStatus.VISIBLE
-
-    # def test_cannot_remove_default(self):
-    #     Organization.objects.all().delete()
-
-    #     org = self.create_organization()
-
-    #     self.login_as(self.user)
-
-    #     url = reverse('sentry-api-0-organization-details', kwargs={
-    #         'organization_slug': org.slug,
-    #     })
-
-    #     with self.settings(SENTRY_SINGLE_ORGANIZATION=True):
-    #         resp = self.client.post(self.path)
-
-    #     assert resp.status_code == 302
-
-    #     organization = Organization.objects.get(id=org.id)
-
-    #     assert organization.status == OrganizationStatus.VISIBLE

--- a/tests/sentry/web/frontend/test_remove_account.py
+++ b/tests/sentry/web/frontend/test_remove_account.py
@@ -1,0 +1,123 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import (
+    Organization, OrganizationMember, OrganizationMemberType,
+    OrganizationStatus, User
+)
+from sentry.testutils import TestCase
+
+
+class RemoveAccountTest(TestCase):
+    def setUp(self):
+        super(RemoveAccountTest, self).setUp()
+
+        other_user = self.create_user('bar@example.com')
+
+        # single owner org
+        self.organization = self.create_organization(name='a', owner=self.user)
+        self.create_member(
+            user=other_user,
+            organization=self.organization,
+            type=OrganizationMemberType.ADMIN,
+            has_global_access=True,
+        )
+        # dual owner
+        self.organization2 = self.create_organization(name='b', owner=self.user)
+        self.create_member(
+            organization=self.organization2,
+            type=OrganizationMemberType.OWNER,
+            has_global_access=True,
+            user=other_user,
+        )
+
+        # non-owned
+        self.organization3 = self.create_organization(name='c', owner=other_user)
+
+        self.path = reverse('sentry-remove-account')
+        self.login_as(self.user)
+
+    def test_renders_with_context(self):
+        resp = self.client.get(self.path)
+
+        assert resp.status_code == 200
+
+        self.assertTemplateUsed(resp, 'sentry/remove-account.html')
+
+        assert resp.context['organization_results'] == [{
+            'organization': self.organization,
+            'single_owner': True,
+        }, {
+            'organization': self.organization2,
+            'single_owner': False,
+        }]
+
+    def test_implicit_delete(self):
+        resp = self.client.post(self.path)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/post-remove-account.html')
+
+        assert not User.objects.get(
+            id=self.user.id,
+        ).is_active
+
+        # should implicitly remove the first organization, but not the 2nd
+        assert Organization.objects.get(
+            id=self.organization.id,
+        ).status == OrganizationStatus.PENDING_DELETION
+
+        assert Organization.objects.get(
+            id=self.organization2.id,
+        ).status == OrganizationStatus.VISIBLE
+        assert not OrganizationMember.objects.filter(
+            user=self.user,
+            organization=self.organization2,
+        ).exists()
+
+        assert Organization.objects.get(
+            id=self.organization3.id,
+        ).status == OrganizationStatus.VISIBLE
+
+    def test_explicit_delete(self):
+        resp = self.client.post(self.path, data={
+            'oID': [self.organization.slug, self.organization2.slug,
+                    self.organization3.slug],
+        })
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/post-remove-account.html')
+
+        # should implicitly remove the first organization, but not the 2nd
+        assert Organization.objects.get(
+            id=self.organization.id,
+        ).status == OrganizationStatus.PENDING_DELETION
+
+        assert Organization.objects.get(
+            id=self.organization2.id,
+        ).status == OrganizationStatus.PENDING_DELETION
+
+        assert Organization.objects.get(
+            id=self.organization3.id,
+        ).status == OrganizationStatus.VISIBLE
+
+    # def test_cannot_remove_default(self):
+    #     Organization.objects.all().delete()
+
+    #     org = self.create_organization()
+
+    #     self.login_as(self.user)
+
+    #     url = reverse('sentry-api-0-organization-details', kwargs={
+    #         'organization_slug': org.slug,
+    #     })
+
+    #     with self.settings(SENTRY_SINGLE_ORGANIZATION=True):
+    #         resp = self.client.post(self.path)
+
+    #     assert resp.status_code == 302
+
+    #     organization = Organization.objects.get(id=org.id)
+
+    #     assert organization.status == OrganizationStatus.VISIBLE

--- a/tests/sentry/web/frontend/test_remove_project.py
+++ b/tests/sentry/web/frontend/test_remove_project.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import mock
-
 from django.core.urlresolvers import reverse
 
 from sentry.models import Project, ProjectStatus
@@ -51,12 +49,9 @@ class RemoveProjectTest(TestCase):
         assert resp.context['team'] == self.team
         assert resp.context['project'] == self.project
 
-    @mock.patch('sentry.web.frontend.remove_project.delete_project')
-    def test_deletion_flow(self, delete_project):
+    def test_deletion_flow(self):
         self.login_as(self.owner)
 
         resp = self.client.post(self.path, {})
         assert resp.status_code == 302
-        delete_project.delay.assert_called_once_with(
-            object_id=self.project.id)
         assert Project.objects.get(id=self.project.id).status == ProjectStatus.PENDING_DELETION


### PR DESCRIPTION
- Account immediately gets marked as inactive
- Single owner orgs are always scheduled for deletion
- Other orgs are selectable for deletion
