### PR TITLE
Switch Event.data ref to Project

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -37,7 +37,12 @@ class Event(Model):
     platform = models.CharField(max_length=64, null=True)
     datetime = models.DateTimeField(default=timezone.now, db_index=True)
     time_spent = BoundedIntegerField(null=True)
-    data = NodeField(blank=True, null=True, ref_func=lambda x: x.group_id or x.group.id)
+    data = NodeField(
+        blank=True,
+        null=True,
+        ref_func=lambda x: x.project_id or x.project.id,
+        ref_version=2,
+    )
 
     objects = BaseManager()
 

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -127,15 +127,16 @@ class EventNodeStoreTest(TestCase):
         assert event.data.id == node_id
 
     def test_screams_bloody_murder_when_ref_fails(self):
-        group1 = self.create_group()
+        project1 = self.create_project()
+        project2 = self.create_project()
+        group1 = self.create_group(project1)
         invalid_event = self.create_event(group=group1)
-        group2 = self.create_group()
+        group2 = self.create_group(project2)
         event = self.create_event(group=group2)
         event.data.bind_ref(invalid_event)
         event.save()
 
-        assert event.data.get_ref(event) == event.group.id
-        assert event.data.get_ref(invalid_event) == invalid_event.group.id
+        assert event.data.get_ref(event) != event.data.get_ref(invalid_event)
 
         with pytest.raises(NodeIntegrityFailure):
             Event.objects.bind_nodes([event], 'data')
@@ -147,8 +148,8 @@ class EventNodeStoreTest(TestCase):
 
         Event.objects.bind_nodes([event], 'data')
 
-        assert event.data.ref == event.group.id
+        assert event.data.ref == event.project.id
 
     def test_basic_ref_binding(self):
         event = self.create_event()
-        assert event.data.get_ref(event) == event.group.id
+        assert event.data.get_ref(event) == event.project.id


### PR DESCRIPTION
This corrects an issue where merging events would cause a ref integrity error due to the fact that refs were bound to the group, which commonly would no longer be the same. To avoid changing the limitations on NodeField (read: keep them immutable) we're changing the ref to still be privacy-scoped. These assertions are mostly a sanity check for us anyways, so losing the old ref's isn't a big issue.
