### PR TITLE
Prevent X-Sentry-Logger header from being multiline

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -173,7 +173,8 @@ class MailPlugin(NotificationPlugin):
             })
 
         headers = {
-            'X-Sentry-Logger': group.logger,
+            # Headers can't be multiline
+            'X-Sentry-Logger': group.logger.splitlines()[0],
             'X-Sentry-Logger-Level': group.get_level_display(),
             'X-Sentry-Team': project.team.name,
             'X-Sentry-Project': project.name,


### PR DESCRIPTION
Apparently we have multiline logger names?

Fixes GH-2533

Not sure if we want to solve this generically for all header values? Seems like we should assess on an individual basis to figure out why that header becomes multiline in the first place.

Typically these should all be safe.
