### PR TITLE
issue#2562, Can not select Chinese locale.

### DIFF
--- a/src/sentry/conf/locale.py
+++ b/src/sentry/conf/locale.py
@@ -2,12 +2,14 @@ import os
 import json
 import sentry
 
-#change locale file dir name to locale code
+
+# change locale file dir name to locale code
 def dirname_to_local(dir_name):
     if '_' in dir_name:
         pre, post = dir_name.split('_', 1)
         dir_name = '{}-{}'.format(pre, post.lower())
     return dir_name
+
 
 with open(os.path.join(os.path.dirname(sentry.__file__),
                        'locale', 'catalogs.json'), 'r') as f:

--- a/src/sentry/conf/locale.py
+++ b/src/sentry/conf/locale.py
@@ -2,7 +2,14 @@ import os
 import json
 import sentry
 
+#change locale file dir name to locale code
+def dirname_to_local(dir_name):
+    if '_' in dir_name:
+        pre, post = dir_name.split('_', 1)
+        dir_name = '{}-{}'.format(pre, post.lower())
+    return dir_name
 
 with open(os.path.join(os.path.dirname(sentry.__file__),
                        'locale', 'catalogs.json'), 'r') as f:
     CATALOGS = json.load(f)['supported_locales']
+    CATALOGS = [dirname_to_local(dirname) for dirname in CATALOGS]


### PR DESCRIPTION
The solution of [issue#2562](https://github.com/getsentry/sentry/issues/2562).

Cannot find the option of Chinese and other which locale code contains `-`.
