### PR TITLE
Use statistics based on event occurred time for project list.

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
@@ -41,7 +41,7 @@ const OrganizationTeams = React.createClass({
     this.api.request(this.getOrganizationStatsEndpoint(), {
       query: {
         since: new Date().getTime() / 1000 - 3600 * 24,
-        stat: 'received',
+        stat: 'generated',
         group: 'project'
       },
       success: (data) => {


### PR DESCRIPTION
This adds a `generated` statistic to the organization statistics
endpoint, and updates the `OrganizationTeams` React component to use it
rather than the `received` statistic. The difference between these two
statistics is that the `generated` statistic is based on when the event
was recorded by the client, and the `received` statistic is based on
when the Sentry server recorded it. Examples of when these statistics
can diverge significantly: mobile application that has been disconnected
from the network and reports after reconnection; an incorrectly
configured system timezone; a clock that is suffering from clock skew.

Precedent for the statistic name is from GH-2705, although we've been
referring to this as "occurred" internally lately. We should probably
update that in the future, but I didn't want to introduce that
inconsistency here.

I didn't document this additional statistic, as it only works when the
`group` parameter is set to `project`. (We don't track events by
occurrence time by organization.)

This fixes GH-2577.
