### PR TITLE
Use spread operator instead of $.extend/Object.assign

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard.jsx
@@ -19,9 +19,10 @@ const ProjectDashboard = React.createClass({
   },
 
   getInitialState() {
-    return jQuery.extend({}, {
-      statsPeriod: this.props.defaultStatsPeriod
-    }, this.getQueryStringState());
+    return {
+      statsPeriod: this.props.defaultStatsPeriod,
+      ...this.getQueryStringState()
+    };
   },
 
   componentWillMount() {
@@ -106,17 +107,17 @@ const ProjectDashboard = React.createClass({
             <div className="btn-group">
               <Link
                 to={url}
-                query={jQuery.extend({}, routeQuery, {statsPeriod: '1h'})}
+                query={{...routeQuery, statsPeriod: '1h'}}
                 active={statsPeriod === '1h'}
                 className={'btn btn-sm btn-default' + (statsPeriod === '1h' ? ' active' : '')}>1h</Link>
               <Link
                 to={url}
-                query={jQuery.extend({}, routeQuery, {statsPeriod: '24h'})}
+                query={{...routeQuery, statsPeriod: '24h'}}
                 active={statsPeriod === '24h'}
                 className={'btn btn-sm btn-default' + (statsPeriod === '24h' ? ' active' : '')}>24h</Link>
               <Link
                 to={url}
-                query={jQuery.extend({}, routeQuery, {statsPeriod: '1w'})}
+                query={{...routeQuery, statsPeriod: '1w'}}
                 className={'btn btn-sm btn-default' + (statsPeriod === '1w' ? ' active' : '')}>1w</Link>
             </div>
           </div>

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -83,9 +83,11 @@ const ProjectReleases = React.createClass({
 
   getProjectReleasesEndpoint() {
     let params = this.props.params;
-    let queryParams = $.extend({}, this.props.location.query);
-    queryParams.limit = 50;
-    queryParams.query = this.state.query;
+    let queryParams = {
+      ...this.props.location.query,
+      limit: 50,
+      query: this.state.query
+    };
 
     return '/projects/' + params.orgId + '/' + params.projectId + '/releases/?' + jQuery.param(queryParams);
   },

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
 import {History} from 'react-router';
-import $ from 'jquery';
 import Cookies from 'js-cookie';
 import Sticky from 'react-sticky';
 import classNames from 'classnames';
@@ -45,7 +44,7 @@ const Stream = React.createClass({
   },
 
   getInitialState() {
-    return $.extend({}, {
+    return {
       groupIds: [],
       selectAllActive: false,
       multiSelected: false,
@@ -61,8 +60,9 @@ const Stream = React.createClass({
       tags: StreamTagStore.getAllTags(),
       tagsLoading: true,
       isSidebarVisible: false,
-      isStickyHeader: false
-    }, this.getQueryStringState());
+      isStickyHeader: false,
+      ...this.getQueryStringState()
+    };
   },
 
   componentWillMount() {
@@ -184,10 +184,11 @@ const Stream = React.createClass({
 
     let url = this.getGroupListEndpoint();
 
-    let requestParams = $.extend({}, this.props.location.query, {
+    let requestParams = {
+      ...this.props.location.query,
       limit: this.props.maxItems,
       statsPeriod: this.state.statsPeriod
-    });
+    };
 
     if (!requestParams.hasOwnProperty('query')) {
       requestParams.query = this.props.defaultQuery;
@@ -280,7 +281,7 @@ const Stream = React.createClass({
   onStreamTagChange(tags) {
     // new object to trigger state change
     this.setState({
-      tags: Object.assign({}, tags)
+      tags: {...tags}
     });
   },
 


### PR DESCRIPTION
I feel we should use spread operator where possible, instead of adding jQuery `$.extend` dependency.
