### PR TITLE
Tell system.url-prefix to prioritize it's on-disk setting if set

### DIFF
--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -7,6 +7,8 @@ from sentry import options
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SuperuserPermission
 
+from django.conf import settings
+
 
 class SystemOptionsEndpoint(Endpoint):
     permission_classes = (SuperuserPermission,)
@@ -18,6 +20,8 @@ class SystemOptionsEndpoint(Endpoint):
                 'field': {
                     'default': k.default,
                     'required': True,
+                    # TODO(mattrobenolt): Expose this as a property on Key.
+                    'disabled': bool(k.flags & options.FLAG_PRIORITIZE_DISK and settings.SENTRY_OPTIONS.get(k.name))
                     # TODO(mattrobenolt): help, placeholder, title, type
                 },
             }

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -11,7 +11,7 @@ from .store import OptionsStore
 from .manager import OptionsManager
 from .manager import (  # NOQA
     DEFAULT_FLAGS, FLAG_IMMUTABLE, FLAG_NOSTORE, FLAG_STOREONLY,
-    FLAG_REQUIRED,
+    FLAG_REQUIRED, FLAG_PRIORITIZE_DISK,
 )
 
 __all__ = (

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -8,7 +8,7 @@ sentry.options.defaults
 from __future__ import absolute_import, print_function
 
 
-from sentry.options import register, FLAG_NOSTORE, FLAG_REQUIRED
+from sentry.options import register, FLAG_NOSTORE, FLAG_REQUIRED, FLAG_PRIORITIZE_DISK
 
 
 register('cache.backend', flags=FLAG_NOSTORE)
@@ -20,4 +20,4 @@ register('system.secret-key', flags=FLAG_NOSTORE)
 register('redis.options', default={}, flags=FLAG_NOSTORE)
 
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
-register('system.url-prefix', ttl=60, grace=3600, flags=FLAG_REQUIRED)
+register('system.url-prefix', ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -78,7 +78,7 @@ class OptionsManager(object):
         # Enforce immutability on key
         assert not (opt.flags & FLAG_IMMUTABLE), '%r cannot be changed at runtime' % key
         # Enforce immutability if value is already set on disk
-        assert not(opt.flags & FLAG_PRIORITIZE_DISK and settings.SENTRY_OPTIONS.get(key)), '%r cannot be changed at runtime because it is configured on disk' % key
+        assert not (opt.flags & FLAG_PRIORITIZE_DISK and settings.SENTRY_OPTIONS.get(key)), '%r cannot be changed at runtime because it is configured on disk' % key
 
         if not isinstance(value, opt.type):
             raise TypeError('got %r, expected %r' % (_type(value), opt.type))

--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -24,6 +24,7 @@ export default class InputField extends FormField {
                  className="form-control"
                  placeholder={this.props.placeholder}
                  onChange={this.onChange.bind(this)}
+                 disabled={this.props.disabled}
                  value={this.state.value} />
           {this.props.help &&
             <p className="help-block">{this.props.help}</p>

--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -1,10 +1,32 @@
+import jQuery from 'jquery';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import FormField from './formField';
 
 export default class InputField extends FormField {
   constructor(props) {
     super(props);
     this.state.value = props.defaultValue || '';
+  }
+
+  // XXX(dcramer): this comes from TooltipMixin
+  componentDidMount() {
+    this.attachTooltips();
+  }
+
+  componentWillUnmount() {
+    this.removeTooltips();
+    jQuery(ReactDOM.findDOMNode(this)).unbind();
+  }
+
+  attachTooltips() {
+    jQuery('.tip', ReactDOM.findDOMNode(this))
+      .tooltip();
+  }
+
+  removeTooltips() {
+    jQuery('.tip', ReactDOM.findDOMNode(this))
+      .tooltip('destroy');
   }
 
   onChange(e) {
@@ -20,6 +42,11 @@ export default class InputField extends FormField {
       <div className="control-group">
         <div className="controls">
           <label>{this.props.label}</label>
+          {this.props.disabled && this.props.disabledReason &&
+            <span className="disabled-indicator tip" title={this.props.disabledReason}>
+              <span className="icon-question" />
+            </span>
+          }
           <input type={this.getType()}
                  className="form-control"
                  placeholder={this.props.placeholder}

--- a/src/sentry/static/sentry/app/options.jsx
+++ b/src/sentry/static/sentry/app/options.jsx
@@ -20,6 +20,10 @@ const definitions = {
   }
 };
 
+const disabledReasons = {
+  diskPriority: 'Value is defined in config.yml'
+};
+
 export function getOption(option) {
   return definitions[option];
 }
@@ -37,7 +41,8 @@ export function getOptionField(option, onChange, value, field) {
         onChange={onChange}
         required={meta.required}
         value={value}
-        disabled={meta.disabled} />
+        disabled={meta.disabled}
+        disabledReason={meta.disabledReason && disabledReasons[meta.disabledReason]} />
   );
 }
 

--- a/src/sentry/static/sentry/app/options.jsx
+++ b/src/sentry/static/sentry/app/options.jsx
@@ -20,8 +20,12 @@ const definitions = {
   }
 };
 
-export function getOptionField(option, onChange, value) {
-  let meta = definitions[option];
+export function getOption(option) {
+  return definitions[option];
+}
+
+export function getOptionField(option, onChange, value, field) {
+  let meta = {...getOption(option), ...field};
   let Field = meta.component || TextField;
   return (
     <Field
@@ -31,13 +35,10 @@ export function getOptionField(option, onChange, value) {
         placeholder={meta.placeholder}
         help={meta.help}
         onChange={onChange}
-        required={true}
-        value={value} />
+        required={meta.required}
+        value={value}
+        disabled={meta.disabled} />
   );
-}
-
-export function getOption(option) {
-  return definitions[option];
 }
 
 export default definitions;

--- a/src/sentry/static/sentry/app/options.jsx
+++ b/src/sentry/static/sentry/app/options.jsx
@@ -21,7 +21,7 @@ const definitions = {
 };
 
 const disabledReasons = {
-  diskPriority: 'Value is defined in config.yml'
+  diskPriority: 'This setting is defined in config.yml and may not be changed via the web UI.',
 };
 
 export function getOption(option) {

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -18,7 +18,7 @@ const SettingsList = React.createClass({
       if (!options[option].value) {
         options[option].value = getOption(option).defaultValue;
       }
-      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options.value));
+      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options.value, options.field));
     }
 
     return {

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -14,11 +14,12 @@ const SettingsList = React.createClass({
     let options = {...this.props.options};
     let requiredOptions = Object.keys(_.pick(options, option => option.field.required));
     let fields = [];
-    for (let option of Object.keys(options)) {
-      if (!options[option].value) {
-        options[option].value = getOption(option).defaultValue;
+    for (let key of Object.keys(options)) {
+      let option = options[key];
+      if (!option.value) {
+        option.value = getOption(key).defaultValue;
       }
-      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options[option].value, options[option].field));
+      fields.push(getOptionField(key, this.onFieldChange.bind(this, key), option.value, option.field));
     }
 
     return {

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -18,7 +18,7 @@ const SettingsList = React.createClass({
       if (!options[option].value) {
         options[option].value = getOption(option).defaultValue;
       }
-      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options.value, options.field));
+      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options[option].value, options[option].field));
     }
 
     return {

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -12,7 +12,9 @@ import {getOption, getOptionField} from '../options';
 const SettingsList = React.createClass({
   getInitialState() {
     let options = {...this.props.options};
-    let requiredOptions = Object.keys(_.pick(options, option => option.field.required));
+    let requiredOptions = Object.keys(_.pick(options, (option) => {
+      return option.field.required && !option.field.disabled;
+    }));
     let fields = [];
     for (let key of Object.keys(options)) {
       let option = options[key];
@@ -20,6 +22,11 @@ const SettingsList = React.createClass({
         option.value = getOption(key).defaultValue;
       }
       fields.push(getOptionField(key, this.onFieldChange.bind(this, key), option.value, option.field));
+      // options is used for submitting to the server, and we dont submit values
+      // that are deleted
+      if (option.field.disabled) {
+        delete options[key];
+      }
     }
 
     return {

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -12,7 +12,9 @@ import {getOption, getOptionField} from '../options';
 const InstallWizardSettings = React.createClass({
   getInitialState() {
     let options = {...this.props.options};
-    let requiredOptions = Object.keys(_.pick(options, option => option.field.required));
+    let requiredOptions = Object.keys(_.pick(options, (option) => {
+      return option.field.required && !option.field.disabled;
+    }));
     let missingOptions = new Set(requiredOptions.filter(option => !options[option].value));
     let fields = [];
     // This is to handle the initial installation case.
@@ -29,6 +31,11 @@ const InstallWizardSettings = React.createClass({
         option.value = getOption(key).defaultValue;
       }
       fields.push(getOptionField(key, this.onFieldChange.bind(this, key), option.value, option.field));
+      // options is used for submitting to the server, and we dont submit values
+      // that are deleted
+      if (option.field.disabled) {
+        delete options[key];
+      }
     }
 
     return {

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -27,7 +27,7 @@ const InstallWizardSettings = React.createClass({
       if (!options[option].value) {
         options[option].value = getOption(option).defaultValue;
       }
-      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options.value));
+      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options[option].value, options[option].field));
     }
 
     return {
@@ -121,7 +121,11 @@ const InstallWizard = React.createClass({
     });
     let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
-    let data = _.mapObject(options, option => option.value);
+    // We only want to send back the values which weren't disabled
+    let data = _.mapObject(
+      _.pick(options, option => !option.field.disabled),
+      option => option.value
+    );
     this.api.request('/internal/options/', {
       method: 'PUT',
       data: data,

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -23,11 +23,12 @@ const InstallWizardSettings = React.createClass({
     if (missingOptions.size === 0) {
       missingOptions = new Set(requiredOptions);
     }
-    for (let option of missingOptions) {
-      if (!options[option].value) {
-        options[option].value = getOption(option).defaultValue;
+    for (let key of missingOptions) {
+      let option = options[key];
+      if (!option.value) {
+        option.value = getOption(key).defaultValue;
       }
-      fields.push(getOptionField(option, this.onFieldChange.bind(this, option), options[option].value, options[option].field));
+      fields.push(getOptionField(key, this.onFieldChange.bind(this, key), option.value, option.field));
     }
 
     return {

--- a/src/sentry/static/sentry/less/forms.less
+++ b/src/sentry/static/sentry/less/forms.less
@@ -97,3 +97,13 @@ label {
 .error {
   color: @red;
 }
+
+input.form-control[disabled] {
+  background: #f9f9f9;
+  color: #999;
+}
+
+.disabled-indicator {
+  margin-left: 5px;
+  font-size: 80%;
+}

--- a/src/sentry/testutils/helpers/options.py
+++ b/src/sentry/testutils/helpers/options.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 __all__ = ['override_options']
 
+from django.test.utils import override_settings
 from contextlib import contextmanager
 from mock import patch
 
@@ -12,6 +13,7 @@ def override_options(options):
     A context manager for overriding specific configuration
     Options.
     """
+    from django.conf import settings
     from sentry.options import default_manager
     wrapped = default_manager.store.get
 
@@ -21,5 +23,9 @@ def override_options(options):
         except KeyError:
             return wrapped(key, **kwargs)
 
-    with patch.object(default_manager.store, 'get', side_effect=new_get):
-        yield
+    # Patch options into SENTRY_OPTIONS as well
+    new_options = settings.SENTRY_OPTIONS.copy()
+    new_options.update(options)
+    with override_settings(SENTRY_OPTIONS=new_options):
+        with patch.object(default_manager.store, 'get', side_effect=new_get):
+            yield


### PR DESCRIPTION
The goal of this is to be able to show the field as disabled during the install wizard instead of letting them override.

This means we're able to set `system.url-prefix` for different environments without them conflicting with each other.

TODO:
Implement tooltip for disabledReason and make disabled state not look shitty, /cc @dcramer 
