### PR TITLE
Clean up buffer lock upon completion

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -141,4 +141,7 @@ class RedisBuffer(Buffer):
             elif k.startswith('e+'):
                 extra_values[k[2:]] = pickle.loads(v)
 
-        super(RedisBuffer, self).process(model, incr_values, filters, extra_values)
+        try:
+            super(RedisBuffer, self).process(model, incr_values, filters, extra_values)
+        finally:
+            client.delete(lock_key)


### PR DESCRIPTION
Previously this would assume that the job would only execute once every 10 seconds, but thats incorrect. The pending buffer task will only ever create new jobs once every 10 seconds, but the process task may happen at say 2s and then again at 7s depending on how long it took them to execute.

Refs GH-2682
