### PR TITLE
Implement shared Redis clusters.

### DIFF
--- a/api-docs/sentry.conf.py
+++ b/api-docs/sentry.conf.py
@@ -5,21 +5,8 @@ import os
 import getpass
 
 
-# for this api docs only.  We
 SENTRY_APIDOCS_REDIS_PORT = 12355
 SENTRY_APIDOCS_WEB_PORT = 12356
-SENTRY_APIDOCS_REDIS_CONF = {
-    'host': '127.0.0.1',
-    'port': SENTRY_APIDOCS_REDIS_PORT,
-}
-SENTRY_APIDOCS_REDIS_OPTIONS = {
-    'hosts': {
-        0: SENTRY_APIDOCS_REDIS_CONF,
-        1: SENTRY_APIDOCS_REDIS_CONF,
-        2: SENTRY_APIDOCS_REDIS_CONF,
-        3: SENTRY_APIDOCS_REDIS_CONF,
-    }
-}
 
 SENTRY_URL_PREFIX = 'https://app.getsentry.com/'
 
@@ -37,12 +24,6 @@ DATABASES = {
     }
 }
 SENTRY_USE_BIG_INTS = True
-
-SENTRY_BUFFER_OPTIONS = SENTRY_APIDOCS_REDIS_OPTIONS
-SENTRY_CACHE_OPTIONS = SENTRY_APIDOCS_REDIS_OPTIONS
-SENTRY_QUOTA_OPTIONS = SENTRY_APIDOCS_REDIS_OPTIONS
-SENTRY_RATELIMITER_OPTIONS = SENTRY_APIDOCS_REDIS_OPTIONS
-SENTRY_TSDB_OPTIONS = SENTRY_APIDOCS_REDIS_OPTIONS
 
 SENTRY_CACHE = 'sentry.cache.redis.RedisCache'
 
@@ -80,5 +61,12 @@ SERVER_EMAIL = 'sentry@getsentry.com'
 
 SECRET_KEY = 'super secret secret key'
 
-SENTRY_OPTIONS['system.admin-email'] = 'admin@getsentry.com'
-SENTRY_OPTIONS['system.url-prefix'] = SENTRY_URL_PREFIX
+SENTRY_OPTIONS.update({
+    'redis.clusters': {
+        'default': {
+            'hosts': {i: {'port': SENTRY_APIDOCS_REDIS_PORT} for i in xrange(0, 4)},
+        },
+    },
+    'system.admin-email': 'admin@getsentry.com',
+    'system.url-prefix': SENTRY_URL_PREFIX,
+})

--- a/docs/buffer.rst
+++ b/docs/buffer.rst
@@ -20,8 +20,6 @@ To specify a backend, simply modify the ``SENTRY_BUFFER`` and
 .. code-block:: python
 
     SENTRY_BUFFER = 'sentry.buffer.base.Buffer'
-    SENTRY_BUFFER_OPTIONS = {}
-
 
 Redis
 `````
@@ -29,36 +27,17 @@ Redis
 Configuring the Redis backend **requires the queue** or you won't see any
 gains (in fact you'll just negatively impact your performance).
 
-Configuration is fairly straight forward:
+Configuration is straight forward:
 
 .. code-block:: python
 
     SENTRY_BUFFER = 'sentry.buffer.redis.RedisBuffer'
-    SENTRY_BUFFER_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': 'localhost',
-                'port': 6379
-            }
-        }
-    }
 
-You also have the ability to specify multiple nodes and have keys automatically
-distributed. It's unlikely that you'll need this functionality, but if you do, a simple
-configuration might look like this:
+By default, this will use the ``default`` named Redis cluster. To use a
+different cluster, provide the ``cluster`` option, as such:
 
 .. code-block:: python
 
     SENTRY_BUFFER_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': '192.168.1.1'
-            },
-            1: {
-                'host': '192.168.1.2'
-            }
-        },
+        'cluster': 'buffer',
     }
-
-With the default configuration this will distribute keys using a simple
-partition router (relatively even distribution).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -211,22 +211,25 @@ you can configure the nodes in very different ones to enable more
 aggressive/optimized LRU.
 
 That said, if you're running a small install you can probably get away
-with just setting up the defaults::
+with just setting up the defaults in ``config.yml``::
 
-    SENTRY_REDIS_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': '127.0.0.1',
-                'port': 6379,
-                'timeout': 3,
-                #'password': 'redis auth password'
-            }
-        }
-    }
+    redis.clusters:
+      default:
+        hosts:
+          0:
+            host: 127.0.0.1
+            port: 6379
+            # password: "my-secret-password"
 
 All built-in Redis implementations (other than the queue) will use these
 default settings, but each individual service also will allow you to
-override it's cluster settings.
+override it's cluster settings by passing the name of the cluster to use as the
+``cluster`` option.
+
+Cluster options are passed directly to rb (a Redis routing library) as keyword
+arguments to the ``Cluster`` constructor. A more thorough discussion of the
+availabile configuration parameters can be found at the `rb GitHub repository
+<https://github.com/getsentry/rb>`_.
 
 See the individual documentation for :doc:`the queue <queue/>`,
 :doc:`update buffers <buffer>`, :doc:`quotas <throttling>`, and

--- a/docs/throttling.rst
+++ b/docs/throttling.rst
@@ -23,32 +23,15 @@ the connection information:
 .. code-block:: python
 
     SENTRY_QUOTAS = 'sentry.quotas.redis.RedisQuota'
-    SENTRY_QUOTA_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': 'localhost',
-                'port': 6379
-            }
-        }
-    }
 
-You also have the ability to specify multiple nodes and have keys automatically
-distributed. It's unlikely that you'll need this functionality, but if you do, a simple
-configuration might look like this:
+By default, this will use the ``default`` named Redis cluster. To use a
+different cluster, provide the ``cluster`` option, as such:
 
 .. code-block:: python
 
     SENTRY_QUOTA_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': '192.168.1.1'
-            },
-            1: {
-                'host': '192.168.1.2'
-            }
-        },
+        'cluster': 'quota',
     }
-
 
 You can also configure the system-wide maximum per-minute rate limit:
 
@@ -71,17 +54,17 @@ Configuration
 
 Like event quotas, the primary implementation uses Redis:
 
-
 .. code-block:: python
 
     SENTRY_RATELIMITER = 'sentry.ratelimits.redis.RedisRateLimiter'
+
+By default, this will use the ``default`` named Redis cluster. To use a
+different cluster, provide the ``cluster`` option, as such:
+
+.. code-block:: python
+
     SENTRY_RATELIMITER_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': 'localhost',
-                'port': 6379
-            }
-        }
+        'cluster': 'ratelimiter',
     }
 
 

--- a/docs/tsdb.rst
+++ b/docs/tsdb.rst
@@ -14,7 +14,6 @@ To specify a backend, simply modify the ``SENTRY_TSDB`` and
 .. code-block:: python
 
     SENTRY_TSDB = 'sentry.tsdb.dummy.DummyTSDB'
-    SENTRY_TSDB_OPTIONS = {}
 
 
 The Redis Backend
@@ -25,32 +24,13 @@ Configuration is fairly straight forward:
 .. code-block:: python
 
     SENTRY_TSDB = 'sentry.tsdb.redis.RedisTSDB'
-    SENTRY_TSDB_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': 'localhost',
-                'port': 6379
-            }
-        }
-    }
 
-Because the Redis buffer relies on the Nydus package, this gives you the
-ability to specify multiple nodes and have keys automatically distributed.
-It's unlikely that you'll need this functionality, but if you do, a simple
-configuration might look like this:
+By default, this will use the ``default`` named Redis cluster. To use a
+different cluster, provide the ``cluster`` option, as such:
 
 .. code-block:: python
 
     SENTRY_TSDB_OPTIONS = {
-        'hosts': {
-            0: {
-                'host': '192.168.1.1'
-            }
-            1: {
-                'host': '192.168.1.2'
-            }
-        },
+        'cluster': 'tsdb',
     }
 
-With the default configuration this will distribute keys using a simple
-partition router (relatively even distribution).

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -7,10 +7,10 @@ sentry.buffer.redis
 """
 from __future__ import absolute_import
 
-from django.conf import settings
+from time import time
+
 from django.db import models
 from django.utils.encoding import force_bytes
-from time import time
 
 from sentry.buffer import Buffer
 from sentry.exceptions import InvalidConfiguration
@@ -19,7 +19,7 @@ from sentry.utils import metrics
 from sentry.utils.compat import pickle
 from sentry.utils.hashlib import md5
 from sentry.utils.imports import import_string
-from sentry.utils.redis import make_rb_cluster
+from sentry.utils.redis import get_cluster_from_options
 
 
 class RedisBuffer(Buffer):
@@ -27,14 +27,7 @@ class RedisBuffer(Buffer):
     pending_key = 'b:p'
 
     def __init__(self, **options):
-        if not options:
-            # inherit default options from REDIS_OPTIONS
-            options = settings.SENTRY_REDIS_OPTIONS
-
-        options.setdefault('hosts', {
-            0: {},
-        })
-        self.cluster = make_rb_cluster(options['hosts'])
+        self.cluster, options = get_cluster_from_options(self, options)
 
     def validate(self):
         try:

--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -8,10 +8,8 @@ sentry.cache.redis
 
 from __future__ import absolute_import
 
-from django.conf import settings
-
 from sentry.utils import json
-from sentry.utils.redis import make_rb_cluster
+from sentry.utils.redis import get_cluster_from_options
 
 from .base import BaseCache
 
@@ -19,18 +17,11 @@ from .base import BaseCache
 class RedisCache(BaseCache):
     key_expire = 60 * 60  # 1 hour
 
-    def __init__(self, version=None, prefix=None, **options):
-        if not options:
-            # inherit default options from REDIS_OPTIONS
-            options = settings.SENTRY_REDIS_OPTIONS
-
-        options.setdefault('hosts', {
-            0: {},
-        })
-        self.cluster = make_rb_cluster(options['hosts'])
+    def __init__(self, **options):
+        self.cluster, options = get_cluster_from_options(self, options)
         self.client = self.cluster.get_routing_client()
 
-        super(RedisCache, self).__init__(version=version, prefix=prefix)
+        super(RedisCache, self).__init__(**options)
 
     def set(self, key, value, timeout, version=None):
         key = self.make_key(key, version=version)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -703,9 +703,6 @@ SENTRY_ALLOW_ORIGIN = None
 # Enable scraping of javascript context for source code
 SENTRY_SCRAPE_JAVASCRIPT_CONTEXT = True
 
-# Redis connection information (see Nydus documentation)
-SENTRY_REDIS_OPTIONS = {}
-
 # Buffer backend
 SENTRY_BUFFER = 'sentry.buffer.Buffer'
 SENTRY_BUFFER_OPTIONS = {}

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -7,8 +7,6 @@ sentry.options
 """
 from __future__ import absolute_import, print_function
 
-from sentry.cache import default_cache
-
 from .store import OptionsStore
 from .manager import OptionsManager
 from .manager import (  # NOQA
@@ -20,7 +18,8 @@ __all__ = (
     'get', 'set', 'delete', 'register', 'UnknownOption',
 )
 
-default_store = OptionsStore(cache=default_cache)
+# See notes in ``runner.initializer`` regarding lazy cache configuration.
+default_store = OptionsStore(cache=None)
 default_store.connect_signals()
 
 default_manager = OptionsManager(store=default_store)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -7,10 +7,10 @@ sentry.options.defaults
 """
 from __future__ import absolute_import, print_function
 
-
-from sentry.options import register, FLAG_NOSTORE, FLAG_REQUIRED, FLAG_PRIORITIZE_DISK
+from sentry.options import (
+    FLAG_IMMUTABLE, FLAG_NOSTORE, FLAG_PRIORITIZE_DISK, FLAG_REQUIRED, register
+)
 from sentry.utils.types import Dict
-
 
 register('cache.backend', flags=FLAG_NOSTORE)
 register('cache.options', type=Dict, flags=FLAG_NOSTORE)
@@ -19,7 +19,21 @@ register('system.databases', type=Dict, flags=FLAG_NOSTORE)
 register('system.debug', default=False, flags=FLAG_NOSTORE)
 register('system.rate-limit', default=0, flags=FLAG_PRIORITIZE_DISK)
 register('system.secret-key', flags=FLAG_NOSTORE)
-register('redis.options', type=Dict, flags=FLAG_NOSTORE)
+register(
+    'redis.clusters',
+    type=Dict,
+    default={
+        'default': {
+            'hosts': {
+                0: {
+                    'host': '127.0.0.1',
+                    'port': 6379,
+                }
+            },
+        },
+    },
+    flags=FLAG_NOSTORE | FLAG_IMMUTABLE
+)
 
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 register('system.url-prefix', ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -1,23 +1,17 @@
 from __future__ import absolute_import
 
-from django.conf import settings
 from time import time
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.ratelimits.base import RateLimiter
-from sentry.utils.redis import make_rb_cluster
+from sentry.utils.redis import get_cluster_from_options
 
 
 class RedisRateLimiter(RateLimiter):
     ttl = 60
 
     def __init__(self, **options):
-        if not options:
-            # inherit default options from REDIS_OPTIONS
-            options = settings.SENTRY_REDIS_OPTIONS
-        options.setdefault('hosts', {0: {}})
-
-        self.cluster = make_rb_cluster(options['hosts'])
+        self.cluster, options = get_cluster_from_options(self, options)
 
     def validate(self):
         try:

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -50,22 +50,6 @@ SENTRY_USE_BIG_INTS = True
 SENTRY_SINGLE_ORGANIZATION = True
 
 #########
-# Redis #
-#########
-
-# Generic Redis configuration used as defaults for various things including:
-# Buffers, Quotas, TSDB
-
-SENTRY_REDIS_OPTIONS = {
-    'hosts': {
-        0: {
-            'host': '127.0.0.1',
-            'port': 6379,
-        }
-    }
-}
-
-#########
 # Cache #
 #########
 

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -11,14 +11,7 @@ from sentry.testutils import TestCase
 
 class RedisBufferTest(TestCase):
     def setUp(self):
-        self.buf = RedisBuffer(hosts={
-            0: {'db': 9}
-        })
-
-    def test_default_host_is_local(self):
-        buf = RedisBuffer()
-        self.assertEquals(len(buf.cluster.hosts), 1)
-        self.assertEquals(buf.cluster.hosts[0].host, 'localhost')
+        self.buf = RedisBuffer()
 
     def test_coerce_val_handles_foreignkeys(self):
         assert self.buf._coerce_val(Project(id=1)) == '1'

--- a/tests/sentry/cache/test_redis.py
+++ b/tests/sentry/cache/test_redis.py
@@ -8,9 +8,7 @@ from sentry.testutils import TestCase
 
 class RedisCacheTest(TestCase):
     def setUp(self):
-        self.backend = RedisCache(hosts={
-            0: {'db': 9}
-        })
+        self.backend = RedisCache()
 
     def test_integration(self):
         self.backend.set('foo', {'foo': 'bar'}, 50)

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -18,7 +18,9 @@ from sentry.testutils import TestCase
 class OptionsManagerTest(TestCase):
     @fixture
     def store(self):
-        return OptionsStore(cache=RedisCache())
+        return OptionsStore(
+            cache=RedisCache()
+        )
 
     @fixture
     def manager(self):

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -17,7 +17,9 @@ from sentry.testutils import TestCase
 class OptionsStoreTest(TestCase):
     @fixture
     def store(self):
-        return OptionsStore(cache=RedisCache())
+        return OptionsStore(
+            cache=RedisCache()
+        )
 
     @fixture
     def key(self):

--- a/tests/sentry/ratelimits/test_redis.py
+++ b/tests/sentry/ratelimits/test_redis.py
@@ -8,9 +8,7 @@ from sentry.testutils import TestCase
 
 class RedisRateLimiterTest(TestCase):
     def setUp(self):
-        self.backend = RedisRateLimiter(hosts={
-            0: {'db': 9}
-        })
+        self.backend = RedisRateLimiter()
 
     def test_integration(self):
         assert not self.backend.is_limited(self.project, 'foo', 1)

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -15,18 +15,16 @@ from sentry.utils.dates import to_timestamp
 
 class RedisTSDBTest(TestCase):
     def setUp(self):
-        self.db = RedisTSDB(hosts={
-            0: {'db': 9}
-        }, rollups=(
-            # time in seconds, samples to keep
-            (10, 30),  # 5 minutes at 10 seconds
-            (ONE_MINUTE, 120),  # 2 hours at 1 minute
-            (ONE_HOUR, 24),  # 1 days at 1 hour
-            (ONE_DAY, 30),  # 30 days at 1 day
-        ), vnodes=64)
-
-        with self.db.cluster.all() as client:
-            client.flushdb()
+        self.db = RedisTSDB(
+            rollups=(
+                # time in seconds, samples to keep
+                (10, 30),  # 5 minutes at 10 seconds
+                (ONE_MINUTE, 120),  # 2 hours at 1 minute
+                (ONE_HOUR, 24),  # 1 days at 1 hour
+                (ONE_DAY, 30),  # 30 days at 1 day
+            ),
+            vnodes=64
+        )
 
     def test_make_counter_key(self):
         result = self.db.make_counter_key(TSDBModel.project, 1368889980, 1)

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -1,0 +1,84 @@
+import functools
+
+import pytest
+
+from sentry.exceptions import InvalidConfiguration
+from sentry.testutils.cases import TestCase
+from sentry.utils.redis import (
+    ClusterManager, _shared_pool, get_cluster_from_options
+)
+
+make_manager = functools.partial(
+    ClusterManager,
+    {
+        'redis.clusters': {
+            'foo': {
+                'hosts': {
+                    0: {'db': 0},
+                },
+            },
+            'bar': {
+                'hosts': {
+                    0: {'db': 0},
+                    1: {'db': 1},
+                }
+            },
+        },
+    },
+)
+
+
+class ClusterManagerTestCase(TestCase):
+    def test_get(self):
+        manager = make_manager()
+        assert manager.get('foo') is manager.get('foo')
+        assert manager.get('foo') is not manager.get('bar')
+        assert manager.get('foo').pool_cls is _shared_pool
+        with pytest.raises(KeyError):
+            manager.get('invalid')
+
+
+def test_get_cluster_from_options():
+    backend = object()
+    manager = make_manager()
+
+    cluster, options = get_cluster_from_options(
+        backend,
+        {
+            'cluster': 'foo',
+            'foo': 'bar',
+        },
+        cluster_manager=manager,
+    )
+
+    assert cluster is manager.get('foo')
+    assert cluster.pool_cls is _shared_pool
+    assert options == {'foo': 'bar'}
+
+    cluster, options = get_cluster_from_options(
+        backend,
+        {
+            'hosts': {
+                0: {'db': 0},
+            },
+            'foo': 'bar',
+        },
+        cluster_manager=manager,
+    )
+
+    assert cluster is not manager.get('foo')  # kind of a silly assertion
+    assert cluster.pool_cls is _shared_pool
+    assert options == {'foo': 'bar'}
+
+    with pytest.raises(InvalidConfiguration):
+        cluster, options = get_cluster_from_options(
+            backend,
+            {
+                'hosts': {
+                    0: {'db': 0},
+                },
+                'cluster': 'foo',
+                'foo': 'bar',
+            },
+            cluster_manager=manager,
+        )


### PR DESCRIPTION
This replaces `SENTRY_REDIS_OPTIONS` and per-backend configuration with named Redis clusters, configured from the value of the `redis.clusters` key in `sentry.options`. The preferred method of configuring Redis-based backends is by providing a _cluster name_, rather than the cluster configuration parameters.

This deprecates:
- `SENTRY_REDIS_OPTIONS` in favor of the `redis.clusters` option.
- Passing `hosts` to any backend in favor of `cluster`.
- `sentry.utils.make_rb_cluster` in favor of retrieving clusters defined in configuration via the clsuter manager.

This also updates all tests to retrieve Redis clusters via the cluster manager, instead of via cluster configuration or direct construction via `rb.Cluster` or `StrictRedis`. This also consolidates all test cluster setup and teardown to the test wrapper methods.

Resolves GH-2530 and references GH-2693.
