### PR TITLE
Add `result` tag to `jobs.duration` metric.

### DIFF
--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -12,11 +12,11 @@ class LoggingBackend(MetricsBackend):
     def incr(self, key, instance=None, tags=None, amount=1, sample_rate=1):
         logger.debug('%r: %+g', key, amount, extra={
             'instance': instance,
-            'tags': tags or [],
+            'tags': tags or {},
         })
 
     def timing(self, key, value, instance=None, tags=None, sample_rate=1):
         logger.debug('%r: %g ms', key, value, extra={
             'instance': instance,
-            'tags': tags or [],
+            'tags': tags or {},
         })

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -23,14 +23,8 @@ def instrumented_task(name, stat_suffix=None, **kwargs):
                 instance = '{}.{}'.format(name, stat_suffix(*args, **kwargs))
             else:
                 instance = name
-            with metrics.timer(key, instance=instance) as tags:
-                try:
-                    result = func(*args, **kwargs)
-                except Exception:
-                    tags['result'] = 'failure'
-                    raise
-                else:
-                    tags['result'] = 'success'
+            with metrics.timer(key, instance=instance):
+                result = func(*args, **kwargs)
             return result
         return app.task(name=name, **kwargs)(_wrapped)
     return wrapped

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -66,6 +66,11 @@ def timing(key, value, instance=None, tags=None):
 
 @contextmanager
 def timer(key, instance=None, tags=None):
+    if tags is None:
+        tags = {}
+
     start = time()
-    yield
-    timing(key, time() - start, instance, tags)
+    try:
+        yield tags
+    finally:
+        timing(key, time() - start, instance, tags)

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -72,5 +72,10 @@ def timer(key, instance=None, tags=None):
     start = time()
     try:
         yield tags
+    except Exception:
+        tags['result'] = 'failure'
+        raise
+    else:
+        tags['result'] = 'success'
     finally:
         timing(key, time() - start, instance, tags)

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+import mock
+import pytest
+
+from sentry.utils.metrics import timer
+
+
+def test_timer_success():
+    with mock.patch('sentry.utils.metrics.timing') as timing:
+        with timer('key', tags={'foo': True}) as tags:
+            tags['bar'] = False
+
+        assert timing.call_count is 1
+        args, kwargs = timing.call_args
+        assert args[0] is 'key'
+        assert args[3] == {
+            'foo': True,
+            'bar': False,
+            'result': 'success',
+        }
+
+
+class ExpectedError(Exception):
+    pass
+
+
+def test_timer_failure():
+    with mock.patch('sentry.utils.metrics.timing') as timing:
+        with pytest.raises(ExpectedError):
+            with timer('key', tags={'foo': True}) as tags:
+                raise ExpectedError
+
+        assert timing.call_count is 1
+        args, kwargs = timing.call_args
+        assert args[0] is 'key'
+        assert args[3] == {
+            'foo': True,
+            'result': 'failure',
+        }


### PR DESCRIPTION
This allows us to track success and failures of specific job types and results
in a metric that looks like the following:

```
2015-10-02 18:53:19,054 8201  DEBUG    sentry.metrics 'jobs.duration': 1.88351e-05 ms; instance='sentry.tasks.store.preprocess_event'; tags={'result': 'failure'}
```

This also fixes an oversight in the logging backend for metrics (tags are a dictionary, not a list.)
