### PR TITLE
Add versioning to plugin configurations

### DIFF
--- a/src/sentry/plugins/base/configuration.py
+++ b/src/sentry/plugins/base/configuration.py
@@ -15,15 +15,9 @@ from django.contrib import messages
 
 
 def default_plugin_config(plugin, project, request):
-    NOTSET = object()
-
     plugin_key = plugin.get_conf_key()
-    if project:
-        form_class = plugin.project_conf_form
-        template = plugin.project_conf_template
-    else:
-        form_class = plugin.site_conf_form
-        template = plugin.site_conf_template
+    form_class = plugin.get_conf_form(project)
+    template = plugin.get_conf_template(project)
 
     if form_class is None:
         return HttpResponseRedirect(reverse(
@@ -31,20 +25,10 @@ def default_plugin_config(plugin, project, request):
 
     test_results = None
 
-    initials = plugin.get_form_initial(project)
-    for field in form_class.base_fields:
-        key = '%s:%s' % (plugin_key, field)
-        if project:
-            value = ProjectOption.objects.get_value(project, key, NOTSET)
-        else:
-            value = options.get(key)
-        if value is not NOTSET:
-            initials[field] = value
-
     form = form_class(
         request.POST if request.POST.get('plugin') == plugin.slug else None,
-        initial=initials,
-        prefix=plugin_key
+        initial=plugin.get_conf_options(project),
+        prefix=plugin_key,
     )
     if form.is_valid():
         if 'action_test' in request.POST and plugin.is_testable():
@@ -87,3 +71,22 @@ def default_plugin_config(plugin, project, request):
         'plugin_test_results': test_results,
         'plugin_is_configured': is_configured,
     }, context_instance=RequestContext(request)))
+
+
+def default_plugin_options(plugin, project):
+    form_class = plugin.get_conf_form(project)
+    if form_class is None:
+        return {}
+
+    NOTSET = object()
+    plugin_key = plugin.get_conf_key()
+    initials = plugin.get_form_initial(project)
+    for field in form_class.base_fields:
+        key = '%s:%s' % (plugin_key, field)
+        if project is not None:
+            value = ProjectOption.objects.get_value(project, key, NOTSET)
+        else:
+            value = options.get(key)
+        if value is not NOTSET:
+            initials[field] = value
+    return initials

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -171,19 +171,41 @@ class IPlugin(local, PluggableViewMixin):
         return self.conf_key
 
     def get_conf_form(self, project=None):
+        """
+        Returns the Form required to configure the plugin.
+
+        >>> plugin.get_conf_form(project)
+        """
         if project is not None:
             return self.project_conf_form
         return self.site_conf_form
 
     def get_conf_template(self, project=None):
+        """
+        Returns the template required to render the configuration page.
+
+        >>> plugin.get_conf_template(project)
+        """
         if project is not None:
             return self.project_conf_template
         return self.site_conf_template
 
     def get_conf_options(self, project=None):
+        """
+        Returns a dict of all of the configured options for a project.
+
+        >>> plugin.get_conf_options(project)
+        """
         return default_plugin_options(self, project)
 
     def get_conf_version(self, project):
+        """
+        Returns a version string that represents the current configuration state.
+
+        If any option changes or new options added, the version will change.
+
+        >>> plugin.get_conf_version(project)
+        """
         options = self.get_conf_options(project)
         return md5(
             '&'.join(sorted('%s=%s' % o for o in options.iteritems()))

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -157,19 +157,41 @@ class IPlugin2(local):
         return self.conf_key
 
     def get_conf_form(self, project=None):
+        """
+        Returns the Form required to configure the plugin.
+
+        >>> plugin.get_conf_form(project)
+        """
         if project is not None:
             return self.project_conf_form
         return self.site_conf_form
 
     def get_conf_template(self, project=None):
+        """
+        Returns the template required to render the configuration page.
+
+        >>> plugin.get_conf_template(project)
+        """
         if project is not None:
             return self.project_conf_template
         return self.site_conf_template
 
     def get_conf_options(self, project=None):
+        """
+        Returns a dict of all of the configured options for a project.
+
+        >>> plugin.get_conf_options(project)
+        """
         return default_plugin_options(self, project)
 
     def get_conf_version(self, project):
+        """
+        Returns a version string that represents the current configuration state.
+
+        If any option changes or new options added, the version will change.
+
+        >>> plugin.get_conf_version(project)
+        """
         options = self.get_conf_options(project)
         return md5(
             '&'.join(sorted('%s=%s' % o for o in options.iteritems()))

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -13,9 +13,12 @@ import logging
 
 from django.http import HttpResponseRedirect
 from threading import local
+from hashlib import md5
 
 from sentry.plugins.base.response import Response
-from sentry.plugins.base.configuration import default_plugin_config
+from sentry.plugins.base.configuration import (
+    default_plugin_config, default_plugin_options,
+)
 
 
 class PluginMount(type):
@@ -153,11 +156,33 @@ class IPlugin2(local):
             self.conf_key = self.get_conf_title().lower().replace(' ', '_')
         return self.conf_key
 
+    def get_conf_form(self, project=None):
+        if project is not None:
+            return self.project_conf_form
+        return self.site_conf_form
+
+    def get_conf_template(self, project=None):
+        if project is not None:
+            return self.project_conf_template
+        return self.site_conf_template
+
+    def get_conf_options(self, project=None):
+        return default_plugin_options(self, project)
+
+    def get_conf_version(self, project):
+        options = self.get_conf_options(project)
+        return md5(
+            '&'.join(sorted('%s=%s' % o for o in options.iteritems()))
+        ).hexdigest()[:3]
+
     def get_conf_title(self):
         """
         Returns a string representing the title to be shown on the configuration page.
         """
         return self.conf_title or self.get_title()
+
+    def get_form_initial(self, project=None):
+        return {}
 
     def has_project_conf(self):
         return self.project_conf_form is not None


### PR DESCRIPTION
Part 1 of GH-1997

This provides a way to query the version of a config form, which is a hash of all of it's config options + values.

/cc @dcramer 
