### PR TITLE
Remove use of time_spent attributes

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -94,7 +94,6 @@ class EventSerializer(Serializer):
             'platform': obj.platform,
             'dateCreated': obj.datetime,
             'dateReceived': received,
-            'timeSpent': obj.time_spent,
             'errors': errors,
         }
         return d

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -124,7 +124,6 @@ class GroupSerializer(Serializer):
             'permalink': permalink,
             'firstSeen': obj.first_seen,
             'lastSeen': obj.last_seen,
-            'timeSpent': obj.avg_time_spent,
             'logger': obj.logger or None,
             'level': LOG_LEVELS.get(obj.level, 'unknown'),
             'status': status_label,

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -38,8 +38,6 @@ SORT_OPTIONS = OrderedDict((
     ('date', _('Last Seen')),
     ('new', _('First Seen')),
     ('freq', _('Frequency')),
-    ('tottime', _('Total Time Spent')),
-    ('avgtime', _('Average Time Spent')),
 ))
 
 SEARCH_SORT_OPTIONS = OrderedDict((

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -269,7 +269,6 @@ class EventManager(object):
 
         data.setdefault('message', '')
         data.setdefault('culprit', None)
-        data.setdefault('time_spent', None)
         data.setdefault('server_name', None)
         data.setdefault('site', None)
         data.setdefault('checksum', None)
@@ -348,9 +347,6 @@ class EventManager(object):
                 data['sentry.interfaces.User'].setdefault(
                     'ip_address', ip_address)
 
-        if data['time_spent']:
-            data['time_spent'] = int(data['time_spent'])
-
         if data['culprit']:
             data['culprit'] = trim(data['culprit'], MAX_CULPRIT_LENGTH)
 
@@ -374,7 +370,6 @@ class EventManager(object):
         level = data.pop('level')
 
         culprit = data.pop('culprit', None)
-        time_spent = data.pop('time_spent', None)
         logger_name = data.pop('logger', None)
         server_name = data.pop('server_name', None)
         site = data.pop('site', None)
@@ -383,6 +378,9 @@ class EventManager(object):
         platform = data.pop('platform', None)
         release = data.pop('release', None)
         environment = data.pop('environment', None)
+
+        # unused
+        time_spent = data.pop('time_spent', None)
 
         if not culprit:
             culprit = generate_culprit(data)
@@ -456,8 +454,6 @@ class EventManager(object):
             'level': level,
             'last_seen': date,
             'first_seen': date,
-            'time_spent_total': time_spent or 0,
-            'time_spent_count': time_spent and 1 or 0,
             'data': {
                 'last_received': event.data.get('received') or float(event.datetime.strftime('%s'))
             },
@@ -807,11 +803,6 @@ class EventManager(object):
         update_kwargs = {
             'times_seen': 1,
         }
-        if event.time_spent:
-            update_kwargs.update({
-                'time_spent_total': event.time_spent,
-                'time_spent_count': 1,
-            })
 
         buffer.incr(Group, update_kwargs, {
             'id': group.id,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -164,12 +164,6 @@ class Group(Model):
         from sentry.models import Event
         return Event.objects.filter(group_id=self.id)
 
-    @property
-    def avg_time_spent(self):
-        if not self.time_spent_count:
-            return
-        return float(self.time_spent_total) / self.time_spent_count
-
     def is_over_resolve_age(self):
         resolve_age = self.project.get_option('sentry:resolve_age', None)
         if not resolve_age:

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -149,11 +149,6 @@ class DjangoSearchBackend(SearchBackend):
         else:
             score_clause = SORT_CLAUSES[sort_by]
 
-        if sort_by == 'tottime':
-            queryset = queryset.filter(time_spent_count__gt=0)
-        elif sort_by == 'avgtime':
-            queryset = queryset.filter(time_spent_count__gt=0)
-
         queryset = queryset.extra(
             select={'sort_value': score_clause},
         )

--- a/src/sentry/search/django/constants.py
+++ b/src/sentry/search/django/constants.py
@@ -14,22 +14,18 @@ SORT_CLAUSES = {
     'date': 'EXTRACT(EPOCH FROM sentry_groupedmessage.last_seen)::int',
     'new': 'EXTRACT(EPOCH FROM sentry_groupedmessage.first_seen)::int',
     'freq': 'sentry_groupedmessage.times_seen',
-    'tottime': 'sentry_groupedmessage.time_spent_total',
-    'avgtime': '(sentry_groupedmessage.time_spent_total / sentry_groupedmessage.time_spent_count)::int',
 }
 
 SQLITE_SORT_CLAUSES = SORT_CLAUSES.copy()
 SQLITE_SORT_CLAUSES.update({
     'date': "cast((julianday(sentry_groupedmessage.last_seen) - 2440587.5) * 86400.0 as INTEGER)",
     'new': "cast((julianday(sentry_groupedmessage.first_seen) - 2440587.5) * 86400.0 as INTEGER)",
-    'avgtime': 'CAST((sentry_groupedmessage.time_spent_total / sentry_groupedmessage.time_spent_count) as INTEGER)',
 })
 
 MYSQL_SORT_CLAUSES = SORT_CLAUSES.copy()
 MYSQL_SORT_CLAUSES.update({
     'date': 'UNIX_TIMESTAMP(sentry_groupedmessage.last_seen)',
     'new': 'UNIX_TIMESTAMP(sentry_groupedmessage.first_seen)',
-    'avgtime': 'CAST((sentry_groupedmessage.time_spent_total / sentry_groupedmessage.time_spent_count) as INTEGER)',
 })
 
 ORACLE_SORT_CLAUSES = SORT_CLAUSES.copy()

--- a/src/sentry/utils/javascript.py
+++ b/src/sentry/utils/javascript.py
@@ -190,7 +190,6 @@ class GroupTransformer(Transformer):
             'permalink': absolute_uri(reverse('sentry-group', args=[obj.organization.slug, obj.project.slug, obj.id])),
             'firstSeen': self.localize_datetime(obj.first_seen, request=request),
             'lastSeen': self.localize_datetime(obj.last_seen, request=request),
-            'timeSpent': obj.avg_time_spent,
             'canResolve': request and request.user.is_authenticated(),
             'status': status_label,
             'isResolved': obj.get_status() == GroupStatus.RESOLVED,


### PR DESCRIPTION
As of Sentry 8 these were effectively removed from the app outside of storage/API. They dont fit the current model of Sentry, and if we want to capture this kind of data in the future we can revisit it.
