### PR TITLE
omit debug files and other useless stuff from codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,8 @@
 [report]
-omit=src/sentry/migrations/*
+omit=
+    src/sentry/migrations/*
+    src/sentry/utils/apidocs.py
+    src/sentry/middleware/profiler.py
+    src/sentry/middleware/debug.py
+    src/sentry/utils/debug.py
+    src/sentry/web/frontend/debug/*


### PR DESCRIPTION
These files are used for debugging purposes and/or leveraged for offline
work and shouldn't count towards overall code coverage. These files are
frequently at the top of the "Uncovered Suggestions" report from
Codecov, so let's just ignore them since there's very little value in
adding coverage to them.
