### PR TITLE
Handle non-JSON error responses

### DIFF
--- a/src/sentry/static/sentry/app/utils/logging.jsx
+++ b/src/sentry/static/sentry/app/utils/logging.jsx
@@ -7,7 +7,10 @@ export function logException(ex, context) {
 }
 
 export function logAjaxError(error, context) {
-  let message = `HTTP ${error.status}: ${error.responseJSON.detail || error.responseJSON.toString()}`;
+  let errorString = (error.responseJSON ?
+    error.responseJSON.detail || error.responseJSON.toString() :
+    error.responseText.substr(0, 255));
+  let message = `HTTP ${error.status}: ${errorString}`;
   Raven.captureMessage(message, {
     extra: context
   });


### PR DESCRIPTION
```
TypeError: Cannot read property 'detail' of undefined
  at apply(~/raven-js/src/raven.js:242:0)
  at apply(~/jquery/dist/jquery.js:8599:0)
  at complete(~/jquery/dist/jquery.js:8266:0)
  at rejectWith(~/jquery/dist/jquery.js:3211:0)
  at fire(~/jquery/dist/jquery.js:3099:0)
  at apply(./app/api.jsx:48:20)
  at apply(./app/views/stream.jsx:171:8)
  at logAjaxError(./app/utils/logging.jsx:10:47)
```
