### PR TITLE
Add event.timestamp with improved range queries

### DIFF
--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -22,9 +22,12 @@ from sentry.utils.db import get_db_engine
 class DjangoSearchBackend(SearchBackend):
     def query(self, project, query=None, status=None, tags=None,
               bookmarked_by=None, assigned_to=None, first_release=None,
-              sort_by='date', age_from=None, age_to=None,
-              unassigned=None, date_from=None, date_to=None, cursor=None,
-              limit=100):
+              sort_by='date', unassigned=None,
+              age_from=None, age_from_inclusive=True,
+              age_to=None, age_to_inclusive=True,
+              date_from=None, date_from_inclusive=True,
+              date_to=None, date_to_inclusive=True,
+              cursor=None, limit=100):
         from sentry.models import Event, Group, GroupStatus
 
         queryset = Group.objects.filter(project=project)
@@ -86,33 +89,35 @@ class DjangoSearchBackend(SearchBackend):
                     )
             queryset = queryset.distinct()
 
-        if age_from and age_to:
-            queryset = queryset.filter(
-                first_seen__gte=age_from,
-                first_seen__lte=age_to,
-            )
-        elif age_from:
-            queryset = queryset.filter(first_seen__gte=age_from)
-        elif age_to:
-            queryset = queryset.filter(first_seen__lte=age_to)
+        if age_from or age_to:
+            params = {}
+            if age_from:
+                if age_from_inclusive:
+                    params['first_seen__gte'] = age_from
+                else:
+                    params['first_seen__gt'] = age_from
+            if age_to:
+                if age_to_inclusive:
+                    params['first_seen__lte'] = age_to
+                else:
+                    params['first_seen__lt'] = age_to
+            queryset = queryset.filter(**params)
 
         if date_from or date_to:
-            if date_from and date_to:
-                event_queryset = Event.objects.filter(
-                    project_id=project.id,
-                    datetime__gte=date_from,
-                    datetime__lte=date_to,
-                )
-            elif date_from:
-                event_queryset = Event.objects.filter(
-                    project_id=project.id,
-                    datetime__gte=date_from,
-                )
-            elif date_to:
-                event_queryset = Event.objects.filter(
-                    project_id=project.id,
-                    datetime__lte=date_to,
-                )
+            params = {
+                'project_id': project.id,
+            }
+            if date_from:
+                if date_from_inclusive:
+                    params['datetime__gte'] = date_from
+                else:
+                    params['datetime__gt'] = date_from
+            if date_to:
+                if date_to_inclusive:
+                    params['datetime__lte'] = date_to
+                else:
+                    params['datetime__lt'] = date_to
+            event_queryset = Event.objects.filter(**params)
             # limit to the first 1000 results
             group_ids = event_queryset.distinct().values_list(
                 'group_id',

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from django.utils import timezone
 
 from sentry.models import EventUser, GroupStatus
@@ -141,6 +141,29 @@ class ParseQueryTest(TestCase):
         assert result['age_from'] < timezone.now() - timedelta(hours=23)
         assert result['age_to'] > timezone.now() - timedelta(hours=13)
         assert result['age_to'] < timezone.now() - timedelta(hours=11)
+
+    def test_date_range(self):
+        result = self.parse_query('event.timestamp:>2016-01-01 event.timestamp:<2016-01-02')
+        assert result['date_from'] == datetime(2016, 01, 01, 0, 0, 0, 0, timezone.utc)
+        assert result['date_from_inclusive']
+        assert result['date_to'] == datetime(2016, 01, 02, 0, 0, 0, 0, timezone.utc)
+        assert not result['date_to_inclusive']
+
+    def test_date_approx_day(self):
+        date_value = datetime(2016, 01, 01, 0, 0, 0, 0, timezone.utc)
+        result = self.parse_query('event.timestamp:2016-01-01')
+        assert result['date_from'] == date_value
+        assert result['date_from_inclusive']
+        assert result['date_to'] == date_value + timedelta(days=1)
+        assert not result['date_to_inclusive']
+
+    def test_date_approx_precise(self):
+        date_value = datetime(2016, 01, 01, 0, 0, 0, 0, timezone.utc)
+        result = self.parse_query('event.timestamp:2016-01-01T00:00:00')
+        assert result['date_from'] == date_value - timedelta(minutes=5)
+        assert result['date_from_inclusive']
+        assert result['date_to'] == date_value + timedelta(minutes=6)
+        assert not result['date_to_inclusive']
 
     def test_has_tag(self):
         result = self.parse_query('has:foo')


### PR DESCRIPTION
This adds the ability to find issues which have an event occurrence at a given datetime. It implies date ranges being from (inclusive) => to (exclusive).

Find issues with an event occurrence on Jan 1st 2016:

```
event.timestamp:2016-01-01
```

Find issues with an event occurrence on Jan 1st 2016 or Jan 2nd 2016:

```
event.timestamp:>2016-01-01 event.timestamp:<2016-01-03
```

Find issues with an event occurrence around Jan 1st 2016 at 05:00 UTC:

```
event.timestamp:2016-01-01T05:00:00
```
