### PR TITLE
linking release snoozing to settings when release tracking is not set up

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -96,7 +96,7 @@ const GroupActions = React.createClass({
     }
 
     let hasRelease = group.tags.filter(item => item.key === 'release').length;
-    let releaseTrackingUrl = '/' + this.getOrganization().slug + '/' + this.getProject().slug + '/settings/release-tracking/'
+    let releaseTrackingUrl = '/' + this.getOrganization().slug + '/' + this.getProject().slug + '/settings/release-tracking/';
 
     return (
       <div className="group-actions">

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -96,6 +96,7 @@ const GroupActions = React.createClass({
     }
 
     let hasRelease = group.tags.filter(item => item.key === 'release').length;
+    let releaseTrackingUrl = '/' + this.getOrganization().slug + '/' + this.getProject().slug + '/settings/release-tracking/'
 
     return (
       <div className="group-actions">
@@ -134,7 +135,7 @@ const GroupActions = React.createClass({
                       <div className="help-text">{t('Snooze notifications until this issue reoccurs in a future release.')}</div>
                     </a>
                   :
-                    <a className="disabled tip" title={t('You need to send release data to Sentry in order to use this feature.')}>
+                    <a href={releaseTrackingUrl} className="disabled tip" title="Set up release tracking in order to use this feature.">
                       <strong>{t('Resolved in next release.')}</strong>
                       <div className="help-text">{t('Snooze notifications until this issue reoccurs in a future release.')}</div>
                     </a>


### PR DESCRIPTION
Make it obvious on the next step on how to get release tracking set up, so they can snooze until next release.
