### PR TITLE
Correct minor spelling error in auth-confirm-link template

### DIFF
--- a/src/sentry/templates/sentry/auth-confirm-link.html
+++ b/src/sentry/templates/sentry/auth-confirm-link.html
@@ -20,7 +20,7 @@
     <div class="align-center">
 
       {% if existing_user.email == identity.email %}
-        <p>We're going to associate your new identity with your existing account which means all of your existing settings will stay in tact.</p>
+        <p>We're going to associate your new identity with your existing account which means all of your existing settings will stay intact.</p>
 
         <p>
           <button class="btn btn-primary" name="op" value="confirm" type="submit">Continue</button>


### PR DESCRIPTION
Sorry to be that guy. Still counts as contributing right? :p
