### PR TITLE
Add logging to digest building and email delivery.

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -92,13 +92,6 @@ def attach_state(project, groups, rules, event_counts, user_counts):
     }
 
 
-def dictmap(f, d):
-    r = {}
-    for k, v in d.items():
-        r[k] = f(v)
-    return r
-
-
 class Pipeline(object):
     def __init__(self):
         self.operations = []

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -52,6 +52,7 @@ class MailPlugin(NotificationPlugin):
                    project=None, group=None, headers=None, context=None):
         send_to = self.get_send_to(project)
         if not send_to:
+            logger.debug('Skipping message rendering, no users to send to.')
             return
 
         subject_prefix = self.get_option('subject_prefix', project) or self.subject_prefix

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-from collections import OrderedDict
+from collections import (
+    OrderedDict,
+    defaultdict,
+)
 
 from exam import fixture
 
@@ -10,7 +13,8 @@ from sentry.digests.notifications import (
     event_to_record,
     rewrite_record,
     group_records,
-    sort_groups,
+    sort_group_contents,
+    sort_rule_groups,
 )
 from sentry.testutils import TestCase
 
@@ -78,7 +82,7 @@ class GroupRecordsTestCase(TestCase):
     def test_success(self):
         events = [self.create_event(group=self.group) for _ in xrange(3)]
         records = [Record(event.id, Notification(event, [self.rule]), event.datetime) for event in events]
-        assert group_records(records) == {
+        assert reduce(group_records, records, defaultdict(lambda: defaultdict(list))) == {
             self.rule: {
                 self.group: records,
             },
@@ -109,7 +113,7 @@ class SortRecordsTestCase(TestCase):
             },
         }
 
-        assert sort_groups(grouped) == OrderedDict((
+        assert sort_rule_groups(sort_group_contents(grouped)) == OrderedDict((
             (rules[1], OrderedDict((
                 (groups[1], []),
                 (groups[2], []),


### PR DESCRIPTION
This adds debug logging in a few places that can result in digest building
being skipped or email delivery being prevented. These cases shouldn't be
representative of any errors, but may be the byproduct of unexpected
configurations.

This can help debugging issues such as #2569.
