### PR TITLE
Add Redis version checks to TSDB backend validation.

### DIFF
--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -84,9 +84,9 @@ class RedisTSDB(BaseTSDB):
             # NOTE: This assumes there is no routing magic going on here, and
             # all requests to this host are being served by the same database.
             key = '{host}:{port}'.format(host=host.host, port=host.port)
-            versions[key] = Version(*map(int, info['redis_version'].split('.', 3)))
+            versions[key] = Version(map(int, info['redis_version'].split('.', 3)))
 
-        check_versions('Redis (TSDB)', versions, Version(2, 8, 9), Version(3, 0, 4))
+        check_versions('Redis (TSDB)', versions, Version((2, 8, 9)), Version((3, 0, 4)))
 
     def make_key(self, model, epoch, model_key):
         if isinstance(model_key, six.integer_types):

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import warnings
+from collections import namedtuple
+
+from sentry.exceptions import InvalidConfiguration
+
+
+class Version(namedtuple('Version', 'major minor patch')):
+    def __str__(self):
+        return '.'.join(map(str, self))
+
+
+def make_upgrade_message(service, modality, version, hosts):
+    return '{service} {modality} be upgraded to {version} on {hosts}.'.format(
+        hosts=', '.join('{0} (currently {1})'.format(*i) for i in hosts),
+        modality=modality,
+        service=service,
+        version=version,
+    )
+
+
+def check_versions(service, versions, required, recommended=None):
+    """
+    Check that all members of mapping hosts fulfill version requirements.
+
+    :param service: service label, such as ``Redis``
+    :param versions: mapping of host to ``Version``
+    :param required: lowest supported ``Version``. If any host does not fulfill
+        this requirement, an ``InvalidConfiguration`` exception is raised.
+    :param recommended: recommended version. If any host does not fulfill this
+        requirement, a ``PendingDeprecationWarning`` is raised.
+    """
+    must_upgrade = filter(lambda (host, version): required > version, versions.items())
+    if must_upgrade:
+        raise InvalidConfiguration(make_upgrade_message(service, 'must', required, must_upgrade))
+
+    if recommended:
+        should_upgrade = filter(lambda (host, version): recommended > version, versions.items())
+        if should_upgrade:
+            warnings.warn(
+                make_upgrade_message(service, 'should', recommended, should_upgrade),
+                PendingDeprecationWarning,
+            )

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -22,7 +22,7 @@ def make_upgrade_message(service, modality, version, hosts):
 
 def check_versions(service, versions, required, recommended=None):
     """
-    Check that all members of mapping hosts fulfill version requirements.
+    Check that hosts fulfill version requirements.
 
     :param service: service label, such as ``Redis``
     :param versions: mapping of host to ``Version``

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -10,9 +10,19 @@ class Version(tuple):
         return '.'.join(map(str, self))
 
 
+def summarize(sequence, max=3):
+    items = sequence[:max]
+    remainder = len(sequence) - max
+    if remainder == 1:
+        items.append('and one other')
+    elif remainder > 1:
+        items.append('and %s others' % (remainder,))
+    return items
+
+
 def make_upgrade_message(service, modality, version, hosts):
     return '{service} {modality} be upgraded to {version} on {hosts}.'.format(
-        hosts=', '.join('{0} (currently {1})'.format(*i) for i in hosts),
+        hosts=','.join(map(str, summarize(hosts.keys(), 2))),
         modality=modality,
         service=service,
         version=version,
@@ -30,12 +40,12 @@ def check_versions(service, versions, required, recommended=None):
     :param recommended: recommended version. If any host does not fulfill this
         requirement, a ``PendingDeprecationWarning`` is raised.
     """
-    must_upgrade = filter(lambda (host, version): required > version, versions.items())
+    must_upgrade = dict(filter(lambda (host, version): required > version, versions.items()))
     if must_upgrade:
         raise InvalidConfiguration(make_upgrade_message(service, 'must', required, must_upgrade))
 
     if recommended:
-        should_upgrade = filter(lambda (host, version): recommended > version, versions.items())
+        should_upgrade = dict(filter(lambda (host, version): recommended > version, versions.items()))
         if should_upgrade:
             warnings.warn(
                 make_upgrade_message(service, 'should', recommended, should_upgrade),

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
 import warnings
-from collections import namedtuple
 
 from sentry.exceptions import InvalidConfiguration
 
 
-class Version(namedtuple('Version', 'major minor patch')):
+class Version(tuple):
     def __str__(self):
         return '.'.join(map(str, self))
 


### PR DESCRIPTION
This ensures all Redis TSDB databases are running Redis 2.8.9 at minimum (for
planned feature support), and recommends running 3.0.4.
