### PR TITLE
Add on a local cache to OptionsStore

### DIFF
--- a/src/sentry/middleware/env.py
+++ b/src/sentry/middleware/env.py
@@ -4,8 +4,6 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from sentry.app import env
-from random import random
-from sentry.options import default_store
 
 
 class SentryEnvMiddleware(object):
@@ -16,12 +14,3 @@ class SentryEnvMiddleware(object):
 
         # bind request to env
         env.request = request
-
-        # Periodically for an expire the local OptionsStore cache.
-        # This cleanup is purely to keep memory low and garbage collect
-        # old values. It's not required to run to keep things consistent.
-        # Internally, if an option is fetched and it's expired, it gets
-        # evicted immediately. This is purely for options that haven't
-        # been fetched since they've expired.
-        if random() < 0.25:
-            default_store.expire_local_cache()

--- a/src/sentry/middleware/env.py
+++ b/src/sentry/middleware/env.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from sentry.app import env
+from random import random
+from sentry.options import default_store
 
 
 class SentryEnvMiddleware(object):
@@ -14,3 +16,12 @@ class SentryEnvMiddleware(object):
 
         # bind request to env
         env.request = request
+
+        # Periodically for an expire the local OptionsStore cache.
+        # This cleanup is purely to keep memory low and garbage collect
+        # old values. It's not required to run to keep things consistent.
+        # Internally, if an option is fetched and it's expired, it gets
+        # evicted immediately. This is purely for options that haven't
+        # been fetched since they've expired.
+        if random() < 0.25:
+            default_store.expire_local_cache()

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -16,6 +16,8 @@ __all__ = (
 )
 
 default_store = OptionsStore()
+default_store.connect_signals()
+
 default_manager = OptionsManager(store=default_store)
 
 # expose public API

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -31,7 +31,7 @@ FLAG_STOREONLY = 0b100
 
 # How long will a cache key exist in local memory before being evicted
 DEFAULT_KEY_TTL = 10
-# How long will a cache key exist in local memory while the backing store is erroring
+# How long will a cache key exist in local memory *after ttl* while the backing store is erroring
 DEFAULT_KEY_GRACE = 60
 
 

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -131,6 +131,12 @@ class OptionsStore(object):
                 # This could only exist in a race condition
                 # where another thread has already deleted this key,
                 # but we'll guard ourselves against it Justin Case.
+                # In this case, it's also possible that another thread
+                # has updated the value at this key, causing us to evict
+                # it prematurely. This isn't ideal, but not terrible
+                # since I don't want to introduce locking to prevent this.
+                # Even if it did happen, the consequence is just another
+                # network hop.
                 pass
 
         # If we're outside the grace window, even if we ask for it

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 from collections import namedtuple
+from time import time
 
 from django.utils import timezone
 from sentry.db.models.query import create_or_update
@@ -16,7 +17,7 @@ from sentry.models import Option
 from sentry.utils.hashlib import md5
 
 
-Key = namedtuple('Key', ('name', 'default', 'type', 'flags', 'cache_key'))
+Key = namedtuple('Key', ('name', 'default', 'type', 'flags', 'ttl', 'grace', 'cache_key'))
 
 CACHE_FETCH_ERR = 'Unable to fetch option cache for %s'
 CACHE_UPDATE_ERR = 'Unable to update option cache for %s'
@@ -24,60 +25,143 @@ CACHE_UPDATE_ERR = 'Unable to update option cache for %s'
 logger = logging.getLogger('sentry')
 
 
+def _make_cache_key(key):
+    return 'o:%s' % md5(key).hexdigest()
+
+
+def _make_cache_value(key, value):
+    now = int(time())
+    return (
+        value,
+        now + key.ttl,
+        now + key.ttl + key.grace,
+    )
+
+
 class OptionsStore(object):
+    """
+    Abstraction for the Option storage logic that should be driven
+    by the OptionsManager.
+
+    OptionsStore is gooey and raw. It provides no protection over
+    what goes into the store. It only knows that it's reading/writing
+    to the right place. If using the OptionsStore directly, it's your
+    job to do validation of the data. You should probably go through
+    OptionsManager instead, unless you need raw access to something.
+    """
+
     def __init__(self, cache=None, ttl=None):
         if cache is None:
             from sentry.cache import default_cache
             cache = default_cache
         self.cache = cache
         self.ttl = ttl
+        self.flush_local_cache()
 
-    def _make_cache_key(self, key):
-        return 'o:%s' % md5(key).hexdigest()
-
-    def make_key(self, name, default, type, flags):
-        return Key(name, default, type, flags, self._make_cache_key(name))
+    def make_key(self, name, default, type, flags, ttl, grace):
+        return Key(name, default, type, flags, int(ttl), int(grace), _make_cache_key(name))
 
     def get(self, key):
-        try:
-            result = self.get_cache(key)
-        except Exception:
-            logger.warn(CACHE_FETCH_ERR, key.name, exc_info=True)
-            result = None
+        """
+        Fetches a value from the options store.
+        """
+        result = self.get_cache(key)
+        if result is not None:
+            return result
 
-        if result is None:
-            try:
-                result = self.get_store(key)
-            except Option.DoesNotExist:
-                result = None
-            except Exception as e:
-                logger.exception(unicode(e))
-                result = None
-            else:
-                # we only attempt to populate the cache if we were previously
-                # able to successfully talk to the backend
-                # NOTE: There is definitely a race condition here between updating
-                # the store and the cache
-                try:
-                    self.set_cache(key, result)
-                except Exception:
-                    logger.warn(CACHE_UPDATE_ERR, key.name, exc_info=True)
-        return result
+        result = self.get_store(key)
+        if result is not None:
+            return result
+
+        # As a last ditch effort, let's hope we have a key
+        # in local cache that's possibly stale
+        return self.get_local_cache(key, grace=True)
 
     def get_cache(self, key):
-        return self.cache.get(key.cache_key)
+        """
+        First check agaist our local in-process cache, falling
+        back to the network cache.
+        """
+        value = self.get_local_cache(key)
+        if value is not None:
+            return value
+
+        cache_key = key.cache_key
+        try:
+            value = self.cache.get(cache_key)
+        except Exception:
+            logger.warn(CACHE_FETCH_ERR, key.name, exc_info=True)
+            value = None
+        else:
+            if key.ttl > 0:
+                self._local_cache[cache_key] = _make_cache_value(key, value)
+        return value
+
+    def get_local_cache(self, key, grace=False):
+        """
+        Attempt to fetch a key out of the local cache.
+
+        If the key exists, but is beyond expiration, we only
+        return it if grace=True. This forces the key to be returned
+        in a disaster scenario as long as we're still holding onto it.
+        This allows the OptionStore to pave over potential network hiccups
+        by returning a stale value.
+        """
+        try:
+            value, expires, grace = self._local_cache[key.cache_key]
+        except KeyError:
+            return None
+
+        now = int(time())
+
+        # Key is within normal expiry window, so just return it
+        if now < expires:
+            return value
+
+        # If we're able to accept within grace window, return it
+        if grace and now < grace:
+            return value
+
+        # Let's clean up values if we're beyond grace.
+        if now > grace:
+            del self._local_cache[key.cache_key]
+
+        # If we're outside the grace window, even if we ask for it
+        # in grace, too bad. The value is considered bad.
+        return None
 
     def get_store(self, key):
-        return Option.objects.get(key=key.name).value
+        """
+        Attempt to fetch value from the database. If successful,
+        also set it back in the cache.
+        """
+        try:
+            value = Option.objects.get(key=key.name).value
+        except Option.DoesNotExist:
+            value = None
+        except Exception as e:
+            logger.exception(unicode(e))
+            value = None
+        else:
+            # we only attempt to populate the cache if we were previously
+            # able to successfully talk to the backend
+            # NOTE: There is definitely a race condition here between updating
+            # the store and the cache
+            try:
+                self.set_cache(key, value)
+            except Exception:
+                logger.warn(CACHE_UPDATE_ERR, key.name, exc_info=True)
+        return value
 
     def set(self, key, value):
+        """
+        Store a value in the option store. Value must get persisted to database first,
+        then attempt caches. If it fails datastore, the entire operation blows up.
+        If cache fails, we ignore silently since it'll get repaired later by sync_options.
+        A boolean is returned to indicate if the network set succeeds.
+        """
         self.set_store(key, value)
-        try:
-            self.set_cache(key, value)
-            return True
-        except Exception:
-            logger.warn(CACHE_UPDATE_ERR, key, exc_info=True)
-            return False
+        return self.set_cache(key, value)
 
     def set_store(self, key, value):
         create_or_update(
@@ -90,19 +174,61 @@ class OptionsStore(object):
         )
 
     def set_cache(self, key, value):
-        self.cache.set(key.cache_key, value, self.ttl)
-
-    def delete(self, key):
-        self.delete_store(key)
+        cache_key = key.cache_key
+        if key.ttl > 0:
+            self._local_cache[cache_key] = _make_cache_value(key, value)
         try:
-            self.delete_cache(key)
+            self.cache.set(cache_key, value, self.ttl)
             return True
         except Exception:
-            logger.warn(CACHE_UPDATE_ERR, key, exc_info=True)
+            logger.warn(CACHE_UPDATE_ERR, key.name, exc_info=True)
             return False
+
+    def delete(self, key):
+        """
+        Remove key out of option stores. This operation must succeed on the
+        database first. If database fails, an exception is raised.
+        If database succeeds, caches are then allowed to fail silently.
+        A boolean is returned to indicate if the network deletion succeeds.
+        """
+        self.delete_store(key)
+        return self.delete_cache(key)
 
     def delete_store(self, key):
         Option.objects.filter(key=key.name).delete()
 
     def delete_cache(self, key):
-        self.cache.delete(key.cache_key)
+        cache_key = key.cache_key
+        try:
+            del self._local_cache[cache_key]
+        except KeyError:
+            pass
+        try:
+            self.cache.delete(cache_key)
+            return True
+        except Exception:
+            logger.warn(CACHE_UPDATE_ERR, key, exc_info=True)
+            return False
+
+    def expire_local_cache(self):
+        """
+        Iterate over our local cache items, and
+        remove the keys that are beyond their grace time.
+        """
+        if not self._local_cache:
+            return
+
+        to_expire = []
+        now = int(time())
+        for k, (_, _, grace) in self._local_cache.iteritems():
+            if now > grace:
+                to_expire.append(k)
+
+        for k in to_expire:
+            del self._local_cache[k]
+
+    def flush_local_cache(self):
+        """
+        Empty store's local in-process cache.
+        """
+        self._local_cache = {}

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -217,7 +217,7 @@ class OptionsStore(object):
             logger.warn(CACHE_UPDATE_ERR, key.name, exc_info=True)
             return False
 
-    def expire_local_cache(self):
+    def clean_local_cache(self):
         """
         Iterate over our local cache items, and
         remove the keys that are beyond their grace time.
@@ -243,7 +243,7 @@ class OptionsStore(object):
         """
         self._local_cache = {}
 
-    def maybe_expire_local_cache(self, **kwargs):
+    def maybe_clean_local_cache(self, **kwargs):
         # Periodically force an expire on the local cache.
         # This cleanup is purely to keep memory low and garbage collect
         # old values. It's not required to run to keep things consistent.
@@ -253,7 +253,7 @@ class OptionsStore(object):
         if not self._local_cache:
             return
         if random() < 0.25:
-            self.expire_local_cache()
+            self.clean_local_cache()
 
     def connect_signals(self):
         from celery.signals import task_postrun

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -271,5 +271,5 @@ class OptionsStore(object):
     def connect_signals(self):
         from celery.signals import task_postrun
         from django.core.signals import request_finished
-        task_postrun.connect(self.maybe_expire_local_cache)
-        request_finished.connect(self.maybe_expire_local_cache)
+        task_postrun.connect(self.maybe_clean_local_cache)
+        request_finished.connect(self.maybe_clean_local_cache)

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -147,6 +147,13 @@ class OptionsStore(object):
         """
         Attempt to fetch value from the database. If successful,
         also set it back in the cache.
+
+        Returns None in both cases, if the key doesn't actually exist,
+        or if we errored fetching it.
+
+        NOTE: This behavior should probably be improved to differentiate
+        between a miss vs error, but not worth it now since the value
+        is limited at the moment.
         """
         try:
             value = Option.objects.get(key=key.name).value
@@ -169,9 +176,9 @@ class OptionsStore(object):
     def set(self, key, value):
         """
         Store a value in the option store. Value must get persisted to database first,
-        then attempt caches. If it fails datastore, the entire operation blows up.
+        then attempt caches. If it fails database, the entire operation blows up.
         If cache fails, we ignore silently since it'll get repaired later by sync_options.
-        A boolean is returned to indicate if the network set succeeds.
+        A boolean is returned to indicate if the network cache was set successfully.
         """
         self.set_store(key, value)
         return self.set_cache(key, value)

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -243,7 +243,7 @@ class OptionsStore(object):
         """
         self._local_cache = {}
 
-    def maybe_expire_local_cache(self):
+    def maybe_expire_local_cache(self, **kwargs):
         # Periodically force an expire on the local cache.
         # This cleanup is purely to keep memory low and garbage collect
         # old values. It's not required to run to keep things consistent.

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from uuid import uuid1
+from exam import fixture
+from mock import patch
+
+from sentry.models import Option
+from sentry.options.store import OptionsStore
+from sentry.testutils import TestCase
+
+
+class OptionsStoreTest(TestCase):
+    store = fixture(OptionsStore)
+
+    @fixture
+    def key(self):
+        return self.make_key()
+
+    def make_key(self, ttl=10, grace=10):
+        return self.store.make_key(uuid1().hex, '', object, 0, ttl, grace)
+
+    def test_simple(self):
+        store, key = self.store, self.key
+        assert store.get(key) is None
+        assert store.set(key, 'bar')
+        assert store.get(key) == 'bar'
+        assert store.delete(key)
+        assert store.get(key) is None
+
+    def test_db_and_cache_unavailable(self):
+        store, key = self.store, self.key
+        with patch.object(Option.objects, 'get_queryset', side_effect=Exception()):
+            # we can't update options if the db is unavailable
+            with self.assertRaises(Exception):
+                store.set(key, 'bar')
+
+        # Assert nothing was written to the local_cache
+        assert not store._local_cache
+
+        store.set(key, 'bar')
+
+        with patch.object(Option.objects, 'get_queryset', side_effect=Exception()):
+            assert store.get(key) == 'bar'
+
+            with patch.object(store.cache, 'get', side_effect=Exception()):
+                assert store.get(key) == 'bar'
+                store.flush_local_cache()
+                assert store.get(key) is None
+
+    @patch('sentry.options.store.time')
+    def test_key_with_grace(self, mocked_time):
+        store, key = self.store, self.make_key(10, 10)
+
+        mocked_time.return_value = 0
+        store.set(key, 'bar')
+
+        with patch.object(Option.objects, 'get_queryset', side_effect=Exception()):
+            with patch.object(store.cache, 'get', side_effect=Exception()):
+                # Serves the value beyond TTL
+                mocked_time.return_value = 15
+                assert store.get(key) == 'bar'
+
+                mocked_time.return_value = 21
+                assert store.get(key) is None
+
+                # It should have also been evicted
+                assert not store._local_cache
+
+    @patch('sentry.options.store.time')
+    def test_key_ttl(self, mocked_time):
+        store, key = self.store, self.make_key(10, 0)
+
+        mocked_time.return_value = 0
+        store.set(key, 'bar')
+
+        with patch.object(Option.objects, 'get_queryset', side_effect=Exception()):
+            with patch.object(store.cache, 'get', side_effect=Exception()):
+                assert store.get(key) == 'bar'
+
+        Option.objects.filter(key=key.name).update(value='lol')
+        store.cache.delete(key.cache_key)
+        # Still within TTL, so don't check database
+        assert store.get(key) == 'bar'
+
+        mocked_time.return_value = 15
+
+        with patch.object(Option.objects, 'get_queryset', side_effect=Exception()):
+            with patch.object(store.cache, 'get', side_effect=Exception()):
+                assert store.get(key) is None
+
+        assert store.get(key) == 'lol'
+
+    @patch('sentry.options.store.time')
+    def test_expire_local_cache(self, mocked_time):
+        store = self.store
+
+        mocked_time.return_value = 0
+
+        key1 = self.make_key(10, 0)  # should expire after 10
+        key2 = self.make_key(10, 5)  # should expire after 15
+        key3 = self.make_key(10, 10)  # should expire after 20
+        key4 = self.make_key(10, 15)  # should expire after 25
+
+        store.set(key1, 'x')
+        store.set(key2, 'x')
+        store.set(key3, 'x')
+        store.set(key4, 'x')
+
+        assert len(store._local_cache) == 4
+
+        mocked_time.return_value = 0
+        store.expire_local_cache()
+        assert len(store._local_cache) == 4
+
+        mocked_time.return_value = 11
+        store.expire_local_cache()
+        assert len(store._local_cache) == 3
+        assert key1.cache_key not in store._local_cache
+
+        mocked_time.return_value = 21
+        store.expire_local_cache()
+        assert len(store._local_cache) == 1
+        assert key1.cache_key not in store._local_cache
+        assert key2.cache_key not in store._local_cache
+        assert key3.cache_key not in store._local_cache
+
+        mocked_time.return_value = 26
+        store.expire_local_cache()
+        assert not store._local_cache

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -93,7 +93,7 @@ class OptionsStoreTest(TestCase):
         assert store.get(key) == 'lol'
 
     @patch('sentry.options.store.time')
-    def test_expire_local_cache(self, mocked_time):
+    def test_clean_local_cache(self, mocked_time):
         store = self.store
 
         mocked_time.return_value = 0
@@ -111,21 +111,21 @@ class OptionsStoreTest(TestCase):
         assert len(store._local_cache) == 4
 
         mocked_time.return_value = 0
-        store.expire_local_cache()
+        store.clean_local_cache()
         assert len(store._local_cache) == 4
 
         mocked_time.return_value = 11
-        store.expire_local_cache()
+        store.clean_local_cache()
         assert len(store._local_cache) == 3
         assert key1.cache_key not in store._local_cache
 
         mocked_time.return_value = 21
-        store.expire_local_cache()
+        store.clean_local_cache()
         assert len(store._local_cache) == 1
         assert key1.cache_key not in store._local_cache
         assert key2.cache_key not in store._local_cache
         assert key3.cache_key not in store._local_cache
 
         mocked_time.return_value = 26
-        store.expire_local_cache()
+        store.clean_local_cache()
         assert not store._local_cache


### PR DESCRIPTION
This local cache is meant to just hold Option values in-process since
it's likely that Options may get queried very frequently.

This implements a TTL + grace scenario for Option keys.

TTL is the time for a key to be alive while everything is healthy.
Meaning, if the TTL hasn't passed, we can make an attempt to fetch from
network storage.

Grace allows us to pave over network failures a bit. If we get a request
within the grace period, but network errors, we can safely default to
just returning the stale value instead of erroring loudly.

/cc @dcramer @tkaemming 
