### PR TITLE
Cap Celery version to prevent kombu version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ tests_require = [
 
 install_requires = [
     'BeautifulSoup>=3.2.1,<3.3.0',
-    'celery>=3.1.8,<3.2.0',
+    'celery>=3.1.8,<3.1.19',
     'cssutils>=0.9.9,<0.10.0',
     'Django>=1.6.0,<1.7',
     'django-bitfield>=1.7.0,<1.8.0',


### PR DESCRIPTION
In Celery 3.1.19 (which is within the `celery>=3.1.8,<3.2.0` range specified in setup.py), the requirements for kombu have changed from `kombu>=3.0.25,<3.1` to `kombu>=3.0.29,<3.1` (see https://github.com/celery/celery/blob/v3.1.19/requirements/default.txt), which are in conflict with the `kombu<3.0.27` in Sentry's setup.py. Since the latter version is pinned due to breaking Django 1.6 compatibility, the required Celery version needs to be capped at 3.1.18 for a clean installation to work.
