### PR TITLE
Add metrics `LoggingBackend`.

### DIFF
--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+import logging
+
+from .base import MetricsBackend
+
+
+logger = logging.getLogger('sentry.metrics')
+
+
+class LoggingBackend(MetricsBackend):
+    def incr(self, key, instance=None, tags=None, amount=1, sample_rate=1):
+        logger.debug('%r: %+g', key, amount, extra={
+            'instance': instance,
+            'tags': tags or [],
+        })
+
+    def timing(self, key, value, instance=None, tags=None, sample_rate=1):
+        logger.debug('%r: %g ms', key, value, extra={
+            'instance': instance,
+            'tags': tags or [],
+        })


### PR DESCRIPTION
This make it easier to understand during development what metrics are
defined.

This can be enabled in the Sentry configuration by updating the
`SENTRY_METRICS_BACKEND` and updating the `LOGGING` configuration:

```
SENTRY_METRICS_BACKEND = 'sentry.metrics.logging.LoggingBackend'

LOGGING['handlers']['console:metrics'] = {
    'level': 'DEBUG',
    'class': 'logging.StreamHandler',
    'formatter': 'simple',
}

LOGGING['loggers']['sentry.metrics'] = {
    'level': 'DEBUG',
    'handlers': ['console:metrics'],
    'propagate': False,
}
```
