### PR TITLE
Upgrade react-bootstrap from 0.13 to 0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "query-string": "^2.4.0",
     "raven-js": "^1.1.20",
     "react": "^0.13.3",
-    "react-bootstrap": "^0.13.0",
+    "react-bootstrap": "^0.26.4",
     "react-document-title": "^1.0.2",
     "react-router": "^0.13.3",
     "react-sticky": "^2.5.2",

--- a/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
+++ b/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
@@ -1,10 +1,9 @@
 import React from "react";
-import Modal from "react-bootstrap/Modal";
-import OverlayMixin from "react-bootstrap/OverlayMixin";
+import Modal from "react-bootstrap/lib/Modal";
 var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
 
 var LinkWithConfirmation = React.createClass({
-  mixins: [OverlayMixin, PureRenderMixin],
+  mixins: [PureRenderMixin],
 
   propTypes: {
     disabled: React.PropTypes.bool,
@@ -41,29 +40,23 @@ var LinkWithConfirmation = React.createClass({
       className += ' disabled';
     }
     return (
-      <a className={className} disabled={this.props.disabled} onClick={this.onToggle} title={this.props.title}>
-        {this.props.children}
-      </a>
-    );
-  },
+      <div>
+        <a className={className} disabled={this.props.disabled} onClick={this.onToggle} title={this.props.title}>
+          {this.props.children}
+        </a>
 
-  renderOverlay() {
-    if (!this.state.isModalOpen) {
-      return <span/>;
-    }
-
-    return (
-      <Modal title="Please confirm" animation={false} onRequestHide={this.onToggle}>
-        <div className="modal-body">
-          <p><strong>{this.props.message}</strong></p>
-        </div>
-        <div className="modal-footer">
-          <button type="button" className="btn btn-default"
-                  onClick={this.onToggle}>Cancel</button>
-          <button type="button" className="btn btn-primary"
-                  onClick={this.onConfirm}>Confirm</button>
-        </div>
-      </Modal>
+        <Modal show={this.state.isModalOpen} title="Please confirm" animation={false} onHide={this.onToggle}>
+          <div className="modal-body">
+            <p><strong>{this.props.message}</strong></p>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-default"
+                    onClick={this.onToggle}>Cancel</button>
+            <button type="button" className="btn btn-primary"
+                    onClick={this.onConfirm}>Confirm</button>
+          </div>
+        </Modal>
+      </div>
     );
   }
 });

--- a/src/sentry/static/sentry/app/views/stream/actionLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actionLink.jsx
@@ -1,5 +1,4 @@
-import Modal from "react-bootstrap/Modal";
-import OverlayMixin from "react-bootstrap/OverlayMixin";
+import Modal from "react-bootstrap/lib/Modal";
 var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
 import React from "react";
 import SelectedGroupStore from "../../stores/selectedGroupStore";
@@ -7,7 +6,7 @@ import TooltipMixin from "../../mixins/tooltip";
 
 var ActionLink = React.createClass({
   mixins: [
-    OverlayMixin, PureRenderMixin,
+    PureRenderMixin,
     TooltipMixin({
       html: false,
       container: 'body'
@@ -43,6 +42,15 @@ var ActionLink = React.createClass({
     };
   },
 
+  handleClick() {
+    var selectedItemIds = SelectedGroupStore.getSelectedIds();
+    if (!this.state.isModalOpen && !this.shouldConfirm(selectedItemIds.size)) {
+      return void this.handleActionSelected();
+    }
+
+    this.handleToggle();
+  },
+
   handleToggle() {
     if (this.props.disabled) {
       return;
@@ -70,22 +78,6 @@ var ActionLink = React.createClass({
     return confirmLabel.toLowerCase() + ' these {count} events';
   },
 
-  render() {
-    var className = this.props.className;
-    if (this.props.disabled) {
-      className += ' disabled';
-    }
-    className += ' tip';
-    return (
-      <a title={this.props.tooltip || this.props.buttonTitle}
-         className={className}
-         disabled={this.props.disabled}
-         onClick={this.handleToggle}>
-        {this.props.children}
-      </a>
-    );
-  },
-
   shouldConfirm(numSelectedItems) {
     // By default, should confirm ...
     var shouldConfirm = true;
@@ -102,45 +94,44 @@ var ActionLink = React.createClass({
     return shouldConfirm;
   },
 
-  renderOverlay() {
-    if (!this.state.isModalOpen) {
-      return null;
+  render() {
+    let className = this.props.className;
+    if (this.props.disabled) {
+      className += ' disabled';
     }
+    className += ' tip';
 
-    var selectedItemIds = SelectedGroupStore.getSelectedIds();
-    if (selectedItemIds.size === 0) {
-      throw new Error('ActionModal rendered without any selected groups');
-    }
 
-    if (!this.shouldConfirm(selectedItemIds.size)) {
-      this.handleActionSelected();
-      this.state.isModalOpen = false;
-      return null;
-    }
-
-    var confirmLabel = this.props.confirmLabel;
-    var actionLabel = this.props.actionLabel || this.defaultActionLabel(confirmLabel);
-    var numEvents = selectedItemIds.size;
-
+    let confirmLabel = this.props.confirmLabel;
+    let numEvents = SelectedGroupStore.getSelectedIds().size;
+    let actionLabel = this.props.actionLabel || this.defaultActionLabel(confirmLabel);
     actionLabel = actionLabel.replace('{count}', numEvents);
 
     return (
-      <Modal title="Please confirm" animation={false} onRequestHide={this.handleToggle}>
-        <div className="modal-body">
-          <p><strong>Are you sure that you want to {actionLabel}?</strong></p>
-          <p>This action cannot be undone.</p>
-        </div>
-        <div className="modal-footer">
-          <button type="button" className="btn btn-default"
-                  onClick={this.handleToggle}>Cancel</button>
-          {this.props.canActionAll &&
-            <button type="button" className="btn btn-danger"
-                    onClick={this.handleActionAll}>{confirmLabel} all recorded events</button>
-          }
-          <button type="button" className="btn btn-primary"
-                  onClick={this.handleActionSelected}>{confirmLabel} {numEvents} selected events</button>
-        </div>
-      </Modal>
+      <span>
+        <a title={this.props.tooltip || this.props.buttonTitle}
+           className={className}
+           disabled={this.props.disabled}
+           onClick={this.handleClick}>
+          {this.props.children}
+        </a>
+        <Modal show={this.state.isModalOpen} title="Please confirm" animation={false} onHide={this.handleToggle}>
+          <div className="modal-body">
+            <p><strong>Are you sure that you want to {this.props.actionLabel}?</strong></p>
+            <p>This action cannot be undone.</p>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-default"
+                    onClick={this.handleToggle}>Cancel</button>
+            {this.props.canActionAll &&
+              <button type="button" className="btn btn-danger"
+                      onClick={this.handleActionAll}>{confirmLabel} all recorded events</button>
+            }
+            <button type="button" className="btn btn-primary"
+                    onClick={this.handleActionSelected}>{confirmLabel} {numEvents} selected events</button>
+          </div>
+        </Modal>
+      </span>
     );
   }
 });

--- a/tests/js/spec/views/stream/actionLink.spec.jsx
+++ b/tests/js/spec/views/stream/actionLink.spec.jsx
@@ -4,7 +4,7 @@ var TestUtils = React.addons.TestUtils;
 import api from "app/api";
 import stubReactComponents from "../../../helpers/stubReactComponent";
 import ActionLink from "app/views/stream/actionLink";
-import Modal from "react-bootstrap/Modal";
+import Modal from "react-bootstrap/lib/Modal";
 
 describe("ActionLink", function() {
 


### PR DESCRIPTION
Just getting react-bootstrap ready for the eventual upgrade to react-bootstrap 0.27/react 0.14.

Note that the API for the `Modal` component changed, and that `OverlayMixin` was removed entirely.

I've changed our usage of `Modal` to match [the examples from react-bootstrap's documentation](http://react-bootstrap.github.io/components.html#modals).
