### PR TITLE
Optimize serialize() calls for group_tags endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+from collections import defaultdict
+from itertools import chain
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import GroupTagValue, GroupTagKey, TagKey, TagKeyStatus
@@ -19,6 +21,7 @@ class GroupTagsEndpoint(GroupEndpoint):
 
         # O(N) db access
         data = []
+        top_values_by_key = {}
         for tag_key in tag_keys:
             total_values = GroupTagValue.get_value_count(group.id, tag_key.key)
             top_values = GroupTagValue.get_top_values(group.id, tag_key.key, limit=10)
@@ -27,13 +30,22 @@ class GroupTagsEndpoint(GroupEndpoint):
             else:
                 key = tag_key.key
 
+            top_values_by_key[key] = top_values
+
             data.append({
                 'id': str(tag_key.id),
                 'key': key,
                 'name': tag_key.get_label(),
                 'uniqueValues': tag_key.values_seen,
                 'totalValues': total_values,
-                'topValues': serialize(top_values, request.user),
             })
+
+        # Serialize all of the values at once to avoid O(n) serialize/db queries
+        top_values_by_key_serialized = defaultdict(list)
+        for value in serialize(list(chain.from_iterable(top_values_by_key.itervalues())), request.user):
+            top_values_by_key_serialized[value['key']].append(value)
+
+        for d in data:
+            d['topValues'] = top_values_by_key_serialized[d['key']]
 
         return Response(data)


### PR DESCRIPTION
serialize() was the slowest step and does 1 or 2 queries per tag_value,
so in some cases, (lots of tag keys), this overhead is significant.

Instead, we'll spend some time working them around in memory to do one
serialize() for all of them.

On my smaller local datasets, but cut the time of the endpoint by more than half.
