### PR TITLE
By defualt, exclude in-progress deletes from searches

### DIFF
--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -27,7 +27,7 @@ class DjangoSearchBackend(SearchBackend):
               bookmarked_by=None, assigned_to=None, first_release=None,
               sort_by='date', date_filter='last_seen', date_from=None,
               date_to=None, cursor=None, limit=100):
-        from sentry.models import Group
+        from sentry.models import Group, GroupStatus
 
         queryset = Group.objects.filter(project=project)
         if query:
@@ -40,7 +40,14 @@ class DjangoSearchBackend(SearchBackend):
                 Q(culprit__icontains=query)
             )
 
-        if status is not None:
+        if status is None:
+            queryset = queryset.exclude(
+                status__in=(
+                    GroupStatus.PENDING_DELETION,
+                    GroupStatus.DELETION_IN_PROGRESS,
+                )
+            )
+        else:
             queryset = queryset.filter(status=status)
 
         if bookmarked_by:

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -45,6 +45,7 @@ class DjangoSearchBackend(SearchBackend):
                 status__in=(
                     GroupStatus.PENDING_DELETION,
                     GroupStatus.DELETION_IN_PROGRESS,
+                    GroupStatus.PENDING_MERGE,
                 )
             )
         else:


### PR DESCRIPTION
As it turns out, by default, we weren't excluding Groups that were in pending states, so it's confusing in the UI when the Group is still visible.

We may still want to adjust the messaging in the alert banner thing, but not sure if that's necessary after this.

fixes gh-2078
