### PR TITLE
Remove Activity.event

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -57,7 +57,6 @@ class Activity(Model):
 
     project = FlexibleForeignKey('sentry.Project')
     group = FlexibleForeignKey('sentry.Group', null=True)
-    event = FlexibleForeignKey('sentry.Event', null=True)
     # index on (type, ident)
     type = BoundedPositiveIntegerField(choices=TYPE)
     ident = models.CharField(max_length=64, null=True)
@@ -95,18 +94,12 @@ class Activity(Model):
         if self.type == Activity.NOTE:
             self.group.update(num_comments=F('num_comments') + 1)
 
-            if self.event:
-                self.event.update(num_comments=F('num_comments') + 1)
-
     def delete(self, *args, **kwargs):
         super(Activity, self).delete(*args, **kwargs)
 
         # HACK: support Group.num_comments
         if self.type == Activity.NOTE:
             self.group.update(num_comments=F('num_comments') - 1)
-
-            if self.event:
-                self.event.update(num_comments=F('num_comments') - 1)
 
     def send_notification(self):
         activity.send_activity_notifications.delay(self.id)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -83,7 +83,7 @@ class Fixtures(object):
     @fixture
     def activity(self):
         return Activity.objects.create(
-            group=self.group, event=self.event, project=self.project,
+            group=self.group, project=self.project,
             type=Activity.NOTE, user=self.user,
             data={}
         )

--- a/src/sentry/web/forms/__init__.py
+++ b/src/sentry/web/forms/__init__.py
@@ -90,7 +90,7 @@ class NewNoteForm(forms.Form):
 
     def save(self, group, user, event=None):
         activity = Activity.objects.create(
-            group=group, event=event, project=group.project,
+            group=group, project=group.project,
             type=Activity.NOTE, user=user,
             data=self.cleaned_data
         )

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -164,7 +164,7 @@ def new_note(request):
         data=load_data('python'),
     )
     note = Activity(
-        group=event.group, event=event, project=event.project,
+        group=event.group, project=event.project,
         type=Activity.NOTE, user=request.user,
         data={'text': 'This is an example note!'},
     )

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -271,7 +271,6 @@ class MailPluginTest(TestCase):
             group=self.group,
             type=Activity.NOTE,
             user=user_foo,
-            event=self.create_event('a' * 32, group=self.group),
             data={
                 'text': 'sup guise',
             },
@@ -300,7 +299,6 @@ class MailPluginTest(TestCase):
             project=self.project,
             type=Activity.RELEASE,
             user=user_foo,
-            event=self.create_event('a' * 32, group=self.group),
             data={
                 'version': release.version,
             },


### PR DESCRIPTION
We need to break apart the Event model from the cluster which would require us to remove the ForeignKey here. Since the column isn't actually used, we might as well just drop

We'll follow up with the actual removal of the column, as well as removal of Event.num_comments.
