### PR TITLE
Remove unnecessary replacement of \n in email html

### DIFF
--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -116,4 +116,4 @@ class Interface(object):
         body = self.to_string(event)
         if not body:
             return ''
-        return '<pre>%s</pre>' % (escape(body).replace('\n', '<br>'),)
+        return '<pre>%s</pre>' % (escape(body),)


### PR DESCRIPTION
Emails get encoded as this [Quoted printable](https://en.wikipedia.org/wiki/Quoted-printable) format, which means lines need to wrap at 76 chars, blah blah blah.

This typically isn't a problem, but since we're rendering a `<pre>` block, the extra whitespace matters.

Here is the raw source of an email that I got that wrapped a line in a bad place:

![image](https://cloud.githubusercontent.com/assets/375744/10331179/18316246-6c88-11e5-877f-f50cf53e9fe3.png)

Which causes it to be rendered like:
![image](https://cloud.githubusercontent.com/assets/375744/10331269/e109a610-6c88-11e5-9a77-cf1f8b1826b2.png)

But as you can see, we're also rendering the entire blob of HTML inside one line and allowing it to wrap.

I don't know why we were replacing the `\n`'s with `<br>`'s in the first place, but inside a `<pre>`, this isn't necessary since it respects whitespace.

Tested on http://localhost:8000/debug/mail/new-event/ and it looks the same:
![image](https://cloud.githubusercontent.com/assets/375744/10331185/2378c338-6c88-11e5-8ffc-41e2214dc799.png)

Was there a reason this was being converted before? Compatibility for some email clients? Just wanted to make sure this is fine before pushing.
