### PR TITLE
Return correct events for next/prev with identical datetimes

### DIFF
--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -45,29 +45,49 @@ class EventDetailsEndpoint(Endpoint):
         base_qs = Event.objects.filter(
             group=event.group_id,
         ).exclude(id=event.id)
-        try:
-            gt = lambda x: x.id > event.id
-            next_event = filter(gt, sorted(
-                base_qs.filter(
-                    datetime__gte=event.datetime,
-                ).order_by('datetime')[0:5],
-                key=lambda x: (x.datetime, x.id),
-            ))[0]
-        except IndexError:
-            next_event = None
 
-        try:
-            lt = lambda x: x.id < event.id
-            prev_event = filter(lt, sorted(
-                base_qs.filter(
-                    id__lt=event.id,
-                    datetime__lte=event.datetime,
-                ).order_by('-datetime')[0:5],
-                key=lambda x: (x.datetime, x.id),
-                reverse=True,
-            ))[0]
-        except IndexError:
-            prev_event = None
+        # First, we collect 5 leading/trailing events
+        next_events = sorted(
+            base_qs.filter(
+                datetime__gte=event.datetime,
+            ).order_by('datetime')[0:5],
+            key=lambda x: (x.datetime, x.id),
+        )
+        prev_events = sorted(
+            base_qs.filter(
+                datetime__lte=event.datetime,
+            ).order_by('-datetime')[0:5],
+            key=lambda x: (x.datetime, x.id),
+            reverse=True,
+        )
+
+        # Now, try and find the real next event.
+        # "next" means:
+        #  * If identical timestamps, greater of the ids
+        #  * else greater of the timestamps
+        next_event = None
+        for e in next_events:
+            if e.datetime == event.datetime and e.id > event.id:
+                next_event = e
+                break
+
+            if e.datetime > event.datetime:
+                next_event = e
+                break
+
+        # Last, pick the previous event
+        # "previous" means:
+        #  * If identical timestamps, lesser of the ids
+        #  * else lesser of the timestamps
+        prev_event = None
+        for e in prev_events:
+            if e.datetime == event.datetime and e.id < event.id:
+                prev_event = e
+                break
+
+            if e.datetime < event.datetime:
+                prev_event = e
+                break
 
         try:
             user_report = UserReport.objects.get(

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -44,27 +44,28 @@ class EventDetailsEndpoint(Endpoint):
         # HACK(dcramer): work around lack of unique sorting on datetime
         base_qs = Event.objects.filter(
             group=event.group_id,
-        )
+        ).exclude(id=event.id)
         try:
-            next_event = sorted(
+            gt = lambda x: x.id > event.id
+            next_event = filter(gt, sorted(
                 base_qs.filter(
-                    id__gt=event.id,
                     datetime__gte=event.datetime,
                 ).order_by('datetime')[0:5],
                 key=lambda x: (x.datetime, x.id),
-            )[0]
+            ))[0]
         except IndexError:
             next_event = None
 
         try:
-            prev_event = sorted(
+            lt = lambda x: x.id < event.id
+            prev_event = filter(lt, sorted(
                 base_qs.filter(
                     id__lt=event.id,
                     datetime__lte=event.datetime,
                 ).order_by('-datetime')[0:5],
                 key=lambda x: (x.datetime, x.id),
                 reverse=True,
-            )[0]
+            ))[0]
         except IndexError:
             prev_event = None
 

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -44,25 +44,31 @@ class EventDetailsEndpoint(Endpoint):
         # HACK(dcramer): work around lack of unique sorting on datetime
         base_qs = Event.objects.filter(
             group=event.group_id,
-        ).exclude(id=event.id)
+        )
         try:
             next_event = sorted(
                 base_qs.filter(
-                    datetime__gte=event.datetime
+                    id__gt=event.id,
+                    datetime__gte=event.datetime,
                 ).order_by('datetime')[0:5],
-                key=lambda x: (x.datetime, x.id)
+                key=lambda x: (x.datetime, x.id),
             )[0]
+            if next_event.id < event.id:
+                next_event = None
         except IndexError:
             next_event = None
 
         try:
             prev_event = sorted(
                 base_qs.filter(
+                    id__lt=event.id,
                     datetime__lte=event.datetime,
                 ).order_by('-datetime')[0:5],
                 key=lambda x: (x.datetime, x.id),
-                reverse=True
+                reverse=True,
             )[0]
+            if prev_event.id > event.id:
+                prev_event = None
         except IndexError:
             prev_event = None
 

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -53,8 +53,6 @@ class EventDetailsEndpoint(Endpoint):
                 ).order_by('datetime')[0:5],
                 key=lambda x: (x.datetime, x.id),
             )[0]
-            if next_event.id < event.id:
-                next_event = None
         except IndexError:
             next_event = None
 
@@ -67,8 +65,6 @@ class EventDetailsEndpoint(Endpoint):
                 key=lambda x: (x.datetime, x.id),
                 reverse=True,
             )[0]
-            if prev_event.id > event.id:
-                prev_event = None
         except IndexError:
             prev_event = None
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -196,6 +196,8 @@ class Group(Model):
         return int(math.log(self.times_seen) * 600 + float(time.mktime(self.last_seen.timetuple())))
 
     def get_latest_event(self):
+        # TODO(mattrobenolt): Deal with conflict resolution if
+        # multiple events have the same same exact datetime
         from sentry.models import Event
 
         if not hasattr(self, '_latest_event'):
@@ -208,6 +210,8 @@ class Group(Model):
         return self._latest_event
 
     def get_oldest_event(self):
+        # TODO(mattrobenolt): Deal with conflict resolution if
+        # multiple events have the same same exact datetime
         from sentry.models import Event
 
         if not hasattr(self, '_oldest_event'):

--- a/tests/sentry/api/endpoints/test_event_details.py
+++ b/tests/sentry/api/endpoints/test_event_details.py
@@ -161,6 +161,62 @@ class EventDetailsTest(APITestCase):
         assert response.data['groupID'] == group.id
         assert not response.data['userReport']
 
+    def test_timestamps_out_of_order(self):
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+        cur_event = self.create_event(
+            event_id='b',
+            group=group,
+            datetime=datetime(2013, 8, 13, 3, 8, 25),
+        )
+        next_event = self.create_event(
+            event_id='c',
+            group=group,
+            datetime=datetime(2013, 8, 13, 3, 8, 26),
+        )
+        prev_event = self.create_event(
+            event_id='a',
+            group=group,
+            datetime=datetime(2013, 8, 13, 3, 8, 24),
+        )
+
+        url = reverse('sentry-api-0-event-details', kwargs={
+            'event_id': cur_event.id,
+        })
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == str(cur_event.id)
+        assert response.data['nextEventID'] == str(next_event.id)
+        assert response.data['previousEventID'] == str(prev_event.id)
+        assert response.data['groupID'] == group.id
+        assert not response.data['userReport']
+
+        url = reverse('sentry-api-0-event-details', kwargs={
+            'event_id': prev_event.id,
+        })
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == str(prev_event.id)
+        assert response.data['nextEventID'] == str(cur_event.id)
+        assert response.data['previousEventID'] is None
+        assert response.data['groupID'] == group.id
+        assert not response.data['userReport']
+
+        url = reverse('sentry-api-0-event-details', kwargs={
+            'event_id': next_event.id,
+        })
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == str(next_event.id)
+        assert response.data['nextEventID'] is None
+        assert response.data['previousEventID'] == str(cur_event.id)
+        assert response.data['groupID'] == group.id
+        assert not response.data['userReport']
+
     def test_user_report(self):
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_event_details.py
+++ b/tests/sentry/api/endpoints/test_event_details.py
@@ -40,6 +40,30 @@ class EventDetailsTest(APITestCase):
         assert response.data['groupID'] == group.id
         assert not response.data['userReport']
 
+        url = reverse('sentry-api-0-event-details', kwargs={
+            'event_id': prev_event.id,
+        })
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == str(prev_event.id)
+        assert response.data['nextEventID'] == str(cur_event.id)
+        assert response.data['previousEventID'] is None
+        assert response.data['groupID'] == group.id
+        assert not response.data['userReport']
+
+        url = reverse('sentry-api-0-event-details', kwargs={
+            'event_id': next_event.id,
+        })
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == str(next_event.id)
+        assert response.data['nextEventID'] is None
+        assert response.data['previousEventID'] == str(cur_event.id)
+        assert response.data['groupID'] == group.id
+        assert not response.data['userReport']
+
     def test_identical_datetime(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Fixes GH-1830

The entire problem is the fact that when an event fell on the boundaries (oldest/latest), it would return back an id for the next greatest/lowest event.

So given the following events and assume they have identical timestamps:

```
[ 1, 2, 3 ]
```

The latest event for us is `3`.

So when browsing event `3`, we asked for next events, and we get back the list (sorted in reverse):

```
[ 2, 1 ]
```

Old logic would choose `2` erroneously when in fact, it shouldn't be since it's `id` is `< 3`.

Conversely for the other side, when browsing the oldest event, `1`, we get back:

```
[ 2, 3 ]
```

And again, old logic would have chosen `2`, when in fact, it shouldn't have one, since `id` is `> 1`.

/cc @dcramer 
