### PR TITLE
Pre-gzip our static files and serve them intelligently

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-gettext-extractor": "^1.0.2",
     "babel-loader": "5.3.3",
     "chai": "3.4.1",
+    "compression-webpack-plugin": "^0.3.0",
     "enzyme": "^1.1.0",
     "eslint": "1.9.0",
     "eslint-plugin-getsentry": "1.0.0",

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -7,7 +7,14 @@ sentry.web.frontend.generic
 """
 from __future__ import absolute_import
 
+import os
+import posixpath
+
 from django.conf import settings
+from django.http import HttpResponseNotFound, Http404
+from django.contrib.staticfiles import finders
+from django.utils.six.moves.urllib.parse import unquote
+from django.views import static
 from django.views.generic import TemplateView as BaseTemplateView
 
 from sentry.web.helpers import render_to_response
@@ -16,12 +23,22 @@ FOREVER_CACHE = 'max-age=315360000'
 NEVER_CACHE = 'max-age=0, no-cache, no-store, must-revalidate'
 
 
+def resolve(path):
+    # Mostly yanked from Django core and changed to return the path:
+    # See: https://github.com/django/django/blob/1.6.11/django/contrib/staticfiles/views.py
+    normalized_path = posixpath.normpath(unquote(path)).lstrip('/')
+    absolute_path = finders.find(normalized_path)
+    if not absolute_path:
+        if path.endswith('/') or path == '':
+            raise Http404("Directory indexes are not allowed here.")
+        raise Http404("'%s' could not be found" % path)
+    return os.path.split(absolute_path)
+
+
 def static_media(request, **kwargs):
     """
     Serve static files below a given point in the directory structure.
     """
-    from django.contrib.staticfiles.views import serve
-
     module = kwargs.get('module')
     path = kwargs.get('path', '')
     version = kwargs.get('version')
@@ -29,7 +46,30 @@ def static_media(request, **kwargs):
     if module:
         path = '%s/%s' % (module, path)
 
-    response = serve(request, path, insecure=True)
+    try:
+        document_root, path = resolve(path)
+    except Http404:
+        # Return back a simpler plain-text 404 response, more suitable
+        # for static files, rather than our full blown HTML.
+        return HttpResponseNotFound('File not found.\n', content_type='text/plain')
+
+    if 'gzip' in request.META.get('HTTP_ACCEPT_ENCODING', '') and not path.endswith('.gz'):
+        paths = (path + '.gz', path)
+    else:
+        paths = (path,)
+
+    for p in paths:
+        try:
+            response = static.serve(request, p, document_root=document_root)
+            break
+        except Http404:
+            # We don't need to handle this since `resolve()` is assuring to us that
+            # at least the non-gzipped version exists, so in theory, this can
+            # only happen on the first .gz path
+            continue
+
+    # Make sure we Vary: Accept-Encoding for gzipped responses
+    response['Vary'] = 'Accept-Encoding'
 
     # We need CORS for font files
     if path.endswith(('.js', '.ttf', '.ttc', '.otf', '.eot', '.woff', '.woff2')):

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import os
 from django.test.utils import override_settings
 from sentry.testutils import TestCase
 from sentry.web.frontend.generic import FOREVER_CACHE, NEVER_CACHE
@@ -12,8 +13,9 @@ class StaticMediaTest(TestCase):
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert response['Cache-Control'] == NEVER_CACHE
-        assert 'Vary' not in response
+        assert response['Vary'] == 'Accept-Encoding'
         assert response['Access-Control-Allow-Origin'] == '*'
+        'Content-Encoding' not in response
 
     @override_settings(DEBUG=False)
     def test_versioned(self):
@@ -21,21 +23,23 @@ class StaticMediaTest(TestCase):
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert response['Cache-Control'] == FOREVER_CACHE
-        assert 'Vary' not in response
+        assert response['Vary'] == 'Accept-Encoding'
         assert response['Access-Control-Allow-Origin'] == '*'
+        'Content-Encoding' not in response
 
         url = '/_static/a43db3b08ddd4918972f80739f15344b/sentry/app/index.js'
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert response['Cache-Control'] == FOREVER_CACHE
-        assert 'Vary' not in response
+        assert response['Vary'] == 'Accept-Encoding'
         assert response['Access-Control-Allow-Origin'] == '*'
+        'Content-Encoding' not in response
 
         with override_settings(DEBUG=True):
             response = self.client.get(url)
             assert response.status_code == 200, response
             assert response['Cache-Control'] == NEVER_CACHE
-            assert 'Vary' not in response
+            assert response['Vary'] == 'Accept-Encoding'
             assert response['Access-Control-Allow-Origin'] == '*'
 
     @override_settings(DEBUG=False)
@@ -44,5 +48,37 @@ class StaticMediaTest(TestCase):
         response = self.client.get(url)
         assert response.status_code == 200, response
         assert response['Cache-Control'] == NEVER_CACHE
-        assert 'Vary' not in response
+        assert response['Vary'] == 'Accept-Encoding'
         assert 'Access-Control-Allow-Origin' not in response
+        'Content-Encoding' not in response
+
+    def test_404(self):
+        url = '/_static/sentry/app/thisfiledoesnotexistlol.js'
+        response = self.client.get(url)
+        assert response.status_code == 404, response
+
+    def test_gzip(self):
+        url = '/_static/sentry/app/index.js'
+        response = self.client.get(url, HTTP_ACCEPT_ENCODING='gzip,deflate')
+        assert response.status_code == 200, response
+        assert response['Vary'] == 'Accept-Encoding'
+        'Content-Encoding' not in response
+
+        try:
+            open('src/sentry/static/sentry/app/index.js.gz', 'a').close()
+
+            # Not a gzip Accept-Encoding, so shouldn't serve gzipped file
+            response = self.client.get(url, HTTP_ACCEPT_ENCODING='lol')
+            assert response.status_code == 200, response
+            assert response['Vary'] == 'Accept-Encoding'
+            'Content-Encoding' not in response
+
+            response = self.client.get(url, HTTP_ACCEPT_ENCODING='gzip,deflate')
+            assert response.status_code == 200, response
+            assert response['Vary'] == 'Accept-Encoding'
+            assert response['Content-Encoding'] == 'gzip'
+        finally:
+            try:
+                os.unlink('src/sentry/static/sentry/app/index.js.gz')
+            except Exception:
+                pass

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -170,6 +170,9 @@ var config = {
   devtool: 'source-map'
 };
 
+// This compression-webpack-plugin generates pre-compressed files
+// ending in .gz, to be picked up and served by our internal static media
+// server as well as nginx when paired with the gzip_static module.
 if (process.env.NODE_ENV === 'production') {
   config.plugins.push(new (require('compression-webpack-plugin'))({
     // zopfli gives us a better gzip compression

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -170,4 +170,13 @@ var config = {
   devtool: 'source-map'
 };
 
+if (process.env.NODE_ENV === 'production') {
+  config.plugins.push(new (require('compression-webpack-plugin'))({
+    // zopfli gives us a better gzip compression
+    // See: http://googledevelopers.blogspot.com/2013/02/compress-data-more-densely-with-zopfli.html
+    algorithm: 'zopfli',
+    regExp: /\.(js|map|css|svg|html|txt|ico|eot|ttf)$/,
+  }));
+}
+
 module.exports = config;


### PR DESCRIPTION
This adds a precompression step to webpack during production builds
only, so this affects our `sdist` builds, etc and these files will get
packaged up for release just fine.

This changes the static file serving to check for a .gz file first, and
if found, serve that appropriately. This is a bit better suited to
handle automatically here, since doing so in nginx requires extra
configuration + a module compiled in and there's little value in trying
to wrangle nginx to do this for on-premise. This assures that we always
serve efficient compressed files, since our javascript files really
benefit from it. Also, it's pointless to compress them on the fly since
they don't change. Our files are large enough that this is helpful.
Compressing a 2MB file isn't free.

This also leverages Zopfli for compression. Zopfli is significantly
slower than zlib, but yields a much better compression. We can leverage
this since compression happens offline.

/cc @benvinegar because webpack change
