### PR TITLE
Gracefully handle no manifests file

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -260,8 +260,11 @@ STATICFILES_FINDERS = (
 )
 
 ASSET_MANIFEST_PATH = os.path.join(STATIC_ROOT, 'sentry', 'dist', 'manifest.json')
-with open(ASSET_MANIFEST_PATH) as manifest_file:
-    ASSET_MANIFEST = json.load(manifest_file)
+try:
+    with open(ASSET_MANIFEST_PATH) as manifest_file:
+        ASSET_MANIFEST = json.load(manifest_file)
+except IOError:
+    ASSET_MANIFEST = {}
 
 # setup a default media root to somewhere useless
 MEDIA_ROOT = '/tmp/sentry-media'

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -11,7 +11,7 @@ register = Library()
 class AssetURLNode(URLNode):
     def render(self, context):
         path = super(AssetURLNode, self).render(context)
-        parts = path.split('/')
+        parts = path.rsplit('/', 1)
         last = parts[-1]
 
         try:

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -11,12 +11,13 @@ register = Library()
 class AssetURLNode(URLNode):
     def render(self, context):
         path = super(AssetURLNode, self).render(context)
-
-        # Replace last part of url path with value from manifest
-        # TODO: Blow up gracefully if not in manifest?
         parts = path.split('/')
         last = parts[-1]
-        parts[-1] = settings.ASSET_MANIFEST[last]
+
+        try:
+            parts[-1] = settings.ASSET_MANIFEST[last]
+        except IndexError:
+            return path
 
         return '/'.join(parts)
 


### PR DESCRIPTION
Turns out, this gets in the way when just doing API things or in `shell` without any web UI.
