### PR TITLE
Make sure date ranges are returned the exact same for stats

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStats/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.jsx
@@ -69,10 +69,14 @@ var OrganizationStats = React.createClass({
     });
 
     var statEndpoint = this.getOrganizationStatsEndpoint();
+    var until = Math.floor(new Date().getTime() / 1000);
+    var since = until - 3600 * 24 * 7;
+
     $.each(this.state.rawOrgData, (statName) => {
       api.request(statEndpoint, {
         query: {
-          since: new Date().getTime() / 1000 - 3600 * 24 * 7,
+          since: since,
+          until: until,
           resolution: '1h',
           stat: statName
         },

--- a/src/sentry/static/sentry/app/views/organizationStats/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.jsx
@@ -21,6 +21,9 @@ var OrganizationStats = React.createClass({
   },
 
   getInitialState() {
+    let until = Math.floor(new Date().getTime() / 1000);
+    let since = until - 3600 * 24 * 7;
+
     return {
       projectsError: false,
       projectsLoading: false,
@@ -33,7 +36,9 @@ var OrganizationStats = React.createClass({
       rawOrgData: {received: null, rejected: null, blacklisted: null},
       orgStats: null,
       orgTotal: null,
-      projectTotals: null
+      projectTotals: null,
+      querySince: since,
+      queryUntil: until
     };
   },
 
@@ -69,14 +74,12 @@ var OrganizationStats = React.createClass({
     });
 
     var statEndpoint = this.getOrganizationStatsEndpoint();
-    var until = Math.floor(new Date().getTime() / 1000);
-    var since = until - 3600 * 24 * 7;
 
     $.each(this.state.rawOrgData, (statName) => {
       api.request(statEndpoint, {
         query: {
-          since: since,
-          until: until,
+          since: this.state.querySince,
+          until: this.state.queryUntil,
           resolution: '1h',
           stat: statName
         },
@@ -99,7 +102,8 @@ var OrganizationStats = React.createClass({
     $.each(this.state.rawProjectData, (statName) => {
       api.request(statEndpoint, {
         query: {
-          since: new Date().getTime() / 1000 - 3600 * 24 * 7,
+          since: this.state.querySince,
+          until: this.state.queryUntil,
           stat: statName,
           group: 'project'
         },


### PR DESCRIPTION
Maybe fixes GH-2071

When `until` isn't declared explicitly, it uses the current timestamp calculated on the server. This is open to clock skew, and, each request has a slightly different range.

My theory is that when close to a boundary, the time ranges returned are slightly different causing the # of points to not match up.

So this explicitly sets `since` and `until` based on the client's time.
