### PR TITLE
Add `digests.enabled` function, disabled when using `DummyBackend`.

### DIFF
--- a/src/sentry/digests/backends/base.py
+++ b/src/sentry/digests/backends/base.py
@@ -95,6 +95,12 @@ class Backend(object):
     def validate(self):
         pass
 
+    def enabled(self, project):
+        """
+        Check if a project has digests enabled.
+        """
+        return True
+
     def add(self, key, record, increment_delay=None, maximum_delay=None):
         """
         Add a record to a timeline.

--- a/src/sentry/digests/backends/dummy.py
+++ b/src/sentry/digests/backends/dummy.py
@@ -9,6 +9,9 @@ class DummyBackend(Backend):
     def add(self, key, record, increment_delay=None, maximum_delay=None):
         pass
 
+    def enabled(self, project):
+        return False
+
     @contextmanager
     def digest(self, key, minimum_delay=None):
         yield []

--- a/src/sentry/templates/sentry/project-notifications.html
+++ b/src/sentry/templates/sentry/project-notifications.html
@@ -36,6 +36,7 @@
       </div>
     </div>
 
+    {% if digests_form %}
     <div class="box">
       <div class="box-header">
         <h3>{% trans "Digests" %}</h3>
@@ -57,6 +58,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
 
     <fieldset class="form-actions">
       <button type="submit" class="btn btn-primary btn-lg">{% trans "Save Changes" %}</button>


### PR DESCRIPTION
This ensures digest dispatch and scheduling is skipped when using a dummy
backend. This also disables the settings form when digests are not used.
