### PR TITLE
Highlight missing translations in JSX files as eslint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -135,5 +135,11 @@
     "react/self-closing-comp": 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
     "react/sort-comp": 2,            // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
     "react/wrap-multilines": 2,      // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
+
+    /**
+     * Custom
+     */
+    "jsx-needs-il8n": 1,             // highlights literals in JSX components w/o translation tags
   }
+
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "test": "node_modules/karma/bin/karma start tests/karma.conf.js --single-run",
     "test-watch": "node_modules/karma/bin/karma start tests/karma.conf.js",
-    "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .jsx"
+    "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .jsx --rulesdir src/sentry/lint/eslint"
   },
   "devDependencies": {
     "babel-core": "5.8.33",

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -66,7 +66,7 @@ def js_lint(file_list=None):
     has_errors = False
     file_list = filter(lambda x: x.endswith(('.js', '.jsx')), file_list)
     if file_list:
-        status = Popen(['node_modules/.bin/eslint', '--ext', '.jsx']
+        status = Popen(['node_modules/.bin/eslint', '--ext', '.jsx', '--rulesdir', 'src/sentry/lint/eslint']
                        + list(file_list)).wait()
         has_errors = status != 0
 

--- a/src/sentry/lint/eslint/jsx-needs-il8n.js
+++ b/src/sentry/lint/eslint/jsx-needs-il8n.js
@@ -23,15 +23,21 @@ module.exports = function(context) {
     return {
 
         Literal: function(node) {
-            if (
-              !/^[\s]+$/.test(node.value) &&
-              /[A-Za-z]/.test(node.value) && // at least one letter; not symbols, numbers
-              node.parent &&
-              node.parent.type !== 'JSXExpressionContainer' &&
-              node.parent.type !== 'JSXAttribute' &&
-              node.parent.type.indexOf('JSX') !== -1
+            if (!/^[\s]+$/.test(node.value) && // ignore whitespace literals
+                /[A-Za-z]/.test(node.value) && // must have at least one letter; not symbols, numbers
+                node.parent
             ) {
-                reportLiteralNode(node);
+               // alt or title attribute
+               if (node.parent.type === 'JSXAttribute' && /title|alt/.test(node.parent.name.name)) {
+                   return void reportLiteralNode(node);
+               }
+
+               // inside component, e.g. <div>literal</div>
+               if (node.parent.type !== 'JSXAttribute' &&
+                   node.parent.type !== 'JSXExpressionContainer' &&
+                   node.parent.type.indexOf('JSX') !== -1) {
+                   return void reportLiteralNode(node);
+               }
             }
         }
 

--- a/src/sentry/lint/eslint/jsx-needs-il8n.js
+++ b/src/sentry/lint/eslint/jsx-needs-il8n.js
@@ -1,0 +1,46 @@
+/*
+ * @fileoverview Modified fork of jsx-no-literals to only consider literals w/
+ *               letters, plus changed warning message string.
+ *               See: https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/jsx-no-literals.js
+ * @author Caleb Morris
+ */
+/*eslint-env node*/
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    function reportLiteralNode(node) {
+        context.report(node, 'Missing translation function around literal string');
+    }
+
+    // --------------------------------------------------------------------------
+    // Public
+    // --------------------------------------------------------------------------
+
+    return {
+
+        Literal: function(node) {
+            if (
+              !/^[\s]+$/.test(node.value) &&
+              /[A-Za-z]/.test(node.value) && // at least one letter; not symbols, numbers
+              node.parent &&
+              node.parent.type !== 'JSXExpressionContainer' &&
+              node.parent.type !== 'JSXAttribute' &&
+              node.parent.type.indexOf('JSX') !== -1
+            ) {
+                reportLiteralNode(node);
+            }
+        }
+
+    };
+
+};
+
+module.exports.schema = [{
+    type: 'object',
+    properties: {},
+    additionalProperties: false
+}];


### PR DESCRIPTION
This rule has some holes, but it (probably) covers 90%+ of likely cases and highlights a ton of missing translations in our app today.
### Things it doesn't catch (currently)

Literals wrapped in another, non il8n function

``` jsx
<span>{getLabel('Example Label')}</span>
```

Literals in attributes

``` jsx
<a title={'Example Title'}>{t('This is fine')}</a>
```

And probably some other edge cases.

But I suggest we merge this as-is, and make future improvements to the plugin as we need them.

Example output from warnings right now:

```
sentry/src/sentry/static/sentry/app/components/assigneeSelector.jsx
  204:56  warning  Missing translation function around literal string  jsx-needs-il8n

sentry/src/sentry/static/sentry/app/components/compactIssue.jsx
  52:15  warning  Missing translation function around literal string  jsx-needs-il8n
  57:17  warning  Missing translation function around literal string  jsx-needs-il8n
  59:78  warning  Missing translation function around literal string  jsx-needs-il8n
  60:75  warning  Missing translation function around literal string  jsx-needs-il8n
  61:76  warning  Missing translation function around literal string  jsx-needs-il8n
  62:46  warning  Missing translation function around literal string  jsx-needs-il8n
  75:40  warning  Declare only one React component per file           react/no-multi-comp

sentry/src/sentry/static/sentry/app/components/contextData.jsx
  107:43  warning  Missing translation function around literal string  jsx-needs-il8n

sentry/src/sentry/static/sentry/app/components/footer.jsx
  29:46  warning  Missing translation function around literal string  jsx-needs-il8n

sentry/src/sentry/static/sentry/app/components/organizationIssueList.jsx
  53:55  warning  Missing translation function around literal string  jsx-needs-il8n

... <snip>

✖ 67 problems (0 errors, 67 warnings)
```
