### PR TITLE
Added support for configurable plugin urls.

### DIFF
--- a/src/sentry/plugins/base/urls.py
+++ b/src/sentry/plugins/base/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import patterns
+
+from sentry.plugins import plugins
+
+
+urlpatterns = patterns('')
+
+for _plugin in plugins.all():
+    _plugin_patterns = _plugin.get_url_patterns()
+    if _plugin_patterns:
+        urlpatterns += _plugin_patterns

--- a/src/sentry/plugins/base/urls.py
+++ b/src/sentry/plugins/base/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.conf.urls import patterns
 
 from sentry.plugins import plugins

--- a/src/sentry/plugins/base/urls.py
+++ b/src/sentry/plugins/base/urls.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import re
+
 from django.conf.urls import patterns, include, url
 
 from sentry.plugins import plugins
@@ -11,5 +13,6 @@ for _plugin in plugins.all():
     _plugin_url_module = _plugin.get_url_module()
     if _plugin_url_module:
         urlpatterns += (
-            url('^plugins/%s/' % _plugin.slug, include(_plugin_url_module)),
+            url('^%s/' % re.escape(_plugin.slug),
+                include(_plugin_url_module)),
         )

--- a/src/sentry/plugins/base/urls.py
+++ b/src/sentry/plugins/base/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns
+from django.conf.urls import patterns, include, url
 
 from sentry.plugins import plugins
 
@@ -8,6 +8,8 @@ from sentry.plugins import plugins
 urlpatterns = patterns('')
 
 for _plugin in plugins.all():
-    _plugin_patterns = _plugin.get_url_patterns()
-    if _plugin_patterns:
-        urlpatterns += _plugin_patterns
+    _plugin_url_module = _plugin.get_url_module()
+    if _plugin_url_module:
+        urlpatterns += (
+            url('^plugins/%s/' % _plugin.slug, include(_plugin_url_module)),
+        )

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -459,6 +459,9 @@ class IPlugin(local, PluggableViewMixin):
         """Configures the plugin."""
         return default_plugin_config(self, project, request)
 
+    def get_url_patterns(self):
+        """Allows a plugin to return a URL module."""
+
 
 class Plugin(IPlugin):
     """

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -459,8 +459,8 @@ class IPlugin(local, PluggableViewMixin):
         """Configures the plugin."""
         return default_plugin_config(self, project, request)
 
-    def get_url_patterns(self):
-        """Allows a plugin to return a URL module."""
+    def get_url_module(self):
+        """Allows a plugin to return the import path to a URL module."""
 
 
 class Plugin(IPlugin):

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -392,8 +392,8 @@ class IPlugin2(local):
         """Configures the plugin."""
         return default_plugin_config(self, project, request)
 
-    def get_url_patterns(self):
-        """Allows a plugin to return a URL module."""
+    def get_url_module(self):
+        """Allows a plugin to return the import path to a URL module."""
 
 
 class Plugin2(IPlugin2):

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -392,6 +392,9 @@ class IPlugin2(local):
         """Configures the plugin."""
         return default_plugin_config(self, project, request)
 
+    def get_url_patterns(self):
+        """Allows a plugin to return a URL module."""
+
 
 class Plugin2(IPlugin2):
     """

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -322,6 +322,9 @@ urlpatterns += patterns(
     url(r'^api/(?P<project_id>[\w_-]+)/crossdomain\.xml$', api.crossdomain_xml,
         name='sentry-api-crossdomain-xml'),
 
+    # plugins
+    url(r'', include('sentry.plugins.base.urls')),
+
     # Generic API
     url(r'^api/(?P<organization_slug>[\w_-]+)/(?P<team_slug>[\w_-]+)/groups/trends/$', api.get_group_trends,
         name='sentry-api-groups-trends'),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -323,7 +323,7 @@ urlpatterns += patterns(
         name='sentry-api-crossdomain-xml'),
 
     # plugins
-    url(r'', include('sentry.plugins.base.urls')),
+    url(r'^plugins/', include('sentry.plugins.base.urls')),
 
     # Generic API
     url(r'^api/(?P<organization_slug>[\w_-]+)/(?P<team_slug>[\w_-]+)/groups/trends/$', api.get_group_trends,


### PR DESCRIPTION
This most likely is the completely wrong way to do it and probably breaks horribly if the module imports too early.  It seems to work though at the moment so I wonder if Django includes url rules late so that this works.

I'm not entirely sure what the right way to do it would be.  Maybe patch urlpatterns late?  The reason I did not do that is because sentry and getsentry both use different url configs and if i just patch the former it the change is not propagated to the latter.
