### PR TITLE
Enable overriding digest minimum, maximum, and incremental delays.

### DIFF
--- a/src/sentry/digests/backends/base.py
+++ b/src/sentry/digests/backends/base.py
@@ -95,7 +95,7 @@ class Backend(object):
     def validate(self):
         pass
 
-    def add(self, key, record):
+    def add(self, key, record, increment_delay=None, maximum_delay=None):
         """
         Add a record to a timeline.
 
@@ -110,7 +110,7 @@ class Backend(object):
         """
         raise NotImplementedError
 
-    def digest(self, key):
+    def digest(self, key, minimum_delay=None):
         """
         Extract records from a timeline for processing.
 

--- a/src/sentry/digests/backends/base.py
+++ b/src/sentry/digests/backends/base.py
@@ -50,13 +50,13 @@ class Backend(object):
     be transitioned to "waiting" instead.)
     """
     def __init__(self, **options):
-        # The ``minimum_delay`` option defines the minimum amount of time (in
-        # seconds) to wait between scheduling digests for delivery after the
-        # initial scheduling.
+        # The ``minimum_delay`` option defines the default minimum amount of
+        # time (in seconds) to wait between scheduling digests for delivery
+        # after the initial scheduling.
         self.minimum_delay = options.pop('minimum_delay', 60 * 5)
 
-        # The ``maximum_delay`` option defines the maximum amount of time (in
-        # seconds) to wait between scheduling digests for delivery.
+        # The ``maximum_delay`` option defines the default maximum amount of
+        # time (in seconds) to wait between scheduling digests for delivery.
         self.maximum_delay = options.pop('maximum_delay', 60 * 30)
 
         # The ``increment_delay`` option defines how long each observation of

--- a/src/sentry/digests/backends/base.py
+++ b/src/sentry/digests/backends/base.py
@@ -50,10 +50,10 @@ class Backend(object):
     be transitioned to "waiting" instead.)
     """
     def __init__(self, **options):
-        # The ``interval`` option defines the minimum amount of time (in
+        # The ``minimum_delay`` option defines the minimum amount of time (in
         # seconds) to wait between scheduling digests for delivery after the
         # initial scheduling.
-        self.interval = options.pop('interval', 60 * 5)
+        self.minimum_delay = options.pop('minimum_delay', 60 * 5)
 
         # The ``maximum_delay`` option defines the maximum amount of time (in
         # seconds) to wait between scheduling digests for delivery.

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -523,7 +523,7 @@ class RedisBackend(Backend):
 
                     cleanup_records(pipeline)
                     pipeline.zrem(make_schedule_key(self.namespace, SCHEDULE_STATE_READY), key)
-                    pipeline.zadd(make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING), time.time() + self.interval, key)
+                    pipeline.zadd(make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING), time.time() + self.minimum_delay, key)
                     pipeline.setex(make_last_processed_timestamp_key(timeline_key), self.ttl, int(time.time()))
                     pipeline.execute()
 

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -232,8 +232,11 @@ class RedisBackend(Backend):
         )
 
     def add(self, key, record, increment_delay=None, maximum_delay=None):
-        increment_delay = increment_delay if increment_delay is not None else self.increment_delay
-        maximum_delay = maximum_delay if maximum_delay is not None else self.maximum_delay
+        if increment_delay is None:
+            increment_delay = self.increment_delay
+
+        if maximum_delay is None:
+            maximum_delay = self.maximum_delay
 
         timeline_key = make_timeline_key(self.namespace, key)
         record_key = make_record_key(timeline_key, record.key)
@@ -461,7 +464,8 @@ class RedisBackend(Backend):
 
     @contextmanager
     def digest(self, key, minimum_delay=None):
-        minimum_delay = minimum_delay if minimum_delay is not None else self.minimum_delay
+        if minimum_delay is None:
+            minimum_delay = self.minimum_delay
 
         timeline_key = make_timeline_key(self.namespace, key)
         digest_key = make_digest_key(timeline_key)

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -80,7 +80,9 @@ class NotificationPlugin(Plugin):
 
             if features.has('projects:digests:store', project):
                 key = unsplit_key(self, event.group.project)
-                if digests.add(key, event_to_record(event, rules)):
+                increment_delay = self.get_option('digests:increment_delay', project=project)
+                maximum_delay = self.get_option('digests:maximum_delay', project=project)
+                if digests.add(key, event_to_record(event, rules), increment_delay=increment_delay, maximum_delay=maximum_delay):
                     deliver_digest.delay(key)
 
         else:

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -21,7 +21,10 @@ from sentry.digests.notifications import (
     unsplit_key,
 )
 from sentry.plugins import Notification, Plugin
-from sentry.models import UserOption
+from sentry.models import (
+    ProjectOption,
+    UserOption,
+)
 from sentry.tasks.digests import deliver_digest
 
 
@@ -79,11 +82,19 @@ class NotificationPlugin(Plugin):
                 self.notify(notification)
 
             if features.has('projects:digests:store', project):
-                key = unsplit_key(self, event.group.project)
-                increment_delay = self.get_option('digests:increment_delay', project=project)
-                maximum_delay = self.get_option('digests:maximum_delay', project=project)
-                if digests.add(key, event_to_record(event, rules), increment_delay=increment_delay, maximum_delay=maximum_delay):
-                    deliver_digest.delay(key)
+                get_digest_option = lambda key: ProjectOption.objects.get_value(
+                    project,
+                    '{0}:digests:{1}'.format(self.get_conf_key(), key),
+                )
+                digest_key = unsplit_key(self, event.group.project)
+                immediate_delivery = digests.add(
+                    digest_key,
+                    event_to_record(event, rules),
+                    increment_delay=get_digest_option('increment_delay'),
+                    maximum_delay=get_digest_option('maximum_delay'),
+                )
+                if immediate_delivery:
+                    deliver_digest.delay(digest_key)
 
         else:
             notification = Notification(event=event, rules=rules)

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -6,6 +6,7 @@ from sentry.digests.notifications import (
     build_digest,
     split_key,
 )
+from sentry.models import ProjectOption
 from sentry.tasks.base import instrumented_task
 
 
@@ -39,7 +40,10 @@ def deliver_digest(key, schedule_timestamp=None):
     from sentry.app import digests
 
     plugin, project = split_key(key)
-    minimum_delay = plugin.get_option('digests:minimum_delay', project=project)
+    minimum_delay = ProjectOption.objects.get_value(
+        project,
+        '{0}:digests:{1}'.format(plugin.get_conf_key(), 'minimum_delay'),
+    )
     with digests.digest(key, minimum_delay=minimum_delay) as records:
         digest = build_digest(project, records)
 

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -39,7 +39,8 @@ def deliver_digest(key, schedule_timestamp=None):
     from sentry.app import digests
 
     plugin, project = split_key(key)
-    with digests.digest(key) as records:
+    minimum_delay = plugin.get_option('digests:minimum_delay', project=project)
+    with digests.digest(key, minimum_delay=minimum_delay) as records:
         digest = build_digest(project, records)
 
     if digest:

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -247,7 +247,7 @@ class DigestTestCase(BaseRedisBackendTestCase):
                 entries = list(entries)
                 assert entries == records[::-1]
 
-            next_scheduled_delivery = timestamp + backend.interval
+            next_scheduled_delivery = timestamp + backend.minimum_delay
             assert client.zscore(waiting_set_key, timeline) == next_scheduled_delivery
             assert int(client.get(make_last_processed_timestamp_key(timeline_key))) == int(timestamp)
 
@@ -314,4 +314,4 @@ class DigestTestCase(BaseRedisBackendTestCase):
                 entries = list(entries)
                 assert entries == (records + extra)[::-1]
 
-            assert client.zscore(waiting_set_key, timeline) == timestamp + backend.interval
+            assert client.zscore(waiting_set_key, timeline) == timestamp + backend.minimum_delay


### PR DESCRIPTION
This allows tuning digest delivery on a per-project basis.

This is the backend component for GH-2328.
