### PR TITLE
Allow overriding some security features at the org level

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -221,3 +221,19 @@ class Organization(Model):
             model.objects.filter(
                 organization=from_org,
             ).update(organization=to_org)
+
+    # TODO: Make these a mixin
+    def update_option(self, *args, **kwargs):
+        from sentry.models import OrganizationOption
+
+        return OrganizationOption.objects.set_value(self, *args, **kwargs)
+
+    def get_option(self, *args, **kwargs):
+        from sentry.models import OrganizationOption
+
+        return OrganizationOption.objects.get_value(self, *args, **kwargs)
+
+    def delete_option(self, *args, **kwargs):
+        from sentry.models import OrganizationOption
+
+        return OrganizationOption.objects.unset_value(self, *args, **kwargs)

--- a/src/sentry/templates/sentry/organization-settings.html
+++ b/src/sentry/templates/sentry/organization-settings.html
@@ -33,6 +33,10 @@
 
         {{ form.allow_shared_issues|as_crispy_field }}
         {{ form.enhanced_privacy|as_crispy_field }}
+        {{ form.scrub_data|as_crispy_field }}
+        {{ form.scrub_defaults|as_crispy_field }}
+        {{ form.sensitive_fields|as_crispy_field }}
+        {{ form.scrub_ip_address|as_crispy_field }}
 
         <fieldset class="form-actions">
           <button type="submit" class="btn btn-primary btn-lg">{% trans "Save Changes" %}</button>

--- a/src/sentry/templates/sentry/organization-settings.html
+++ b/src/sentry/templates/sentry/organization-settings.html
@@ -33,10 +33,10 @@
 
         {{ form.allow_shared_issues|as_crispy_field }}
         {{ form.enhanced_privacy|as_crispy_field }}
-        {{ form.scrub_data|as_crispy_field }}
-        {{ form.scrub_defaults|as_crispy_field }}
+        {{ form.require_scrub_data|as_crispy_field }}
+        {{ form.require_scrub_defaults|as_crispy_field }}
         {{ form.sensitive_fields|as_crispy_field }}
-        {{ form.scrub_ip_address|as_crispy_field }}
+        {{ form.require_scrub_ip_address|as_crispy_field }}
 
         <fieldset class="form-actions">
           <button type="submit" class="btn btn-primary btn-lg">{% trans "Save Changes" %}</button>

--- a/src/sentry/templates/sentry/projects/manage.html
+++ b/src/sentry/templates/sentry/projects/manage.html
@@ -146,6 +146,18 @@
         snap: true
       });
     });
+
+    $.each({{ form.org_overrides|to_json|safe }}, function(n, value) {
+      if ($('#id_' + value).attr('disabled')) {
+        $('<span/>').addClass('disabled-indicator tip')
+          .attr('title', {% filter to_json %}{% trans "This option is enforced by your organization's settings and cannot be customized per-project." %}{% endfilter %})
+          .append(
+            $('<span/>').addClass('icon-question')
+          ).insertBefore('#hint_id_' + value);
+      }
+    });
+
+    $('.tip').tooltip();
   }());
   </script>
 {% endblock %}

--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -57,7 +57,7 @@ class SensitiveDataFilter(object):
             fields = ()
         if include_defaults:
             fields += DEFAULT_SCRUBBED_FIELDS
-        self.fields = fields
+        self.fields = set(fields)
 
     def apply(self, data):
         # TODO(dcramer): move this into each interface

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -362,7 +362,7 @@ class StoreView(APIView):
         scrub_data_key = 'sentry:scrub_data'
         scrub_data = org_options.get(scrub_data_key, False)
         if not scrub_data:
-            scrub_data = project.get_option('sentry:scrub_data', True)
+            scrub_data = project.get_option(scrub_data_key, True)
         if scrub_data:
             # We filter data immediately before it ever gets into the queue
             sensitive_fields_key = 'sentry:sensitive_fields'

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -341,10 +341,10 @@ class StoreView(APIView):
 
         org_options = OrganizationOption.objects.get_all_values(project.organization_id)
 
-        scrub_ip_address_key = 'sentry:scrub_ip_address'
-        scrub_ip_address = org_options.get(scrub_ip_address_key, False)
-        if not scrub_ip_address:
-            scrub_ip_address = project.get_option(scrub_ip_address_key, False)
+        if org_options.get('sentry:require_scrub_ip_address', False):
+            scrub_ip_address = True
+        else:
+            scrub_ip_address = project.get_option('sentry:scrub_ip_address', False)
 
         # insert IP address if not available
         if auth.is_public and not scrub_ip_address:
@@ -359,10 +359,11 @@ class StoreView(APIView):
         if cache.get(cache_key) is not None:
             raise APIForbidden('An event with the same ID already exists (%s)' % (event_id,))
 
-        scrub_data_key = 'sentry:scrub_data'
-        scrub_data = org_options.get(scrub_data_key, False)
-        if not scrub_data:
-            scrub_data = project.get_option(scrub_data_key, True)
+        if org_options.get('sentry:require_scrub_data', False):
+            scrub_data = True
+        else:
+            scrub_data = project.get_option('sentry:scrub_data', True)
+
         if scrub_data:
             # We filter data immediately before it ever gets into the queue
             sensitive_fields_key = 'sentry:sensitive_fields'
@@ -371,10 +372,10 @@ class StoreView(APIView):
                 project.get_option(sensitive_fields_key, [])
             )
 
-            scrub_defaults_key = 'sentry:scrub_defaults'
-            scrub_defaults = org_options.get(scrub_defaults_key, False)
-            if not scrub_defaults:
-                scrub_defaults = project.get_option(scrub_defaults_key, True)
+            if org_options.get('sentry:require_scrub_defaults', False):
+                scrub_defaults = True
+            else:
+                scrub_defaults = project.get_option('sentry:scrub_defaults', True)
 
             inst = SensitiveDataFilter(
                 fields=sensitive_fields,

--- a/src/sentry/web/frontend/organization_settings.py
+++ b/src/sentry/web/frontend/organization_settings.py
@@ -40,19 +40,20 @@ class OrganizationSettingsForm(forms.ModelForm):
         help_text=_('Enable sharing of limited details on issues to anonymous users.'),
         required=False,
     )
-    scrub_data = forms.BooleanField(
-        label=_('Data Scrubber'),
-        help_text=_('Enable organization-wide server-side data scrubbing.'),
+    require_scrub_data = forms.BooleanField(
+        label=_('Require Data Scrubber'),
+        help_text=_('Require server-side data scrubbing be enabled for all projects.'),
         required=False
     )
-    scrub_defaults = forms.BooleanField(
-        label=_('Use Default Scrubbers'),
-        help_text=_('Apply organization-wide default scrubbers to prevent things like passwords and credit cards from being stored.'),
+    require_scrub_defaults = forms.BooleanField(
+        label=_('Require Using Default Scrubbers'),
+        help_text=_('Require the default scrubbers be applied to prevent things like passwords and credit cards from being stored for all projects.'),
         required=False
     )
     sensitive_fields = forms.CharField(
-        label=_('Additional sensitive fields'),
-        help_text=_('Additional organization-wide field names to match against when scrubbing data. Separate multiple entries with a newline.'),
+        label=_('Global additional sensitive fields'),
+        help_text=_('Additional field names to match against when scrubbing data for all projects. '
+                    'Separate multiple entries with a newline.<br /><strong>Note: These fields will be used in addition to project specific fields.</strong>'),
         widget=forms.Textarea(attrs={
             'placeholder': mark_safe(_('e.g. email')),
             'class': 'span8',
@@ -60,9 +61,9 @@ class OrganizationSettingsForm(forms.ModelForm):
         }),
         required=False,
     )
-    scrub_ip_address = forms.BooleanField(
-        label=_('Don\'t store IP Addresses'),
-        help_text=_('Prevent IP addresses from being stored for new events organization-wide.'),
+    require_scrub_ip_address = forms.BooleanField(
+        label=_('Require not storing IP Addresses'),
+        help_text=_('Require preventing IP addresses from being stored for new events on all projects.'),
         required=False
     )
 
@@ -90,10 +91,10 @@ class OrganizationSettingsView(OrganizationView):
                 'allow_joinleave': bool(organization.flags.allow_joinleave),
                 'enhanced_privacy': bool(organization.flags.enhanced_privacy),
                 'allow_shared_issues': bool(not organization.flags.disable_shared_issues),
-                'scrub_data': bool(organization.get_option('sentry:scrub_data', False)),
-                'scrub_defaults': bool(organization.get_option('sentry:scrub_defaults', False)),
+                'require_scrub_data': bool(organization.get_option('sentry:require_scrub_data', False)),
+                'require_scrub_defaults': bool(organization.get_option('sentry:require_scrub_defaults', False)),
                 'sensitive_fields': '\n'.join(organization.get_option('sentry:sensitive_fields', None) or []),
-                'scrub_ip_address': bool(organization.get_option('sentry:scrub_ip_address', False)),
+                'require_scrub_ip_address': bool(organization.get_option('sentry:require_scrub_ip_address', False)),
             }
         )
 
@@ -107,10 +108,10 @@ class OrganizationSettingsView(OrganizationView):
             organization.save()
 
             for opt in (
-                    'scrub_data',
-                    'scrub_defaults',
+                    'require_scrub_data',
+                    'require_scrub_defaults',
                     'sensitive_fields',
-                    'scrub_ip_address'):
+                    'require_scrub_ip_address'):
                 value = form.cleaned_data.get(opt)
                 if value is None:
                     organization.delete_option('sentry:%s' % (opt,))

--- a/src/sentry/web/frontend/project_settings.py
+++ b/src/sentry/web/frontend/project_settings.py
@@ -68,11 +68,24 @@ class EditProjectForm(forms.ModelForm):
     blacklisted_ips = IPNetworksField(label=_('Blacklisted IP Addresses'), required=False,
         help_text=_('Separate multiple entries with a newline.'))
 
+    # Options that are overridden by Organization level settings
+    org_overrides = ('scrub_data', 'scrub_defaults', 'scrub_ip_address')
+
     class Meta:
         fields = ('name', 'team', 'slug')
         model = Project
 
     def __init__(self, request, organization, team_list, data, instance, *args, **kwargs):
+        # First, we need to check for the value overrides from the Organization options
+        # We need to do this before `initial` gets passed into the Form.
+        disabled = []
+        if 'initial' in kwargs:
+            for opt in self.org_overrides:
+                value = bool(organization.get_option('sentry:%s' % (opt,), False))
+                if value:
+                    disabled.append(opt)
+                    kwargs['initial'][opt] = value
+
         super(EditProjectForm, self).__init__(data=data, instance=instance, *args, **kwargs)
 
         self.organization = organization
@@ -80,6 +93,11 @@ class EditProjectForm(forms.ModelForm):
 
         self.fields['team'].choices = self.get_team_choices(team_list, instance.team)
         self.fields['team'].widget.choices = self.fields['team'].choices
+
+        # After the Form is initialized, we now need to disable the fields that have been
+        # overridden from Organization options.
+        for opt in disabled:
+            self.fields[opt].widget.attrs['disabled'] = 'disabled'
 
     def get_team_label(self, team):
         return '%s (%s)' % (team.name, team.slug)
@@ -161,7 +179,8 @@ class ProjectSettingsView(ProjectView):
 
         return EditProjectForm(
             request, organization, team_list, request.POST or None,
-            instance=project, initial={
+            instance=project,
+            initial={
                 'origins': '\n'.join(project.get_option('sentry:origins', ['*'])),
                 'token': security_token,
                 'resolve_age': int(project.get_option('sentry:resolve_age', 0)),
@@ -186,9 +205,12 @@ class ProjectSettingsView(ProjectView):
                     'scrub_data',
                     'scrub_defaults',
                     'sensitive_fields',
-                    'scrub_ip_addresses',
+                    'scrub_ip_address',
                     'scrape_javascript',
                     'blacklisted_ips'):
+                # Value can't be overridden if set on the org level
+                if opt in form.org_overrides and organization.get_option('sentry:%s' % (opt,), False):
+                    continue
                 value = form.cleaned_data.get(opt)
                 if value is None:
                     project.delete_option('sentry:%s' % (opt,))

--- a/src/sentry/web/frontend/project_settings.py
+++ b/src/sentry/web/frontend/project_settings.py
@@ -81,7 +81,7 @@ class EditProjectForm(forms.ModelForm):
         disabled = []
         if 'initial' in kwargs:
             for opt in self.org_overrides:
-                value = bool(organization.get_option('sentry:%s' % (opt,), False))
+                value = bool(organization.get_option('sentry:require_%s' % (opt,), False))
                 if value:
                     disabled.append(opt)
                     kwargs['initial'][opt] = value

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -139,6 +139,145 @@ class StoreViewTest(TestCase):
         assert not call_data['sentry.interfaces.User'].get('ip_address')
         assert not call_data['sentry.interfaces.Http']['env'].get('REMOTE_ADDR')
 
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
+    def test_scrubs_org_ip_address_override(self, mock_insert_data_to_database):
+        self.organization.update_option('sentry:scrub_ip_address', True)
+        self.project.update_option('sentry:scrub_ip_address', False)
+        body = {
+            "message": "foo bar",
+            "sentry.interfaces.User": {"ip_address": "127.0.0.1"},
+            "sentry.interfaces.Http": {
+                "method": "GET",
+                "url": "http://example.com/",
+                "env": {"REMOTE_ADDR": "127.0.0.1"}
+            },
+        }
+        resp = self._postWithHeader(body)
+        assert resp.status_code == 200, resp.content
+
+        call_data = mock_insert_data_to_database.call_args[0][0]
+        assert not call_data['sentry.interfaces.User'].get('ip_address')
+        assert not call_data['sentry.interfaces.Http']['env'].get('REMOTE_ADDR')
+
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
+    def test_scrub_data_off(self, mock_insert_data_to_database):
+        self.project.update_option('sentry:scrub_data', False)
+        self.project.update_option('sentry:scrub_defaults', False)
+        body = {
+            "message": "foo bar",
+            "sentry.interfaces.User": {"ip_address": "127.0.0.1"},
+            "sentry.interfaces.Http": {
+                "method": "GET",
+                "url": "http://example.com/",
+                "data": "password=lol&foo=1&bar=2&baz=3"
+            },
+        }
+        resp = self._postWithHeader(body)
+        assert resp.status_code == 200, resp.content
+
+        call_data = mock_insert_data_to_database.call_args[0][0]
+        assert call_data['sentry.interfaces.Http']['data'] == 'password=lol&foo=1&bar=2&baz=3'
+
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
+    def test_scrub_data_on(self, mock_insert_data_to_database):
+        self.project.update_option('sentry:scrub_data', True)
+        self.project.update_option('sentry:scrub_defaults', False)
+        body = {
+            "message": "foo bar",
+            "sentry.interfaces.User": {"ip_address": "127.0.0.1"},
+            "sentry.interfaces.Http": {
+                "method": "GET",
+                "url": "http://example.com/",
+                "data": "password=lol&foo=1&bar=2&baz=3"
+            },
+        }
+        resp = self._postWithHeader(body)
+        assert resp.status_code == 200, resp.content
+
+        call_data = mock_insert_data_to_database.call_args[0][0]
+        assert call_data['sentry.interfaces.Http']['data'] == 'password=lol&foo=1&bar=2&baz=3'
+
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
+    def test_scrub_data_defaults(self, mock_insert_data_to_database):
+        self.project.update_option('sentry:scrub_data', True)
+        self.project.update_option('sentry:scrub_defaults', True)
+        body = {
+            "message": "foo bar",
+            "sentry.interfaces.User": {"ip_address": "127.0.0.1"},
+            "sentry.interfaces.Http": {
+                "method": "GET",
+                "url": "http://example.com/",
+                "data": "password=lol&foo=1&bar=2&baz=3"
+            },
+        }
+        resp = self._postWithHeader(body)
+        assert resp.status_code == 200, resp.content
+
+        call_data = mock_insert_data_to_database.call_args[0][0]
+        assert call_data['sentry.interfaces.Http']['data'] == 'password=[Filtered]&foo=1&bar=2&baz=3'
+
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
+    def test_scrub_data_sensitive_fields(self, mock_insert_data_to_database):
+        self.project.update_option('sentry:scrub_data', True)
+        self.project.update_option('sentry:scrub_defaults', True)
+        self.project.update_option('sentry:sensitive_fields', ['foo', 'bar'])
+        body = {
+            "message": "foo bar",
+            "sentry.interfaces.User": {"ip_address": "127.0.0.1"},
+            "sentry.interfaces.Http": {
+                "method": "GET",
+                "url": "http://example.com/",
+                "data": "password=lol&foo=1&bar=2&baz=3"
+            },
+        }
+        resp = self._postWithHeader(body)
+        assert resp.status_code == 200, resp.content
+
+        call_data = mock_insert_data_to_database.call_args[0][0]
+        assert call_data['sentry.interfaces.Http']['data'] == 'password=[Filtered]&foo=[Filtered]&bar=[Filtered]&baz=3'
+
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
+    def test_scrub_data_org_override(self, mock_insert_data_to_database):
+        self.organization.update_option('sentry:scrub_data', True)
+        self.project.update_option('sentry:scrub_data', False)
+        self.organization.update_option('sentry:scrub_defaults', True)
+        self.project.update_option('sentry:scrub_defaults', False)
+        body = {
+            "message": "foo bar",
+            "sentry.interfaces.User": {"ip_address": "127.0.0.1"},
+            "sentry.interfaces.Http": {
+                "method": "GET",
+                "url": "http://example.com/",
+                "data": "password=lol&foo=1&bar=2&baz=3"
+            },
+        }
+        resp = self._postWithHeader(body)
+        assert resp.status_code == 200, resp.content
+
+        call_data = mock_insert_data_to_database.call_args[0][0]
+        assert call_data['sentry.interfaces.Http']['data'] == 'password=[Filtered]&foo=1&bar=2&baz=3'
+
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
+    def test_scrub_data_org_override_sensitive_fields(self, mock_insert_data_to_database):
+        self.organization.update_option('sentry:scrub_data', True)
+        self.organization.update_option('sentry:scrub_defaults', True)
+        self.organization.update_option('sentry:sensitive_fields', ['baz'])
+        self.project.update_option('sentry:sensitive_fields', ['foo', 'bar'])
+        body = {
+            "message": "foo bar",
+            "sentry.interfaces.User": {"ip_address": "127.0.0.1"},
+            "sentry.interfaces.Http": {
+                "method": "GET",
+                "url": "http://example.com/",
+                "data": "password=lol&foo=1&bar=2&baz=3"
+            },
+        }
+        resp = self._postWithHeader(body)
+        assert resp.status_code == 200, resp.content
+
+        call_data = mock_insert_data_to_database.call_args[0][0]
+        assert call_data['sentry.interfaces.Http']['data'] == 'password=[Filtered]&foo=[Filtered]&bar=[Filtered]&baz=[Filtered]'
+
 
 class CrossDomainXmlTest(TestCase):
     @fixture

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -141,7 +141,7 @@ class StoreViewTest(TestCase):
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrubs_org_ip_address_override(self, mock_insert_data_to_database):
-        self.organization.update_option('sentry:scrub_ip_address', True)
+        self.organization.update_option('sentry:require_scrub_ip_address', True)
         self.project.update_option('sentry:scrub_ip_address', False)
         body = {
             "message": "foo bar",
@@ -238,9 +238,9 @@ class StoreViewTest(TestCase):
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrub_data_org_override(self, mock_insert_data_to_database):
-        self.organization.update_option('sentry:scrub_data', True)
+        self.organization.update_option('sentry:require_scrub_data', True)
         self.project.update_option('sentry:scrub_data', False)
-        self.organization.update_option('sentry:scrub_defaults', True)
+        self.organization.update_option('sentry:require_scrub_defaults', True)
         self.project.update_option('sentry:scrub_defaults', False)
         body = {
             "message": "foo bar",
@@ -259,8 +259,8 @@ class StoreViewTest(TestCase):
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrub_data_org_override_sensitive_fields(self, mock_insert_data_to_database):
-        self.organization.update_option('sentry:scrub_data', True)
-        self.organization.update_option('sentry:scrub_defaults', True)
+        self.organization.update_option('sentry:require_scrub_data', True)
+        self.organization.update_option('sentry:require_scrub_defaults', True)
         self.organization.update_option('sentry:sensitive_fields', ['baz'])
         self.project.update_option('sentry:sensitive_fields', ['foo', 'bar'])
         body = {


### PR DESCRIPTION
Fixes GH-2757

This adds the following fields into Organization settings:
![image](https://cloud.githubusercontent.com/assets/375744/13368085/5593e558-dc9c-11e5-91e3-16a68e072418.png)

Then values are checked, the widgets on the project page become disabled:
![image](https://cloud.githubusercontent.com/assets/375744/13367326/856ef552-dc96-11e5-9eba-9095196f53d1.png)
