### PR TITLE
Don't generate absolute asset urls by default

### DIFF
--- a/src/sentry/templates/sentry/emails/activity/note.html
+++ b/src/sentry/templates/sentry/emails/activity/note.html
@@ -21,7 +21,7 @@
         <img class="avatar" width="48" height="48" src="{% gravatar_url author.email size 96 %}">
       </td>
       <td class="notch-column">
-        <img width="7" height="48" src="{% asset_url 'sentry' 'images/email/avatar-notch.png' %}">
+        <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">
       </td>
       <td>
         <div class="note-body">{{ data.text|urlize|linebreaks }}</div>

--- a/src/sentry/templates/sentry/emails/base.html
+++ b/src/sentry/templates/sentry/emails/base.html
@@ -17,7 +17,7 @@
         <div class="container">
           {% block header %}
           <h1>
-            <a href="{% absolute_uri %}"><img src="{% asset_url 'sentry' 'images/email/sentry_logo_full.png' %}" width="125px" height="29px" alt="Sentry"></a>
+            <a href="{% absolute_uri %}"><img src="{% absolute_asset_url 'sentry' 'images/email/sentry_logo_full.png' %}" width="125px" height="29px" alt="Sentry"></a>
           </h1>
           {% endblock %}
         </div>

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -2,7 +2,7 @@
 
 <style type="text/css">
   body {
-    background-image: url("{% asset_url 'sentry' 'images/email/sentry-pattern.png' %}");
+    background-image: url("{% absolute_asset_url 'sentry' 'images/email/sentry-pattern.png' %}");
   }
   body, .main {
     width: 100%;

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -16,13 +16,13 @@
   <meta name="robots" content="NONE,NOARCHIVE">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link href="{% asset_url "sentry" "images/favicon.ico" %}" rel="shortcut icon" type="image/png"/>
+  <link href="{% absolute_asset_url "sentry" "images/favicon.ico" %}" rel="shortcut icon" type="image/png"/>
 
-  <link rel="icon" href="{% asset_url "sentry" "images/icons/apple-touch-icon.png" %}">
-  <link rel="apple-touch-icon" href="{% asset_url "sentry" "images/icons/apple-touch-icon.png" %}">
-  <link rel="apple-touch-icon" sizes="76x76" href="{% asset_url "sentry" "images/icons/apple-touch-icon-76x76.png" %}">
-  <link rel="apple-touch-icon" sizes="120x120" href="{% asset_url "sentry" "images/icons/apple-touch-icon-120x120.png" %}">
-  <link rel="apple-touch-icon" sizes="152x152" href="{% asset_url "sentry" "images/icons/apple-touch-icon-152x152.png" %}">
+  <link rel="icon" href="{% absolute_asset_url "sentry" "images/icons/apple-touch-icon.png" %}">
+  <link rel="apple-touch-icon" href="{% absolute_asset_url "sentry" "images/icons/apple-touch-icon.png" %}">
+  <link rel="apple-touch-icon" sizes="76x76" href="{% absolute_asset_url "sentry" "images/icons/apple-touch-icon-76x76.png" %}">
+  <link rel="apple-touch-icon" sizes="120x120" href="{% absolute_asset_url "sentry" "images/icons/apple-touch-icon-120x120.png" %}">
+  <link rel="apple-touch-icon" sizes="152x152" href="{% absolute_asset_url "sentry" "images/icons/apple-touch-icon-152x152.png" %}">
 
   {% block css %}
   <link href="{% asset_url "sentry" "dist/sentry.css" %}" rel="stylesheet"/>

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -8,13 +8,16 @@ from sentry.utils.http import absolute_uri
 register = Library()
 
 
+register.simple_tag(get_asset_url, name='asset_url')
+
+
 @register.simple_tag
-def asset_url(module, path):
+def absolute_asset_url(module, path):
     """
-    Returns a versioned asset URL (located within Sentry's static files).
+    Returns a versioned absolute asset URL (located within Sentry's static files).
 
     Example:
-      {% asset_url 'sentry' 'dist/sentry.css' %}
+      {% absolute_asset_url 'sentry' 'dist/sentry.css' %}
       =>  "http://sentry.example.com/_static/74d127b78dc7daf2c51f/sentry/dist/sentry.css"
     """
     return absolute_uri(get_asset_url(module, path))


### PR DESCRIPTION
Introduces a new template tag `absolute_asset_url` to give a fully
resolved url.

Fixes GH-2436

I've made sure that all assets referenced in emails and the `<link>` tags for favicon and `apple-touch-icon` were kept absolute.

![image](https://cloud.githubusercontent.com/assets/375744/11702778/2c6cdbd6-9e8e-11e5-8793-70f4d9020df7.png)

/cc @tkaemming 
