### PR TITLE
Add logging around seenBy failing to render

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/seenBy.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/seenBy.jsx
@@ -5,6 +5,7 @@ import Gravatar from "../../components/gravatar";
 import GroupState from "../../mixins/groupState";
 import {userDisplayName} from "../../utils/formatters";
 import TooltipMixin from "../../mixins/tooltip";
+import {logException} from "../../utils/logging";
 
 var GroupSeenBy = React.createClass({
   mixins: [
@@ -17,15 +18,20 @@ var GroupSeenBy = React.createClass({
 
   render() {
     var group = this.getGroup();
+    var seenByNodes;
 
-    var seenByNodes = group.seenBy.map((user, userIdx) => {
-      let title = userDisplayName(user) + '<br/>' + moment(user.lastSeen).format("LL");
-      return (
-        <li key={userIdx} className="tip" data-title={title}>
-          <Gravatar size={52} email={user.email} />
-        </li>
-      );
-    });
+    try {
+      seenByNodes = group.seenBy.map((user, userIdx) => {
+        let title = userDisplayName(user) + '<br/>' + moment(user.lastSeen).format("LL");
+        return (
+          <li key={userIdx} className="tip" data-title={title}>
+            <Gravatar size={52} email={user.email} />
+          </li>
+        );
+      });
+    } catch(ex) {
+      logException(ex, group);
+    }
 
     if (!seenByNodes) {
       return null;


### PR DESCRIPTION
Investigating:
https://beta.getsentry.com/sentry/javascript/group/77664062/
https://beta.getsentry.com/sentry/javascript/group/78235451/

Somehow `group.seenBy` does not exist, and the API for sure adds on a `seenBy` key for `Group` objects, so the running theory is that possibly `this.getGroup()` doesn't return a `Group` object, but instead, something else?

At minimum, this continues to let the page render.

/cc @benvinegar 
