### PR TITLE
Use Router.Link for pagination links

### DIFF
--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import utils from '../utils';
+import {Link} from 'react-router';
 
 const Pagination = React.createClass({
   propTypes: {
-    onPage: React.PropTypes.func.isRequired,
     pageLinks: React.PropTypes.string.isRequired,
   },
 
-  onPage(cursor) {
-    this.props.onPage(cursor);
+  contextTypes: {
+    location: React.PropTypes.object
   },
 
   render(){
@@ -28,19 +28,23 @@ const Pagination = React.createClass({
       nextPageClassName += ' disabled';
     }
 
+    let location = this.context.location;
     return (
       <div className="stream-pagination">
         <div className="btn-group pull-right">
-          <a className={previousPageClassName}
-             disabled={links.previous.results === false}
-             onClick={this.onPage.bind(this, links.previous.cursor)}>
+          <Link
+            to={this.props.to || location.pathname}
+            query={{...location.query, cursor: links.previous.cursor}}
+            className={previousPageClassName}
+            disabled={links.previous.results === false}>
             <span title="Previous" className="icon-arrow-left"></span>
-          </a>
-          <a className={nextPageClassName}
-             disabled={links.next.results === false}
-             onClick={this.onPage.bind(this, links.next.cursor)}>
+          </Link>
+          <Link to={this.props.to || location.pathname}
+            query={{...location.query, cursor: links.next.cursor}}
+            className={nextPageClassName}
+            disabled={links.next.results === false}>
             <span title="Next" className="icon-arrow-right"></span>
-          </a>
+          </Link>
         </div>
       </div>
     );

--- a/src/sentry/static/sentry/app/views/adminOrganizations.jsx
+++ b/src/sentry/static/sentry/app/views/adminOrganizations.jsx
@@ -1,4 +1,3 @@
-import jQuery from 'jquery';
 import React from 'react';
 import {Link, History} from 'react-router';
 
@@ -62,13 +61,6 @@ const AdminOrganizations = React.createClass({
         });
       }
     });
-  },
-
-  onPage(cursor) {
-    let queryParams = jQuery.extend({}, this.props.location.query, {
-      cursor: cursor
-    });
-    this.history.pushState(null, '/manage/organizations/', queryParams);
   },
 
   onSearch(query) {
@@ -163,7 +155,7 @@ const AdminOrganizations = React.createClass({
             ))}
           </tbody>
         </table>
-        <Pagination pageLinks={this.state.pageLinks} onPage={this.onPage} />
+        <Pagination pageLinks={this.state.pageLinks}/>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -30,7 +30,8 @@ const GroupEvents = React.createClass({
   },
 
   componentDidUpdate(prevProps) {
-    if (prevProps.params.groupId !== this.props.params.groupId) {
+    if (prevProps.params.groupId !== this.props.params.groupId ||
+      prevProps.location.search !== this.props.location.search) {
       this.fetchData();
     }
   },
@@ -61,17 +62,6 @@ const GroupEvents = React.createClass({
         });
       }
     });
-  },
-
-  onPage(cursor) {
-    let queryParams = {...this.props.location.query, cursor: cursor};
-
-    let {orgId, projectId, groupId} = this.props.params;
-    this.history.pushState(
-      null,
-      `/${orgId}/${projectId}/group/${groupId}/events/`,
-      queryParams
-    );
   },
 
   render() {
@@ -159,7 +149,7 @@ const GroupEvents = React.createClass({
             </tbody>
           </table>
         </div>
-        <Pagination pageLinks={this.state.pageLinks} onPage={this.onPage} />
+        <Pagination pageLinks={this.state.pageLinks}/>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -30,6 +30,12 @@ const GroupTagValues = React.createClass({
     this.fetchData();
   },
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.location.search !== this.props.location.search) {
+      this.fetchData();
+    }
+  },
+
   fetchData() {
     let params = this.props.params;
     let queryParams = this.props.location.query;
@@ -70,14 +76,6 @@ const GroupTagValues = React.createClass({
         });
       }
     });
-  },
-
-  onPage(cursor) {
-    let queryParams = jQuery.extend({}, this.props.location.query, {
-      cursor: cursor
-    });
-
-    this.history.pushState(null, this.props.location.pathname, queryParams);
   },
 
   render() {
@@ -138,7 +136,7 @@ const GroupTagValues = React.createClass({
             {children}
           </tbody>
         </table>
-        <Pagination pageLinks={this.state.pageLinks} onPage={this.onPage} />
+        <Pagination pageLinks={this.state.pageLinks}/>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/groupUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/groupUserReports.jsx
@@ -28,6 +28,12 @@ const GroupUserReports = React.createClass({
     this.fetchData();
   },
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.location.search !== this.props.location.search) {
+      this.fetchData();
+    }
+  },
+
   fetchData() {
     let queryParams = this.props.params;
     let querystring = $.param(queryParams);
@@ -53,17 +59,6 @@ const GroupUserReports = React.createClass({
         });
       }
     });
-  },
-
-  onPage(cursor) {
-    let queryParams = $.extend({}, this.props.location.query, {cursor: cursor});
-
-    let {orgId, projectId, groupId} = this.props.params;
-    this.history.pushState(
-      null,
-      `/${orgId}/${projectId}/group/${groupId}/reports/`,
-      queryParams
-    );
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/projectEvents.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents.jsx
@@ -60,7 +60,9 @@ const ProjectEvents = React.createClass({
   },
 
   componentDidUpdate(prevProps, prevState) {
-    if (prevProps.params.projectId !== this.props.params.projectId) {
+    if (prevProps.params.projectId !== this.props.params.projectId ||
+      prevProps.location.search !== this.props.location.search)
+    {
       this._poller.disable();
       this.fetchData();
     }
@@ -149,14 +151,6 @@ const ProjectEvents = React.createClass({
     }
   },
 
-  onPage(cursor) {
-    let queryParams = jQuery.extend({}, this.props.location.query, {
-      cursor: cursor
-    });
-
-    this.history.pushState(null, this.props.location.pathname, queryParams);
-  },
-
   transitionTo() {
     let queryParams = {};
 
@@ -235,7 +229,7 @@ const ProjectEvents = React.createClass({
             eventIds={this.state.eventIds} />
         </div>
         {this.renderBody()}
-        <Pagination pageLinks={this.state.pageLinks} onPage={this.onPage} />
+        <Pagination pageLinks={this.state.pageLinks}/>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -90,14 +90,6 @@ const ProjectReleases = React.createClass({
     return '/projects/' + params.orgId + '/' + params.projectId + '/releases/?' + jQuery.param(queryParams);
   },
 
-  onPage(cursor) {
-    let queryParams = $.extend({}, this.props.location.query);
-    queryParams.cursor = cursor;
-
-    let {orgId, projectId} = this.props.params;
-    this.history.pushState(null, `/${orgId}/${projectId}/releases/`, queryParams);
-  },
-
   getReleaseTrackingUrl() {
     let params = this.props.params;
 

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {History} from 'react-router';
-import jQuery from 'jquery';
 
 import api from '../api';
 import FileSize from '../components/fileSize';
@@ -63,15 +62,6 @@ const ReleaseArtifacts = React.createClass({
     });
   },
 
-  onPage(cursor) {
-    let queryParams = jQuery.extend({}, this.props.location.query, {
-      cursor: cursor
-    });
-
-    let {orgId, projectId, version} = this.props.params;
-    this.history.pushState(null, `/${orgId}/${projectId}/releases/${version}/artifacts/`, queryParams);
-  },
-
   render() {
     if (this.state.loading)
       return <LoadingIndicator />;
@@ -100,7 +90,7 @@ const ReleaseArtifacts = React.createClass({
           })}
           </tbody>
         </table>
-        <Pagination pageLinks={this.state.pageLinks} onPage={this.onPage} />
+        <Pagination pageLinks={this.state.pageLinks}/>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -230,10 +230,6 @@ const Stream = React.createClass({
         let links = parseLinkHeader(jqXHR.getResponseHeader('Link'));
         if (links && links.previous) {
           this._poller.setEndpoint(links.previous.href);
-
-          if (this.state.realtimeActive) {
-            this._poller.enable();
-          }
         }
       }
     });
@@ -286,14 +282,6 @@ const Stream = React.createClass({
     this.setState({
       tags: Object.assign({}, tags)
     });
-  },
-
-  onPage(cursor) {
-    let params = this.props.params;
-    let queryParams = $.extend({}, this.props.location.query);
-    queryParams.cursor = cursor;
-
-    this.history.pushState(null, `/${params.orgId}/${params.projectId}/`, queryParams);
   },
 
   onSearch(query) {
@@ -437,7 +425,7 @@ const Stream = React.createClass({
             </Sticky>
           </div>
           {this.renderStreamBody()}
-          <Pagination pageLinks={this.state.pageLinks} onPage={this.onPage} />
+          <Pagination pageLinks={this.state.pageLinks}/>
         </div>
         <StreamSidebar
           loading={this.state.tagsLoading}


### PR DESCRIPTION
Benefits:
- Less code (no more `onPage` handlers; transitions handled by router prop changes)
- Pagination links now show url + cursor query string (instead of nothing)

Writing pagination unit tests for all of the affected components felt a little daunting ... but we should at least try this on staging.
