### PR TITLE
Ensure that TSDB rollups exist and satisfy range constraints.

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -194,7 +194,7 @@ class StatsMixin(object):
         if resolution:
             resolution = self._parse_resolution(resolution)
 
-            assert any(r for r in tsdb.rollups if r[0] == resolution)
+            assert any(r for r in tsdb.rollups.items() if r[0] == resolution)
 
         end = request.GET.get('until')
         if end:

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -193,8 +193,7 @@ class StatsMixin(object):
         resolution = request.GET.get('resolution')
         if resolution:
             resolution = self._parse_resolution(resolution)
-
-            assert any(r for r in tsdb.rollups.items() if r[0] == resolution)
+            assert resolution in tsdb.rollups
 
         end = request.GET.get('until')
         if end:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -761,7 +761,6 @@ SENTRY_SEARCH_OPTIONS = {}
 SENTRY_TSDB = 'sentry.tsdb.dummy.DummyTSDB'
 SENTRY_TSDB_OPTIONS = {}
 
-# rollups must be ordered from highest granularity to lowest
 SENTRY_TSDB_ROLLUPS = (
     # (time in seconds, samples to keep)
     (10, 360),  # 60 minutes at 10 seconds

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -29,7 +29,7 @@ class InMemoryTSDB(BaseTSDB):
         if timestamp is None:
             timestamp = timezone.now()
 
-        for rollup, max_values in self.rollups:
+        for rollup, max_values in self.rollups.items():
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
             self.data[model][key][norm_epoch] += count
 
@@ -37,8 +37,7 @@ class InMemoryTSDB(BaseTSDB):
         normalize_to_epoch = self.normalize_to_epoch
         normalize_to_rollup = self.normalize_to_rollup
 
-        if rollup is None:
-            rollup = self.get_optimal_rollup(start, end)
+        rollup = self.get_optimal_rollup(start, end, rollup)
 
         results = []
         timestamp = end
@@ -64,7 +63,7 @@ class InMemoryTSDB(BaseTSDB):
         if timestamp is None:
             timestamp = timezone.now()
 
-        for rollup, max_values in self.rollups:
+        for rollup, max_values in self.rollups.items():
             r = self.normalize_to_rollup(timestamp, rollup)
             self.sets[model][key][r].update(values)
 
@@ -125,7 +124,7 @@ class InMemoryTSDB(BaseTSDB):
             for key, items in request.items():
                 items = {k: float(v) for k, v in items.items()}
                 source = self.frequencies[model][key]
-                for rollup, _ in self.rollups:
+                for rollup, _ in self.rollups.items():
                     source[self.normalize_to_rollup(timestamp, rollup)].update(items)
 
     def get_most_frequent(self, model, keys, start, end=None, rollup=None, limit=None):

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -155,7 +155,7 @@ class RedisTSDB(BaseTSDB):
             timestamp = timezone.now()
 
         with self.cluster.map() as client:
-            for rollup, max_values in self.rollups:
+            for rollup, max_values in self.rollups.items():
                 norm_rollup = normalize_to_rollup(timestamp, rollup)
                 for model, key in items:
                     model_key = self.get_model_key(key)
@@ -181,8 +181,7 @@ class RedisTSDB(BaseTSDB):
         normalize_to_rollup = self.normalize_to_rollup
         make_key = self.make_counter_key
 
-        if rollup is None:
-            rollup = self.get_optimal_rollup(start, end)
+        rollup = self.get_optimal_rollup(start, end, rollup)
 
         results = []
         timestamp = end
@@ -222,7 +221,7 @@ class RedisTSDB(BaseTSDB):
         with self.cluster.fanout() as client:
             for model, key, values in items:
                 c = client.target_key(key)
-                for rollup, max_values in self.rollups:
+                for rollup, max_values in self.rollups.items():
                     k = self.make_key(
                         model,
                         rollup,
@@ -310,7 +309,7 @@ class RedisTSDB(BaseTSDB):
 
                 # Figure out all of the keys we need to be incrementing, as
                 # well as their expiration policies.
-                for rollup, max_values in self.rollups:
+                for rollup, max_values in self.rollups.items():
                     chunk = self.make_frequency_table_keys(model, rollup, ts, key)
                     keys.extend(chunk)
 

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -400,7 +400,9 @@ class EventManagerTest(TransactionTestCase):
 
     def test_record_frequencies(self):
         project = self.project
-        manager = EventManager(self.make_event())
+        manager = EventManager(self.make_event(
+            timestamp=time(),
+        ))
         event = manager.save(project)
 
         assert tsdb.get_most_frequent(
@@ -425,6 +427,7 @@ class EventManagerTest(TransactionTestCase):
 
     def test_event_user(self):
         manager = EventManager(self.make_event(**{
+            'timestamp': time(),
             'sentry.interfaces.User': {
                 'id': '1',
             }

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -56,7 +56,7 @@ class RedisTSDBTest(TestCase):
             (TSDBModel.project, 2),
         ], dts[3], count=4)
 
-        results = self.db.get_range(TSDBModel.project, [1], dts[0], dts[-1])
+        results = self.db.get_range(TSDBModel.project, [1], dts[0], dts[-1], rollup=3600)
         assert results == {
             1: [
                 (timestamp(dts[0]), 1),
@@ -65,7 +65,8 @@ class RedisTSDBTest(TestCase):
                 (timestamp(dts[3]), 4),
             ],
         }
-        results = self.db.get_range(TSDBModel.project, [2], dts[0], dts[-1])
+
+        results = self.db.get_range(TSDBModel.project, [2], dts[0], dts[-1], rollup=3600)
         assert results == {
             2: [
                 (timestamp(dts[0]), 0),
@@ -125,7 +126,7 @@ class RedisTSDBTest(TestCase):
             dts[3],
         )
 
-        assert self.db.get_distinct_counts_series(model, [1], dts[0], dts[-1]) == {
+        assert self.db.get_distinct_counts_series(model, [1], dts[0], dts[-1], rollup=3600) == {
             1: [
                 (timestamp(dts[0]), 2),
                 (timestamp(dts[1]), 1),
@@ -134,7 +135,7 @@ class RedisTSDBTest(TestCase):
             ],
         }
 
-        assert self.db.get_distinct_counts_series(model, [2], dts[0], dts[-1]) == {
+        assert self.db.get_distinct_counts_series(model, [2], dts[0], dts[-1], rollup=3600) == {
             2: [
                 (timestamp(dts[0]), 0),
                 (timestamp(dts[1]), 0),


### PR DESCRIPTION
This prevents the caller from being able to specify an invalid `rollup` parameter in TSDB queries. Otherwise, the caller would receive a result where all values are zeroes.

This also ensures that the requested rollup can actually satisfy the lower bound of the range that was requested due to TTL constraints.
