### PR TITLE
Change slugify instance behavior to generate a random string

### DIFF
--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -85,6 +85,7 @@ def slugify_instance(inst, label, reserved=(), max_length=30, *args, **kwargs):
         (1, 2),  # (36^2) possibilities, 2 attempts
         (5, 3),  # (36^3) possibilities, 3 attempts
         (20, 5),  # (36^5) possibilities, 20 attempts
+        (1, 12),  # (36^12) possibilities, 1 final attempt
     )
     for attempts, size in sizes:
         for i in xrange(attempts):
@@ -92,4 +93,6 @@ def slugify_instance(inst, label, reserved=(), max_length=30, *args, **kwargs):
             inst.slug = base_slug[:max_length - size - 1] + '-' + end
             if not base_qs.filter(slug__iexact=inst.slug).exists():
                 return
-    raise ValueError('Unable to generate unique slug')
+
+    # If at this point, we've exhausted all possibilities, we'll just end up hitting
+    # an IntegrityError from database, which is ok, and unlikely to happen

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 from django.db.models import F
 from django.db.models.expressions import ExpressionNode
+from django.utils.crypto import get_random_string
 from django.template.defaultfilters import slugify
 
 from sentry.db.exceptions import CannotResolveExpression
@@ -71,7 +72,24 @@ def slugify_instance(inst, label, reserved=(), max_length=30, *args, **kwargs):
         base_qs = base_qs.filter(*args, **kwargs)
 
     inst.slug = base_slug
-    n = 0
-    while base_qs.filter(slug__iexact=inst.slug).exists():
-        n += 1
-        inst.slug = base_slug[:max_length - len(str(n)) - 1] + '-' + str(n)
+
+    # We don't need to further mutate if we're unique at this point
+    if not base_qs.filter(slug__iexact=inst.slug).exists():
+        return
+
+    # We want to sanely generate the shortest unique slug possible, so
+    # we try different length endings until we get one that works, or bail.
+
+    # At most, we have 26 attempts here to derive a unique slug
+    sizes = (
+        (1, 2),  # (36^2) possibilities, 2 attempts
+        (5, 3),  # (36^3) possibilities, 3 attempts
+        (20, 5),  # (36^5) possibilities, 20 attempts
+    )
+    for attempts, size in sizes:
+        for i in xrange(attempts):
+            end = get_random_string(size, allowed_chars='abcdefghijklmnopqrstuvwxyz0123456790')
+            inst.slug = base_slug[:max_length - size - 1] + '-' + end
+            if not base_qs.filter(slug__iexact=inst.slug).exists():
+                return
+    raise ValueError('Unable to generate unique slug')

--- a/tests/sentry/db/models/test_utils.py
+++ b/tests/sentry/db/models/test_utils.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+from sentry.db.models.utils import slugify_instance
+from sentry.models import Organization
+
+
+class SlugifyInstanceTest(TestCase):
+    def test_no_conflict(self):
+        org = Organization(name='matt')
+        slugify_instance(org, 'matt')
+        assert org.slug == 'matt'
+        assert not Organization.objects.filter(slug='matt').exists()
+
+    def test_conflict(self):
+        base_slug = self.organization.slug
+        org = Organization(name='foo')
+        slugify_instance(org, base_slug)
+        assert org.slug.startswith(base_slug + '-'), org.slug
+        assert not Organization.objects.filter(slug=org.slug).exists()
+
+    def test_reserved(self):
+        base_slug = self.organization.slug
+        org = Organization(name='foo')
+        slugify_instance(org, base_slug, reserved=(base_slug,))
+        assert not org.slug.startswith(base_slug + '-'), org.slug
+        assert not Organization.objects.filter(slug=org.slug).exists()
+
+    def test_max_length(self):
+        org = Organization(name='matt')
+        slugify_instance(org, 'matt', max_length=2)
+        assert org.slug == 'ma', org.slug
+        assert not Organization.objects.filter(slug='ma').exists()


### PR DESCRIPTION
This prevents a potential DoS scenario with a lot of conflicting slugs.

Since we were incrementing ids, this results in an O(n) queries per
conflict. If there are 1000 orgs with the slug 'test', that means
there'd be 1000+ queries just to determine the next available slug.

Switch to generating random strings to cap the number of attempts needed
to calculate unique slug, and raise exception if we exceed the finite
number of attempts.
