### PR TITLE
Fix missing "all" metrics for dashboard

### DIFF
--- a/src/sentry/receivers/stats.py
+++ b/src/sentry/receivers/stats.py
@@ -33,6 +33,7 @@ def record_task_signal(signal, name, **options):
         if not isinstance(sender, basestring):
             sender = _get_task_name(sender)
         metrics.incr('jobs.{0}'.format(name), instance=sender, **options)
+        metrics.incr('jobs.all.{0}'.format(name))
 
     signal.connect(
         handler,


### PR DESCRIPTION
This was erronously dropped in 11e37d1f

Fixes GH-2623

/cc @dcramer I couldn't tell if this was removed at some point accidentally or if the admin dashboard was looking for wrong stat, but it seems like this stat was lost at some point in history. Just wanted to make sure this wasn't intentional or something.
