### PR TITLE
Feature to disable publicly shared issues

### DIFF
--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -31,6 +31,9 @@ class SharedGroupDetailsEndpoint(Endpoint):
         except Group.DoesNotExist:
             raise ResourceDoesNotExist
 
+        if group.organization.flags.disable_shared_issues:
+            raise ResourceDoesNotExist
+
         event = group.get_latest_event()
 
         context = serialize(group, request.user, SharedGroupSerializer())

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -37,6 +37,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
 
         if getattr(obj.flags, 'allow_joinleave'):
             feature_list.append('open-membership')
+        if not getattr(obj.flags, 'disable_shared_issues'):
+            feature_list.append('shared-issues')
 
         context = super(DetailedOrganizationSerializer, self).serialize(
             obj, attrs, user)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -82,6 +82,7 @@ class Organization(Model):
     flags = BitField(flags=(
         ('allow_joinleave', 'Allow members to join and leave teams without requiring approval.'),
         ('enhanced_privacy', 'Enable enhanced privacy controls to limit personally identifiable information (PII) as well as source code in things like notifications.'),
+        ('disable_shared_issues', 'Disable sharing of limited details on issues to anonymous users.'),
     ), default=1)
 
     objects = OrganizationManager(cache_fields=(

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -73,6 +73,7 @@ const GroupHeader = React.createClass({
 
   render() {
     let group = this.props.group,
+        orgFeatures = new Set(this.getOrganization().features),
         userCount = group.userCount,
         features = this.getProjectFeatures();
 
@@ -143,13 +144,15 @@ const GroupHeader = React.createClass({
         </div>
         <GroupSeenBy />
         <GroupActions />
-        <div className="pull-right">
-          <div className="group-privacy">
-            <a onClick={this.onShare}>
-              <span className="icon" /> {t('Share this event')}
-            </a>
+        {orgFeatures.has('shared-issues') &&
+          <div className="pull-right">
+            <div className="group-privacy">
+              <a onClick={this.onShare}>
+                <span className="icon" /> {t('Share this event')}
+              </a>
+            </div>
           </div>
-        </div>
+        }
         <ul className="nav nav-tabs">
           <ListLink to={`/${orgId}/${projectId}/issues/${groupId}/`} isActive={function (to) {
             let rootGroupPath = `/${orgId}/${projectId}/issues/${groupId}/`;

--- a/src/sentry/templates/sentry/organization-settings.html
+++ b/src/sentry/templates/sentry/organization-settings.html
@@ -31,6 +31,7 @@
 
         <legend>Security &amp; Privacy</legend>
 
+        {{ form.allow_shared_issues|as_crispy_field }}
         {{ form.enhanced_privacy|as_crispy_field }}
 
         <fieldset class="form-actions">

--- a/src/sentry/web/frontend/organization_settings.py
+++ b/src/sentry/web/frontend/organization_settings.py
@@ -34,6 +34,11 @@ class OrganizationSettingsForm(forms.ModelForm):
         help_text=_('Enable enhanced privacy controls to limit personally identifiable information (PII) as well as source code in things like notifications.'),
         required=False,
     )
+    allow_shared_issues = forms.BooleanField(
+        label=_('Allow Shared Issues'),
+        help_text=_('Enable sharing of limited details on issues to anonymous users.'),
+        required=False,
+    )
 
     class Meta:
         fields = ('name', 'slug', 'default_role')
@@ -51,6 +56,7 @@ class OrganizationSettingsView(OrganizationView):
                 'default_role': organization.default_role,
                 'allow_joinleave': bool(organization.flags.allow_joinleave),
                 'enhanced_privacy': bool(organization.flags.enhanced_privacy),
+                'allow_shared_issues': bool(not organization.flags.disable_shared_issues),
             }
         )
 
@@ -60,6 +66,7 @@ class OrganizationSettingsView(OrganizationView):
             instance = form.save(commit=False)
             instance.flags.allow_joinleave = form.cleaned_data['allow_joinleave']
             instance.flags.enhanced_privacy = form.cleaned_data['enhanced_privacy']
+            instance.flags.disable_shared_issues = not form.cleaned_data['allow_shared_issues']
             instance.save()
 
             AuditLogEntry.objects.create(

--- a/tests/sentry/api/endpoints/test_shared_group_details.py
+++ b/tests/sentry/api/endpoints/test_shared_group_details.py
@@ -16,3 +16,16 @@ class SharedGroupDetailsTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data['id'] == str(group.id)
         assert response.data['latestEvent']['id'] == str(event.id)
+
+    def test_feature_disabled(self):
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+        org = group.organization
+        org.flags.disable_shared_issues = True
+        org.save()
+
+        url = '/api/0/shared/issues/{}/'.format(group.get_share_id())
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 404


### PR DESCRIPTION
![screenshot 2016-02-11 12 18 33](https://cloud.githubusercontent.com/assets/23610/12989282/97c076ce-d0b9-11e5-8a44-093cf21169b4.png)

This doesnt resolve 404s not failing gracefully on the share link, but it will prevent them from loading.
