### PR TITLE
Added a copy of the sentry/bases/auth.html template to 7.7.x

### DIFF
--- a/src/sentry/templates/sentry/bases/auth.html
+++ b/src/sentry/templates/sentry/bases/auth.html
@@ -1,0 +1,15 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block wrapperclass %}narrow auth org-login hide-sidebar{% endblock %}
+
+{% block main %}
+  <section class="body org-login">
+    {% block auth_main %}{% endblock %}
+  </section>
+{% endblock %}
+
+{% block footer %}
+{% endblock %}


### PR DESCRIPTION
When I try to enable GitHub authorization (after installing [sentry-auth-github](https://github.com/getsentry/sentry-auth-github)) I get an error -- TemplateDoesNotExist is raised as Django is unable to locate sentry/bases/auth.html. This pull requests corrects this behaviour for sentry 7.7.x by placing a copy of the template (taken over from master branch) in sentry/bases subfolder.
