### PR TITLE
Clarify comment in autogenerated sentry.conf.py

### DIFF
--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -179,7 +179,7 @@ SENTRY_FILESTORE_OPTIONS = {
 # You MUST configure the absolute URI root for Sentry:
 SENTRY_URL_PREFIX = 'http://sentry.example.com'  # No trailing slash!
 
-# If you're using a reverse proxy, you should enable the X-Forwarded-Proto
+# If you're using a reverse SSL proxy, you should enable the X-Forwarded-Proto
 # header and uncomment the following settings
 # SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
I've hit the same issue as in #2069: My sentry setup is "behind reverse proxy", so I figured I should enable `HTTP_SECURE_COOKIE`. I wasn't really aware of this option's effect -- that is, only allowing cookies to be set from a HTTPS connection. Since my setup doesn't include any SSL, this broke login for me.
