### PR TITLE
Support bulk mutations on issues

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from datetime import datetime, timedelta
 from django.db import IntegrityError, transaction
-from django.db.models import Q
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
@@ -68,6 +67,10 @@ STATUS_CHOICES = {
 }
 
 
+class ValidationError(Exception):
+    pass
+
+
 class GroupSerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=zip(
         STATUS_CHOICES.keys(), STATUS_CHOICES.keys()
@@ -93,6 +96,70 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             return datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%fZ').replace(
                 tzinfo=timezone.utc,
             )
+
+    def _build_query_params_from_request(self, request, project):
+        query_kwargs = {
+            'project': project,
+        }
+
+        if request.GET.get('status'):
+            try:
+                query_kwargs['status'] = STATUS_CHOICES[request.GET['status']]
+            except KeyError:
+                raise ValidationError('invalid status')
+
+        if request.user.is_authenticated() and request.GET.get('bookmarks'):
+            query_kwargs['bookmarked_by'] = request.user
+
+        if request.user.is_authenticated() and request.GET.get('assigned'):
+            query_kwargs['assigned_to'] = request.user
+
+        sort_by = request.GET.get('sort')
+        if sort_by is None:
+            sort_by = DEFAULT_SORT_OPTION
+
+        query_kwargs['sort_by'] = sort_by
+
+        tags = {}
+        for tag_key in TagKey.objects.all_keys(project):
+            if request.GET.get(tag_key):
+                tags[tag_key] = request.GET[tag_key]
+        if tags:
+            query_kwargs['tags'] = tags
+
+        # TODO: dates should include timestamps
+        date_from = request.GET.get('since')
+        date_to = request.GET.get('until')
+        date_filter = request.GET.get('date_filter')
+
+        limit = request.GET.get('limit')
+        if limit:
+            try:
+                query_kwargs['limit'] = int(limit)
+            except ValueError:
+                raise ValidationError('invalid limit')
+
+        if date_from:
+            date_from = self._parse_date(date_from)
+
+        if date_to:
+            date_to = self._parse_date(date_to)
+
+        query_kwargs['date_from'] = date_from
+        query_kwargs['date_to'] = date_to
+        if date_filter:
+            query_kwargs['date_filter'] = date_filter
+
+        # TODO: proper pagination support
+        cursor = request.GET.get('cursor')
+        if cursor:
+            query_kwargs['cursor'] = Cursor.from_string(cursor)
+
+        query = request.GET.get('query', 'is:unresolved').strip()
+        if query:
+            query_kwargs.update(parse_query(project, query, request.user))
+
+        return query_kwargs
 
     # bookmarks=0/1
     # status=<x>
@@ -126,10 +193,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                                      belong to.
         :auth: required
         """
-        query_kwargs = {
-            'project': project,
-        }
-
         stats_period = request.GET.get('statsPeriod')
         if stats_period not in (None, '', '24h', '14d'):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
@@ -140,61 +203,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             # disable stats
             stats_period = None
 
-        if request.GET.get('status'):
-            try:
-                query_kwargs['status'] = STATUS_CHOICES[request.GET['status']]
-            except KeyError:
-                return Response('{"detail": "invalid status"}', status=400)
-
-        if request.user.is_authenticated() and request.GET.get('bookmarks'):
-            query_kwargs['bookmarked_by'] = request.user
-
-        if request.user.is_authenticated() and request.GET.get('assigned'):
-            query_kwargs['assigned_to'] = request.user
-
-        sort_by = request.GET.get('sort')
-        if sort_by is None:
-            sort_by = DEFAULT_SORT_OPTION
-
-        query_kwargs['sort_by'] = sort_by
-
-        tags = {}
-        for tag_key in TagKey.objects.all_keys(project):
-            if request.GET.get(tag_key):
-                tags[tag_key] = request.GET[tag_key]
-        if tags:
-            query_kwargs['tags'] = tags
-
-        # TODO: dates should include timestamps
-        date_from = request.GET.get('since')
-        date_to = request.GET.get('until')
-        date_filter = request.GET.get('date_filter')
-
-        limit = request.GET.get('limit')
-        if limit:
-            try:
-                query_kwargs['limit'] = int(limit)
-            except ValueError:
-                return Response('{"detail": "invalid limit"}', status=400)
-
-        if date_from:
-            date_from = self._parse_date(date_from)
-
-        if date_to:
-            date_to = self._parse_date(date_to)
-
-        query_kwargs['date_from'] = date_from
-        query_kwargs['date_to'] = date_to
-        if date_filter:
-            query_kwargs['date_filter'] = date_filter
-
-        # TODO: proper pagination support
-        cursor = request.GET.get('cursor')
-        if cursor:
-            query_kwargs['cursor'] = Cursor.from_string(cursor)
-
-        query = request.GET.get('query', 'is:unresolved').strip()
-        if len(query) == 32:
+        query = request.GET.get('query')
+        if query and len(query) == 32:
             # check to see if we've got an event ID
             try:
                 matching_event = EventMapping.objects.filter(
@@ -210,8 +220,10 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                     )
                 ))
 
-        if query is not None:
-            query_kwargs.update(parse_query(project, query, request.user))
+        try:
+            query_kwargs = self._build_query_params_from_request(request, project)
+        except ValidationError as exc:
+            return Response({'detail': unicode(exc)}, status=400)
 
         cursor_result = search.query(**query_kwargs)
 
@@ -292,7 +304,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             group_list = Group.objects.filter(project=project, id__in=group_ids)
             # filter down group ids to only valid matches
             group_ids = [g.id for g in group_list]
-
             if not group_ids:
                 return Response(status=204)
         else:
@@ -306,21 +317,25 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
 
         acting_user = request.user if request.user.is_authenticated() else None
 
-        # validate that we've passed a selector for non-status bulk operations
-        if not group_ids and result.keys() != ['status']:
-            return Response('{"detail": "You must specify a list of IDs for this operation"}', status=400)
-
-        if group_ids:
-            filters = [Q(id__in=group_ids)]
-        else:
-            filters = [Q(project=project)]
-
-        if request.GET.get('status'):
+        if not group_ids:
             try:
-                status_filter = STATUS_CHOICES[request.GET['status']]
-            except KeyError:
-                return Response('{"detail": "Invalid status"}', status=400)
-            filters.append(Q(status=status_filter))
+                query_kwargs = self._build_query_params_from_request(request, project)
+            except ValidationError as exc:
+                return Response({'detail': unicode(exc)}, status=400)
+
+            # bulk mutations are limited to 1000 items
+            # TODO(dcramer): it'd be nice to support more than this, but its
+            # a bit too complicated right now
+            query_kwargs['limit'] = 1000
+
+            cursor_result = search.query(**query_kwargs)
+
+            group_list = list(cursor_result)
+            group_ids = [g.id for g in group_list]
+
+        queryset = Group.objects.filter(
+            id__in=group_ids,
+        )
 
         if result.get('status') == 'resolvedInNextRelease':
             try:
@@ -344,13 +359,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                         group=group,
                     ), False
 
-                Group.objects.filter(
-                    id=group.id,
-                ).update(
-                    status=GroupStatus.RESOLVED,
-                    resolved_at=now,
-                )
-
                 if created:
                     activity = Activity.objects.create(
                         project=group.project,
@@ -365,6 +373,11 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                     )
                     activity.send_notification()
 
+            queryset.update(
+                status=GroupStatus.RESOLVED,
+                resolved_at=now,
+            )
+
             result.update({
                 'status': 'resolved',
                 'statusDetails': {
@@ -375,7 +388,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         elif result.get('status') == 'resolved':
             now = timezone.now()
 
-            happened = Group.objects.filter(*filters).exclude(
+            happened = queryset.exclude(
                 status=GroupStatus.RESOLVED,
             ).update(
                 status=GroupStatus.RESOLVED,
@@ -383,7 +396,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             )
 
             GroupResolution.objects.filter(
-                group__in=Group.objects.filter(*filters),
+                group__in=group_ids,
             ).delete()
 
             if group_list and happened:
@@ -403,14 +416,14 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         elif result.get('status'):
             new_status = STATUS_CHOICES[result['status']]
 
-            happened = Group.objects.filter(*filters).exclude(
+            happened = queryset.exclude(
                 status=new_status,
             ).update(
                 status=new_status,
             )
 
             GroupResolution.objects.filter(
-                group__in=Group.objects.filter(*filters),
+                group__in=group_ids,
             ).delete()
 
             if new_status == GroupStatus.MUTED:
@@ -431,7 +444,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                         }
                 else:
                     GroupSnooze.objects.filter(
-                        group__in=group_list,
+                        group__in=group_ids,
                     ).delete()
                     snooze_until = None
                     result['statusDetails'] = {}
@@ -480,7 +493,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         if result.get('isBookmarked'):
             for group in group_list:
                 GroupBookmark.objects.get_or_create(
-                    project=group.project,
+                    project=project,
                     group=group,
                     user=request.user,
                 )
@@ -491,9 +504,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             ).delete()
 
         if result.get('isPublic'):
-            Group.objects.filter(
-                id__in=group_ids,
-            ).update(is_public=True)
+            queryset.update(is_public=True)
             for group in group_list:
                 if group.is_public:
                     continue
@@ -505,9 +516,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                     user=acting_user,
                 )
         elif result.get('isPublic') is False:
-            Group.objects.filter(
-                id__in=group_ids,
-            ).update(is_public=False)
+            queryset.update(is_public=False)
             for group in group_list:
                 if not group.is_public:
                     continue

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -115,25 +115,6 @@ const StreamActions = React.createClass({
     });
   },
 
-  onResolveProject(event) {
-    this.actionSelectedGroups(this.props.actionTypes.ALL, (itemIds) => {
-      let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
-
-      api.bulkUpdate({
-        orgId: this.props.orgId,
-        projectId: this.props.projectId,
-        itemIds: itemIds,
-        data: {
-          status: 'resolved',
-        }
-      }, {
-        complete: () => {
-          IndicatorStore.remove(loadingIndicator);
-        }
-      });
-    });
-  },
-
   onSelectedGroupChange() {
     this.setState({
       selectAllActive: SelectedGroupStore.allSelected(),
@@ -173,13 +154,15 @@ const StreamActions = React.createClass({
                       'Are you sure you want to resolve these %d issues?',
                       count)
                }
+               confirmAllLabel={t('Resolve all matching issues')}
                confirmLabel={
-                 (count) => 
+                 (count) =>
                    tn('Resolve %d selected issue',
                       'Resolve %d selected issues',
                       count)
                }
                tooltip={t('Set Status to Resolved')}
+               canActionAll={true}
                onlyIfBulk={true}
                selectAllActive={this.state.selectAllActive}>
               <i aria-hidden="true" className="icon-checkmark"></i>
@@ -192,7 +175,7 @@ const StreamActions = React.createClass({
                neverConfirm={true}
                buttonTitle={t('Bookmark')}
                confirmLabel={
-                 (count) => 
+                 (count) =>
                    tn('Bookmark %d selected issue',
                       'Bookmark %d selected issues',
                       count)
@@ -213,20 +196,6 @@ const StreamActions = React.createClass({
               <MenuItem noAnchor={true}>
                 <ActionLink
                    actionTypes={this.props.actionTypes}
-                   className="action-resolve-project"
-                   onAction={this.onResolveProject}
-                   confirmationQuestion={t('Are you sure you want to resolve all issues within this project?')}
-                   extraDescription={t('This will resolve all unresolved issues throughout this project. This does not respect search filters.')}
-                   canActionAll={false}
-                   confirmLabel={t('Confirm')}
-                   selectAllActive={this.state.selectAllActive}>
-                  {t('Resolve all Issues in Project')}
-                </ActionLink>
-              </MenuItem>
-              <MenuItem divider={true} />
-              <MenuItem noAnchor={true}>
-                <ActionLink
-                   actionTypes={this.props.actionTypes}
                    className="action-merge"
                    disabled={!this.state.multiSelected}
                    onAction={this.onMerge}
@@ -237,7 +206,7 @@ const StreamActions = React.createClass({
                           count)
                    }
                    confirmLabel={
-                     (count) => 
+                     (count) =>
                        tn('Merge %d selected issue',
                           'Merge %d selected issues',
                           count)
@@ -253,7 +222,6 @@ const StreamActions = React.createClass({
                    className="action-remove-bookmark"
                    disabled={!this.state.anySelected}
                    onAction={this.onUpdate.bind(this, {isBookmarked: false})}
-                   neverConfirm={true}
                    confirmationQuestion={
                      (count) =>
                        tn('Are you sure you want to remove this %d issue from your bookmarks?',
@@ -261,7 +229,6 @@ const StreamActions = React.createClass({
                           count)
                    }
                    onlyIfBulk={true}
-                   canActionAll={false}
                    selectAllActive={this.state.selectAllActive}>
                  {t('Remove from Bookmarks')}
                 </ActionLink>
@@ -273,15 +240,21 @@ const StreamActions = React.createClass({
                    className="action-unresolve"
                    disabled={!this.state.anySelected}
                    onAction={this.onUpdate.bind(this, {status: 'unresolved'})}
-                   neverConfirm={true}
+                   confirmAllLabel={t('Unresolve all matching issues')}
+                   confirmationQuestion={
+                     (count) =>
+                       tn('Are you sure you want to unresolve these %d issue?',
+                          'Are you sure you want to unresolve these %d issues?',
+                          count)
+                   }
                    confirmLabel={
-                     (count) => 
+                     (count) =>
                        tn('Unresolve %d selected issue',
                           'Unresolve %d selected issues',
                           count)
                    }
-                   onlyIfBulk={false}
-                   canActionAll={false}
+                   onlyIfBulk={true}
+                   canActionAll={true}
                    selectAllActive={this.state.selectAllActive}
                    groupIds={this.props.groupIds}>
                  {t('Set status to: Unresolved')}
@@ -293,15 +266,21 @@ const StreamActions = React.createClass({
                    className="action-mute"
                    disabled={!this.state.anySelected}
                    onAction={this.onUpdate.bind(this, {status: 'muted'})}
-                   neverConfirm={true}
+                   confirmAllLabel={t('Mute all matching issues')}
+                   confirmationQuestion={
+                     (count) =>
+                       tn('Are you sure you want to mute these %d issue?',
+                          'Are you sure you want to mute these %d issues?',
+                          count)
+                   }
                    confirmLabel={
-                     (count) => 
+                     (count) =>
                        tn('Mute %d selected issue',
                           'Mute %d selected issues',
                           count)
                    }
-                   onlyIfBulk={false}
-                   canActionAll={false}
+                   onlyIfBulk={true}
+                   canActionAll={true}
                    selectAllActive={this.state.selectAllActive}>
                  {t('Set status to: Muted')}
                 </ActionLink>
@@ -320,7 +299,7 @@ const StreamActions = React.createClass({
                           count)
                    }
                    confirmLabel={
-                     (count) => 
+                     (count) =>
                        tn('Delete %d selected issue',
                           'Delete %d selected issues',
                           count)


### PR DESCRIPTION
This removes the separate action to "Resolve all issues in project" and implements the beginnings of bulk mutation based on filters. It's currently limited to the first 1,000 matches, which should cover most cases.

It exists on in the UI for:
- Resolve
- Unresolve
- Mute

![screenshot 2015-12-01 15 10 48](https://cloud.githubusercontent.com/assets/23610/11517355/c82672e6-983d-11e5-9cc7-7df82fa5a598.png)
