### PR TITLE
Enable react/prop-types eslint rule; add missing propTypes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -132,6 +132,9 @@
     "react/no-did-mount-set-state": [2, "allow-in-func"], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
     "react/no-did-update-set-state": 2, // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md"
     "react/no-unknown-property": 2,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
+    "react/prop-types": [2, {
+      "ignore": ["className", "children", "location", "params"]
+    }],
     "react/react-in-jsx-scope": 2,   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
     "react/self-closing-comp": 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
     "react/sort-comp": 2,            // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md

--- a/src/sentry/static/sentry/app/components/activity/feed.jsx
+++ b/src/sentry/static/sentry/app/components/activity/feed.jsx
@@ -9,6 +9,13 @@ import {t} from '../../locale';
 import {logException} from '../../utils/logging';
 
 const ActivityFeed = React.createClass({
+  propTypes: {
+    endpoint: React.PropTypes.string,
+    query: React.PropTypes.object,
+    renderEmpty: React.PropTypes.func,
+    pagination: React.PropTypes.bool
+  },
+
   mixins: [ApiMixin],
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/activity/item.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item.jsx
@@ -12,6 +12,12 @@ import {tct} from '../../locale';
 
 
 const ActivityItem = React.createClass({
+  propTypes: {
+    clipHeight: React.PropTypes.number,
+    defaultClipped: React.PropTypes.bool,
+    item: React.PropTypes.object.isRequired,
+    orgId: React.PropTypes.string.isRequired
+  },
 
   getDefaultProps() {
     return {

--- a/src/sentry/static/sentry/app/components/activity/note.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note.jsx
@@ -1,5 +1,6 @@
-import marked from 'marked';
 import React from 'react';
+
+import marked from 'marked';
 import TimeSince from '../../components/timeSince';
 import ConfigStore from '../../stores/configStore';
 import LinkWithConfirmation from '../../components/linkWithConfirmation';
@@ -11,6 +12,13 @@ marked.setOptions({
 });
 
 const Note = React.createClass({
+  propTypes: {
+    author: React.PropTypes.object.isRequired,
+    item: React.PropTypes.object.isRequired,
+    onEdit: React.PropTypes.func.isRequired,
+    onDelete: React.PropTypes.func.isRequired,
+  },
+
   canEdit() {
     let user = ConfigStore.get('user');
     return user.isSuperuser || user.id === this.props.item.user.id;

--- a/src/sentry/static/sentry/app/components/activity/noteContainer.jsx
+++ b/src/sentry/static/sentry/app/components/activity/noteContainer.jsx
@@ -4,6 +4,13 @@ import Note from './note';
 import NoteInput from './noteInput';
 
 const NoteContainer = React.createClass({
+  propTypes: {
+    group: React.PropTypes.object.isRequired,
+    item: React.PropTypes.object.isRequired,
+    author: React.PropTypes.object.isRequired,
+    onDelete: React.PropTypes.func.isRequired
+  },
+
   getInitialState() {
     return {
       editing: false

--- a/src/sentry/static/sentry/app/components/activity/noteInput.jsx
+++ b/src/sentry/static/sentry/app/components/activity/noteInput.jsx
@@ -1,5 +1,6 @@
-import marked from 'marked';
 import React from 'react';
+import marked from 'marked';
+
 import ApiMixin from '../../mixins/apiMixin';
 import GroupStore from '../../stores/groupStore';
 import IndicatorStore from '../../stores/indicatorStore';
@@ -15,6 +16,12 @@ function makeDefaultErrorJson() {
 }
 
 const NoteInput = React.createClass({
+  propTypes: {
+    item: React.PropTypes.object,
+    group: React.PropTypes.object.isRequired,
+    onFinish: React.PropTypes.func
+  },
+
   mixins: [
     PureRenderMixin,
     ApiMixin

--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -5,8 +5,10 @@ import {t} from '../locale';
 
 const AlertMessage = React.createClass({
   propTypes: {
-    type: React.PropTypes.string,
-    message: React.PropTypes.string
+    className: React.PropTypes.string,
+    id: React.PropTypes.number.isRequired,
+    message: React.PropTypes.string.isRequired,
+    type: React.PropTypes.string
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/barChart.jsx
@@ -10,6 +10,9 @@ const BarChart = React.createClass({
       y: React.PropTypes.number.isRequired,
       label: React.PropTypes.string
     })),
+    interval: React.PropTypes.string,
+    height: React.PropTypes.number,
+    width: React.PropTypes.number,
     placement: React.PropTypes.string,
     label: React.PropTypes.string,
     markers: React.PropTypes.arrayOf(React.PropTypes.shape({
@@ -58,8 +61,7 @@ const BarChart = React.createClass({
       placement: 'bottom',
       points: [],
       markers: [],
-      width: null,
-      viewport: null
+      width: null
     };
   },
 

--- a/src/sentry/static/sentry/app/components/clippedBox.jsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.jsx
@@ -5,7 +5,8 @@ import {t} from '../locale';
 const ClippedBox = React.createClass({
   propTypes: {
     title: React.PropTypes.string,
-    defaultClipped: React.PropTypes.bool
+    defaultClipped: React.PropTypes.bool,
+    clipHeight: React.PropTypes.number
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -19,6 +19,12 @@ const Snooze = {
 
 
 const SnoozeAction = React.createClass({
+  propTypes: {
+    disabled: React.PropTypes.bool,
+    onSnooze: React.PropTypes.func.isRequired,
+    tooltip: React.PropTypes.string
+  },
+
   getInitialState() {
     return {
       isModalOpen: false
@@ -73,6 +79,13 @@ const SnoozeAction = React.createClass({
 });
 
 const CompactIssue = React.createClass({
+  propTypes: {
+    data: React.PropTypes.object,
+    id: React.PropTypes.string,
+    orgId: React.PropTypes.string,
+    statsPeriod: React.PropTypes.string
+  },
+
   mixins: [
     ApiMixin,
     Reflux.listenTo(GroupStore, 'onGroupChange')

--- a/src/sentry/static/sentry/app/components/dateTime.jsx
+++ b/src/sentry/static/sentry/app/components/dateTime.jsx
@@ -5,6 +5,7 @@ import ConfigStore from '../stores/configStore.jsx';
 const DateTime = React.createClass({
   propTypes: {
     date: React.PropTypes.any.isRequired,
+    seconds: React.PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -6,11 +6,13 @@ require('bootstrap/js/dropdown');
 
 const DropdownLink = React.createClass({
   propTypes: {
-    title:     React.PropTypes.node,
-    caret:     React.PropTypes.bool,
-    disabled:  React.PropTypes.bool,
-    onOpen:    React.PropTypes.func,
-    onClose:   React.PropTypes.func,
+    title: React.PropTypes.node,
+    caret: React.PropTypes.bool,
+    disabled: React.PropTypes.bool,
+    onOpen: React.PropTypes.func,
+    onClose: React.PropTypes.func,
+    topLevelClasses: React.PropTypes.string,
+    menuClasses: React.PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/events/errorItem.jsx
+++ b/src/sentry/static/sentry/app/components/events/errorItem.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import {t} from '../../locale';
 
 const EventErrorItem = React.createClass({
+  propTypes: {
+    error: React.PropTypes.object.isRequired
+  },
+
   getInitialState(){
     return {
       isOpen: false,

--- a/src/sentry/static/sentry/app/components/events/eventRow.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventRow.jsx
@@ -6,7 +6,9 @@ import TimeSince from '../timeSince';
 
 const EventRow = React.createClass({
   propTypes: {
-    id: React.PropTypes.string.isRequired
+    id: React.PropTypes.string.isRequired,
+    orgSlug: React.PropTypes.string.isRequired,
+    projectSlug: React.PropTypes.string.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
@@ -5,6 +5,7 @@ import StacktraceContent from './stacktraceContent';
 
 const ExceptionContent = React.createClass({
   propTypes: {
+    values: React.PropTypes.array.isRequired,
     view: React.PropTypes.string.isRequired,
     platform: React.PropTypes.string,
     newestFirst: React.PropTypes.bool

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -10,7 +10,8 @@ import {t} from '../../../locale';
 
 const Frame = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: React.PropTypes.object.isRequired,
+    isExpanded: React.PropTypes.bool
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -3,7 +3,8 @@ import rawStacktraceContent from './rawStacktraceContent';
 
 const RawExceptionContent = React.createClass({
   propTypes: {
-    platform: React.PropTypes.string
+    platform: React.PropTypes.string,
+    values: React.PropTypes.array.isRequired,
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/requestActions.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/requestActions.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
+
 import ConfigStore from '../../../stores/configStore';
 import {t} from '../../../locale';
 
 const RequestActions = React.createClass({
+  propTypes: {
+    organization: React.PropTypes.object.isRequired,
+    project: React.PropTypes.object.isRequired,
+    group: React.PropTypes.object.isRequired,
+    event: React.PropTypes.object.isRequired
+  },
+
   render(){
     let org = this.props.organization;
     let project = this.props.project;

--- a/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
@@ -9,6 +9,9 @@ import queryString from 'query-string';
 import {t} from '../../../locale';
 
 const RichHttpContent = React.createClass({
+  propTypes: {
+    data: React.PropTypes.object.isRequired
+  },
 
   /**
    * Converts an object of body/querystring key/value pairs

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -12,7 +12,8 @@ const StacktraceInterface = React.createClass({
     group: PropTypes.Group.isRequired,
     event: PropTypes.Event.isRequired,
     type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    data: React.PropTypes.object.isRequired,
+    platform: React.PropTypes.string
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/message.jsx
@@ -4,6 +4,11 @@ import utils from '../../utils';
 import {t} from '../../locale';
 
 const Message = React.createClass({
+  propTypes: {
+    group: React.PropTypes.object.isRequired,
+    event: React.PropTypes.object.isRequired
+  },
+
   render() {
     return (
       <EventDataSection

--- a/src/sentry/static/sentry/app/components/events/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/user.jsx
@@ -1,5 +1,6 @@
-import _ from 'underscore';
 import React from 'react';
+import _ from 'underscore';
+
 import Gravatar from '../../components/gravatar';
 import KeyValueList from './interfaces/keyValueList';
 import EventDataSection from './eventDataSection';
@@ -7,6 +8,11 @@ import {t} from '../../locale';
 
 
 const EventUser = React.createClass({
+  propTypes: {
+    event: React.PropTypes.object.isRequired,
+    group: React.PropTypes.object.isRequired
+  },
+
   render() {
     let user = this.props.event.user;
     let builtins = [];

--- a/src/sentry/static/sentry/app/components/events/userReport.jsx
+++ b/src/sentry/static/sentry/app/components/events/userReport.jsx
@@ -5,6 +5,10 @@ import utils from '../../utils';
 
 
 const EventUserReport = React.createClass({
+  propTypes: {
+    event: React.PropTypes.object.isRequired
+  },
+
   render() {
     let report = this.props.event.userReport;
 

--- a/src/sentry/static/sentry/app/components/flotChart.jsx
+++ b/src/sentry/static/sentry/app/components/flotChart.jsx
@@ -69,7 +69,8 @@ let tickFormatter = (value, axis) => {
 
 const FlotChart = React.createClass({
   propTypes: {
-    plotData: React.PropTypes.array
+    plotData: React.PropTypes.array,
+    style: React.PropTypes.object
   },
 
   componentDidMount() {

--- a/src/sentry/static/sentry/app/components/forms/form.jsx
+++ b/src/sentry/static/sentry/app/components/forms/form.jsx
@@ -3,6 +3,12 @@ import React from 'react';
 import {t} from '../../locale';
 
 const Form = React.createClass({
+  propTypes: {
+    onSubmit: React.PropTypes.func.isRequired,
+    submitDisabled: React.PropTypes.bool,
+    submitLabel: React.PropTypes.string.isRequired
+  },
+
   getDefaultProps() {
     return {
       submitLabel: t('Save Changes'),

--- a/src/sentry/static/sentry/app/components/gravatar.jsx
+++ b/src/sentry/static/sentry/app/components/gravatar.jsx
@@ -6,7 +6,8 @@ const Gravatar = React.createClass({
   propTypes: {
     email: React.PropTypes.string,
     size: React.PropTypes.number,
-    default: React.PropTypes.string
+    default: React.PropTypes.string,
+    title: React.PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/group/chart.jsx
+++ b/src/sentry/static/sentry/app/components/group/chart.jsx
@@ -8,7 +8,10 @@ import {t} from '../../locale';
 const GroupChart = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
-    statsPeriod: React.PropTypes.string.isRequired
+    statsPeriod: React.PropTypes.string.isRequired,
+    firstSeen: React.PropTypes.string.isRequired,
+    lastSeen: React.PropTypes.string.isRequired,
+    title: React.PropTypes.string
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import jQuery from 'jquery';
+
 import ApiMixin from '../mixins/apiMixin';
 import GroupListHeader from '../components/groupListHeader';
 import GroupStore from '../stores/groupStore';
@@ -16,7 +17,8 @@ const GroupList = React.createClass({
     query: React.PropTypes.string.isRequired,
     canSelectGroups: React.PropTypes.bool,
     orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    projectId: React.PropTypes.string.isRequired,
+    bulkActions: React.PropTypes.bool.isRequired
   },
 
   contextTypes: {

--- a/src/sentry/static/sentry/app/components/header/index.jsx
+++ b/src/sentry/static/sentry/app/components/header/index.jsx
@@ -14,7 +14,10 @@ import TodoList from '../todos';
 
 const OnboardingStatus = React.createClass({
   propTypes: {
-    onHideTodos: React.PropTypes.func
+    org: React.PropTypes.object.isRequired,
+    onToggleTodos: React.PropTypes.func.isRequired,
+    showTodos: React.PropTypes.bool,
+    onHideTodos: React.PropTypes.func,
   },
 
   render() {
@@ -46,6 +49,10 @@ const OnboardingStatus = React.createClass({
 });
 
 const Header = React.createClass({
+  propTypes: {
+    orgId: React.PropTypes.string.isRequired
+  },
+
   mixins: [ApiMixin, OrganizationState],
 
   getInitialState: function() {

--- a/src/sentry/static/sentry/app/components/header/organizationSelector.jsx
+++ b/src/sentry/static/sentry/app/components/header/organizationSelector.jsx
@@ -8,6 +8,10 @@ import ConfigStore from '../../stores/configStore';
 import {t} from '../../locale';
 
 const OrganizationSelector = React.createClass({
+  propTypes: {
+    organization: React.PropTypes.object
+  },
+
   mixins: [
     AppState,
   ],

--- a/src/sentry/static/sentry/app/components/issueList.jsx
+++ b/src/sentry/static/sentry/app/components/issueList.jsx
@@ -9,6 +9,14 @@ import Pagination from './pagination';
 import {t} from '../locale';
 
 const IssueList = React.createClass({
+  propTypes: {
+    endpoint: React.PropTypes.string.isRequired,
+    query: React.PropTypes.object,
+    pagination: React.PropTypes.bool,
+    renderEmpty: React.PropTypes.func,
+    statsPeriod: React.PropTypes.string
+  },
+
   mixins: [ApiMixin],
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
+++ b/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
@@ -7,6 +7,7 @@ const LinkWithConfirmation = React.createClass({
   propTypes: {
     disabled: React.PropTypes.bool,
     message: React.PropTypes.string.isRequired,
+    title: React.PropTypes.string.isRequired,
     onConfirm: React.PropTypes.func.isRequired
   },
 

--- a/src/sentry/static/sentry/app/components/listLink.jsx
+++ b/src/sentry/static/sentry/app/components/listLink.jsx
@@ -10,6 +10,7 @@ const ListLink = React.createClass({
     to: React.PropTypes.string.isRequired,
     query: React.PropTypes.object,
     onClick: React.PropTypes.func,
+    index: React.PropTypes.bool,
 
     // If supplied by parent component, decides whether link element
     // is "active" or not ... overriding default behavior of strict

--- a/src/sentry/static/sentry/app/components/loadingIndicator.jsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.jsx
@@ -1,3 +1,4 @@
+/*eslint react/prop-types:0*/
 import classNames from 'classnames';
 import React from 'react';
 

--- a/src/sentry/static/sentry/app/components/menuItem.jsx
+++ b/src/sentry/static/sentry/app/components/menuItem.jsx
@@ -4,18 +4,19 @@ import classNames from 'classnames';
 
 const MenuItem = React.createClass({
   propTypes: {
-    header:    React.PropTypes.bool,
-    divider:   React.PropTypes.bool,
-    title:     React.PropTypes.string,
-    onSelect:  React.PropTypes.func,
-    eventKey:  React.PropTypes.any,
-    isActive:  React.PropTypes.bool,
-    noAnchor:  React.PropTypes.bool,
+    header: React.PropTypes.bool,
+    divider: React.PropTypes.bool,
+    title: React.PropTypes.string,
+    onSelect: React.PropTypes.func,
+    eventKey: React.PropTypes.any,
+    isActive: React.PropTypes.bool,
+    noAnchor: React.PropTypes.bool,
     // basic link
-    href:      React.PropTypes.string,
+    href: React.PropTypes.string,
     // router link
-    to:        React.PropTypes.string,
-    query:     React.PropTypes.object,
+    to: React.PropTypes.string,
+    query: React.PropTypes.object,
+    linkClassName: React.PropTypes.string
   },
 
   handleClick(e) {

--- a/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
@@ -7,6 +7,11 @@ import {t} from '../locale';
 const ERR_JOIN = 'There was an error while trying to join the team.';
 
 const MissingProjectMembership = React.createClass({
+  propTypes: {
+    organization: React.PropTypes.object.isRequired,
+    team: React.PropTypes.object.isRequired
+  },
+
   mixins: [
     ApiMixin
   ],

--- a/src/sentry/static/sentry/app/components/mutedBox.jsx
+++ b/src/sentry/static/sentry/app/components/mutedBox.jsx
@@ -5,6 +5,10 @@ import DateTime from './dateTime';
 import {t} from '../locale';
 
 const MutedBox = React.createClass({
+  propTypes: {
+    statusDetails: React.PropTypes.object.isRequired
+  },
+
   mixins: [PureRenderMixin],
 
   render() {

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -7,6 +7,12 @@ import OrganizationHomeContainer from './organizations/homeContainer';
 import {t} from '../locale';
 
 const OrganizationIssueList = React.createClass({
+  propTypes: {
+    title: React.PropTypes.string,
+    endpoint: React.PropTypes.string.isRequired,
+    pageSize: React.PropTypes.number
+  },
+
   getInitialState() {
     return this.getQueryStringState(this.props);
   },

--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -6,6 +6,7 @@ import {t} from '../locale';
 const Pagination = React.createClass({
   propTypes: {
     pageLinks: React.PropTypes.string.isRequired,
+    to: React.PropTypes.string
   },
 
   contextTypes: {

--- a/src/sentry/static/sentry/app/components/projectHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/index.jsx
@@ -6,6 +6,12 @@ import ProjectSelector from './projectSelector';
 import {t} from '../../locale';
 
 const ProjectHeader = React.createClass({
+  propTypes: {
+    project: React.PropTypes.object.isRequired,
+    organization: React.PropTypes.object.isRequired,
+    activeSection: React.PropTypes.string
+  },
+
   render() {
     let navSection = this.props.activeSection;
     let urlPrefix = ConfigStore.get('urlPrefix');

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -2,12 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Link} from 'react-router';
 import jQuery from 'jquery';
+
 import ConfigStore from '../../stores/configStore';
 import DropdownLink from '../dropdownLink';
 import MenuItem from '../menuItem';
 import {t} from '../../locale';
 
 const ProjectSelector = React.createClass({
+  propTypes: {
+    projectId: React.PropTypes.string,
+    organization: React.PropTypes.object.isRequired
+  },
+
   contextTypes: {
     location: React.PropTypes.object
   },
@@ -94,7 +100,7 @@ const ProjectSelector = React.createClass({
 
     let menuItemProps = {
       key: projectId, // TODO: what if two projects w/ same name under diff orgs?
-      linkClassName: projectId == this.props.projectId && 'active',
+      linkClassName: projectId == this.props.projectId ? 'active' : '',
 
       // When router is available, use `to` property. Otherwise, use href
       // property. For example - when project selector is loaded on

--- a/src/sentry/static/sentry/app/components/searchBar.jsx
+++ b/src/sentry/static/sentry/app/components/searchBar.jsx
@@ -3,6 +3,13 @@ import ReactDOM from 'react-dom';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 const SearchBar = React.createClass({
+  propTypes: {
+    query: React.PropTypes.string,
+    defaultQuery: React.PropTypes.string,
+    onSearch: React.PropTypes.func,
+    onQueryChange: React.PropTypes.func,
+    placeholder: React.PropTypes.string
+  },
 
   mixins: [PureRenderMixin],
 

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -2,6 +2,15 @@ import React from 'react';
 import jQuery from 'jquery';
 
 const SelectInput = React.createClass({
+  propTypes: {
+    disabled: React.PropTypes.bool,
+    multiple: React.PropTypes.bool,
+    required: React.PropTypes.bool,
+    placeholder: React.PropTypes.string,
+    value: React.PropTypes.string,
+    onChange: React.PropTypes.func,
+  },
+
   getDefaultProps() {
     return {
       // HTML attrs

--- a/src/sentry/static/sentry/app/components/todos.jsx
+++ b/src/sentry/static/sentry/app/components/todos.jsx
@@ -8,6 +8,7 @@ import OrganizationState from '../mixins/organizationState';
 const TodoItem = React.createClass({
   propTypes: {
     task: React.PropTypes.object,
+    onSkip: React.PropTypes.func.isRequired
   },
 
   mixins: [OrganizationState],
@@ -99,6 +100,8 @@ const TodoItem = React.createClass({
 const Confirmation = React.createClass({
   propTypes: {
     task: React.PropTypes.number,
+    onSkip: React.PropTypes.func.isRequired,
+    dismiss: React.PropTypes.func.isRequired
   },
 
   skip: function(e) {

--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -3,6 +3,7 @@ import {Link} from 'react-router';
 
 const Version = React.createClass({
   propTypes: {
+    anchor: React.PropTypes.bool,
     version: React.PropTypes.string.isRequired,
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired

--- a/src/sentry/static/sentry/app/views/adminBuffer.jsx
+++ b/src/sentry/static/sentry/app/views/adminBuffer.jsx
@@ -7,6 +7,13 @@ import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 
 const InternalChart = React.createClass({
+  propTypes: {
+    since: React.PropTypes.number.isRequired,
+    resolution: React.PropTypes.string.isRequired,
+    stat: React.PropTypes.string.isRequired,
+    label: React.PropTypes.string
+  },
+
   mixins: [ApiMixin],
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
@@ -6,6 +6,10 @@ import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 
 const ApiChart = React.createClass({
+  propTypes: {
+    since: React.PropTypes.number.isRequired
+  },
+
   mixins: [
     ApiMixin
   ],

--- a/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
@@ -7,6 +7,11 @@ import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 
 const EventChart = React.createClass({
+  propTypes: {
+    since: React.PropTypes.number.isRequired,
+    resolution: React.PropTypes.string.isRequired
+  },
+
   mixins: [
     ApiMixin
   ],

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -16,6 +16,12 @@ const optionsAvailable = [
 ];
 
 const SettingsList = React.createClass({
+  propTypes: {
+    formDisabled: React.PropTypes.bool,
+    options: React.PropTypes.object.isRequired,
+    onSubmit: React.PropTypes.func.isRequired,
+  },
+
   getInitialState() {
     let options = this.props.options;
     let formData = {};

--- a/src/sentry/static/sentry/app/views/groupActivity/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/index.jsx
@@ -19,6 +19,9 @@ import {t, tn} from '../../locale';
 
 const GroupActivity = React.createClass({
   // TODO(dcramer): only re-render on group/activity change
+  propTypes: {
+    group: React.PropTypes.object
+  },
 
   mixins: [
     GroupState,

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -14,6 +14,11 @@ let ERROR_TYPES = {
 };
 
 const GroupDetails = React.createClass({
+  propTypes: {
+    setProjectNavSection: React.PropTypes.func,
+    memberList: React.PropTypes.array
+  },
+
   childContextTypes: {
     group: PropTypes.Group,
   },

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -13,7 +13,8 @@ import {t} from '../../locale';
 
 const GroupHeader = React.createClass({
   propTypes: {
-    memberList: React.PropTypes.instanceOf(Array).isRequired
+    group: React.PropTypes.object.isRequired,
+    memberList: React.PropTypes.array.isRequired
   },
 
   contextTypes: {

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -10,6 +10,12 @@ import LoadingIndicator from '../components/loadingIndicator';
 import {getOption, getOptionField} from '../options';
 
 const InstallWizardSettings = React.createClass({
+  propTypes: {
+    options: React.PropTypes.object.isRequired,
+    formDisabled: React.PropTypes.bool,
+    onSubmit: React.PropTypes.func.isRequired
+  },
+
   getInitialState() {
     let options = {...this.props.options};
     let requiredOptions = Object.keys(_.pick(options, (option) => {
@@ -81,6 +87,10 @@ const InstallWizardSettings = React.createClass({
 });
 
 const InstallWizard = React.createClass({
+  propTypes: {
+    onConfigured: React.PropTypes.func.isRequired
+  },
+
   mixins: [
     ApiMixin
   ],

--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -8,6 +8,11 @@ import OrganizationHomeContainer from '../components/organizations/homeContainer
 import {t} from '../locale';
 
 const AssignedIssues = React.createClass({
+  propTypes: {
+    statsPeriod: React.PropTypes.string,
+    pageSize: React.PropTypes.number
+  },
+
   getEndpoint() {
     return `/organizations/${this.props.params.orgId}/members/me/issues/assigned/?`;
   },
@@ -34,6 +39,11 @@ const AssignedIssues = React.createClass({
 });
 
 const NewIssues = React.createClass({
+  propTypes: {
+    statsPeriod: React.PropTypes.string,
+    pageSize: React.PropTypes.number
+  },
+
   getEndpoint() {
     return `/organizations/${this.props.params.orgId}/issues/new/`;
   },

--- a/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
@@ -8,6 +8,15 @@ import OrganizationState from '../../mixins/organizationState';
 import {t,tct} from '../../locale';
 
 const RangeInput = React.createClass({
+  propTypes: {
+    min: React.PropTypes.number.isRequired,
+    max: React.PropTypes.number.isRequired,
+    step: React.PropTypes.number.isRequired,
+    defaultValue: React.PropTypes.number,
+    formatLabel: React.PropTypes.func.isRequired,
+    onChange: React.PropTypes.func.isRequired
+  },
+
   getDefaultProps() {
     return {
       min: 1,
@@ -65,6 +74,10 @@ const RangeInput = React.createClass({
 });
 
 const RateLimitEditor = React.createClass({
+  propTypes: {
+    organization: React.PropTypes.object.isRequired
+  },
+
   mixins: [ApiMixin],
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
@@ -15,6 +15,13 @@ let getPercent = (item, total) => {
 };
 
 const ProjectTable = React.createClass({
+  propTypes: {
+    projectMap: React.PropTypes.object.isRequired,
+    projectTotals: React.PropTypes.array.isRequired,
+    orgTotal: React.PropTypes.number.isRequired,
+    organization: React.PropTypes.object.isRequired
+  },
+
   mixins: [PureRenderMixin],
 
   render() {

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
@@ -8,6 +8,7 @@ import {tct} from '../../locale';
 
 const AllTeamsList = React.createClass({
   propTypes: {
+    access: React.PropTypes.object.isRequired,
     organization: PropTypes.Organization.isRequired,
     teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
     openMembership: React.PropTypes.bool

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
@@ -8,6 +8,13 @@ import {t} from '../../locale';
 // TODO(dcramer): this isnt great UX
 
 const AllTeamsRow = React.createClass({
+  propTypes: {
+    access: React.PropTypes.object.isRequired,
+    organization: React.PropTypes.object.isRequired,
+    team: React.PropTypes.object.isRequired,
+    openMembership: React.PropTypes.bool.isRequired
+  },
+
   mixins: [
     ApiMixin
   ],

--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -11,9 +11,12 @@ import {t, tct} from '../../locale';
 
 const ExpandedTeamList = React.createClass({
   propTypes: {
+    access: React.PropTypes.object.isRequired,
     organization: PropTypes.Organization.isRequired,
     teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
-    projectStats: React.PropTypes.object
+    projectStats: React.PropTypes.object,
+    showAllTeams: React.PropTypes.func.isRequired,
+    hasTeams: React.PropTypes.bool
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/projectDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard.jsx
@@ -14,6 +14,11 @@ const PERIODS = new Set([PERIOD_HOUR, PERIOD_DAY, PERIOD_WEEK]);
 
 
 const ProjectDashboard = React.createClass({
+  propTypes: {
+    defaultStatsPeriod: React.PropTypes.string,
+    setProjectNavSection: React.PropTypes.func
+  },
+
   mixins: [
     ProjectState
   ],

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -7,6 +7,11 @@ import LoadingIndicator from '../../components/loadingIndicator';
 import ProjectState from '../../mixins/projectState';
 
 const ProjectChart = React.createClass({
+  propTypes: {
+    dateSince: React.PropTypes.number.isRequired,
+    resolution: React.PropTypes.string.isRequired
+  },
+
   mixins: [
     ApiMixin,
     ProjectState

--- a/src/sentry/static/sentry/app/views/projectEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/index.jsx
@@ -12,6 +12,7 @@ import {t} from '../../locale';
 
 const ProjectEvents = React.createClass({
   propTypes: {
+    defaultQuery: React.PropTypes.string,
     setProjectNavSection: React.PropTypes.func
   },
 

--- a/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 
 const LanguageNav = React.createClass({
+  propTypes: {
+    name: React.PropTypes.string.isRequired,
+    active: React.PropTypes.bool
+  },
+
   getInitialState() {
     return {
       isVisible: this.props.active || false

--- a/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
@@ -5,6 +5,10 @@ import AutoSelectText from '../../components/autoSelectText';
 import {t, tct} from '../../locale';
 
 const ProjectInstallOverview = React.createClass({
+  propTypes: {
+    platformData: React.PropTypes.object
+  },
+
   getInitialState() {
     return {
       data: this.props.platformData

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -8,6 +8,10 @@ import LoadingIndicator from '../../components/loadingIndicator';
 import {t, tct} from '../../locale';
 
 const ProjectInstallPlatform = React.createClass({
+  propTypes: {
+    platformData: React.PropTypes.object.isRequired
+  },
+
   mixins: [
     ApiMixin
   ],

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -1,6 +1,7 @@
 import jQuery from 'jquery';
 import React from 'react';
 import {History} from 'react-router';
+
 import ApiMixin from '../../mixins/apiMixin';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
@@ -12,6 +13,7 @@ import ReleaseList from './releaseList';
 
 const ProjectReleases = React.createClass({
   propTypes: {
+    defaultQuery: React.PropTypes.string,
     setProjectNavSection: React.PropTypes.func
   },
 

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
@@ -4,10 +4,10 @@ import TimeSince from '../../components/timeSince';
 import Version from '../../components/version';
 
 const ReleaseList = React.createClass({
-
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired,
+    releaseList: React.PropTypes.array.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
+++ b/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
@@ -7,6 +7,16 @@ import LoadingIndicator from '../components/loadingIndicator';
 import {t} from '../locale';
 
 const SavedSearchRow = React.createClass({
+  propTypes: {
+    orgId: React.PropTypes.string.isRequired,
+    projectId: React.PropTypes.string.isRequired,
+    data: React.PropTypes.object.isRequired,
+
+    onDefault: React.PropTypes.func.isRequired,
+    onUserDefault: React.PropTypes.func.isRequired,
+    onRemove: React.PropTypes.func.isRequired,
+  },
+
   mixins: [ApiMixin],
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/projectUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/projectUserReports.jsx
@@ -13,6 +13,7 @@ import {t} from '../locale';
 
 const ProjectUserReports = React.createClass({
   propTypes: {
+    defaultQuery: React.PropTypes.string,
     setProjectNavSection: React.PropTypes.func
   },
 

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -95,7 +95,7 @@ const ReleaseDetails = React.createClass({
     let {orgId, projectId} = this.props.params;
     return (
       <DocumentTitle title={this.getTitle()}>
-        <div className={this.props.classname}>
+        <div>
           <div className="release-details">
             <div className="row">
               <div className="col-sm-6 col-xs-12">

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -3,6 +3,10 @@ import Raven from 'raven-js';
 import React from 'react';
 
 const RouteError = React.createClass({
+  propTypes: {
+    error: React.PropTypes.object.isRequired
+  },
+
   componentWillMount() {
     // TODO(dcramer): show something in addition to embed (that contains it?)
     // TODO(dcramer): capture better context

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -10,8 +10,11 @@ import RuleNodeList from './ruleNodeList';
 
 const RuleEditor = React.createClass({
   propTypes: {
-    actions: React.PropTypes.instanceOf(Array).isRequired,
-    conditions: React.PropTypes.instanceOf(Array).isRequired
+    actions: React.PropTypes.array.isRequired,
+    conditions: React.PropTypes.array.isRequired,
+    rule: React.PropTypes.object.isRequired,
+    project: React.PropTypes.object.isRequired,
+    organization: React.PropTypes.object.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNode.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNode.jsx
@@ -7,7 +7,8 @@ const RuleNode = React.createClass({
     data: React.PropTypes.object.isRequired,
     node: React.PropTypes.shape({
       html: React.PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    onDelete: React.PropTypes.func.isRequired
   },
 
   componentDidMount() {

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
@@ -4,6 +4,11 @@ import SelectInput from '../../components/selectInput';
 import RuleNode from './ruleNode';
 
 const RuleNodeList = React.createClass({
+  propTypes: {
+    initialItems: React.PropTypes.array,
+    nodes: React.PropTypes.array.isRequired
+  },
+
   getInitialState() {
     return {
       items: this.props.initialItems || []

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
@@ -13,7 +13,6 @@ import PropTypes from '../../proptypes';
 import SharedGroupHeader from './sharedGroupHeader';
 
 const SharedGroupDetails = React.createClass({
-
   childContextTypes: {
     group: PropTypes.Group,
   },

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/sharedGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/sharedGroupHeader.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
 const SharedGroupHeader = React.createClass({
+  propTypes: {
+    group: React.PropTypes.object.isRequired
+  },
+
   render() {
     let group = this.props.group;
 

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -26,6 +26,10 @@ import {t, tct} from '../locale';
 
 const Stream = React.createClass({
   propTypes: {
+    defaultSort: React.PropTypes.string,
+    defaultStatsPeriod: React.PropTypes.string,
+    defaultQuery: React.PropTypes.string,
+    maxItems: React.PropTypes.number,
     setProjectNavSection: React.PropTypes.func
   },
 

--- a/src/sentry/static/sentry/app/views/stream/actionLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actionLink.jsx
@@ -14,7 +14,9 @@ const ActionLink = React.createClass({
     disabled: React.PropTypes.bool,
     onAction: React.PropTypes.func.isRequired,
     onlyIfBulk: React.PropTypes.bool,
-    selectAllActive: React.PropTypes.bool.isRequired // "select all" checkbox
+    selectAllActive: React.PropTypes.bool.isRequired, // "select all" checkbox
+    tooltip: React.PropTypes.string,
+    extraDescription: React.PropTypes.string
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -18,7 +18,8 @@ const StreamActions = React.createClass({
     onRealtimeChange: React.PropTypes.func.isRequired,
     onSelectStatsPeriod: React.PropTypes.func.isRequired,
     realtimeActive: React.PropTypes.bool.isRequired,
-    statsPeriod: React.PropTypes.string.isRequired
+    statsPeriod: React.PropTypes.string.isRequired,
+    query: React.PropTypes.string.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -8,7 +8,23 @@ import {t} from '../../locale';
 const StreamFilters = React.createClass({
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    projectId: React.PropTypes.string.isRequired,
+    access: React.PropTypes.object.isRequired,
+    tags: React.PropTypes.object.isRequired,
+
+    searchId: React.PropTypes.string,
+    savedSearchList: React.PropTypes.array.isRequired,
+
+    defaultQuery: React.PropTypes.string,
+    sort: React.PropTypes.string,
+    filter: React.PropTypes.string,
+    query: React.PropTypes.string,
+    isSearchDisabled: React.PropTypes.bool,
+
+    onSortChange: React.PropTypes.func,
+    onSearch: React.PropTypes.func,
+    onSidebarToggle: React.PropTypes.func,
+    onSavedSearchCreate: React.PropTypes.func.isRequired
   },
 
   contextTypes: {

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -16,6 +16,19 @@ const SaveSearchState = {
 };
 
 const SaveSearchButton = React.createClass({
+  propTypes: {
+    orgId: React.PropTypes.string.isRequired,
+    projectId: React.PropTypes.string.isRequired,
+
+    query: React.PropTypes.string.isRequired,
+    disabled: React.PropTypes.bool,
+    style: React.PropTypes.object,
+    tooltip: React.PropTypes.string,
+    buttonTitle: React.PropTypes.string,
+
+    onSave: React.PropTypes.func.isRequired,
+  },
+
   mixins: [ApiMixin],
 
   getInitialState() {
@@ -138,6 +151,15 @@ const SaveSearchButton = React.createClass({
 });
 
 const SavedSearchSelector = React.createClass({
+  propTypes: {
+    orgId: React.PropTypes.string.isRequired,
+    projectId: React.PropTypes.string.isRequired,
+    searchId: React.PropTypes.string,
+    access: React.PropTypes.object.isRequired,
+    savedSearchList: React.PropTypes.array.isRequired,
+    onSavedSearchCreate: React.PropTypes.func.isRequired
+  },
+
   mixins: [ApiMixin],
 
   getTitle() {

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -17,7 +17,16 @@ import SearchDropdown from './searchDropdown';
 const SearchBar = React.createClass({
   propTypes: {
     orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    projectId: React.PropTypes.string.isRequired,
+
+    defaultQuery: React.PropTypes.string,
+    query: React.PropTypes.string,
+    defaultSearchItems: React.PropTypes.array.isRequired,
+    disabled: React.PropTypes.bool,
+    placeholder: React.PropTypes.string,
+
+    onQueryChange: React.PropTypes.func,
+    onSearch: React.PropTypes.func
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -6,6 +6,13 @@ import LoadingIndicator from '../../components/loadingIndicator';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 const SearchDropdown = React.createClass({
+  propTypes: {
+    items: React.PropTypes.array.isRequired,
+    searchSubstring: React.PropTypes.string,
+    onClick: React.PropTypes.func.isRequired,
+    loading: React.PropTypes.bool
+  },
+
   mixins: [PureRenderMixin],
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/views/stream/sidebar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sidebar.jsx
@@ -10,11 +10,14 @@ let TEXT_FILTER_DEBOUNCE_IN_MS = 300;
 
 const StreamSidebar = React.createClass({
   propTypes: {
+    orgId: React.PropTypes.string.isRequired,
+    projectId: React.PropTypes.string.isRequired,
+
     tags: React.PropTypes.object.isRequired,
+    query: React.PropTypes.string,
     onQueryChange: React.PropTypes.func.isRequired,
     defaultQuery: React.PropTypes.string,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    loading: React.PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -5,6 +5,11 @@ import MenuItem from '../../components/menuItem';
 import {t} from '../../locale';
 
 const SortOptions = React.createClass({
+  propTypes: {
+    sort: React.PropTypes.string,
+    onSelect: React.PropTypes.func
+  },
+
   mixins: [PureRenderMixin],
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
+++ b/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
@@ -6,7 +6,9 @@ const StreamTagFilter = React.createClass({
   propTypes: {
     tag: React.PropTypes.object.isRequired,
     orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    projectId: React.PropTypes.string.isRequired,
+    value: React.PropTypes.string,
+    onSelect: React.PropTypes.func
   },
 
   statics: {

--- a/src/sentry/static/sentry/app/views/teamSettings.jsx
+++ b/src/sentry/static/sentry/app/views/teamSettings.jsx
@@ -12,6 +12,13 @@ const FormState = {
 };
 
 const TeamSettingsForm = React.createClass({
+  propTypes: {
+    orgId: React.PropTypes.string.isRequired,
+    teamId: React.PropTypes.string.isRequired,
+    initialData: React.PropTypes.object,
+    onSave: React.PropTypes.func.isRequired
+  },
+
   mixins: [ApiMixin],
 
   getInitialState() {
@@ -100,6 +107,13 @@ const TeamSettingsForm = React.createClass({
 });
 
 const TeamSettings = React.createClass({
+  propTypes: {
+    orgId: React.PropTypes.object.isRequired,
+    teamId: React.PropTypes.object.isRequired,
+    team: React.PropTypes.object.isRequired,
+    onTeamChange: React.PropTypes.func.isRequired
+  },
+
   render() {
     let {orgId, teamId} = this.props.params;
     let team = this.props.team;


### PR DESCRIPTION
This adds an eslint rule requiring everyone to specify `propTypes` for each React component.

Specifying prop types adds run-time prop validation that helps locate and eliminate bugs. This checking is only done in development; the code is stripped in production builds.

We were really inconsistent in our use of specifying them, so adding this rule will make sure we always specify prop types going forward.
