### PR TITLE
Stop event bubbling when clicking on value toggle

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -80,6 +80,7 @@ const ContextData = React.createClass({
 
   renderValue(value) {
     function toggle(evt) {
+      evt.stopPropagation();
       jQuery(evt.target).parent().toggleClass('val-toggle-open');
       evt.preventDefault();
     }

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -80,7 +80,6 @@ const ContextData = React.createClass({
 
   renderValue(value) {
     function toggle(evt) {
-      evt.stopPropagation();
       jQuery(evt.target).parent().toggleClass('val-toggle-open');
       evt.preventDefault();
     }

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameVariables.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameVariables.jsx
@@ -18,7 +18,7 @@ const FrameVariables = React.createClass({
     let data = objectToArray(this.props.data);
 
     return (
-      <KeyValueList data={data} isContextData={true} />
+      <KeyValueList data={data} isContextData={true} onClick={this.preventToggling} />
     );
   }
 });

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
@@ -6,7 +6,8 @@ import ContextData from '../../contextData';
 const KeyValueList = React.createClass({
   propTypes: {
     data: React.PropTypes.array.isRequired,
-    isContextData: React.PropTypes.bool
+    isContextData: React.PropTypes.bool,
+    onClick: React.PropTypes.func
   },
 
   getDefaultProps() {
@@ -17,8 +18,9 @@ const KeyValueList = React.createClass({
 
   render() {
     let data = _.sortBy(this.props.data, (key, value) => key);
+    const props = (this.props.onClick) ? {onClick: this.props.onClick} : {};
     return (
-      <table className="table key-value">
+      <table className="table key-value" {...props}>
         <tbody>
         {data.map(([key, value]) => {
           if (this.props.isContextData) {


### PR DESCRIPTION
- Call `evt.stopPropagation()` when clicking on a value toggle, otherwise
  the click event bubbles and closes the entire value section.
