### PR TITLE
add utf-8 supporting for sentry_mail

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -43,6 +43,13 @@ class MailPlugin(NotificationPlugin):
 
         subject_prefix = self.get_option('subject_prefix', project) or self.subject_prefix
 
+        try:
+            subject_prefix = subject_prefix.encode("utf-8")
+            subject = subject.encode("utf-8")
+        except UnicodeDecodeError:
+            subject_prefix = unicode(subject_prefix, "utf-8")
+            subject = unicode(subject, "utf-8")
+
         msg = MessageBuilder(
             subject='%s%s' % (subject_prefix, subject),
             template=template,


### PR DESCRIPTION
currently, sentry_mail does not support Chinese,

When raised an exception with Chinese by raven_php 

try {
    throw new Exception('测试中文');
}
catch (Exception $e) {
    $client->captureException($e);
}

The worker got this error

[2016-01-04 10:21:19,748: ERROR/Worker-3] Error processing 'rule_notify' on 'MailPlugin': 'ascii' codec can't decode byte 0xe6 in position 1: ordinal not in range(128)
Traceback (most recent call last):
  File "/home/aidan/.virtualenvs/doordu-logging/local/lib/python2.7/site-packages/sentry/utils/safe.py", line 26, in safe_execute
    result = func(_args, *_kwargs)
  File "/home/aidan/.virtualenvs/doordu-logging/local/lib/python2.7/site-packages/sentry/plugins/bases/notify.py", line 59, in rule_notify
    self.notify(notification)
  File "/home/aidan/.virtualenvs/doordu-logging/local/lib/python2.7/site-packages/sentry/plugins/sentry_mail/models.py", line 191, in notify
    context=context,
  File "/home/aidan/.virtualenvs/doordu-logging/local/lib/python2.7/site-packages/sentry/plugins/sentry_mail/models.py", line 47, in _send_mail
    subject='%s%s' % (subject_prefix, subject),
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 1: ordinal not in range(128)
