### PR TITLE
Add tooling to bring configuration warnings into the UI.

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -11,7 +11,7 @@ import os
 
 import click
 
-from sentry.utils.warnings import manager as warnings
+from sentry.utils import warnings
 
 
 def install_plugin_apps(settings):

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -11,6 +11,8 @@ import os
 
 import click
 
+from sentry.utils.warnings import manager as warnings
+
 
 def install_plugin_apps(settings):
     # entry_points={
@@ -127,7 +129,6 @@ def initialize_app(config, skip_backend_validation=False):
     # Commonly setups don't correctly configure themselves for production envs
     # so lets try to provide a bit more guidance
     if settings.CELERY_ALWAYS_EAGER and not settings.DEBUG:
-        import warnings
         warnings.warn('Sentry is configured to run asynchronous tasks in-process. '
                       'This is not recommended within production environments. '
                       'See https://docs.getsentry.com/on-premise/server/queue/ for more information.')
@@ -223,25 +224,21 @@ def show_big_error(message):
 def apply_legacy_settings(settings):
     # SENTRY_USE_QUEUE used to determine if Celery was eager or not
     if hasattr(settings, 'SENTRY_USE_QUEUE'):
-        import warnings
         warnings.warn('SENTRY_USE_QUEUE is deprecated. Please use CELERY_ALWAYS_EAGER instead. '
                       'See https://docs.getsentry.com/on-premise/server/queue/ for more information.', DeprecationWarning)
         settings.CELERY_ALWAYS_EAGER = (not settings.SENTRY_USE_QUEUE)
 
     if not settings.SENTRY_OPTIONS.get('system.admin-email') and hasattr(settings, 'SENTRY_ADMIN_EMAIL'):
-        import warnings
         warnings.warn('SENTRY_ADMIN_EMAIL is deprecated. '
                       "Use SENTRY_OPTIONS instead, key 'system.admin-email'", DeprecationWarning)
         settings.SENTRY_OPTIONS['system.admin-email'] = settings.SENTRY_ADMIN_EMAIL
 
     if not settings.SENTRY_OPTIONS.get('system.url-prefix') and hasattr(settings, 'SENTRY_URL_PREFIX'):
-        import warnings
         warnings.warn('SENTRY_URL_PREFIX is deprecated. '
                       "Use SENTRY_OPTIONS instead, key 'system.url-prefix'", DeprecationWarning)
         settings.SENTRY_OPTIONS['system.url-prefix'] = settings.SENTRY_URL_PREFIX
 
     if not settings.SENTRY_OPTIONS.get('system.rate-limit') and hasattr(settings, 'SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE'):
-        import warnings
         warnings.warn('SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE is deprecated. '
                       "Use SENTRY_OPTIONS instead, key 'system.rate-limit'", DeprecationWarning)
         settings.SENTRY_OPTIONS['system.rate-limit'] = settings.SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE
@@ -250,7 +247,6 @@ def apply_legacy_settings(settings):
         if 'redis.clusters' in settings.SENTRY_OPTIONS:
             raise Exception("Cannot specify both SENTRY_OPTIONS['redis.clusters'] option and SENTRY_REDIS_OPTIONS setting.")
         else:
-            import warnings
             warnings.warn("SENTRY_REDIS_OPTIONS is deprecated. Use SENTRY_OPTIONS instead, key 'redis.clusters'", DeprecationWarning)
             settings.SENTRY_OPTIONS['redis.clusters'] = {
                 'default': settings.SENTRY_REDIS_OPTIONS,
@@ -282,7 +278,6 @@ def apply_legacy_settings(settings):
         settings.ALLOWED_HOSTS = AllowedHosts()
 
     if hasattr(settings, 'SENTRY_ALLOW_REGISTRATION'):
-        import warnings
         warnings.warn('SENTRY_ALLOW_REGISTRATION is deprecated. Use SENTRY_FEATURES instead.', DeprecationWarning)
         settings.SENTRY_FEATURES['auth:register'] = settings.SENTRY_ALLOW_REGISTRATION
 

--- a/src/sentry/status_checks/__init__.py
+++ b/src/sentry/status_checks/__init__.py
@@ -2,14 +2,18 @@ from __future__ import absolute_import
 
 __all__ = ('check_all', 'Problem', 'StatusCheck')
 
+from sentry.utils.warnings import seen_warnings
+
 from .base import Problem, StatusCheck  # NOQA
 from .celery_alive import CeleryAliveCheck
 from .celery_app_version import CeleryAppVersionCheck
+from .warnings import WarningStatusCheck
 
 
 checks = [
     CeleryAliveCheck(),
     CeleryAppVersionCheck(),
+    WarningStatusCheck(seen_warnings),
 ]
 
 

--- a/src/sentry/status_checks/warnings.py
+++ b/src/sentry/status_checks/warnings.py
@@ -1,0 +1,14 @@
+import functools
+
+from .base import Problem, StatusCheck
+
+
+class WarningStatusCheck(StatusCheck):
+    def __init__(self, warning_set):
+        self.__warning_set = warning_set
+
+    def check(self):
+        return map(
+            functools.partial(Problem, severity=Problem.SEVERITY_WARNING),
+            self.__warning_set,
+        )

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import functools
 import posixpath
-import warnings
 from threading import Lock
 
 import rb
@@ -12,6 +11,7 @@ from redis.connection import ConnectionPool
 
 from sentry import options
 from sentry.exceptions import InvalidConfiguration
+from sentry.utils.warnings import manager as warnings
 from sentry.utils.versioning import Version, check_versions
 
 _pool_cache = {}

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -11,7 +11,7 @@ from redis.connection import ConnectionPool
 
 from sentry import options
 from sentry.exceptions import InvalidConfiguration
-from sentry.utils.warnings import manager as warnings
+from sentry.utils import warnings
 from sentry.utils.versioning import Version, check_versions
 
 _pool_cache = {}

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-import warnings
-
 from sentry.exceptions import InvalidConfiguration
+from sentry.utils.warnings import manager as warnings
 
 
 class Version(tuple):

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.exceptions import InvalidConfiguration
-from sentry.utils.warnings import manager as warnings
+from sentry.utils import warnings
 
 
 class Version(tuple):

--- a/src/sentry/utils/warnings.py
+++ b/src/sentry/utils/warnings.py
@@ -14,7 +14,8 @@ class WarningManager(object):
 
     def warn(self, message, category=None, stacklevel=None):
         if isinstance(message, Warning):
-            # Maybe log if `category` was passed and isn't an instance of `category`?
+            # Maybe log if `category` was passed and isn't a subclass of
+            # `type(message)`?
             warning = message
         else:
             if category is None:

--- a/src/sentry/utils/warnings.py
+++ b/src/sentry/utils/warnings.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+import collections
+import warnings
+
+
+class WarningManager(object):
+    """
+    Transforms warnings into a standard form and invokes handlers.
+    """
+    def __init__(self, handlers, default_category=Warning):
+        self.__handlers = handlers
+        self.__default_category = default_category
+
+    def warn(self, message, category=None, stacklevel=None):
+        if isinstance(message, Warning):
+            # Maybe log if `category` was passed and isn't an instance of `category`?
+            warning = message
+        else:
+            if category is None:
+                category = self.__default_category
+
+            assert issubclass(category, Warning)
+            warning = category(message)
+
+        kwargs = {}
+        if stacklevel is not None:
+            kwargs['stacklevel'] = stacklevel
+
+        for handler in self.__handlers:
+            handler(warning, **kwargs)
+
+
+class WarningSet(collections.Set):
+    """
+    Add-only set structure for storing unique warnings.
+    """
+    def __init__(self):
+        self.__warnings = {}
+
+    def __contains__(self, value):
+        assert isinstance(value, Warning)
+        return self.__get_key(value) in self.__warnings
+
+    def __len__(self):
+        return len(self.__warnings)
+
+    def __iter__(self):
+        return self.__warnings.itervalues()
+
+    def __get_key(self, warning):
+        return (
+            type(warning),
+            warning.args if hasattr(warning, 'args') else str(warning),
+        )
+
+    def add(self, warning, stacklevel=None):
+        self.__warnings[self.__get_key(warning)] = warning
+
+
+# Maintains all unique warnings seen since system startup.
+seen_warnings = WarningSet()
+
+manager = WarningManager((
+    lambda warning, stacklevel=1: warnings.warn(
+        warning,
+        stacklevel=stacklevel + 2,
+    ),
+    seen_warnings.add,
+))

--- a/src/sentry/utils/warnings.py
+++ b/src/sentry/utils/warnings.py
@@ -69,3 +69,6 @@ manager = WarningManager((
     ),
     seen_warnings.add,
 ))
+
+# Make this act like the standard library ``warnings`` module.
+warn = manager.warn


### PR DESCRIPTION
This adds `sentry.utils.warnings`, which is API compatible with the
normal `warnings` mechanisms. By default, any warnings dispatched via
`sentry.utils.warings` are stored for later display to system
administrators as well as being dispatched via the standard `warnings`
system (with the appropriate stack level.)
