### PR TITLE
Add versioning and prefixes to caches

### DIFF
--- a/src/sentry/cache/base.py
+++ b/src/sentry/cache/base.py
@@ -8,10 +8,22 @@ sentry.cache.base
 
 from __future__ import absolute_import
 
+from django.conf import settings
+
 from threading import local
 
 
 class BaseCache(local):
+    prefix = 'c'
+
+    def __init__(self, version=None, prefix=None):
+        self.version = version or settings.CACHE_VERSION
+        if prefix is not None:
+            self.prefix = prefix
+
+    def make_key(self, key):
+        return '{}:{}:{}'.format(self.prefix, self.version, key)
+
     def set(self, key, value, timeout):
         raise NotImplementedError
 

--- a/src/sentry/cache/django.py
+++ b/src/sentry/cache/django.py
@@ -9,15 +9,16 @@ sentry.cache.django
 from __future__ import absolute_import
 
 from django.core.cache import cache
-from threading import local
+
+from .base import BaseCache
 
 
-class DjangoCache(local):
+class DjangoCache(BaseCache):
     def set(self, key, value, timeout):
-        cache.set(key, value, timeout)
+        cache.set(key, value, timeout, version=self.version)
 
     def delete(self, key):
-        cache.delete(key)
+        cache.delete(key, version=self.version)
 
     def get(self, key):
-        return cache.get(key)
+        return cache.get(key, version=self.version)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -43,12 +43,6 @@ NODE_MODULES_ROOT = os.path.join(PROJECT_ROOT, os.pardir, os.pardir, 'node_modul
 
 sys.path.insert(0, os.path.normpath(os.path.join(PROJECT_ROOT, os.pardir)))
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    }
-}
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -561,8 +555,6 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 SENTRY_CLIENT = 'sentry.utils.raven.SentryInternalClient'
 
-SENTRY_CACHE_BACKEND = 'default'
-
 SENTRY_FEATURES = {
     'auth:register': True,
     'organizations:create': True,
@@ -687,6 +679,19 @@ SENTRY_BUFFER_OPTIONS = {}
 # and causes serious confusion with the default django cache
 SENTRY_CACHE = None
 SENTRY_CACHE_OPTIONS = {}
+
+# The internal Django cache is still used in many places
+# TODO(dcramer): convert uses over to Sentry's backend
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
+# The cache version affects both Django's internal cache (at runtime) as well
+# as Sentry's cache. This automatically overrides VERSION on the default
+# CACHES backend.
+CACHE_VERSION = 1
 
 # Quota backend
 SENTRY_QUOTAS = 'sentry.quotas.Quota'

--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -311,6 +311,8 @@ def initialize_app(config, skip_backend_validation=False):
     settings.SUDO_COOKIE_SECURE = getattr(settings, 'SESSION_COOKIE_SECURE', False)
     settings.SUDO_COOKIE_DOMAIN = getattr(settings, 'SESSION_COOKIE_DOMAIN', None)
 
+    settings.CACHES['default']['VERSION'] = settings.CACHE_VERSION
+
     if USE_GEVENT:
         from django.db import connections
         connections['default'].allow_thread_sharing = True


### PR DESCRIPTION
While this doesnt do anything magical to fix things (we eaisly could add model versioning), it will at least help us avoid the need to flush caches on upgrades.
