### PR TITLE
Swap from yaml.load to yaml.safe_load for security

### DIFF
--- a/src/sentry/utils/ua_parser/parser.py
+++ b/src/sentry/utils/ua_parser/parser.py
@@ -417,7 +417,7 @@ def GetFilters(user_agent_string, js_user_agent_string=None,
 
 def load_regexes(path):
     with open(path) as fp:
-        return yaml.load(fp)
+        return yaml.safe_load(fp)
 
 
 def load_user_agent_parsers(regexes):


### PR DESCRIPTION
I'm checking through some popular open source projects with [Bandit]() and found a potential vulnerability regarding yaml.load.

```
>> Issue: Use of unsafe yaml load. Allows instantiation of arbitrary objects. Consider yaml.safe_load().
   Severity: Medium   Confidence: High
   Location: sentry/src/sentry/utils/ua_parser/parser.py:420
419     with open(path) as fp:
420         return yaml.load(fp)
```

As the warning mentions, `yaml.load()` is unfortunately the unsafe version. I did a [blog post](http://kevinlondon.com/2015/08/15/dangerous-python-functions-pt2.html) on the security risks for yaml's load function, as did [Ned Batchelder](http://nedbatchelder.com/blog/201302/war_is_peace.html) and [others](http://blog.codeclimate.com/blog/2013/01/10/rails-remote-code-execution-vulnerability-explained/). 
