### PR TITLE
Give orgs -> projects -> all teams a permament url/route

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -38,8 +38,8 @@ const HomeSidebar = React.createClass({
         <ul className="nav nav-stacked">
           <ListLink to={`/organizations/${orgId}/dashboard/`}>{t('Dashboard')}</ListLink>
           <ListLink to={`/${orgId}/`} isActive={() => {
-            // return true if path matches /slug-name/
-            return /^\/[^\/]+\/$/.test(this.context.location.pathname);
+            // return true if path matches /slug-name/ OR /organizations/slug-name/all-teams/
+            return /^\/([^\/]+|organizations\/[^\/]+\/all-teams)\/$/.test(this.context.location.pathname);
           }}>{t('Projects')}</ListLink>
           {access.has('org:read') &&
             <ListLink to={`/organizations/${orgId}/stats/`}>{t('Stats')}</ListLink>

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -23,6 +23,7 @@ import OrganizationDetails from './views/organizationDetails';
 import OrganizationRateLimits from './views/organizationRateLimits';
 import OrganizationStats from './views/organizationStats';
 import OrganizationTeams from './views/organizationTeams';
+import AllTeamsList from './views/organizationTeams/allTeamsList';
 import ProjectChooser from './views/projectChooser';
 import ProjectDashboard from './views/projectDashboard';
 import ProjectDetails from './views/projectDetails';
@@ -69,7 +70,10 @@ let routes = (
     <Route path="/share/issue/:shareId/" component={errorHandler(SharedGroupDetails)} />
 
     <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
-      <IndexRoute component={errorHandler(OrganizationTeams)} />
+      <IndexRoute component={errorHandler(OrganizationTeams)}/>
+      <Route path="/organizations/:orgId/all-teams/" component={errorHandler(OrganizationTeams)}>
+        <IndexRoute component={errorHandler(AllTeamsList)}/>
+      </Route>
 
       <Route path="/organizations/:orgId/dashboard/" component={errorHandler(OrganizationDashboard)} />
       <Route path="/organizations/:orgId/issues/assigned/" component={errorHandler(MyIssuesAssignedToMe)} />

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
@@ -8,9 +8,9 @@ import {tct} from '../../locale';
 
 const AllTeamsList = React.createClass({
   propTypes: {
-    access: React.PropTypes.object.isRequired,
-    organization: PropTypes.Organization.isRequired,
-    teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
+    access: React.PropTypes.object,
+    organization: PropTypes.Organization,
+    teamList: React.PropTypes.arrayOf(PropTypes.Team),
     openMembership: React.PropTypes.bool
   },
 

--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -15,7 +15,6 @@ const ExpandedTeamList = React.createClass({
     organization: PropTypes.Organization.isRequired,
     teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
     projectStats: React.PropTypes.object,
-    showAllTeams: React.PropTypes.func.isRequired,
     hasTeams: React.PropTypes.bool
   },
 
@@ -120,17 +119,12 @@ const ExpandedTeamList = React.createClass({
     );
   },
 
-  showAllTeams(e) {
-    e.preventDefault();
-    this.props.showAllTeams();
-  },
-
   renderEmpty() {
     if (this.props.hasTeams) {
       return (
         <p>
           {tct('You are not a member of any teams. [joinLink:Join an existing team] or [createLink:create a new one].', {
-            joinLink: <a onClick={this.showAllTeams} />,
+            joinLink: <Link to={`/organizations/${this.props.organization.slug}/all-teams/`}/>,
             createLink: <a href={this.urlPrefix() + '/teams/new/'} />
           })}
         </p>


### PR DESCRIPTION
The "All Teams" page is now a route available at `/organizations/sentry/all-teams/`. It's a little odd toggling between tabs and having the URL vary so much, but it's nice to be able to permalink to this page or refresh the page without returning to the regular team list. It also makes some of the code cleaner (no passing around a tab toggle function between views – just just `<Link/>`).

Note: this would be cleaner if `IndexRoute` let you specify sub routes with parent containers (like `Route`), but it doesn't, hence the bizarre `props.children` check in `OrganizationTeams`.
