### PR TITLE
Automatically generate culprits when missing

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -37,6 +37,7 @@ from sentry.tasks.merge import merge_group
 from sentry.tasks.post_process import post_process_group
 from sentry.utils.db import get_db_engine
 from sentry.utils.safe import safe_execute, trim, trim_dict
+from sentry.utils.strings import truncatechars
 
 
 def count_limit(count):
@@ -107,6 +108,30 @@ else:
             return False
 
         return True
+
+
+def generate_culprit(data):
+    from sentry.interfaces.stacktrace import Stacktrace
+
+    try:
+        stacktraces = [
+            e['stacktrace']
+            for e in data['sentry.interfaces.Exception']['values']
+            if e.get('stacktrace')
+        ]
+    except KeyError:
+        if 'sentry.interfaces.Stacktrace' in data:
+            stacktraces = [data['sentry.interfaces.Stacktrace']]
+        else:
+            return ''
+
+    if not stacktraces:
+        return ''
+
+    return truncatechars(
+        Stacktrace.to_python(stacktraces[-1]).get_culprit_string(),
+        MAX_CULPRIT_LENGTH
+    )
 
 
 def plugin_is_regression(group, event):
@@ -293,7 +318,7 @@ class EventManager(object):
         message = data.pop('message')
         level = data.pop('level')
 
-        culprit = data.pop('culprit', None) or ''
+        culprit = data.pop('culprit', None)
         time_spent = data.pop('time_spent', None)
         logger_name = data.pop('logger', None)
         server_name = data.pop('server_name', None)
@@ -302,6 +327,9 @@ class EventManager(object):
         fingerprint = data.pop('fingerprint', None)
         platform = data.pop('platform', None)
         release = data.pop('release', None)
+
+        if not culprit:
+            culprit = generate_culprit(data)
 
         date = datetime.fromtimestamp(data.pop('timestamp'))
         date = date.replace(tzinfo=timezone.utc)

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -363,6 +363,15 @@ class Frame(Interface):
             'context_line': self.context_line,
         }).strip('\n')
 
+    def get_culprit_string(self):
+        fileloc = self.module or self.filename
+        if not fileloc:
+            return ''
+        return '%s in %s' % (
+            fileloc,
+            self.function or '?',
+        )
+
 
 class Stacktrace(Interface):
     """
@@ -603,3 +612,12 @@ class Stacktrace(Interface):
         ]
 
         return '\n'.join(result)
+
+    def get_culprit_string(self):
+        default = None
+        for frame in reversed(self.frames):
+            if frame.in_app:
+                return frame.get_culprit_string()
+            elif default is None:
+                default = frame.get_culprit_string()
+        return default


### PR DESCRIPTION
Attempts to find the best frame by looking for the most recent frame marked as in_app, or the most recent frame if not present.

Refs GH-1989
