### PR TITLE
Enable react/sort-comp eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -128,6 +128,7 @@
     "react/no-unknown-property": 2,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
     "react/react-in-jsx-scope": 2,   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
     "react/self-closing-comp": 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
+    "react/sort-comp": 2,            // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
     "react/wrap-multilines": 2,      // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
   }
 }

--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -3,12 +3,12 @@ import AlertActions from '../actions/alertActions';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 var AlertMessage = React.createClass({
-  mixins: [PureRenderMixin],
-
   propTypes: {
     type: React.PropTypes.string,
     message: React.PropTypes.string
   },
+
+  mixins: [PureRenderMixin],
 
   closeAlert: function() {
     AlertActions.closeAlert(this.props.id);

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -14,6 +14,10 @@ import {valueIsEqual} from "../utils";
 import TooltipMixin from "../mixins/tooltip";
 
 var AssigneeSelector = React.createClass({
+  propTypes: {
+    id: React.PropTypes.string.isRequired
+  },
+
   mixins: [
     Reflux.listenTo(GroupStore, "onGroupChange"),
     TooltipMixin({
@@ -21,10 +25,6 @@ var AssigneeSelector = React.createClass({
       selector: ".tip"
     })
   ],
-
-  propTypes: {
-    id: React.PropTypes.string.isRequired
-  },
 
   getInitialState() {
     var group = GroupStore.get(this.props.id);
@@ -58,6 +58,12 @@ var AssigneeSelector = React.createClass({
       return true;
     }
     return valueIsEqual(nextState.assignedTo, this.state.assignedTo, true);
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    // XXX(dcramer): fix odd dedraw issue as of Chrome 45.0.2454.15 dev (64-bit)
+    var node = jQuery(ReactDOM.findDOMNode(this.refs.container));
+    node.hide().show(0);
   },
 
   onGroupChange(itemIds) {
@@ -115,12 +121,6 @@ var AssigneeSelector = React.createClass({
         {text.substr(idx + highlightText.length)}
       </span>
     );
-  },
-
-  componentDidUpdate(prevProps, prevState) {
-    // XXX(dcramer): fix odd dedraw issue as of Chrome 45.0.2454.15 dev (64-bit)
-    var node = jQuery(ReactDOM.findDOMNode(this.refs.container));
-    node.hide().show(0);
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/barChart.jsx
@@ -4,6 +4,20 @@ import { valueIsEqual } from "../utils";
 import TooltipMixin from "../mixins/tooltip";
 
 var BarChart = React.createClass({
+  propTypes: {
+    points: React.PropTypes.arrayOf(React.PropTypes.shape({
+      x: React.PropTypes.number.isRequired,
+      y: React.PropTypes.number.isRequired,
+      label: React.PropTypes.string
+    })),
+    placement: React.PropTypes.string,
+    label: React.PropTypes.string,
+    markers: React.PropTypes.arrayOf(React.PropTypes.shape({
+      x: React.PropTypes.number.isRequired,
+      label: React.PropTypes.string
+    }))
+  },
+
   mixins: [
     TooltipMixin(function () {
       var barChartInstance = this;
@@ -30,25 +44,10 @@ var BarChart = React.createClass({
     })
   ],
 
-
   statics: {
     getInterval(points) {
       return points.length > 1 ? points[1].x - points[0].x : null;
     }
-  },
-
-  propTypes: {
-    points: React.PropTypes.arrayOf(React.PropTypes.shape({
-      x: React.PropTypes.number.isRequired,
-      y: React.PropTypes.number.isRequired,
-      label: React.PropTypes.string
-    })),
-    placement: React.PropTypes.string,
-    label: React.PropTypes.string,
-    markers: React.PropTypes.arrayOf(React.PropTypes.shape({
-      x: React.PropTypes.number.isRequired,
-      label: React.PropTypes.string
-    }))
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/count.jsx
+++ b/src/sentry/static/sentry/app/components/count.jsx
@@ -5,6 +5,10 @@ var Count = React.createClass({
     value: React.PropTypes.any.isRequired
   },
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.props.value !== nextProps.value;
+  },
+
   numberFormats: [
       [1000000000, 'b'],
       [1000000, 'm'],
@@ -34,10 +38,6 @@ var Count = React.createClass({
           }
       }
       return '' + number;
-  },
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return this.props.value !== nextProps.value;
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -28,6 +28,10 @@ var EventEntries = React.createClass({
     };
   },
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.props.event.id !== nextProps.event.id;
+  },
+
   // TODO(dcramer): make this extensible
   interfaces: {
     exception: require("./interfaces/exception"),
@@ -35,10 +39,6 @@ var EventEntries = React.createClass({
     stacktrace: require("./interfaces/stacktrace"),
     template: require("./interfaces/template"),
     csp: require("./interfaces/csp"),
-  },
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return this.props.event.id !== nextProps.event.id;
   },
 
   render(){

--- a/src/sentry/static/sentry/app/components/fileSize.jsx
+++ b/src/sentry/static/sentry/app/components/fileSize.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 var FileSize = React.createClass({
-  units: ['KB','MB','GB','TB','PB','EB','ZB','YB'],
-
   propTypes: {
     bytes: React.PropTypes.number.isRequired
   },
+
+  units: ['KB','MB','GB','TB','PB','EB','ZB','YB'],
 
   formatBytes: function(bytes) {
       var thresh = 1024;

--- a/src/sentry/static/sentry/app/components/flotChart.jsx
+++ b/src/sentry/static/sentry/app/components/flotChart.jsx
@@ -72,6 +72,24 @@ var FlotChart = React.createClass({
     plotData: React.PropTypes.array
   },
 
+  componentDidMount() {
+    this.renderChart();
+    jQuery(window).resize(this.renderChart);
+  },
+
+  shouldComponentUpdate(nextProps, nextState) {
+    // TODO(dcramer): improve logic here
+    return nextProps.plotData.length > 0;
+  },
+
+  componentDidUpdate() {
+    this.renderChart();
+  },
+
+  componentWillUnmount() {
+    jQuery(window).unbind('resize', this.renderChart);
+  },
+
   renderChart(options) {
     var series = this.props.plotData;
     var plotOptions = {
@@ -116,24 +134,6 @@ var FlotChart = React.createClass({
 
     var chart = ReactDOM.findDOMNode(this.refs.chartNode);
     jQuery.plot(chart, series, plotOptions);
-  },
-
-  shouldComponentUpdate(nextProps, nextState) {
-    // TODO(dcramer): improve logic here
-    return nextProps.plotData.length > 0;
-  },
-
-  componentDidUpdate() {
-    this.renderChart();
-  },
-
-  componentDidMount() {
-    this.renderChart();
-    jQuery(window).resize(this.renderChart);
-  },
-
-  componentWillUnmount() {
-    jQuery(window).unbind('resize', this.renderChart);
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/group/chart.jsx
+++ b/src/sentry/static/sentry/app/components/group/chart.jsx
@@ -4,12 +4,12 @@ import PropTypes from "../../proptypes";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 var GroupChart = React.createClass({
-  mixins: [PureRenderMixin],
-
   propTypes: {
     group: PropTypes.Group.isRequired,
     statsPeriod: React.PropTypes.string.isRequired
   },
+
+  mixins: [PureRenderMixin],
 
   render: function() {
     var group = this.props.group;

--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -41,14 +41,14 @@ var GroupList = React.createClass({
     };
   },
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return !utils.valueIsEqual(this.state, nextState, true);
-  },
-
   componentWillMount() {
     this._streamManager = new utils.StreamManager(GroupStore);
 
     this.fetchData();
+  },
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return !utils.valueIsEqual(this.state, nextState, true);
   },
 
   componentDidUpdate(prevProps) {

--- a/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
+++ b/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
@@ -3,13 +3,13 @@ import Modal from "react-bootstrap/lib/Modal";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 var LinkWithConfirmation = React.createClass({
-  mixins: [PureRenderMixin],
-
   propTypes: {
     disabled: React.PropTypes.bool,
     message: React.PropTypes.string.isRequired,
     onConfirm: React.PropTypes.func.isRequired
   },
+
+  mixins: [PureRenderMixin],
 
   getInitialState() {
     return {

--- a/src/sentry/static/sentry/app/components/listLink.jsx
+++ b/src/sentry/static/sentry/app/components/listLink.jsx
@@ -3,8 +3,6 @@ import {Link, History} from "react-router";
 import classNames from 'classnames';
 
 var ListLink = React.createClass({
-  mixins: [History],
-
   displayName: 'ListLink',
 
   propTypes: {
@@ -18,6 +16,8 @@ var ListLink = React.createClass({
     // route matching
     isActive: React.PropTypes.func
   },
+
+  mixins: [History],
 
   getDefaultProps() {
     return {

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -7,14 +7,20 @@ import DropdownLink from "../dropdownLink";
 import MenuItem from "../menuItem";
 
 var ProjectSelector = React.createClass({
+  contextTypes: {
+    location: React.PropTypes.object
+  },
+
   getInitialState() {
     return {
       filter: ''
     };
   },
 
-  contextTypes: {
-    location: React.PropTypes.object
+  componentDidUpdate(prevProps, prevState) {
+    // XXX(dcramer): fix odd dedraw issue as of Chrome 45.0.2454.15 dev (64-bit)
+    var node = jQuery(ReactDOM.findDOMNode(this.refs.container));
+    node.hide().show(0);
   },
 
   onFilterChange(evt) {
@@ -122,12 +128,6 @@ var ProjectSelector = React.createClass({
     this.setState({
       filter: ''
     });
-  },
-
-  componentDidUpdate(prevProps, prevState) {
-    // XXX(dcramer): fix odd dedraw issue as of Chrome 45.0.2454.15 dev (64-bit)
-    var node = jQuery(ReactDOM.findDOMNode(this.refs.container));
-    node.hide().show(0);
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -18,6 +18,22 @@ var SelectInput = React.createClass({
     };
   },
 
+  componentDidMount() {
+    this.create();
+  },
+
+  componentWillUpdate() {
+    this.destroy();
+  },
+
+  componentDidUpdate() {
+    this.create();
+  },
+
+  componentWillUnmount() {
+    this.destroy();
+  },
+
   getValue() {
     return this.select2.getValue();
   },
@@ -33,22 +49,6 @@ var SelectInput = React.createClass({
 
   onChange(...args) {
     this.props.onChange.call(this, this.select2, ...args);
-  },
-
-  componentDidMount() {
-    this.create();
-  },
-
-  componentWillUnmount() {
-    this.destroy();
-  },
-
-  componentWillUpdate() {
-    this.destroy();
-  },
-
-  componentDidUpdate() {
-    this.create();
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -15,10 +15,6 @@ import SelectedGroupStore from "../../stores/selectedGroupStore";
 import {valueIsEqual} from "../../utils";
 
 var StreamGroup = React.createClass({
-  mixins: [
-    Reflux.listenTo(GroupStore, "onGroupChange")
-  ],
-
   propTypes: {
     id: React.PropTypes.string.isRequired,
     orgId: React.PropTypes.string.isRequired,
@@ -26,6 +22,10 @@ var StreamGroup = React.createClass({
     statsPeriod: React.PropTypes.string.isRequired,
     canSelect: React.PropTypes.bool
   },
+
+  mixins: [
+    Reflux.listenTo(GroupStore, "onGroupChange")
+  ],
 
   getDefaultProps() {
     return {

--- a/src/sentry/static/sentry/app/components/stream/groupChart.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.jsx
@@ -5,14 +5,14 @@ import GroupStore from "../../stores/groupStore";
 import {valueIsEqual} from "../../utils";
 
 var GroupChart = React.createClass({
-  mixins: [
-    Reflux.listenTo(GroupStore, "onGroupChange")
-  ],
-
   propTypes: {
     id: React.PropTypes.string.isRequired,
     statsPeriod: React.PropTypes.string.isRequired,
   },
+
+  mixins: [
+    Reflux.listenTo(GroupStore, "onGroupChange")
+  ],
 
   getInitialState() {
     var data = GroupStore.get(this.props.id);

--- a/src/sentry/static/sentry/app/components/stream/groupCheckBox.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupCheckBox.jsx
@@ -4,13 +4,13 @@ import Reflux from "reflux";
 import SelectedGroupStore from "../../stores/selectedGroupStore";
 
 var GroupCheckBox = React.createClass({
-  mixins: [
-    Reflux.listenTo(SelectedGroupStore, "onSelectedGroupChange")
-  ],
-
   propTypes: {
     id: React.PropTypes.string.isRequired
   },
+
+  mixins: [
+    Reflux.listenTo(SelectedGroupStore, "onSelectedGroupChange")
+  ],
 
   getInitialState() {
     return {

--- a/src/sentry/static/sentry/app/components/timeSince.jsx
+++ b/src/sentry/static/sentry/app/components/timeSince.jsx
@@ -3,6 +3,11 @@ import moment from "moment";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 var TimeSince = React.createClass({
+  propTypes: {
+    date: React.PropTypes.any.isRequired,
+    suffix: React.PropTypes.string
+  },
+
   mixins: [
     PureRenderMixin
   ],
@@ -14,11 +19,6 @@ var TimeSince = React.createClass({
       }
       return date;
     }
-  },
-
-  propTypes: {
-    date: React.PropTypes.any.isRequired,
-    suffix: React.PropTypes.string
   },
 
   getDefaultProps() {
@@ -37,6 +37,13 @@ var TimeSince = React.createClass({
     this.setRelativeDateTicker();
   },
 
+  componentWillUnmount() {
+    if (this.ticker) {
+      clearTimeout(this.ticker);
+      this.ticker = null;
+    }
+  },
+
   setRelativeDateTicker() {
     const ONE_MINUTE_IN_MS = 3600;
 
@@ -51,13 +58,6 @@ var TimeSince = React.createClass({
   getRelativeDate() {
     let date = TimeSince.getDateObj(this.props.date);
     return moment(date).fromNow(true);
-  },
-
-  componentWillUnmount() {
-    if (this.ticker) {
-      clearTimeout(this.ticker);
-      this.ticker = null;
-    }
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/adminOrganizations.jsx
+++ b/src/sentry/static/sentry/app/views/adminOrganizations.jsx
@@ -27,6 +27,16 @@ const AdminOrganizations = React.createClass({
     this.fetchData();
   },
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.location.search !== this.props.location.search) {
+      this.setState({
+        query: this.props.location.query,
+        loading: true,
+        error: false
+      }, this.fetchData);
+    }
+  },
+
   remountComponent() {
     this.setState(this.getInitialState(), this.fetchData);
   },
@@ -52,16 +62,6 @@ const AdminOrganizations = React.createClass({
         });
       }
     });
-  },
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.location.search !== this.props.location.search) {
-      this.setState({
-        query: this.props.location.query,
-        loading: true,
-        error: false
-      }, this.fetchData);
-    }
   },
 
   onPage(cursor) {

--- a/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
@@ -6,10 +6,6 @@ import LoadingError from "../../components/loadingError";
 import LoadingIndicator from "../../components/loadingIndicator";
 
 const ApiChart = React.createClass({
-  componentWillMount() {
-    this.fetchData();
-  },
-
   getInitialState() {
     return {
       error: false,
@@ -20,6 +16,10 @@ const ApiChart = React.createClass({
         "client-api.all-versions.responses.5xx": null
       },
     };
+  },
+
+  componentWillMount() {
+    this.fetchData();
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
@@ -7,10 +7,6 @@ import LoadingError from "../../components/loadingError";
 import LoadingIndicator from "../../components/loadingIndicator";
 
 const EventChart = React.createClass({
-  componentWillMount() {
-    this.fetchData();
-  },
-
   getInitialState() {
     return {
       error: false,
@@ -22,6 +18,10 @@ const EventChart = React.createClass({
       stats: {received: [], rejected: []},
       systemTotal: {received: 0, rejected: 0, accepted: 0}
     };
+  },
+
+  componentWillMount() {
+    this.fetchData();
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -13,19 +13,13 @@ const ERROR_TYPES = {
 };
 
 var GroupDetails = React.createClass({
-  mixins: [
-    Reflux.listenTo(GroupStore, "onGroupChange")
-  ],
-
   childContextTypes: {
     group: PropTypes.Group,
   },
 
-  getChildContext() {
-    return {
-      group: this.state.group,
-    };
-  },
+  mixins: [
+    Reflux.listenTo(GroupStore, "onGroupChange")
+  ],
 
   getInitialState() {
     return {
@@ -33,6 +27,12 @@ var GroupDetails = React.createClass({
       loading: true,
       error: false,
       errorType: null
+    };
+  },
+
+  getChildContext() {
+    return {
+      group: this.state.group,
     };
   },
 

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -11,18 +11,18 @@ import ListLink from "../../components/listLink";
 import ProjectState from "../../mixins/projectState";
 
 var GroupHeader = React.createClass({
-  mixins: [
-    ProjectState,
-    History
-  ],
+  propTypes: {
+    memberList: React.PropTypes.instanceOf(Array).isRequired
+  },
 
   contextTypes: {
     location: React.PropTypes.object
   },
 
-  propTypes: {
-    memberList: React.PropTypes.instanceOf(Array).isRequired
-  },
+  mixins: [
+    ProjectState,
+    History
+  ],
 
   onToggleMute() {
     var group = this.props.group;

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -29,6 +29,12 @@ var GroupEvents = React.createClass({
     this.fetchData();
   },
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.params.groupId !== this.props.params.groupId) {
+      this.fetchData();
+    }
+  },
+
   fetchData() {
     var queryParams = this.props.location.query;
 
@@ -55,12 +61,6 @@ var GroupEvents = React.createClass({
         });
       }
     });
-  },
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.params.groupId !== this.props.params.groupId) {
-      this.fetchData();
-    }
   },
 
   onPage(cursor) {

--- a/src/sentry/static/sentry/app/views/organizationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails.jsx
@@ -18,12 +18,6 @@ var OrganizationDetails = React.createClass({
     organization: PropTypes.Organization
   },
 
-  getChildContext() {
-    return {
-      organization: this.state.organization
-    };
-  },
-
   getInitialState() {
     return {
       loading: true,
@@ -33,8 +27,20 @@ var OrganizationDetails = React.createClass({
     };
   },
 
+  getChildContext() {
+    return {
+      organization: this.state.organization
+    };
+  },
+
   componentWillMount() {
     this.fetchData();
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.params.orgId !== this.props.params.orgId) {
+      this.remountComponent();
+    }
   },
 
   componentWillUnmount() {
@@ -43,12 +49,6 @@ var OrganizationDetails = React.createClass({
 
   remountComponent() {
     this.setState(this.getInitialState(), this.fetchData);
-  },
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.params.orgId !== this.props.params.orgId) {
-      this.remountComponent();
-    }
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
@@ -8,10 +8,6 @@ import OrganizationState from "../../mixins/organizationState";
 import {defined} from "../../utils";
 
 var OrganizationStatOverview = React.createClass({
-  mixins: [
-    OrganizationState
-  ],
-
   propTypes: {
     orgId: React.PropTypes.string
   },
@@ -19,6 +15,10 @@ var OrganizationStatOverview = React.createClass({
   contextTypes: {
     location: React.PropTypes.object
   },
+
+  mixins: [
+    OrganizationState
+  ],
 
   getInitialState() {
     return {

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -20,6 +20,17 @@ var ProjectChart = React.createClass({
     };
   },
 
+  componentWillMount() {
+    this.fetchData();
+  },
+
+  componentWillReceiveProps() {
+    this.setState({
+      loading: true,
+      error: false
+    }, this.fetchData);
+  },
+
   getStatsEndpoint() {
     var org = this.getOrganization();
     var project = this.getProject();
@@ -30,17 +41,6 @@ var ProjectChart = React.createClass({
     var org = this.getOrganization();
     var project = this.getProject();
     return '/projects/' + org.slug + '/' + project.slug + '/releases/';
-  },
-
-  componentWillMount() {
-    this.fetchData();
-  },
-
-  componentWillReceiveProps() {
-    this.setState({
-      loading: true,
-      error: false
-    }, this.fetchData);
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/projectDashboard/eventNode.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/eventNode.jsx
@@ -6,11 +6,11 @@ import TimeSince from "../../components/timeSince";
 import ProjectState from "../../mixins/projectState";
 
 var EventNode = React.createClass({
-  mixins: [ProjectState],
-
   propTypes: {
     group: PropTypes.Group.isRequired
   },
+
+  mixins: [ProjectState],
 
   makeGroupLink(title) {
     var group = this.props.group;

--- a/src/sentry/static/sentry/app/views/projectDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectDetails.jsx
@@ -17,23 +17,16 @@ const ERROR_TYPES = {
 };
 
 var ProjectDetails = React.createClass({
-  mixins: [
-    Reflux.connect(MemberListStore, "memberList"),
-    Reflux.listenTo(TeamStore, "onTeamChange"),
-    OrganizationState
-  ],
-
   childContextTypes: {
     project: PropTypes.Project,
     team: PropTypes.Team
   },
 
-  getChildContext() {
-    return {
-      project: this.state.project,
-      team: this.state.team
-    };
-  },
+  mixins: [
+    Reflux.connect(MemberListStore, "memberList"),
+    Reflux.listenTo(TeamStore, "onTeamChange"),
+    OrganizationState
+  ],
 
   getInitialState() {
     return {
@@ -47,12 +40,15 @@ var ProjectDetails = React.createClass({
     };
   },
 
-  componentWillMount() {
-    this.fetchData();
+  getChildContext() {
+    return {
+      project: this.state.project,
+      team: this.state.team
+    };
   },
 
-  remountComponent() {
-    this.setState(this.getInitialState(), this.fetchData);
+  componentWillMount() {
+    this.fetchData();
   },
 
   componentWillReceiveProps(nextProps) {
@@ -60,6 +56,10 @@ var ProjectDetails = React.createClass({
       nextProps.params.orgId != this.props.params.orgId) {
       this.remountComponent();
     }
+  },
+
+  remountComponent() {
+    this.setState(this.getInitialState(), this.fetchData);
   },
 
   onTeamChange() {

--- a/src/sentry/static/sentry/app/views/projectEvents.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents.jsx
@@ -13,14 +13,14 @@ import Pagination from "../components/pagination";
 import utils from "../utils";
 
 var ProjectEvents = React.createClass({
+  propTypes: {
+    setProjectNavSection: React.PropTypes.func
+  },
+
   mixins: [
     Reflux.listenTo(EventStore, "onEventChange"),
     History
   ],
-
-  propTypes: {
-    setProjectNavSection: React.PropTypes.func
-  },
 
   getInitialState() {
     return {
@@ -30,10 +30,6 @@ var ProjectEvents = React.createClass({
       loading: true,
       error: false
     };
-  },
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return !utils.valueIsEqual(this.state, nextState, true);
   },
 
   componentWillMount() {
@@ -59,9 +55,8 @@ var ProjectEvents = React.createClass({
     this.fetchData();
   },
 
-  componentWillUnmount() {
-    this._poller.disable();
-    EventStore.reset();
+  shouldComponentUpdate(nextProps, nextState) {
+    return !utils.valueIsEqual(this.state, nextState, true);
   },
 
   componentDidUpdate(prevProps, prevState) {
@@ -78,6 +73,11 @@ var ProjectEvents = React.createClass({
         this._poller.disable();
       }
     }
+  },
+
+  componentWillUnmount() {
+    this._poller.disable();
+    EventStore.reset();
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/projectEvents/actions.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/actions.jsx
@@ -3,14 +3,14 @@ import React from "react";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 var EventActions = React.createClass({
-  mixins: [
-    PureRenderMixin
-  ],
-
   propTypes: {
     onRealtimeChange: React.PropTypes.func.isRequired,
     realtimeActive: React.PropTypes.bool.isRequired
   },
+
+  mixins: [
+    PureRenderMixin
+  ],
 
   getInitialState() {
     return {

--- a/src/sentry/static/sentry/app/views/projectInstall/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/index.jsx
@@ -9,19 +9,19 @@ const ProjectInstall = React.createClass({
     setProjectNavSection: React.PropTypes.func
   },
 
+  getInitialState() {
+    return {
+      loading: true,
+      platformList: null
+    };
+  },
+
   componentWillMount() {
     this.props.setProjectNavSection('settings');
   },
 
   componentDidMount() {
     this.fetchData();
-  },
-
-  getInitialState() {
-    return {
-      loading: true,
-      platformList: null
-    };
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -10,16 +10,16 @@ import SearchBar from "../../components/searchBar.jsx";
 import ReleaseList from "./releaseList";
 
 var ProjectReleases = React.createClass({
+  propTypes: {
+    setProjectNavSection: React.PropTypes.func
+  },
+
   mixins: [ History ],
 
   getDefaultProps() {
     return {
       defaultQuery: ""
     };
-  },
-
-  propTypes: {
-    setProjectNavSection: React.PropTypes.func
   },
 
   getInitialState() {
@@ -34,15 +34,6 @@ var ProjectReleases = React.createClass({
     };
   },
 
-  onSearch(query) {
-    var targetQueryParams = {};
-    if (query !== '')
-      targetQueryParams.query = query;
-
-    let {orgId, projectId} = this.props.params;
-    this.history.pushState(null, `/${orgId}/${projectId}/releases/`, targetQueryParams);
-  },
-
   componentWillMount() {
     this.props.setProjectNavSection('releases');
     this.fetchData();
@@ -55,6 +46,15 @@ var ProjectReleases = React.createClass({
         query: queryParams.query
       }, this.fetchData);
     }
+  },
+
+  onSearch(query) {
+    var targetQueryParams = {};
+    if (query !== '')
+      targetQueryParams.query = query;
+
+    let {orgId, projectId} = this.props.params;
+    this.history.pushState(null, `/${orgId}/${projectId}/releases/`, targetQueryParams);
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -7,13 +7,20 @@ import LoadingError from "../../components/loadingError";
 import LoadingIndicator from "../../components/loadingIndicator";
 
 const ProjectSettings = React.createClass({
+  propTypes: {
+    setProjectNavSection: React.PropTypes.func
+  },
 
   contextTypes: {
     location: React.PropTypes.object
   },
 
-  propTypes: {
-    setProjectNavSection: React.PropTypes.func
+  getInitialState() {
+    return {
+      loading: true,
+      error: false,
+      project: null
+    };
   },
 
   componentWillMount() {
@@ -30,14 +37,6 @@ const ProjectSettings = React.createClass({
         error: false
       }, this.fetchData);
     }
-  },
-
-  getInitialState() {
-    return {
-      loading: true,
-      error: false,
-      project: null
-    };
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -9,11 +9,11 @@ import LoadingIndicator from "../components/loadingIndicator";
 import Pagination from "../components/pagination";
 
 var ReleaseArtifacts = React.createClass({
-  mixins: [ History ],
-
   contextTypes: {
     release: React.PropTypes.object
   },
+
+  mixins: [ History ],
 
   getInitialState() {
     return {

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -10,10 +10,6 @@ import TimeSince from "../components/timeSince";
 import Version from "../components/version";
 
 var ReleaseDetails = React.createClass({
-  mixins: [
-    ProjectState
-  ],
-
   propTypes: {
     setProjectNavSection: React.PropTypes.func
   },
@@ -26,17 +22,21 @@ var ReleaseDetails = React.createClass({
     release: React.PropTypes.object
   },
 
-  getChildContext() {
-    return {
-      release: this.state.release
-    };
-  },
+  mixins: [
+    ProjectState
+  ],
 
   getInitialState() {
     return {
       release: null,
       loading: true,
       error: false
+    };
+  },
+
+  getChildContext() {
+    return {
+      release: this.state.release
     };
   },
 

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -20,6 +20,12 @@ var RuleEditor = React.createClass({
     };
   },
 
+  componentDidUpdate() {
+    if (this.state.error) {
+      $(document.body).scrollTop($(ReactDOM.findDOMNode(this.refs.form)).offset().top);
+    }
+  },
+
   serializeNode(node) {
     var result = {};
     $(node).find('input, select').each((_, el) => {
@@ -28,12 +34,6 @@ var RuleEditor = React.createClass({
       }
     });
     return result;
-  },
-
-  componentDidUpdate() {
-    if (this.state.error) {
-      $(document.body).scrollTop($(ReactDOM.findDOMNode(this.refs.form)).offset().top);
-    }
   },
 
   onSubmit(e) {

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
@@ -18,12 +18,6 @@ var SharedGroupDetails = React.createClass({
     group: PropTypes.Group,
   },
 
-  getChildContext() {
-    return {
-      group: this.state.group,
-    };
-  },
-
   getInitialState() {
     return {
       group: null,
@@ -32,10 +26,10 @@ var SharedGroupDetails = React.createClass({
     };
   },
 
-  getTitle() {
-    if (this.state.group)
-      return this.state.group.title;
-    return 'Sentry';
+  getChildContext() {
+    return {
+      group: this.state.group,
+    };
   },
 
   componentWillMount() {
@@ -45,6 +39,12 @@ var SharedGroupDetails = React.createClass({
 
   componentWillUnmount() {
     jQuery(document.body).removeClass("shared-group");
+  },
+
+  getTitle() {
+    if (this.state.group)
+      return this.state.group.title;
+    return 'Sentry';
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -23,15 +23,15 @@ import utils from "../utils";
 import parseLinkHeader from '../utils/parseLinkHeader';
 
 var Stream = React.createClass({
+  propTypes: {
+    setProjectNavSection: React.PropTypes.func
+  },
+
   mixins: [
     Reflux.listenTo(GroupStore, "onGroupChange"),
     Reflux.listenTo(StreamTagStore, "onStreamTagChange"),
     History
   ],
-
-  propTypes: {
-    setProjectNavSection: React.PropTypes.func
-  },
 
   getDefaultProps() {
     return {
@@ -65,27 +65,6 @@ var Stream = React.createClass({
     }, this.getQueryStringState());
   },
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return !_.isEqual(this.state, nextState, true);
-  },
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.location.search !== this.props.location.search) {
-      this.setState(this.getQueryStringState(nextProps), this.fetchData);
-      this._poller.disable();
-    }
-  },
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.realtimeActive !== this.state.realtimeActive) {
-      if (this.state.realtimeActive) {
-        this._poller.enable();
-      } else {
-        this._poller.disable();
-      }
-    }
-  },
-
   componentWillMount() {
     this.props.setProjectNavSection('stream');
 
@@ -108,6 +87,27 @@ var Stream = React.createClass({
 
     this.fetchTags();
     this.fetchData();
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.location.search !== this.props.location.search) {
+      this.setState(this.getQueryStringState(nextProps), this.fetchData);
+      this._poller.disable();
+    }
+  },
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return !_.isEqual(this.state, nextState, true);
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.realtimeActive !== this.state.realtimeActive) {
+      if (this.state.realtimeActive) {
+        this._poller.enable();
+      } else {
+        this._poller.disable();
+      }
+    }
   },
 
   componentWillUnmount() {

--- a/src/sentry/static/sentry/app/views/stream/actionLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actionLink.jsx
@@ -5,14 +5,6 @@ import SelectedGroupStore from "../../stores/selectedGroupStore";
 import TooltipMixin from "../../mixins/tooltip";
 
 var ActionLink = React.createClass({
-  mixins: [
-    PureRenderMixin,
-    TooltipMixin({
-      html: false,
-      container: 'body'
-    })
-  ],
-
   propTypes: {
     actionLabel: React.PropTypes.string,
     canActionAll: React.PropTypes.bool.isRequired,
@@ -23,6 +15,14 @@ var ActionLink = React.createClass({
     onlyIfBulk: React.PropTypes.bool,
     selectAllActive: React.PropTypes.bool.isRequired
   },
+
+  mixins: [
+    PureRenderMixin,
+    TooltipMixin({
+      html: false,
+      container: 'body'
+    })
+  ],
 
   getDefaultProps() {
     return {

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -9,11 +9,6 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import SelectedGroupStore from "../../stores/selectedGroupStore";
 
 var StreamActions = React.createClass({
-  mixins: [
-    Reflux.listenTo(SelectedGroupStore, 'onSelectedGroupChange'),
-    PureRenderMixin
-  ],
-
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired,
@@ -24,14 +19,10 @@ var StreamActions = React.createClass({
     statsPeriod: React.PropTypes.string.isRequired
   },
 
-  getInitialState() {
-    return {
-      datePickerActive: false,
-      selectAllActive: false,
-      anySelected: false,
-      multiSelected: false,
-    };
-  },
+  mixins: [
+    Reflux.listenTo(SelectedGroupStore, 'onSelectedGroupChange'),
+    PureRenderMixin
+  ],
 
   getDefaultProps() {
     return {
@@ -39,6 +30,15 @@ var StreamActions = React.createClass({
         ALL: 'all',
         SELECTED: 'selected'
       }
+    };
+  },
+
+  getInitialState() {
+    return {
+      datePickerActive: false,
+      selectAllActive: false,
+      anySelected: false,
+      multiSelected: false,
     };
   },
 

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -10,6 +10,10 @@ var StreamFilters = React.createClass({
     projectId: React.PropTypes.string.isRequired
   },
 
+  contextTypes: {
+    location: React.PropTypes.object
+  },
+
   getDefaultProps() {
     return {
       defaultQuery: "",
@@ -21,10 +25,6 @@ var StreamFilters = React.createClass({
       onSearch: function() {},
       onSidebarToggle: function () {}
     };
-  },
-
-  contextTypes: {
-    location: React.PropTypes.object
   },
 
   getActiveButton() {

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -24,7 +24,26 @@ var SearchBar = React.createClass({
     Reflux.listenTo(MemberListStore, 'onMemberListStoreChange')
   ],
 
-  DROPDOWN_BLUR_DURATION: 200,
+  statics: {
+    /**
+     * Given a query, and the current cursor position, return the string-delimiting
+     * index of the search term designated by the cursor.
+     */
+    getLastTermIndex(query, cursor) {
+      // TODO: work with quoted-terms
+      let cursorOffset = query.slice(cursor).search(/\s|$/);
+      return cursor + (cursorOffset === -1 ? 0 : cursorOffset);
+    },
+
+    /**
+     * Returns an array of query terms, including incomplete terms
+     *
+     * e.g. ["is:unassigned", "browser:\"Chrome 33.0\"", "assigned"]
+     */
+    getQueryTerms(query, cursor) {
+      return query.slice(0, cursor).match(/\S+:"[^"]*"?|\S+/g);
+    }
+  },
 
   getDefaultProps() {
     return {
@@ -89,26 +108,7 @@ var SearchBar = React.createClass({
     }
   },
 
-  statics: {
-    /**
-     * Given a query, and the current cursor position, return the string-delimiting
-     * index of the search term designated by the cursor.
-     */
-    getLastTermIndex(query, cursor) {
-      // TODO: work with quoted-terms
-      let cursorOffset = query.slice(cursor).search(/\s|$/);
-      return cursor + (cursorOffset === -1 ? 0 : cursorOffset);
-    },
-
-    /**
-     * Returns an array of query terms, including incomplete terms
-     *
-     * e.g. ["is:unassigned", "browser:\"Chrome 33.0\"", "assigned"]
-     */
-    getQueryTerms(query, cursor) {
-      return query.slice(0, cursor).match(/\S+:"[^"]*"?|\S+/g);
-    }
-  },
+  DROPDOWN_BLUR_DURATION: 200,
 
   blur() {
     ReactDOM.findDOMNode(this.refs.searchInput).blur();

--- a/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
+++ b/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
@@ -9,6 +9,15 @@ var StreamTagFilter = React.createClass({
     projectId: React.PropTypes.string.isRequired
   },
 
+  statics: {
+    tagValueToSelect2Format: (key) => {
+      return {
+        id: key,
+        text: key
+      };
+    }
+  },
+
   getDefaultProps() {
     return {
       tag: {},
@@ -22,26 +31,6 @@ var StreamTagFilter = React.createClass({
       loading: false,
       value: this.props.value,
     };
-  },
-
-  statics: {
-    tagValueToSelect2Format: (key) => {
-      return {
-        id: key,
-        text: key
-      };
-    }
-  },
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== this.state.value) {
-      this.setState({
-        value: nextProps.value
-      }, () => {
-        let select = this.refs.select;
-        $(select).select2('val', this.state.value);
-      });
-    }
   },
 
   componentDidMount() {
@@ -80,6 +69,17 @@ var StreamTagFilter = React.createClass({
     $(select)
       .select2(selectOpts)
       .on('change', this.onSelectValue);
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value !== this.state.value) {
+      this.setState({
+        value: nextProps.value
+      }, () => {
+        let select = this.refs.select;
+        $(select).select2('val', this.state.value);
+      });
+    }
   },
 
   componentWillUnmount() {

--- a/tests/js/helpers/stubContext.jsx
+++ b/tests/js/helpers/stubContext.jsx
@@ -18,9 +18,9 @@ function stubContext(BaseComponent, context) {
 
   var StubbedContextParent = React.createClass({
     displayName: 'StubbedContextParent',
+    contextTypes: _contextTypes,
     childContextTypes: _contextTypes,
     getChildContext() { return _context; },
-    contextTypes: _contextTypes,
 
     render() {
       return React.Children.only(this.props.children);


### PR DESCRIPTION
Rule description: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md

TL;DR enforces React class methods appear in a certain order for consistency / increased readability. 

I've wanted to make this change for a while; it's nice to have all lifecycle methods / type declarations in the same place in each file.
