### PR TITLE
Handle invalid sourcemap location references

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -559,29 +559,23 @@ class SourceProcessor(object):
                 })
             elif sourcemap_idx:
                 last_state = state
-                state = find_source(sourcemap_idx, frame.lineno, frame.colno)
 
                 if is_data_uri(sourcemap_url):
                     sourcemap_label = frame.abs_path
                 else:
                     sourcemap_label = sourcemap_url
 
-                abs_path = urljoin(sourcemap_url, state.src)
-
-                logger.debug('Mapping compressed source %r to mapping in %r', frame.abs_path, abs_path)
-                source = self.get_source(abs_path, release)
-                if not source:
-                    frame.data = {
+                try:
+                    state = find_source(sourcemap_idx, frame.lineno, frame.colno)
+                except Exception:
+                    state = None
+                    all_errors.append({
+                        'type': EventError.JS_INVALID_SOURCEMAP_LOCATION,
+                        'column': frame.colno,
+                        'row': frame.lineno,
+                        'source': frame.abs_path,
                         'sourcemap': sourcemap_label,
-                    }
-                    errors = cache.get_errors(abs_path)
-                    if errors:
-                        all_errors.extend(errors)
-                    else:
-                        all_errors.append({
-                            'type': EventError.JS_MISSING_SOURCE,
-                            'url': force_bytes(abs_path, errors='replace'),
-                        })
+                    })
 
                 # Store original data in annotation
                 frame.data = {
@@ -593,45 +587,62 @@ class SourceProcessor(object):
                     'sourcemap': sourcemap_label,
                 }
 
-                # SourceMap's return zero-indexed lineno's
-                frame.lineno = state.src_line + 1
-                frame.colno = state.src_col
-                # The offending function is always the previous function in the stack
-                # Honestly, no idea what the bottom most frame is, so we're ignoring that atm
-                if last_state:
-                    frame.function = last_state.name or frame.function
-                else:
-                    frame.function = state.name or frame.function
+                if state is not None:
+                    abs_path = urljoin(sourcemap_url, state.src)
 
-                filename = state.src
-                # special case webpack support
-                # abs_path will always be the full path with webpack:/// prefix.
-                # filename will be relative to that
-                if abs_path.startswith('webpack:'):
-                    filename = abs_path
-                    # webpack seems to use ~ to imply "relative to resolver root"
-                    # which is generally seen for third party deps
-                    # (i.e. node_modules)
-                    if '/~/' in filename:
-                        filename = '~/' + abs_path.split('/~/', 1)[-1]
+                    logger.debug('Mapping compressed source %r to mapping in %r', frame.abs_path, abs_path)
+                    source = self.get_source(abs_path, release)
+
+                if not source:
+                    errors = cache.get_errors(abs_path)
+                    if errors:
+                        all_errors.extend(errors)
                     else:
-                        filename = filename.split('webpack:///', 1)[-1]
+                        all_errors.append({
+                            'type': EventError.JS_MISSING_SOURCE,
+                            'url': force_bytes(abs_path, errors='replace'),
+                        })
 
-                    # As noted above, '~/' means they're coming from node_modules,
-                    # so these are not app dependencies
-                    if filename.startswith('~/'):
-                        frame.in_app = False
-                    # And conversely, local dependencies start with './'
-                    elif filename.startswith('./'):
-                        frame.in_app = True
+                if state is not None:
+                    # SourceMap's return zero-indexed lineno's
+                    frame.lineno = state.src_line + 1
+                    frame.colno = state.src_col
+                    # The offending function is always the previous function in the stack
+                    # Honestly, no idea what the bottom most frame is, so we're ignoring that atm
+                    if last_state:
+                        frame.function = last_state.name or frame.function
+                    else:
+                        frame.function = state.name or frame.function
 
-                    # We want to explicitly generate a webpack module name
-                    frame.module = generate_module(filename)
+                    filename = state.src
+                    # special case webpack support
+                    # abs_path will always be the full path with webpack:/// prefix.
+                    # filename will be relative to that
+                    if abs_path.startswith('webpack:'):
+                        filename = abs_path
+                        # webpack seems to use ~ to imply "relative to resolver root"
+                        # which is generally seen for third party deps
+                        # (i.e. node_modules)
+                        if '/~/' in filename:
+                            filename = '~/' + abs_path.split('/~/', 1)[-1]
+                        else:
+                            filename = filename.split('webpack:///', 1)[-1]
 
-                frame.abs_path = abs_path
-                frame.filename = filename
-                if not frame.module and abs_path.startswith(('http:', 'https:', 'webpack:')):
-                    frame.module = generate_module(abs_path)
+                        # As noted above, '~/' means they're coming from node_modules,
+                        # so these are not app dependencies
+                        if filename.startswith('~/'):
+                            frame.in_app = False
+                        # And conversely, local dependencies start with './'
+                        elif filename.startswith('./'):
+                            frame.in_app = True
+
+                        # We want to explicitly generate a webpack module name
+                        frame.module = generate_module(filename)
+
+                    frame.abs_path = abs_path
+                    frame.filename = filename
+                    if not frame.module and abs_path.startswith(('http:', 'https:', 'webpack:')):
+                        frame.module = generate_module(abs_path)
 
             elif sourcemap_url:
                 frame.data = {

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -16,6 +16,7 @@ class EventError(object):
     JS_INVALID_SOURCEMAP = 'js_invalid_source'
     JS_TOO_MANY_REMOTE_SOURCES = 'js_too_many_sources'
     JS_INVALID_SOURCE_ENCODING = 'js_invalid_source_encoding'
+    JS_INVALID_SOURCEMAP_LOCATION = 'js_invalid_sourcemap_location'
 
     _messages = {
         INVALID_DATA: 'Discarded invalid value for parameter \'{name}\'',
@@ -30,7 +31,8 @@ class EventError(object):
         JS_MISSING_SOURCE: 'Source code was not found for {url}',
         JS_INVALID_SOURCEMAP: 'Sourcemap was invalid or not parseable: {url}',
         JS_TOO_MANY_REMOTE_SOURCES: 'The maximum number of remote source requests was made',
-        JS_INVALID_SOURCE_ENCODING: 'Source file was not \'{value}\' encoding: {url}'
+        JS_INVALID_SOURCE_ENCODING: 'Source file was not \'{value}\' encoding: {url}',
+        JS_INVALID_SOURCEMAP_LOCATION: 'Invalid location in sourcemap: ({column}, {row})',
     }
 
     @classmethod


### PR DESCRIPTION
This will handle reporting when bad sourcemap location is sent to us.

This can happen for any number of reasons, but the current result is the entire event fails in the pipeline and is discarded.

Now we capture the error and display it in the UI.
