### PR TITLE
Ensure that we don't ingest tag data for reserved keys

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -37,7 +37,7 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         :auth: required
         """
         # XXX(dcramer): kill sentry prefix for internal reserved tags
-        if key in ('release', 'user', 'filename', 'function'):
+        if TagKey.is_reserved_key(key):
             lookup_key = 'sentry:{0}'.format(key)
         else:
             lookup_key = key

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -35,7 +35,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         :auth: required
         """
         # XXX(dcramer): kill sentry prefix for internal reserved tags
-        if key in ('release', 'user', 'filename', 'function'):
+        if TagKey.is_reserved_key(key):
             lookup_key = 'sentry:{0}'.format(key)
         else:
             lookup_key = key

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -16,7 +16,7 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
             {method} {path}
 
         """
-        if key in ('release', 'user', 'filename', 'function'):
+        if TagKey.is_reserved_key(key):
             lookup_key = 'sentry:{0}'.format(key)
         else:
             lookup_key = key

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -25,7 +25,7 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint):
         :pparam string key: the tag key to look up.
         :auth: required
         """
-        if key in ('release', 'user', 'filename', 'function'):
+        if TagKey.is_reserved_key(key):
             lookup_key = 'sentry:{0}'.format(key)
         else:
             lookup_key = key

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -477,6 +477,15 @@ class ClientApiHelper(object):
                 # support tags with spaces by converting them
                 k = k.replace(' ', '-')
 
+                if TagKey.is_reserved_key(k):
+                    self.log.info('Discarding reserved tag key: %s', k)
+                    data['errors'].append({
+                        'type': EventError.INVALID_DATA,
+                        'name': 'tags',
+                        'value': pair,
+                    })
+                    continue
+
                 if not TagKey.is_valid_key(k):
                     self.log.info('Discarded invalid tag key: %s', k)
                     data['errors'].append({

--- a/src/sentry/models/tagkey.py
+++ b/src/sentry/models/tagkey.py
@@ -22,6 +22,10 @@ from sentry.utils.cache import cache
 # Valid pattern for tag key names
 TAG_KEY_RE = re.compile(r'^[a-zA-Z0-9_\.:-]+$')
 
+# These tags are special and are used in pairing with `sentry:{}`
+# they should not be allowed to be set via data ingest due to abiguity
+INTERNAL_TAG_KEYS = frozenset(('release', 'user', 'filename', 'function'))
+
 
 # TODO(dcramer): pull in enum library
 class TagKeyStatus(object):
@@ -77,6 +81,10 @@ class TagKey(Model):
     @classmethod
     def is_valid_key(self, key):
         return TAG_KEY_RE.match(key)
+
+    @classmethod
+    def is_reserved_key(self, key):
+        return key in INTERNAL_TAG_KEYS
 
     @classmethod
     def get_standardized_key(cls, key):

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -260,6 +260,17 @@ class ValidateDataTest(BaseAPITest):
         assert data['errors'][0]['name'] == 'tags'
         assert data['errors'][0]['value'] == ('biz', 'baz', 'boz')
 
+    def test_reserved_tags(self):
+        data = self.helper.validate_data(self.project, {
+            'message': 'foo',
+            'tags': [('foo', 'bar'), ('release', 'abc123')],
+        })
+        assert data['tags'] == [('foo', 'bar')]
+        assert len(data['errors']) == 1
+        assert data['errors'][0]['type'] == 'invalid_data'
+        assert data['errors'][0]['name'] == 'tags'
+        assert data['errors'][0]['value'] == ('release', 'abc123')
+
     def test_extra_as_string(self):
         data = self.helper.validate_data(self.project, {
             'message': 'foo',


### PR DESCRIPTION
This causes confusion since we internally transform a set of keys into
sentry:%s key names.

/cc @dcramer 
