### PR TITLE
Add system.rate-limit to configurable options

### DIFF
--- a/docs/throttling.rst
+++ b/docs/throttling.rst
@@ -50,12 +50,11 @@ configuration might look like this:
     }
 
 
-You can also configure system-wide maximums, and a default value for all projects:
+You can also configure the system-wide maximum per-minute rate limit:
 
 .. code-block:: python
 
-   SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE = '90%'
-   SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE = 500
+   system.rate-limit = 500
 
 If you have additional needs, you're freely available to extend the base
 Quota class just as the Redis implementation does.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -740,9 +740,6 @@ SENTRY_RATELIMITER_OPTIONS = {}
 # The default value for project-level quotas
 SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE = '90%'
 
-# The maximum number of events per minute the system should accept.
-SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE = 0
-
 # Node storage backend
 SENTRY_NODESTORE = 'sentry.nodestore.django.DjangoNodeStorage'
 SENTRY_NODESTORE_OPTIONS = {}

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -16,6 +16,7 @@ register('cache.options', default={}, flags=FLAG_NOSTORE)
 register('system.admin-email', flags=FLAG_REQUIRED)
 register('system.databases', default={}, flags=FLAG_NOSTORE)
 register('system.debug', default=False, flags=FLAG_NOSTORE)
+register('system.rate-limit', default=0, type=int)
 register('system.secret-key', flags=FLAG_NOSTORE)
 register('redis.options', default={}, flags=FLAG_NOSTORE)
 

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -11,6 +11,8 @@ from collections import namedtuple
 from functools import partial
 from django.conf import settings
 
+from sentry import options
+
 RateLimit = namedtuple('RateLimit', ('is_limited', 'retry_after'))
 NotRateLimited = RateLimit(False, None)
 RateLimited = partial(RateLimit, is_limited=True)
@@ -96,5 +98,5 @@ class Quota(object):
     def get_organization_quota(self, organization):
         return self.translate_quota(
             settings.SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE,
-            settings.SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE,
+            options.get('system.rate-limit'),
         )

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -212,6 +212,12 @@ def apply_legacy_settings(settings):
                       "Use SENTRY_OPTIONS instead, key 'system.url-prefix'", DeprecationWarning)
         settings.SENTRY_OPTIONS['system.url-prefix'] = settings.SENTRY_URL_PREFIX
 
+    if not settings.SENTRY_OPTIONS.get('system.rate-limit') and hasattr(settings, 'SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE'):
+        import warnings
+        warnings.warn('SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE is deprecated.'
+                      "Use SENTRY_OPTIONS instead, key 'system.rate-limit'", DeprecationWarning)
+        settings.SENTRY_OPTIONS['system.rate-limit'] = settings.SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE
+
     if not hasattr(settings, 'SENTRY_URL_PREFIX'):
         from sentry import options
         url_prefix = options.get('system.url-prefix', silent=True)

--- a/src/sentry/static/sentry/app/components/forms/form.jsx
+++ b/src/sentry/static/sentry/app/components/forms/form.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import {t} from '../../locale';
+
+const Form = React.createClass({
+  getDefaultProps() {
+    return {
+      submitLabel: t('Save Changes'),
+      submitDisabled: false,
+    };
+  },
+
+  onSubmit(e) {
+    e.preventDefault();
+    this.props.onSubmit();
+  },
+
+  render() {
+    return (
+      <form onSubmit={this.onSubmit}>
+        {this.props.children}
+        <div className="form-actions" style={{marginTop: 25}}>
+          <button className="btn btn-primary"
+                  disabled={this.props.submitDisabled}
+                  type="submit">{this.props.submitLabel}</button>
+        </div>
+      </form>
+    );
+  }
+});
+
+export default Form;

--- a/src/sentry/static/sentry/app/components/forms/index.jsx
+++ b/src/sentry/static/sentry/app/components/forms/index.jsx
@@ -1,2 +1,3 @@
+export {default as Form} from './form';
 export {default as EmailField} from './emailField';
 export {default as TextField} from './textField';

--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -6,7 +6,10 @@ import FormField from './formField';
 export default class InputField extends FormField {
   constructor(props) {
     super(props);
-    this.state.value = props.value || props.defaultValue || '';
+
+    this.state.value = (
+      props.value !== '' ? props.value : (props.defaultValue || '')
+    );
   }
 
   // XXX(dcramer): this comes from TooltipMixin

--- a/src/sentry/static/sentry/app/options.jsx
+++ b/src/sentry/static/sentry/app/options.jsx
@@ -8,7 +8,7 @@ const definitions = {
     label: t('Root URL'),
     placeholder: 'https://sentry.example.com',
     help: t('The root web address which is used to communicate with the Sentry backend.'),
-    defaultValue: () => `${document.location.protocol}//${document.location.host}`
+    defaultValue: () => `${document.location.protocol}//${document.location.host}`,
   },
   'system.admin-email': {
     label: t('Admin Email'),
@@ -16,8 +16,13 @@ const definitions = {
     help: t('The technical contact for this Sentry installation.'),
     // TODO(dcramer): this shoudl not be hardcoded to a component
     component: EmailField,
-    defaultValue: () => ConfigStore.get('user').email
-  }
+    defaultValue: () => ConfigStore.get('user').email,
+  },
+  'system.rate-limit': {
+    label: t('Rate Limit'),
+    placeholder: 'e.g. 500',
+    help: t('The maximum number of events the system should accept per minute. A value of 0 will disable the default rate limit.'),
+  },
 };
 
 const disabledReasons = {
@@ -35,7 +40,7 @@ export function getOptionField(option, onChange, value, field) {
     <Field
         key={option}
         label={meta.label}
-        defaultValue={meta.defaultValue()}
+        defaultValue={meta.defaultValue ? meta.defaultValue() : undefined}
         placeholder={meta.placeholder}
         help={meta.help}
         onChange={onChange}

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -112,7 +112,9 @@ const InstallWizard = React.createClass({
   },
 
   fetchData(callback) {
-    this.api.request('/internal/options/', {
+    // TODO(dcramer): ideally this would only be fetching options that aren't
+    // already configured
+    this.api.request('/internal/options/?query=is:required', {
       method: 'GET',
       success: (data) => {
         this.setState({

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -16,48 +16,48 @@ class QuotaTest(TestCase):
         project = self.create_project(organization=org)
 
         with self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE=0):
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=0):
+            with self.options({'system.rate-limit': 0}):
                 assert self.backend.get_project_quota(project) == 0
 
             ProjectOption.objects.set_value(
                 project, 'quotas:per_minute', '80%'
             )
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=100):
+            with self.options({'system.rate-limit': 100}):
                 assert self.backend.get_project_quota(project) == 80
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=0):
+            with self.options({'system.rate-limit': 0}):
                 assert self.backend.get_project_quota(project) == 0
 
             ProjectOption.objects.set_value(
                 project, 'quotas:per_minute', '50'
             )
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=100):
+            with self.options({'system.rate-limit': 100}):
                 assert self.backend.get_project_quota(project) == 50
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=0):
+            with self.options({'system.rate-limit': 0}):
                 assert self.backend.get_project_quota(project) == 50
 
             OrganizationOption.objects.set_value(
                 org, 'sentry:project-rate-limit', 80,
             )
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=100):
+            with self.options({'system.rate-limit': 100}):
                 assert self.backend.get_project_quota(project) == 50
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=50):
+            with self.options({'system.rate-limit': 50}):
                 assert self.backend.get_project_quota(project) == 40
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=0):
+            with self.options({'system.rate-limit': 0}):
                 assert self.backend.get_project_quota(project) == 50
 
             ProjectOption.objects.set_value(
                 project, 'quotas:per_minute', ''
             )
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=100):
+            with self.options({'system.rate-limit': 100}):
                 assert self.backend.get_project_quota(project) == 80
 
-            with self.settings(SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE=0):
+            with self.options({'system.rate-limit': 0}):
                 assert self.backend.get_project_quota(project) == 0


### PR DESCRIPTION
This includes various cleanup to forms, some fixes for the API endpoints to make them usable, and adds the system.rate-limit configuration option (to replace SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE).
