### PR TITLE
Add a better type system for Options

### DIFF
--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -31,7 +31,7 @@ class SystemOptionsEndpoint(Endpoint):
             results[k.name] = {
                 'value': options.get(k.name),
                 'field': {
-                    'default': k.default,
+                    'default': k.default(),
                     'required': bool(k.flags & options.FLAG_REQUIRED),
                     # We're disabled if the disk has taken priority
                     'disabled': diskPriority,

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -18,7 +18,7 @@ class SystemOptionsEndpoint(Endpoint):
         if query == 'is:required':
             option_list = options.filter(flag=options.FLAG_REQUIRED)
         elif query:
-            raise ValueError('{} is not a supported search query'.format(query))
+            return Response('{} is not a supported search query'.format(query), status=400)
         else:
             option_list = options.all()
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -9,16 +9,17 @@ from __future__ import absolute_import, print_function
 
 
 from sentry.options import register, FLAG_NOSTORE, FLAG_REQUIRED, FLAG_PRIORITIZE_DISK
+from sentry.options.types import Dict
 
 
 register('cache.backend', flags=FLAG_NOSTORE)
-register('cache.options', default={}, flags=FLAG_NOSTORE)
+register('cache.options', type=Dict, flags=FLAG_NOSTORE)
 register('system.admin-email', flags=FLAG_REQUIRED)
-register('system.databases', default={}, flags=FLAG_NOSTORE)
+register('system.databases', type=Dict, flags=FLAG_NOSTORE)
 register('system.debug', default=False, flags=FLAG_NOSTORE)
-register('system.rate-limit', default=0, type=int, flags=FLAG_PRIORITIZE_DISK)
+register('system.rate-limit', default=0, flags=FLAG_PRIORITIZE_DISK)
 register('system.secret-key', flags=FLAG_NOSTORE)
-register('redis.options', default={}, flags=FLAG_NOSTORE)
+register('redis.options', type=Dict, flags=FLAG_NOSTORE)
 
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 register('system.url-prefix', ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -201,7 +201,7 @@ class OptionsManager(object):
         # If we don't have a default, but we have a type, pull the default
         # value from the type
         if default_value is None:
-            default = type()
+            default = type
 
         self.registry[key] = self.store.make_key(key, default, type, flags, ttl, grace)
 

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -11,7 +11,7 @@ import logging
 from itertools import ifilter
 from types import NoneType
 from django.conf import settings
-from .types import InvalidTypeError, type_from_value, Any
+from .types import type_from_value, Any
 
 # Prevent outselves from clobbering the builtin
 _type = type
@@ -217,9 +217,7 @@ class OptionsManager(object):
     def validate_option(self, key, value):
         opt = self.lookup_key(key)
         assert not (opt.flags & FLAG_STOREONLY), '%r is not allowed to be loaded from config' % key
-        try:
-            opt.type(value)
-        except InvalidTypeError:
+        if not opt.type.test(value):
             raise TypeError('%r: got %r, expected %r' % (key, _type(value), opt.type))
 
     def all(self):

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -179,8 +179,6 @@ class OptionsManager(object):
         else:
             default_value = default()
 
-        print(default, default_value, default())
-
         # Guess type based on the default value
         if type is None:
             # the default value would be equivilent to '' if no type / default

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -140,12 +140,16 @@ class OptionsManager(object):
         # Some values we don't want to allow them to be configured through
         # config files and should only exist in the datastore
         if opt.flags & FLAG_STOREONLY:
+            if callable(opt.default):
+                return opt.default()
             return opt.default
 
         try:
             # default to the hardcoded local configuration for this key
             return settings.SENTRY_OPTIONS[key]
         except KeyError:
+            if callable(opt.default):
+                return opt.default()
             return opt.default
 
     def delete(self, key):

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -11,6 +11,7 @@ import logging
 from itertools import ifilter
 from types import NoneType
 from django.conf import settings
+from .types import InvalidTypeError, type_from_value, Any
 
 # Prevent outselves from clobbering the builtin
 _type = type
@@ -80,16 +81,10 @@ class OptionsManager(object):
         # Enforce immutability if value is already set on disk
         assert not (opt.flags & FLAG_PRIORITIZE_DISK and settings.SENTRY_OPTIONS.get(key)), '%r cannot be changed at runtime because it is configured on disk' % key
 
-        if not self._value_is_of_type(opt.type, value):
-            if not coerce:
-                raise TypeError('got %r, expected %r' % (_type(value), opt.type))
-            else:
-                # TODO(dcramer): implement more explicit coercion error
-                # with custom types
-                try:
-                    value = opt.type(value)
-                except (ValueError, TypeError):
-                    raise TypeError('Unable to coerce %r to %r' % (_type(value), opt.type))
+        if coerce:
+            value = opt.type(value)
+        elif not opt.type.test(value):
+            raise TypeError('got %r, expected %r' % (_type(value), opt.type))
 
         return self.store.set(opt, value)
 
@@ -104,7 +99,7 @@ class OptionsManager(object):
                 logger.debug('Using legacy key: %s', key, exc_info=True)
                 # History shows, there was an expectation of no types, and empty string
                 # as the default response value
-                return self.store.make_key(key, '', object, DEFAULT_FLAGS, 0, 0)
+                return self.store.make_key(key, '', Any, DEFAULT_FLAGS, 0, 0)
             raise UnknownOption(key)
 
     def get(self, key, silent=False):
@@ -172,35 +167,40 @@ class OptionsManager(object):
 
         return self.store.delete(opt)
 
-    def _value_is_of_type(self, type, value):
-        # TODO(dcramer): replace with basic types
-        if type in (unicode, str):
-            type = basestring
-        return isinstance(value, type)
-
     def register(self, key, default=None, type=None, flags=DEFAULT_FLAGS,
                  ttl=DEFAULT_KEY_TTL, grace=DEFAULT_KEY_GRACE):
         assert key not in self.registry, 'Option already registered: %r' % key
+
+        # If our default is a callable, execute it to
+        # see what value is returns, so we can use that to derive the type
+        if callable(default):
+            default_value = default()
+        else:
+            default_value = default
+
         # Guess type based on the default value
         if type is None:
             # the default value would be equivilent to '' if no type / default
             # is specified and we assume unicode for safety
             if default is None:
-                type = unicode
-                default = u''
-            elif isinstance(default, basestring):
-                type = unicode
-            else:
-                type = _type(default)
+                default = default_value = u''
+            type = type_from_value(default_value)
+
         # We disallow None as a value for options since this is ambiguous and doesn't
         # really make sense as config options. There should be a sensible default
         # value instead that matches the type expected, rather than relying on None.
         if type is NoneType:
             raise TypeError('Options must not be NoneType')
-        if default is not None and not self._value_is_of_type(type, default):
+
+        # Make sure the type is correct at registration time
+        if default_value is not None and not type.test(default_value):
             raise TypeError('got %r, expected %r' % (_type(default), type))
-        if default is None:
+
+        # If we don't have a default, but we have a type, pull the default
+        # value from the type
+        if default_value is None:
             default = type()
+
         self.registry[key] = self.store.make_key(key, default, type, flags, ttl, grace)
 
     def unregister(self, key):
@@ -217,7 +217,9 @@ class OptionsManager(object):
     def validate_option(self, key, value):
         opt = self.lookup_key(key)
         assert not (opt.flags & FLAG_STOREONLY), '%r is not allowed to be loaded from config' % key
-        if not self._value_is_of_type(opt.type, value):
+        try:
+            opt.type(value)
+        except InvalidTypeError:
             raise TypeError('%r: got %r, expected %r' % (key, _type(value), opt.type))
 
     def all(self):

--- a/src/sentry/options/types.py
+++ b/src/sentry/options/types.py
@@ -1,0 +1,169 @@
+"""
+sentry.options.types
+~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+from __future__ import absolute_import, print_function
+
+from sentry.utils.yaml import safe_load
+from yaml.parser import ParserError
+from yaml.scanner import ScannerError
+
+__all__ = (
+    'InvalidTypeError',
+    'Any', 'Bool', 'Int', 'Float', 'String', 'Dict', 'Sequence',
+)
+
+
+class InvalidTypeError(TypeError):
+    pass
+
+
+class OptionType(object):
+    "Base OptionType that provides type coersion"
+    name = ''
+    default = None
+    expected_types = (object,)
+    compatible_types = (basestring,)
+
+    def __call__(self, value=None):
+        if value is None:
+            return self._default()
+        if self.test(value):
+            return value
+        if isinstance(value, self.compatible_types):
+            rv = self.convert(value)
+            # Make sure convert was able to do the right thing
+            # and give us the type we were expecting
+            if self.test(rv):
+                return rv
+        raise InvalidTypeError('{!r} is not a valid {}'.format(value, repr(self)))
+
+    def convert(self, value):
+        return value
+
+    def _default(self):
+        return self.default
+
+    def test(self, value):
+        return isinstance(value, self.expected_types)
+
+    def __repr__(self):
+        return self.name
+
+
+class AnyType(OptionType):
+    "A type that accepts any value and does no coersion"
+    name = 'any'
+
+
+class BoolType(OptionType):
+    "Coerce a boolean from a string"
+    name = 'boolean'
+    default = False
+    expected_types = (bool,)
+
+    def convert(self, value):
+        if value.lower() in ('y', 'yes', 't', 'true', '1'):
+            return True
+        if value.lower() in ('n', 'no', 'f', 'false', '0'):
+            return False
+
+
+class IntType(OptionType):
+    "Coerce an integer from a string"
+    name = 'integer'
+    default = 0
+    expected_types = (int,)
+
+    def convert(self, value):
+        try:
+            return int(value)
+        except ValueError:
+            return
+
+
+class FloatType(OptionType):
+    "Coerce a float from a string or integer"
+    name = 'float'
+    default = 0.0
+    expected_types = (float,)
+    compatible_types = (basestring, float, int)
+
+    def convert(self, value):
+        try:
+            return float(value)
+        except ValueError:
+            return
+
+
+class StringType(OptionType):
+    "String type without any coersion, must be a string"
+    name = 'string'
+    default = u''
+    expected_types = basestring
+    compatible_types = basestring
+
+
+class DictType(OptionType):
+    "Coerce a dict out of a json/yaml string"
+    name = 'dictionary'
+    expected_types = (dict,)
+
+    def _default(self):
+        # make sure we create a fresh dict each time
+        return {}
+
+    def convert(self, value):
+        try:
+            return safe_load(value)
+        except (AttributeError, ParserError, ScannerError):
+            return
+
+
+class SequenceType(OptionType):
+    "Coerce a tuple out of a json/yaml string or a list"
+    name = 'sequence'
+    default = ()
+    expected_types = (tuple,)
+    compatible_types = (basestring, tuple, list)
+
+    def convert(self, value):
+        if isinstance(value, basestring):
+            try:
+                value = safe_load(value)
+            except (AttributeError, ParserError, ScannerError):
+                return
+        if isinstance(value, list):
+            value = tuple(value)
+        return value
+
+
+# Initialize singletons of each type for easy reuse
+Any = AnyType()
+Bool = BoolType()
+Int = IntType()
+Float = FloatType()
+String = StringType()
+Dict = DictType()
+Sequence = SequenceType()
+
+
+# Mapping for basic types into what their OptionType is
+_type_mapping = {
+    bool: Bool,
+    int: Int,
+    float: Float,
+    str: String,
+    unicode: String,
+    dict: Dict,
+    tuple: Sequence,
+    list: Sequence,
+}
+
+
+def type_from_value(value):
+    "Fetch OptionType based on a primitive value"
+    return _type_mapping[type(value)]

--- a/src/sentry/options/types.py
+++ b/src/sentry/options/types.py
@@ -51,7 +51,7 @@ class OptionType(object):
         return self.default
 
     def test(self, value):
-        """Check if the value needs to be coerced or not"""
+        """Check if the value is the correct type or not"""
         return isinstance(value, self.expected_types)
 
     def __repr__(self):

--- a/src/sentry/options/types.py
+++ b/src/sentry/options/types.py
@@ -22,7 +22,7 @@ class InvalidTypeError(TypeError):
 
 
 class OptionType(object):
-    "Base OptionType that provides type coersion"
+    """Base OptionType that provides type coersion"""
     name = ''
     # Default value to be returned when initializing
     default = None
@@ -51,7 +51,7 @@ class OptionType(object):
         return self.default
 
     def test(self, value):
-        "Check if the value needs to be coerced or not"
+        """Check if the value needs to be coerced or not"""
         return isinstance(value, self.expected_types)
 
     def __repr__(self):
@@ -59,7 +59,7 @@ class OptionType(object):
 
 
 class AnyType(OptionType):
-    "A type that accepts any value and does no coersion"
+    """A type that accepts any value and does no coersion"""
     name = 'any'
 
 
@@ -77,7 +77,7 @@ class BoolType(OptionType):
 
 
 class IntType(OptionType):
-    "Coerce an integer from a string"
+    """Coerce an integer from a string"""
     name = 'integer'
     default = 0
     expected_types = (int,)
@@ -90,7 +90,7 @@ class IntType(OptionType):
 
 
 class FloatType(OptionType):
-    "Coerce a float from a string or integer"
+    """Coerce a float from a string or integer"""
     name = 'float'
     default = 0.0
     expected_types = (float,)
@@ -104,7 +104,7 @@ class FloatType(OptionType):
 
 
 class StringType(OptionType):
-    "String type without any coersion, must be a string"
+    """String type without any coersion, must be a string"""
     name = 'string'
     default = u''
     expected_types = (basestring,)
@@ -112,7 +112,7 @@ class StringType(OptionType):
 
 
 class DictType(OptionType):
-    "Coerce a dict out of a json/yaml string"
+    """Coerce a dict out of a json/yaml string"""
     name = 'dictionary'
     expected_types = (dict,)
 
@@ -128,7 +128,7 @@ class DictType(OptionType):
 
 
 class SequenceType(OptionType):
-    "Coerce a tuple out of a json/yaml string or a list"
+    """Coerce a tuple out of a json/yaml string or a list"""
     name = 'sequence'
     default = ()
     expected_types = (tuple,)
@@ -169,5 +169,5 @@ _type_mapping = {
 
 
 def type_from_value(value):
-    "Fetch OptionType based on a primitive value"
+    """Fetch OptionType based on a primitive value"""
     return _type_mapping[type(value)]

--- a/src/sentry/options/types.py
+++ b/src/sentry/options/types.py
@@ -107,8 +107,8 @@ class StringType(OptionType):
     "String type without any coersion, must be a string"
     name = 'string'
     default = u''
-    expected_types = basestring
-    compatible_types = basestring
+    expected_types = (basestring,)
+    compatible_types = (basestring,)
 
 
 class DictType(OptionType):

--- a/src/sentry/options/types.py
+++ b/src/sentry/options/types.py
@@ -27,7 +27,7 @@ class OptionType(object):
     # Default value to be returned when initializing
     default = None
     # Types that do not need to be coerced
-    expected_types = (object,)
+    expected_types = ()
     # Types that are acceptable for coersion
     compatible_types = (basestring,)
 
@@ -61,6 +61,8 @@ class OptionType(object):
 class AnyType(OptionType):
     """A type that accepts any value and does no coersion"""
     name = 'any'
+    expected_types = (object,)
+    compatible_types = (object,)
 
 
 class BoolType(OptionType):

--- a/src/sentry/options/types.py
+++ b/src/sentry/options/types.py
@@ -72,9 +72,10 @@ class BoolType(OptionType):
     expected_types = (bool,)
 
     def convert(self, value):
-        if value.lower() in ('y', 'yes', 't', 'true', '1'):
+        value = value.lower()
+        if value in ('y', 'yes', 't', 'true', '1'):
             return True
-        if value.lower() in ('n', 'no', 'f', 'false', '0'):
+        if value in ('n', 'no', 'f', 'false', '0'):
             return False
 
 

--- a/src/sentry/options/types.py
+++ b/src/sentry/options/types.py
@@ -24,8 +24,11 @@ class InvalidTypeError(TypeError):
 class OptionType(object):
     "Base OptionType that provides type coersion"
     name = ''
+    # Default value to be returned when initializing
     default = None
+    # Types that do not need to be coerced
     expected_types = (object,)
+    # Types that are acceptable for coersion
     compatible_types = (basestring,)
 
     def __call__(self, value=None):
@@ -48,6 +51,7 @@ class OptionType(object):
         return self.default
 
     def test(self, value):
+        "Check if the value needs to be coerced or not"
         return isinstance(value, self.expected_types)
 
     def __repr__(self):

--- a/src/sentry/runner/commands/config.py
+++ b/src/sentry/runner/commands/config.py
@@ -52,6 +52,8 @@ def set(option, value):
         options.set(option, value)
     except UnknownOption:
         raise click.ClickException('unknown option: %s' % option)
+    except TypeError as e:
+        raise click.ClickException(unicode(e))
 
 
 @config.command()

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+
+class SystemOptionsTest(APITestCase):
+    url = reverse('sentry-api-0-system-options')
+
+    def test_simple(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert 'system.secret-key' in response.data
+        assert 'system.url-prefix' in response.data
+        assert 'system.admin-email' in response.data
+        assert 'cache.backend' in response.data
+
+    def test_bad_query(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.url, {'query': 'nonsense'})
+        assert response.status_code == 400
+        assert 'nonsense' in response.data
+
+    def test_required(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.url, {'query': 'is:required'})
+        assert response.status_code == 200
+        assert 'system.rate-limit' not in response.data
+        assert 'system.url-prefix' in response.data
+
+    def test_not_logged_in(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 401

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -107,6 +107,8 @@ class OptionsManagerTest(TestCase):
         assert self.manager.get('awesome') == 'lol'
         self.manager.register('callback', default=lambda: True)
         assert self.manager.get('callback') is True
+        self.manager.register('default-type', type=Int)
+        assert self.manager.get('default-type') == 0
 
     def test_flag_immutable(self):
         self.manager.register('immutable', flags=FLAG_IMMUTABLE)

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -10,6 +10,7 @@ from sentry.options.store import OptionsStore
 from sentry.options.manager import (
     OptionsManager, UnknownOption, DEFAULT_FLAGS,
     FLAG_IMMUTABLE, FLAG_NOSTORE, FLAG_STOREONLY, FLAG_REQUIRED, FLAG_PRIORITIZE_DISK)
+from sentry.options.types import Int, String
 from sentry.testutils import TestCase
 
 
@@ -60,10 +61,24 @@ class OptionsManagerTest(TestCase):
             self.manager.register('foo')
 
         with self.assertRaises(TypeError):
-            self.manager.register('wrong-type', default=1, type=basestring)
+            self.manager.register('wrong-type', default=1, type=String)
 
         with self.assertRaises(TypeError):
             self.manager.register('none-type', default=None, type=type(None))
+
+    def test_coerce(self):
+        self.manager.register('some-int', type=Int)
+
+        self.manager.set('some-int', 0)
+        assert self.manager.get('some-int') == 0
+        self.manager.set('some-int', '0')
+        assert self.manager.get('some-int') == 0
+
+        with self.assertRaises(TypeError):
+            self.manager.set('some-int', 'foo')
+
+        with self.assertRaises(TypeError):
+            self.manager.set('some-int', '0', coerce=False)
 
     def test_legacy_key(self):
         """
@@ -77,7 +92,7 @@ class OptionsManagerTest(TestCase):
         assert self.manager.get('sentry:foo') == ''
 
     def test_types(self):
-        self.manager.register('some-int', type=int, default=0)
+        self.manager.register('some-int', type=Int, default=0)
         with self.assertRaises(TypeError):
             self.manager.set('some-int', 'foo')
         self.manager.set('some-int', 1)
@@ -90,6 +105,8 @@ class OptionsManagerTest(TestCase):
         assert self.manager.get('awesome') == 'bar'
         self.manager.delete('awesome')
         assert self.manager.get('awesome') == 'lol'
+        self.manager.register('callback', default=lambda: True)
+        assert self.manager.get('callback') is True
 
     def test_flag_immutable(self):
         self.manager.register('immutable', flags=FLAG_IMMUTABLE)

--- a/tests/sentry/options/test_types.py
+++ b/tests/sentry/options/test_types.py
@@ -42,6 +42,7 @@ class OptionsTypesTest(TestCase):
     def test_int(self):
         assert Int(1) == 1
         assert Int('1') == 1
+        assert Int('-1') == -1
         assert Int() == 0
         with self.assertRaises(InvalidTypeError):
             Int('foo')
@@ -51,6 +52,7 @@ class OptionsTypesTest(TestCase):
     def test_float(self):
         assert Float(1.0) == 1.0
         assert Float('1') == 1.0
+        assert Float('-1.1') == -1.1
         assert Float(1) == 1.0
         assert Float() == 0.0
         with self.assertRaises(InvalidTypeError):

--- a/tests/sentry/options/test_types.py
+++ b/tests/sentry/options/test_types.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from sentry.options.types import (
+    InvalidTypeError,
+    Any, Bool, Int, Float, String, Dict, Sequence,
+)
+from sentry.testutils import TestCase
+
+
+class OptionsTypesTest(TestCase):
+    def test_any(self):
+        assert Any('foo') == 'foo'
+        assert Any(1) == 1
+        assert Any(None) is None
+        assert Any() is None
+        assert Any.test(None)
+        assert Any.test('foo')
+        assert Any.test('bar')
+
+    def test_bool(self):
+        assert Bool(True) is True
+        assert Bool('y') is True
+        assert Bool('YES') is True
+        assert Bool('t') is True
+        assert Bool('true') is True
+        assert Bool('1') is True
+        assert Bool(False) is False
+        assert Bool('n') is False
+        assert Bool('NO') is False
+        assert Bool('f') is False
+        assert Bool('false') is False
+        assert Bool('0') is False
+        assert Bool() is False
+        assert Bool.test(None) is False
+        assert Bool(True) is True
+        assert Bool.test('foo') is False
+        with self.assertRaises(InvalidTypeError):
+            Bool('foo')
+
+    def test_int(self):
+        assert Int(1) == 1
+        assert Int('1') == 1
+        assert Int() == 0
+        with self.assertRaises(InvalidTypeError):
+            Int('foo')
+        with self.assertRaises(InvalidTypeError):
+            Int('1.1')
+
+    def test_float(self):
+        assert Float(1.0) == 1.0
+        assert Float('1') == 1.0
+        assert Float(1) == 1.0
+        assert Float() == 0.0
+        with self.assertRaises(InvalidTypeError):
+            Float('foo')
+
+    def test_string(self):
+        assert String('foo') == 'foo'
+        assert String(u'foo') == u'foo'
+        assert String() == u''
+        with self.assertRaises(InvalidTypeError):
+            String(0)
+
+    def test_dict(self):
+        assert Dict({}) == {}
+        assert Dict({'foo': 'bar'}) == {'foo': 'bar'}
+        assert Dict('{foo: bar}') == {'foo': 'bar'}
+        assert Dict() == {}
+        with self.assertRaises(InvalidTypeError):
+            assert Dict('[]')
+        with self.assertRaises(InvalidTypeError):
+            assert Dict([])
+        with self.assertRaises(InvalidTypeError):
+            assert Dict('')
+        with self.assertRaises(InvalidTypeError):
+            # malformed yaml/json
+            assert Dict('{foo:bar}')
+
+    def test_sequence(self):
+        assert Sequence(()) == ()
+        assert Sequence([]) == ()
+        assert Sequence((1, 2, 3)) == (1, 2, 3)
+        assert Sequence('[1,2,3]') == (1, 2, 3)
+        with self.assertRaises(InvalidTypeError):
+            Sequence('{}')
+        with self.assertRaises(InvalidTypeError):
+            Sequence({})
+        with self.assertRaises(InvalidTypeError):
+            Sequence('')
+        with self.assertRaises(InvalidTypeError):
+            # malformed yaml/json
+            Sequence('[1,')


### PR DESCRIPTION
- More sane coersion rules per type.
- Testing if the type needs coersion.
- No hacks for str vs unicode types, encompassed under StringType.
- Coersion from json/yaml strings into complex objects, DictType and SequenceType.
- default value is a callable

/cc @dcramer @tkaemming 
