### PR TITLE
Fix bad bg color on django-powered success alerts

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -16,7 +16,7 @@ $(function(){
 });
 </script>
 {% if messages %}
-  <div id="messages">
+  <div id="messages" class="messages-container">
     {% for message in messages %}
     	{% with message.tags|split:" " as message_tags %}
           <div class="alert{% if message.tags %}{% for tag in message_tags %} alert-{{ tag }}{% endfor %}{% endif %}">


### PR DESCRIPTION
Before: 

![image](https://cloud.githubusercontent.com/assets/2153/13091843/d81afd92-d4b1-11e5-826c-24c6fe244f54.png)

After:

![image](https://cloud.githubusercontent.com/assets/2153/13091814/cda8c790-d4b1-11e5-81c5-35c81657571c.png)

cc @ckj 
