### PR TITLE
Deprecate old methods of Redis configuration in 8.5.

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -250,7 +250,13 @@ def apply_legacy_settings(settings):
         if 'redis.clusters' in settings.SENTRY_OPTIONS:
             raise Exception("Cannot specify both SENTRY_OPTIONS['redis.clusters'] option and SENTRY_REDIS_OPTIONS setting.")
         else:
-            warnings.warn(DeprecatedSettingWarning('SENTRY_REDIS_OPTIONS', 'SENTRY_OPTIONS["redis.clusters"]'))
+            warnings.warn(
+                DeprecatedSettingWarning(
+                    'SENTRY_REDIS_OPTIONS',
+                    'SENTRY_OPTIONS["redis.clusters"]',
+                    removed_in_version='8.5',
+                )
+            )
             settings.SENTRY_OPTIONS['redis.clusters'] = {
                 'default': settings.SENTRY_REDIS_OPTIONS,
             }

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -51,7 +51,8 @@ def make_rb_cluster(*args, **kwargs):
     # plugin compatibility but isn't actionable by the system administrator.
     import warnings
     warnings.warn(
-        'Direct Redis cluster construction is deprecated, please use named clusters.',
+        'Direct Redis cluster construction is deprecated, please use named clusters. ',
+        'Direct cluster construction will be removed in Sentry 8.5.',
         DeprecationWarning,
     )
     return _make_rb_cluster(*args, **kwargs)
@@ -106,6 +107,7 @@ def get_cluster_from_options(setting, options, cluster_manager=clusters):
                         setting,
                         cluster_option_name,
                     ),
+                    removed_in_version='8.5',
                 ),
                 stacklevel=2
             )

--- a/src/sentry/utils/warnings.py
+++ b/src/sentry/utils/warnings.py
@@ -5,10 +5,11 @@ import warnings
 
 
 class DeprecatedSettingWarning(DeprecationWarning):
-    def __init__(self, setting, replacement, url=None):
+    def __init__(self, setting, replacement, url=None, removed_in_version=None):
         self.setting = setting
         self.replacement = replacement
         self.url = url
+        self.removed_in_version = removed_in_version
         super(DeprecatedSettingWarning, self).__init__(setting, replacement, url)
 
     def __str__(self):
@@ -18,6 +19,13 @@ class DeprecatedSettingWarning(DeprecationWarning):
                 self.replacement,
             )
         ]
+
+        if self.removed_in_version:
+            chunks.append(
+                'This setting will be removed in Sentry {}.'.format(
+                    self.removed_in_version,
+                ),
+            )
 
         # TODO(tkaemming): This will be removed from the message in the future
         # when it's added to the API payload separately.


### PR DESCRIPTION
The deprecation policy is no longer actually documented (it was removed in 4e36ab552cff08f1419db5f14509a90e25ca1bbe), but this would follow what was previously defined.

@mattrobenolt - I don't know if you're queuing up release notes already, but it's probably worth noting for 8.2 that the old methods of Redis configuration will be removed in 8.4.

Also, we should document the deprecation policy again.

References GH-2693.
