### PR TITLE
Guard against an IndexError when Group.message is an empty string

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -116,7 +116,7 @@ class GroupSerializer(Serializer):
 
         event_type = obj.data.get('type', 'default')
         metadata = obj.data.get('metadata') or {
-            'title': obj.message.splitlines()[0][:100],
+            'title': obj.message_short,
         }
 
         return {


### PR DESCRIPTION
Fixes issue 115020698

@dcramer I'd have just pushed this, but I wasn't sure what the expected behavior should be. Is a `title` here with an empty string acceptable? or would you prefer not having a `title` key at all.

The alternative here is doing:

``` python
metadata = obj.data.get('metadata')
if not metadata and obj.message:
    metadata = {'title': obj.message.splitlines()[0][:100]}
```
