### PR TITLE
Handle invalid source encodings

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -344,6 +344,20 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
         }
         raise CannotFetchSource(error)
 
+    # Make sure the file we're getting back is unicode, if it's not,
+    # it's either some encoding that we don't understand, or it's binary
+    # data which we can't process.
+    if not isinstance(result[1], unicode):
+        try:
+            result[1] = result[1].decode('utf8')
+        except UnicodeDecodeError:
+            error = {
+                'type': EventError.JS_INVALID_SOURCE_ENCODING,
+                'value': 'utf8',
+                'url': url,
+            }
+            raise CannotFetchSource(error)
+
     return UrlResult(url, result[0], result[1])
 
 

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -349,7 +349,7 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
     # data which we can't process.
     if not isinstance(result[1], unicode):
         try:
-            result[1] = result[1].decode('utf8')
+            result = (result[0], result[1].decode('utf8'), result[2])
         except UnicodeDecodeError:
             error = {
                 'type': EventError.JS_INVALID_SOURCE_ENCODING,

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -15,6 +15,7 @@ class EventError(object):
     JS_MISSING_SOURCE = 'js_no_source'
     JS_INVALID_SOURCEMAP = 'js_invalid_source'
     JS_TOO_MANY_REMOTE_SOURCES = 'js_too_many_sources'
+    JS_INVALID_SOURCE_ENCODING = 'js_invalid_source_encoding'
 
     _messages = {
         INVALID_DATA: 'Discarded invalid value for parameter \'{name}\'',
@@ -29,6 +30,7 @@ class EventError(object):
         JS_MISSING_SOURCE: 'Source code was not found for {url}',
         JS_INVALID_SOURCEMAP: 'Sourcemap was invalid or not parseable: {url}',
         JS_TOO_MANY_REMOTE_SOURCES: 'The maximum number of remote source requests was made',
+        JS_INVALID_SOURCE_ENCODING: 'Source file was not \'{value}\' encoding: {url}'
     }
 
     @classmethod


### PR DESCRIPTION
Assert that any source files needed in JS pipeline are unicodes. If not a unicode, attempt to encode as utf-8. If this fails, we show an error.

![image](https://cloud.githubusercontent.com/assets/375744/12187971/b3e8a368-b565-11e5-94b3-707a5e15e195.png)

Previously, this just failed silently in the pipeline. Lines would get extracted out of files and put into the JSON blob, then we error writing the JSON blob into memcache since it can't be JSON encoded and the pipeline just halts.
