### PR TITLE
Linkify a larger request URL region

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -83,7 +83,10 @@ const RequestInterface = React.createClass({
 
     children.push(
       <h3 key="title">
-        <strong>{data.method || 'GET'} <a href={fullUrl}>{parsedUrl.pathname}</a></strong>
+        <a href={fullUrl}>
+          <strong>{data.method || 'GET'} {parsedUrl.pathname}</strong>
+          <em className="icon-open" style={{paddingLeft: '5px'}} />
+        </a>
         <small style={{marginLeft: 20}}>{parsedUrl.hostname}</small>
       </h3>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -85,7 +85,9 @@ const RequestInterface = React.createClass({
       <h3 key="title">
         <a href={fullUrl}>
           <strong>{data.method || 'GET'} {parsedUrl.pathname}</strong>
-          <em className="icon-open" style={{paddingLeft: '5px'}} />
+          <span className="external-icon">
+            <em className="icon-open" />
+          </span>
         </a>
         <small style={{marginLeft: 20}}>{parsedUrl.hostname}</small>
       </h3>

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -366,7 +366,8 @@ pre.plain {
   word-break: break-all;
 }
 
-a.external-icon {
+.external-icon {
+  .transition(.1s linear color);
   color: inherit;
   font-size: 11px;
   padding: 0 5px;
@@ -376,6 +377,10 @@ a.external-icon {
   &:hover {
     color: @gray;
   }
+}
+
+.box-header a:hover .external-icon {
+  color: @gray;
 }
 
 table.vars {


### PR DESCRIPTION
Fixes GH-2183

This is now the clickable region:

![image](https://cloud.githubusercontent.com/assets/375744/13238477/16cc7d24-d988-11e5-8949-ec4851421c33.png)

This was really bad in cases where the url was just "/", the only clickable part was the single slash.
