### PR TITLE
Fixed #2239 - removed new project flag when creating new user

### DIFF
--- a/src/sentry/web/forms/__init__.py
+++ b/src/sentry/web/forms/__init__.py
@@ -42,8 +42,6 @@ class BaseUserForm(forms.ModelForm):
 
 
 class NewUserForm(BaseUserForm):
-    create_project = forms.BooleanField(required=False,
-        help_text=_("Create a project for this user."))
     send_welcome_mail = forms.BooleanField(required=False,
         help_text=_("Send this user a welcome email which will contain their generated password."))
 

--- a/src/sentry/web/frontend/admin.py
+++ b/src/sentry/web/frontend/admin.py
@@ -129,25 +129,12 @@ def create_new_user(request):
 
         user.save()
 
-        if form.cleaned_data['create_project']:
-            project = Project.objects.create(
-                name='%s\'s New Project' % user.username.capitalize()
-            )
-            member = project.organization.member_set.get(user=user)
-            key = project.key_set.get(user=user)
-
         if form.cleaned_data['send_welcome_mail']:
             context = {
                 'username': user.username,
                 'password': password,
                 'url': absolute_uri(reverse('sentry')),
             }
-            if form.cleaned_data['create_project']:
-                context.update({
-                    'project': project,
-                    'member': member,
-                    'dsn': key.get_dsn(),
-                })
             body = render_to_string('sentry/emails/welcome_mail.txt', context, request)
 
             try:


### PR DESCRIPTION
I decided to remove the new project flag from NewUserForm.
The alternative was to add the Organization.get_default() but we also needed the team and I think it's best to just create the user without the project.
