### PR TITLE
Cache static files by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,11 @@ CLI
 
 The `sentry` CLI tooling has been rewritten to be faster and less confusing.
 
+Static files
+~~~~~~~~~~~~
+
+Static files are now served with a far-futures Cache-Control header, and are versioned by default. If you were serving `/_static/` explicitly from your server config, you may need to update your rules or adjust the `STATIC_URL` setting accordingly.
+
 General
 ~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -355,6 +355,7 @@ class BuildJavascriptCommand(Command):
                     files.append(filename[len(base):].lstrip(os.path.sep))
 
         files.append('src/sentry/sentry-package.json')
+        files.append('src/sentry/static/version')
 
     def _build_static(self):
         work_path = self.work_path
@@ -386,6 +387,8 @@ class BuildJavascriptCommand(Command):
         }
         with open(self.sentry_package_json_path, 'w') as fp:
             json.dump(manifest, fp)
+        with open(self.sentry_static_version_path, 'w') as fp:
+            fp.write(version_info['build'])
         return manifest
 
     @property
@@ -397,6 +400,11 @@ class BuildJavascriptCommand(Command):
     def sentry_package_json_path(self):
         return os.path.abspath(os.path.join(
             self.build_lib, 'sentry/sentry-package.json'))
+
+    @property
+    def sentry_static_version_path(self):
+        return os.path.abspath(os.path.join(
+            self.build_lib, 'sentry/static/version'))
 
 
 class SentrySDistCommand(SDistCommand):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -262,7 +262,7 @@ INSTALLED_APPS = (
 )
 
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, 'static'))
-STATIC_URL = '/_static/'
+STATIC_URL = '/_static/{version}/'
 
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",

--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -18,6 +18,14 @@ from sentry.utils.safe import safe_execute
 
 class SentryLocaleMiddleware(LocaleMiddleware):
     def process_request(self, request):
+        # No locale for static media
+        # This avoids touching user session, which means we avoid
+        # setting `Vary: Cookie` as a response header which will
+        # break HTTP caching entirely.
+        self.__is_static = request.path_info[:9] == '/_static/'
+        if self.__is_static:
+            return
+
         safe_execute(self.load_user_conf, request,
                      _with_transaction=False)
 
@@ -36,3 +44,11 @@ class SentryLocaleMiddleware(LocaleMiddleware):
             user=request.user, project=None, key='timezone', default=None)
         if timezone:
             request.timezone = pytz.timezone(timezone)
+
+    def process_response(self, request, response):
+        # If static bound, we don't want to run the normal process_response since this
+        # adds an extra `Vary: Accept-Language`. Static files don't need this and is
+        # less effective for caching.
+        if self.__is_static:
+            return response
+        return super(SentryLocaleMiddleware, self).process_response(request, response)

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -20,6 +20,7 @@ def static_media(request, **kwargs):
 
     module = kwargs.get('module')
     path = kwargs.get('path', '')
+    version = kwargs.get('version')
 
     if module:
         path = '%s/%s' % (module, path)
@@ -29,6 +30,11 @@ def static_media(request, **kwargs):
     # We need CORS for font files
     if path.endswith(('.eot', '.ttf', '.woff', '.js')):
         response['Access-Control-Allow-Origin'] = '*'
+
+    # If we have a version, we can cache it FOREVER
+    if version is not None:
+        response['Cache-Control'] = 'max-age=315360000'
+
     return response
 
 

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -127,8 +127,8 @@ urlpatterns += patterns(
     url(r'^api/(?P<project_id>\d+)/csp-report/$', api.CspReportView.as_view(),
         name='sentry-api-csp-report'),
 
-    # The static version is either a 10 digit timestamp, or a 32 char md5 hash
-    url(r'^_static/(?:(?P<version>\d{10}|[a-f0-9]{32})/)?(?P<module>[^/]+)/(?P<path>.*)$', generic.static_media,
+    # The static version is either a 10 digit timestamp, a sha1, or md5 hash
+    url(r'^_static/(?:(?P<version>\d{10}|[a-f0-9]{32,40})/)?(?P<module>[^/]+)/(?P<path>.*)$', generic.static_media,
         name='sentry-media'),
 
     # API

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -127,7 +127,8 @@ urlpatterns += patterns(
     url(r'^api/(?P<project_id>\d+)/csp-report/$', api.CspReportView.as_view(),
         name='sentry-api-csp-report'),
 
-    url(r'^_static/(?P<module>[^/]+)/(?P<path>.*)$', generic.static_media,
+    # The static version is either a 10 digit timestamp, or a 32 char md5 hash
+    url(r'^_static/(?:(?P<version>\d{10}|[a-f0-9]{32})/)?(?P<module>[^/]+)/(?P<path>.*)$', generic.static_media,
         name='sentry-media'),
 
     # API

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -5,7 +5,7 @@ from sentry.testutils import TestCase
 
 class StaticMediaTest(TestCase):
     def test_basic(self):
-        url = '/_static/sentry/dist/app.js'
+        url = '/_static/sentry/app/index.js'
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert 'Cache-Control' not in response
@@ -13,22 +13,22 @@ class StaticMediaTest(TestCase):
         assert response['Access-Control-Allow-Origin'] == '*'
 
     def test_versioned(self):
-        url = '/_static/1234567890/sentry/dist/app.js'
+        url = '/_static/1234567890/sentry/app/index.js'
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert 'Cache-Control' in response
         assert 'Vary' not in response
         assert response['Access-Control-Allow-Origin'] == '*'
 
-        url = '/_static/a43db3b08ddd4918972f80739f15344b/sentry/dist/app.js'
+        url = '/_static/a43db3b08ddd4918972f80739f15344b/sentry/app/index.js'
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert 'Cache-Control' in response
         assert 'Vary' not in response
         assert response['Access-Control-Allow-Origin'] == '*'
 
-    def test_css(self):
-        url = '/_static/sentry/dist/sentry.css'
+    def test_no_cors(self):
+        url = '/_static/sentry/images/favicon.ico'
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert 'Cache-Control' not in response

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+
+class StaticMediaTest(TestCase):
+    def test_basic(self):
+        url = '/_static/sentry/dist/app.js'
+        response = self.client.get(url)
+        assert response.status_code == 200, response
+        assert 'Cache-Control' not in response
+        assert 'Vary' not in response
+        assert response['Access-Control-Allow-Origin'] == '*'
+
+    def test_versioned(self):
+        url = '/_static/1234567890/sentry/dist/app.js'
+        response = self.client.get(url)
+        assert response.status_code == 200, response
+        assert 'Cache-Control' in response
+        assert 'Vary' not in response
+        assert response['Access-Control-Allow-Origin'] == '*'
+
+        url = '/_static/a43db3b08ddd4918972f80739f15344b/sentry/dist/app.js'
+        response = self.client.get(url)
+        assert response.status_code == 200, response
+        assert 'Cache-Control' in response
+        assert 'Vary' not in response
+        assert response['Access-Control-Allow-Origin'] == '*'
+
+    def test_css(self):
+        url = '/_static/sentry/dist/sentry.css'
+        response = self.client.get(url)
+        assert response.status_code == 200, response
+        assert 'Cache-Control' not in response
+        assert 'Vary' not in response
+        assert 'Access-Control-Allow-Origin' not in response


### PR DESCRIPTION
- Add in the `{version}` key to `STATIC_URL` by default so assets get a version.
- Make sure `/_static/` requests don't get a `Vary` header.
- Set a long lived `Cache-Control` header if we see a versioned request.
- Packages up static version with sdist for distribution.
