### PR TITLE
Bundle moment + sentry locale files into individual bundles (e.g. locale/fr)

### DIFF
--- a/src/sentry/static/sentry/app/translations.jsx
+++ b/src/sentry/static/sentry/app/translations.jsx
@@ -1,17 +1,14 @@
-export const translations = (function() {
-  let ctx = require.context('../../../locale/', true, /\.po$/);
-  let rv = {};
-  ctx.keys().forEach((translation) => {
-    let langCode = translation.match(/([a-zA-Z_]+)/)[1];
-    rv[langCode] = ctx(translation);
-  });
-  return rv;
-})();
-
 export function getTranslations(language) {
-  return translations[language] || translations.en;
+  return language === 'en'
+    ? {'':{domain:'sentry'}}
+    : require('sentry-locale/' + language + '/LC_MESSAGES/django.po');
 }
 
 export function translationsExist(language) {
-  return translations[language] !== undefined;
+  try {
+    require('sentry-locale/' + language + '/LC_MESSAGES/django.po');
+  } catch (e) {
+    return false;
+  }
+  return true;
 }

--- a/src/sentry/static/sentry/app/translations.jsx
+++ b/src/sentry/static/sentry/app/translations.jsx
@@ -1,10 +1,18 @@
+// zh-cn => zh_CN
+function convertToDjangoLocaleFormat(language) {
+  let [left, right] = language.split('-');
+  return left + (
+    right ? '_' + right.toUpperCase() : ''
+  );
+}
+
 export function getTranslations(language) {
-  return language === 'en'
-    ? {'':{domain:'sentry'}}
-    : require('sentry-locale/' + language + '/LC_MESSAGES/django.po');
+  language = convertToDjangoLocaleFormat(language);
+  return require('sentry-locale/' + language + '/LC_MESSAGES/django.po');
 }
 
 export function translationsExist(language) {
+  language = convertToDjangoLocaleFormat(language);
   try {
     require('sentry-locale/' + language + '/LC_MESSAGES/django.po');
   } catch (e) {

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -56,5 +56,5 @@ def locale_js_include(context):
     if lang_code == 'en' or lang_code not in settings.SUPPORTED_LANGUAGES:
         return ''
 
-    href = get_asset_url("sentry", "dist/moment/locale/" + lang_code + ".js")
+    href = get_asset_url("sentry", "dist/locale/" + lang_code + ".js")
     return "<script src=\"{0}\"{1}></script>".format(href, crossorigin())

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -32,7 +32,8 @@ module.exports = function(config) {
       resolve: {
         alias: {
           'app': appPrefix,
-          sinon: 'sinon/pkg/sinon' // see [1] above
+          sinon: 'sinon/pkg/sinon', // see [1] above
+          'sentry-locale': path.join(__dirname, '..', 'src', 'sentry', 'locale')
         },
         modulesDirectories: ['node_modules'],
         extensions: ['', '.jsx', '.js', '.json']

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -17,7 +17,7 @@ class AssetsTest(TestCase):
             'request': Mock(LANGUAGE_CODE='fr'),  # French, in locale/catalogs.json
         }))
 
-        assert '<script src="/_static/{version}/sentry/dist/moment/locale/fr.js"></script>' in result
+        assert '<script src="/_static/{version}/sentry/dist/locale/fr.js"></script>' in result
 
     def test_unsupported_foreign_lang(self):
         result = self.TEMPLATE.render(Context({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,7 @@ localeCatalog.supported_locales.forEach(function (locale) {
   var normalizedLocale = locale.toLowerCase().replace('_', '-');
   entry['locale/' + normalizedLocale] = [
     'moment/locale/' + normalizedLocale,
-    'sentry-locale/' + normalizedLocale + '/LC_MESSAGES/django.po' // relative to static/sentry
+    'sentry-locale/' + locale + '/LC_MESSAGES/django.po' // relative to static/sentry
   ];
   localeEntries.push('locale/' + normalizedLocale);
 });


### PR DESCRIPTION
Before this patch, only moment.js locale files were being served separately, with Sentry translations embedded inside of dist/app.js.

After this change, **both** moment.js locale files + Sentry translation files will be included in the same bundle (e.g. the `locale/fr` bundle contains both `moment/locale/fr.js` and `sentry-locale/fr/LC_MESSAGES/django.po`).

This significantly reduces the file size of dist/app.js (stats TBA).

This patch also fixes #2679.
