### PR TITLE
Log exceptions from store endpoint

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -111,12 +111,12 @@ class APIView(BaseView):
             if isinstance(e, APIRateLimited) and e.retry_after is not None:
                 response['Retry-After'] = str(e.retry_after)
 
-        except Exception:
-            if settings.DEBUG or True:
+        except Exception as e:
+            if settings.DEBUG:
                 content = traceback.format_exc()
             else:
                 content = ''
-            traceback.print_exc()
+            logger.exception(e)
             response = HttpResponse(content,
                                     content_type='text/plain',
                                     status=500)


### PR DESCRIPTION
@dcramer, it seems like this was an explicit decision not to do this, so curious why. We get a number of 500s from the store endpoint, and there's no way to debug since they don't get logged. I've seen them in stdout on the server, but these mostly are going unnoticed because logs.
