### PR TITLE
Replace gunicorn with uwsgi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,6 @@ coverage: develop
 	make test-python-coverage
 	coverage html
 
-run-uwsgi:
-	uwsgi --http 127.0.0.1:8000 --need-app --disable-logging --wsgi-file src/sentry/wsgi.py --processes 1 --threads 5
-
 publish:
 	python setup.py sdist bdist_wheel upload
 
@@ -139,7 +136,7 @@ extract-api-docs:
 	cd api-docs; python generator.py
 
 
-.PHONY: develop dev-postgres dev-docs setup-git build clean locale update-transifex update-submodules test testloop test-cli test-js test-python test-python-coverage lint lint-python lint-js coverage run-uwsgi publish
+.PHONY: develop dev-postgres dev-docs setup-git build clean locale update-transifex update-submodules test testloop test-cli test-js test-python test-python-coverage lint lint-python lint-js coverage publish
 
 
 ############################

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -86,7 +86,7 @@ The following settings are available for the built-in webserver:
 
 .. describe:: SENTRY_WEB_OPTIONS
 
-    A dictionary of additional configuration options to pass to gunicorn.
+    A dictionary of additional configuration options to pass to uwsgi.
 
     Defaults to ``{}``.
 
@@ -94,13 +94,8 @@ The following settings are available for the built-in webserver:
 
         SENTRY_WEB_OPTIONS = {
             'workers': 10,
-            'worker_class': 'gevent',
+            'buffer-size': 32768,
         }
-
-    Note: The logging options of gunicorn is overridden by the default logging
-    configuration of Sentry. In order to reuse loggers from gunicorn, put
-    ``LOGGING['disable_existing_loggers'] = False`` into your configuration
-    file.
 
 .. _config-smtp-server:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -289,7 +289,7 @@ future versions of Sentry.
 Starting the Web Service
 ------------------------
 
-Sentry provides a built-in webserver (powered by gunicorn and eventlet) to
+Sentry provides a built-in webserver (powered by uWSGI) to
 get you off the ground quickly, also you can setup Sentry as WSGI
 application, in that case skip to section `Running Sentry as WSGI
 application`.

--- a/docs/nginx.rst
+++ b/docs/nginx.rst
@@ -80,52 +80,6 @@ Below is a sample production ready configuration for Nginx with Sentry::
     }
 
 
-Proxying uWSGI
---------------
-
-While Sentry provides a default webserver, you'll likely want to move to
-something a bit more powerful. We suggest using `uWSGI
-<http://projects.unbit.it/uwsgi/>`_ to run Sentry.
-
-Install uWSGI into your virtualenv (refer to quickstart if you're
-confused)::
-
-    pip install uwsgi
-
-Create a uWSGI configuration which references the Sentry configuration::
-
-    [uwsgi]
-    env = SENTRY_CONF=/etc/sentry
-    module = sentry.wsgi
-
-    ; spawn the master and 4 processes with 8 threads each
-    http = 127.0.0.1:9000
-    master = true
-    processes = 4
-    threads = 8
-
-    ; allow longer headers for raven.js if applicable
-    ; default: 4096
-    buffer-size = 32768
-
-    ; allow large file uploads
-    limit-post = 5242880
-
-    ; various other explicit defaults
-    post-buffering = 65536
-    thunder-lock = true
-    disable-logging = true
-    enable-threads = true
-    single-interpreter = true
-    lazy-apps = true
-    log-x-forwarded-for = true
-
-
-Finally, re-configure supervisor to run uwsgi instead of 'sentry start'::
-
-  /www/sentry/bin/uwsgi --ini /www/sentry/uwsgi.ini
-
-
 Hosting Sentry at a Subpath
 ----------------------------
 
@@ -134,18 +88,13 @@ Hosting Sentry at a Subpath
 If your web server is hosting several applications then hosting Sentry at '/' may not be feasible for you. It is possible to configure your webserver such that all traffic going to '/sentry' can be directed at Sentry and everything else can remain as is.
 
 
-Subpath with uWSGI
-^^^^^^^^^^^^^^^^^^
+Add the following to your ``SENTRY_WEB_OPTIONS``::
 
-Hosting apps at a subpath is officially supported by uWSGI with a configuration option. (Source: `uWSGI - Hosting multiple apps <http://uwsgi-docs.readthedocs.org/en/latest/Nginx.html#hosting-multiple-apps-in-the-same-process-aka-managing-script-name-and-path-info>`_)
-
-**uWSGI Configuration**
-
-If you are using a uWSGI configuration file, add these lines::
-
-    ; Host Sentry at /sentry
-    mount = /sentry=path/to/sentry/wsgi.py
-    manage-script-name = true
+    SENTRY_WEB_OPTIONS = {
+      # Host Sentry at /sentry
+      'mount': '/sentry=path/to/sentry/wsgi.py'
+      'manage-script-name': True
+    }
 
 If you call uWSGI directly, possibly from Supervisor, see :ref:`performance-web-server`.
 

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,6 @@ install_requires = [
     'email-reply-parser>=0.2.0,<0.3.0',
     'enum34>=0.9.18,<0.10.0',
     'exam>=0.5.1',
-    'gunicorn>=19.2.1,<20.0.0',
     'hiredis>=0.1.0,<0.2.0',
     'ipaddr>=2.1.11,<2.2.0',
     'kombu==3.0.30',
@@ -130,6 +129,7 @@ install_requires = [
     'toronado>=0.0.4,<0.1.0',
     'ua-parser>=0.6.1,<0.7.0',
     'urllib3>=1.11,<1.12',
+    'uwsgi>2.0.0,<2.1.0',
     'rb>=1.3.0,<2.0.0',
 ]
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -246,7 +246,6 @@ INSTALLED_APPS = (
     'captcha',
     'crispy_forms',
     'debug_toolbar',
-    'gunicorn',
     'raven.contrib.django.raven_compat',
     'rest_framework',
     'sentry',

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -172,8 +172,7 @@ SENTRY_FILESTORE_OPTIONS = {
 SENTRY_WEB_HOST = '0.0.0.0'
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
-    # 'workers': 3,  # the number of gunicorn workers
-    # 'secure_scheme_headers': {'X-FORWARDED-PROTO': 'https'},
+    # 'workers': 3,  # the number of web workers
 }
 
 ###############

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -165,7 +165,7 @@ SENTRY_FILESTORE_OPTIONS = {
 # SESSION_COOKIE_SECURE = True
 # CSRF_COOKIE_SECURE = True
 
-# If you're not hosting at the root of your web server, and not using uWSGI,
+# If you're not hosting at the root of your web server,
 # you need to uncomment and set it to the path where Sentry is hosted.
 # FORCE_SCRIPT_NAME = '/sentry'
 

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -44,7 +44,6 @@ class SentryHTTPServer(Service):
         options = (settings.SENTRY_WEB_OPTIONS or {}).copy()
         options.setdefault('module', 'sentry.wsgi:application')
         options.setdefault('protocol', 'http')
-        options.setdefault('http-socket', '%s:%s' % (self.host, self.port))
         options.setdefault('auto-procname', True)
         options.setdefault('procname-prefix-spaced', '[Sentry]')
         options.setdefault('workers', 3)
@@ -65,6 +64,8 @@ class SentryHTTPServer(Service):
         options.setdefault('disable-write-exception', True)
         options.setdefault('virtualenv', sys.prefix)
         options.setdefault('log-format', '%(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"')
+
+        options.setdefault('%s-socket' % options['protocol'], '%s:%s' % (self.host, self.port))
 
         # We only need to set uid/gid when stepping down from root, but if
         # we are trying to run as root, then ignore it entirely.

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -2,37 +2,29 @@
 sentry.services.http
 ~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, print_function
 
-from gunicorn.app.base import Application
-
+import os
+import sys
 from sentry.services.base import Service
 
 
-class SentryGunicornCommand(Application):
-    def __init__(self, options):
-        self.usage = None
-        self.prog = None
-        self.cfg = None
-        self.config_file = ""
-        self.options = options
-        self.callable = None
-        self.project_path = None
-        self.do_load_config()
-
-    def init(self, *args):
-        cfg = {}
-        for k, v in self.options.items():
-            if k.lower() in self.cfg.settings and v is not None:
-                cfg[k.lower()] = v
-        return cfg
-
-    def load(self):
-        import sentry.wsgi
-        return sentry.wsgi.application
+def add_option_to_env(k, v):
+    key = 'UWSGI_' + k.upper().replace('-', '_')
+    if isinstance(v, basestring):
+        value = v
+    elif v is True:
+        value = 'true'
+    elif v is False:
+        value = 'false'
+    elif isinstance(v, (int, long)):
+        value = str(v)
+    else:
+        raise TypeError('Unknown option type: %r (%s)' % (k, type(v)))
+    os.environ[key] = value
 
 
 class SentryHTTPServer(Service):
@@ -50,18 +42,63 @@ class SentryHTTPServer(Service):
         self.workers = workers
 
         options = (settings.SENTRY_WEB_OPTIONS or {}).copy()
-        options.setdefault('bind', '%s:%s' % (self.host, self.port))
-        options.setdefault('timeout', 30)
-        options.setdefault('proc_name', 'Sentry')
+        options.setdefault('module', 'sentry.wsgi:application')
+        options.setdefault('protocol', 'http')
+        options.setdefault('http-socket', '%s:%s' % (self.host, self.port))
+        options.setdefault('auto-procname', True)
+        options.setdefault('procname-prefix-spaced', '[Sentry]')
         options.setdefault('workers', 3)
-        options.setdefault('accesslog', '-')
-        options.setdefault('errorlog', '-')
-        options.setdefault('loglevel', 'info')
-        options.setdefault('limit_request_line', 0)
-        options['preload'] = False
+        options.setdefault('threads', 1)
+        options.setdefault('http-timeout', 30)
+        options.setdefault('vacuum', True)
+        options.setdefault('thunder-lock', True)
+        options.setdefault('log-x-forwarded-for', False)
+        options.setdefault('buffer-size', 32768)
+        options.setdefault('post-buffering', 65536)
+        options.setdefault('limit-post', 20971520)
+        options.setdefault('need-app', True)
+        options.setdefault('disable-logging', False)
+        options.setdefault('memory-report', True)
+        options.setdefault('reload-on-rss', 600)
+        options.setdefault('ignore-sigpipe', True)
+        options.setdefault('ignore-write-errors', True)
+        options.setdefault('disable-write-exception', True)
+        options.setdefault('virtualenv', sys.prefix)
+        options.setdefault('log-format', '%(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"')
+        options.setdefault('uid', os.getuid())
+        options.setdefault('gid', os.getgid())
+
+        # Required arguments that should not be overridden
+        options['master'] = True
+        options['enable-threads'] = True
+        options['lazy-apps'] = True
+        options['single-interpreter'] = True
 
         if workers:
             options['workers'] = workers
+
+        # Old options from gunicorn
+        if 'bind' in options:
+            options['http-socket'] = options['bind']
+            del options['bind']
+        if 'accesslog' in options:
+            if options['accesslog'] != '-':
+                options['logto'] = options['accesslog']
+            del options['accesslog']
+        if 'errorlog' in options:
+            if options['errorlog'] != '-':
+                options['logto2'] = options['errorlog']
+            del options['errorlog']
+        if 'timeout' in options:
+            options['http-timeout'] = options['timeout']
+            del options['timeout']
+        if 'proc_name' in options:
+            options['procname-prefix-spaced'] = options['proc_name']
+            del options['proc_name']
+        if 'secure_scheme_headers' in options:
+            del options['secure_scheme_headers']
+        if 'loglevel' in options:
+            del options['loglevel']
 
         self.options = options
 
@@ -72,4 +109,11 @@ class SentryHTTPServer(Service):
         validate_settings(django_settings)
 
     def run(self):
-        SentryGunicornCommand(self.options).run()
+        for k, v in self.options.iteritems():
+            if v is not None:
+                add_option_to_env(k, v)
+
+        # This has already been validated inside __init__
+        os.environ['SENTRY_SKIP_BACKEND_VALIDATION'] = '1'
+
+        os.execvp('uwsgi', ('uwsgi',))

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -48,7 +48,7 @@ class SentryHTTPServer(Service):
         options.setdefault('auto-procname', True)
         options.setdefault('procname-prefix-spaced', '[Sentry]')
         options.setdefault('workers', 3)
-        options.setdefault('threads', 1)
+        options.setdefault('threads', 4)
         options.setdefault('http-timeout', 30)
         options.setdefault('vacuum', True)
         options.setdefault('thunder-lock', True)
@@ -79,8 +79,7 @@ class SentryHTTPServer(Service):
 
         # Old options from gunicorn
         if 'bind' in options:
-            options['http-socket'] = options['bind']
-            del options['bind']
+            options['http-socket'] = options.pop('bind')
         if 'accesslog' in options:
             if options['accesslog'] != '-':
                 options['logto'] = options['accesslog']
@@ -90,11 +89,9 @@ class SentryHTTPServer(Service):
                 options['logto2'] = options['errorlog']
             del options['errorlog']
         if 'timeout' in options:
-            options['http-timeout'] = options['timeout']
-            del options['timeout']
+            options['http-timeout'] = options.pop('timeout')
         if 'proc_name' in options:
-            options['procname-prefix-spaced'] = options['proc_name']
-            del options['proc_name']
+            options['procname-prefix-spaced'] = options.pop('proc_name')
         if 'secure_scheme_headers' in options:
             del options['secure_scheme_headers']
         if 'loglevel' in options:

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -65,8 +65,15 @@ class SentryHTTPServer(Service):
         options.setdefault('disable-write-exception', True)
         options.setdefault('virtualenv', sys.prefix)
         options.setdefault('log-format', '%(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"')
-        options.setdefault('uid', os.getuid())
-        options.setdefault('gid', os.getgid())
+
+        # We only need to set uid/gid when stepping down from root, but if
+        # we are trying to run as root, then ignore it entirely.
+        uid = os.getuid()
+        if uid > 0:
+            options.setdefault('uid', uid)
+        gid = os.getgid()
+        if gid > 0:
+            options.setdefault('gid', gid)
 
         # Required arguments that should not be overridden
         options['master'] = True

--- a/tests/sentry/services/test_http.py
+++ b/tests/sentry/services/test_http.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+from django.test.utils import override_settings
+from sentry.testutils import TestCase
+from sentry.services.http import SentryHTTPServer, convert_options_to_env
+
+
+class HTTPServiceTest(TestCase):
+    def test_convert(self):
+        options = {
+            'true': True,
+            'false': False,
+            'string': 'foo',
+            'int': 1,
+            'long': 1L,
+            'none': None,
+            'hy-phen': 'foo',
+        }
+        expected = [
+            ('UWSGI_TRUE', 'true'),
+            ('UWSGI_FALSE', 'false'),
+            ('UWSGI_STRING', 'foo'),
+            ('UWSGI_INT', '1'),
+            ('UWSGI_LONG', '1'),
+            ('UWSGI_HY_PHEN', 'foo'),
+        ]
+        assert set(convert_options_to_env(options)) == set(expected)
+
+    def test_options(self):
+        cls = SentryHTTPServer
+
+        server = cls(host='1.1.1.1', port=80)
+        assert server.options['http-socket'] == '1.1.1.1:80'
+
+        with override_settings(SENTRY_WEB_HOST='1.1.1.1', SENTRY_WEB_PORT=80):
+            assert server.options['http-socket'] == '1.1.1.1:80'
+
+        server = cls(workers=10)
+        assert server.options['workers'] == 10
+
+        # Make sure that changing `protocol` to uwsgi sets the right socket
+        options = {'protocol': 'uwsgi'}
+        with override_settings(SENTRY_WEB_OPTIONS=options):
+            server = cls()
+            assert 'http-socket' not in server.options
+            assert 'uwsgi-socket' in server.options
+
+        options = {
+            'bind': '1.1.1.1:80',
+            'accesslog': '/tmp/access.log',
+            'errorlog': '/tmp/error.log',
+            'timeout': 69,
+            'proc_name': 'LOL',
+            'secure_scheme_headers': {},
+            'loglevel': 'info',
+        }
+        with override_settings(SENTRY_WEB_OPTIONS=options):
+            server = cls()
+            assert server.options['http-socket'] == '1.1.1.1:80'
+            assert 'bind' not in server.options
+            assert server.options['logto'] == '/tmp/access.log'
+            assert 'accesslog' not in server.options
+            assert server.options['logto2'] == '/tmp/error.log'
+            assert 'errorlog' not in server.options
+            assert server.options['http-timeout'] == 69
+            assert 'timeout' not in server.options
+            assert server.options['procname-prefix-spaced'] == 'LOL'
+            assert 'proc_name' not in server.options
+            assert 'secure_scheme_headers' not in server.options
+            assert 'loglevel' not in server.options


### PR DESCRIPTION
Replacing our existing `gunicorn` http service with `uwsgi`.

This maintains the same options that existed in `SENTRY_WEB_OPTIONS` as well as the CLI arguments for `$ sentry start` without breaking backwards compatibility.

/cc @dcramer @mitsuhiko 
