### PR TITLE
Add icon to notes to indicate Markdown support

### DIFF
--- a/src/sentry/static/sentry/app/views/groupActivity/noteInput.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/noteInput.jsx
@@ -214,6 +214,9 @@ const NoteInput = React.createClass({
             <li className={preview ? "active" : ""}>
               <a onClick={this.togglePreview}>Preview</a>
             </li>
+            <li className="markdown">
+              <span className="icon-markdown" /><span className="supported">Markdown supported</span>
+            </li>
           </ul>
           {preview ?
             <div className="note-preview"

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2094,6 +2094,24 @@ table.integrations {
     }
   }
 
+  > li.markdown {
+    float: right;
+    color: lighten(@gray, 10);
+    margin-right: 0;
+
+    > .icon-markdown {
+      font-size: 20px;
+    }
+
+    > .supported {
+      // The text doesn't quit line up with the icon, so we
+      // manually fudge this to make it look better.
+      position: relative;
+      top: -4px;
+      left: 5px;
+    }
+  }
+
   &.border-bottom {
     border-bottom: 1px solid lighten(@trim, 2);
   }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/375744/10859884/f206fc6c-7f1e-11e5-88ec-4aaedc65a1aa.png)
