### PR TITLE
Pretty up the CSP interface in the UI

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/cspContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspContent.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import {objectToArray} from "../../../utils";
+import DefinitionList from "./definitionList";
+
+const CSPContent = React.createClass({
+  propTypes: {
+    data: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    let {data} = this.props;
+    return (
+      <div>
+        <h4>
+          <span>{data.effective_directive}</span>
+        </h4>
+        <DefinitionList data={objectToArray(data)} isContextData={true}/>
+      </div>
+    );
+  }
+});
+
+export default CSPContent;

--- a/src/sentry/static/sentry/app/components/events/interfaces/cspHelp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspHelp.jsx
@@ -1,0 +1,119 @@
+import React from "react";
+
+const help = {
+  'base-uri': `
+The <code>base-uri</code> directive defines the URIs that a user agent
+may use as the document base URL. If this value is absent, then any URI
+is allowed. If this directive is absent, the user agent will use the
+value in the <code>base</code> element.`,
+  'child-src': `
+The <code>child-src</code> directive defines the valid sources for web
+workers and nested browsing contexts loaded using elements such as
+<frame> and <iframe>. This directive is preferred over the
+<code>frame-src</code> directive, which is deprecated. For workers,
+non-compliant requests are treated as fatal network errors by the user agent.`,
+  'connect-src': `
+The <code>connect-src</code> directive defines valid sources for fetch,
+<code>XMLHttpRequest</code>, <code>WebSocket</code>, and
+<code>EventSource</code> connections.`,
+  'font-src': `
+The <code>font-src</code> directive specifies valid sources for fonts
+loaded using <code>@font-face</code>.`,
+  'form-action': `
+The <code>form-action</code> directive specifies valid endpoints for
+<code>&lt;form&gt;</code> submissions.`,
+  'frame-ancestors': `
+The <code>frame-ancestors</code> directive specifies valid parents that
+may embed a page using the <code>&lt;frame&gt;</code> and
+<code>&lt;iframe&gt;</code> elements.`,
+  'img-src': `
+The <code>img-src</code> directive specifies valid sources of images and
+favicons.`,
+  'manifest-src': `
+The <code>manifest-src</code> directive specifies which manifest can be
+applied to the resource.`,
+  'media-src': `
+The <code>media-src</code> directive specifies valid sources for loading
+media using the <code>&lt;audio&gt;</code> and <code>&lt;video&gt;</code>
+elements.`,
+  'object-src': `
+The <code>object-src</code> directive specifies valid sources for the
+<code>&lt;object&gt;</code>, <code>&lt;embed&gt;</code>, and
+<code>&lt;applet&gt;</code> elements.`,
+  'plugin-types': `
+The <code>plugin-types</code> directive specifies the valid plugins that
+the user agent may invoke.`,
+  'referrer': `
+The <code>referrer</code> directive specifies information in the
+<code>Referer</code> header for links away from a page.`,
+  'script-src': `
+The <code>script-src</code> directive specifies valid sources
+for JavaScript. When either the <code>script-src</code> or the
+<code>default-src</code> directive is included, inline script and
+<code>eval()</code> are disabled unless you specify 'unsafe-inline'
+and 'unsafe-eval', respectively.`,
+  'style-src': `
+The <code>style-src</code> directive specifies valid sources for
+stylesheets. This includes both externally-loaded stylesheets and inline
+use of the <code>&lt;style&gt;</code> element and HTML style attributes.
+Stylesheets from sources that aren't included in the source list are not
+requested or loaded. When either the <code>style-src</code> or the
+<code>default-src</code> directive is included, inline use of the
+<code>&lt;style&gt;</code> element and HTML style attributes are disabled
+unless you specify 'unsafe-inline'.`,
+};
+
+const linkOverrides = {
+  'script-src': 'script-src_2',
+};
+
+function getHelp(key) {
+  return {
+    __html: help[key]
+  };
+}
+
+function getLinkHref(key) {
+  let link = key;
+  if (key in linkOverrides) {
+    link = linkOverrides[key];
+  }
+  return `https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#${link}`;
+}
+
+function getLink(key) {
+  let href = getLinkHref(key);
+
+  return (
+    <span>
+      <a href={href}>developer.mozilla.org</a>
+      <a href={href} className="external-icon">
+        <em className="icon-open" />
+      </a>
+    </span>
+  );
+}
+
+const CSPHelp = React.createClass({
+  propTypes: {
+    data: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    let {data} = this.props;
+    let key = data.effective_directive;
+    return (
+      <div>
+        <h4>
+          <code>{key}</code>
+        </h4>
+        <blockquote dangerouslySetInnerHTML={getHelp(key)}/>
+        <p style={{textAlign: 'right'}}>
+          &mdash; MDN ({getLink(key)})
+        </p>
+      </div>
+    );
+  }
+});
+
+export default CSPHelp;


### PR DESCRIPTION
This adds three panes to the CSP interface:
- Report: Pretty much the same as it was before.
- Raw: The raw JSON view of the report sent from browser.
- Help: Show help information from MDN for each violated directive.

![image](https://cloud.githubusercontent.com/assets/375744/10836777/dc45ebd2-7e6e-11e5-8c77-46b6223b2ae5.png)
![image](https://cloud.githubusercontent.com/assets/375744/10836780/e48c3404-7e6e-11e5-8f0c-93692470438e.png)
![image](https://cloud.githubusercontent.com/assets/375744/10836784/ee243ef8-7e6e-11e5-9b28-2a44c9557217.png)
