### PR TITLE
Fix styling of links in comment boxes

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -511,6 +511,10 @@
 
         p {
           margin: 0;
+
+          a {
+            word-wrap: break-word;
+          }
         }
 
         .activity-author {


### PR DESCRIPTION
Links with long texts didn't respect the container bounds:
<img width="1020" alt="screen shot 2015-09-23 at 1 16 26 pm" src="https://cloud.githubusercontent.com/assets/1501339/10053237/54ee2b2e-6201-11e5-8abf-c4fc12b3eee9.png">

Fixed it by setting the word-wrap property to break-word.
