### PR TITLE
Truncate Group.message more intelligently

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -150,9 +150,10 @@ class Group(Model):
             self.first_seen = self.last_seen
         if not self.active_at:
             self.active_at = self.first_seen
+        # We limit what we store for the message body
+        self.message = strip(self.message)
         if self.message:
-            # We limit what we store for the message body
-            self.message = self.message.splitlines()[0][:255]
+            self.message = truncatechars(self.message.splitlines()[0], 255)
         super(Group, self).save(*args, **kwargs)
 
     def get_absolute_url(self):

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -118,3 +118,9 @@ class GroupTest(TestCase):
 
         group = Group.objects.get(id=group.id)
         assert group.first_release == release
+
+    def test_save_truncate_message(self):
+        assert len(self.create_group(message='x' * 300).message) == 255
+        assert self.create_group(message='\nfoo\n   ').message == 'foo'
+        assert self.create_group(message='foo').message == 'foo'
+        assert self.create_group(message='').message == ''


### PR DESCRIPTION
Prior, it was taking the first line, and chopping from there, but if
this first line was empty, Group.message was an empty string.

This change applies the same logic used elsewhere for truncating
messages so we strip leading/trailing first.
