### PR TITLE
Support CORS check on POST

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -182,6 +182,29 @@ class BaseTestCase(Fixtures, Exam):
             )
         return resp
 
+    def _postWithReferer(self, data, key=None, referer='getsentry.com', protocol='4'):
+        if key is None:
+            key = self.projectkey.public_key
+
+        headers = {}
+        if referer is not None:
+            headers['HTTP_REFERER'] = referer
+
+        message = self._makeMessage(data)
+        qs = {
+            'sentry_version': protocol,
+            'sentry_client': 'raven-js/lol',
+            'sentry_key': key,
+        }
+        with self.tasks():
+            resp = self.client.post(
+                '%s?%s' % (reverse('sentry-api-store', args=(self.project.pk,)), urllib.urlencode(qs)),
+                data=message,
+                content_type='application/json',
+                **headers
+            )
+        return resp
+
     _postWithSignature = _postWithHeader
     _postWithNewSignature = _postWithHeader
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -194,17 +194,18 @@ class APIView(BaseView):
 
             if auth.version != '2.0':
                 if not auth.secret_key:
-                    # We fall back to checking CORS if either:
-                    #  * Request was a GET or
-                    #  * Missing secret_key on any other method
-                    # If an Origin isn't passed, it's possible that the project allows no origin,
-                    # so we need to explicitly check for that here. If Origin is not None,
-                    # it can be safely assumed that it was checked previously and it's ok.
-                    if origin is None and not is_valid_origin(origin, project):
-                        if request.method == 'GET':
-                            # Special case for GET request since it will never use a sentry_secret
-                            raise APIForbidden('Missing required Origin or Referer header')
+                    # If we're missing a secret_key, check if we are allowed
+                    # to do a CORS request.
+
+                    # If we're missing an Origin/Referrer header entirely,
+                    # we only want to support this on GET requests. By allowing
+                    # un-authenticated CORS checks for POST, we basially
+                    # are obsoleting our need for a secret key entirely.
+                    if origin is None and request.method != 'GET':
                         raise APIForbidden('Missing required attribute in authentication header: sentry_secret')
+
+                    if not is_valid_origin(origin, project):
+                        raise APIForbidden('Missing required Origin or Referer header')
 
             response = super(APIView, self).dispatch(
                 request=request,

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -193,7 +193,7 @@ class APIView(BaseView):
             Raven.tags_context(helper.context.get_tags_context())
 
             if auth.version != '2.0':
-                if request.method == 'GET' or not auth.secret_key:
+                if not auth.secret_key:
                     # We fall back to checking CORS if either:
                     #  * Request was a GET or
                     #  * Missing secret_key on any other method

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -202,9 +202,9 @@ class APIView(BaseView):
                         # Special case an error message for a None origin when None wasn't allowed
                         raise APIForbidden('Missing required Origin or Referer header')
                 else:
-                    # Version 3 enforces secret key for server side requests
                     if not auth.secret_key:
-                        raise APIForbidden('Missing required attribute in authentication header: sentry_secret')
+                        if origin is None and not is_valid_origin(origin, project):
+                            raise APIForbidden('Missing required attribute in authentication header: sentry_secret')
 
             response = super(APIView, self).dispatch(
                 request=request,

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -201,10 +201,10 @@ class APIView(BaseView):
                     # so we need to explicitly check for that here. If Origin is not None,
                     # it can be safely assumed that it was checked previously and it's ok.
                     if origin is None and not is_valid_origin(origin, project):
-                        if origin is None:
-                            raise APIForbidden('Missing required attribute in authentication header: sentry_secret')
-                        # Special case an error message for a None origin when None wasn't allowed
-                        raise APIForbidden('Missing required Origin or Referer header')
+                        if request.method == 'GET':
+                            # Special case for GET request since it will never use a sentry_secret
+                            raise APIForbidden('Missing required Origin or Referer header')
+                        raise APIForbidden('Missing required attribute in authentication header: sentry_secret')
 
             response = super(APIView, self).dispatch(
                 request=request,

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -226,7 +226,7 @@ class SentryRemoteTest(TestCase):
         self.project.update_option('sentry:origins', '')
         kwargs = {'message': 'hello'}
         resp = self._postWithReferer(kwargs, referer=None, protocol='4')
-        assert resp.status_code == 200, (resp.status_code, resp.get('X-Sentry-Error'))
+        assert resp.status_code == 403, (resp.status_code, resp.get('X-Sentry-Error'))
 
     def test_signature(self):
         kwargs = {'message': 'hello'}


### PR DESCRIPTION
Fixes GH-1383

/cc @benvinegar 

This change allows to POST to a url like: `/api/1/store/?sentry_version=5&sentry_key=<pubkey>` Basically just like it does for CSP posting, except this also validates on an Origin/Referer header.

This is to support POSTing from raven-js without private key.

For GET requests, we allowed requests to come through without an Origin/Referer header at all if `*` was allowed. This behavior is different for POST since we don't want to just allow any request to send with only public key. For anything non-GET that's trying to use CORS, we require the Origin/Referer header to be set explicitly.
