### PR TITLE
Implemented new setup commands that can build in src or build folders.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -363,8 +363,8 @@ class ExtendedDistribution(Distribution):
 setup(
     name='sentry',
     version='8.0.0.dev0',
-    author='David Cramer',
-    author_email='dcramer@gmail.com',
+    author='Sentry',
+    author_email='hello@getsentry.com',
     url='https://getsentry.com',
     description='A realtime logging and aggregation server.',
     long_description=open(os.path.join(ROOT, 'README.rst')).read(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,11 @@ var path = require("path"),
 var staticPrefix = "src/sentry/static/sentry",
     distPath = staticPrefix + "/dist";
 
+// this is set by setup.py sdist
+if (process.env.SENTRY_STATIC_DIST_PATH) {
+    distPath = process.env.SENTRY_STATIC_DIST_PATH;
+}
+
 var config = {
   context: path.join(__dirname, staticPrefix),
   entry: {


### PR DESCRIPTION
This changes setup.py for source distributions but also makes it more
flexible for building in general as it builds in a temporary folder.

This is the new behavior:
-   most builds happen in build/lib instead of the source folder
-   the exception to this is a `install` build which happens in
  the source folder as before.  This means that nothing about
  setup.py install changes.
-   the source files are now properly added to the manifest which
  solves the problems we had with the 7.7.N releases where the
  build files contained the previous version of the build.

Do not merge yet, needs more testing.
