### PR TITLE
Don't show extra buttons in Request interface for partial interfaces.

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -57,31 +57,36 @@ var RequestInterface = React.createClass({
     var parsedUrl = document.createElement("a");
     parsedUrl.href = fullUrl;
 
+    var children = [];
+
+    if (!this.isPartial()) {
+      children.push(
+        <div className="pull-right">
+          {!this.props.isShare &&
+            <RequestActions organization={this.context.organization}
+                            project={this.context.project}
+                            group={group}
+                            event={evt} />
+          }
+        </div>,
+        <div className="btn-group">
+          <a className={(view === "rich" ? "active" : "") + " btn btn-default btn-sm"}
+             onClick={this.toggleView.bind(this, "rich")}>Rich</a>
+          <a className={(view === "curl" ? "active" : "") + " btn btn-default btn-sm"}
+             onClick={this.toggleView.bind(this, "curl")}><code>curl</code></a>
+        </div>
+      );
+    }
+
+    children.push(
+      <h3>
+        <strong>{data.method || 'GET'} <a href={fullUrl}>{parsedUrl.pathname}</a></strong>
+        <small style={{marginLeft: 20}}>{parsedUrl.hostname}</small>
+      </h3>
+    );
+
     var title = (
-      <div>
-        {!this.isPartial() &&
-          <div>
-            <div className="pull-right">
-              {!this.props.isShare &&
-                <RequestActions organization={this.context.organization}
-                                project={this.context.project}
-                                group={group}
-                                event={evt} />
-              }
-            </div>
-            <div className="btn-group">
-              <a className={(view === "rich" ? "active" : "") + " btn btn-default btn-sm"}
-                 onClick={this.toggleView.bind(this, "rich")}>Rich</a>
-              <a className={(view === "curl" ? "active" : "") + " btn btn-default btn-sm"}
-                 onClick={this.toggleView.bind(this, "curl")}><code>curl</code></a>
-            </div>
-          </div>
-        }
-        <h3>
-          <strong>{data.method || 'GET'} <a href={fullUrl}>{parsedUrl.pathname}</a></strong>
-          <small style={{marginLeft: 20}}>{parsedUrl.hostname}</small>
-        </h3>
-      </div>
+      <div>{children}</div>
     );
 
     return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -26,6 +26,13 @@ var RequestInterface = React.createClass({
     };
   },
 
+  isPartial() {
+    // We assume we only have a partial interface is we're missing
+    // an HTTP method. This means we don't have enough information
+    // to reliably construct a full HTTP request.
+    return !this.props.data.method;
+  },
+
   toggleView(value) {
     this.setState({
       view: value
@@ -52,20 +59,24 @@ var RequestInterface = React.createClass({
 
     var title = (
       <div>
-        <div className="pull-right">
-          {!this.props.isShare &&
-            <RequestActions organization={this.context.organization}
-                            project={this.context.project}
-                            group={group}
-                            event={evt} />
-          }
-        </div>
-        <div className="btn-group">
-          <a className={(view === "rich" ? "active" : "") + " btn btn-default btn-sm"}
-             onClick={this.toggleView.bind(this, "rich")}>Rich</a>
-          <a className={(view === "curl" ? "active" : "") + " btn btn-default btn-sm"}
-             onClick={this.toggleView.bind(this, "curl")}><code>curl</code></a>
-        </div>
+        {!this.isPartial() &&
+          <div>
+            <div className="pull-right">
+              {!this.props.isShare &&
+                <RequestActions organization={this.context.organization}
+                                project={this.context.project}
+                                group={group}
+                                event={evt} />
+              }
+            </div>
+            <div className="btn-group">
+              <a className={(view === "rich" ? "active" : "") + " btn btn-default btn-sm"}
+                 onClick={this.toggleView.bind(this, "rich")}>Rich</a>
+              <a className={(view === "curl" ? "active" : "") + " btn btn-default btn-sm"}
+                 onClick={this.toggleView.bind(this, "curl")}><code>curl</code></a>
+            </div>
+          </div>
+        }
         <h3>
           <strong>{data.method || 'GET'} <a href={fullUrl}>{parsedUrl.pathname}</a></strong>
           <small style={{marginLeft: 20}}>{parsedUrl.hostname}</small>


### PR DESCRIPTION
This removes the confusing UI for 'curl' and 'replay' when we don't have
enough information to reliably construct this.
