### PR TITLE
Make email reply signatures case insensitive

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -14,8 +14,9 @@ from random import randrange
 
 from django.conf import settings
 from django.core.mail import get_connection, EmailMultiAlternatives
-from django.core.signing import Signer
-from django.utils.encoding import force_bytes
+from django.core.signing import Signer, BadSignature
+from django.utils.crypto import constant_time_compare
+from django.utils.encoding import force_bytes, force_str, force_text
 from django.utils.functional import cached_property
 from email.utils import parseaddr
 
@@ -24,10 +25,40 @@ from sentry.web.helpers import render_to_string
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
-signer = Signer()
-
 SMTP_HOSTNAME = getattr(settings, 'SENTRY_SMTP_HOSTNAME', 'localhost')
 ENABLE_EMAIL_REPLIES = getattr(settings, 'SENTRY_ENABLE_EMAIL_REPLIES', False)
+
+
+class _CaseInsensitiveSigner(Signer):
+    """
+    Generate a signature that is comprised of only lowercase letters.
+
+    WARNING: Do not use this for anything that needs to be cryptographically
+    secure! This is losing entropy and has a much higher chance of collision
+    due to dropping to lowercase letters. For our purposes, this lack of entropy
+    is ok and doesn't pose a risk.
+
+    NOTE: This is needed strictly for signatures used in email addresses. Some
+    clients, coughAirmailcough, treat email addresses as being case-insensitive,
+    and sends the value as all lowercase.
+    """
+    def signature(self, value):
+        sig = super(_CaseInsensitiveSigner, self).signature(value)
+        return sig.lower()
+
+    def unsign(self, signed_value):
+        # This unsign is identical to subclass except for the lowercasing
+        # See: https://github.com/django/django/blob/1.6.11/django/core/signing.py#L165-L172
+        signed_value = force_str(signed_value)
+        if self.sep not in signed_value:
+            raise BadSignature('No "%s" found in value' % self.sep)
+        value, sig = signed_value.rsplit(self.sep, 1)
+        if constant_time_compare(sig.lower(), self.signature(value)):
+            return force_text(value)
+        raise BadSignature('Signature "%s" does not match' % sig)
+
+
+signer = _CaseInsensitiveSigner()
 
 
 def email_to_group_id(address):

--- a/tests/sentry/smtp/tests.py
+++ b/tests/sentry/smtp/tests.py
@@ -5,7 +5,9 @@ import os.path
 from sentry.models import Activity
 from sentry.services.smtp import SentrySMTPServer, STATUS
 from sentry.testutils import TestCase
-from sentry.utils.email import group_id_to_email, email_to_group_id
+from sentry.utils.email import (
+    group_id_to_email, email_to_group_id, _CaseInsensitiveSigner,
+)
 
 fixture = open(os.path.dirname(os.path.realpath(__file__)) + '/email.txt').read()
 
@@ -37,3 +39,12 @@ class SentrySMTPTest(TestCase):
     def test_process_message_invalid_email(self):
         with self.tasks():
             self.assertEqual(self.server.process_message('', self.user.email, ['lol@localhost'], fixture), STATUS[550])
+
+
+class CaseInsensitiveSignerTests(TestCase):
+    def test_it_works(self):
+        with self.settings(SECRET_KEY='a'):
+            signer = _CaseInsensitiveSigner()
+            assert signer.unsign(signer.sign('foo')) == 'foo'
+            assert signer.sign('foo') == 'foo:wkpxg5djz3d4m0zktktfl9hdzw4'
+            assert signer.unsign('foo:WKPXG5DJZ3D4M0ZKTKTFL9HDZW4') == 'foo'


### PR DESCRIPTION
Airmail treats email addresses as case-insensitive, which causes email
replies to not work since the signature is mutated, and we're rejecting
it (rightfully so). This change causes us to just force all signatures
as lowercase, losing some entropy as well. This is fine for our case
since it doesn't matter if it's cryptographically secure, we just want
to make sure the value is correct. The value is ultimately verified for
permission anyways even if somehow, a signature conflicted.

See open issue on Airmail at:
https://airmail.tenderapp.com/help/discussions/287/113-case-sensitive-email-addresses-being-sent-out-as-all-lowercase

Watch Airmail in action:

![image](https://i.imgur.com/h2KixVT.gif)
