### PR TITLE
Add missing options in docs/cli/start/index.rst

### DIFF
--- a/docs/cli/start/index.rst
+++ b/docs/cli/start/index.rst
@@ -7,6 +7,8 @@ Options
 ```````
 
 - ``-b, --bind ADDRESS``: Bind address.
+- ``-w, --workers INTEGER``: Specify how many workers (default 3).
 - ``--upgrade``: Upgrade before starting.
 - ``--noinput``: Do not prompt the user for input of any kind.
+- ``--debug``: Debug mode.
 - ``--help``: print this help page.


### PR DESCRIPTION
Two options from [start.py](https://github.com/getsentry/sentry/blob/ba84bc973618dddcf1b727009e710ddcfb5394d6/src/sentry/runner/commands/start.py#L21-L24) were not in the docs.

Feel free to improve the wording.
