### PR TITLE
Speed up Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,18 @@ cache:
     - "$HOME/virtualenv/python2.7.9"
 env:
   matrix:
-    - DB=sqlite
-    - DB=mysql
-    - DB=postgres
+    - TEST_SUITE=sqlite
+    - TEST_SUITE=mysql
+    - TEST_SUITE=postgres
+    - TEST_SUITE=js
+    - TEST_SUITE=cli
   global:
     - SENTRY_LIGHT_BUILD=1
     - SKIP_BACKEND_VALIDATION=1
 install:
-  - python -m pip install --upgrade pip==7.1.2
-  - time make develop dev-postgres dev-mysql
-before_script:
-  - mysql -e 'create database sentry;'
-  - psql -c 'create database sentry;' -U postgres
-  - "echo \"create keyspace sentry with replication = {'class' : 'SimpleStrategy', 'replication_factor': 1};\" | cqlsh --cqlversion=3.0.3"
-  - echo 'create table nodestore (key text primary key, value blob, flags int);' | cqlsh -k sentry --cqlversion=3.0.3
+  - make travis-install-$TEST_SUITE
 script:
-  - make lint
-  - make test-js
-  - coverage run --source=src/sentry -m py.test tests
-  - make test-cli
+  - make lint-$TEST_SUITE
+  - make test-$TEST_SUITE
 after_success:
-  - codecov -e DB
+  - codecov -e TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
     - SKIP_BACKEND_VALIDATION=1
 install:
   - time make develop dev-postgres dev-mysql
-  - time pip install codecov
 before_script:
   - mysql -e 'create database sentry;'
   - psql -c 'create database sentry;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 cache:
   directories:
     - node_modules
-    - .pip_download_cache
+    - $HOME/.cache/pip
     - "$HOME/virtualenv/python2.7.9"
 env:
   matrix:
@@ -20,10 +20,10 @@ env:
     - DB=mysql
     - DB=postgres
   global:
-    - PIP_DOWNLOAD_CACHE=".pip_download_cache"
     - SENTRY_LIGHT_BUILD=1
     - SKIP_BACKEND_VALIDATION=1
 install:
+  - python -m pip install --upgrade pip==7.1.2
   - time make develop dev-postgres dev-mysql
 before_script:
   - mysql -e 'create database sentry;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - TEST_SUITE=sqlite
     - TEST_SUITE=mysql
     - TEST_SUITE=postgres
+    - TEST_SUITE=webpack
     - TEST_SUITE=js
     - TEST_SUITE=cli
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 install:
   - make travis-install-$TEST_SUITE
 script:
-  - make lint-$TEST_SUITE
-  - make test-$TEST_SUITE
+  - make travis-lint-$TEST_SUITE
+  - make travis-test-$TEST_SUITE
 after_success:
   - codecov -e TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   global:
     - PIP_DOWNLOAD_CACHE=".pip_download_cache"
     - SENTRY_LIGHT_BUILD=1
+    - SKIP_BACKEND_VALIDATION=1
 install:
   - time make develop dev-postgres dev-mysql
   - time pip install codecov

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-npm:
 install-python-tests:
 	pip install "file://`pwd`#egg=sentry[tests]"
 
-develop-only: update-submodules install-python install-node
+develop-only: update-submodules install-python install-npm
 
 develop: update-submodules setup-git develop-only install-python-tests
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ travis-install-mysql: travis-install-python dev-mysql
 	mysql -e 'create database sentry;'
 
 travis-install-js:
-	npm install
+	npm install --ignore-scripts
 
 travis-install-cli: travis-install-python develop
 

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ travis-test-python:
 test-postgres: travis-test-python
 test-mysql: travis-test-python
 test-sqlite: travis-test-python
+test-webpack:
+	@echo "--> Compiling webpack"
+	./node_modules/.bin/webpack
 
 lint:
 	@echo "--> Linting all the things"
@@ -117,6 +120,7 @@ lint-mysql: lint-python
 lint-postgres: lint-python
 lint-python: lint
 lint-js: lint
+lint-webpack: lint
 lint-cli:
 	@echo "Nothing to lint :("
 
@@ -152,6 +156,8 @@ travis-install-mysql: travis-install-python dev-mysql
 
 travis-install-js:
 	npm install --ignore-scripts
+
+travis-install-webpack: travis-install-js
 
 travis-install-cli: travis-install-python
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,6 @@ lint-python:
 
 lint-js:
 	@echo "--> Linting JavaScript files"
-	@npm install
 	@npm run lint
 	@echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -89,17 +89,15 @@ test-python:
 	py.test tests || exit 1
 	@echo ""
 
-lint: lint-python lint-js
-
-lint-python:
-	@echo "--> Linting Python files"
+lint:
+	@echo "--> Linting all the things"
 	bin/lint src/sentry tests
 	@echo ""
 
-lint-js:
-	@echo "--> Linting JavaScript files"
-	@npm run lint
-	@echo ""
+# These are just aliases for backwards compat
+# our linter does both now
+lint-python: lint
+lint-js: lint
 
 coverage: develop
 	coverage run --source=src/sentry -m py.test

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -37,6 +37,9 @@ def py_lint(file_list):
 
 
 def js_lint(file_list):
+    if not os.path.isdir('node_modules'):
+        print '!! Skipping JavaScript linting because no `node_modules` folder found.'
+        return False
     has_errors = False
     file_list = filter(lambda x: x.endswith(('.js', '.jsx')), file_list)
     if file_list and os.system('npm run-script lint'):


### PR DESCRIPTION
tl;dr this cuts the runtime by half on Travis.
- `SKIP_BACKEND_VALIDATION` since not really needed
- Don't install `codecov`, Travis has it pre-installed
- The JS linter was being run twice
- Parallelize the js and cli test suites in matrix build
- Each test suite only installs what is needed. `mysql` installs `mysql` stuff only, not `postgres`, for example.

By splitting out the js test suite, our python builds sqlite/mysql/postgres/cli now don't even attempt to touch `npm` or running webpack. And conversely, for js builds, there's no installing python dependencies.

I also removed the running of `webpack -p` due to the `postinstall` hook from `npm install` by doing `npm install --no-scripts`. The webpack build isn't necessary to tests to run, but not sure if it's nice to have their as a sanity check. My assumption was that eslint would have it covered. I'll happily add it back if found necessary.

/cc @dcramer @benvinegar 
