### PR TITLE
Vary access and membership for teams

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 __all__ = ['from_user', 'from_member', 'DEFAULT']
 
+import warnings
+
 from django.conf import settings
 
 from sentry.models import AuthIdentity, AuthProvider, OrganizationMember
@@ -10,7 +12,10 @@ from sentry.models import AuthIdentity, AuthProvider, OrganizationMember
 class BaseAccess(object):
     is_active = False
     sso_is_valid = False
+    # teams with valid access
     teams = ()
+    # teams with valid membership
+    memberships = ()
     scopes = frozenset()
 
     def has_scope(self, scope):
@@ -19,12 +24,22 @@ class BaseAccess(object):
         return scope in self.scopes
 
     def has_team(self, team):
+        warnings.warn('has_team() is deprecated in favor of has_team_access',
+                      DeprecationWarning)
+        return self.has_team_access(team)
+
+    def has_team_access(self, team):
         if not self.is_active:
             return False
         return team in self.teams
 
+    def has_team_membership(self, team):
+        if not self.is_active:
+            return False
+        return team in self.memberships
+
     def has_team_scope(self, team, scope):
-        return self.has_team(team) and self.has_scope(scope)
+        return self.has_team_access(team) and self.has_scope(scope)
 
     def to_django_context(self):
         return {
@@ -37,8 +52,9 @@ class Access(BaseAccess):
     # TODO(dcramer): this is still a little gross, and ideally backend access
     # would be based on the same scopes as API access so theres clarity in
     # what things mean
-    def __init__(self, scopes, is_active, teams, sso_is_valid):
+    def __init__(self, scopes, is_active, teams, memberships, sso_is_valid):
         self.teams = teams
+        self.memberships = memberships
         self.scopes = scopes
 
         self.is_active = is_active
@@ -50,10 +66,12 @@ def from_request(request, organization):
         return DEFAULT
 
     if request.is_superuser():
+        team_list = list(organization.team_set.all())
         return Access(
             scopes=settings.SENTRY_SCOPES,
             is_active=True,
-            teams=organization.team_set.all(),
+            teams=team_list,
+            memberships=team_list,
             sso_is_valid=True,
         )
     return from_user(request.user, organization)
@@ -73,6 +91,9 @@ def from_user(user, organization):
         )
     except OrganizationMember.DoesNotExist:
         return DEFAULT
+
+    # ensure cached relation
+    om.organization = organization
 
     return from_member(om)
 
@@ -100,11 +121,18 @@ def from_member(member):
             else:
                 sso_is_valid = auth_identity.is_valid(member)
 
+    team_memberships = member.get_teams()
+    if member.organization.flags.allow_joinleave:
+        team_access = list(member.organization.team_set.all())
+    else:
+        team_access = team_memberships
+
     return Access(
         is_active=True,
         sso_is_valid=sso_is_valid,
         scopes=member.get_scopes(),
-        teams=member.get_teams(),
+        memberships=team_memberships,
+        teams=team_access,
     )
 
 
@@ -119,6 +147,10 @@ class NoAccess(BaseAccess):
 
     @property
     def teams(self):
+        return ()
+
+    @property
+    def memberships(self):
         return ()
 
     @property

--- a/src/sentry/static/sentry/app/views/projectDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectDetails.jsx
@@ -91,9 +91,9 @@ const ProjectDetails = React.createClass({
       return;
     }
     let [activeTeam, activeProject] = this.identifyProject();
-    let isMember = activeTeam && activeTeam.isMember;
+    let hasAccess = activeTeam && activeTeam.hasAccess;
 
-    if (activeProject && isMember) {
+    if (activeProject && hasAccess) {
       // TODO(dcramer): move member list to organization level
       this.api.request(this.getMemberListEndpoint(), {
         success: (data) => {
@@ -108,7 +108,7 @@ const ProjectDetails = React.createClass({
         error: false,
         errorType: null
       });
-    } else if (isMember === false) {
+    } else if (activeTeam && activeTeam.isMember) {
       this.setState({
         project: activeProject,
         team: activeTeam,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -276,7 +276,10 @@ class PermissionTestCase(TestCase):
     def setUp(self):
         super(PermissionTestCase, self).setUp()
         self.owner = self.create_user(is_superuser=False)
-        self.organization = self.create_organization(owner=self.owner)
+        self.organization = self.create_organization(
+            owner=self.owner,
+            flags=0,  # disable default allow_joinleave access
+        )
         self.team = self.create_team(organization=self.organization)
 
     def assert_can_access(self, user, path, method='GET'):

--- a/tests/sentry/api/endpoints/test_organization_access_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_access_request_details.py
@@ -112,10 +112,14 @@ class UpdateOrganizationAccessRequestTest(APITestCase):
 
         assert resp.status_code == 204
 
-    def test_teamless_admin_cannot_approve(self):
+    def test_teamless_admin_cannot_approve_with_closed_membership(self):
         self.login_as(user=self.user)
 
-        organization = self.create_organization(name='foo', owner=self.user)
+        organization = self.create_organization(
+            name='foo',
+            owner=self.user,
+            flags=0,  # kill allow_joinleave
+        )
         user = self.create_user('bar@example.com')
         member = self.create_member(
             organization=organization,

--- a/tests/sentry/web/frontend/test_organization_members.py
+++ b/tests/sentry/web/frontend/test_organization_members.py
@@ -58,7 +58,11 @@ class OrganizationMembersTest(TestCase):
         ]
 
     def test_shows_access_requests_for_team_admin(self):
-        organization = self.create_organization(name='foo', owner=self.user)
+        organization = self.create_organization(
+            name='foo',
+            owner=self.user,
+            flags=0,  # kill default allow_joinleave
+        )
         team_1 = self.create_team(name='foo', organization=organization)
         team_2 = self.create_team(name='bar', organization=organization)
 


### PR DESCRIPTION
This adjusts team scoping to add an additional 'can access' concept in addition to 'is member'. When a team has open membership, or a user is a superuser, they will have access to teams but not (by default) be a member. This most importantly allows users to view issue details without joining a team, and also fixes some odd behavior wherein superusers appeared like members when they weren't.

Fixes GH-2241
