### PR TITLE
Add CSRF_COOKIE_SECURE in settings.py

### DIFF
--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -164,6 +164,7 @@ SENTRY_FILESTORE_OPTIONS = {
 # header and uncomment the following settings
 # SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # SESSION_COOKIE_SECURE = True
+# CSRF_COOKIE_SECURE = True
 
 # If you're not hosting at the root of your web server, and not using uWSGI,
 # you need to uncomment and set it to the path where Sentry is hosted.


### PR DESCRIPTION
`installation.rst` suggests using `CSRF_COOKIE_SECURE = True` but it's not in the default config.

I wonder if it should also be added to `cases.py` just like `SESSION_COOKIE_SECURE`. See:
https://github.com/getsentry/sentry/blob/a030e24429a2892c3bc0e24069997b6315b2e06b/src/sentry/testutils/cases.py#L84
