### PR TITLE
Show public dsn on client key page

### DIFF
--- a/src/sentry/templates/sentry/projects/keys.html
+++ b/src/sentry/templates/sentry/projects/keys.html
@@ -22,7 +22,7 @@
       {% for key in key_list %}
         <div class="client-key-item">
           <div class="pull-right">
-            <a class="btn btn-default btn-sm" href="{% url 'sentry-edit-project-key' project.organization.slug project.slug key.id %}">Info</a>
+            <a class="btn btn-default btn-sm" href="{% url 'sentry-edit-project-key' project.organization.slug project.slug key.id %}">{% trans "Details" %}</a>
             {% if ACCESS.project_write %}
               {% if key.is_active %}
               <form method="POST" action="{% url 'sentry-disable-project-key' project.organization.slug project.slug key.id %}" style="display:inline">
@@ -48,7 +48,17 @@
           {% else %}
             <h5><a href="{% url 'sentry-edit-project-key' project.organization.slug project.slug key.id %}">{{ key.public_key }}</a></h5>
           {% endif %}
-          <div class="form-control disabled auto-select">{{ key.dsn_private }}</div>
+
+          <div class="form-group">
+            <label>{% trans "DSN" %}</label>
+            <div class="form-control disabled auto-select">{{ key.dsn_private }}</div>
+          </div>
+
+          <div class="form-group">
+            <label>{% trans "DSN (Public)" %}</label>
+            <div class="form-control disabled auto-select">{{ key.dsn_public }}</div>
+            <div class="help-block">{% blocktrans with 'https://github.com/getsentry/raven-js' as link %}Use your public DSN with browser-based clients such as <a href="{{ link }}">raven-js</a>.{% endblocktrans %}</div>
+          </div>
         </div>
       {% endfor %}
     </div>

--- a/src/sentry/templates/sentry/projects/manage.html
+++ b/src/sentry/templates/sentry/projects/manage.html
@@ -182,7 +182,7 @@
         <a href="{% absolute_uri '/{}/{}/settings/install/' project.organization.slug project.slug %}">{% trans "Instructions" %}</a>
     </li>
     <li{% if page == 'keys' %} class="active"{% endif %}>
-        <a href="{% url 'sentry-manage-project-keys' project.organization.slug project.slug %}">{% trans "Client Keys" %}</a>
+        <a href="{% url 'sentry-manage-project-keys' project.organization.slug project.slug %}">{% trans "Client Keys (DSN)" %}</a>
     </li>
   </ul>
   {% with project|get_plugins as plugins %}


### PR DESCRIPTION
Right now we only list the private DSN, which is confusing for people who are copy/pasting this value into client libraries like Raven.js.

This patch also adds "(DSN)" to the sidebar menu under "Client Keys", since we often refer to only "DSN" in our docs.

Before:

![image](https://cloud.githubusercontent.com/assets/2153/12043309/e559e3aa-ae38-11e5-8f35-bde32643d3d3.png)

After patch:

![image](https://cloud.githubusercontent.com/assets/2153/12043301/becce246-ae38-11e5-98e6-fb88318851b3.png)
