### PR TITLE
Convert var -> let where can be done safely

### DIFF
--- a/src/sentry/static/sentry/app/actions/alertActions.jsx
+++ b/src/sentry/static/sentry/app/actions/alertActions.jsx
@@ -1,5 +1,5 @@
 import Reflux from "reflux";
 
-var AlertActions = Reflux.createActions(["addAlert", "closeAlert"]);
+let AlertActions = Reflux.createActions(["addAlert", "closeAlert"]);
 
 export default AlertActions;

--- a/src/sentry/static/sentry/app/actions/groupActions.jsx
+++ b/src/sentry/static/sentry/app/actions/groupActions.jsx
@@ -4,7 +4,7 @@ import Reflux from "reflux";
 
 // TODO(dcramer): we should probably just make every parameter update
 // work on bulk groups
-var GroupActions = Reflux.createActions([
+let GroupActions = Reflux.createActions([
   "assignTo",
   "assignToError",
   "assignToSuccess",

--- a/src/sentry/static/sentry/app/actions/teamActions.jsx
+++ b/src/sentry/static/sentry/app/actions/teamActions.jsx
@@ -1,7 +1,7 @@
 
 import Reflux from "reflux";
 
-var TeamActions = Reflux.createActions([
+let TeamActions = Reflux.createActions([
   "update",
   "updateError",
   "updateSuccess"

--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -24,7 +24,7 @@ class Client {
   }
 
   uniqueId() {
-    var s4 = () => {
+    let s4 = () => {
       return Math.floor((1 + Math.random()) * 0x10000)
                  .toString(16)
                  .substring(1);
@@ -40,7 +40,7 @@ class Client {
     }
 
     return (...args) => {
-      var req = this.activeRequests[id];
+      let req = this.activeRequests[id];
       if (cleanup === true) {
         delete this.activeRequests[id];
       }
@@ -51,16 +51,16 @@ class Client {
   }
 
   request(path, options = {}) {
-    var query = $.param(options.query || "", true);
-    var method = options.method || (options.data ? "POST" : "GET");
-    var data = options.data;
-    var id = this.uniqueId();
+    let query = $.param(options.query || "", true);
+    let method = options.method || (options.data ? "POST" : "GET");
+    let data = options.data;
+    let id = this.uniqueId();
 
     if (typeof data !== "undefined" && method !== 'GET') {
       data = JSON.stringify(data);
     }
 
-    var fullUrl;
+    let fullUrl;
     if (path.indexOf(this.baseUrl) === -1) {
       fullUrl = this.baseUrl + path;
     } else {
@@ -112,9 +112,9 @@ class Client {
   }
 
   bulkDelete(params, options) {
-    var path = "/projects/" + params.orgId + "/" + params.projectId + "/groups/";
-    var query = (params.itemIds ? {id: params.itemIds} : undefined);
-    var id = this.uniqueId();
+    let path = "/projects/" + params.orgId + "/" + params.projectId + "/groups/";
+    let query = (params.itemIds ? {id: params.itemIds} : undefined);
+    let id = this.uniqueId();
 
     GroupActions.delete(id, params.itemIds);
 
@@ -131,9 +131,9 @@ class Client {
   }
 
   bulkUpdate(params, options) {
-    var path = "/projects/" + params.orgId + "/" + params.projectId + "/groups/";
-    var query = (params.itemIds ? {id: params.itemIds} : undefined);
-    var id = this.uniqueId();
+    let path = "/projects/" + params.orgId + "/" + params.projectId + "/groups/";
+    let query = (params.itemIds ? {id: params.itemIds} : undefined);
+    let id = this.uniqueId();
 
     GroupActions.update(id, params.itemIds, params.data);
 
@@ -151,9 +151,9 @@ class Client {
   }
 
   merge(params, options) {
-    var path = "/projects/" + params.orgId + "/" + params.projectId + "/groups/";
-    var query = (params.itemIds ? {id: params.itemIds} : undefined);
-    var id = this.uniqueId();
+    let path = "/projects/" + params.orgId + "/" + params.projectId + "/groups/";
+    let query = (params.itemIds ? {id: params.itemIds} : undefined);
+    let id = this.uniqueId();
 
     GroupActions.merge(id, params.itemIds);
 
@@ -171,8 +171,8 @@ class Client {
   }
 
   assignTo(params, options) {
-    var path = "/groups/" + params.id + "/";
-    var id = this.uniqueId();
+    let path = "/groups/" + params.id + "/";
+    let id = this.uniqueId();
 
     GroupActions.assignTo(id, params.id, {email: params.email});
 
@@ -189,8 +189,8 @@ class Client {
   }
 
   joinTeam(params, options) {
-    var path = "/organizations/" + params.orgId + "/members/" + (params.memberId || 'me') + "/teams/" + params.teamId + "/";
-    var id = this.uniqueId();
+    let path = "/organizations/" + params.orgId + "/members/" + (params.memberId || 'me') + "/teams/" + params.teamId + "/";
+    let id = this.uniqueId();
 
     TeamActions.update(id, params.teamId);
 
@@ -206,8 +206,8 @@ class Client {
   }
 
   leaveTeam(params, options) {
-    var path = "/organizations/" + params.orgId + "/members/" + (params.memberId || 'me') + "/teams/" + params.teamId + "/";
-    var id = this.uniqueId();
+    let path = "/organizations/" + params.orgId + "/members/" + (params.memberId || 'me') + "/teams/" + params.teamId + "/";
+    let id = this.uniqueId();
 
     TeamActions.update(id, params.teamId);
 

--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import AlertActions from '../actions/alertActions';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var AlertMessage = React.createClass({
+const AlertMessage = React.createClass({
   propTypes: {
     type: React.PropTypes.string,
     message: React.PropTypes.string
@@ -15,7 +15,7 @@ var AlertMessage = React.createClass({
   },
 
   render: function() {
-    var className = this.props.className || 'alert';
+    let className = this.props.className || 'alert';
     if (this.props.type !== '') {
       className += ' alert-' + this.props.type;
     }

--- a/src/sentry/static/sentry/app/components/alerts.jsx
+++ b/src/sentry/static/sentry/app/components/alerts.jsx
@@ -5,7 +5,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import AlertStore from '../stores/alertStore';
 import AlertMessage from './alertMessage';
 
-var Alerts = React.createClass({
+const Alerts = React.createClass({
   mixins: [
     PureRenderMixin,
     Reflux.connect(AlertStore, "alerts")

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -13,7 +13,7 @@ import {userDisplayName} from "../utils/formatters";
 import {valueIsEqual} from "../utils";
 import TooltipMixin from "../mixins/tooltip";
 
-var AssigneeSelector = React.createClass({
+const AssigneeSelector = React.createClass({
   propTypes: {
     id: React.PropTypes.string.isRequired
   },
@@ -27,7 +27,7 @@ var AssigneeSelector = React.createClass({
   ],
 
   getInitialState() {
-    var group = GroupStore.get(this.props.id);
+    let group = GroupStore.get(this.props.id);
 
     return {
       assignedTo: group.assignedTo,
@@ -38,9 +38,9 @@ var AssigneeSelector = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    var loading = GroupStore.hasStatus(nextProps.id, 'assignTo');
+    let loading = GroupStore.hasStatus(nextProps.id, 'assignTo');
     if (nextProps.id != this.props.id || loading != this.state.loading) {
-      var group = GroupStore.get(this.props.id);
+      let group = GroupStore.get(this.props.id);
       this.setState({
         assignedTo: group.assignedTo,
         memberList: MemberListStore.getAll(),
@@ -62,7 +62,7 @@ var AssigneeSelector = React.createClass({
 
   componentDidUpdate(prevProps, prevState) {
     // XXX(dcramer): fix odd dedraw issue as of Chrome 45.0.2454.15 dev (64-bit)
-    var node = jQuery(ReactDOM.findDOMNode(this.refs.container));
+    let node = jQuery(ReactDOM.findDOMNode(this.refs.container));
     node.hide().show(0);
   },
 
@@ -70,7 +70,7 @@ var AssigneeSelector = React.createClass({
     if (!itemIds.has(this.props.id)) {
       return;
     }
-    var group = GroupStore.get(this.props.id);
+    let group = GroupStore.get(this.props.id);
     this.setState({
       assignedTo: group.assignedTo,
       loading: GroupStore.hasStatus(this.props.id, 'assignTo')
@@ -108,7 +108,7 @@ var AssigneeSelector = React.createClass({
       return text;
     }
     highlightText = highlightText.toLowerCase();
-    var idx = text.toLowerCase().indexOf(highlightText);
+    let idx = text.toLowerCase().indexOf(highlightText);
     if (idx === -1) {
       return text;
     }
@@ -124,18 +124,18 @@ var AssigneeSelector = React.createClass({
   },
 
   render() {
-    var loading = this.state.loading;
-    var assignedTo = this.state.assignedTo;
-    var filter = this.state.filter;
+    let loading = this.state.loading;
+    let assignedTo = this.state.assignedTo;
+    let filter = this.state.filter;
 
-    var className = "assignee-selector anchor-right";
+    let className = "assignee-selector anchor-right";
     if (!assignedTo) {
       className += " unassigned";
     }
 
-    var memberNodes = [];
+    let memberNodes = [];
     this.state.memberList.forEach(function(item){
-      var fullName = [item.name, item.email].join(' ').toLowerCase();
+      let fullName = [item.name, item.email].join(' ').toLowerCase();
       if (filter && fullName.indexOf(filter) === -1) {
         return;
       }
@@ -150,7 +150,7 @@ var AssigneeSelector = React.createClass({
       );
     }.bind(this));
 
-    var tooltipTitle = null;
+    let tooltipTitle = null;
     if (assignedTo) {
       tooltipTitle = userDisplayName(assignedTo);
     }

--- a/src/sentry/static/sentry/app/components/autoSelectText.jsx
+++ b/src/sentry/static/sentry/app/components/autoSelectText.jsx
@@ -14,7 +14,7 @@ const AutoSelectText = React.createClass({
   },
 
   selectText() {
-    var node = ReactDOM.findDOMNode(this.refs.element).firstChild;
+    let node = ReactDOM.findDOMNode(this.refs.element).firstChild;
     if (document.selection) {
       let range = document.body.createTextRange();
       range.moveToElementText(node);

--- a/src/sentry/static/sentry/app/components/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/barChart.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { valueIsEqual } from "../utils";
 import TooltipMixin from "../mixins/tooltip";
 
-var BarChart = React.createClass({
+const BarChart = React.createClass({
   propTypes: {
     points: React.PropTypes.arrayOf(React.PropTypes.shape({
       x: React.PropTypes.number.isRequired,
@@ -20,7 +20,7 @@ var BarChart = React.createClass({
 
   mixins: [
     TooltipMixin(function () {
-      var barChartInstance = this;
+      let barChartInstance = this;
       return {
         html: true,
         placement: this.props.placement,
@@ -82,13 +82,13 @@ var BarChart = React.createClass({
   },
 
   floatFormat(number, places) {
-    var multi = Math.pow(10, places);
+    let multi = Math.pow(10, places);
     return parseInt(number * multi, 10) / multi;
   },
 
   timeLabelAsHour(point) {
-    var timeMoment = moment(point.x * 1000);
-    var nextMoment = timeMoment.clone().add(59, "minute");
+    let timeMoment = moment(point.x * 1000);
+    let nextMoment = timeMoment.clone().add(59, "minute");
 
     return (
       '<span>' +
@@ -99,7 +99,7 @@ var BarChart = React.createClass({
   },
 
   timeLabelAsDay(point) {
-    var timeMoment = moment(point.x * 1000);
+    let timeMoment = moment(point.x * 1000);
 
     return (
       '<span>' +
@@ -109,8 +109,8 @@ var BarChart = React.createClass({
   },
 
   timeLabelAsRange(interval, point) {
-    var timeMoment = moment(point.x * 1000);
-    var nextMoment = timeMoment.clone().add(interval - 1, "second");
+    let timeMoment = moment(point.x * 1000);
+    let nextMoment = timeMoment.clone().add(interval - 1, "second");
 
     return (
       '<span>' +
@@ -122,7 +122,7 @@ var BarChart = React.createClass({
   },
 
   timeLabelAsFull(point) {
-    var timeMoment = moment(point.x * 1000);
+    let timeMoment = moment(point.x * 1000);
     return timeMoment.format("lll");
   },
 
@@ -140,7 +140,7 @@ var BarChart = React.createClass({
   },
 
   maxPointValue() {
-    var maxval = 10;
+    let maxval = 10;
     this.props.points.forEach((point) => {
       if (point.y > maxval) {
         maxval = point.y;
@@ -150,17 +150,17 @@ var BarChart = React.createClass({
   },
 
   renderMarker(marker) {
-    var timeLabel = moment(marker.x * 1000).format("lll");
-    var title = (
+    let timeLabel = moment(marker.x * 1000).format("lll");
+    let title = (
       '<div style="width:130px">' +
         marker.label + '<br/>' +
         timeLabel +
       '</div>'
     );
-    var className = "chart-marker tip " + (marker.className || '');
+    let className = "chart-marker tip " + (marker.className || '');
 
     // example key: m-last-seen-22811123, m-first-seen-228191
-    var key = ['m', marker.className, marker.x].join('-');
+    let key = ['m', marker.className, marker.x].join('-');
 
     return (
       <a key={key} className={className} data-title={title}>
@@ -200,14 +200,14 @@ var BarChart = React.createClass({
   },
 
   renderChart() {
-    var points = this.props.points;
-    var pointWidth = this.floatFormat(100.0 / points.length, 2) + "%";
+    let points = this.props.points;
+    let pointWidth = this.floatFormat(100.0 / points.length, 2) + "%";
 
-    var maxval = this.maxPointValue();
+    let maxval = this.maxPointValue();
 
-    var markers = this.props.markers.slice();
+    let markers = this.props.markers.slice();
 
-    var children = [];
+    let children = [];
     points.forEach((point, pointIdx) => {
       while(markers.length && markers[0].x <= point.x) {
         children.push(this.renderMarker(markers.shift()));
@@ -226,8 +226,8 @@ var BarChart = React.createClass({
   },
 
   render() {
-    var figureClass = [this.props.className, 'barchart'].join(" ");
-    var maxval = this.maxPointValue();
+    let figureClass = [this.props.className, 'barchart'].join(" ");
+    let maxval = this.maxPointValue();
 
     return (
       <figure className={figureClass} height={this.props.height} width={this.props.width}>

--- a/src/sentry/static/sentry/app/components/clippedBox.jsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
-var ClippedBox = React.createClass({
+const ClippedBox = React.createClass({
   propTypes: {
     title: React.PropTypes.string,
     defaultClipped: React.PropTypes.bool
@@ -21,7 +21,7 @@ var ClippedBox = React.createClass({
   },
 
   componentDidMount() {
-    var renderedHeight = ReactDOM.findDOMNode(this).offsetHeight;
+    let renderedHeight = ReactDOM.findDOMNode(this).offsetHeight;
 
     if (renderedHeight > this.props.clipHeight ) {
       /*eslint react/no-did-mount-set-state:0*/
@@ -40,7 +40,7 @@ var ClippedBox = React.createClass({
   },
 
   render() {
-    var className = "box-clippable";
+    let className = "box-clippable";
     if (this.state.clipped) {
       className += " clipped";
     }

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import jQuery from 'jquery';
 
 function looksLikeObjectRepr(value) {
-  var a = value[0];
-  var z = value[value.length - 1];
+  let a = value[0];
+  let z = value[value.length - 1];
   if (a == '<' && z == '>') {
     return true;
   } else if (a == '[' && z == ']') {
@@ -22,13 +22,13 @@ function looksLikeMultiLineString(value) {
 
 function padNumbersInString(string) {
   return string.replace(/(\d+)/g, function(num) {
-    var isNegative = false;
+    let isNegative = false;
     num = parseInt(num, 10);
     if (num < 0) {
       num *= -1;
       isNegative = true;
     }
-    var s = '0000000000000' + num;
+    let s = '0000000000000' + num;
     s = s.substr(s.length - (isNegative ? 11 : 12));
     if (isNegative) {
       s = '-' + s;
@@ -44,7 +44,7 @@ function naturalCaseInsensitiveSort(a, b) {
 }
 
 function analyzeStringForRepr(value) {
-  var rv = {
+  let rv = {
     repr: value,
     isString: true,
     isMultiLine: false,
@@ -67,7 +67,7 @@ function analyzeStringForRepr(value) {
 }
 
 
-var ContextData = React.createClass({
+const ContextData = React.createClass({
   propTypes: {
     data: React.PropTypes.any
   },
@@ -101,13 +101,13 @@ var ContextData = React.createClass({
 
     /*eslint no-shadow:0*/
     function walk(value, depth) {
-      var i = 0, children = [];
+      let i = 0, children = [];
       if (value === null) {
         return <span className="val-null">None</span>;
       } else if (value === true || value === false) {
         return <span className="val-bool">{value ? 'True' : 'False'}</span>;
       } else if (typeof value === 'string' || value instanceof String) {
-        var valueInfo = analyzeStringForRepr(value);
+        let valueInfo = analyzeStringForRepr(value);
         return (
           <span className={
             (valueInfo.isString ? 'val-string' : 'val-repr') +
@@ -135,10 +135,10 @@ var ContextData = React.createClass({
           </span>
         );
       } else {
-        var keys = Object.keys(value);
+        let keys = Object.keys(value);
         keys.sort(naturalCaseInsensitiveSort);
         for (i = 0; i < keys.length; i++) {
-          var key = keys[i];
+          let key = keys[i];
           children.push(
             <span className="val-dict-pair" key={key}>
               <span className="val-dict-key">
@@ -174,11 +174,11 @@ var ContextData = React.createClass({
 
   render() {
     // XXX(dcramer): babel does not support this yet
-    // var {data, className, ...other} = this.props;
-    var data = this.props.data;
-    var className = this.props.className;
-    var other = {};
-    for (var key in this.props) {
+    // let {data, className, ...other} = this.props;
+    let data = this.props.data;
+    let className = this.props.className;
+    let other = {};
+    for (let key in this.props) {
       if (key !== 'data' && key !== 'className') {
         other[key] = this.props[key];
       }

--- a/src/sentry/static/sentry/app/components/count.jsx
+++ b/src/sentry/static/sentry/app/components/count.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var Count = React.createClass({
+const Count = React.createClass({
   propTypes: {
     value: React.PropTypes.any.isRequired
   },
@@ -16,17 +16,17 @@ var Count = React.createClass({
   ],
 
   floatFormat(number, places) {
-      var multi = Math.pow(10, places);
+      let multi = Math.pow(10, places);
       return parseInt(number * multi, 10) / multi;
   },
 
   formatNumber(number){
-      var b, x, y, o, p;
+      let b, x, y, o, p;
 
       number = parseInt(number, 10);
 
       /*eslint no-cond-assign:0*/
-      for (var i = 0; (b = this.numberFormats[i]); i++){
+      for (let i = 0; (b = this.numberFormats[i]); i++){
           x = b[0];
           y = b[1];
           o = Math.floor(number / x);

--- a/src/sentry/static/sentry/app/components/dateTime.jsx
+++ b/src/sentry/static/sentry/app/components/dateTime.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import moment from "moment";
 
-var DateTime = React.createClass({
+const DateTime = React.createClass({
   propTypes: {
     date: React.PropTypes.any.isRequired
   },
 
   render() {
-    var date = this.props.date;
+    let date = this.props.date;
 
     if (typeof date === "string" || typeof date === "number") {
       date = new Date(date);

--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 
 require("bootstrap/js/dropdown");
 
-var DropdownLink = React.createClass({
+const DropdownLink = React.createClass({
   propTypes: {
     title:     React.PropTypes.node,
     caret:     React.PropTypes.bool,
@@ -41,12 +41,12 @@ var DropdownLink = React.createClass({
   },
 
   render() {
-    var className = classNames({
+    let className = classNames({
       "dropdown-toggle": true,
       "disabled": this.props.disabled,
     });
 
-    var topLevelClasses = classNames({
+    let topLevelClasses = classNames({
       "dropdown" : true,
     });
 

--- a/src/sentry/static/sentry/app/components/events/errorItem.jsx
+++ b/src/sentry/static/sentry/app/components/events/errorItem.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var EventErrorItem = React.createClass({
+const EventErrorItem = React.createClass({
   getInitialState(){
     return {
       isOpen: false,
@@ -16,8 +16,8 @@ var EventErrorItem = React.createClass({
   },
 
   render() {
-    var error = this.props.error;
-    var isOpen = this.state.isOpen;
+    let error = this.props.error;
+    let isOpen = this.state.isOpen;
     return (
       <li>
         {error.message}

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -4,7 +4,7 @@ import EventDataSection from "./eventDataSection";
 import EventErrorItem from "./errorItem";
 import PropTypes from "../../proptypes";
 
-var EventErrors = React.createClass({
+const EventErrors = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired
@@ -28,9 +28,9 @@ var EventErrors = React.createClass({
   },
 
   render() {
-    var errors = this.props.event.errors;
-    var numErrors = errors.length;
-    var isOpen = this.state.isOpen;
+    let errors = this.props.event.errors;
+    let numErrors = errors.length;
+    let isOpen = this.state.isOpen;
     return (
       <EventDataSection
           group={this.props.group}

--- a/src/sentry/static/sentry/app/components/events/eventDataSection.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "../../proptypes";
 
-var GroupEventDataSection = React.createClass({
+const GroupEventDataSection = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -11,7 +11,7 @@ import EventUser from "./user";
 import PropTypes from "../../proptypes";
 import utils from "../../utils";
 
-var EventEntries = React.createClass({
+const EventEntries = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,
@@ -42,13 +42,13 @@ var EventEntries = React.createClass({
   },
 
   render(){
-    var group = this.props.group;
-    var evt = this.props.event;
-    var isShare = this.props.isShare;
+    let group = this.props.group;
+    let evt = this.props.event;
+    let isShare = this.props.isShare;
 
-    var entries = evt.entries.map((entry, entryIdx) => {
+    let entries = evt.entries.map((entry, entryIdx) => {
       try {
-        var Component = this.interfaces[entry.type];
+        let Component = this.interfaces[entry.type];
         if (!Component) {
           /*eslint no-console:0*/
           window.console && console.error && console.error('Unregistered interface: ' + entry.type);

--- a/src/sentry/static/sentry/app/components/events/eventRow.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventRow.jsx
@@ -4,7 +4,7 @@ import EventStore from "../../stores/eventStore";
 import Gravatar from "../gravatar";
 import TimeSince from "../timeSince";
 
-var EventRow = React.createClass({
+const EventRow = React.createClass({
   propTypes: {
     id: React.PropTypes.string.isRequired
   },
@@ -28,11 +28,11 @@ var EventRow = React.createClass({
   },
 
   render() {
-    var event = this.state.event;
-    var eventLink = `/${this.props.orgSlug}/${this.props.projectSlug}/groups/${event.groupID}/events/${event.id}/`;
+    let event = this.state.event;
+    let eventLink = `/${this.props.orgSlug}/${this.props.projectSlug}/groups/${event.groupID}/events/${event.id}/`;
 
-    var tagList = [];
-    for (var key in event.tags) {
+    let tagList = [];
+    for (let key in event.tags) {
       tagList.push([key, event.tags[key]]);
     }
 

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -7,7 +7,7 @@ import PropTypes from "../../proptypes";
 import EventDataSection from "./eventDataSection";
 import {isUrl} from "../../utils";
 
-var EventTags = React.createClass({
+const EventTags = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,

--- a/src/sentry/static/sentry/app/components/events/extraData.jsx
+++ b/src/sentry/static/sentry/app/components/events/extraData.jsx
@@ -5,7 +5,7 @@ import {objectToArray} from "../../utils";
 import EventDataSection from "./eventDataSection";
 import DefinitionList from "./interfaces/definitionList";
 
-var EventExtraData = React.createClass({
+const EventExtraData = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired

--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
@@ -5,7 +5,7 @@ import {objectToArray} from "../../../utils";
 import EventDataSection from "../eventDataSection";
 import DefinitionList from "./definitionList";
 
-var CSPInterface = React.createClass({
+const CSPInterface = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,

--- a/src/sentry/static/sentry/app/components/events/interfaces/definitionList.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/definitionList.jsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import ContextData from "../../contextData";
 
-var DefinitionList = React.createClass({
+const DefinitionList = React.createClass({
   propTypes: {
     data: React.PropTypes.array.isRequired,
     isContextData: React.PropTypes.bool

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -5,7 +5,7 @@ import PropTypes from "../../../proptypes";
 import ExceptionContent from "./exceptionContent";
 import RawExceptionContent from "./rawExceptionContent";
 
-var ExceptionInterface = React.createClass({
+const ExceptionInterface = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,
@@ -14,11 +14,11 @@ var ExceptionInterface = React.createClass({
   },
 
   getInitialState() {
-    var user = ConfigStore.get("user");
+    let user = ConfigStore.get("user");
     // user may not be authenticated
-    var options = user ? user.options : {};
-    var platform = this.props.event.platform;
-    var newestFirst;
+    let options = user ? user.options : {};
+    let platform = this.props.event.platform;
+    let newestFirst;
     switch (options.stacktraceOrder) {
       case "newestFirst":
         newestFirst = true;
@@ -44,13 +44,13 @@ var ExceptionInterface = React.createClass({
   },
 
   render() {
-    var group = this.props.group;
-    var evt = this.props.event;
-    var data = this.props.data;
-    var stackView = this.state.stackView;
-    var newestFirst = this.state.newestFirst;
+    let group = this.props.group;
+    let evt = this.props.event;
+    let data = this.props.data;
+    let stackView = this.state.stackView;
+    let newestFirst = this.state.newestFirst;
 
-    var title = (
+    let title = (
       <div>
         <div className="btn-group">
           {data.hasSystemFrames &&

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
@@ -3,7 +3,7 @@ import {defined} from "../../../utils";
 
 import StacktraceContent from "./stacktraceContent";
 
-var ExceptionContent = React.createClass({
+const ExceptionContent = React.createClass({
   propTypes: {
     view: React.PropTypes.string.isRequired,
     platform: React.PropTypes.string,
@@ -11,8 +11,8 @@ var ExceptionContent = React.createClass({
   },
 
   render() {
-    var stackView = this.props.view;
-    var children = this.props.values.map((exc, excIdx) => {
+    let stackView = this.props.view;
+    let children = this.props.values.map((exc, excIdx) => {
       return (
         <div key={excIdx}>
           <h4>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -7,7 +7,7 @@ import TooltipMixin from "../../../mixins/tooltip";
 import FrameVariables from "./frameVariables";
 
 
-var Frame = React.createClass({
+const Frame = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired
   },

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameVariables.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameVariables.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import ContextData from "../../contextData";
 
-var FrameVariables = React.createClass({
+const FrameVariables = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired
   },
@@ -14,11 +14,11 @@ var FrameVariables = React.createClass({
   },
 
   render() {
-    var children = [];
-    var data = this.props.data;
+    let children = [];
+    let data = this.props.data;
 
-    for (var key in data) {
-      var value = data[key];
+    for (let key in data) {
+      let value = data[key];
       children.push(<dt key={'dt-' + key}>{key}</dt>);
       children.push((
         <dd key={'dd-' + key}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import rawStacktraceContent from "./rawStacktraceContent";
 
-var RawExceptionContent = React.createClass({
+const RawExceptionContent = React.createClass({
   propTypes: {
     platform: React.PropTypes.string
   },
 
   render() {
-    var children = this.props.values.map((exc, excIdx) => {
+    let children = this.props.values.map((exc, excIdx) => {
       return (
         <pre key={excIdx} className="traceback plain">
           {exc.stacktrace && rawStacktraceContent(exc.stacktrace, this.props.platform, exc)}

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
@@ -1,7 +1,7 @@
 import {defined, trim} from "../../../utils";
 
 function getJavaScriptFrame(frame) {
-  var result = '';
+  let result = '';
   if (defined(frame.function)) {
     result += '  at ' + frame.function + '(';
   } else {
@@ -23,7 +23,7 @@ function getJavaScriptFrame(frame) {
 }
 
 function getRubyFrame(frame) {
-  var result = '  from ';
+  let result = '  from ';
   if (defined(frame.filename)) {
     result += frame.filename;
   } else if (defined(frame.module)) {
@@ -44,7 +44,7 @@ function getRubyFrame(frame) {
 }
 
 export function getPythonFrame(frame) {
-  var result = '';
+  let result = '';
   if (defined(frame.filename)) {
     result += '  File "' + frame.filename + '"';
   } else if (defined(frame.module)) {
@@ -72,7 +72,7 @@ export function getPythonFrame(frame) {
 }
 
 export function getJavaFrame(frame) {
-  var result = '    at';
+  let result = '    at';
   if (defined(frame.module)) {
     result += ' ' + frame.module + '.';
   }
@@ -105,8 +105,8 @@ function getFrame(frame, platform) {
 }
 
 export default function render (data, platform, exception) {
-  var firstFrameOmitted, lastFrameOmitted;
-  var children = [];
+  let firstFrameOmitted, lastFrameOmitted;
+  let children = [];
 
   if (exception) {
     children.push(exception.type + ': ' + exception.value);

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -6,7 +6,7 @@ import {getCurlCommand} from "./utils";
 
 import RequestActions from "./requestActions";
 
-var RequestInterface = React.createClass({
+const RequestInterface = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,
@@ -40,12 +40,12 @@ var RequestInterface = React.createClass({
   },
 
   render() {
-    var group = this.props.group;
-    var evt = this.props.event;
-    var data = this.props.data;
-    var view = this.state.view;
+    let group = this.props.group;
+    let evt = this.props.event;
+    let data = this.props.data;
+    let view = this.state.view;
 
-    var fullUrl = data.url;
+    let fullUrl = data.url;
     if (data.query) {
       fullUrl = fullUrl + '?' + data.query;
     }
@@ -54,10 +54,10 @@ var RequestInterface = React.createClass({
     }
 
     // lol
-    var parsedUrl = document.createElement("a");
+    let parsedUrl = document.createElement("a");
     parsedUrl.href = fullUrl;
 
-    var children = [];
+    let children = [];
 
     if (!this.isPartial()) {
       children.push(
@@ -85,7 +85,7 @@ var RequestInterface = React.createClass({
       </h3>
     );
 
-    var title = (
+    let title = (
       <div>{children}</div>
     );
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/requestActions.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/requestActions.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import ConfigStore from "../../../stores/configStore";
 
-var RequestActions = React.createClass({
+const RequestActions = React.createClass({
   render(){
-    var org = this.props.organization;
-    var project = this.props.project;
-    var group = this.props.group;
-    var evt = this.props.event;
-    var urlPrefix = (
+    let org = this.props.organization;
+    let project = this.props.project;
+    let group = this.props.group;
+    let evt = this.props.event;
+    let urlPrefix = (
       ConfigStore.get('urlPrefix') + '/' + org.slug + '/' +
       project.slug + '/group/' + group.id
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
@@ -7,7 +7,7 @@ import ContextData from "../../contextData";
 import {objectIsEmpty} from "../../../utils";
 import queryString from "query-string";
 
-var RichHttpContent = React.createClass({
+const RichHttpContent = React.createClass({
 
   /**
    * Converts an object of body/querystring key/value pairs

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -5,7 +5,7 @@ import PropTypes from "../../../proptypes";
 import rawStacktraceContent from "./rawStacktraceContent";
 import StacktraceContent from "./stacktraceContent";
 
-var StacktraceInterface = React.createClass({
+const StacktraceInterface = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,
@@ -14,11 +14,11 @@ var StacktraceInterface = React.createClass({
   },
 
   getInitialState() {
-    var user = ConfigStore.get("user");
+    let user = ConfigStore.get("user");
     // user may not be authenticated
-    var options = user ? user.options : {};
-    var platform = this.props.event.platform;
-    var newestFirst;
+    let options = user ? user.options : {};
+    let platform = this.props.event.platform;
+    let newestFirst;
     switch (options.stacktraceOrder) {
       case "newestFirst":
         newestFirst = true;
@@ -44,13 +44,13 @@ var StacktraceInterface = React.createClass({
   },
 
   render() {
-    var group = this.props.group;
-    var evt = this.props.event;
-    var data = this.props.data;
-    var stackView = this.state.stackView;
-    var newestFirst = this.state.newestFirst;
+    let group = this.props.group;
+    let evt = this.props.event;
+    let data = this.props.data;
+    let stackView = this.state.stackView;
+    let newestFirst = this.state.newestFirst;
 
-    var title = (
+    let title = (
       <div>
         <div className="btn-group">
           {data.hasSystemFrames &&

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -2,7 +2,7 @@ import React from "react";
 //import GroupEventDataSection from "../eventDataSection";
 import Frame from "./frame";
 
-var StacktraceContent = React.createClass({
+const StacktraceContent = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired,
     includeSystemFrames: React.PropTypes.bool,
@@ -16,9 +16,9 @@ var StacktraceContent = React.createClass({
   },
 
   render() {
-    var data = this.props.data;
-    var firstFrameOmitted, lastFrameOmitted;
-    var includeSystemFrames = this.props.includeSystemFrames;
+    let data = this.props.data;
+    let firstFrameOmitted, lastFrameOmitted;
+    let includeSystemFrames = this.props.includeSystemFrames;
 
     if (data.framesOmitted) {
       firstFrameOmitted = data.framesOmitted[0];
@@ -28,7 +28,7 @@ var StacktraceContent = React.createClass({
       lastFrameOmitted = null;
     }
 
-    var frames = [];
+    let frames = [];
     data.frames.forEach((frame, frameIdx) => {
       if (includeSystemFrames || frame.inApp) {
         frames.push(<Frame key={frameIdx} data={frame} />);

--- a/src/sentry/static/sentry/app/components/events/interfaces/template.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/template.jsx
@@ -3,7 +3,7 @@ import GroupEventDataSection from "../eventDataSection";
 import PropTypes from "../../../proptypes";
 import Frame from "./frame";
 
-var TemplateInterface = React.createClass({
+const TemplateInterface = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -6,7 +6,7 @@ export function escapeQuotes(v) {
 
 // TODO(dcramer): support cookies
 export function getCurlCommand(data) {
-  var result = 'curl';
+  let result = 'curl';
 
   if (defined(data.method) && data.method !== 'GET') {
     result += ' \\\n -X ' + data.method;

--- a/src/sentry/static/sentry/app/components/events/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/message.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import EventDataSection from "./eventDataSection";
 import utils from "../../utils";
 
-var Message = React.createClass({
+const Message = React.createClass({
   render() {
     return (
       <EventDataSection

--- a/src/sentry/static/sentry/app/components/events/packageData.jsx
+++ b/src/sentry/static/sentry/app/components/events/packageData.jsx
@@ -4,7 +4,7 @@ import PropTypes from "../../proptypes";
 import EventDataSection from "./eventDataSection";
 import ClippedBox from "../clippedBox";
 
-var EventPackageData = React.createClass({
+const EventPackageData = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired
@@ -15,14 +15,14 @@ var EventPackageData = React.createClass({
   },
 
   render() {
-    var packages = this.props.event.packages;
-    var packageKeys = [];
+    let packages = this.props.event.packages;
+    let packageKeys = [];
     for (let key in packages) {
       packageKeys.push(key);
     }
     packageKeys.sort();
 
-    var children = [];
+    let children = [];
     packageKeys.forEach((key) => {
       children.push(<dt key={'dt-' + key}>{key}</dt>);
       children.push(<dd key={'dd-' + key}><pre>{packages[key]}</pre></dd>);

--- a/src/sentry/static/sentry/app/components/events/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/user.jsx
@@ -5,11 +5,11 @@ import DefinitionList from "./interfaces/definitionList";
 import EventDataSection from "./eventDataSection";
 
 
-var EventUser = React.createClass({
+const EventUser = React.createClass({
   render() {
-    var user = this.props.event.user;
-    var builtins = [];
-    var children = [];
+    let user = this.props.event.user;
+    let builtins = [];
+    let children = [];
 
     // Handle our native attributes special
     user.id && builtins.push(['ID', user.id]);

--- a/src/sentry/static/sentry/app/components/fileSize.jsx
+++ b/src/sentry/static/sentry/app/components/fileSize.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var FileSize = React.createClass({
+const FileSize = React.createClass({
   propTypes: {
     bytes: React.PropTypes.number.isRequired
   },
@@ -8,12 +8,12 @@ var FileSize = React.createClass({
   units: ['KB','MB','GB','TB','PB','EB','ZB','YB'],
 
   formatBytes: function(bytes) {
-      var thresh = 1024;
+      let thresh = 1024;
       if (bytes < thresh) {
         return bytes + ' B';
       }
 
-      var u = -1;
+      let u = -1;
       do {
         bytes /= thresh;
         ++u;

--- a/src/sentry/static/sentry/app/components/flotChart.jsx
+++ b/src/sentry/static/sentry/app/components/flotChart.jsx
@@ -9,7 +9,7 @@ require('flot/jquery.flot.stack');
 require('flot/jquery.flot.time');
 require('flot-tooltip/jquery.flot.tooltip');
 
-var timeUnitSize = {
+let timeUnitSize = {
   "second": 1000,
   "minute": 60 * 1000,
   "hour": 60 * 60 * 1000,
@@ -19,15 +19,15 @@ var timeUnitSize = {
   "year": 365.2425 * 24 * 60 * 60 * 1000
 };
 
-var numberWithCommas = function(x) {
+let numberWithCommas = function(x) {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };
 
-var buildTooltipHandler = function(series) {
+let buildTooltipHandler = function(series) {
   return function(_l, xval, _y, flotItem) {
-    var yval;
-    var content = '<h6>' + moment(parseInt(xval, 10)).format('llll') + '</h6>';
-    for (var i = 0; i < series.length; i++) {
+    let yval;
+    let content = '<h6>' + moment(parseInt(xval, 10)).format('llll') + '</h6>';
+    for (let i = 0; i < series.length; i++) {
       // we're assuming series are identical
       yval = numberWithCommas(series[i].data[flotItem.dataIndex][1] || 0);
       content += '<strong style="color:' + series[i].color + '">' + series[i].label + ':</strong> ' + yval + '<br>';
@@ -36,12 +36,12 @@ var buildTooltipHandler = function(series) {
   };
 };
 
-var tickFormatter = (value, axis) => {
-  var d = moment(parseInt(value, 10));
+let tickFormatter = (value, axis) => {
+  let d = moment(parseInt(value, 10));
 
-  var t = axis.tickSize[0] * timeUnitSize[axis.tickSize[1]];
-  var span = axis.max - axis.min;
-  var fmt;
+  let t = axis.tickSize[0] * timeUnitSize[axis.tickSize[1]];
+  let span = axis.max - axis.min;
+  let fmt;
 
   if (t < timeUnitSize.minute) {
     fmt = 'LT';
@@ -67,7 +67,7 @@ var tickFormatter = (value, axis) => {
   return d.format(fmt);
 };
 
-var FlotChart = React.createClass({
+const FlotChart = React.createClass({
   propTypes: {
     plotData: React.PropTypes.array
   },
@@ -91,8 +91,8 @@ var FlotChart = React.createClass({
   },
 
   renderChart(options) {
-    var series = this.props.plotData;
-    var plotOptions = {
+    let series = this.props.plotData;
+    let plotOptions = {
       xaxis: {
         mode: "time",
         minTickSize: [1, "day"],
@@ -132,7 +132,7 @@ var FlotChart = React.createClass({
       lines: { show: false }
     };
 
-    var chart = ReactDOM.findDOMNode(this.refs.chartNode);
+    let chart = ReactDOM.findDOMNode(this.refs.chartNode);
     jQuery.plot(chart, series, plotOptions);
   },
 

--- a/src/sentry/static/sentry/app/components/footer.jsx
+++ b/src/sentry/static/sentry/app/components/footer.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import ConfigStore from "../stores/configStore";
 import HookStore from "../stores/hookStore";
 
-var Footer = React.createClass({
+const Footer = React.createClass({
   render() {
-    var config = ConfigStore.getConfig();
-    var children = [];
+    let config = ConfigStore.getConfig();
+    let children = [];
     HookStore.get('footer').forEach((cb) => {
       children.push(cb());
     });

--- a/src/sentry/static/sentry/app/components/gravatar.jsx
+++ b/src/sentry/static/sentry/app/components/gravatar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import $ from "jquery";
 import MD5 from "crypto-js/md5";
 
-var Gravatar = React.createClass({
+const Gravatar = React.createClass({
   propTypes: {
     email: React.PropTypes.string,
     size: React.PropTypes.number,
@@ -17,11 +17,11 @@ var Gravatar = React.createClass({
   },
 
   buildGravatarUrl() {
-    var url = "https://secure.gravatar.com/avatar/";
+    let url = "https://secure.gravatar.com/avatar/";
 
     url += MD5(this.props.email.toLowerCase());
 
-    var query = {
+    let query = {
       s: this.props.size || undefined,
       d: this.props.default || undefined
     };

--- a/src/sentry/static/sentry/app/components/group/chart.jsx
+++ b/src/sentry/static/sentry/app/components/group/chart.jsx
@@ -3,7 +3,7 @@ import BarChart from "../../components/barChart";
 import PropTypes from "../../proptypes";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var GroupChart = React.createClass({
+const GroupChart = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     statsPeriod: React.PropTypes.string.isRequired
@@ -12,16 +12,16 @@ var GroupChart = React.createClass({
   mixins: [PureRenderMixin],
 
   render: function() {
-    var group = this.props.group;
-    var stats = group.stats[this.props.statsPeriod];
-    var points = stats.map((point) => {
+    let group = this.props.group;
+    let stats = group.stats[this.props.statsPeriod];
+    let points = stats.map((point) => {
       return {x: point[0], y: point[1]};
     });
-    var className = "bar-chart group-chart " + (this.props.className || '');
+    let className = "bar-chart group-chart " + (this.props.className || '');
 
-    var markers = [];
-    var firstSeenX = new Date(this.props.firstSeen).getTime() / 1000;
-    var lastSeenX = new Date(this.props.lastSeen).getTime() / 1000;
+    let markers = [];
+    let firstSeenX = new Date(this.props.firstSeen).getTime() / 1000;
+    let lastSeenX = new Date(this.props.lastSeen).getTime() / 1000;
     if (firstSeenX >= points[0].x) {
       markers.push({
         label: "First seen",

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -4,7 +4,7 @@ import TimeSince from "../../components/timeSince";
 import Version from "../../components/version";
 import utils from "../../utils";
 
-var SeenInfo = React.createClass({
+const SeenInfo = React.createClass({
   propTypes: {
     date: React.PropTypes.any.isRequired,
     release: React.PropTypes.shape({
@@ -15,7 +15,7 @@ var SeenInfo = React.createClass({
   },
 
   render() {
-    var {date, release} = this.props;
+    let {date, release} = this.props;
     return (
       <dl>
         <dt key={0}>When:</dt>

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -4,13 +4,13 @@ import GroupState from "../../mixins/groupState";
 import SeenInfo from "./seenInfo";
 import TagDistributionMeter from "./tagDistributionMeter";
 
-var GroupSidebar = React.createClass({
+const GroupSidebar = React.createClass({
   mixins: [GroupState],
 
   render(){
-    var orgId = this.getOrganization().slug;
-    var projectId = this.getProject().slug;
-    var group = this.getGroup();
+    let orgId = this.getOrganization().slug;
+    let projectId = this.getProject().slug;
+    let group = this.getGroup();
 
     return (
       <div className="group-stats">

--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -5,7 +5,7 @@ import PropTypes from "../../proptypes";
 import TooltipMixin from "../../mixins/tooltip";
 import {escape, percent} from "../../utils";
 
-var TagDistributionMeter = React.createClass({
+const TagDistributionMeter = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
     tag: React.PropTypes.string.isRequired,
@@ -36,7 +36,7 @@ var TagDistributionMeter = React.createClass({
   },
 
   fetchData() {
-    var url = '/groups/' + this.props.group.id + '/tags/' + encodeURIComponent(this.props.tag) + '/';
+    let url = '/groups/' + this.props.group.id + '/tags/' + encodeURIComponent(this.props.tag) + '/';
 
     this.setState({
       loading: true,
@@ -84,8 +84,8 @@ var TagDistributionMeter = React.createClass({
     return (
       <div className="segments">
         {data.topValues.map((value) => {
-          var pct = percent(value.count, totalValues);
-          var pctLabel = Math.floor(pct);
+          let pct = percent(value.count, totalValues);
+          let pctLabel = Math.floor(pct);
 
           return (
             <Link

--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -10,7 +10,7 @@ import ProjectState from "../mixins/projectState";
 import StreamGroup from "../components/stream/group";
 import utils from "../utils";
 
-var GroupList = React.createClass({
+const GroupList = React.createClass({
   propTypes: {
     query: React.PropTypes.string.isRequired,
     canSelectGroups: React.PropTypes.bool,
@@ -90,18 +90,18 @@ var GroupList = React.createClass({
   },
 
   getGroupListEndpoint() {
-    var queryParams = this.context.location.query;
+    let queryParams = this.context.location.query;
     queryParams.limit = 50;
     queryParams.sort = 'new';
     queryParams.query = this.props.query;
-    var querystring = jQuery.param(queryParams);
+    let querystring = jQuery.param(queryParams);
 
     let props = this.props;
     return '/projects/' + props.orgId + '/' + props.projectId + '/groups/?' + querystring;
   },
 
   onGroupChange() {
-    var groupIds = this._streamManager.getAllItems().map((item) => item.id);
+    let groupIds = this._streamManager.getAllItems().map((item) => item.id);
     if (!utils.valueIsEqual(groupIds, this.state.groupIds)) {
       this.setState({
         groupIds: groupIds
@@ -122,13 +122,13 @@ var GroupList = React.createClass({
         </div>
       );
 
-    var wrapperClass;
+    let wrapperClass;
 
     if (!this.props.bulkActions) {
       wrapperClass = "stream-no-bulk-actions";
     }
 
-    var {orgId, projectId} = this.props;
+    let {orgId, projectId} = this.props;
 
     return (
       <div className={wrapperClass}>

--- a/src/sentry/static/sentry/app/components/groupListHeader.jsx
+++ b/src/sentry/static/sentry/app/components/groupListHeader.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var GroupListHeader = React.createClass({
+const GroupListHeader = React.createClass({
   render() {
     return (
       <div className="group-header">

--- a/src/sentry/static/sentry/app/components/header/index.jsx
+++ b/src/sentry/static/sentry/app/components/header/index.jsx
@@ -6,12 +6,12 @@ import {Link} from "react-router";
 import UserNav from "./userNav";
 import OrganizationSelector from "./organizationSelector";
 
-var Header = React.createClass({
+const Header = React.createClass({
   mixins: [OrganizationState],
 
   render() {
-    var user = ConfigStore.get('user');
-    var logo;
+    let user = ConfigStore.get('user');
+    let logo;
 
     if (user) {
       logo = <span className="icon-sentry-logo"/>;

--- a/src/sentry/static/sentry/app/components/header/organizationSelector.jsx
+++ b/src/sentry/static/sentry/app/components/header/organizationSelector.jsx
@@ -6,7 +6,7 @@ import AppState from "../../mixins/appState";
 import OrganizationStore from "../../stores/organizationStore";
 import ConfigStore from "../../stores/configStore";
 
-var OrganizationSelector = React.createClass({
+const OrganizationSelector = React.createClass({
   mixins: [
     AppState,
   ],
@@ -16,15 +16,15 @@ var OrganizationSelector = React.createClass({
   },
 
   render() {
-    var singleOrganization = ConfigStore.get('singleOrganization');
-    var activeOrg = this.props.organization;
+    let singleOrganization = ConfigStore.get('singleOrganization');
+    let activeOrg = this.props.organization;
 
     if (singleOrganization || !activeOrg) {
       return null;
     }
 
-    var urlPrefix = ConfigStore.get('urlPrefix');
-    var features = ConfigStore.get('features');
+    let urlPrefix = ConfigStore.get('urlPrefix');
+    let features = ConfigStore.get('features');
 
     return (
       <DropdownLink

--- a/src/sentry/static/sentry/app/components/header/userNav.jsx
+++ b/src/sentry/static/sentry/app/components/header/userNav.jsx
@@ -4,21 +4,21 @@ import DropdownLink from "../dropdownLink";
 import Gravatar from "../gravatar";
 import MenuItem from "../menuItem";
 
-var UserNav = React.createClass({
+const UserNav = React.createClass({
   shouldComponentUpdate(nextProps, nextState) {
     return false;
   },
 
   render() {
-    var urlPrefix = ConfigStore.get('urlPrefix');
-    var user = ConfigStore.get('user');
+    let urlPrefix = ConfigStore.get('urlPrefix');
+    let user = ConfigStore.get('user');
 
     if (!user) {
       // TODO
       return null;
     }
 
-    var title = (
+    let title = (
       <Gravatar email={user.email} className="avatar" />
     );
 

--- a/src/sentry/static/sentry/app/components/indicators.jsx
+++ b/src/sentry/static/sentry/app/components/indicators.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Reflux from "reflux";
 import IndicatorStore from '../stores/indicatorStore';
 
-var Indicators = React.createClass({
+const Indicators = React.createClass({
   mixins: [
     Reflux.connect(IndicatorStore, "items")
   ],

--- a/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
+++ b/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Modal from "react-bootstrap/lib/Modal";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var LinkWithConfirmation = React.createClass({
+const LinkWithConfirmation = React.createClass({
   propTypes: {
     disabled: React.PropTypes.bool,
     message: React.PropTypes.string.isRequired,
@@ -35,7 +35,7 @@ var LinkWithConfirmation = React.createClass({
   },
 
   render() {
-    var className = this.props.className;
+    let className = this.props.className;
     if (this.props.disabled) {
       className += ' disabled';
     }

--- a/src/sentry/static/sentry/app/components/listLink.jsx
+++ b/src/sentry/static/sentry/app/components/listLink.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Link, History} from "react-router";
 import classNames from 'classnames';
 
-var ListLink = React.createClass({
+const ListLink = React.createClass({
   displayName: 'ListLink',
 
   propTypes: {
@@ -30,7 +30,7 @@ var ListLink = React.createClass({
   },
 
   getClassName() {
-    var _classNames = {};
+    let _classNames = {};
 
     if (this.props.className)
       _classNames[this.props.className] = true;

--- a/src/sentry/static/sentry/app/components/loadingError.jsx
+++ b/src/sentry/static/sentry/app/components/loadingError.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var LoadingError = React.createClass({
+const LoadingError = React.createClass({
   propTypes: {
     onRetry: React.PropTypes.func,
     message: React.PropTypes.string

--- a/src/sentry/static/sentry/app/components/loadingIndicator.jsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.jsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React from "react";
 
-var LoadingIndicator = React.createClass({
+const LoadingIndicator = React.createClass({
   propTypes: {
     global: React.PropTypes.bool,
     mini:  React.PropTypes.bool,
@@ -13,7 +13,7 @@ var LoadingIndicator = React.createClass({
   },
 
   render() {
-    var className = classNames({
+    let className = classNames({
       "loading": true,
       "mini": this.props.mini,
       "global": this.props.global,

--- a/src/sentry/static/sentry/app/components/menuItem.jsx
+++ b/src/sentry/static/sentry/app/components/menuItem.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Link} from "react-router";
 import classNames from "classnames";
 
-var MenuItem = React.createClass({
+const MenuItem = React.createClass({
   propTypes: {
     header:    React.PropTypes.bool,
     divider:   React.PropTypes.bool,
@@ -49,13 +49,13 @@ var MenuItem = React.createClass({
   },
 
   render() {
-    var classes = {
+    let classes = {
       "dropdown-header": this.props.header,
       "divider": this.props.divider,
       "active": this.props.isActive
     };
 
-    var children = null;
+    let children = null;
     if (this.props.noAnchor) {
       children = this.props.children;
     } else if (this.props.header) {

--- a/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
@@ -5,7 +5,7 @@ import api from "../api";
 
 const ERR_JOIN = 'There was an error while trying to join the team.';
 
-var MissingProjectMembership = React.createClass({
+const MissingProjectMembership = React.createClass({
   getInitialState() {
     return {
       loading: false,

--- a/src/sentry/static/sentry/app/components/mutedBox.jsx
+++ b/src/sentry/static/sentry/app/components/mutedBox.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var MutedBox = React.createClass({
+const MutedBox = React.createClass({
   mixins: [PureRenderMixin],
 
   render() {

--- a/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import OrganizationHomeSidebar from "./homeSidebar";
 import OrganizationState from "../../mixins/organizationState";
 
-var HomeContainer = React.createClass({
+const HomeContainer = React.createClass({
   mixins: [OrganizationState],
 
   render() {

--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -6,17 +6,17 @@ import OrganizationState from "../../mixins/organizationState";
 import ConfigStore from "../../stores/configStore";
 import HookStore from "../../stores/hookStore";
 
-var HomeSidebar = React.createClass({
+const HomeSidebar = React.createClass({
   mixins: [OrganizationState],
 
   render() {
-    var access = this.getAccess();
-    var features = this.getFeatures();
-    var org = this.getOrganization();
-    var urlPrefix = ConfigStore.get('urlPrefix') + '/organizations/' + org.slug;
+    let access = this.getAccess();
+    let features = this.getFeatures();
+    let org = this.getOrganization();
+    let urlPrefix = ConfigStore.get('urlPrefix') + '/organizations/' + org.slug;
 
     // Allow injection via getsentry et all
-    var children = [];
+    let children = [];
     HookStore.get('organization:sidebar').forEach((cb) => {
       children.push(cb(org));
     });

--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import utils from "../utils";
 
-var Pagination = React.createClass({
+const Pagination = React.createClass({
   propTypes: {
     onPage: React.PropTypes.func.isRequired,
     pageLinks: React.PropTypes.string.isRequired,
@@ -16,14 +16,14 @@ var Pagination = React.createClass({
       return null;
     }
 
-    var links = utils.parseLinkHeader(this.props.pageLinks);
+    let links = utils.parseLinkHeader(this.props.pageLinks);
 
-    var previousPageClassName = 'btn btn-default btn-lg prev';
+    let previousPageClassName = 'btn btn-default btn-lg prev';
     if (links.previous.results === false) {
       previousPageClassName += ' disabled';
     }
 
-    var nextPageClassName = 'btn btn-default btn-lg next';
+    let nextPageClassName = 'btn btn-default btn-lg next';
     if (links.next.results === false) {
       nextPageClassName += ' disabled';
     }

--- a/src/sentry/static/sentry/app/components/projectHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/index.jsx
@@ -4,13 +4,13 @@ import ConfigStore from "../../stores/configStore";
 
 import ProjectSelector from "./projectSelector";
 
-var ProjectHeader = React.createClass({
+const ProjectHeader = React.createClass({
   render() {
-    var navSection = this.props.activeSection;
-    var urlPrefix = ConfigStore.get('urlPrefix');
-    var project = this.props.project;
-    var org = this.props.organization;
-    var access = new Set(org.access);
+    let navSection = this.props.activeSection;
+    let urlPrefix = ConfigStore.get('urlPrefix');
+    let project = this.props.project;
+    let org = this.props.organization;
+    let access = new Set(org.access);
 
     return (
       <div>

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -6,7 +6,7 @@ import ConfigStore from "../../stores/configStore";
 import DropdownLink from "../dropdownLink";
 import MenuItem from "../menuItem";
 
-var ProjectSelector = React.createClass({
+const ProjectSelector = React.createClass({
   contextTypes: {
     location: React.PropTypes.object
   },
@@ -19,7 +19,7 @@ var ProjectSelector = React.createClass({
 
   componentDidUpdate(prevProps, prevState) {
     // XXX(dcramer): fix odd dedraw issue as of Chrome 45.0.2454.15 dev (64-bit)
-    var node = jQuery(ReactDOM.findDOMNode(this.refs.container));
+    let node = jQuery(ReactDOM.findDOMNode(this.refs.container));
     node.hide().show(0);
   },
 
@@ -57,7 +57,7 @@ var ProjectSelector = React.createClass({
       return text;
     }
     highlightText = highlightText.toLowerCase();
-    var idx = text.toLowerCase().indexOf(highlightText);
+    let idx = text.toLowerCase().indexOf(highlightText);
     if (idx === -1) {
       return text;
     }
@@ -91,7 +91,7 @@ var ProjectSelector = React.createClass({
   },
 
   getProjectLabel(team, project, hasSingleTeam) {
-    var label = project.name;
+    let label = project.name;
     if (!hasSingleTeam && label.indexOf(team.name) === -1) {
       label = team.name + ' / ' + project.name;
     }
@@ -99,8 +99,8 @@ var ProjectSelector = React.createClass({
   },
 
   getRawLink(project) {
-    var org = this.props.organization;
-    var urlPrefix = ConfigStore.get('urlPrefix');
+    let org = this.props.organization;
+    let urlPrefix = ConfigStore.get('urlPrefix');
     return urlPrefix + '/' + org.slug + '/' + project.slug + '/';
   },
 
@@ -131,12 +131,12 @@ var ProjectSelector = React.createClass({
   },
 
   render() {
-    var org = this.props.organization;
-    var filter = this.state.filter.toLowerCase();
-    var children = [];
-    var activeTeam;
-    var activeProject;
-    var hasSingleTeam = org.teams.length === 1;
+    let org = this.props.organization;
+    let filter = this.state.filter.toLowerCase();
+    let children = [];
+    let activeTeam;
+    let activeProject;
+    let hasSingleTeam = org.teams.length === 1;
 
     org.teams.forEach((team) => {
       if (!team.isMember) {
@@ -147,7 +147,7 @@ var ProjectSelector = React.createClass({
           activeTeam = team;
           activeProject = project;
         }
-        var fullName = [team.name, project.name, team.slug, project.slug].join(' ').toLowerCase();
+        let fullName = [team.name, project.name, team.slug, project.slug].join(' ').toLowerCase();
         if (filter && fullName.indexOf(filter) === -1) {
           return;
         }

--- a/src/sentry/static/sentry/app/components/searchBar.jsx
+++ b/src/sentry/static/sentry/app/components/searchBar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var SearchBar = React.createClass({
+const SearchBar = React.createClass({
 
   mixins: [PureRenderMixin],
 

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import jQuery from "jquery";
 
-var SelectInput = React.createClass({
+const SelectInput = React.createClass({
   getDefaultProps() {
     return {
       // HTML attrs
@@ -52,7 +52,7 @@ var SelectInput = React.createClass({
   },
 
   render() {
-    var opts = {
+    let opts = {
         ref: 'select',
         disabled: this.props.disabled,
         required: this.props.required,

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -14,7 +14,7 @@ import SelectedGroupStore from "../../stores/selectedGroupStore";
 
 import {valueIsEqual} from "../../utils";
 
-var StreamGroup = React.createClass({
+const StreamGroup = React.createClass({
   propTypes: {
     id: React.PropTypes.string.isRequired,
     orgId: React.PropTypes.string.isRequired,
@@ -63,8 +63,8 @@ var StreamGroup = React.createClass({
     if (!itemIds.has(this.props.id)) {
       return;
     }
-    var id = this.props.id;
-    var data = GroupStore.get(id);
+    let id = this.props.id;
+    let data = GroupStore.get(id);
     this.setState({
       data: data,
     });
@@ -82,10 +82,10 @@ var StreamGroup = React.createClass({
   },
 
   render() {
-    var data = this.state.data;
-    var userCount = data.userCount;
+    let data = this.state.data;
+    let userCount = data.userCount;
 
-    var className = "group row";
+    let className = "group row";
     if (data.isBookmarked) {
       className += " isBookmarked";
     }

--- a/src/sentry/static/sentry/app/components/stream/groupChart.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.jsx
@@ -4,7 +4,7 @@ import BarChart from "../barChart";
 import GroupStore from "../../stores/groupStore";
 import {valueIsEqual} from "../../utils";
 
-var GroupChart = React.createClass({
+const GroupChart = React.createClass({
   propTypes: {
     id: React.PropTypes.string.isRequired,
     statsPeriod: React.PropTypes.string.isRequired,
@@ -15,7 +15,7 @@ var GroupChart = React.createClass({
   ],
 
   getInitialState() {
-    var data = GroupStore.get(this.props.id);
+    let data = GroupStore.get(this.props.id);
     return {
       stats: data ? data.stats[this.props.statsPeriod] : null
     };
@@ -23,7 +23,7 @@ var GroupChart = React.createClass({
 
   componentWillReceiveProps(nextProps) {
     if (!valueIsEqual(nextProps, this.props)) {
-      var data = GroupStore.get(this.props.id);
+      let data = GroupStore.get(this.props.id);
       this.setState({
         stats: data.stats[this.props.statsPeriod]
       });
@@ -45,8 +45,8 @@ var GroupChart = React.createClass({
       return;
     }
 
-    var id = this.props.id;
-    var data = GroupStore.get(id);
+    let id = this.props.id;
+    let data = GroupStore.get(id);
 
     this.setState({
       stats: data.stats[this.props.statsPeriod],
@@ -57,7 +57,7 @@ var GroupChart = React.createClass({
     if (!this.state.stats)
       return null;
 
-    var chartData = this.state.stats.map((point) => {
+    let chartData = this.state.stats.map((point) => {
       return {x: point[0], y: point[1]};
     });
 

--- a/src/sentry/static/sentry/app/components/stream/groupCheckBox.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupCheckBox.jsx
@@ -3,7 +3,7 @@ import Reflux from "reflux";
 
 import SelectedGroupStore from "../../stores/selectedGroupStore";
 
-var GroupCheckBox = React.createClass({
+const GroupCheckBox = React.createClass({
   propTypes: {
     id: React.PropTypes.string.isRequired
   },
@@ -31,7 +31,7 @@ var GroupCheckBox = React.createClass({
   },
 
   onSelectedGroupChange() {
-    var isSelected = SelectedGroupStore.isSelected(this.props.id);
+    let isSelected = SelectedGroupStore.isSelected(this.props.id);
     if (isSelected !== this.state.isSelected) {
       this.setState({
         isSelected: isSelected,
@@ -40,7 +40,7 @@ var GroupCheckBox = React.createClass({
   },
 
   onSelect() {
-    var id = this.props.id;
+    let id = this.props.id;
     SelectedGroupStore.toggleSelect(id);
   },
 

--- a/src/sentry/static/sentry/app/components/timeSince.jsx
+++ b/src/sentry/static/sentry/app/components/timeSince.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import moment from "moment";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var TimeSince = React.createClass({
+const TimeSince = React.createClass({
   propTypes: {
     date: React.PropTypes.any.isRequired,
     suffix: React.PropTypes.string

--- a/src/sentry/static/sentry/app/components/userInfo.jsx
+++ b/src/sentry/static/sentry/app/components/userInfo.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 
 function getUserDisplayName(name) {
-  var parts = name.split(/@/);
+  let parts = name.split(/@/);
   if (parts.length == 1) {
     return parts[0];
   }
   return parts[0].toLowerCase().replace(/[\.-_]+/, ' ');
 }
 
-var UserInfo = React.createClass({
+const UserInfo = React.createClass({
   propTypes: {
     user: React.PropTypes.any.isRequired
   },
@@ -16,16 +16,16 @@ var UserInfo = React.createClass({
   render() {
     // XXX(dcramer): not supported by babel
     // var {user, ...other} = this.props;
-    var user = this.props.user;
-    var other = {};
-    for (var key in this.props) {
+    let user = this.props.user;
+    let other = {};
+    for (let key in this.props) {
       if (key !== 'user') {
         other[key] = this.props[key];
       }
     }
 
-    var name = user.name || user.email;
-    var displayName = getUserDisplayName(name);
+    let name = user.name || user.email;
+    let displayName = getUserDisplayName(name);
 
     return (
       <span title={name} {...other}>{displayName}</span>

--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {Link} from "react-router";
 
-var Version = React.createClass({
+const Version = React.createClass({
   propTypes: {
     version: React.PropTypes.string.isRequired,
     orgId: React.PropTypes.string.isRequired,
@@ -17,8 +17,8 @@ var Version = React.createClass({
   render() {
     // NOTE: version is encoded because it can contain slashes "/",
     //       which can interfere with URL construction
-    var version = encodeURIComponent(this.props.version);
-    var shortVersion = version.length === 40 ? version.substr(0, 12) : version;
+    let version = encodeURIComponent(this.props.version);
+    let shortVersion = version.length === 40 ? version.substr(0, 12) : version;
 
     let {orgId, projectId} = this.props;
 

--- a/src/sentry/static/sentry/app/mixins/apiMixin.jsx
+++ b/src/sentry/static/sentry/app/mixins/apiMixin.jsx
@@ -1,6 +1,6 @@
 import api from "../api";
 
-var ApiMixin = {
+let ApiMixin = {
   componentWillMount() {
     this._pendingRequests = new Set();
     this._id = 0;
@@ -13,9 +13,9 @@ var ApiMixin = {
   },
 
   apiRequest(path, options) {
-    var self = this;
+    let self = this;
 
-    var completeFunc = options.complete;
+    let completeFunc = options.complete;
     options.complete = function(...params) {
       self._pendingRequests.delete(this);
 
@@ -24,7 +24,7 @@ var ApiMixin = {
       }
     };
 
-    var req = api.request(path, options);
+    let req = api.request(path, options);
     this._pendingRequests.add(req);
   }
 };

--- a/src/sentry/static/sentry/app/mixins/appState.jsx
+++ b/src/sentry/static/sentry/app/mixins/appState.jsx
@@ -1,6 +1,6 @@
 import OrganizationStore from "../stores/organizationStore";
 
-var AppState = {
+let AppState = {
   getOrganizationList() {
     return OrganizationStore.getAll();
   }

--- a/src/sentry/static/sentry/app/mixins/groupState.jsx
+++ b/src/sentry/static/sentry/app/mixins/groupState.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "../proptypes";
 import ProjectState from "./projectState";
 
-var GroupState = {
+let GroupState = {
   mixins: [ProjectState],
 
   contextTypes: {

--- a/src/sentry/static/sentry/app/mixins/organizationState.jsx
+++ b/src/sentry/static/sentry/app/mixins/organizationState.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "../proptypes";
 
-var OrganizationState = {
+let OrganizationState = {
   contextTypes: {
     organization: PropTypes.Organization,
   },

--- a/src/sentry/static/sentry/app/mixins/projectState.jsx
+++ b/src/sentry/static/sentry/app/mixins/projectState.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "../proptypes";
 import TeamState from "./teamState";
 
-var ProjectState = {
+let ProjectState = {
   mixins: [TeamState],
 
   contextTypes: {

--- a/src/sentry/static/sentry/app/mixins/teamState.jsx
+++ b/src/sentry/static/sentry/app/mixins/teamState.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "../proptypes";
 import OrganizationState from "./organizationState";
 
-var TeamState = {
+let TeamState = {
   mixins: [OrganizationState],
 
   contextTypes: {

--- a/src/sentry/static/sentry/app/proptypes.jsx
+++ b/src/sentry/static/sentry/app/proptypes.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var PropTypes = {
+let PropTypes = {
   AnyModel: React.PropTypes.shape({
     id: React.PropTypes.string.isRequired
   }),

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -31,7 +31,7 @@ import RouteNotFound from "./views/routeNotFound";
 import SharedGroupDetails from "./views/sharedGroupDetails";
 import Stream from "./views/stream";
 
-var routes = (
+let routes = (
   <Route path="/" component={App}>
     <Route path="/organizations/:orgId/" component={OrganizationDetails}>
       <Route path="stats/" component={OrganizationStats} />

--- a/src/sentry/static/sentry/app/stores/alertStore.jsx
+++ b/src/sentry/static/sentry/app/stores/alertStore.jsx
@@ -1,7 +1,7 @@
 import Reflux from "reflux";
 import AlertActions from '../actions/alertActions';
 
-var AlertStore = Reflux.createStore({
+const AlertStore = Reflux.createStore({
   listenables: AlertActions,
 
   init: function() {

--- a/src/sentry/static/sentry/app/stores/configStore.jsx
+++ b/src/sentry/static/sentry/app/stores/configStore.jsx
@@ -1,7 +1,7 @@
 import moment from "moment-timezone";
 import Reflux from "reflux";
 
-var ConfigStore = Reflux.createStore({
+const ConfigStore = Reflux.createStore({
   init() {
     this.config = {};
   },
@@ -12,7 +12,7 @@ var ConfigStore = Reflux.createStore({
 
   set(key, value) {
     this.config[key] = value;
-    var out = {};
+    let out = {};
     out[key] = value;
     this.trigger(out);
   },

--- a/src/sentry/static/sentry/app/stores/eventStore.jsx
+++ b/src/sentry/static/sentry/app/stores/eventStore.jsx
@@ -1,7 +1,7 @@
 import jQuery from "jquery";
 import Reflux from "reflux";
 
-var EventStore = Reflux.createStore({
+const EventStore = Reflux.createStore({
   init() {
     this.reset();
   },
@@ -13,7 +13,7 @@ var EventStore = Reflux.createStore({
   loadInitialData(items) {
     this.reset();
 
-    var itemIds = new Set();
+    let itemIds = new Set();
     items.forEach((item) => {
       itemIds.add(item.id);
       this.items.push(item);
@@ -27,8 +27,8 @@ var EventStore = Reflux.createStore({
       items = [items];
     }
 
-    var itemsById = {};
-    var itemIds = new Set();
+    let itemsById = {};
+    let itemIds = new Set();
     items.forEach((item) => {
       itemsById[item.id] = item;
       itemIds.add(item.id);
@@ -41,7 +41,7 @@ var EventStore = Reflux.createStore({
       }
     });
 
-    for (var itemId in itemsById) {
+    for (let itemId in itemsById) {
       this.items.push(itemsById[itemId]);
     }
 
@@ -59,7 +59,7 @@ var EventStore = Reflux.createStore({
   },
 
   get(id) {
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].id === id) {
         return this.items[i];
       }

--- a/src/sentry/static/sentry/app/stores/groupStore.jsx
+++ b/src/sentry/static/sentry/app/stores/groupStore.jsx
@@ -4,14 +4,14 @@ import AlertActions from "../actions/alertActions";
 import GroupActions from '../actions/groupActions';
 import utils from "../utils";
 
-var ERR_CHANGE_ASSIGNEE = 'Unable to change assignee. Please try again.';
-var ERR_SCHEDULE_DELETE = 'Unable to delete events. Please try again.';
-var ERR_SCHEDULE_MERGE = 'Unable to merge events. Please try again.';
-var ERR_UPDATE = 'Unable to update events. Please try again.';
-var OK_SCHEDULE_DELETE = 'The selected events have been scheduled for deletion.';
-var OK_SCHEDULE_MERGE = 'The selected events have been scheduled for merge.';
+const ERR_CHANGE_ASSIGNEE = 'Unable to change assignee. Please try again.';
+const ERR_SCHEDULE_DELETE = 'Unable to delete events. Please try again.';
+const ERR_SCHEDULE_MERGE = 'Unable to merge events. Please try again.';
+const ERR_UPDATE = 'Unable to update events. Please try again.';
+const OK_SCHEDULE_DELETE = 'The selected events have been scheduled for deletion.';
+const OK_SCHEDULE_MERGE = 'The selected events have been scheduled for merge.';
 
-var GroupStore = Reflux.createStore({
+const GroupStore = Reflux.createStore({
   listenables: [GroupActions],
 
   init() {
@@ -30,7 +30,7 @@ var GroupStore = Reflux.createStore({
   loadInitialData(items) {
     this.reset();
 
-    var itemIds = new Set();
+    let itemIds = new Set();
     items.forEach((item) => {
       itemIds.add(item.id);
       this.items.push(item);
@@ -44,8 +44,8 @@ var GroupStore = Reflux.createStore({
       items = [items];
     }
 
-    var itemsById = {};
-    var itemIds = new Set();
+    let itemsById = {};
+    let itemIds = new Set();
     items.forEach((item) => {
       itemsById[item.id] = item;
       itemIds.add(item.id);
@@ -58,7 +58,7 @@ var GroupStore = Reflux.createStore({
       }
     });
 
-    for (var itemId in itemsById) {
+    for (let itemId in itemsById) {
       this.items.push(itemsById[itemId]);
     }
 
@@ -97,10 +97,10 @@ var GroupStore = Reflux.createStore({
   },
 
   indexOfActivity(group_id, id) {
-    var group = this.get(group_id);
+    let group = this.get(group_id);
     if (!group) return -1;
 
-    for (var i = 0; i < group.activity.length; i++) {
+    for (let i = 0; i < group.activity.length; i++) {
       if (group.activity[i].id === id) {
         return i;
       }
@@ -109,7 +109,7 @@ var GroupStore = Reflux.createStore({
   },
 
   addActivity(id, data, index = -1) {
-    var group = this.get(id);
+    let group = this.get(id);
     if (!group) return;
 
     // insert into beginning by default
@@ -125,10 +125,10 @@ var GroupStore = Reflux.createStore({
   },
 
   updateActivity(group_id, id, data) {
-    var group = this.get(group_id);
+    let group = this.get(group_id);
     if (!group) return;
 
-    var index = this.indexOfActivity(group_id, id);
+    let index = this.indexOfActivity(group_id, id);
     if (index === -1) return;
 
     // Here, we want to merge the new `data` being passed in
@@ -139,13 +139,13 @@ var GroupStore = Reflux.createStore({
   },
 
   removeActivity(group_id, id) {
-    var group = this.get(group_id);
+    let group = this.get(group_id);
     if (!group) return -1;
 
-    var index = this.indexOfActivity(group.id, id);
+    let index = this.indexOfActivity(group.id, id);
     if (index === -1) return -1;
 
-    var activity = group.activity.splice(index, 1);
+    let activity = group.activity.splice(index, 1);
 
     if (activity[0].type === 'note')
       group.numComments--;
@@ -155,21 +155,21 @@ var GroupStore = Reflux.createStore({
   },
 
   get(id) {
-    var pendingForId = [];
+    let pendingForId = [];
     this.pendingChanges.forEach(change => {
       if (change.id === id) {
         pendingForId.push(change);
       }
     });
 
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].id === id) {
-        var rItem = this.items[i];
+        let rItem = this.items[i];
         if (pendingForId.length) {
           // copy the object so dirty state doesnt mutate original
           rItem = jQuery.extend(true, {}, rItem);
 
-          for (var c = 0; c < pendingForId.length; c++) {
+          for (let c = 0; c < pendingForId.length; c++) {
             rItem = jQuery.extend(true, rItem, pendingForId[c].params);
           }
         }
@@ -184,7 +184,7 @@ var GroupStore = Reflux.createStore({
 
   getAllItems() {
     // regroup pending changes by their itemID
-    var pendingById = {};
+    let pendingById = {};
     this.pendingChanges.forEach(change => {
       if (typeof pendingById[change.id] === 'undefined') {
         pendingById[change.id] = [];
@@ -193,7 +193,7 @@ var GroupStore = Reflux.createStore({
     });
 
     return this.items.map(item => {
-      var rItem = item;
+      let rItem = item;
       if (typeof pendingById[item.id] !== 'undefined') {
         // copy the object so dirty state doesnt mutate original
         rItem = jQuery.extend(true, {}, rItem);
@@ -217,7 +217,7 @@ var GroupStore = Reflux.createStore({
   },
 
   onAssignToSuccess(changeId, itemId, response) {
-    var item = this.get(itemId);
+    let item = this.get(itemId);
     if (!item) {
       return;
     }
@@ -242,7 +242,7 @@ var GroupStore = Reflux.createStore({
   },
 
   onDeleteSuccess(changeId, itemIds, response) {
-    var itemIdSet = new Set(itemIds);
+    let itemIdSet = new Set(itemIds);
     itemIds.forEach(itemId => {
       delete this.statuses[itemId];
       this.clearStatus(itemId, 'delete');
@@ -273,7 +273,7 @@ var GroupStore = Reflux.createStore({
     });
 
     // Remove all but parent id (items were merged into this one)
-    var mergedIdSet = new Set(mergedIds);
+    let mergedIdSet = new Set(mergedIds);
     this.items = this.items.filter(
       (item) => !mergedIdSet.has(item.id) || item.id === response.merge.parent
     );

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -1,13 +1,13 @@
 
 import Reflux from "reflux";
 
-var validHookNames = new Set([
+let validHookNames = new Set([
   'footer',
   'organization:header',
   'organization:sidebar'
 ]);
 
-var HookStore = Reflux.createStore({
+const HookStore = Reflux.createStore({
   init() {
     this.hooks = {};
   },

--- a/src/sentry/static/sentry/app/stores/indicatorStore.jsx
+++ b/src/sentry/static/sentry/app/stores/indicatorStore.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Reflux from "reflux";
 import LoadingIndicator from '../components/loadingIndicator';
 
-var IndicatorStore = Reflux.createStore({
+const IndicatorStore = Reflux.createStore({
   init() {
     this.items = [];
   },

--- a/src/sentry/static/sentry/app/stores/memberListStore.jsx
+++ b/src/sentry/static/sentry/app/stores/memberListStore.jsx
@@ -1,9 +1,6 @@
-
 import Reflux from "reflux";
 
-// var MemberActions = require('../actions/groupActions');
-
-var MemberListStore = Reflux.createStore({
+const MemberListStore = Reflux.createStore({
   // listenables: MemberActions,
 
   init() {
@@ -18,7 +15,7 @@ var MemberListStore = Reflux.createStore({
 
   getById(id) {
     id = '' + id;
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].id === id) {
         return this.items[i];
       }
@@ -28,7 +25,7 @@ var MemberListStore = Reflux.createStore({
 
   getByEmail(email) {
     email = email.toLowerCase();
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].email.toLowerCase() === email) {
         return this.items[i];
       }

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -1,12 +1,12 @@
 import Reflux from "reflux";
 
-var OrganizationStore = Reflux.createStore({
+const OrganizationStore = Reflux.createStore({
   init() {
     this.items = [];
   },
 
   get(slug) {
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].slug === slug) {
         return this.items[i];
       }

--- a/src/sentry/static/sentry/app/stores/selectedGroupStore.jsx
+++ b/src/sentry/static/sentry/app/stores/selectedGroupStore.jsx
@@ -1,7 +1,7 @@
 import Reflux from "reflux";
 import GroupStore from "./groupStore";
 
-var SelectedGroupStore = Reflux.createStore({
+const SelectedGroupStore = Reflux.createStore({
   init() {
     this.records = {};
 
@@ -15,7 +15,7 @@ var SelectedGroupStore = Reflux.createStore({
   },
 
   add(ids) {
-    var allSelected = this.allSelected();
+    let allSelected = this.allSelected();
     ids.forEach((id) => {
       if (!this.records.hasOwnProperty(id)) {
         this.records[id] = allSelected;
@@ -24,10 +24,10 @@ var SelectedGroupStore = Reflux.createStore({
   },
 
   prune() {
-    var existingIds = new Set(GroupStore.getAllItemIds());
+    let existingIds = new Set(GroupStore.getAllItemIds());
 
     // Remove ids that no longer exist
-    for (var itemId in this.records) {
+    for (let itemId in this.records) {
       if (!existingIds.has(itemId)) {
         delete this.records[itemId];
       }
@@ -35,24 +35,24 @@ var SelectedGroupStore = Reflux.createStore({
   },
 
   allSelected() {
-    var itemIds = this.getSelectedIds();
-    var numRecords = Object.keys(this.records).length;
+    let itemIds = this.getSelectedIds();
+    let numRecords = Object.keys(this.records).length;
     return itemIds.size > 0 && itemIds.size === numRecords;
   },
 
   anySelected() {
-    var itemIds = this.getSelectedIds();
+    let itemIds = this.getSelectedIds();
     return itemIds.size > 0;
   },
 
   multiSelected() {
-    var itemIds = this.getSelectedIds();
+    let itemIds = this.getSelectedIds();
     return itemIds.size > 1;
   },
 
   getSelectedIds() {
-    var selected = new Set();
-    for (var itemId in this.records) {
+    let selected = new Set();
+    for (let itemId in this.records) {
       if (this.records[itemId]) {
         selected.add(itemId);
       }
@@ -65,7 +65,7 @@ var SelectedGroupStore = Reflux.createStore({
   },
 
   deselectAll() {
-    for (var itemId in this.records) {
+    for (let itemId in this.records) {
       this.records[itemId] = false;
     }
     this.trigger();
@@ -78,9 +78,9 @@ var SelectedGroupStore = Reflux.createStore({
   },
 
   toggleSelectAll() {
-    var allSelected = !this.allSelected();
+    let allSelected = !this.allSelected();
 
-    for (var itemId in this.records) {
+    for (let itemId in this.records) {
       this.records[itemId] = allSelected;
     }
 

--- a/src/sentry/static/sentry/app/stores/streamTagStore.jsx
+++ b/src/sentry/static/sentry/app/stores/streamTagStore.jsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import StreamTagActions from "../actions/streamTagActions";
 import MemberListStore from "./memberListStore";
-var StreamTagStore = Reflux.createStore({
+const StreamTagStore = Reflux.createStore({
   listenables: StreamTagActions,
 
   init() {

--- a/src/sentry/static/sentry/app/stores/teamStore.jsx
+++ b/src/sentry/static/sentry/app/stores/teamStore.jsx
@@ -1,8 +1,7 @@
-
 import Reflux from "reflux";
 import TeamActions from "../actions/teamActions";
 
-var TeamStore = Reflux.createStore({
+const TeamStore = Reflux.createStore({
   init() {
     this.items = [];
 
@@ -22,7 +21,7 @@ var TeamStore = Reflux.createStore({
     if (!response) {
       return;
     }
-    var item = this.getBySlug(itemId);
+    let item = this.getBySlug(itemId);
     if (!item) {
       this.items.push(response);
     } else {
@@ -33,7 +32,7 @@ var TeamStore = Reflux.createStore({
 
   getById(id) {
     id = '' + id;
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].id === id) {
         return this.items[i];
       }
@@ -42,7 +41,7 @@ var TeamStore = Reflux.createStore({
   },
 
   getBySlug(slug) {
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].slug === slug) {
         return this.items[i];
       }

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -1,7 +1,7 @@
 import _ from "underscore";
 
 /*eslint no-use-before-define:0*/
-var modelsEqual = function(obj1, obj2) {
+const modelsEqual = function(obj1, obj2) {
   if (!obj1 && !obj2)
     return true;
   if (obj1.id && !obj2)
@@ -11,7 +11,7 @@ var modelsEqual = function(obj1, obj2) {
   return obj1.id === obj2.id;
 };
 
-var arrayIsEqual = function(arr, other, deep) {
+const arrayIsEqual = function(arr, other, deep) {
   // if the other array is a falsy value, return
   if (!arr && !other) {
     return true;
@@ -26,12 +26,12 @@ var arrayIsEqual = function(arr, other, deep) {
     return false;
   }
 
-  for (var i = 0, l = Math.max(arr.length, other.length); i < l; i++) {
+  for (let i = 0, l = Math.max(arr.length, other.length); i < l; i++) {
     return valueIsEqual(arr[i], other[i], deep);
   }
 };
 
-var valueIsEqual = function(value, other, deep) {
+const valueIsEqual = function(value, other, deep) {
   if (value === other) {
     return true;
   } else if (value instanceof Array || other instanceof Array) {
@@ -46,8 +46,8 @@ var valueIsEqual = function(value, other, deep) {
   return false;
 };
 
-var objectMatchesSubset = function(obj, other, deep){
-  var k;
+const objectMatchesSubset = function(obj, other, deep){
+  let k;
 
   if (deep !== true) {
     for (k in other) {
@@ -70,13 +70,13 @@ var objectMatchesSubset = function(obj, other, deep){
 // miserably if a param was named 'length'
 const objectToArray = function(obj) {
   let result = [];
-  for (var key in obj) {
+  for (let key in obj) {
     result.push([key, obj[key]]);
   }
   return result;
 };
 
-var compareArrays = function(arr1, arr2, compFunc) {
+const compareArrays = function(arr1, arr2, compFunc) {
   if (arr1 === arr2) {
     return true;
   }
@@ -91,7 +91,7 @@ var compareArrays = function(arr1, arr2, compFunc) {
     return false;
   }
 
-  for (var i = 0; i < Math.max(arr1.length, arr2.length); i++) {
+  for (let i = 0; i < Math.max(arr1.length, arr2.length); i++) {
     if (!arr1[i]) {
       return false;
     }
@@ -107,9 +107,8 @@ var compareArrays = function(arr1, arr2, compFunc) {
 
 export default {
   getQueryParams() {
-    var vars = {},
-        href = window.location.href,
-        hashes, hash;
+    let hashes, hash;
+    let vars = {}, href = window.location.href;
 
     if (href.indexOf('?') == -1)
       return vars;
@@ -133,10 +132,9 @@ export default {
 
   sortArray(arr, score_fn) {
     arr.sort((a, b) => {
-      var a_score = score_fn(a),
-          b_score = score_fn(b);
+      let a_score = score_fn(a), b_score = score_fn(b);
 
-      for (var i = 0; i < a_score.length; i++) {
+      for (let i = 0; i < a_score.length; i++) {
         if (a_score[i] > b_score[i]) {
           return 1;
         }
@@ -151,7 +149,7 @@ export default {
   },
 
   objectIsEmpty(obj) {
-    for (var prop in obj) {
+    for (let prop in obj) {
       if (obj.hasOwnProperty(prop)) {
         return false;
       }

--- a/src/sentry/static/sentry/app/utils/collection.jsx
+++ b/src/sentry/static/sentry/app/utils/collection.jsx
@@ -1,4 +1,4 @@
-var defaults = {
+let defaults = {
   limit: null,
   key: function(item) {
     return item.id;
@@ -6,7 +6,7 @@ var defaults = {
 };
 
 function Collection(collection, options) {
-  var i;
+  let i;
 
   Array.call(this);
 
@@ -45,7 +45,7 @@ Collection.prototype.push = function push(items) {
   }
 
   items.forEach(function(item){
-    var existing = this.pop(item);
+    let existing = this.pop(item);
     if (existing) {
       $.extend(true, existing, item);
       item = existing;
@@ -61,7 +61,7 @@ Collection.prototype.unshift = function unshift(items) {
     items = [items];
   }
   items.reverse().forEach(function(item){
-    var existing = this.pop(item);
+    let existing = this.pop(item);
     if (existing) {
       $.extend(true, existing, item);
       item = existing;
@@ -73,7 +73,7 @@ Collection.prototype.unshift = function unshift(items) {
 };
 
 Collection.prototype.get = function get(key) {
-  var idx = this.indexOf(key);
+  let idx = this.indexOf(key);
   if (idx === -1) {
     return null;
   }
@@ -81,7 +81,7 @@ Collection.prototype.get = function get(key) {
 };
 
 Collection.prototype.pop = function pop(item) {
-  var idx = this.indexOf(this.options.key(item));
+  let idx = this.indexOf(this.options.key(item));
   if (idx === -1) {
     return null;
   }
@@ -95,8 +95,8 @@ Collection.prototype.empty = function empty() {
 };
 
 Collection.prototype.indexOf = function indexOf(key) {
-  var keyFunc = this.options.key;
-  for (var i = 0; i < this.length; i++) {
+  let keyFunc = this.options.key;
+  for (let i = 0; i < this.length; i++) {
     if (keyFunc(this[i]) === key) {
       return i;
     }
@@ -106,7 +106,7 @@ Collection.prototype.indexOf = function indexOf(key) {
 
 Collection.prototype.update = function update(item) {
   // returns true if the item already existed and was updated (as configured)
-  var existing = this.indexOf(this.options.key(item));
+  let existing = this.indexOf(this.options.key(item));
   if (existing !== -1) {
     $.extend(true, this[existing], item);
     return true;

--- a/src/sentry/static/sentry/app/utils/cursorPoller.jsx
+++ b/src/sentry/static/sentry/app/utils/cursorPoller.jsx
@@ -13,7 +13,7 @@ class CursorPoller {
   }
 
   getDelay() {
-    var delay = this._baseDelay * (this._reqsWithoutData + 1);
+    let delay = this._baseDelay * (this._reqsWithoutData + 1);
     return Math.min(delay, this._maxDelay);
   }
 
@@ -54,7 +54,7 @@ class CursorPoller {
           this._reqsWithoutData -= 1;
         }
 
-        var links = parseLinkHeader(jqXHR.getResponseHeader('Link'));
+        let links = parseLinkHeader(jqXHR.getResponseHeader('Link'));
         this._pollingEndpoint = links.previous.href;
 
         this.options.success(data, jqXHR.getResponseHeader('Link'));

--- a/src/sentry/static/sentry/app/utils/localStorage.jsx
+++ b/src/sentry/static/sentry/app/utils/localStorage.jsx
@@ -1,7 +1,7 @@
-var functions = {};
+let functions = {};
 
 try {
-  var mod = 'sentry';
+  let mod = 'sentry';
   localStorage.setItem(mod, mod);
   localStorage.removeItem(mod);
 

--- a/src/sentry/static/sentry/app/utils/parseLinkHeader.jsx
+++ b/src/sentry/static/sentry/app/utils/parseLinkHeader.jsx
@@ -3,12 +3,11 @@ export default function(header) {
     return {};
   }
 
-  var header_vals = header.split(','),
-      links = {};
+  let header_vals = header.split(','), links = {};
 
   header_vals.forEach((val) => {
-    var match = /<([^>]+)>; rel="([^"]+)"(?:; results="([^"]+)")?(?:; cursor="([^"]+)")?/g.exec(val);
-    var hasResults = (match[3] === 'true' ? true : (match[3] === 'false' ? false : null));
+    let match = /<([^>]+)>; rel="([^"]+)"(?:; results="([^"]+)")?(?:; cursor="([^"]+)")?/g.exec(val);
+    let hasResults = (match[3] === 'true' ? true : (match[3] === 'false' ? false : null));
 
     links[match[2]] = {
       href: match[1],

--- a/src/sentry/static/sentry/app/utils/stream.jsx
+++ b/src/sentry/static/sentry/app/utils/stream.jsx
@@ -16,7 +16,7 @@ import _ from "underscore";
  */
 
 export function queryToObj(queryStr) {
-  var text = [];
+  let text = [];
 
   let queryItems = queryStr.match(/\S+:"[^"]*"?|\S+/g);
   let queryObj = _.inject(queryItems, (obj, item) => {

--- a/src/sentry/static/sentry/app/utils/streamManager.jsx
+++ b/src/sentry/static/sentry/app/utils/streamManager.jsx
@@ -1,5 +1,5 @@
-var removeFromList = (item, list) => {
-  var idx = list.indexOf(item);
+let removeFromList = (item, list) => {
+  let idx = list.indexOf(item);
 
   if (idx !== -1) {
     list.splice(idx, 1);
@@ -16,7 +16,7 @@ class StreamManager {
   }
 
   trim() {
-    var excess = this.idList.splice(this.limit, this.idList.length - this.limit);
+    let excess = this.idList.splice(this.limit, this.idList.length - this.limit);
     excess.forEach(this.store.remove);
   }
 
@@ -27,7 +27,7 @@ class StreamManager {
     items = items.filter((item) => item.hasOwnProperty("id"));
 
     items.forEach((item) => removeFromList(item.id, this.idList));
-    var ids = items.map((item) => item.id);
+    let ids = items.map((item) => item.id);
     this.idList = [].concat(this.idList, ids);
 
     this.trim();
@@ -46,7 +46,7 @@ class StreamManager {
     if (items.length === 0) return this;
 
     items.forEach((item) => removeFromList(item.id, this.idList));
-    var ids = items.map((item) => item.id);
+    let ids = items.map((item) => item.id);
     this.idList = [].concat(ids, this.idList);
 
     this.trim();

--- a/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
@@ -21,7 +21,7 @@ const ApiChart = React.createClass({
   componentWillMount() {
     this.fetchData();
   },
-
+  
   fetchData() {
     let statNameList = [
       "client-api.all-versions.responses.2xx",

--- a/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
@@ -63,12 +63,12 @@ const EventChart = React.createClass({
   },
 
   processOrgData() {
-    var {rawData} = this.state;
-    var oReceived = 0;
-    var oRejected = 0;
-    var sReceived = {};
-    var sRejected = {};
-    var aReceived = [0, 0]; // received, points
+    let {rawData} = this.state;
+    let oReceived = 0;
+    let oRejected = 0;
+    let sReceived = {};
+    let sRejected = {};
+    let aReceived = [0, 0]; // received, points
     jQuery.each(rawData['events.total'], function(idx, point){
       let dReceived = point[1];
       let dRejected = rawData['events.dropped'][idx][1];

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -6,7 +6,7 @@ import Indicators from "../components/indicators";
 import LoadingIndicator from "../components/loadingIndicator";
 import OrganizationStore from "../stores/organizationStore";
 
-var App = React.createClass({
+const App = React.createClass({
   getInitialState() {
     return {
       loading: false,

--- a/src/sentry/static/sentry/app/views/groupActivity/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/index.jsx
@@ -8,8 +8,8 @@ import ConfigStore from "../../stores/configStore";
 import NoteContainer from "./noteContainer";
 import NoteInput from "./noteInput";
 
-var formatActivity = function(item) {
-  var data = item.data;
+let formatActivity = function(item) {
+  let data = item.data;
 
   switch(item.type) {
     case "note":
@@ -31,7 +31,7 @@ var formatActivity = function(item) {
     case "first_seen":
       return "first saw this event";
     case "assigned":
-      var assignee;
+      let assignee;
       if (data.assignee === item.user.id) {
         assignee = 'themselves';
       } else {
@@ -46,26 +46,26 @@ var formatActivity = function(item) {
   }
 };
 
-var GroupActivity = React.createClass({
+const GroupActivity = React.createClass({
   // TODO(dcramer): only re-render on group/activity change
 
   mixins: [GroupState],
 
   render() {
-    var group = this.props.group;
-    var me = ConfigStore.get('user');
+    let group = this.props.group;
+    let me = ConfigStore.get('user');
 
-    var children = group.activity.map((item, itemIdx) => {
-      var avatar = (item.user ?
+    let children = group.activity.map((item, itemIdx) => {
+      let avatar = (item.user ?
         <Gravatar email={item.user.email} size={64} className="avatar" /> :
         <div className="avatar sentry"><span className="icon-sentry-logo"></span></div>);
 
-      var author = {
+      let author = {
         name: item.user ? item.user.name : 'Sentry',
         avatar: avatar,
       };
 
-      var label = formatActivity(item);
+      let label = formatActivity(item);
 
       if (item.type === 'note') {
         return (

--- a/src/sentry/static/sentry/app/views/groupActivity/note.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/note.jsx
@@ -4,16 +4,16 @@ import TimeSince from "../../components/timeSince";
 import ConfigStore from "../../stores/configStore";
 import LinkWithConfirmation from "../../components/linkWithConfirmation";
 
-var Note = React.createClass({
+const Note = React.createClass({
   canEdit() {
-    var user = ConfigStore.get('user');
+    let user = ConfigStore.get('user');
     return user.isSuperuser || user.id === this.props.item.user.id;
   },
 
   render() {
-    var {item, author, onEdit, onDelete} = this.props;
+    let {item, author, onEdit, onDelete} = this.props;
 
-    var noteBody = marked(item.data.text);
+    let noteBody = marked(item.data.text);
     return (
       <div>
         <TimeSince date={item.dateCreated} />

--- a/src/sentry/static/sentry/app/views/groupActivity/noteContainer.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/noteContainer.jsx
@@ -6,7 +6,7 @@ import GroupStore from "../../stores/groupStore";
 import Note from "./note";
 import NoteInput from "./noteInput";
 
-var NoteContainer = React.createClass({
+const NoteContainer = React.createClass({
   getInitialState() {
     return {
       editing: false
@@ -22,12 +22,12 @@ var NoteContainer = React.createClass({
   },
 
   onDelete() {
-    var {group, item} = this.props;
+    let {group, item} = this.props;
 
-    var loadingIndicator = IndicatorStore.add('Removing comment..');
+    let loadingIndicator = IndicatorStore.add('Removing comment..');
 
     // Optimistically remove from UI
-    var index = GroupStore.removeActivity(group.id, item.id);
+    let index = GroupStore.removeActivity(group.id, item.id);
     if (index === -1) {
         // I dunno, the id wasn't found in the GroupStore
         return;
@@ -47,7 +47,7 @@ var NoteContainer = React.createClass({
   },
 
   render() {
-    var {group, item, author} = this.props;
+    let {group, item, author} = this.props;
 
     return (
       <li className="activity-note">

--- a/src/sentry/static/sentry/app/views/groupActivity/noteInput.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/noteInput.jsx
@@ -10,20 +10,20 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 const localStorageKey = 'noteinput:latest';
 const DEFAULT_ERROR_JSON = {detail: 'Unknown error. Please try again.'};
 
-var NoteInput = React.createClass({
+const NoteInput = React.createClass({
   mixins: [PureRenderMixin],
 
   getInitialState() {
-    var {item, group} = this.props;
-    var updating = !!item;
-    var defaultText = '';
+    let {item, group} = this.props;
+    let updating = !!item;
+    let defaultText = '';
 
     if (updating) {
       defaultText = item.data.text;
     } else {
-      var storage = getItem(localStorageKey);
+      let storage = getItem(localStorageKey);
       if (storage) {
-        var {groupId, value} = JSON.parse(storage);
+        let {groupId, value} = JSON.parse(storage);
         if (groupId === group.id) {
           defaultText = value;
         }
@@ -87,9 +87,9 @@ var NoteInput = React.createClass({
   },
 
   create() {
-    var {group} = this.props;
+    let {group} = this.props;
 
-    var loadingIndicator = IndicatorStore.add('Posting comment..');
+    let loadingIndicator = IndicatorStore.add('Posting comment..');
 
     api.request('/groups/' + group.id + '/notes/', {
       method: 'POST',
@@ -121,9 +121,9 @@ var NoteInput = React.createClass({
   },
 
   update() {
-    var {group, item} = this.props;
+    let {group, item} = this.props;
 
-    var loadingIndicator = IndicatorStore.add('Updating comment..');
+    let loadingIndicator = IndicatorStore.add('Updating comment..');
 
     api.request('/groups/' + group.id + '/notes/' + item.id + '/', {
       method: 'PUT',
@@ -179,7 +179,7 @@ var NoteInput = React.createClass({
     // onFocus event
     if (!this.state._hasFocused) {
       this.setState({_hasFocused: true});
-      var value = e.target.value;
+      let value = e.target.value;
       e.target.value = '';
       e.target.value = value;
     }
@@ -193,8 +193,8 @@ var NoteInput = React.createClass({
   },
 
   render() {
-    var {error, errorJSON, loading, preview, updating, value} = this.state;
-    var classNames = 'activity-field';
+    let {error, errorJSON, loading, preview, updating, value} = this.state;
+    let classNames = 'activity-field';
     if (error) {
       classNames += ' error';
     }
@@ -202,7 +202,7 @@ var NoteInput = React.createClass({
       classNames += ' loading';
     }
 
-    var btnText = updating ? 'Save' : 'Post';
+    let btnText = updating ? 'Save' : 'Post';
 
     return (
       <form className={classNames} onSubmit={this.onSubmit}>

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -8,11 +8,11 @@ import LoadingError from "../components/loadingError";
 import LoadingIndicator from "../components/loadingIndicator";
 import PropTypes from "../proptypes";
 
-const ERROR_TYPES = {
+let ERROR_TYPES = {
   GROUP_NOT_FOUND: "GROUP_NOT_FOUND"
 };
 
-var GroupDetails = React.createClass({
+const GroupDetails = React.createClass({
   childContextTypes: {
     group: PropTypes.Group,
   },
@@ -73,7 +73,7 @@ var GroupDetails = React.createClass({
   },
 
   onGroupChange(itemIds) {
-    var id = this.props.params.groupId;
+    let id = this.props.params.groupId;
     if (itemIds.has(id)) {
       this.setState({
         group: GroupStore.get(id),
@@ -82,7 +82,7 @@ var GroupDetails = React.createClass({
   },
 
   getGroupDetailsEndpoint() {
-    var id = this.props.params.groupId;
+    let id = this.props.params.groupId;
 
     return '/groups/' + id + '/';
   },
@@ -94,8 +94,8 @@ var GroupDetails = React.createClass({
   },
 
   render() {
-    var group = this.state.group;
-    var params = this.props.params;
+    let group = this.state.group;
+    let params = this.props.params;
 
     if (this.state.error) {
       switch (this.state.errorType) {

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -7,17 +7,17 @@ import IndicatorStore from "../../stores/indicatorStore";
 import MenuItem from "../../components/menuItem";
 import LinkWithConfirmation from "../../components/linkWithConfirmation";
 
-var GroupActions = React.createClass({
+const GroupActions = React.createClass({
   mixins: [
     GroupState,
     History
   ],
 
   onDelete() {
-    var group = this.getGroup();
-    var project = this.getProject();
-    var org = this.getOrganization();
-    var loadingIndicator = IndicatorStore.add('Delete event..');
+    let group = this.getGroup();
+    let project = this.getProject();
+    let org = this.getOrganization();
+    let loadingIndicator = IndicatorStore.add('Delete event..');
 
     api.bulkDelete({
       orgId: org.slug,
@@ -33,10 +33,10 @@ var GroupActions = React.createClass({
   },
 
   onToggleResolve() {
-    var group = this.getGroup();
-    var project = this.getProject();
-    var org = this.getOrganization();
-    var loadingIndicator = IndicatorStore.add('Saving changes..');
+    let group = this.getGroup();
+    let project = this.getProject();
+    let org = this.getOrganization();
+    let loadingIndicator = IndicatorStore.add('Saving changes..');
 
     api.bulkUpdate({
       orgId: org.slug,
@@ -53,10 +53,10 @@ var GroupActions = React.createClass({
   },
 
   onToggleBookmark() {
-    var group = this.getGroup();
-    var project = this.getProject();
-    var org = this.getOrganization();
-    var loadingIndicator = IndicatorStore.add('Saving changes..');
+    let group = this.getGroup();
+    let project = this.getProject();
+    let org = this.getOrganization();
+    let loadingIndicator = IndicatorStore.add('Saving changes..');
 
     api.bulkUpdate({
       orgId: org.slug,
@@ -73,14 +73,14 @@ var GroupActions = React.createClass({
   },
 
   render() {
-    var group = this.getGroup();
+    let group = this.getGroup();
 
-    var resolveClassName = "group-resolve btn btn-default btn-sm";
+    let resolveClassName = "group-resolve btn btn-default btn-sm";
     if (group.status === "resolved") {
       resolveClassName += " active";
     }
 
-    var bookmarkClassName = "group-bookmark btn btn-default btn-sm";
+    let bookmarkClassName = "group-bookmark btn btn-default btn-sm";
     if (group.isBookmarked) {
       bookmarkClassName += " active";
     }

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -4,7 +4,7 @@ import PropTypes from "../../proptypes";
 import DateTime from "../../components/dateTime";
 import FileSize from "../../components/fileSize";
 
-var GroupEventToolbar  = React.createClass({
+let GroupEventToolbar  = React.createClass({
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired,

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -10,7 +10,7 @@ import IndicatorStore from "../../stores/indicatorStore";
 import ListLink from "../../components/listLink";
 import ProjectState from "../../mixins/projectState";
 
-var GroupHeader = React.createClass({
+const GroupHeader = React.createClass({
   propTypes: {
     memberList: React.PropTypes.instanceOf(Array).isRequired
   },
@@ -25,10 +25,10 @@ var GroupHeader = React.createClass({
   ],
 
   onToggleMute() {
-    var group = this.props.group;
-    var project = this.getProject();
-    var org = this.getOrganization();
-    var loadingIndicator = IndicatorStore.add('Saving changes..');
+    let group = this.props.group;
+    let project = this.getProject();
+    let org = this.getOrganization();
+    let loadingIndicator = IndicatorStore.add('Saving changes..');
 
     api.bulkUpdate({
       orgId: org.slug,
@@ -50,10 +50,10 @@ var GroupHeader = React.createClass({
   },
 
   onTogglePublic() {
-    var group = this.props.group;
-    var project = this.getProject();
-    var org = this.getOrganization();
-    var loadingIndicator = IndicatorStore.add('Saving changes..');
+    let group = this.props.group;
+    let project = this.getProject();
+    let org = this.getOrganization();
+    let loadingIndicator = IndicatorStore.add('Saving changes..');
 
     api.bulkUpdate({
       orgId: org.slug,
@@ -70,11 +70,11 @@ var GroupHeader = React.createClass({
   },
 
   render() {
-    var group = this.props.group,
+    let group = this.props.group,
         userCount = group.userCount,
         features = this.getProjectFeatures();
 
-    var className = "group-detail level-" + group.level;
+    let className = "group-detail level-" + group.level;
     if (group.isBookmarked) {
       className += " isBookmarked";
     }

--- a/src/sentry/static/sentry/app/views/groupDetails/seenBy.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/seenBy.jsx
@@ -7,7 +7,7 @@ import GroupState from "../../mixins/groupState";
 import {userDisplayName} from "../../utils/formatters";
 import TooltipMixin from "../../mixins/tooltip";
 
-var GroupSeenBy = React.createClass({
+const GroupSeenBy = React.createClass({
   mixins: [
     GroupState,
     TooltipMixin({
@@ -17,7 +17,7 @@ var GroupSeenBy = React.createClass({
   ],
 
   render() {
-    var activeUser = ConfigStore.get('user');
+    let activeUser = ConfigStore.get('user');
     let group = this.getGroup();
 
     let seenByNodes = group.seenBy.filter((user, userIdx) => {

--- a/src/sentry/static/sentry/app/views/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupEventDetails.jsx
@@ -10,7 +10,7 @@ import LoadingError from "../components/loadingError";
 import LoadingIndicator from "../components/loadingIndicator";
 
 
-var GroupEventDetails = React.createClass({
+const GroupEventDetails = React.createClass({
   mixins: [
     ApiMixin,
     GroupState
@@ -36,9 +36,9 @@ var GroupEventDetails = React.createClass({
   },
 
   fetchData() {
-    var eventId = this.props.params.eventId || 'latest';
+    let eventId = this.props.params.eventId || 'latest';
 
-    var url = (eventId === 'latest' || eventId === 'oldest' ?
+    let url = (eventId === 'latest' || eventId === 'oldest' ?
       '/groups/' + this.getGroup().id + '/events/' + eventId + '/' :
       '/events/' + eventId + '/');
 
@@ -73,9 +73,9 @@ var GroupEventDetails = React.createClass({
   },
 
   render() {
-    var group = this.getGroup();
-    var evt = this.state.event;
-    var params = this.props.params;
+    let group = this.getGroup();
+    let evt = this.state.event;
+    let params = this.props.params;
 
     return (
       <div>

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -10,7 +10,7 @@ import LoadingError from "../components/loadingError";
 import LoadingIndicator from "../components/loadingIndicator";
 import Pagination from "../components/pagination";
 
-var GroupEvents = React.createClass({
+const GroupEvents = React.createClass({
   mixins: [
     GroupState,
     History
@@ -36,7 +36,7 @@ var GroupEvents = React.createClass({
   },
 
   fetchData() {
-    var queryParams = this.props.location.query;
+    let queryParams = this.props.location.query;
 
     this.setState({
       loading: true,
@@ -64,7 +64,7 @@ var GroupEvents = React.createClass({
   },
 
   onPage(cursor) {
-    var queryParams = {...this.props.location.query, cursor: cursor};
+    let queryParams = {...this.props.location.query, cursor: cursor};
 
     let {orgId, projectId, groupId} = this.props.params;
     this.history.pushState(
@@ -81,23 +81,23 @@ var GroupEvents = React.createClass({
       return <LoadingError onRetry={this.fetchData} />;
     }
 
-    var group = this.getGroup();
-    var tagList = group.tags.filter((tag) => {
+    let group = this.getGroup();
+    let tagList = group.tags.filter((tag) => {
       return tag.key !== 'user';
     });
 
-    var hasUser = false;
-    for (var i = 0; i < this.state.eventList.length; i++) {
+    let hasUser = false;
+    for (let i = 0; i < this.state.eventList.length; i++) {
       if (this.state.eventList[i].user) {
         hasUser = true;
         break;
       }
     }
 
-    var {orgId, projectId, groupId} = this.props.params;
+    let {orgId, projectId, groupId} = this.props.params;
 
-    var children = this.state.eventList.map((event, eventIdx) => {
-      var tagMap = {};
+    let children = this.state.eventList.map((event, eventIdx) => {
+      let tagMap = {};
       event.tags.forEach((tag) => {
         tagMap[tag.key] = tag.value;
       });

--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -10,7 +10,7 @@ import Pagination from "../components/pagination";
 import TimeSince from "../components/timeSince";
 import {isUrl, percent} from "../utils";
 
-var GroupTagValues = React.createClass({
+const GroupTagValues = React.createClass({
   mixins: [
     History,
     GroupState
@@ -31,9 +31,9 @@ var GroupTagValues = React.createClass({
   },
 
   fetchData() {
-    var params = this.props.params;
-    var queryParams = this.props.location.query;
-    var querystring = jQuery.param(queryParams);
+    let params = this.props.params;
+    let queryParams = this.props.location.query;
+    let querystring = jQuery.param(queryParams);
 
     this.setState({
       loading: true,
@@ -73,7 +73,7 @@ var GroupTagValues = React.createClass({
   },
 
   onPage(cursor) {
-    var queryParams = jQuery.extend({}, this.props.location.query, {
+    let queryParams = jQuery.extend({}, this.props.location.query, {
       cursor: cursor
     });
 
@@ -87,9 +87,9 @@ var GroupTagValues = React.createClass({
       return <LoadingError onRetry={this.fetchData} />;
     }
 
-    var tagKey = this.state.tagKey;
-    var children = this.state.tagValueList.map((tagValue, tagValueIdx) => {
-      var pct = percent(tagValue.count, tagKey.totalValues).toFixed(2);
+    let tagKey = this.state.tagKey;
+    let children = this.state.tagValueList.map((tagValue, tagValueIdx) => {
+      let pct = percent(tagValue.count, tagKey.totalValues).toFixed(2);
       let orgId = this.getOrganization().slug;
       let projectId = this.getProject().slug;
       return (

--- a/src/sentry/static/sentry/app/views/groupTags.jsx
+++ b/src/sentry/static/sentry/app/views/groupTags.jsx
@@ -7,7 +7,7 @@ import LoadingError from "../components/loadingError";
 import LoadingIndicator from "../components/loadingIndicator";
 import {percent} from "../utils";
 
-var GroupTags = React.createClass({
+const GroupTags = React.createClass({
   mixins: [
     ApiMixin,
     GroupState
@@ -63,16 +63,16 @@ var GroupTags = React.createClass({
       return <LoadingError onRetry={this.fetchData} />;
     }
 
-    var children = [];
+    let children = [];
 
-    var orgId = this.getOrganization().slug;
-    var projectId = this.getProject().slug;
-    var groupId = this.getGroup().id;
+    let orgId = this.getOrganization().slug;
+    let projectId = this.getProject().slug;
+    let groupId = this.getGroup().id;
 
     if (this.state.tagList) {
       children = this.state.tagList.map((tag, tagIdx) => {
-        var valueChildren = tag.topValues.map((tagValue, tagValueIdx) => {
-          var pct = percent(tagValue.count, tag.totalValues);
+        let valueChildren = tag.topValues.map((tagValue, tagValueIdx) => {
+          let pct = percent(tagValue.count, tag.totalValues);
           return (
             <li key={tagValueIdx}>
               <Link

--- a/src/sentry/static/sentry/app/views/groupUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/groupUserReports.jsx
@@ -9,7 +9,7 @@ import LoadingIndicator from "../components/loadingIndicator";
 import TimeSince from "../components/timeSince";
 import utils from "../utils";
 
-var GroupUserReports = React.createClass({
+const GroupUserReports = React.createClass({
   mixins: [
     GroupState,
     History
@@ -29,8 +29,8 @@ var GroupUserReports = React.createClass({
   },
 
   fetchData() {
-    var queryParams = this.props.params;
-    var querystring = $.param(queryParams);
+    let queryParams = this.props.params;
+    let querystring = $.param(queryParams);
 
     this.setState({
       loading: true,
@@ -56,7 +56,7 @@ var GroupUserReports = React.createClass({
   },
 
   onPage(cursor) {
-    var queryParams = $.extend({}, this.props.location.query, {cursor: cursor});
+    let queryParams = $.extend({}, this.props.location.query, {cursor: cursor});
 
     let {orgId, projectId, groupId} = this.props.params;
     this.history.pushState(
@@ -73,8 +73,8 @@ var GroupUserReports = React.createClass({
       return <LoadingError onRetry={this.fetchData} />;
     }
 
-    var children = this.state.reportList.map((item, itemIdx) => {
-      var body = utils.nl2br(utils.urlize(utils.escape(item.comments)));
+    let children = this.state.reportList.map((item, itemIdx) => {
+      let body = utils.nl2br(utils.urlize(utils.escape(item.comments)));
 
       return (
         <li className="activity-note" key={itemIdx}>

--- a/src/sentry/static/sentry/app/views/organizationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails.jsx
@@ -9,11 +9,11 @@ import LoadingIndicator from "../components/loadingIndicator";
 import PropTypes from "../proptypes";
 import TeamStore from "../stores/teamStore";
 
-const ERROR_TYPES = {
+let ERROR_TYPES = {
   ORG_NOT_FOUND: "ORG_NOT_FOUND"
 };
 
-var OrganizationDetails = React.createClass({
+const OrganizationDetails = React.createClass({
   childContextTypes: {
     organization: PropTypes.Organization
   },
@@ -110,13 +110,13 @@ var OrganizationDetails = React.createClass({
     }
 
     // Allow injection via getsentry et all
-    var org = this.state.organization;
-    var children = [];
+    let org = this.state.organization;
+    let children = [];
     HookStore.get('organization:header').forEach((cb) => {
       children.push(cb(org));
     });
 
-    var params = this.props.params;
+    let params = this.props.params;
 
     return (
       <DocumentTitle title={this.getTitle()}>

--- a/src/sentry/static/sentry/app/views/organizationStats/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.jsx
@@ -9,7 +9,7 @@ import OrganizationState from "../../mixins/organizationState";
 
 import ProjectTable from "./projectTable";
 
-var OrganizationStats = React.createClass({
+const OrganizationStats = React.createClass({
   mixins: [
     OrganizationState
   ],
@@ -41,14 +41,13 @@ var OrganizationStats = React.createClass({
   },
 
   componentDidUpdate(prevProps) {
-    let prevParams = prevProps.params,
-      currentParams = this.props.params;
+    let prevParams = prevProps.params, currentParams = this.props.params;
 
     if (prevParams.orgId !== currentParams.orgId) {
       this.fetchData();
     }
 
-    var state = this.state;
+    let state = this.state;
     if (state.statsLoading && !state.statsRequestsPending) {
       this.processOrgData();
     }
@@ -67,7 +66,7 @@ var OrganizationStats = React.createClass({
       projectsRequestsPending: 4
     });
 
-    var statEndpoint = this.getOrganizationStatsEndpoint();
+    let statEndpoint = this.getOrganizationStatsEndpoint();
 
     $.each(this.state.rawOrgData, (statName) => {
       api.request(statEndpoint, {
@@ -119,7 +118,7 @@ var OrganizationStats = React.createClass({
 
     api.request(this.getOrganizationProjectsEndpoint(), {
       success: (data) => {
-        var projectMap = {};
+        let projectMap = {};
         data.forEach((project) => {
           projectMap[project.id] = project;
         });
@@ -139,29 +138,29 @@ var OrganizationStats = React.createClass({
   },
 
   getOrganizationStatsEndpoint() {
-    var params = this.props.params;
+    let params = this.props.params;
     return '/organizations/' + params.orgId + '/stats/';
   },
 
   getOrganizationProjectsEndpoint() {
-    var params = this.props.params;
+    let params = this.props.params;
     return '/organizations/' + params.orgId + '/projects/';
   },
 
   processOrgData() {
-    var oReceived = 0;
-    var oRejected = 0;
-    var oBlacklisted = 0;
-    var sReceived = {};
-    var sRejected = {};
-    var sBlacklisted = {};
-    var aReceived = [0, 0]; // received, points
-    var rawOrgData = this.state.rawOrgData;
+    let oReceived = 0;
+    let oRejected = 0;
+    let oBlacklisted = 0;
+    let sReceived = {};
+    let sRejected = {};
+    let sBlacklisted = {};
+    let aReceived = [0, 0]; // received, points
+    let rawOrgData = this.state.rawOrgData;
     $.each(rawOrgData.received, (idx, point) => {
-      var dReceived = point[1];
-      var dRejected = rawOrgData.rejected[idx][1];
-      var dBlacklisted = rawOrgData.blacklisted[idx][1];
-      var ts = point[0] * 1000;
+      let dReceived = point[1];
+      let dRejected = rawOrgData.rejected[idx][1];
+      let dBlacklisted = rawOrgData.blacklisted[idx][1];
+      let ts = point[0] * 1000;
       if (sReceived[ts] === undefined) {
         sReceived[ts] = dReceived;
         sRejected[ts] = dRejected;
@@ -203,12 +202,12 @@ var OrganizationStats = React.createClass({
   },
 
   processProjectData() {
-    var rawProjectData = this.state.rawProjectData;
-    var projectTotals = [];
+    let rawProjectData = this.state.rawProjectData;
+    let projectTotals = [];
     $.each(rawProjectData.received, (projectId, data) => {
-      var pReceived = 0;
-      var pRejected = 0;
-      var pBlacklisted = 0;
+      let pReceived = 0;
+      let pRejected = 0;
+      let pBlacklisted = 0;
       $.each(data, (idx, point) => {
         pReceived += point[1];
         pRejected += rawProjectData.rejected[projectId][idx][1];
@@ -229,7 +228,7 @@ var OrganizationStats = React.createClass({
   },
 
   getChartPlotData() {
-    var stats = this.state.orgStats;
+    let stats = this.state.orgStats;
 
     return [
       {

--- a/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
@@ -3,7 +3,7 @@ import ConfigStore from "../../stores/configStore";
 import Count from "../../components/count";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var getPercent = (item, total) => {
+let getPercent = (item, total) => {
   if (total === 0) {
     return '';
   }
@@ -13,15 +13,15 @@ var getPercent = (item, total) => {
   return parseInt(item / total * 100, 10) + '%';
 };
 
-var ProjectTable = React.createClass({
+const ProjectTable = React.createClass({
   mixins: [PureRenderMixin],
 
   render() {
-    var projectMap = this.props.projectMap;
-    var projectTotals = this.props.projectTotals;
-    var orgTotal = this.props.orgTotal;
-    var org = this.props.organization;
-    var urlPrefix = ConfigStore.get('urlPrefix') + '/' + org.slug;
+    let projectMap = this.props.projectMap;
+    let projectTotals = this.props.projectTotals;
+    let orgTotal = this.props.orgTotal;
+    let org = this.props.organization;
+    let urlPrefix = ConfigStore.get('urlPrefix') + '/' + org.slug;
 
     if (!projectTotals) {
       return <div/>;
@@ -45,7 +45,7 @@ var ProjectTable = React.createClass({
         </thead>
         <tbody>
           {projectTotals.map((item) => {
-            var project = projectMap[item.id];
+            let project = projectMap[item.id];
 
             return (
               <tr key={item.id}>

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
@@ -5,7 +5,7 @@ import PropTypes from "../../proptypes";
 
 import AllTeamsRow from "./allTeamsRow";
 
-var AllTeamsList = React.createClass({
+const AllTeamsList = React.createClass({
   propTypes: {
     organization: PropTypes.Organization.isRequired,
     teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
@@ -13,10 +13,10 @@ var AllTeamsList = React.createClass({
   },
 
   render() {
-    var {organization, openMembership} = this.props;
-    var urlPrefix = ConfigStore.get('urlPrefix') + '/organizations/' + organization.slug;
+    let {organization, openMembership} = this.props;
+    let urlPrefix = ConfigStore.get('urlPrefix') + '/organizations/' + organization.slug;
 
-    var teamNodes = this.props.teamList.map((team, teamIdx) => {
+    let teamNodes = this.props.teamList.map((team, teamIdx) => {
       return (
         <AllTeamsRow
           team={team}

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
@@ -7,7 +7,7 @@ import AlertActions from "../../actions/alertActions";
 const ERR_JOIN = 'There was an error while trying to join the team.';
 const ERR_LEAVE = 'There was an error while trying to leave the team.';
 
-var AllTeamsRow = React.createClass({
+const AllTeamsRow = React.createClass({
   getInitialState() {
     return {
       loading: false,

--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -8,7 +8,7 @@ import ConfigStore from "../../stores/configStore";
 import PropTypes from "../../proptypes";
 import {sortArray} from "../../utils";
 
-var ExpandedTeamList = React.createClass({
+const ExpandedTeamList = React.createClass({
   propTypes: {
     organization: PropTypes.Organization.isRequired,
     teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
@@ -24,7 +24,7 @@ var ExpandedTeamList = React.createClass({
   },
 
   urlPrefix() {
-    var org = this.props.organization;
+    let org = this.props.organization;
     return ConfigStore.get('urlPrefix') + '/organizations/' + org.slug;
   },
 
@@ -87,9 +87,9 @@ var ExpandedTeamList = React.createClass({
   },
 
   renderProject(project) {
-    var org = this.props.organization;
-    var projectStats = this.props.projectStats;
-    var chartData = null;
+    let org = this.props.organization;
+    let projectStats = this.props.projectStats;
+    let chartData = null;
     if (projectStats[project.id]) {
       chartData = projectStats[project.id].map((point) => {
         return {x: point[0], y: point[1]};
@@ -139,14 +139,14 @@ var ExpandedTeamList = React.createClass({
   },
 
   renderTeamNodes() {
-    var urlPrefix = this.urlPrefix();
+    let urlPrefix = this.urlPrefix();
     return this.props.teamList.map((team) => {
       return this.renderTeamNode(team, urlPrefix);
     });
   },
 
   render() {
-    var hasTeams = this.props.teamList.length > 0;
+    let hasTeams = this.props.teamList.length > 0;
 
     return (
       <div>

--- a/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
@@ -13,7 +13,7 @@ import ExpandedTeamList from "./expandedTeamList";
 import AllTeamsList from "./allTeamsList";
 import OrganizationStatOverview from "./organizationStatOverview";
 
-var OrganizationTeams = React.createClass({
+const OrganizationTeams = React.createClass({
   mixins: [
     OrganizationState,
     Reflux.listenTo(TeamStore, "onTeamListChange"),
@@ -53,12 +53,12 @@ var OrganizationTeams = React.createClass({
   },
 
   getOrganizationStatsEndpoint() {
-    var params = this.props.params;
+    let params = this.props.params;
     return '/organizations/' + params.orgId + '/stats/';
   },
 
   onTeamListChange() {
-    var newTeamList = TeamStore.getAll();
+    let newTeamList = TeamStore.getAll();
 
     this.setState({
       teamList: sortArray(newTeamList, function(o) {
@@ -79,14 +79,14 @@ var OrganizationTeams = React.createClass({
     if (!this.context.organization)
       return null;
 
-    var access = this.getAccess();
-    var features = this.getFeatures();
-    var org = this.getOrganization();
-    var urlPrefix = ConfigStore.get('urlPrefix') + '/organizations/' + org.slug;
+    let access = this.getAccess();
+    let features = this.getFeatures();
+    let org = this.getOrganization();
+    let urlPrefix = ConfigStore.get('urlPrefix') + '/organizations/' + org.slug;
 
-    var activeNav = this.state.activeNav;
-    var allTeams = this.state.teamList;
-    var activeTeams = this.state.teamList.filter((team) => team.isMember);
+    let activeNav = this.state.activeNav;
+    let allTeams = this.state.teamList;
+    let activeTeams = this.state.teamList.filter((team) => team.isMember);
 
     return (
       <OrganizationHomeContainer>

--- a/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
@@ -7,7 +7,7 @@ import OrganizationState from "../../mixins/organizationState";
 
 import {defined} from "../../utils";
 
-var OrganizationStatOverview = React.createClass({
+const OrganizationStatOverview = React.createClass({
   propTypes: {
     orgId: React.PropTypes.string
   },
@@ -36,14 +36,14 @@ var OrganizationStatOverview = React.createClass({
   },
 
   fetchData() {
-    var statsEndpoint = this.getOrganizationStatsEndpoint();
+    let statsEndpoint = this.getOrganizationStatsEndpoint();
     api.request(statsEndpoint, {
       query: {
         since: new Date().getTime() / 1000 - 3600 * 24,
         stat: 'rejected'
       },
       success: (data) => {
-        var totalRejected = 0;
+        let totalRejected = 0;
         data.forEach((point) => {
           totalRejected += point[1];
         });
@@ -57,14 +57,14 @@ var OrganizationStatOverview = React.createClass({
         stat: 'received'
       },
       success: (data) => {
-        var received = [0, 0];
+        let received = [0, 0];
         data.forEach((point) => {
           if (point[1] > 0) {
             received[0] += point[1];
             received[1] += 1;
           }
         });
-        var epm = (received[1] ? parseInt((received[0] / received[1]) / 60, 10) : 0);
+        let epm = (received[1] ? parseInt((received[0] / received[1]) / 60, 10) : 0);
         this.setState({epm: epm});
       }
     });
@@ -74,9 +74,9 @@ var OrganizationStatOverview = React.createClass({
     if (!defined(this.state.epm) || !defined(this.state.totalRejected))
       return null;
 
-    var access = this.getAccess();
+    let access = this.getAccess();
 
-    var rejectedClasses = ['count'];
+    let rejectedClasses = ['count'];
     if (this.state.totalRejected > 0)
       rejectedClasses.push('rejected');
 

--- a/src/sentry/static/sentry/app/views/projectDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard.jsx
@@ -7,7 +7,7 @@ import ProjectState from "../mixins/projectState";
 import ProjectChart from "./projectDashboard/chart";
 
 
-var ProjectDashboard = React.createClass({
+const ProjectDashboard = React.createClass({
   mixins: [
     ProjectState
   ],
@@ -34,8 +34,8 @@ var ProjectDashboard = React.createClass({
 
   getQueryStringState(props) {
     props = props || this.props;
-    var currentQuery = props.location.query;
-    var statsPeriod = currentQuery.statsPeriod;
+    let currentQuery = props.location.query;
+    let statsPeriod = currentQuery.statsPeriod;
 
     if (statsPeriod !== '1w' && statsPeriod !== '24h' && statsPeriod != '1h') {
       statsPeriod = props.defaultStatsPeriod;

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -6,7 +6,7 @@ import LoadingError from "../../components/loadingError";
 import LoadingIndicator from "../../components/loadingIndicator";
 import ProjectState from "../../mixins/projectState";
 
-var ProjectChart = React.createClass({
+const ProjectChart = React.createClass({
   mixins: [
     ProjectState,
   ],
@@ -32,14 +32,14 @@ var ProjectChart = React.createClass({
   },
 
   getStatsEndpoint() {
-    var org = this.getOrganization();
-    var project = this.getProject();
+    let org = this.getOrganization();
+    let project = this.getProject();
     return "/projects/" + org.slug + "/" + project.slug + "/stats/?resolution=" + this.props.resolution;
   },
 
   getProjectReleasesEndpoint() {
-    var org = this.getOrganization();
-    var project = this.getProject();
+    let org = this.getOrganization();
+    let project = this.getProject();
     return '/projects/' + org.slug + '/' + project.slug + '/releases/';
   },
 
@@ -73,12 +73,12 @@ var ProjectChart = React.createClass({
   },
 
   renderChart() {
-    var points = this.state.stats.map((point) => {
+    let points = this.state.stats.map((point) => {
       return {x: point[0], y: point[1]};
     });
-    var startX = (new Date().getTime() / 1000) - 3600 * 24 * 7;
-    var markers = this.state.releaseList.filter((release) => {
-      var date = new Date(release.dateCreated).getTime() / 1000;
+    let startX = (new Date().getTime() / 1000) - 3600 * 24 * 7;
+    let markers = this.state.releaseList.filter((release) => {
+      let date = new Date(release.dateCreated).getTime() / 1000;
       return date >= startX;
     }).map((release) => {
       return {

--- a/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from "../../components/loadingIndicator";
 
 import EventNode from "./eventNode";
 
-var EventList = React.createClass({
+const EventList = React.createClass({
   propTypes: {
     title: React.PropTypes.string.isRequired,
     endpoint: React.PropTypes.string.isRequired
@@ -32,7 +32,7 @@ var EventList = React.createClass({
   },
 
   fetchData() {
-    var minutes;
+    let minutes;
     switch(this.state.statsPeriod) {
       case "15m":
         minutes = "15";
@@ -74,7 +74,7 @@ var EventList = React.createClass({
   },
 
   render() {
-    var eventNodes = this.state.groupList.map((item) => {
+    let eventNodes = this.state.groupList.map((item) => {
       return <EventNode group={item} key={item.id} />;
     });
 

--- a/src/sentry/static/sentry/app/views/projectDashboard/eventNode.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/eventNode.jsx
@@ -5,7 +5,7 @@ import PropTypes from "../../proptypes";
 import TimeSince from "../../components/timeSince";
 import ProjectState from "../../mixins/projectState";
 
-var EventNode = React.createClass({
+const EventNode = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired
   },
@@ -13,8 +13,8 @@ var EventNode = React.createClass({
   mixins: [ProjectState],
 
   makeGroupLink(title) {
-    var group = this.props.group;
-    var org = this.getOrganization();
+    let group = this.props.group;
+    let org = this.getOrganization();
 
     let orgId = org.slug;
     let projectId = group.project.slug;
@@ -28,8 +28,8 @@ var EventNode = React.createClass({
   },
 
   render() {
-    var group = this.props.group;
-    var userCount = group.userCount;
+    let group = this.props.group;
+    let userCount = group.userCount;
 
     return (
       <li className="group">

--- a/src/sentry/static/sentry/app/views/projectDashboard/statsBar.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/statsBar.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var TeamStatsBar = React.createClass({
+const TeamStatsBar = React.createClass({
   render() {
     return (
       <div className="row team-stats">

--- a/src/sentry/static/sentry/app/views/projectDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectDetails.jsx
@@ -16,7 +16,7 @@ const ERROR_TYPES = {
   PROJECT_NOT_FOUND: "PROJECT_NOT_FOUND"
 };
 
-var ProjectDetails = React.createClass({
+const ProjectDetails = React.createClass({
   childContextTypes: {
     project: PropTypes.Project,
     team: PropTypes.Team
@@ -67,10 +67,10 @@ var ProjectDetails = React.createClass({
   },
 
   identifyProject() {
-    var params = this.props.params;
-    var projectSlug = params.projectId;
-    var activeProject = null;
-    var activeTeam = null;
+    let params = this.props.params;
+    let projectSlug = params.projectId;
+    let activeProject = null;
+    let activeTeam = null;
     let org = this.context.organization;
     org.teams.forEach((team) => {
       team.projects.forEach((project) => {
@@ -126,7 +126,7 @@ var ProjectDetails = React.createClass({
   },
 
   getMemberListEndpoint() {
-    var params = this.props.params;
+    let params = this.props.params;
     return '/projects/' + params.orgId + '/' + params.projectId + '/members/';
   },
 

--- a/src/sentry/static/sentry/app/views/projectEvents.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents.jsx
@@ -12,7 +12,7 @@ import LoadingIndicator from "../components/loadingIndicator";
 import Pagination from "../components/pagination";
 import utils from "../utils";
 
-var ProjectEvents = React.createClass({
+const ProjectEvents = React.createClass({
   propTypes: {
     setProjectNavSection: React.PropTypes.func
   },
@@ -41,9 +41,9 @@ var ProjectEvents = React.createClass({
       endpoint: this.getEventListEndpoint()
     });
 
-    var realtime = Cookies.get("realtimeActive");
+    let realtime = Cookies.get("realtimeActive");
     if (realtime) {
-      var realtimeActive = realtime === "true";
+      let realtimeActive = realtime === "true";
       this.setState({
         realtimeActive: realtimeActive
       });
@@ -88,7 +88,7 @@ var ProjectEvents = React.createClass({
       error: false
     });
 
-    var url = this.getEventListEndpoint();
+    let url = this.getEventListEndpoint();
 
     api.request(url, {
       success: (data, _, jqXHR) => {
@@ -116,10 +116,10 @@ var ProjectEvents = React.createClass({
   },
 
   getEventListEndpoint() {
-    var params = this.props.params;
-    var queryParams = this.props.location.query;
+    let params = this.props.params;
+    let queryParams = this.props.location.query;
     queryParams.limit = 50;
-    var querystring = jQuery.param(queryParams);
+    let querystring = jQuery.param(queryParams);
 
     return '/projects/' + params.orgId + '/' + params.projectId + '/events/?' + querystring;
   },
@@ -141,7 +141,7 @@ var ProjectEvents = React.createClass({
   },
 
   onEventChange() {
-    var eventIds = this._streamManager.getAllItems().map((item) => item.id);
+    let eventIds = this._streamManager.getAllItems().map((item) => item.id);
     if (!utils.valueIsEqual(eventIds, this.state.eventIds)) {
       this.setState({
         eventIds: eventIds
@@ -150,7 +150,7 @@ var ProjectEvents = React.createClass({
   },
 
   onPage(cursor) {
-    var queryParams = jQuery.extend({}, this.props.location.query, {
+    let queryParams = jQuery.extend({}, this.props.location.query, {
       cursor: cursor
     });
 
@@ -158,9 +158,9 @@ var ProjectEvents = React.createClass({
   },
 
   transitionTo() {
-    var queryParams = {};
+    let queryParams = {};
 
-    for (var prop in this.state.filter) {
+    for (let prop in this.state.filter) {
       queryParams[prop] = this.state.filter[prop];
     }
 
@@ -177,8 +177,8 @@ var ProjectEvents = React.createClass({
   },
 
   renderEventNodes(ids) {
-    var params = this.props.params;
-    var nodes = ids.map((id) => {
+    let params = this.props.params;
+    let nodes = ids.map((id) => {
       return (
         <EventRow key={id} id={id} orgSlug={params.orgId}
             projectSlug={params.projectId} />
@@ -206,7 +206,7 @@ var ProjectEvents = React.createClass({
   },
 
   renderBody() {
-    var body;
+    let body;
 
     if (this.state.loading) {
       body = this.renderLoading();
@@ -222,7 +222,7 @@ var ProjectEvents = React.createClass({
   },
 
   render() {
-    var params = this.props.params;
+    let params = this.props.params;
 
     return (
       <div>

--- a/src/sentry/static/sentry/app/views/projectEvents/actions.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/actions.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var EventActions = React.createClass({
+const EventActions = React.createClass({
   propTypes: {
     onRealtimeChange: React.PropTypes.func.isRequired,
     realtimeActive: React.PropTypes.bool.isRequired

--- a/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var LanguageNav = React.createClass({
+const LanguageNav = React.createClass({
   getInitialState() {
     return {
       isVisible: this.props.active || false
@@ -12,7 +12,7 @@ var LanguageNav = React.createClass({
   },
 
   render() {
-    var {isVisible} = this.state;
+    let {isVisible} = this.state;
     return (
       <div>
         <ul className="list-group">

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -6,13 +6,13 @@ import LanguageNav from "./languageNav";
 import LoadingError from "../../components/loadingError";
 import LoadingIndicator from "../../components/loadingIndicator";
 
-var ProjectInstallPlatform = React.createClass({
+const ProjectInstallPlatform = React.createClass({
 
   getInitialState() {
     let params = this.props.params;
-    var key = params.platform;
-    var integration;
-    var platform;
+    let key = params.platform;
+    let integration;
+    let platform;
     this.props.platformData.platforms.forEach((p_item) => {
       if (integration) {
         return;
@@ -75,7 +75,7 @@ var ProjectInstallPlatform = React.createClass({
   },
 
   render() {
-    var {integration, platform} = this.state;
+    let {integration, platform} = this.state;
 
     return (
       <div className="install row">

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -9,7 +9,7 @@ import SearchBar from "../../components/searchBar.jsx";
 
 import ReleaseList from "./releaseList";
 
-var ProjectReleases = React.createClass({
+const ProjectReleases = React.createClass({
   propTypes: {
     setProjectNavSection: React.PropTypes.func
   },
@@ -23,7 +23,7 @@ var ProjectReleases = React.createClass({
   },
 
   getInitialState() {
-    var queryParams = this.props.location.query;
+    let queryParams = this.props.location.query;
 
     return {
       releaseList: [],
@@ -49,7 +49,7 @@ var ProjectReleases = React.createClass({
   },
 
   onSearch(query) {
-    var targetQueryParams = {};
+    let targetQueryParams = {};
     if (query !== '')
       targetQueryParams.query = query;
 
@@ -82,8 +82,8 @@ var ProjectReleases = React.createClass({
   },
 
   getProjectReleasesEndpoint() {
-    var params = this.props.params;
-    var queryParams = $.extend({}, this.props.location.query);
+    let params = this.props.params;
+    let queryParams = $.extend({}, this.props.location.query);
     queryParams.limit = 50;
     queryParams.query = this.state.query;
 
@@ -91,7 +91,7 @@ var ProjectReleases = React.createClass({
   },
 
   onPage(cursor) {
-    var queryParams = $.extend({}, this.props.location.query);
+    let queryParams = $.extend({}, this.props.location.query);
     queryParams.cursor = cursor;
 
     let {orgId, projectId} = this.props.params;
@@ -99,13 +99,13 @@ var ProjectReleases = React.createClass({
   },
 
   getReleaseTrackingUrl() {
-    var params = this.props.params;
+    let params = this.props.params;
 
     return '/' + params.orgId + '/' + params.projectId + '/settings/release-tracking/';
   },
 
   renderStreamBody() {
-    var body;
+    let body;
 
     let params = this.props.params;
 

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
@@ -3,7 +3,7 @@ import Count from "../../components/count";
 import TimeSince from "../../components/timeSince";
 import Version from "../../components/version";
 
-var ReleaseList = React.createClass({
+const ReleaseList = React.createClass({
 
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
@@ -11,7 +11,7 @@ var ReleaseList = React.createClass({
   },
 
   render() {
-    var {orgId, projectId} = this.props;
+    let {orgId, projectId} = this.props;
 
     return (
       <ul className="release-list">

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -29,7 +29,7 @@ const ProjectSettings = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    var params = this.props.params;
+    let params = this.props.params;
     if (nextProps.params.projectId !== params.projectId ||
         nextProps.params.orgId !== params.orgId) {
       this.setState({
@@ -40,7 +40,7 @@ const ProjectSettings = React.createClass({
   },
 
   fetchData() {
-    var params = this.props.params;
+    let params = this.props.params;
 
     api.request(`/projects/${params.orgId}/${params.projectId}/`, {
       success: (data) => {

--- a/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Link} from "react-router";
 import GroupList from "../components/groupList";
 
-var ReleaseAllEvents = React.createClass({
+const ReleaseAllEvents = React.createClass({
   contextTypes: {
     release: React.PropTypes.object
   },

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -8,7 +8,7 @@ import LoadingError from "../components/loadingError";
 import LoadingIndicator from "../components/loadingIndicator";
 import Pagination from "../components/pagination";
 
-var ReleaseArtifacts = React.createClass({
+const ReleaseArtifacts = React.createClass({
   contextTypes: {
     release: React.PropTypes.object
   },
@@ -35,8 +35,8 @@ var ReleaseArtifacts = React.createClass({
   },
 
   fetchData() {
-    var params = this.props.params;
-    var endpoint = '/projects/' + params.orgId + '/' + params.projectId + '/releases/' + params.version + '/files/';
+    let params = this.props.params;
+    let endpoint = '/projects/' + params.orgId + '/' + params.projectId + '/releases/' + params.version + '/files/';
 
     this.setState({
       loading: true,
@@ -62,7 +62,7 @@ var ReleaseArtifacts = React.createClass({
   },
 
   onPage(cursor) {
-    var queryParams = jQuery.extend({}, this.props.location.query, {
+    let queryParams = jQuery.extend({}, this.props.location.query, {
       cursor: cursor
     });
 

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -9,7 +9,7 @@ import ProjectState from "../mixins/projectState";
 import TimeSince from "../components/timeSince";
 import Version from "../components/version";
 
-var ReleaseDetails = React.createClass({
+const ReleaseDetails = React.createClass({
   propTypes: {
     setProjectNavSection: React.PropTypes.func
   },
@@ -46,9 +46,9 @@ var ReleaseDetails = React.createClass({
   },
 
   getTitle() {
-    var project = this.getProject();
-    var team = this.getTeam();
-    var params = this.props.params;
+    let project = this.getProject();
+    let team = this.getTeam();
+    let params = this.props.params;
     return 'Release ' + params.version + ' | ' + team.name + ' / ' + project.name;
   },
 
@@ -74,10 +74,10 @@ var ReleaseDetails = React.createClass({
   },
 
   getReleaseDetailsEndpoint() {
-    var params = this.props.params;
-    var orgId = params.orgId;
-    var projectId = params.projectId;
-    var version = params.version;
+    let params = this.props.params;
+    let orgId = params.orgId;
+    let projectId = params.projectId;
+    let version = params.version;
 
     return '/projects/' + orgId + '/' + projectId + '/releases/' + version + '/';
   },
@@ -88,9 +88,9 @@ var ReleaseDetails = React.createClass({
     else if (this.state.error)
       return <LoadingError onRetry={this.fetchData} />;
 
-    var release = this.state.release;
+    let release = this.state.release;
 
-    var {orgId, projectId} = this.props.params;
+    let {orgId, projectId} = this.props.params;
     return (
       <DocumentTitle title={this.getTitle()}>
         <div className={this.props.classname}>

--- a/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Link} from "react-router";
 import GroupList from "../components/groupList";
 
-var ReleaseNewEvents = React.createClass({
+const ReleaseNewEvents = React.createClass({
   contextTypes: {
     release: React.PropTypes.object
   },

--- a/src/sentry/static/sentry/app/views/routeNotFound.jsx
+++ b/src/sentry/static/sentry/app/views/routeNotFound.jsx
@@ -3,7 +3,7 @@ import DocumentTitle from "react-document-title";
 import Footer from "../components/footer";
 import Header from "../components/header";
 
-var RouteNotFound = React.createClass({
+const RouteNotFound = React.createClass({
   statics: {
     // Try and append a trailing slash to the route when we "404".
     //

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -7,7 +7,7 @@ import SelectInput from "../../components/selectInput";
 
 import RuleNodeList from "./ruleNodeList";
 
-var RuleEditor = React.createClass({
+const RuleEditor = React.createClass({
   propTypes: {
     actions: React.PropTypes.instanceOf(Array).isRequired,
     conditions: React.PropTypes.instanceOf(Array).isRequired
@@ -27,7 +27,7 @@ var RuleEditor = React.createClass({
   },
 
   serializeNode(node) {
-    var result = {};
+    let result = {};
     $(node).find('input, select').each((_, el) => {
       if (el.name) {
         result[el.name] = $(el).val();
@@ -38,32 +38,32 @@ var RuleEditor = React.createClass({
 
   onSubmit(e) {
     e.preventDefault();
-    var form = $(ReactDOM.findDOMNode(this.refs.form));
-    var conditions = [];
+    let form = $(ReactDOM.findDOMNode(this.refs.form));
+    let conditions = [];
     form.find('.rule-condition-list .rule-form').each((_, el) => {
       conditions.push(this.serializeNode(el));
     });
-    var actions = [];
+    let actions = [];
     form.find('.rule-action-list .rule-form').each((_, el) => {
       actions.push(this.serializeNode(el));
     });
-    var actionMatch = $(ReactDOM.findDOMNode(this.refs.actionMatch)).val();
-    var name = $(ReactDOM.findDOMNode(this.refs.name)).val();
-    var data = {
+    let actionMatch = $(ReactDOM.findDOMNode(this.refs.actionMatch)).val();
+    let name = $(ReactDOM.findDOMNode(this.refs.name)).val();
+    let data = {
       actionMatch: actionMatch,
       actions: actions,
       conditions: conditions,
       name: name
     };
-    var rule = this.props.rule;
-    var project = this.props.project;
-    var org = this.props.organization;
-    var endpoint = '/projects/' + org.slug + '/' + project.slug + '/rules/';
+    let rule = this.props.rule;
+    let project = this.props.project;
+    let org = this.props.organization;
+    let endpoint = '/projects/' + org.slug + '/' + project.slug + '/rules/';
     if (rule.id) {
       endpoint += rule.id + '/';
     }
 
-    var loadingIndicator = IndicatorStore.add('Saving...');
+    let loadingIndicator = IndicatorStore.add('Saving...');
     api.request(endpoint, {
       method: (rule.id ? "PUT" : "POST"),
       data: data,
@@ -83,15 +83,15 @@ var RuleEditor = React.createClass({
   },
 
   hasError(field) {
-    var {error} = this.state;
+    let {error} = this.state;
     if (!error) return false;
     return !!error[field];
   },
 
   render() {
-    var rule = this.props.rule;
-    var {loading, error} = this.state;
-    var {actionMatch, actions, conditions, name} = rule;
+    let rule = this.props.rule;
+    let {loading, error} = this.state;
+    let {actionMatch, actions, conditions, name} = rule;
 
     return (
       <form onSubmit={this.onSubmit} ref="form">

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNode.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNode.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import $ from "jquery";
 
-var RuleNode = React.createClass({
+const RuleNode = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired,
     node: React.PropTypes.shape({

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import SelectInput from "../../components/selectInput";
 import RuleNode from "./ruleNode";
 
-var RuleNodeList = React.createClass({
+const RuleNodeList = React.createClass({
   getInitialState() {
     return {
       items: this.props.initialItems || []

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
@@ -12,7 +12,7 @@ import PropTypes from "../../proptypes";
 
 import SharedGroupHeader from "./sharedGroupHeader";
 
-var SharedGroupDetails = React.createClass({
+const SharedGroupDetails = React.createClass({
 
   childContextTypes: {
     group: PropTypes.Group,
@@ -69,20 +69,20 @@ var SharedGroupDetails = React.createClass({
   },
 
   getGroupDetailsEndpoint() {
-    var id = this.props.params.shareId;
+    let id = this.props.params.shareId;
 
     return '/shared/groups/' + id + '/';
   },
 
   render() {
-    var group = this.state.group;
+    let group = this.state.group;
 
     if (this.state.loading || !group)
       return <LoadingIndicator />;
     else if (this.state.error)
       return <LoadingError onRetry={this.fetchData} />;
 
-    var evt = this.state.group.latestEvent;
+    let evt = this.state.group.latestEvent;
 
     return (
       <DocumentTitle title={this.getTitle()}>

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/sharedGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/sharedGroupHeader.jsx
@@ -2,10 +2,9 @@ import React from "react";
 
 import Count from "../../components/count";
 
-var SharedGroupHeader = React.createClass({
+const SharedGroupHeader = React.createClass({
   render() {
-    var group = this.props.group,
-        userCount = group.userCount;
+    let group = this.props.group, userCount = group.userCount;
 
     return (
       <div className="group-detail">

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -22,7 +22,7 @@ import StreamSidebar from "./stream/sidebar";
 import utils from "../utils";
 import parseLinkHeader from '../utils/parseLinkHeader';
 
-var Stream = React.createClass({
+const Stream = React.createClass({
   propTypes: {
     setProjectNavSection: React.PropTypes.func
   },
@@ -74,9 +74,9 @@ var Stream = React.createClass({
       endpoint: this.getGroupListEndpoint()
     });
 
-    var realtime = Cookies.get("realtimeActive");
+    let realtime = Cookies.get("realtimeActive");
     if (realtime) {
-      var realtimeActive = realtime === "true";
+      let realtimeActive = realtime === "true";
       this.setState({
         realtimeActive: realtimeActive
       });
@@ -138,26 +138,26 @@ var Stream = React.createClass({
 
   getQueryStringState(props) {
     props = props || this.props;
-    var currentQuery = props.location.query;
+    let currentQuery = props.location.query;
 
-    var filter = {};
+    let filter = {};
     if (currentQuery.bookmarks) {
       filter = { bookmarks: "1" };
     } else if (currentQuery.assigned) {
       filter = { assigned: "1" };
     }
 
-    var query =
+    let query =
       currentQuery.hasOwnProperty("query") ?
       currentQuery.query :
       this.props.defaultQuery;
 
-    var sort =
+    let sort =
       currentQuery.hasOwnProperty("sort") ?
       currentQuery.sort :
       this.props.defaultSort;
 
-    var statsPeriod =
+    let statsPeriod =
       currentQuery.hasOwnProperty("statsPeriod") ?
       currentQuery.statsPeriod :
       this.props.defaultStatsPeriod;
@@ -182,9 +182,9 @@ var Stream = React.createClass({
       error: false
     });
 
-    var url = this.getGroupListEndpoint();
+    let url = this.getGroupListEndpoint();
 
-    var requestParams = $.extend({}, this.props.location.query, {
+    let requestParams = $.extend({}, this.props.location.query, {
       limit: this.props.maxItems,
       statsPeriod: this.state.statsPeriod
     });
@@ -227,7 +227,7 @@ var Stream = React.createClass({
       complete: (jqXHR) => {
         this.lastRequest = null;
 
-        var links = parseLinkHeader(jqXHR.getResponseHeader('Link'));
+        let links = parseLinkHeader(jqXHR.getResponseHeader('Link'));
         if (links && links.previous) {
           this._poller.setEndpoint(links.previous.href);
 
@@ -240,7 +240,7 @@ var Stream = React.createClass({
   },
 
   getGroupListEndpoint() {
-    var params = this.props.params;
+    let params = this.props.params;
 
     return '/projects/' + params.orgId + '/' + params.projectId + '/groups/';
   },
@@ -273,7 +273,7 @@ var Stream = React.createClass({
   },
 
   onGroupChange() {
-    var groupIds = this._streamManager.getAllItems().map((item) => item.id);
+    let groupIds = this._streamManager.getAllItems().map((item) => item.id);
     if (!utils.valueIsEqual(groupIds, this.state.groupIds)) {
       this.setState({
         groupIds: groupIds
@@ -289,8 +289,8 @@ var Stream = React.createClass({
   },
 
   onPage(cursor) {
-    var params = this.props.params;
-    var queryParams = $.extend({}, this.props.location.query);
+    let params = this.props.params;
+    let queryParams = $.extend({}, this.props.location.query);
     queryParams.cursor = cursor;
 
     this.history.pushState(null, `/${params.orgId}/${params.projectId}/`, queryParams);
@@ -327,9 +327,9 @@ var Stream = React.createClass({
   },
 
   transitionTo() {
-    var queryParams = {};
+    let queryParams = {};
 
-    for (var prop in this.state.filter) {
+    for (let prop in this.state.filter) {
       queryParams[prop] = this.state.filter[prop];
     }
 
@@ -350,8 +350,8 @@ var Stream = React.createClass({
   },
 
   renderGroupNodes(ids, statsPeriod) {
-    var {orgId, projectId} = this.props.params;
-    var groupNodes = ids.map((id) => {
+    let {orgId, projectId} = this.props.params;
+    let groupNodes = ids.map((id) => {
       return (
         <StreamGroup
           key={id}
@@ -383,7 +383,7 @@ var Stream = React.createClass({
   },
 
   renderStreamBody() {
-    var body;
+    let body;
 
     if (this.state.loading) {
       body = this.renderLoading();

--- a/src/sentry/static/sentry/app/views/stream/actionLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actionLink.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import SelectedGroupStore from "../../stores/selectedGroupStore";
 import TooltipMixin from "../../mixins/tooltip";
 
-var ActionLink = React.createClass({
+const ActionLink = React.createClass({
   propTypes: {
     actionLabel: React.PropTypes.string,
     canActionAll: React.PropTypes.bool.isRequired,
@@ -43,7 +43,7 @@ var ActionLink = React.createClass({
   },
 
   handleClick() {
-    var selectedItemIds = SelectedGroupStore.getSelectedIds();
+    let selectedItemIds = SelectedGroupStore.getSelectedIds();
     if (!this.state.isModalOpen && !this.shouldConfirm(selectedItemIds.size)) {
       return void this.handleActionSelected();
     }
@@ -80,7 +80,7 @@ var ActionLink = React.createClass({
 
   shouldConfirm(numSelectedItems) {
     // By default, should confirm ...
-    var shouldConfirm = true;
+    let shouldConfirm = true;
 
     // Unless `neverConfirm` is true, then return false
     if (this.props.neverConfirm === true) {

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -8,7 +8,7 @@ import MenuItem from "../../components/menuItem";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import SelectedGroupStore from "../../stores/selectedGroupStore";
 
-var StreamActions = React.createClass({
+const StreamActions = React.createClass({
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired,
@@ -47,12 +47,12 @@ var StreamActions = React.createClass({
   },
 
   actionSelectedGroups(actionType, callback) {
-    var selectedIds;
+    let selectedIds;
 
     if (actionType === this.props.actionTypes.ALL) {
       selectedIds = undefined; // undefined means "all"
     } else if (actionType === this.props.actionTypes.SELECTED) {
-      var itemIdSet = SelectedGroupStore.getSelectedIds();
+      let itemIdSet = SelectedGroupStore.getSelectedIds();
       selectedIds = this.props.groupIds.filter(
         (itemId) => itemIdSet.has(itemId)
       );
@@ -67,7 +67,7 @@ var StreamActions = React.createClass({
 
   onUpdate(data, event, actionType) {
     this.actionSelectedGroups(actionType, (itemIds) => {
-      var loadingIndicator = IndicatorStore.add('Saving changes..');
+      let loadingIndicator = IndicatorStore.add('Saving changes..');
 
       api.bulkUpdate({
         orgId: this.props.orgId,
@@ -83,7 +83,7 @@ var StreamActions = React.createClass({
   },
 
   onDelete(event, actionType) {
-    var loadingIndicator = IndicatorStore.add('Removing events..');
+    let loadingIndicator = IndicatorStore.add('Removing events..');
 
     this.actionSelectedGroups(actionType, (itemIds) => {
       api.bulkDelete({
@@ -99,7 +99,7 @@ var StreamActions = React.createClass({
   },
 
   onMerge(event, actionType) {
-    var loadingIndicator = IndicatorStore.add('Merging events..');
+    let loadingIndicator = IndicatorStore.add('Merging events..');
 
     this.actionSelectedGroups(actionType, (itemIds) => {
       api.merge({

--- a/src/sentry/static/sentry/app/views/stream/filterSelectLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filterSelectLink.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-var FilterSelectLink = React.createClass({
+const FilterSelectLink = React.createClass({
   propTypes: {
     label: React.PropTypes.string,
     onSelect: React.PropTypes.func,
@@ -14,7 +14,7 @@ var FilterSelectLink = React.createClass({
   },
 
   render() {
-    var className = this.props.extraClass;
+    let className = this.props.extraClass;
 
     if (this.props.isActive) {
       className += ' active';

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -4,7 +4,7 @@ import FilterSelectLink from "./filterSelectLink";
 import SearchBar from "./searchBar";
 import SortOptions from "./sortOptions";
 
-var StreamFilters = React.createClass({
+const StreamFilters = React.createClass({
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired
@@ -28,8 +28,8 @@ var StreamFilters = React.createClass({
   },
 
   getActiveButton() {
-    var queryParams = this.context.location.query;
-    var activeButton;
+    let queryParams = this.context.location.query;
+    let activeButton;
     if (queryParams.bookmarks) {
       activeButton = 'bookmarks';
     } else if (queryParams.assigned) {

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -13,7 +13,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 import SearchDropdown from "./searchDropdown";
 
-var SearchBar = React.createClass({
+const SearchBar = React.createClass({
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired
@@ -204,7 +204,7 @@ var SearchBar = React.createClass({
    * with results
    */
   getPredefinedTagValues: function (tag, query, callback) {
-    var values = tag.values
+    let values = tag.values
       .filter(value => value.indexOf(query) > -1);
 
     callback(values, tag.key);
@@ -234,8 +234,8 @@ var SearchBar = React.createClass({
       this.blurTimeout = null;
     }
 
-    var cursor = this.getCursorPosition();
-    var query = this.state.query;
+    let cursor = this.getCursorPosition();
+    let query = this.state.query;
 
     let lastTermIndex = SearchBar.getLastTermIndex(query, cursor);
     let terms = SearchBar.getQueryTerms(query.slice(0, lastTermIndex));
@@ -378,7 +378,7 @@ var SearchBar = React.createClass({
       query: newQuery
     }, () => {
       // setting a new input value will lose focus; restore it
-      var node = ReactDOM.findDOMNode(this.refs.searchInput);
+      let node = ReactDOM.findDOMNode(this.refs.searchInput);
       node.focus();
 
       // then update the autocomplete box with new contextTypes
@@ -393,7 +393,7 @@ var SearchBar = React.createClass({
   },
 
   render() {
-    var dropdownStyle = {
+    let dropdownStyle = {
       display: this.state.dropdownVisible ? 'block' : 'none'
     };
 

--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from "../../components/loadingIndicator";
 
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-var SearchDropdown = React.createClass({
+const SearchDropdown = React.createClass({
   mixins: [PureRenderMixin],
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/views/stream/sidebar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sidebar.jsx
@@ -7,7 +7,7 @@ import {queryToObj, objToQuery} from "../../utils/stream";
 
 let TEXT_FILTER_DEBOUNCE_IN_MS = 300;
 
-var StreamSidebar = React.createClass({
+const StreamSidebar = React.createClass({
   propTypes: {
     tags: React.PropTypes.object.isRequired,
     onQueryChange: React.PropTypes.func.isRequired,

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import DropdownLink from "../../components/dropdownLink";
 import MenuItem from "../../components/menuItem";
 
-var SortOptions = React.createClass({
+const SortOptions = React.createClass({
   mixins: [PureRenderMixin],
 
   getInitialState() {
@@ -42,7 +42,7 @@ var SortOptions = React.createClass({
   },
 
   render() {
-    var dropdownTitle = (
+    let dropdownTitle = (
       <span>
         <span>Sort by:</span>
         &nbsp; {this.getSortLabel(this.state.sortKey)}

--- a/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
+++ b/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import _ from "underscore";
 
-var StreamTagFilter = React.createClass({
+const StreamTagFilter = React.createClass({
   propTypes: {
     tag: React.PropTypes.object.isRequired,
     orgId: React.PropTypes.string.isRequired,

--- a/tests/js/helpers/stubContext.jsx
+++ b/tests/js/helpers/stubContext.jsx
@@ -1,12 +1,12 @@
 /*eslint react/no-multi-comp:0*/
 // https://github.com/karlbright/react-stub-context/blob/master/src/index.js
 
-var React = require('react');
+let React = require('react');
 
 function stubContext(BaseComponent, context) {
   if(typeof context === 'undefined' || context === null) context = {};
 
-  var _contextTypes = {}, _context = context;
+  let _contextTypes = {}, _context = context;
 
   try {
     Object.keys(_context).forEach(function(key) {
@@ -16,7 +16,7 @@ function stubContext(BaseComponent, context) {
     throw new TypeError('createdStubbedContextComponent requires an object');
   }
 
-  var StubbedContextParent = React.createClass({
+  const StubbedContextParent = React.createClass({
     displayName: 'StubbedContextParent',
     contextTypes: _contextTypes,
     childContextTypes: _contextTypes,
@@ -27,7 +27,7 @@ function stubContext(BaseComponent, context) {
     }
   });
 
-  var StubbedContextHandler = React.createClass({
+  const StubbedContextHandler = React.createClass({
     displayName: 'StubbedContextHandler',
     childContextTypes: _contextTypes,
     getChildContext() { return _context; },

--- a/tests/js/helpers/stubReactComponent.jsx
+++ b/tests/js/helpers/stubReactComponent.jsx
@@ -1,9 +1,9 @@
 // Inspired by TimothyRHuertas
 // https://gist.github.com/TimothyRHuertas/d7d06313c5411fe242bb
 
-var React = require("react");
-var divFactory = React.createFactory("div");
-var originalCreateElement = React.createElement;
+let React = require("react");
+let divFactory = React.createFactory("div");
+let originalCreateElement = React.createElement;
 
 export default function(stubber, stubbedComponents) {
   stubber.stub(React, "createElement", function(component, props) {
@@ -11,8 +11,8 @@ export default function(stubber, stubbedComponents) {
     if (stubbedComponents.indexOf(component) === -1) {
       return originalCreateElement.apply(React, arguments);
     } else {
-      var componentFactory = React.createFactory(component);
-      var displayName = componentFactory(props).type.displayName;
+      let componentFactory = React.createFactory(component);
+      let displayName = componentFactory(props).type.displayName;
 
       if (displayName) {
         if (props.className) {

--- a/tests/js/spec/components/barChart.spec.jsx
+++ b/tests/js/spec/components/barChart.spec.jsx
@@ -9,19 +9,19 @@ describe("BarChart", function() {
   describe("render()", function() {
 
     it("renders with default props", function() {
-      var comp = TestUtils.renderIntoDocument(<BarChart />);
+      let comp = TestUtils.renderIntoDocument(<BarChart />);
       expect(comp).to.be.ok;
     });
 
     it("renders with points data", function () {
-      var points = [
+      let points = [
         { x: 1439766000, y: 10 },
         { x: 1439769600, y: 20 },
         { x: 1439773200, y: 30 },
       ];
 
-      var comp = TestUtils.renderIntoDocument(<BarChart points={points}/>);
-      var columns = ReactDOM.findDOMNode(comp).querySelectorAll('.chart-column');
+      let comp = TestUtils.renderIntoDocument(<BarChart points={points}/>);
+      let columns = ReactDOM.findDOMNode(comp).querySelectorAll('.chart-column');
 
       expect(columns).to.have.property('length', 3);
       expect(columns[0]).to.have.property('textContent', '10'); // check y values
@@ -30,18 +30,18 @@ describe("BarChart", function() {
     });
 
     it("renders with points and markers", function () {
-      var points = [
+      let points = [
         { x: 1439769600, y: 10 },
         { x: 1439773200, y: 20 },
         { x: 1439776800, y: 30 }
       ];
-      var markers = [
+      let markers = [
         { x: 1439769600, className: 'first-seen', label: 'first seen' }, // matches first point
         { x: 1439776800, className: 'last-seen', label: 'last seen' } // matches last point
       ];
 
-      var comp = TestUtils.renderIntoDocument(<BarChart points={points} markers={markers}/>);
-      var columns = ReactDOM.findDOMNode(comp).getElementsByTagName('a');
+      let comp = TestUtils.renderIntoDocument(<BarChart points={points} markers={markers}/>);
+      let columns = ReactDOM.findDOMNode(comp).getElementsByTagName('a');
 
       expect(columns).to.have.property('length', 5);
 
@@ -54,16 +54,16 @@ describe("BarChart", function() {
     });
 
     it("renders with points and markers, when first and last seen are same data point", function () {
-      var points = [
+      let points = [
         { x: 1439776800, y: 30 }
       ];
-      var markers = [
+      let markers = [
         { x: 1439776800, className: 'first-seen', label: 'first seen' },
         { x: 1439776800, className: 'last-seen', label: 'last seen' }
       ];
 
-      var comp = TestUtils.renderIntoDocument(<BarChart points={points} markers={markers}/>);
-      var columns = ReactDOM.findDOMNode(comp).getElementsByTagName('a');
+      let comp = TestUtils.renderIntoDocument(<BarChart points={points} markers={markers}/>);
+      let columns = ReactDOM.findDOMNode(comp).getElementsByTagName('a');
 
       expect(columns).to.have.property('length', 3);
 

--- a/tests/js/spec/components/events/interfaces/definitionList.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/definitionList.spec.jsx
@@ -7,73 +7,73 @@ import DefinitionList from "app/components/events/interfaces/definitionList";
 describe('DefinitionList', function () {
   describe("render", function () {
     it("should render a definition list of key/value pairs", function () {
-      var data = [
+      let data = [
         ['a', 'x'], ['b', 'y']
       ];
-      var elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
+      let elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
 
-      var dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
+      let dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
       expect(ReactDOM.findDOMNode(dts[0]).textContent).to.eql('a');
       expect(ReactDOM.findDOMNode(dts[1]).textContent).to.eql('b');
 
-      var dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
+      let dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
       expect(ReactDOM.findDOMNode(dds[0]).textContent).to.eql('x');
       expect(ReactDOM.findDOMNode(dds[1]).textContent).to.eql('y');
     });
 
     it("should sort sort key/value pairs", function () {
-      var data = [
+      let data = [
         ['b', 'y'], ['a', 'x']
       ];
-      var elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
+      let elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
 
-      var dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
+      let dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
       expect(ReactDOM.findDOMNode(dts[0]).textContent).to.eql('a');
       expect(ReactDOM.findDOMNode(dts[1]).textContent).to.eql('b');
 
-      var dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
+      let dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
       expect(ReactDOM.findDOMNode(dds[0]).textContent).to.eql('x');
       expect(ReactDOM.findDOMNode(dds[1]).textContent).to.eql('y');
     });
 
     it("should use a single space for values that are an empty string", function () {
-      var data = [
+      let data = [
         ['b', 'y'], ['a', ''] // empty string
       ];
-      var elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
+      let elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
 
-      var dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
+      let dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
       expect(ReactDOM.findDOMNode(dts[0]).textContent).to.eql('a');
       expect(ReactDOM.findDOMNode(dts[1]).textContent).to.eql('b');
 
-      var dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
+      let dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
       expect(ReactDOM.findDOMNode(dds[0]).textContent).to.eql(' ');
       expect(ReactDOM.findDOMNode(dds[1]).textContent).to.eql('y');
     });
 
     it("should coerce non-strings into strings", function () {
-      var data = [
+      let data = [
         ['a', false]
       ];
-      var elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
+      let elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
 
-      var dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
+      let dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
       expect(ReactDOM.findDOMNode(dts[0]).textContent).to.eql('a');
 
-      var dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
+      let dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
       expect(ReactDOM.findDOMNode(dds[0]).textContent).to.eql('false');
     });
 
     it("shouldn't blow up on null", function () {
-      var data = [
+      let data = [
         ['a', null]
       ];
-      var elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
+      let elem = TestUtils.renderIntoDocument(<DefinitionList data={data} />);
 
-      var dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
+      let dts = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dt');
       expect(ReactDOM.findDOMNode(dts[0]).textContent).to.eql('a');
 
-      var dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
+      let dds = TestUtils.scryRenderedDOMComponentsWithTag(elem, 'dd');
       expect(ReactDOM.findDOMNode(dds[0]).textContent).to.eql('null');
     });
   });

--- a/tests/js/spec/components/events/interfaces/richHttpContent.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/richHttpContent.spec.jsx
@@ -64,7 +64,7 @@ describe("RichHttpContent", function () {
     });
 
     it("should return a DefinitionList element when Content-Type is x-www-form-urlencoded", function () {
-      var out = this.elem.getBodySection({
+      let out = this.elem.getBodySection({
         headers: [
           ['lol' , 'no'],
           ['Content-Type', 'application/x-www-form-urlencoded']
@@ -92,7 +92,7 @@ describe("RichHttpContent", function () {
     });
 
     it("should return a ContextData element when Content-Type is application/json", function () {
-      var out = this.elem.getBodySection({
+      let out = this.elem.getBodySection({
         headers: [
           ['lol' , 'no'],
           ['Content-Type', 'application/json']
@@ -108,7 +108,7 @@ describe("RichHttpContent", function () {
     });
 
     it("should return a ContextData element when content is JSON, ignoring Content-Type", function () {
-      var out = this.elem.getBodySection({
+      let out = this.elem.getBodySection({
         headers: [
           ['Content-Type', 'application/x-www-form-urlencoded']
         ], // no content-type header,

--- a/tests/js/spec/views/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/organizationTeams.spec.jsx
@@ -17,7 +17,7 @@ describe("OrganizationTeams", function() {
     this.stubbedApiRequest = this.sandbox.stub(api, "request");
     stubReactComponent(this.sandbox, [ExpandedTeamList, AllTeamsList, OrganizationHomeContainer]);
 
-    var ContextStubbedOrganizationTeams = stubContext(OrganizationTeams, {
+    let ContextStubbedOrganizationTeams = stubContext(OrganizationTeams, {
       organization: { id: "1337" }
     });
 
@@ -30,7 +30,7 @@ describe("OrganizationTeams", function() {
 
   describe("fetchStats()", function() {
     it('should make a request to the organizations endpoint', function () {
-      var organizationTeams = TestUtils.renderIntoDocument(this.Element).refs.wrapped;
+      let organizationTeams = TestUtils.renderIntoDocument(this.Element).refs.wrapped;
 
       // NOTE: creation of OrganizationTeams causes a bunch of API requests to fire ...
       //       reset the request stub so that we can get an accurate count

--- a/tests/js/spec/views/projectReleases.spec.jsx
+++ b/tests/js/spec/views/projectReleases.spec.jsx
@@ -43,7 +43,7 @@ describe("ProjectReleases", function () {
 
   describe("onSearch", function () {
     it("should change query string with new search parameter", function () {
-      var projectReleases = this.projectReleases;
+      let projectReleases = this.projectReleases;
 
       let pushState = this.sandbox.stub();
       projectReleases.history = {
@@ -65,7 +65,7 @@ describe("ProjectReleases", function () {
 
   describe("componentWillReceiveProps()", function () {
     it("should update state with latest query pulled from query string", function () {
-      var projectReleases = this.projectReleases;
+      let projectReleases = this.projectReleases;
 
       let setState = this.sandbox.stub(projectReleases, 'setState');
 

--- a/tests/js/spec/views/stream.spec.jsx
+++ b/tests/js/spec/views/stream.spec.jsx
@@ -13,8 +13,8 @@ import StreamSidebar from "app/views/stream/sidebar";
 import StreamActions from "app/views/stream/actions";
 import stubReactComponents from "../../helpers/stubReactComponent";
 
-var findWithClass = TestUtils.findRenderedDOMComponentWithClass;
-var findWithType = TestUtils.findRenderedComponentWithType;
+const findWithClass = TestUtils.findRenderedDOMComponentWithClass;
+const findWithType = TestUtils.findRenderedComponentWithType;
 
 const DEFAULT_LINKS_HEADER =
   '<http://127.0.0.1:8000/api/0/projects/sentry/ludic-science/groups/?cursor=1443575731:0:1>; rel="previous"; results="false"; cursor="1443575731:0:1", ' +
@@ -57,7 +57,7 @@ describe("Stream", function() {
       it("should reset the poller endpoint and sets cursor URL", function() {
         this.linkHeader = DEFAULT_LINKS_HEADER;
 
-        var stream = TestUtils.renderIntoDocument(this.Element);
+        let stream = TestUtils.renderIntoDocument(this.Element);
         stream.fetchData();
 
         expect(CursorPoller.prototype.setEndpoint
@@ -69,7 +69,7 @@ describe("Stream", function() {
         this.linkHeader =
         '<http://127.0.0.1:8000/api/0/projects/sentry/ludic-science/groups/?cursor=1443575731:0:0>; rel="next"; results="true"; cursor="1443575731:0:0';
 
-        var stream = TestUtils.renderIntoDocument(this.Element);
+        let stream = TestUtils.renderIntoDocument(this.Element);
         stream.fetchData();
 
         expect(CursorPoller.prototype.setEndpoint.notCalled).to.be.ok;
@@ -79,8 +79,8 @@ describe("Stream", function() {
     it("should cancel any previous, unfinished fetches", function () {
       this.stubbedApiRequest.restore();
 
-      var requestCancel = this.sandbox.stub();
-      var requestOptions;
+      let requestCancel = this.sandbox.stub();
+      let requestOptions;
       this.sandbox.stub(Api, "request", function (url, options) {
         requestOptions = options;
         return {
@@ -89,7 +89,7 @@ describe("Stream", function() {
       });
 
       // NOTE: fetchData called once after render automatically
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
 
       // 2nd fetch should call cancel
       stream.fetchData();
@@ -109,42 +109,42 @@ describe("Stream", function() {
   describe("render()", function() {
 
     it("displays a loading indicator when component is loading", function() {
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
       stream.setState({ loading: true });
-      var expected = findWithType(stream, LoadingIndicator);
+      let expected = findWithType(stream, LoadingIndicator);
 
       expect(expected).to.be.ok;
     });
 
     it("displays an error when component has errored", function() {
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
       stream.setState({
         error: true,
         loading: false
       });
-      var expected = findWithType(stream, LoadingError);
+      let expected = findWithType(stream, LoadingError);
       expect(expected).to.be.ok;
     });
 
     it("displays the group list", function() {
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
       stream.setState({
         error: false,
         groupIds: ["1"],
         loading: false
       });
-      var expected = findWithClass(stream, "group-list");
+      let expected = findWithClass(stream, "group-list");
       expect(expected).to.be.ok;
     });
 
     it("displays empty with no ids", function() {
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
       stream.setState({
         error: false,
         groupIds: [],
         loading: false
       });
-      var expected = findWithClass(stream, "empty-stream");
+      let expected = findWithClass(stream, "empty-stream");
       expect(expected).to.be.ok;
     });
 
@@ -159,7 +159,7 @@ describe("Stream", function() {
     it("reads the realtimeActive state from a cookie", function(done) {
       Cookies.set("realtimeActive", "false");
 
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
       setTimeout(() => {
         expect(stream.state.realtimeActive).to.not.be.ok;
         done();
@@ -168,7 +168,7 @@ describe("Stream", function() {
 
     it("reads the true realtimeActive state from a cookie", function(done) {
       Cookies.set("realtimeActive", "true");
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
 
       setTimeout(() => {
         expect(stream.state.realtimeActive).to.be.ok;
@@ -181,7 +181,7 @@ describe("Stream", function() {
   describe("onRealtimeChange", function() {
 
     it("sets the realtimeActive state", function() {
-      var stream = TestUtils.renderIntoDocument(this.Element);
+      let stream = TestUtils.renderIntoDocument(this.Element);
       stream.state.realtimeActive = false;
       stream.onRealtimeChange(true);
       expect(stream.state.realtimeActive).to.eql(true);
@@ -197,7 +197,7 @@ describe("Stream", function() {
   describe("getInitialState", function() {
 
     it("sets the right defaults", function() {
-      var expected = {
+      let expected = {
         groupIds: [],
         selectAllActive: false,
         multiSelected: false,
@@ -208,10 +208,10 @@ describe("Stream", function() {
         loading: true,
         error: false
       };
-      var stream = TestUtils.renderIntoDocument(this.Element);
-      var actual = stream.getInitialState();
+      let stream = TestUtils.renderIntoDocument(this.Element);
+      let actual = stream.getInitialState();
 
-      for (var property in expected) {
+      for (let property in expected) {
         expect(actual[property]).to.eql(expected[property]);
       }
     });

--- a/tests/js/spec/views/stream/actionLink.spec.jsx
+++ b/tests/js/spec/views/stream/actionLink.spec.jsx
@@ -21,7 +21,7 @@ describe("ActionLink", function() {
 
   describe("shouldConfirm()", function() {
     it('should always return true by default', function () {
-      var actionLink = TestUtils.renderIntoDocument(
+      let actionLink = TestUtils.renderIntoDocument(
         <ActionLink onAction={function(){}} selectAllActive={false}/>
       );
 
@@ -31,7 +31,7 @@ describe("ActionLink", function() {
     });
 
     it('should return false when props.neverConfirm is true', function () {
-      var actionLink = TestUtils.renderIntoDocument(
+      let actionLink = TestUtils.renderIntoDocument(
         <ActionLink neverConfirm={true} onAction={function(){}} selectAllActive={false}/>
       );
 
@@ -42,7 +42,7 @@ describe("ActionLink", function() {
 
 
     it('should return (mostly) true when props.onlyIfBulk is true and all are selected', function () {
-      var actionLink = TestUtils.renderIntoDocument(
+      let actionLink = TestUtils.renderIntoDocument(
         <ActionLink onlyIfBulk={true} selectAllActive={true} onAction={function(){}}/>
       );
 
@@ -52,7 +52,7 @@ describe("ActionLink", function() {
     });
 
     it('should return false when props.onlyIfBulk is true and not all are selected', function () {
-      var actionLink = TestUtils.renderIntoDocument(
+      let actionLink = TestUtils.renderIntoDocument(
         <ActionLink onlyIfBulk={true} selectAllActive={false} onAction={function(){}}/>
       );
 

--- a/tests/js/spec/views/stream/actions.spec.jsx
+++ b/tests/js/spec/views/stream/actions.spec.jsx
@@ -40,7 +40,7 @@ describe("StreamActions", function() {
     describe("for all items", function () {
       it("should invoke the callback with 'undefined' and deselect all", function () {
         this.sandbox.stub(SelectedGroupStore, 'deselectAll');
-        var callback = this.sandbox.stub();
+        let callback = this.sandbox.stub();
 
         this.actions.actionSelectedGroups(this.actions.props.actionTypes.ALL, callback);
 
@@ -54,7 +54,7 @@ describe("StreamActions", function() {
         this.sandbox.stub(SelectedGroupStore, 'deselectAll');
         this.sandbox.stub(SelectedGroupStore, 'getSelectedIds').returns(new Set([1,2,3]));
 
-        var callback = this.sandbox.stub();
+        let callback = this.sandbox.stub();
         this.actions.actionSelectedGroups(this.actions.props.actionTypes.SELECTED, callback);
 
         expect(callback.withArgs([1,2,3]).calledOnce).to.be.ok;

--- a/tests/js/spec/views/stream/filterSelectLink.spec.jsx
+++ b/tests/js/spec/views/stream/filterSelectLink.spec.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import TestUtils from "react-addons-test-utils";
 import FilterSelectLink from "app/views/stream/filterSelectLink";
 
-var findWithClass = TestUtils.findRenderedDOMComponentWithClass;
+let findWithClass = TestUtils.findRenderedDOMComponentWithClass;
 
 describe("FilterSelectLink", function() {
 
@@ -18,25 +18,25 @@ describe("FilterSelectLink", function() {
   describe("render()", function() {
 
     it("shows a button", function(){
-      var wrapper = TestUtils.renderIntoDocument(<FilterSelectLink extraClass="test-btn" />);
-      var expected = findWithClass(wrapper, "test-btn");
+      let wrapper = TestUtils.renderIntoDocument(<FilterSelectLink extraClass="test-btn" />);
+      let expected = findWithClass(wrapper, "test-btn");
       expect(expected).to.be.ok;
     });
 
     it("shows active state when passed isActive=true", function(){
-      var wrapper = TestUtils.renderIntoDocument(<FilterSelectLink isActive={true} />);
-      var expected = findWithClass(wrapper, "active");
+      let wrapper = TestUtils.renderIntoDocument(<FilterSelectLink isActive={true} />);
+      let expected = findWithClass(wrapper, "active");
       expect(expected).to.be.ok;
     });
 
     it("doesn't show active state when passed isActive=false", function(){
-      var wrapper = TestUtils.renderIntoDocument(<FilterSelectLink isActive={false} />);
+      let wrapper = TestUtils.renderIntoDocument(<FilterSelectLink isActive={false} />);
       expect(() => findWithClass(wrapper, "active")).to.throw();
     });
 
     it("calls onSelect() when anchor clicked", function(){
-      var onSelect = this.sandbox.spy();
-      var wrapper = TestUtils.renderIntoDocument(<FilterSelectLink onSelect={onSelect} />);
+      let onSelect = this.sandbox.spy();
+      let wrapper = TestUtils.renderIntoDocument(<FilterSelectLink onSelect={onSelect} />);
 
       TestUtils.Simulate.click(ReactDOM.findDOMNode(wrapper));
 

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -9,7 +9,7 @@ import stubReactComponents from "../../../helpers/stubReactComponent";
 
 import stubContext from "../../../helpers/stubContext";
 
-var findWithClass = TestUtils.findRenderedDOMComponentWithClass;
+let findWithClass = TestUtils.findRenderedDOMComponentWithClass;
 
 describe("SearchBar", function() {
 
@@ -57,13 +57,13 @@ describe("SearchBar", function() {
   describe("clearSearch()", function() {
 
     it("clears the query", function() {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "is:unresolved ruby",
         defaultQuery: "is:unresolved"
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
 
       wrapper.clearSearch();
 
@@ -71,14 +71,14 @@ describe("SearchBar", function() {
     });
 
     it("calls onSearch()", function(done) {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "is:unresolved ruby",
         defaultQuery: "is:unresolved",
         onSearch: this.sandbox.spy()
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
 
       wrapper.clearSearch();
 
@@ -93,7 +93,7 @@ describe("SearchBar", function() {
   describe("onQueryFocus()", function() {
 
     it("displays the drop down", function() {
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar orgId="123" projectId="456"/>).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar orgId="123" projectId="456"/>).refs.wrapped;
       expect(wrapper.state.dropdownVisible).to.be.false;
 
       wrapper.onQueryFocus();
@@ -106,10 +106,10 @@ describe("SearchBar", function() {
   describe("onQueryBlur()", function() {
 
     it("hides the drop down", function() {
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar orgId="123" projectId="456"/>).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar orgId="123" projectId="456"/>).refs.wrapped;
       wrapper.state.dropdownVisible = true;
 
-      var clock = this.sandbox.useFakeTimers();
+      let clock = this.sandbox.useFakeTimers();
       wrapper.onQueryBlur();
       clock.tick(201); // doesn't close until 200ms
 
@@ -122,10 +122,10 @@ describe("SearchBar", function() {
     describe("escape", function () {
       it("blurs the input", function () {
         // needs to be rendered into document.body or cannot query document.activeElement
-        var wrapper = ReactDOM.render(<this.ContextStubbedSearchBar orgId="123" projectId="456"/>, document.body).refs.wrapped;
+        let wrapper = ReactDOM.render(<this.ContextStubbedSearchBar orgId="123" projectId="456"/>, document.body).refs.wrapped;
         wrapper.state.dropdownVisible = true;
 
-        var input = ReactDOM.findDOMNode(wrapper.refs.searchInput);
+        let input = ReactDOM.findDOMNode(wrapper.refs.searchInput);
 
         input.focus();
 
@@ -141,8 +141,8 @@ describe("SearchBar", function() {
   describe("render()", function() {
 
     it("invokes onSearch() when submitting the form", function() {
-      var stubbedOnSearch = this.sandbox.spy();
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar onSearch={stubbedOnSearch} orgId="123" projectId="456"/>).refs.wrapped;
+      let stubbedOnSearch = this.sandbox.spy();
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar onSearch={stubbedOnSearch} orgId="123" projectId="456"/>).refs.wrapped;
 
       TestUtils.Simulate.submit(wrapper.refs.searchForm, { preventDefault() {} });
 
@@ -150,15 +150,15 @@ describe("SearchBar", function() {
     });
 
     it("invokes onSearch() when search is cleared", function(done) {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "is:unresolved",
         onSearch: this.sandbox.spy()
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
 
-      var cancelButton = findWithClass(wrapper, "search-clear-form");
+      let cancelButton = findWithClass(wrapper, "search-clear-form");
       TestUtils.Simulate.click(cancelButton);
 
       setTimeout(function () {
@@ -182,12 +182,12 @@ describe("SearchBar", function() {
 
   describe("updateAutoCompleteItems()", function() {
     it("sets state when empty", function() {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "",
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
       wrapper.updateAutoCompleteItems();
       expect(wrapper.state.searchTerm).to.eql('');
       expect(wrapper.state.searchItems).to.eql(wrapper.props.defaultSearchItems);
@@ -195,12 +195,12 @@ describe("SearchBar", function() {
     });
 
     it("sets state when incomplete tag", function() {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "fu",
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
       wrapper.updateAutoCompleteItems();
       expect(wrapper.state.searchTerm).to.eql('fu');
       expect(wrapper.state.searchItems).to.eql([]);
@@ -208,12 +208,12 @@ describe("SearchBar", function() {
     });
 
     it("sets state with complete tag", function() {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "url:\"fu\"",
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
       wrapper.updateAutoCompleteItems();
       expect(wrapper.state.searchTerm).to.eql('"fu"');
       expect(wrapper.state.searchItems).to.eql([]);
@@ -221,12 +221,12 @@ describe("SearchBar", function() {
     });
 
     it("sets state when incomplete tag as second input", function() {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "is:unresolved fu",
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
       wrapper.updateAutoCompleteItems();
       expect(wrapper.state.searchTerm).to.eql('unresolved');
       expect(wrapper.state.searchItems.length).to.eql(1);
@@ -236,12 +236,12 @@ describe("SearchBar", function() {
     });
 
     it("sets state when value has colon", function() {
-      var props = {
+      let props = {
         orgId: "123",
         projectId: "456",
         query: "url:\"http://example.com\"",
       };
-      var wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
+      let wrapper = TestUtils.renderIntoDocument(<this.ContextStubbedSearchBar {...props} />).refs.wrapped;
       wrapper.updateAutoCompleteItems();
       expect(wrapper.state.searchTerm).to.eql('"http://example.com"');
       expect(wrapper.state.searchItems).to.eql([]);


### PR DESCRIPTION
This was done w/ [jscodeshift](https://github.com/facebook/jscodeshift/pull/39/files) + [js-codemod/no-vars](https://github.com/cpojer/js-codemod/blob/master/transforms/no-vars.js) transform rules. I modified that script so that it only does `var` => `let` (removed `const` transformations) – mostly because it was declaring variables as `const` if they **happened** not to be reassigned in a block. I felt this didn't capture intent properly so I punted.

In cases where the codemod script blew up (didn't like functions declared in JSX prop passing), I converted manually.

Tests pass and the app seems to run fine. Might wanna throw on staging and do some passes to be extra sure.

**Update**: I made sure classes and function declarations are all `const`.
