### PR TITLE
Fix alerts on legacy pages

### DIFF
--- a/src/sentry/templates/sentry/bases/account.html
+++ b/src/sentry/templates/sentry/bases/account.html
@@ -5,10 +5,6 @@
 
 {% block title %}{% trans "Settings" %} | {{ block.super }}{% endblock %}
 
-{% block alerts %}
-{% endblock %}
-
-
 {% block content %}
 <div class="box">
     <div class="box-content with-padding">
@@ -30,7 +26,7 @@
         {% endif %}
         </ul>
       {% endblock %}
-      {% include "sentry/partial/alerts.html" %}
+
       {% block main %}
       {% endblock %}
     </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ var config = {
       "bootstrap/js/dropdown",
       "bootstrap/js/tab",
       "bootstrap/js/tooltip",
+      "bootstrap/js/alert",
       "crypto-js/md5",
       "jquery",
       "marked",


### PR DESCRIPTION
- Moves success alert on account details into nav header (with other alerts)
- Fixes alerts on non-React pages not dismissable

Fixes #1984, #1878 
