### PR TITLE
Coerce mixed exception values to type-based

### DIFF
--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -52,13 +52,19 @@ class SingleException(Interface):
         else:
             stacktrace = None
 
+        type = data.get('type')
         value = data.get('value')
+        if not type and ':' in value.split(' ', 1)[0]:
+            type, value = value.split(':', 1)
+            # in case of TypeError: foo (no space)
+            value = value.strip()
+
         if value is not None and not isinstance(value, basestring):
             value = json.dumps(value)
         value = trim(value, 4096)
 
         kwargs = {
-            'type': trim(data.get('type'), 128),
+            'type': trim(type, 128),
             'value': value,
             'module': trim(data.get('module'), 128),
             'stacktrace': stacktrace,

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -221,6 +221,19 @@ class SingleExceptionTest(TestCase):
         ))
         assert result.value == '{"unauthorized":true}'
 
+    def test_handles_type_in_value(self):
+        result = SingleException.to_python(dict(
+            value='ValueError: unauthorized',
+        ))
+        assert result.type == 'ValueError'
+        assert result.value == 'unauthorized'
+
+        result = SingleException.to_python(dict(
+            value='ValueError:unauthorized',
+        ))
+        assert result.type == 'ValueError'
+        assert result.value == 'unauthorized'
+
 
 class TrimExceptionsTest(TestCase):
     def test_under_max(self):


### PR DESCRIPTION
In an ideal world all clients would correctly send uniform data, but in some cases (read: browser implementations) that doesn't happen and we end up with worse data and grouping. It's easier to resolve this on the server, so let's just do it.

An example awkward error:

```
null: ReferenceError: Can't find variable: fieldset
  at ? (/accept/61433/redacted/:3:251)
```

Produced by:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 9_2 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/47.0.2526.107 Mobile/13C75 Safari/601.1.46 (000278)
```
