### PR TITLE
Breakout single plugin actions into link

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -192,7 +192,7 @@ const GroupActions = React.createClass({
             <span className="icon-trash"></span>
           </LinkWithConfirmation>
         </div>
-        {group.pluginActions.length !== 0 &&
+        {group.pluginActions.length > 1 ?
           <div className="btn-group more">
             <DropdownLink
                 className="btn btn-default btn-sm"
@@ -206,6 +206,17 @@ const GroupActions = React.createClass({
               })}
             </DropdownLink>
           </div>
+        : group.pluginActions.length !== 0 &&
+          group.pluginActions.map((action, actionIdx) => {
+            return (
+              <div className="btn-group" key={actionIdx}>
+                <a className="btn btn-default btn-sm"
+                   href={action[1]}>
+                  {action[0]}
+                </a>
+              </div>
+            );
+          })
         }
       </div>
     );


### PR DESCRIPTION
This changes actions so if there's only one (which there usually is) it becomes a direct action instead of a dropdown.

![screenshot 2016-03-11 11 09 58](https://cloud.githubusercontent.com/assets/23610/13712679/d7019224-e779-11e5-80b2-a90f259cd0c7.png)
