### PR TITLE
supervisor documentation fix

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -370,7 +370,7 @@ go.
 
   [program:sentry-web]
   directory=/www/sentry/
-  environment=SENTRY_CONF=/www/sentry/sentry.conf.py
+  environment=SENTRY_CONF="/www/sentry/sentry.conf.py"
   command=/www/sentry/bin/sentry start
   autostart=true
   autorestart=true
@@ -380,7 +380,7 @@ go.
 
   [program:sentry-worker]
   directory=/www/sentry/
-  environment=SENTRY_CONF=/www/sentry/sentry.conf.py
+  environment=SENTRY_CONF="/www/sentry/sentry.conf.py"
   command=/www/sentry/bin/sentry celery worker -B
   autostart=true
   autorestart=true


### PR DESCRIPTION
At least some old supervisor releases, like in Ubuntu 12.04, require quoting of environment variables.
