### PR TITLE
Build and link to moment.js locale files separately (fixes #2661)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -349,9 +349,9 @@ class BuildJavascriptCommand(Command):
         # the current folder.  This will chop off the right path for the
         # manifest.
         for root in self.sentry_static_dist_path, INTEGRATION_DOC_FOLDER:
-            for dirname, dirnames, filenames in os.walk(root):
+            for dirname, _, filenames in os.walk(root):
                 for filename in filenames:
-                    filename = os.path.join(root, filename)
+                    filename = os.path.join(dirname, filename)
                     files.append(filename[len(base):].lstrip(os.path.sep))
 
         files.append('src/sentry/sentry-package.json')

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -173,6 +173,8 @@ from .locale import CATALOGS
 LANGUAGES = tuple((code, name) for code, name in LANGUAGES
                   if code in CATALOGS)
 
+SUPPORTED_LANGUAGES = frozenset(CATALOGS)
+
 SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -32,6 +32,7 @@
 
   {% block scripts %}
   <script src="{% asset_url "sentry" "dist/vendor.js" %}"{% crossorigin %}></script>
+  {% locale_js_include %}
   <script src="{% asset_url "sentry" "dist/app.js" %}"{% crossorigin %}></script>
 
   <script>

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -35,3 +35,18 @@ def crossorigin():
         # They share the same domain prefix, so we don't need CORS
         return ''
     return ' crossorigin="anonymous"'
+
+
+@register.simple_tag(takes_context=True)
+def locale_js_include(context):
+    """
+    If the user has a non-English locale set, returns a <script> tag pointing
+    to the relevant locale JavaScript file
+    """
+    request = context['request']
+    lang_code = request.LANGUAGE_CODE
+    if lang_code == 'en' or lang_code not in settings.SUPPORTED_LANGUAGES:
+        return ''
+
+    href = get_asset_url("sentry", "dist/moment/locale/" + lang_code + ".js")
+    return "<script src=\"{0}\"{1}></script>".format(href, crossorigin())

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+from django.template import Context, Template
+from mock import Mock
+
+from sentry.testutils import TestCase
+
+
+class FeaturesTest(TestCase):
+    TEMPLATE = Template("""
+        {% load sentry_assets %}
+        {% locale_js_include %}
+    """)
+
+    def test_supported_foreign_lang(self):
+        result = self.TEMPLATE.render(Context({
+            'request': Mock(LANGUAGE_CODE='fr'),  # French, in locale/catalogs.json
+        }))
+
+        assert '<script src="/_static/{version}/sentry/dist/moment/locale/fr.js"></script>' in result
+
+    def test_unsupported_foreign_lang(self):
+        result = self.TEMPLATE.render(Context({
+            'request': Mock(LANGUAGE_CODE='ro'),  # Romanian, not in locale/catalogs.json
+        }))
+
+        assert result.strip() == ''
+
+    def test_english(self):
+        result = self.TEMPLATE.render(Context({
+            'request': Mock(LANGUAGE_CODE='en'),
+        }))
+
+        assert result.strip() == ''
+
+    def test_no_lang(self):
+        result = self.TEMPLATE.render(Context({
+            'request': Mock(),
+        }))
+
+        assert result.strip() == ''

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 /*eslint-env node*/
 var path = require('path'),
+    fs = require('fs'),
     webpack = require('webpack'),
     ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -33,45 +34,52 @@ if (process.env.SENTRY_EXTRACT_TRANSLATIONS === '1') {
   };
 }
 
+var entry = {
+  // js
+  'app': 'app',
+  'translations': [
+    'app/translations'
+  ],
+  'vendor': [
+    'babel-core/polyfill',
+    'bootstrap/js/dropdown',
+    'bootstrap/js/tab',
+    'bootstrap/js/tooltip',
+    'bootstrap/js/alert',
+    'crypto-js/md5',
+    'jed',
+    'jquery',
+    'marked',
+    'moment',
+    'moment-timezone',
+    'raven-js',
+    'react-document-title',
+    'react-router',
+    'react-bootstrap',
+    'reflux',
+    'select2',
+    'flot/jquery.flot',
+    'flot/jquery.flot.stack',
+    'flot/jquery.flot.time',
+    'flot-tooltip/jquery.flot.tooltip',
+    'vendor/simple-slider/simple-slider'
+  ],
+
+  // css
+  // NOTE: this will also create an empty 'sentry.js' file
+  // TODO: figure out how to not generate this
+  'sentry': 'less/sentry.less'
+};
+
+// dynamically iterate over locale files and add to `entry` config
+fs.readdirSync('node_modules/moment/locale').forEach(function(file) {
+  var module = 'moment/locale/' + file.replace(/\.js$/, '');
+  entry[module] = [module];
+});
+
 var config = {
+  entry: entry,
   context: path.join(__dirname, staticPrefix),
-  entry: {
-    // js
-    'app': 'app',
-    'translations': [
-      'app/translations'
-    ],
-    'vendor': [
-      'babel-core/polyfill',
-      'bootstrap/js/dropdown',
-      'bootstrap/js/tab',
-      'bootstrap/js/tooltip',
-      'bootstrap/js/alert',
-      'crypto-js/md5',
-      'jed',
-      'jquery',
-      'marked',
-      'moment',
-      'moment-timezone',
-      'raven-js',
-      'react-document-title',
-      'react-router',
-      'react-bootstrap',
-      'reflux',
-      'select2',
-      'flot/jquery.flot',
-      'flot/jquery.flot.stack',
-      'flot/jquery.flot.time',
-      'flot-tooltip/jquery.flot.tooltip',
-      'vendor/simple-slider/simple-slider'
-    ],
-
-    // css
-    // NOTE: this will also create an empty 'sentry.js' file
-    // TODO: figure out how to not generate this
-    'sentry': 'less/sentry.less'
-
-  },
   module: {
     loaders: [
       {
@@ -114,7 +122,8 @@ var config = {
       'root.jQuery': 'jquery',
       Raven: 'raven-js'
     }),
-    new ExtractTextPlugin('[name].css')
+    new ExtractTextPlugin('[name].css'),
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/) // ignore moment.js locale files
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
vendor.js **before**: 1,133,100 bytes _(using `webpack -p`, aka minified-but-not-gzipped)_
vendor.js **after**: 980,973 bytes

Okay, not exactly the 500kb savings I thought I was looking at ... but still very worthwhile.
