### PR TITLE
Disable frequency sketches for Redis by default.

### DIFF
--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -101,7 +101,7 @@ class RedisTSDB(BaseTSDB):
 
     def validate(self):
         logger.debug('Validating Redis version...')
-        version = Version((2, 8, 18 if self.enable_frequency_sketches else 9))
+        version = Version((2, 8, 18)) if self.enable_frequency_sketches else Version((2, 8, 9))
         check_cluster_versions(
             self.cluster,
             version,

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -23,7 +23,8 @@ class RedisTSDBTest(TestCase):
                 (ONE_HOUR, 24),  # 1 days at 1 hour
                 (ONE_DAY, 30),  # 30 days at 1 day
             ),
-            vnodes=64
+            vnodes=64,
+            enable_frequency_sketches=True,
         )
 
     def test_make_counter_key(self):


### PR DESCRIPTION
This allows disabling frequency sketches for older Redis versions, since
the data is currently unused. The write path becomes a noop, and read
paths raise an exception.

Enabling the frequency sketch implementation changes the version
requirement from 2.8.9 to 2.8.18, when Lua BitOp was made available to
the embedded Lua interpreter.[1](https://raw.githubusercontent.com/antirez/redis/2.8/00-RELEASENOTES)

This fixes GH-2835.
