### PR TITLE
Add severity level to status check results.

### DIFF
--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -45,7 +45,7 @@ const App = React.createClass({
       success: (data) => {
         if (data && data.problems) {
           data.problems.forEach(problem => {
-            AlertActions.addAlert(problem, 'error', 0);
+            AlertActions.addAlert(problem.message, 'error', 0);
           });
         }
       },

--- a/src/sentry/status_checks/__init__.py
+++ b/src/sentry/status_checks/__init__.py
@@ -6,19 +6,12 @@ from .base import Problem, StatusCheck  # NOQA
 from .celery_alive import CeleryAliveCheck
 from .celery_app_version import CeleryAppVersionCheck
 
-check_classes = [
-    CeleryAliveCheck,
-    CeleryAppVersionCheck,
+
+checks = [
+    CeleryAliveCheck(),
+    CeleryAppVersionCheck(),
 ]
 
 
 def check_all():
-    checks = {}
-    problems = []
-    for cls in check_classes:
-        problem = cls().check()
-        if problem:
-            problems.extend(problem)
-        checks[cls.__name__] = not bool(problem)
-
-    return problems, checks
+    return {check: check.check() for check in checks}

--- a/src/sentry/status_checks/base.py
+++ b/src/sentry/status_checks/base.py
@@ -2,14 +2,53 @@ from __future__ import absolute_import
 
 
 class Problem(object):
-    def __init__(self, message):
+
+    # Used for issues that may render the system inoperable or have effects on
+    # data integrity (e.g. issues in the processing pipeline.)
+    SEVERITY_CRITICAL = 'critical'
+
+    # Used for issues that may cause the system to operate in a degraded (but
+    # still operational) state, as well as configuration options that are set
+    # in unexpected ways or deprecated in future versions.
+    SEVERITY_WARNING = 'warning'
+
+    # Mapping of severity level to a priority score, where the greater the
+    # score, the more critical the issue. (The numeric values should only be
+    # used for comparison purposes, and are subject to change as levels are
+    # modified.)
+    SEVERITY_LEVELS = {
+        SEVERITY_CRITICAL: 2,
+        SEVERITY_WARNING: 1,
+    }
+
+    def __init__(self, message, severity=SEVERITY_CRITICAL):
+        assert severity in self.SEVERITY_LEVELS
         self.message = unicode(message)
+        self.severity = severity
+
+    def __cmp__(self, other):
+        if not isinstance(other, Problem):
+            return NotImplemented
+
+        return cmp(
+            self.SEVERITY_LEVELS[self.severity],
+            self.SEVERITY_LEVELS[other.severity],
+        )
 
     def __str__(self):
         return self.message.encode('utf-8')
 
     def __unicode__(self):
         return self.message
+
+    @classmethod
+    def threshold(cls, severity):
+        threshold = cls.SEVERITY_LEVELS[severity]
+
+        def predicate(problem):
+            return cls.SEVERITY_LEVELS[problem.severity] >= threshold
+
+        return predicate
 
 
 class StatusCheck(object):

--- a/src/sentry/templatetags/sentry_status.py
+++ b/src/sentry/templatetags/sentry_status.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function
 
+import itertools
+
 from django import template
 
 from sentry import status_checks
@@ -9,7 +11,7 @@ register = template.Library()
 
 @register.inclusion_tag('sentry/partial/system-status.html', takes_context=True)
 def show_system_status(context):
-    problems, _ = status_checks.check_all()
+    problems = list(itertools.chain.from_iterable(status_checks.check_all().values()))
 
     return {
         'problems': problems,


### PR DESCRIPTION
This also changes registered status checks to be expect `StatusCheck` _instances_ rather than uninstantated `StatusCheck` classes. This will be needed to bring deprecation warnings into the UI (see GH-2770) which will require `StatusCheck` instances to maintain state.

This does not include visual changes to map severity levels to different CSS classes, since the default `warning` style is pretty ugly.
