### PR TITLE
Improve Java stack frame formatting.

### DIFF
--- a/src/sentry/templates/sentry/partial/frames/java.txt
+++ b/src/sentry/templates/sentry/partial/frames/java.txt
@@ -1,4 +1,4 @@
 {% load sentry_helpers %}{% autoescape off %}
-    at {% if filename %}{{ filename }}{% elif module %}{{ module }}{% else %}?{% endif %}{% if function %}.{{ function }}{% endif %}{% if filename %}({{ filename|basename }}{% if lineno != None %}:{{ lineno }}{% endif %}){% endif %}{% if context_line %}
+    at {% if module %}{{ module }}.{% endif %}{% if function %}{{ function }}{% endif %}{% if filename %}({{ filename|basename }}{% if lineno >= 0 %}:{{ lineno }}{% endif %}){% endif %}{% if context_line %}
     {{ context_line.strip }}{% endif %}
 {% endautoescape %}


### PR DESCRIPTION
This makes the formatting consistent with the [reference
implementation](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8u40-b25/java/lang/StackTraceElement.java#StackTraceElement.toString%28%29) as well as the [JavaScript implementation](https://github.com/getsentry/sentry/blob/38efc3472787c8969f25b33a1e69624979151173/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx#L74-L90)
used in the web UI.
