### PR TITLE
Add is_configured to NotificationPlugin

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,7 @@ General
   back to ``VISIBLE``.
 - Membership permissions have been overhauled and have been flattened into a single tiered
   role. Additionally owners will no longer be automatically added to new teams.
+- ``NotificationPlugin`` now requires ``is_configured`` to be declared.
 
 Client API
 ~~~~~~~~~~

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -129,7 +129,13 @@ class NotificationPlugin(Plugin):
             limit=10,
         )
 
+    def is_configured(self, project):
+        raise NotImplementedError
+
     def should_notify(self, group, event):
+        if not self.is_configured(project=event.project):
+            return False
+
         if group.is_muted():
             return False
 

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -81,6 +81,10 @@ class MailPlugin(NotificationPlugin):
             project.slug,
         ]))
 
+    def is_configured(self, project, **kwargs):
+        # Nothing to configure here
+        return True
+
     def should_notify(self, group, event):
         send_to = self.get_sendable_users(group.project)
         if not send_to:


### PR DESCRIPTION
All of the upstream projects that we load in that subclass
NotificationPlugin, already implement is_configured(self, project). So
this adds that API to the base NotificationPlugin class, and enforces
that it's called before trying to send notifications.

Fixes GH-2319
