### PR TITLE
Make sure all React pages have a CSRF token in session

### DIFF
--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -159,13 +159,19 @@ const InstallWizard = React.createClass({
           // ...
         }
         let errorMessage = '';
-        switch (err.error) {
-          case 'unknown_option':
-            errorMessage = t('An invalid option (%s) was passed to the server. Please report this issue to the Sentry team.',
-                             err.errorDetail.option);
-            break;
-          default:
-            errorMessage = t('An unknown error occurred. Please take a look at the service logs.');
+        if (err.detail) {
+          // err.detail comes back on some API responses
+          // specifically on a failed CSRF
+          errorMessage = err.detail;
+        } else {
+          switch (err.error) {
+            case 'unknown_option':
+              errorMessage = t('An invalid option (%s) was passed to the server. Please report this issue to the Sentry team.',
+                               err.errorDetail.option);
+              break;
+            default:
+              errorMessage = t('An unknown error occurred. Please take a look at the service logs.');
+          }
         }
         this.setState({
           submitInProgress: false,

--- a/src/sentry/templates/sentry/bases/react.html
+++ b/src/sentry/templates/sentry/bases/react.html
@@ -3,7 +3,6 @@
 {% load sentry_api %}
 
 {% block body %}
-  {% csrf_token %}
   <div id="blk_router">
     <div class="loading triangle">
       <div class="loading-mask"></div>

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.core.context_processors import csrf
+from django.middleware.csrf import get_token as get_csrf_token
 from django.http import HttpResponse
 from django.template import loader, Context
 
@@ -10,7 +10,12 @@ from sentry.web.frontend.base import BaseView, OrganizationView
 class ReactMixin(object):
     def handle_react(self, request):
         context = Context({'request': request})
-        context.update(csrf(request))
+
+        # Force a new CSRF token to be generated and set in user's
+        # Cookie. Alternatively, we could use context_processor +
+        # template tag, but in this case, we don't need a form on the
+        # page. So there's no point in rendering a random `<input>` field.
+        get_csrf_token(request)
 
         template = loader.render_to_string('sentry/bases/react.html', context)
 

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from django.core.context_processors import csrf
 from django.http import HttpResponse
 from django.template import loader, Context
 
@@ -9,6 +10,8 @@ from sentry.web.frontend.base import BaseView, OrganizationView
 class ReactMixin(object):
     def handle_react(self, request):
         context = Context({'request': request})
+        context.update(csrf(request))
+
         template = loader.render_to_string('sentry/bases/react.html', context)
 
         response = HttpResponse(template)


### PR DESCRIPTION
Fixes GH-2419

I wonder how many other edge cases would have been broken in v8 that we never noticed before since it likely hit a non-react page first?
