### PR TITLE
Fix compatibility with older djangorestframework

### DIFF
--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -44,7 +44,7 @@ class ApiClient(object):
             data = json.loads(json.dumps(data))
 
         rf = APIRequestFactory()
-        mock_request = getattr(rf, method.lower())(full_path, data)
+        mock_request = getattr(rf, method.lower())(full_path, data or {})
 
         if request:
             mock_request.auth = getattr(request, 'auth', None)


### PR DESCRIPTION
We say we're compatible with 2.3.9+, but we're broken, and we should
need 2.3.13 because we seem to rely on this behavior:
https://github.com/tomchristie/django-rest-framework/commit/1319da59ce8e62d2b2d9fa938de8ac5b5ccfaf20

data can't be None passed into the drf test client prior to that commit.

Fixes gh-2643

/cc @dcramer alternatively, we can bump our setup.py minimum version for DRF. Not sure if you have an opinion here. We run a much newer version on getsentry.com which is why we never noticed this.
