### PR TITLE
Implement wsgi.file_wrapper for static file delivery

### DIFF
--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -26,7 +26,27 @@ if settings.SESSION_FILE_PATH and not os.path.exists(settings.SESSION_FILE_PATH)
     except OSError:
         pass
 
+from django.core.handlers.wsgi import WSGIHandler
+
+
+class FileWrapperWSGIHandler(WSGIHandler):
+    """A WSGIHandler implementation that handles a StreamingHttpResponse
+    from django to leverage wsgi.file_wrapper for delivering large streaming
+    responses.
+
+    Note: this was added natively into Django 1.8, so if by some reason,
+    we upgraded, this wouldn't be relevant anymore."""
+    def __call__(self, environ, start_response):
+        response = super(FileWrapperWSGIHandler, self).__call__(environ, start_response)
+        if response.streaming:
+            try:
+                response = environ['wsgi.file_wrapper'](response.streaming_content)
+            except KeyError:
+                # In our case, we're shipping with uwsgi, so it's safer to assume
+                # that wsgi.file_wrapper does exist. It'd be exceptional otherwise.
+                pass
+        return response
+
 # Run WSGI handler for the application
-from django.core.wsgi import get_wsgi_application
 from raven.contrib.django.middleware.wsgi import Sentry
-application = Sentry(get_wsgi_application())
+application = Sentry(FileWrapperWSGIHandler())


### PR DESCRIPTION
This is implemented in Django 1.8+, but backporting this for our use
yields a 20% gain in throughput testing locally, and frees up blocking a
python process for our 2.2MB vendor.js delivery since this work is now
deferred to uWSGI instead of Django.

`uwsgi.file_wrapper` is implemented in both `uwsgi` and `gunicorn` at minimum, but we only need it for uwsgi.

I should add that this will be more useful the larger the streaming bodies are. So if we wanted to serve back the user uploads from the `File` model or something like that, this would help everything since it's not even possible to serve them directly from a web server.
