### PR TITLE
Set project_id context for potentially problematic tasks

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -24,6 +24,7 @@ def instrumented_task(name, stat_suffix=None, **kwargs):
                 instance = '{}.{}'.format(name, stat_suffix(*args, **kwargs))
             else:
                 instance = name
+            Raven.tags_context({'task_name': name})
             with metrics.timer(key, instance=instance):
                 try:
                     result = func(*args, **kwargs)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, print_function
 
 from celery.utils.log import get_task_logger
 from django.db import IntegrityError, transaction
+from raven.contrib.django.models import client as Raven
 
 from sentry.plugins import plugins
 from sentry.tasks.base import instrumented_task
@@ -45,7 +46,12 @@ def post_process_group(event, is_new, is_regression, is_sample, **kwargs):
     from sentry.models import Project
     from sentry.rules.processor import RuleProcessor
 
-    project = Project.objects.get_from_cache(id=event.group.project_id)
+    project_id = event.group.project_id
+    Raven.tags_context({
+        'project': project_id,
+    })
+
+    project = Project.objects.get_from_cache(id=project_id)
 
     _capture_stats(event, is_new)
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -9,6 +9,7 @@ sentry.tasks.store
 from __future__ import absolute_import
 
 from celery.utils.log import get_task_logger
+from raven.contrib.django.models import client as Raven
 from time import time
 
 from sentry.cache import default_cache
@@ -37,6 +38,9 @@ def preprocess_event(cache_key=None, data=None, start_time=None, **kwargs):
         return
 
     project = data['project']
+    Raven.tags_context({
+        'project': project,
+    })
 
     # TODO(dcramer): ideally we would know if data changed by default
     has_changed = False
@@ -75,6 +79,9 @@ def save_event(cache_key=None, data=None, start_time=None, **kwargs):
         return
 
     project = data.pop('project')
+    Raven.tags_context({
+        'project': project,
+    })
 
     try:
         manager = EventManager(data)


### PR DESCRIPTION
Anywhere else you can think of?
