### PR TITLE
Better load balancer support for health check endpoint

### DIFF
--- a/docs/health-checks.rst
+++ b/docs/health-checks.rst
@@ -16,6 +16,13 @@ The following endpoint is exposed to aid in automated reporting:
 Generally this is most useful if you're using it as a health check in something
 like HAProxy.
 
+In HAProxy, you could add this to your config:
+
+::
+
+    option httpchk /_health/
+
+
 That said, we also expose additional checks via the same endpoint by passing
 ``?full``:
 

--- a/docs/health-checks.rst
+++ b/docs/health-checks.rst
@@ -17,11 +17,11 @@ Generally this is most useful if you're using it as a health check in something
 like HAProxy.
 
 That said, we also expose additional checks via the same endpoint by passing
-``full=1``:
+``?full``:
 
 .. code-block:: bash
 
-    $ curl -i http://sentry.example.com/_health/?full=1
+    $ curl -i http://sentry.example.com/_health/?full
     HTTP/1.0 500 INTERNAL SERVER ERROR
     Content-Type: application/json
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -201,6 +201,7 @@ MIDDLEWARE_CLASSES = (
     'sentry.middleware.debug.NoIfModifiedSinceMiddleware',
     'sentry.middleware.stats.RequestTimingMiddleware',
     'sentry.middleware.stats.ResponseCodeMiddleware',
+    'sentry.middleware.health.HealthCheck',  # Must exist before CommonMiddleware
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -16,10 +16,8 @@ try:
 except ImportError:
     # django < 1.5 compat
     from django.conf.urls.defaults import include, patterns, url  # NOQA
-from django.http import HttpResponse
 
-from sentry import django_admin, status_checks
-from sentry.utils import json
+from sentry import django_admin
 from sentry.web.urls import urlpatterns as web_urlpatterns
 from sentry.web.frontend.csrf_failure import CsrfFailureView
 from sentry.web.frontend.error_404 import Error404View
@@ -29,23 +27,8 @@ handler404 = Error404View.as_view()
 handler500 = Error500View.as_view()
 
 
-def handler_healthcheck(request):
-    problems, checks = status_checks.check_all()
-
-    if request.GET.get('full'):
-        return HttpResponse(json.dumps({
-            'problems': map(unicode, problems),
-            'healthy': checks,
-        }), content_type='application/json', status=(500 if problems else 200))
-    elif problems:
-        return handler500(request)
-    else:
-        return HttpResponse('ok')
-
-
 urlpatterns = patterns(
     '',
-    url(r'^_health/$', handler_healthcheck, name='healthcheck'),
     url(r'^admin/', include(django_admin.site.urls)),
     url(r'^500/', handler500, name='error-500'),
     url(r'^404/', handler404, name='error-404'),

--- a/src/sentry/middleware/health.py
+++ b/src/sentry/middleware/health.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+from django.http import HttpResponse
+
+
+class HealthCheck(object):
+    def process_request(self, request):
+        # Our health check can't be a done as a view, because we need
+        # to bypass the ALLOWED_HOSTS check. We need to do this
+        # since not all load balancers can send the expected Host header
+        # which would cause a 400 BAD REQUEST, marking the node dead.
+        # Instead, we just intercept the request at this point, and return
+        # our success/failure immediately.
+        if request.path != '/_health/':
+            return
+
+        if 'full' not in request.GET:
+            return HttpResponse('ok', content_type='text/plain')
+
+        from sentry.status_checks import check_all
+        from sentry.utils import json
+        problems, checks = check_all()
+
+        return HttpResponse(json.dumps({
+            'problems': map(unicode, problems),
+            'healthy': checks,
+        }), content_type='application/json', status=(500 if problems else 200))

--- a/tests/sentry/middleware/test_health.py
+++ b/tests/sentry/middleware/test_health.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+
+from mock import patch
+from exam import fixture
+
+from django.test import RequestFactory
+from sentry.testutils import TestCase
+from sentry.middleware.health import HealthCheck
+from sentry.utils import json
+
+
+class HealthCheckTest(TestCase):
+    middleware = fixture(HealthCheck)
+    factory = fixture(RequestFactory)
+
+    @patch('sentry.status_checks.check_all')
+    def test_other_url(self, check_all):
+        req = self.factory.get('/')
+        resp = self.middleware.process_request(req)
+        assert resp is None, resp
+        assert check_all.call_count == 0
+
+    @patch('sentry.status_checks.check_all')
+    def test_basic_health(self, check_all):
+        req = self.factory.get('/_health/')
+        resp = self.middleware.process_request(req)
+        assert resp.status_code == 200, resp
+        assert check_all.call_count == 0
+
+    @patch('sentry.status_checks.check_all')
+    def test_full_health_ok(self, check_all):
+        check_all.return_value = [], []
+        req = self.factory.get('/_health/?full')
+        resp = self.middleware.process_request(req)
+        assert resp.status_code == 200, resp
+        body = json.loads(resp.content)
+        assert 'problems' in body
+        assert 'healthy' in body
+        assert check_all.call_count == 1
+
+    @patch('sentry.status_checks.check_all')
+    def test_full_health_bad(self, check_all):
+        check_all.return_value = ['foo'], []
+        req = self.factory.get('/_health/?full')
+        resp = self.middleware.process_request(req)
+        assert resp.status_code == 500, resp
+        body = json.loads(resp.content)
+        assert 'problems' in body
+        assert 'healthy' in body
+        assert check_all.call_count == 1


### PR DESCRIPTION
This commit changes two things:
- Moves `/_health/` endpoint into a middleware to avoid a 400 error from
  load balancers that aren't setting a proper Host header. This is
  specifically a problem with ELB, which is not configurable to send the
  expected `Host` header.
- Require `?full` to check backing services from `system_health`. This
  allows a non `?full` check to just check that the web process is
  running, not the health of the entire system. Pingdom checks and the
  like should be directed to `?full` explicitly. This also aligns now
  with what the documentation suggests what `?full` actually does.

Fixes GH-2590
