### PR TITLE
Change RateLimiter interface to not use project

### DIFF
--- a/src/sentry/plugins/base/notifier.py
+++ b/src/sentry/plugins/base/notifier.py
@@ -31,7 +31,7 @@ class Notifier(object):
         project = group.project
 
         rate_limited = ratelimiter.is_limited(
-            project=project,
+            value=project.id,
             key=self.get_conf_key(),
             limit=10,
         )

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -96,7 +96,7 @@ class NotificationPlugin(Plugin):
         project = group.project
 
         rate_limited = ratelimiter.is_limited(
-            project=project,
+            value=project.id,
             key=self.get_conf_key(),
             limit=10,
         )

--- a/src/sentry/ratelimits/base.py
+++ b/src/sentry/ratelimits/base.py
@@ -10,5 +10,5 @@ class RateLimiter(object):
         Raise ``InvalidConfiguration`` if there is a configuration error.
         """
 
-    def is_limited(self, project, key, limit):
+    def is_limited(self, value, key, limit):
         return False

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -26,13 +26,13 @@ class RedisRateLimiter(RateLimiter):
         except Exception as e:
             raise InvalidConfiguration(unicode(e))
 
-    def is_limited(self, project, key, limit):
+    def is_limited(self, value, key, limit):
         key = 'rl:%s:%s:%s' % (
-            key, project.id, int(time() / self.ttl)
+            key, value, int(time() / self.ttl)
         )
 
         with self.cluster.map() as client:
-            proj_result = client.incr(key)
+            result = client.incr(key)
             client.expire(key, self.ttl)
 
-        return proj_result.value > limit
+        return result.value > limit

--- a/tests/sentry/ratelimits/test_redis.py
+++ b/tests/sentry/ratelimits/test_redis.py
@@ -13,5 +13,5 @@ class RedisRateLimiterTest(TestCase):
         })
 
     def test_integration(self):
-        assert not self.backend.is_limited(self.project, 'foo', 1)
-        assert self.backend.is_limited(self.project, 'foo', 1)
+        assert not self.backend.is_limited(self.project.id, 'foo', 1)
+        assert self.backend.is_limited(self.project.id, 'foo', 1)


### PR DESCRIPTION
This is so the generic RateLimiter abstraction can be used for other things
