### PR TITLE
Don't require a cache to be used with `OptionsStore`.

### DIFF
--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -7,6 +7,8 @@ sentry.options
 """
 from __future__ import absolute_import, print_function
 
+from sentry.cache import default_cache
+
 from .store import OptionsStore
 from .manager import OptionsManager
 from .manager import (  # NOQA
@@ -18,7 +20,7 @@ __all__ = (
     'get', 'set', 'delete', 'register', 'UnknownOption',
 )
 
-default_store = OptionsStore()
+default_store = OptionsStore(cache=default_cache)
 default_store.connect_signals()
 
 default_manager = OptionsManager(store=default_store)

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -188,6 +188,8 @@ class OptionsStore(object):
         If cache fails, we ignore silently since it'll get repaired later by sync_options.
         A boolean is returned to indicate if the network cache was set successfully.
         """
+        assert self.cache is not None, 'cache must be configured before mutating options'
+
         self.set_store(key, value)
         return self.set_cache(key, value)
 
@@ -207,9 +209,6 @@ class OptionsStore(object):
         if key.ttl > 0:
             self._local_cache[cache_key] = _make_cache_value(key, value)
 
-        if self.cache is None:
-            return
-
         try:
             self.cache.set(cache_key, value, self.ttl)
             return True
@@ -224,6 +223,8 @@ class OptionsStore(object):
         If database succeeds, caches are then allowed to fail silently.
         A boolean is returned to indicate if the network deletion succeeds.
         """
+        assert self.cache is not None, 'cache must be configured before mutating options'
+
         self.delete_store(key)
         return self.delete_cache(key)
 
@@ -236,9 +237,6 @@ class OptionsStore(object):
             del self._local_cache[cache_key]
         except KeyError:
             pass
-
-        if self.cache is None:
-            return
 
         try:
             self.cache.delete(cache_key)

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from exam import fixture, around
 from mock import patch
 
+from sentry.cache.redis import RedisCache
 from sentry.models import Option
 from sentry.options.store import OptionsStore
 from sentry.options.manager import (
@@ -15,7 +16,9 @@ from sentry.testutils import TestCase
 
 
 class OptionsManagerTest(TestCase):
-    store = fixture(OptionsStore)
+    @fixture
+    def store(self):
+        return OptionsStore(cache=RedisCache())
 
     @fixture
     def manager(self):

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -3,7 +3,9 @@
 from __future__ import absolute_import
 
 from uuid import uuid1
-from exam import fixture, before
+
+import pytest
+from exam import before, fixture
 from mock import patch
 
 from sentry.cache.redis import RedisCache
@@ -41,9 +43,12 @@ class OptionsStoreTest(TestCase):
         key = self.key
 
         assert store.get(key) is None
-        assert store.set(key, 'bar') is None
-        assert store.get(key) == 'bar'
-        assert store.delete(key) is None
+
+        with pytest.raises(AssertionError):
+            store.set(key, 'bar')
+
+        with pytest.raises(AssertionError):
+            store.delete(key)
 
     def test_db_and_cache_unavailable(self):
         store, key = self.store, self.key

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -24,7 +24,7 @@ class SendBeaconTest(TestCase):
             'version': {'stable': '1.0.0'},
         })
 
-        assert options.set('system.admin-email', 'foo@example.com') is not False
+        assert options.set('system.admin-email', 'foo@example.com')
         send_beacon()
 
         install_id = options.get('sentry:install-id')

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -24,7 +24,7 @@ class SendBeaconTest(TestCase):
             'version': {'stable': '1.0.0'},
         })
 
-        assert options.set('system.admin-email', 'foo@example.com')
+        assert options.set('system.admin-email', 'foo@example.com') is not False
         send_beacon()
 
         install_id = options.get('sentry:install-id')


### PR DESCRIPTION
This will allow the default options store to be initialized without a cache in the future, so that values in the options store can be used to configure the cache itself.

This is work to support GH-2693.
