### PR TITLE
Strip bad characters out of the http bodies

### DIFF
--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -59,9 +59,21 @@ def format_cookies(value):
         value = value.items()
 
     return [
-        (k.encode('utf8').strip(), v)
+        (k.encode('utf8', errors='replace').strip(), v)
         for k, v in value
     ]
+
+
+def fix_broken_encoding(value):
+    """
+    Strips broken characters that can't be represented at all
+    in utf8. This prevents our parsers from breaking elsewhere.
+    """
+    if isinstance(value, unicode):
+        value = value.encode('utf8', errors='replace')
+    if isinstance(value, str):
+        value = value.decode('utf8', errors='replace')
+    return value
 
 
 class Http(Interface):
@@ -153,7 +165,7 @@ class Http(Interface):
         kwargs['cookies'] = trim_pairs(format_cookies(cookies))
         kwargs['env'] = trim_dict(data.get('env') or {})
         kwargs['headers'] = trim_pairs(headers)
-        kwargs['data'] = body
+        kwargs['data'] = fix_broken_encoding(body)
         kwargs['url'] = urlunsplit((scheme, netloc, path, '', ''))
         kwargs['fragment'] = trim(fragment, 1024)
 

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -59,7 +59,7 @@ def format_cookies(value):
         value = value.items()
 
     return [
-        (k.encode('utf8', errors='replace').strip(), v)
+        map(fix_broken_encoding, (k.strip(), v))
         for k, v in value
     ]
 


### PR DESCRIPTION
If we get these bad characters, typically from binary data, we
ultimately fail to serialize the structures back to a json string.

This strips the bad characters in hopes that we can at least keep the
data.

Refs: GH-2482
