### PR TITLE
Refactoring of sentry.options for more structure

### DIFF
--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -15,3 +15,4 @@ default_manager = OptionsManager()
 get = default_manager.get
 set = default_manager.set
 delete = default_manager.delete
+register = default_manager.register

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -72,7 +72,7 @@ class OptionsManager(object):
         if logger is not None:
             self.logger = logger
 
-        self.registy = {}
+        self.registry = {}
 
     def _make_cache_key(self, key):
         return 'o:{0}'.format(md5(key).hexdigest())

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -118,6 +118,8 @@ class OptionsManager(object):
             # we special case them here and construct a faux key until we migrate.
             if key[:7] == 'sentry:':
                 self.logger.info('Using legacy key: %s', key, exc_info=True)
+                # History shows, there was an expectation of no types, and empty string
+                # as the default response value
                 return Key(key, '', object, self.FLAG_DEFAULT, self._make_cache_key(key))
             raise UnknownOption(key)
 

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -129,6 +129,8 @@ class OptionsManager(object):
         >>> from sentry import options
         >>> options.get('option')
         """
+        # TODO(mattrobenolt): Perform validation on key returned for type Justin Case
+        # values change. This case is unlikely, but good to cover our bases.
         opt = self.lookup_key(key)
 
         if not (opt.flags & self.FLAG_NOSTORE):

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -48,7 +48,7 @@ class OptionsManager(object):
     """
     cache = default_cache
     logger = logging.getLogger('sentry')
-    registry = {}
+    registry = None
 
     # we generally want to always persist
     ttl = None
@@ -71,6 +71,8 @@ class OptionsManager(object):
 
         if logger is not None:
             self.logger = logger
+
+        self.registy = {}
 
     def _make_cache_key(self, key):
         return 'o:{0}'.format(md5(key).hexdigest())

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -23,6 +23,8 @@ CACHE_FETCH_ERR = 'Unable to fetch option cache for %s'
 CACHE_UPDATE_ERR = 'Unable to update option cache for %s'
 
 Key = namedtuple('Key', ('name', 'default', 'type', 'flags', 'cache_key'))
+# Prevent outselves from clobbering the builtin
+_type = type
 
 
 class UnknownOption(KeyError):
@@ -93,7 +95,7 @@ class OptionsManager(object):
         assert not (opt.flags & self.FLAG_IMMUTABLE), '%r cannot be changed at runtime' % key
 
         if not isinstance(value, opt.type):
-            raise TypeError('got %r, expected %r' % (type(value), opt.type))
+            raise TypeError('got %r, expected %r' % (_type(value), opt.type))
 
         create_or_update(
             model=Option,
@@ -209,6 +211,8 @@ class OptionsManager(object):
 
     def register(self, key, default='', type=basestring, flags=FLAG_DEFAULT):
         assert key not in self.registry, 'Option already registered: %r' % key
+        if not isinstance(default, type):
+            raise TypeError('got %r, expected %r' % (_type(default), type))
         self.registry[key] = Key(key, default, type, flags, self._make_cache_key(key))
 
     def unregister(self, key):

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -113,7 +113,7 @@ class OptionsManager(object):
             # Fortunately, they all share the same prefix, 'sentry:', so
             # we special case them here and construct a faux key until we migrate.
             if key[:7] == 'sentry:':
-                self.logger.info('Using legacy key: %s', key, exc_info=True)
+                self.logger.debug('Using legacy key: %s', key, exc_info=True)
                 # History shows, there was an expectation of no types, and empty string
                 # as the default response value
                 return Key(key, '', object, self.DEFAULT_FLAGS, self._make_cache_key(key))

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -56,7 +56,7 @@ class OptionsManager(object):
     # we generally want to always persist
     ttl = None
 
-    FLAG_DEFAULT = 0b000
+    DEFAULT_FLAGS = 0b000
     # Value can't be changed at runtime
     FLAG_IMMUTABLE = 0b001
     # Don't check/set in the datastore. Option only exists from file.
@@ -125,7 +125,7 @@ class OptionsManager(object):
                 self.logger.info('Using legacy key: %s', key, exc_info=True)
                 # History shows, there was an expectation of no types, and empty string
                 # as the default response value
-                return Key(key, '', object, self.FLAG_DEFAULT, self._make_cache_key(key))
+                return Key(key, '', object, self.DEFAULT_FLAGS, self._make_cache_key(key))
             raise UnknownOption(key)
 
     def get(self, key):
@@ -210,7 +210,7 @@ class OptionsManager(object):
     def update_cached_value(self, cache_key, value):
         self.cache.set(cache_key, value, self.ttl)
 
-    def register(self, key, default='', type=basestring, flags=FLAG_DEFAULT):
+    def register(self, key, default='', type=basestring, flags=DEFAULT_FLAGS):
         assert key not in self.registry, 'Option already registered: %r' % key
         # We disallow None as a value for options since this is ambiguous and doesn't
         # really make sense as config options. There should be a sensible default

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 from collections import namedtuple
+from types import NoneType
 
 from django.conf import settings
 from django.utils import timezone
@@ -211,6 +212,11 @@ class OptionsManager(object):
 
     def register(self, key, default='', type=basestring, flags=FLAG_DEFAULT):
         assert key not in self.registry, 'Option already registered: %r' % key
+        # We disallow None as a value for options since this is ambiguous and doesn't
+        # really make sense as config options. There should be a sensible default
+        # value instead that matches the type expected, rather than relying on None.
+        if type is NoneType:
+            raise TypeError('Options must not be NoneType')
         if not isinstance(default, type):
             raise TypeError('got %r, expected %r' % (_type(default), type))
         self.registry[key] = Key(key, default, type, flags, self._make_cache_key(key))

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -57,6 +57,26 @@ class OptionsManagerTest(TestCase):
         self.manager.get('sentry:foo')
         self.manager.set('sentry:foo', 'bar')
 
+    def test_types(self):
+        self.manager.register('some-int', type=int)
+        with self.assertRaises(TypeError):
+            self.manager.set('some-int', 'foo')
+        self.manager.set('some-int', 1)
+        assert self.manager.get('some-int') == 1
+
+    def test_default(self):
+        self.manager.register('awesome', default='lol')
+        assert self.manager.get('awesome') == 'lol'
+        self.manager.set('awesome', 'bar')
+        assert self.manager.get('awesome') == 'bar'
+        self.manager.delete('awesome')
+        assert self.manager.get('awesome') == 'lol'
+
+    def test_immutible(self):
+        self.manager.register('immutible', flags=OptionsManager.FLAG_IMMUTABLE)
+        with self.assertRaises(AssertionError):
+            self.manager.set('immutible', 'thing')
+
     def test_db_unavailable(self):
         with patch.object(Option.objects, 'get_queryset', side_effect=Exception()):
             # we can't update options if the db is unavailable

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -79,12 +79,12 @@ class OptionsManagerTest(TestCase):
         self.manager.delete('awesome')
         assert self.manager.get('awesome') == 'lol'
 
-    def test_flag_immutible(self):
-        self.manager.register('immutible', flags=OptionsManager.FLAG_IMMUTABLE)
+    def test_flag_immutable(self):
+        self.manager.register('immutable', flags=OptionsManager.FLAG_IMMUTABLE)
         with self.assertRaises(AssertionError):
-            self.manager.set('immutible', 'thing')
+            self.manager.set('immutable', 'thing')
         with self.assertRaises(AssertionError):
-            self.manager.delete('immutible')
+            self.manager.delete('immutable')
 
     def test_flag_nostore(self):
         self.manager.register('nostore', flags=OptionsManager.FLAG_NOSTORE)

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -35,7 +35,7 @@ class OptionsManagerTest(TestCase):
 
         assert self.manager.get('foo') == ''
 
-    def test_unregistered_key(self):
+    def test_register(self):
         with self.assertRaises(UnknownOption):
             self.manager.get('does-not-exit')
 
@@ -53,6 +53,9 @@ class OptionsManagerTest(TestCase):
             # This key should already exist, and we can't re-register
             self.manager.register('foo')
 
+        with self.assertRaises(TypeError):
+            self.manager.register('wrong-type', default=1, type=basestring)
+
     def test_legacy_key(self):
         """
         Allow sentry: prefixed keys without any registration
@@ -65,7 +68,7 @@ class OptionsManagerTest(TestCase):
         assert self.manager.get('sentry:foo') == ''
 
     def test_types(self):
-        self.manager.register('some-int', type=int)
+        self.manager.register('some-int', type=int, default=0)
         with self.assertRaises(TypeError):
             self.manager.set('some-int', 'foo')
         self.manager.set('some-int', 1)

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -159,3 +159,7 @@ class OptionsManagerTest(TestCase):
 
             with patch.object(self.manager.cache, 'set', side_effect=Exception()):
                 assert self.manager.get('foo') == 'baz'
+
+    def test_unregister(self):
+        with self.assertRaises(UnknownOption):
+            self.manager.unregister('does-not-exist')

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -56,6 +56,9 @@ class OptionsManagerTest(TestCase):
         with self.assertRaises(TypeError):
             self.manager.register('wrong-type', default=1, type=basestring)
 
+        with self.assertRaises(TypeError):
+            self.manager.register('none-type', default=None, type=type(None))
+
     def test_legacy_key(self):
         """
         Allow sentry: prefixed keys without any registration


### PR DESCRIPTION
This is a refactor of `sentry.options` with the goals of disallowing free-form options, and instead having more structured keys.

The end goal of this is to start replacing most of our Django `settings` variables and replacing with `sentry.options`, but this means now we have a bunch of magic strings floating around.

Restructuring this makes sure that we don't accidentally use unregistered keys, and also gives plugins a way of registering config options.

There's also an introduction of flags which allows keys to have different permissions defined at registration. For example, to declare a key as something that can't be changed at runtime vs keys that only exist in database, and not from disk config file, etc.

This is backwards compatible with all of our uses today.
