### PR TITLE
Make rollup expiry relative to the input timestamp.

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -101,6 +101,17 @@ class BaseTSDB(object):
                 return rollup
         return self.rollups[-1][0]
 
+    def calculate_expiry(self, rollup, samples, timestamp):
+        """
+        Calculate the expiration time for a rollup.
+
+        :param rollup: rollup interval (in seconds)
+        :param samples: number of samples to maintain
+        :param timestamp: datetime used to calculate the rollup epoch
+        """
+        epoch = self.normalize_to_epoch(timestamp, rollup)
+        return epoch + (rollup * samples)
+
     def incr(self, model, key, timestamp=None, count=1):
         """
         Increment project ID=1:

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 
 import pytz
 
-from datetime import datetime
+from datetime import (
+    datetime,
+    timedelta,
+)
 
 from sentry.testutils import TestCase
 from sentry.tsdb.base import TSDBModel, ONE_MINUTE, ONE_HOUR, ONE_DAY
@@ -39,33 +42,41 @@ class RedisTSDBTest(TestCase):
         assert result == 'bf4e529197e56a48ae2737505b9736e4'
 
     def test_simple(self):
-        timestamp = datetime(2013, 5, 18, 15, 13, 58, tzinfo=pytz.UTC)
-        start = timestamp
-        self.db.incr(TSDBModel.project, 1, timestamp)
+        now = datetime.utcnow().replace(tzinfo=pytz.UTC)
+        dts = [now + timedelta(hours=i) for i in xrange(4)]
 
-        timestamp = datetime(2013, 5, 18, 16, 13, 58, tzinfo=pytz.UTC)
-        self.db.incr(TSDBModel.project, 1, timestamp, count=3)
+        def timestamp(d):
+            t = int(d.strftime('%s'))
+            return t - (t % 3600)
 
-        timestamp = datetime(2013, 5, 18, 17, 13, 58, tzinfo=pytz.UTC)
-        self.db.incr(TSDBModel.project, 1, timestamp)
-
-        timestamp = datetime(2013, 5, 18, 18, 13, 58, tzinfo=pytz.UTC)
-        end = timestamp
+        self.db.incr(TSDBModel.project, 1, dts[0])
+        self.db.incr(TSDBModel.project, 1, dts[1], count=3)
+        self.db.incr(TSDBModel.project, 1, dts[2])
         self.db.incr_multi([
             (TSDBModel.project, 1),
             (TSDBModel.project, 2),
-        ], timestamp, count=4)
+        ], dts[3], count=4)
 
-        results = self.db.get_range(TSDBModel.project, [1], start, end)
+        results = self.db.get_range(TSDBModel.project, [1], dts[0], dts[-1])
         assert results == {
-            1: [(1368889200, 1), (1368892800, 3), (1368896400, 1), (1368900000, 4)],
+            1: [
+                (timestamp(dts[0]), 1),
+                (timestamp(dts[1]), 3),
+                (timestamp(dts[2]), 1),
+                (timestamp(dts[3]), 4),
+            ],
         }
-        results = self.db.get_range(TSDBModel.project, [2], start, end)
+        results = self.db.get_range(TSDBModel.project, [2], dts[0], dts[-1])
         assert results == {
-            2: [(1368889200, 0), (1368892800, 0), (1368896400, 0), (1368900000, 4)],
+            2: [
+                (timestamp(dts[0]), 0),
+                (timestamp(dts[1]), 0),
+                (timestamp(dts[2]), 0),
+                (timestamp(dts[3]), 4),
+            ],
         }
 
-        results = self.db.get_sums(TSDBModel.project, [1, 2], start, end)
+        results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
         assert results == {
             1: 9,
             2: 4,


### PR DESCRIPTION
Right now the expiration time is calculated relative to the time that the write
is performed, meaning that items could persist too long or expire too early.
This instead fixes the expiration time to the interval epoch timetamp.
