### PR TITLE
Clean up lingering api requests on unmount (fixes #2387)

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import GroupActions from './actions/groupActions';
 import TeamActions from './actions/teamActions';
 
-class Request {
+export class Request {
   constructor(xhr) {
     this.xhr = xhr;
     this.alive = true;
@@ -14,7 +14,7 @@ class Request {
   }
 }
 
-class Client {
+export class Client {
   constructor(options) {
     if (typeof options === 'undefined') {
       options = {};
@@ -48,6 +48,12 @@ class Client {
         return func.apply(req, args);
       }
     };
+  }
+
+  clear() {
+    for (let request of this.activeRequests) {
+      request.cancel();
+    }
   }
 
   request(path, options = {}) {
@@ -223,4 +229,3 @@ class Client {
   }
 }
 
-export default new Client();

--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -51,8 +51,8 @@ export class Client {
   }
 
   clear() {
-    for (let request of this.activeRequests) {
-      request.cancel();
+    for (let id in this.activeRequests) {
+      this.activeRequests[id].cancel();
     }
   }
 

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
 import classNames from 'classnames';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import Gravatar from '../components/gravatar';
 import GroupStore from '../stores/groupStore';
 import DropdownLink from './dropdownLink';
@@ -23,7 +23,8 @@ const AssigneeSelector = React.createClass({
     TooltipMixin({
       html: true,
       selector: '.tip'
-    })
+    }),
+    ApiMixin
   ],
 
   statics: {
@@ -92,12 +93,12 @@ const AssigneeSelector = React.createClass({
   },
 
   assignTo(member) {
-    api.assignTo({id: this.props.id, email: member.email});
+    this.api.assignTo({id: this.props.id, email: member.email});
     this.setState({filter: '', loading: true});
   },
 
   clearAssignTo() {
-    api.assignTo({id: this.props.id, email: ''});
+    this.api.assignTo({id: this.props.id, email: ''});
     this.setState({filter: '', loading: true});
   },
 

--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -43,7 +43,7 @@ const TagDistributionMeter = React.createClass({
       error: false
     });
 
-    this.apiRequest(url, {
+    this.api.request(url, {
       success: (data, _, jqXHR) => {
         this.setState({
           data: data,

--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import jQuery from 'jquery';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import GroupListHeader from '../components/groupListHeader';
 import GroupStore from '../stores/groupStore';
 import LoadingError from '../components/loadingError';
@@ -26,6 +26,7 @@ const GroupList = React.createClass({
   mixins: [
     ProjectState,
     Reflux.listenTo(GroupStore, 'onGroupChange'),
+    ApiMixin
   ],
 
   getDefaultProps() {
@@ -71,7 +72,7 @@ const GroupList = React.createClass({
       error: false
     });
 
-    api.request(this.getGroupListEndpoint(), {
+    this.api.request(this.getGroupListEndpoint(), {
       success: (data, _, jqXHR) => {
         this._streamManager.push(data);
 

--- a/src/sentry/static/sentry/app/components/header/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/header/broadcasts.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import DropdownLink from '../dropdownLink';
 import LoadingIndicator from '../loadingIndicator';
 import {t} from '../../locale';
 
 const Broadcasts = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
+
   getInitialState() {
     return {
       broadcasts: [],
@@ -37,7 +41,7 @@ const Broadcasts = React.createClass({
     if (this.poller) {
       window.clearTimeout(this.poller);
     }
-    api.request('/broadcasts/', {
+    this.api.request('/broadcasts/', {
       method: 'GET',
       success: (data) => {
         this.setState({
@@ -77,7 +81,7 @@ const Broadcasts = React.createClass({
     if (broadcastIds.length === 0)
       return;
 
-    api.request('/broadcasts/', {
+    this.api.request('/broadcasts/', {
       method: 'PUT',
       query: {id: broadcastIds},
       data: {

--- a/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 import AlertActions from '../actions/alertActions';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import {t} from '../locale';
 
 const ERR_JOIN = 'There was an error while trying to join the team.';
 
 const MissingProjectMembership = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
+
   getInitialState() {
     return {
       loading: false,
@@ -19,7 +23,7 @@ const MissingProjectMembership = React.createClass({
       loading: true
     });
 
-    api.joinTeam({
+    this.api.joinTeam({
       orgId: this.props.organization.slug,
       teamId: this.props.team.slug
     }, {

--- a/src/sentry/static/sentry/app/mixins/apiMixin.jsx
+++ b/src/sentry/static/sentry/app/mixins/apiMixin.jsx
@@ -1,33 +1,13 @@
-import api from '../api';
+import {Client} from '../api';
 
 let ApiMixin = {
   componentWillMount() {
-    this._pendingRequests = new Set();
-    this._id = 0;
+    this.api = new Client();
   },
 
   componentWillUnmount() {
-    this._pendingRequests.forEach((req) => {
-      req.cancel();
-    });
-  },
-
-  apiRequest(path, options) {
-    let self = this;
-
-    let completeFunc = options.complete;
-    options.complete = function(...params) {
-      self._pendingRequests.delete(this);
-
-      if (typeof completeFunc !== 'undefined') {
-        completeFunc.apply(this, params);
-      }
-    };
-
-    let req = api.request(path, options);
-    this._pendingRequests.add(req);
+    this.api.clear();
   }
 };
 
 export default ApiMixin;
-

--- a/src/sentry/static/sentry/app/views/adminOrganizations.jsx
+++ b/src/sentry/static/sentry/app/views/adminOrganizations.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link, History} from 'react-router';
 
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import Pagination from '../components/pagination';
@@ -9,7 +9,10 @@ import SearchBar from '../components/searchBar.jsx';
 import {t} from '../locale';
 
 const AdminOrganizations = React.createClass({
-  mixins: [History],
+  mixins: [
+    ApiMixin,
+    History
+  ],
 
   getInitialState() {
     let queryParams = this.props.location.query;
@@ -44,7 +47,7 @@ const AdminOrganizations = React.createClass({
   fetchData() {
     let queryParams = this.props.location.query;
 
-    api.request(`/organizations/`, {
+    this.api.request(`/organizations/`, {
       method: 'GET',
       data: queryParams,
       success: (data, _, jqXHR) => {

--- a/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import FlotChart from '../../components/flotChart';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 
 const ApiChart = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
+
   getInitialState() {
     return {
       error: false,
@@ -30,7 +34,7 @@ const ApiChart = React.createClass({
     ];
 
     statNameList.forEach((statName) => {
-      api.request('/internal/stats/', {
+      this.api.request('/internal/stats/', {
         method: 'GET',
         data: {
           since: this.props.since,

--- a/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
@@ -1,12 +1,16 @@
 import jQuery from 'jquery';
 import React from 'react';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import FlotChart from '../../components/flotChart';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 
 const EventChart = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
+
   getInitialState() {
     return {
       error: false,
@@ -33,7 +37,7 @@ const EventChart = React.createClass({
     statNameList.forEach((statName) => {
       // query the organization stats via a separate call as its possible the project stats
       // are too heavy
-      api.request('/internal/stats/', {
+      this.api.request('/internal/stats/', {
         method: 'GET',
         data: {
           since: this.props.since,

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import Alerts from '../components/alerts';
 import AlertActions from '../actions/alertActions.jsx';
 import Indicators from '../components/indicators';
@@ -8,6 +8,10 @@ import OrganizationStore from '../stores/organizationStore';
 import ConfigStore from '../stores/configStore';
 
 const App = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
+
   getInitialState() {
     return {
       loading: false,
@@ -16,7 +20,7 @@ const App = React.createClass({
   },
 
   componentWillMount() {
-    api.request('/organizations/', {
+    this.api.request('/organizations/', {
       query: {
         'member': '1'
       },
@@ -34,7 +38,7 @@ const App = React.createClass({
       }
     });
 
-    api.request('/internal/health/', {
+    this.api.request('/internal/health/', {
       success: (data) => {
         if (data && data.problems) {
           data.problems.forEach(problem => {
@@ -48,7 +52,6 @@ const App = React.createClass({
     ConfigStore.get('messages').forEach((msg) => {
       AlertActions.addAlert(msg.message, msg.level);
     });
-
   },
 
   componentWillUnmount() {

--- a/src/sentry/static/sentry/app/views/groupActivity/noteContainer.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/noteContainer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import IndicatorStore from '../../stores/indicatorStore';
 import GroupStore from '../../stores/groupStore';
 
@@ -8,6 +8,10 @@ import NoteInput from './noteInput';
 import {t} from '../../locale';
 
 const NoteContainer = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
+
   getInitialState() {
     return {
       editing: false
@@ -34,7 +38,7 @@ const NoteContainer = React.createClass({
         return;
     }
 
-    api.request('/issues/' + group.id + '/comments/' + item.id + '/' , {
+    this.api.request('/issues/' + group.id + '/comments/' + item.id + '/' , {
       method: 'DELETE',
       error: (error) => {
         // TODO(mattrobenolt): Show an actual error that this failed,

--- a/src/sentry/static/sentry/app/views/groupActivity/noteInput.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/noteInput.jsx
@@ -1,6 +1,6 @@
 import marked from 'marked';
 import React from 'react';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import GroupStore from '../../stores/groupStore';
 import IndicatorStore from '../../stores/indicatorStore';
 import {logException} from '../../utils/logging';
@@ -15,7 +15,10 @@ function makeDefaultErrorJson() {
 }
 
 const NoteInput = React.createClass({
-  mixins: [PureRenderMixin],
+  mixins: [
+    PureRenderMixin,
+    ApiMixin
+  ],
 
   getInitialState() {
     let {item, group} = this.props;
@@ -95,7 +98,7 @@ const NoteInput = React.createClass({
 
     let loadingIndicator = IndicatorStore.add(t('Posting comment..'));
 
-    api.request('/issues/' + group.id + '/comments/', {
+    this.api.request('/issues/' + group.id + '/comments/', {
       method: 'POST',
       data: {
         text: this.state.value
@@ -129,7 +132,7 @@ const NoteInput = React.createClass({
 
     let loadingIndicator = IndicatorStore.add(t('Updating comment..'));
 
-    api.request('/issues/' + group.id + '/comments/' + item.id + '/', {
+    this.api.request('/issues/' + group.id + '/comments/' + item.id + '/', {
       method: 'PUT',
       data: {
         text: this.state.value

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import DocumentTitle from 'react-document-title';
 import GroupHeader from './groupDetails/header';
 import GroupStore from '../stores/groupStore';
@@ -19,6 +19,7 @@ const GroupDetails = React.createClass({
   },
 
   mixins: [
+    ApiMixin,
     Reflux.listenTo(GroupStore, 'onGroupChange')
   ],
 
@@ -47,7 +48,7 @@ const GroupDetails = React.createClass({
   },
 
   fetchData() {
-    api.request(this.getGroupDetailsEndpoint(), {
+    this.api.request(this.getGroupDetailsEndpoint(), {
       success: (data) => {
         this.setState({
           loading: false,

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {History} from 'react-router';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import DropdownLink from '../../components/dropdownLink';
 import GroupState from '../../mixins/groupState';
 import IndicatorStore from '../../stores/indicatorStore';
@@ -18,6 +18,7 @@ const Snooze = {
 
 const GroupActions = React.createClass({
   mixins: [
+    ApiMixin,
     GroupState,
     History,
     TooltipMixin({
@@ -32,7 +33,7 @@ const GroupActions = React.createClass({
     let org = this.getOrganization();
     let loadingIndicator = IndicatorStore.add(t('Delete event..'));
 
-    api.bulkDelete({
+    this.api.bulkDelete({
       orgId: org.slug,
       projectId: project.slug,
       itemIds: [group.id]
@@ -51,7 +52,7 @@ const GroupActions = React.createClass({
     let org = this.getOrganization();
     let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
-    api.bulkUpdate({
+    this.api.bulkUpdate({
       orgId: org.slug,
       projectId: project.slug,
       itemIds: [group.id],

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 // import Router from "react-router";
 import {Link, History} from 'react-router';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import AssigneeSelector from '../../components/assigneeSelector';
 import Count from '../../components/count';
 import GroupActions from './actions';
@@ -21,6 +21,7 @@ const GroupHeader = React.createClass({
   },
 
   mixins: [
+    ApiMixin,
     ProjectState,
     History
   ],
@@ -31,7 +32,7 @@ const GroupHeader = React.createClass({
     let org = this.getOrganization();
     let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
-    api.bulkUpdate({
+    this.api.bulkUpdate({
       orgId: org.slug,
       projectId: project.slug,
       itemIds: [group.id],
@@ -56,7 +57,7 @@ const GroupHeader = React.createClass({
     let org = this.getOrganization();
     let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
-    api.bulkUpdate({
+    this.api.bulkUpdate({
       orgId: org.slug,
       projectId: project.slug,
       itemIds: [group.id],

--- a/src/sentry/static/sentry/app/views/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupEventDetails.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import api from '../api';
 import ApiMixin from '../mixins/apiMixin';
 import EventEntries from '../components/events/eventEntries';
 import GroupEventToolbar from './groupDetails/eventToolbar';
@@ -48,7 +47,7 @@ const GroupEventDetails = React.createClass({
       error: false
     });
 
-    this.apiRequest(url, {
+    this.api.request(url, {
       success: (data, _, jqXHR) => {
         this.setState({
           event: data,
@@ -56,7 +55,7 @@ const GroupEventDetails = React.createClass({
           loading: false
         });
 
-        api.bulkUpdate({
+        this.api.bulkUpdate({
           orgId: this.getOrganization().slug,
           projectId: this.getProject().slug,
           itemIds: [this.getGroup().id],

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {History, Link} from 'react-router';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 
 import GroupState from '../mixins/groupState';
 
@@ -12,6 +12,7 @@ import Pagination from '../components/pagination';
 
 const GroupEvents = React.createClass({
   mixins: [
+    ApiMixin,
     GroupState,
     History
   ],
@@ -44,7 +45,7 @@ const GroupEvents = React.createClass({
       error: false
     });
 
-    api.request(`/issues/${this.getGroup().id}/events/`, {
+    this.api.request(`/issues/${this.getGroup().id}/events/`, {
       method: 'GET',
       data: queryParams,
       success: (data, _, jqXHR) => {

--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link, History} from 'react-router';
 import jQuery from 'jquery';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import Count from '../components/count';
 import GroupState from '../mixins/groupState';
 import LoadingError from '../components/loadingError';
@@ -13,6 +13,7 @@ import {t, tn} from '../locale';
 
 const GroupTagValues = React.createClass({
   mixins: [
+    ApiMixin,
     History,
     GroupState
   ],
@@ -47,7 +48,7 @@ const GroupTagValues = React.createClass({
       error: false
     });
 
-    api.request('/issues/' + this.getGroup().id + '/tags/' + params.tagKey + '/', {
+    this.api.request('/issues/' + this.getGroup().id + '/tags/' + params.tagKey + '/', {
       success: (data) => {
         this.setState({
           tagKey: data,
@@ -62,7 +63,7 @@ const GroupTagValues = React.createClass({
       }
     });
 
-    api.request('/issues/' + this.getGroup().id + '/tags/' + params.tagKey + '/values/?' + querystring, {
+    this.api.request('/issues/' + this.getGroup().id + '/tags/' + params.tagKey + '/values/?' + querystring, {
       success: (data, _, jqXHR) => {
         this.setState({
           tagValueList: data,

--- a/src/sentry/static/sentry/app/views/groupTags.jsx
+++ b/src/sentry/static/sentry/app/views/groupTags.jsx
@@ -33,7 +33,7 @@ const GroupTags = React.createClass({
 
     // TODO(dcramer): each tag should be a separate query as the tags endpoint
     // is not performant
-    this.apiRequest('/issues/' + this.getGroup().id + '/tags/', {
+    this.api.request('/issues/' + this.getGroup().id + '/tags/', {
       success: (data) => {
         if (!this.isMounted()) {
           return;

--- a/src/sentry/static/sentry/app/views/groupUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/groupUserReports.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import React from 'react';
 import {History} from 'react-router';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import Gravatar from '../components/gravatar';
 import GroupState from '../mixins/groupState';
 import LoadingError from '../components/loadingError';
@@ -12,6 +12,7 @@ import {t} from '../locale';
 
 const GroupUserReports = React.createClass({
   mixins: [
+    ApiMixin,
     GroupState,
     History
   ],
@@ -44,7 +45,7 @@ const GroupUserReports = React.createClass({
       error: false
     });
 
-    api.request('/issues/' + this.getGroup().id + '/user-reports/?' + querystring, {
+    this.api.request('/issues/' + this.getGroup().id + '/user-reports/?' + querystring, {
       success: (data, _, jqXHR) => {
         this.setState({
           error: false,

--- a/src/sentry/static/sentry/app/views/organizationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import DocumentTitle from 'react-document-title';
 import Footer from '../components/footer';
 import Header from '../components/header';
@@ -18,6 +18,10 @@ const OrganizationDetails = React.createClass({
   childContextTypes: {
     organization: PropTypes.Organization
   },
+
+  mixins: [
+    ApiMixin
+  ],
 
   getInitialState() {
     return {
@@ -53,7 +57,7 @@ const OrganizationDetails = React.createClass({
   },
 
   fetchData() {
-    api.request(this.getOrganizationDetailsEndpoint(), {
+    this.api.request(this.getOrganizationDetailsEndpoint(), {
       success: (data) => {
         this.setState({
           organization: data,

--- a/src/sentry/static/sentry/app/views/organizationStats/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.jsx
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import React from 'react';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import FlotChart from '../../components/flotChart';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
@@ -12,6 +12,7 @@ import {t} from '../../locale';
 
 const OrganizationStats = React.createClass({
   mixins: [
+    ApiMixin,
     OrganizationState
   ],
 
@@ -70,7 +71,7 @@ const OrganizationStats = React.createClass({
     let statEndpoint = this.getOrganizationStatsEndpoint();
 
     $.each(this.state.rawOrgData, (statName) => {
-      api.request(statEndpoint, {
+      this.api.request(statEndpoint, {
         query: {
           since: this.state.querySince,
           until: this.state.queryUntil,
@@ -94,7 +95,7 @@ const OrganizationStats = React.createClass({
     });
 
     $.each(this.state.rawProjectData, (statName) => {
-      api.request(statEndpoint, {
+      this.api.request(statEndpoint, {
         query: {
           since: this.state.querySince,
           until: this.state.queryUntil,
@@ -117,7 +118,7 @@ const OrganizationStats = React.createClass({
       });
     });
 
-    api.request(this.getOrganizationProjectsEndpoint(), {
+    this.api.request(this.getOrganizationProjectsEndpoint(), {
       success: (data) => {
         let projectMap = {};
         data.forEach((project) => {

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import AlertActions from '../../actions/alertActions';
 import {t} from '../../locale';
 
 // TODO(dcramer): this isnt great UX
 
 const AllTeamsRow = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
+
   getInitialState() {
     return {
       loading: false,
@@ -19,7 +23,7 @@ const AllTeamsRow = React.createClass({
       loading: true
     });
 
-    api.joinTeam({
+    this.api.joinTeam({
       orgId: this.props.organization.slug,
       teamId: this.props.team.slug
     }, {
@@ -47,7 +51,7 @@ const AllTeamsRow = React.createClass({
       loading: true
     });
 
-    api.leaveTeam({
+    this.api.leaveTeam({
       orgId: this.props.organization.slug,
       teamId: this.props.team.slug
     }, {

--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Link} from 'react-router';
 import LazyLoad from 'react-lazy-load';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import BarChart from '../../components/barChart';
 import ConfigStore from '../../stores/configStore';
 import PropTypes from '../../proptypes';
@@ -16,9 +16,13 @@ const ExpandedTeamList = React.createClass({
     projectStats: React.PropTypes.object
   },
 
+  mixins: [
+    ApiMixin
+  ],
+
   leaveTeam(team) {
     // TODO(dcramer): handle loading indicator
-    api.leaveTeam({
+    this.api.leaveTeam({
       orgId: this.props.organization.slug,
       teamId: team.slug
     });

--- a/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 
 import {t} from '../../locale';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import ConfigStore from '../../stores/configStore';
 import OrganizationHomeContainer from '../../components/organizations/homeContainer';
 import OrganizationState from '../../mixins/organizationState';
@@ -16,6 +16,7 @@ import OrganizationStatOverview from './organizationStatOverview';
 
 const OrganizationTeams = React.createClass({
   mixins: [
+    ApiMixin,
     OrganizationState,
     Reflux.listenTo(TeamStore, 'onTeamListChange'),
     TooltipMixin({
@@ -39,7 +40,7 @@ const OrganizationTeams = React.createClass({
 
   // TODO(dcramer): handle updating project stats when items change
   fetchStats() {
-    api.request(this.getOrganizationStatsEndpoint(), {
+    this.api.request(this.getOrganizationStatsEndpoint(), {
       query: {
         since: new Date().getTime() / 1000 - 3600 * 24,
         stat: 'received',

--- a/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Link} from 'react-router';
 import classNames from 'classnames';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import OrganizationState from '../../mixins/organizationState';
 
 import {defined} from '../../utils';
@@ -18,6 +18,7 @@ const OrganizationStatOverview = React.createClass({
   },
 
   mixins: [
+    ApiMixin,
     OrganizationState
   ],
 
@@ -38,7 +39,7 @@ const OrganizationStatOverview = React.createClass({
 
   fetchData() {
     let statsEndpoint = this.getOrganizationStatsEndpoint();
-    api.request(statsEndpoint, {
+    this.api.request(statsEndpoint, {
       query: {
         since: new Date().getTime() / 1000 - 3600 * 24,
         stat: 'rejected'
@@ -51,7 +52,7 @@ const OrganizationStatOverview = React.createClass({
         this.setState({totalRejected: totalRejected});
       }
     });
-    api.request(statsEndpoint, {
+    this.api.request(statsEndpoint, {
       query: {
         since: new Date().getTime() / 1000 - 3600 * 3,
         resolution: '1h',

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import BarChart from '../../components/barChart';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
@@ -8,7 +8,8 @@ import ProjectState from '../../mixins/projectState';
 
 const ProjectChart = React.createClass({
   mixins: [
-    ProjectState,
+    ApiMixin,
+    ProjectState
   ],
 
   getInitialState() {
@@ -44,7 +45,7 @@ const ProjectChart = React.createClass({
   },
 
   fetchData() {
-    api.request(this.getStatsEndpoint(), {
+    this.api.request(this.getStatsEndpoint(), {
       query: {
         since: this.props.dateSince
       },
@@ -63,7 +64,7 @@ const ProjectChart = React.createClass({
       }
     });
 
-    api.request(this.getProjectReleasesEndpoint(), {
+    this.api.request(this.getProjectReleasesEndpoint(), {
       success: (data, _, jqXHR) => {
         this.setState({
           releaseList: data,

--- a/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 import {t} from '../../locale';
@@ -11,6 +11,10 @@ const EventList = React.createClass({
     title: React.PropTypes.string.isRequired,
     endpoint: React.PropTypes.string.isRequired
   },
+
+  mixins: [
+    ApiMixin
+  ],
 
   getInitialState() {
     return {
@@ -47,7 +51,7 @@ const EventList = React.createClass({
         break;
     }
 
-    api.request(this.props.endpoint, {
+    this.api.request(this.props.endpoint, {
       query: {
         limit: 5,
         minutes: minutes

--- a/src/sentry/static/sentry/app/views/projectDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectDetails.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import DocumentTitle from 'react-document-title';
 import MemberListStore from '../stores/memberListStore';
 import LoadingError from '../components/loadingError';
@@ -24,6 +24,7 @@ const ProjectDetails = React.createClass({
   },
 
   mixins: [
+    ApiMixin,
     Reflux.connect(MemberListStore, 'memberList'),
     Reflux.listenTo(TeamStore, 'onTeamChange'),
     OrganizationState
@@ -94,7 +95,7 @@ const ProjectDetails = React.createClass({
 
     if (activeProject && isMember) {
       // TODO(dcramer): move member list to organization level
-      api.request(this.getMemberListEndpoint(), {
+      this.api.request(this.getMemberListEndpoint(), {
         success: (data) => {
           MemberListStore.loadInitialData(data);
         }

--- a/src/sentry/static/sentry/app/views/projectInstall/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 
@@ -8,6 +8,10 @@ const ProjectInstall = React.createClass({
   propTypes: {
     setProjectNavSection: React.PropTypes.func
   },
+
+  mixins: [
+    ApiMixin
+  ],
 
   getInitialState() {
     return {
@@ -26,7 +30,7 @@ const ProjectInstall = React.createClass({
 
   fetchData() {
     let {orgId, projectId} = this.props.params;
-    api.request(`/projects/${orgId}/${projectId}/docs/`, {
+    this.api.request(`/projects/${orgId}/${projectId}/docs/`, {
       success: (data) => {
         this.setState({
           loading: false,

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import {Link} from 'react-router';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import LanguageNav from './languageNav';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 import {t, tct} from '../../locale';
 
 const ProjectInstallPlatform = React.createClass({
+  mixins: [
+    ApiMixin
+  ],
 
   getInitialState() {
     let params = this.props.params;
@@ -47,7 +50,7 @@ const ProjectInstallPlatform = React.createClass({
 
   fetchData() {
     let {orgId, projectId, platform} = this.props.params;
-    api.request(`/projects/${orgId}/${projectId}/docs/${platform}/`, {
+    this.api.request(`/projects/${orgId}/${projectId}/docs/${platform}/`, {
       success: (data) => {
         this.setState({
           loading: false,

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -1,7 +1,7 @@
 import jQuery from 'jquery';
 import React from 'react';
 import {History} from 'react-router';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 import Pagination from '../../components/pagination';
@@ -15,7 +15,10 @@ const ProjectReleases = React.createClass({
     setProjectNavSection: React.PropTypes.func
   },
 
-  mixins: [History],
+  mixins: [
+    ApiMixin,
+    History
+  ],
 
   getDefaultProps() {
     return {
@@ -64,7 +67,7 @@ const ProjectReleases = React.createClass({
       error: false
     });
 
-    api.request(this.getProjectReleasesEndpoint(), {
+    this.api.request(this.getProjectReleasesEndpoint(), {
       success: (data, _, jqXHR) => {
         this.setState({
           error: false,

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import ConfigStore from '../../stores/configStore';
 import ListLink from '../../components/listLink';
 import LoadingError from '../../components/loadingError';
@@ -15,6 +15,10 @@ const ProjectSettings = React.createClass({
   contextTypes: {
     location: React.PropTypes.object
   },
+
+  mixins: [
+    ApiMixin
+  ],
 
   getInitialState() {
     return {
@@ -43,7 +47,7 @@ const ProjectSettings = React.createClass({
   fetchData() {
     let params = this.props.params;
 
-    api.request(`/projects/${params.orgId}/${params.projectId}/`, {
+    this.api.request(`/projects/${params.orgId}/${params.projectId}/`, {
       success: (data) => {
         this.setState({
           project: data,

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {History} from 'react-router';
 
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import FileSize from '../components/fileSize';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
@@ -13,7 +13,10 @@ const ReleaseArtifacts = React.createClass({
     release: React.PropTypes.object
   },
 
-  mixins: [History],
+  mixins: [
+    ApiMixin,
+    History
+  ],
 
   getInitialState() {
     return {
@@ -43,7 +46,7 @@ const ReleaseArtifacts = React.createClass({
       error: false
     });
 
-    api.request(endpoint, {
+    this.api.request(endpoint, {
       method: 'GET',
       data: this.props.location.query,
       success: (data, _, jqXHR) => {

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 import Count from '../components/count';
 import DocumentTitle from 'react-document-title';
 import ListLink from '../components/listLink';
@@ -24,6 +24,7 @@ const ReleaseDetails = React.createClass({
   },
 
   mixins: [
+    ApiMixin,
     ProjectState
   ],
 
@@ -59,7 +60,7 @@ const ReleaseDetails = React.createClass({
       error: false
     });
 
-    api.request(this.getReleaseDetailsEndpoint(), {
+    this.api.request(this.getReleaseDetailsEndpoint(), {
       success: (data) => {
         this.setState({
           loading: false,

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import IndicatorStore from '../../stores/indicatorStore';
 import SelectInput from '../../components/selectInput';
 import {t} from '../../locale';
@@ -13,6 +13,10 @@ const RuleEditor = React.createClass({
     actions: React.PropTypes.instanceOf(Array).isRequired,
     conditions: React.PropTypes.instanceOf(Array).isRequired
   },
+
+  mixins: [
+    ApiMixin
+  ],
 
   getInitialState() {
     return {
@@ -65,7 +69,7 @@ const RuleEditor = React.createClass({
     }
 
     let loadingIndicator = IndicatorStore.add('Saving...');
-    api.request(endpoint, {
+    this.api.request(endpoint, {
       method: (rule.id ? 'PUT' : 'POST'),
       data: data,
       success: () => {

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import jQuery from 'jquery';
 import DocumentTitle from 'react-document-title';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import EventEntries from '../../components/events/eventEntries';
 import Footer from '../../components/footer';
 import Header from '../../components/header';
@@ -17,6 +17,10 @@ const SharedGroupDetails = React.createClass({
   childContextTypes: {
     group: PropTypes.Group,
   },
+
+  mixins: [
+    ApiMixin
+  ],
 
   getInitialState() {
     return {
@@ -53,7 +57,7 @@ const SharedGroupDetails = React.createClass({
       error: false
     });
 
-    api.request(this.getGroupDetailsEndpoint(), {
+    this.api.request(this.getGroupDetailsEndpoint(), {
       success: (data) => {
         this.setState({
           loading: false,

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -6,7 +6,7 @@ import Sticky from 'react-sticky';
 import classNames from 'classnames';
 import _ from 'underscore';
 
-import api from '../api';
+import ApiMixin from '../mixins/apiMixin';
 
 import GroupStore from '../stores/groupStore';
 import LoadingError from '../components/loadingError';
@@ -30,7 +30,8 @@ const Stream = React.createClass({
   mixins: [
     Reflux.listenTo(GroupStore, 'onGroupChange'),
     Reflux.listenTo(StreamTagStore, 'onStreamTagChange'),
-    History
+    History,
+    ApiMixin
   ],
 
   getDefaultProps() {
@@ -121,7 +122,7 @@ const Stream = React.createClass({
     });
 
     let params = this.props.params;
-    api.request(`/projects/${params.orgId}/${params.projectId}/tags/`, {
+    this.api.request(`/projects/${params.orgId}/${params.projectId}/tags/`, {
       success: (tags) => {
         this.setState({tagsLoading: false});
         StreamTagActions.loadTagsSuccess(tags);
@@ -197,7 +198,7 @@ const Stream = React.createClass({
 
     this._poller.disable();
 
-    this.lastRequest = api.request(url, {
+    this.lastRequest = this.api.request(url, {
       method: 'GET',
       data: requestParams,
       success: (data, ignore, jqXHR) => {

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import ActionLink from './actionLink';
 import DropdownLink from '../../components/dropdownLink';
 import IndicatorStore from '../../stores/indicatorStore';
@@ -21,6 +21,7 @@ const StreamActions = React.createClass({
   },
 
   mixins: [
+    ApiMixin,
     Reflux.listenTo(SelectedGroupStore, 'onSelectedGroupChange'),
     PureRenderMixin
   ],
@@ -70,7 +71,7 @@ const StreamActions = React.createClass({
     this.actionSelectedGroups(actionType, (itemIds) => {
       let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
-      api.bulkUpdate({
+      this.api.bulkUpdate({
         orgId: this.props.orgId,
         projectId: this.props.projectId,
         itemIds: itemIds,
@@ -87,7 +88,7 @@ const StreamActions = React.createClass({
     let loadingIndicator = IndicatorStore.add(t('Removing events..'));
 
     this.actionSelectedGroups(actionType, (itemIds) => {
-      api.bulkDelete({
+      this.api.bulkDelete({
         orgId: this.props.orgId,
         projectId: this.props.projectId,
         itemIds: itemIds
@@ -103,7 +104,7 @@ const StreamActions = React.createClass({
     let loadingIndicator = IndicatorStore.add(t('Merging events..'));
 
     this.actionSelectedGroups(actionType, (itemIds) => {
-      api.merge({
+      this.api.merge({
         orgId: this.props.orgId,
         projectId: this.props.projectId,
         itemIds: itemIds,

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import StreamTagStore from '../../stores/streamTagStore';
 import MemberListStore from '../../stores/memberListStore';
 
-import api from '../../api';
+import ApiMixin from '../../mixins/apiMixin';
 import {t} from '../../locale';
 
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -21,8 +21,9 @@ const SearchBar = React.createClass({
   },
 
   mixins: [
+    ApiMixin,
     PureRenderMixin,
-    Reflux.listenTo(MemberListStore, 'onMemberListStoreChange')
+    Reflux.listenTo(MemberListStore, 'onMemberListStoreChange'),
   ],
 
   statics: {
@@ -185,7 +186,7 @@ const SearchBar = React.createClass({
     });
 
     let {orgId, projectId} = this.props;
-    api.request(`/projects/${orgId}/${projectId}/tags/${tag.key}/values/`, {
+    this.api.request(`/projects/${orgId}/${projectId}/tags/${tag.key}/values/`, {
       data: {
         query: query
       },

--- a/tests/js/spec/api.spec.jsx
+++ b/tests/js/spec/api.spec.jsx
@@ -1,0 +1,31 @@
+import {Client, Request} from 'app/api';
+
+describe('api', function () {
+  beforeEach(function () {
+    this.sandbox = sinon.sandbox.create();
+    this.api = new Client();
+  });
+
+  describe('Client', function () {
+    describe('cancel()', function () {
+      it('should abort any open XHR requests', function () {
+        let req1 = new Request({
+          abort: sinon.stub()
+        });
+        let req2 = new Request({
+          abort: sinon.stub()
+        });
+
+        this.api.activeRequests = {
+          1: req1,
+          2: req2
+        };
+
+        this.api.clear();
+
+        expect(req1.xhr.abort.calledOnce).to.be.ok;
+        expect(req2.xhr.abort.calledOnce).to.be.ok;
+      });
+    });
+  });
+});

--- a/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
+++ b/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
@@ -3,7 +3,7 @@ import ReactDOMServer from 'react-dom/server';
 
 import TestUtils from 'react-addons-test-utils';
 
-import api from 'app/api';
+import {Client} from 'app/api';
 import TagDistributionMeter from 'app/components/group/tagDistributionMeter';
 
 describe('TagDistributionMeter', function() {
@@ -11,7 +11,7 @@ describe('TagDistributionMeter', function() {
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
 
-    this.stubbedApiRequest = this.sandbox.stub(api, 'request');
+    this.stubbedApiRequest = this.sandbox.stub(Client.prototype, 'request');
 
     this.element = TestUtils.renderIntoDocument(
       <TagDistributionMeter tag="browser" group={{id:'1337'}} orgId="123" projectId="456"/>

--- a/tests/js/spec/views/groupDetails/seenBy.spec.jsx
+++ b/tests/js/spec/views/groupDetails/seenBy.spec.jsx
@@ -52,4 +52,3 @@ describe('OrganizationTeams', function() {
     });
   });
 });
-

--- a/tests/js/spec/views/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/organizationTeams.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
-import api from 'app/api';
+import {Client} from 'app/api';
 import OrganizationTeams from 'app/views/organizationTeams';
 import ExpandedTeamList from 'app/views/organizationTeams/expandedTeamList';
 import AllTeamsList from 'app/views/organizationTeams/allTeamsList';
@@ -14,7 +14,7 @@ describe('OrganizationTeams', function() {
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
 
-    this.stubbedApiRequest = this.sandbox.stub(api, 'request');
+    this.stubbedApiRequest = this.sandbox.stub(Client.prototype, 'request');
     stubReactComponent(this.sandbox, [ExpandedTeamList, AllTeamsList, OrganizationHomeContainer]);
 
     let ContextStubbedOrganizationTeams = stubContext(OrganizationTeams, {

--- a/tests/js/spec/views/projectReleases.spec.jsx
+++ b/tests/js/spec/views/projectReleases.spec.jsx
@@ -3,7 +3,7 @@ import TestUtils from 'react-addons-test-utils';
 
 import stubReactComponents from '../../helpers/stubReactComponent';
 
-import api from 'app/api';
+import {Client} from 'app/api';
 import ProjectReleases from 'app/views/projectReleases';
 import SearchBar from 'app/views/stream/searchBar';
 import Pagination from 'app/components/pagination';
@@ -12,7 +12,7 @@ describe('ProjectReleases', function () {
   beforeEach(function () {
     this.sandbox = sinon.sandbox.create();
 
-    this.sandbox.stub(api, 'request');
+    this.sandbox.stub(Client.prototype, 'request');
     stubReactComponents(this.sandbox, [SearchBar, Pagination]);
 
     this.props = {
@@ -31,7 +31,7 @@ describe('ProjectReleases', function () {
 
   describe('fetchData()', function () {
     it('should call releases endpoint', function () {
-      expect(api.request.args[0][0]).to.equal('/projects/123/456/releases/?limit=50&query=derp');
+      expect(Client.prototype.request.args[0][0]).to.equal('/projects/123/456/releases/?limit=50&query=derp');
     });
   });
 

--- a/tests/js/spec/views/releaseArtifacts.spec.jsx
+++ b/tests/js/spec/views/releaseArtifacts.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 
-import Api from 'app/api';
+import {Client} from 'app/api';
 import ReleaseArtifacts from 'app/views/releaseArtifacts';
 import Pagination from 'app/components/pagination';
 
@@ -12,7 +12,7 @@ describe('ReleaseArtifacts', function() {
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
 
-    this.stubbedApiRequest = this.sandbox.stub(Api, 'request');
+    this.stubbedApiRequest = this.sandbox.stub(Client.prototype, 'request');
     stubReactComponents(this.sandbox, [Pagination]);
 
   });

--- a/tests/js/spec/views/stream.spec.jsx
+++ b/tests/js/spec/views/stream.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import Cookies from 'js-cookie';
 import Sticky from 'react-sticky';
-import Api from 'app/api';
+import {Client} from 'app/api';
 import CursorPoller from 'app/utils/cursorPoller';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -25,7 +25,7 @@ describe('Stream', function() {
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
 
-    this.stubbedApiRequest = this.sandbox.stub(Api, 'request', (url, options) => {
+    this.stubbedApiRequest = this.sandbox.stub(Client.prototype, 'request', (url, options) => {
       options.complete && options.complete();
     });
 
@@ -87,7 +87,7 @@ describe('Stream', function() {
 
       let requestCancel = this.sandbox.stub();
       let requestOptions;
-      this.sandbox.stub(Api, 'request', function (url, options) {
+      this.sandbox.stub(Client.prototype, 'request', function (url, options) {
         requestOptions = options;
         return {
           cancel: requestCancel

--- a/tests/js/spec/views/stream/actionLink.spec.jsx
+++ b/tests/js/spec/views/stream/actionLink.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 
-import api from 'app/api';
+import {Client} from 'app/api';
 import stubReactComponents from '../../../helpers/stubReactComponent';
 import ActionLink from 'app/views/stream/actionLink';
 import Modal from 'react-bootstrap/lib/Modal';
@@ -11,7 +11,7 @@ describe('ActionLink', function() {
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
 
-    this.stubbedApiRequest = this.sandbox.stub(api, 'request');
+    this.stubbedApiRequest = this.sandbox.stub(Client.prototype, 'request');
     stubReactComponents(this.sandbox, [Modal]);
   });
 

--- a/tests/js/spec/views/stream/actions.spec.jsx
+++ b/tests/js/spec/views/stream/actions.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 
-import api from 'app/api';
+import {Client} from 'app/api';
 import stubReactComponents from '../../../helpers/stubReactComponent';
 import StreamActions from 'app/views/stream/actions';
 import ActionLink from 'app/views/stream/actionLink';
@@ -14,7 +14,7 @@ describe('StreamActions', function() {
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
 
-    this.stubbedApiRequest = this.sandbox.stub(api, 'request');
+    this.stubbedApiRequest = this.sandbox.stub(Client.prototype, 'request');
     stubReactComponents(this.sandbox, [ActionLink, DropdownLink, MenuItem]);
   });
 

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import api from 'app/api';
+import {Client} from 'app/api';
 import SearchBar from 'app/views/stream/searchBar';
 import SearchDropdown from 'app/views/stream/searchDropdown';
 import StreamTagStore from 'app/stores/streamTagStore';
@@ -18,7 +18,7 @@ describe('SearchBar', function() {
 
     this.sandbox = sinon.sandbox.create();
 
-    this.sandbox.stub(api, 'request');
+    this.sandbox.stub(Client.prototype, 'request');
 
     stubReactComponents(this.sandbox, [SearchDropdown]);
     this.ContextStubbedSearchBar = stubContext(SearchBar);


### PR DESCRIPTION
- `api` module no longer exports singleton, now its the `Client` class
- `ApiMixin` is revived to expose a local api Client instance to each registered component
- `ApiMixin` cleans up any lingering connection when the component unmounts
