### PR TITLE
Fix key composition in digest schedule script.

### DIFF
--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -60,46 +60,49 @@ class RedisScriptTestCase(BaseRedisBackendTestCase):
 
         waiting_set_size = functools.partial(client.zcard, 'waiting')
         ready_set_size = functools.partial(client.zcard, 'ready')
+
         timeline_score_in_waiting_set = functools.partial(client.zscore, 'waiting', timeline)
         timeline_score_in_ready_set = functools.partial(client.zscore, 'ready', timeline)
+
+        keys = ('waiting', 'ready', 'last-processed')
 
         # The first addition should cause the timeline to be added to the ready set.
         with self.assertChanges(ready_set_size, before=0, after=1), \
                 self.assertChanges(timeline_score_in_ready_set, before=None, after=timestamp):
-            assert ensure_timeline_scheduled(('waiting', 'ready'), (timeline, timestamp, 1, 10), client) == 1
+            assert ensure_timeline_scheduled(keys, (timeline, timestamp, 1, 10), client) == 1
 
         # Adding it again with a timestamp in the future should not change the schedule time.
         with self.assertDoesNotChange(waiting_set_size), \
                 self.assertDoesNotChange(ready_set_size), \
                 self.assertDoesNotChange(timeline_score_in_ready_set):
-            assert ensure_timeline_scheduled(('waiting', 'ready'), (timeline, timestamp + 50, 1, 10), client) is None
+            assert ensure_timeline_scheduled(keys, (timeline, timestamp + 50, 1, 10), client) is None
 
         # Move the timeline from the ready set to the waiting set.
         client.zrem('ready', timeline)
         client.zadd('waiting', timestamp, timeline)
-        client.set(make_last_processed_timestamp_key(timeline), timestamp)
+        client.set('last-processed', timestamp)
 
         increment = 1
         with self.assertDoesNotChange(waiting_set_size), \
                 self.assertChanges(timeline_score_in_waiting_set, before=timestamp, after=timestamp + increment):
-            assert ensure_timeline_scheduled(('waiting', 'ready'), (timeline, timestamp, increment, 10), client) is None
+            assert ensure_timeline_scheduled(keys, (timeline, timestamp, increment, 10), client) is None
 
         # Make sure the schedule respects the maximum value.
         with self.assertDoesNotChange(waiting_set_size), \
                 self.assertChanges(timeline_score_in_waiting_set, before=timestamp + 1, after=timestamp):
-            assert ensure_timeline_scheduled(('waiting', 'ready'), (timeline, timestamp, increment, 0), client) is None
+            assert ensure_timeline_scheduled(keys, (timeline, timestamp, increment, 0), client) is None
 
         # Test to ensure a missing last processed timestamp can be handled
         # correctly (chooses minimum of schedule value and record timestamp.)
         client.zadd('waiting', timestamp, timeline)
-        client.delete(make_last_processed_timestamp_key(timeline))
+        client.delete('last-processed')
         with self.assertDoesNotChange(waiting_set_size), \
                 self.assertDoesNotChange(timeline_score_in_waiting_set):
-            assert ensure_timeline_scheduled(('waiting', 'ready'), (timeline, timestamp + 100, increment, 10), client) is None
+            assert ensure_timeline_scheduled(keys, (timeline, timestamp + 100, increment, 10), client) is None
 
         with self.assertDoesNotChange(waiting_set_size), \
                 self.assertChanges(timeline_score_in_waiting_set, before=timestamp, after=timestamp - 100):
-            assert ensure_timeline_scheduled(('waiting', 'ready'), (timeline, timestamp - 100, increment, 10), client) is None
+            assert ensure_timeline_scheduled(keys, (timeline, timestamp - 100, increment, 10), client) is None
 
     def test_truncate_timeline_script(self):
         client = StrictRedis(db=9)


### PR DESCRIPTION
Incorrectly constructing the last processed timestamp in the Lua script
caused digests to be scheduled too quickly upon receiving new events --
instead of additional events delaying scheduling processing, they
actually reduced the delay:
https://github.com/getsentry/sentry/blob/e60b095bf3ba3e371ce3230b66b3301a36af7450/src/sentry/digests/backends/redis.py#L99-L104

This patch changes the the last processed timestamp to be passed as a
key to the script, ensuring that it is constructed for reading using the
same method as is used when it is set during processing. This removes
the potential for these two methods of key generation to diverge.

This also verifies the presence of all keys and arguments to the
schedule script. This ensures the correct number of keys and arguments
are provided, throwing an error if too few arguments are passed
(otherwise, missing argument or keys would have been silently converted
to `nil`.)
