### PR TITLE
Support relaying internal errors to an upstream Sentry

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -16,6 +16,7 @@ __all__ = (
 import base64
 import os.path
 import urllib
+from contextlib import contextmanager
 
 from click.testing import CliRunner
 from django.conf import settings
@@ -212,6 +213,19 @@ class BaseTestCase(Fixtures, Exam):
         back to the original value when exiting the context.
         """
         return override_options(options)
+
+    @contextmanager
+    def dsn(self, dsn):
+        """
+        A context manager that temporarily sets the internal client's DSN
+        """
+        from raven.contrib.django.models import client
+
+        try:
+            client.set_dsn(dsn)
+            yield
+        finally:
+            client.set_dsn(None)
 
     _postWithSignature = _postWithHeader
     _postWithNewSignature = _postWithHeader

--- a/tests/sentry/utils/test_raven.py
+++ b/tests/sentry/utils/test_raven.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 from mock import Mock, patch
 from raven.contrib.django.models import client
+from raven.base import Client
 
 from sentry.models import Event
 from sentry.testutils import TestCase
@@ -10,7 +11,8 @@ from sentry.utils.raven import SentryInternalClient
 
 class SentryInternalClientTest(TestCase):
     @patch.object(SentryInternalClient, 'is_enabled', Mock(return_value=True))
-    def test_simple(self):
+    @patch.object(Client, 'send')
+    def test_simple(self, send):
         assert client.__class__ is SentryInternalClient
 
         with self.tasks():
@@ -18,3 +20,21 @@ class SentryInternalClientTest(TestCase):
 
         event = Event.objects.get()
         assert event.message == 'internal client test'
+        assert send.call_count == 0
+
+    @patch.object(SentryInternalClient, 'is_enabled', Mock(return_value=True))
+    @patch.object(Client, 'send')
+    def test_upstream(self, send):
+        with self.dsn('http://foo:bar@example.com/1'):
+            with self.options({'sentry:install-id': 'abc123'}):
+                with self.tasks():
+                    client.captureMessage('internal client test')
+
+                event = Event.objects.get()
+                assert event.message == 'internal client test'
+
+                # Make sure that the event also got sent upstream
+                assert send.call_count == 1
+                _, kwargs = send.call_args
+                # and got tagged properly
+                assert kwargs['tags']['install-id'] == 'abc123'


### PR DESCRIPTION
Right now, this will rely on the environment variable `SENTRY_DSN` until we figure out how this could/should be exposed into config settings.
