### PR TITLE
Optimizations to SentryLocaleMiddleware

### DIFF
--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -22,12 +22,8 @@ class SentryLocaleMiddleware(LocaleMiddleware):
         if settings.MAINTENANCE:
             return
 
-        # We don't care about locale for API
-        if '/api/0/' in request.path:
-            return
-
-        # Or our store endpoint
-        if request.path[-7:] == '/store/':
+        # We don't care about locale for anything under api
+        if request.path[:5] == '/api/':
             return
 
         if not request.user.is_authenticated():


### PR DESCRIPTION
Skip all attempts to use locale for our store endpoint, and skip using a
transaction with the call to `safe_execute`.

Related to: https://app.getsentry.com/sentry/sentry/group/56648683/

Lots of these events are coming from `load_user_conf`, and we don't
need a transaction here. So this is also creating an unnecessary
transaction on every /store/ call.

/cc @dcramer Any reason this is a bad idea?
