### PR TITLE
Use dynamic webpack ctx to restrict .po files pulled into dist/app.js

### DIFF
--- a/src/sentry/static/sentry/app/translations.jsx
+++ b/src/sentry/static/sentry/app/translations.jsx
@@ -1,18 +1,9 @@
-import {_} from 'underscore';
-
-const catalogs = (function() {
-  let info = require('../../../locale/catalogs.json');
-  return info.supported_locales;
-})();
-
 export const translations = (function() {
   let ctx = require.context('../../../locale/', true, /\.po$/);
   let rv = {};
   ctx.keys().forEach((translation) => {
     let langCode = translation.match(/([a-zA-Z_]+)/)[1];
-    if (_.contains(catalogs, langCode)) {
-      rv[langCode] = ctx(translation);
-    }
+    rv[langCode] = ctx(translation);
   });
   return rv;
 })();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,9 +38,6 @@ if (process.env.SENTRY_EXTRACT_TRANSLATIONS === '1') {
 var entry = {
   // js
   'app': 'app',
-  'translations': [
-    'app/translations'
-  ],
   'vendor': [
     'babel-core/polyfill',
     'bootstrap/js/dropdown',
@@ -131,7 +128,16 @@ var config = {
       Raven: 'raven-js'
     }),
     new ExtractTextPlugin('[name].css'),
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/) // ignore moment.js locale files
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // ignore moment.js locale files
+
+    // restrict translation files pulled into dist/app.js to only those specified
+    // in locale/catalogs.json
+    new webpack.ContextReplacementPlugin(
+      /\.\.\/\.\.\/\.\.\/locale\/$/,
+      path.join(__dirname, 'src', 'sentry', 'locale', path.sep),
+      true,
+      new RegExp('(' + localeCatalog.supported_locales.join('|') + ')\/.*\\.po$')
+    )
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
Before this patch, we were pulling every django.po file into dist/app.js. After this, we only pull supported langs.

Long term – these .po files should not be injected into app.js. They should be loaded dynamically depending on the user's language setting. But, until that is set up, this is an improvement.
