### PR TITLE
Add command line util to list and purge queues

### DIFF
--- a/src/sentry/monitoring/__init__.py
+++ b/src/sentry/monitoring/__init__.py
@@ -1,0 +1,7 @@
+"""
+sentry.monitoring
+~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -1,0 +1,68 @@
+"""
+sentry.monitoring.queues
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+
+class RedisBackend(object):
+    def __init__(self, app):
+        from redis import StrictRedis
+        self.client = StrictRedis.from_url(app.conf.BROKER_URL)
+
+    def bulk_get_sizes(self, queues):
+        return [(queue.name, self.get_size(queue)) for queue in queues]
+
+    def get_size(self, queue):
+        return self.client.llen(queue.name)
+
+    def purge_queue(self, queue):
+        # This is slightly inaccurate since things could be queued between calling
+        # LLEN and DEL, but it's close enough for this use case.
+        size = self.get_size(queue)
+        self.client.delete(queue.name)
+        return size
+
+
+class AmqpBackend(object):
+    def __init__(self, app):
+        self.app = app
+
+    def _get_size_from_conn(self, conn, queue):
+        # In AMQP, the way to do this is to attempt to create a queue passively.
+        # which is basically checking for it's existence (passive=True), this also
+        # returns back the queue size.
+        _, size, _ = self.app.amqp.queues[queue.name](conn.default_channel).queue_declare(passive=True)
+        return size
+
+    def bulk_get_sizes(self, queues):
+        sizes = []
+        with self.app.connection_or_acquire() as conn:
+            for queue in queues:
+                sizes.append((queue.name, self._get_size_from_conn(conn, queue)))
+        return sizes
+
+    def get_size(self, queue):
+        with self.app.connection_or_acquire() as conn:
+            return self._get_size_from_conn(conn, queue)
+
+    def purge_queue(self, queue):
+        with self.app.connection_or_acquire() as conn:
+            return self.app.amqp.queues[queue.name](conn.default_channel).purge()
+
+
+def get_backend_for_celery(app):
+    from urlparse import urlparse
+    return backends[urlparse(app.conf.BROKER_URL).scheme](app)
+
+
+backends = {
+    'redis': RedisBackend,
+    'amqp': AmqpBackend,
+
+    # Ideally these are never used
+    'librabbitmq': AmqpBackend,
+    'pyamqp': AmqpBackend,
+}

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -55,6 +55,7 @@ map(lambda cmd: cli.add_command(import_string(cmd)), (
     'sentry.runner.commands.backup.import_',
     'sentry.runner.commands.init.init',
     'sentry.runner.commands.plugins.plugins',
+    'sentry.runner.commands.queues.queues',
     'sentry.runner.commands.repair.repair',
     'sentry.runner.commands.start.start',
     'sentry.runner.commands.upgrade.upgrade',

--- a/src/sentry/runner/commands/queues.py
+++ b/src/sentry/runner/commands/queues.py
@@ -1,0 +1,74 @@
+"""
+sentry.runner.commands.queues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+from __future__ import absolute_import, print_function
+
+import click
+from sentry.runner.decorators import configuration
+
+
+@click.group()
+def queues():
+    "Manage Sentry queues."
+
+
+@queues.command()
+@click.option('-S', 'sort_size', default=False, is_flag=True, help='Sort by size.')
+@click.option('-r', 'reverse', default=False, is_flag=True, help='Reverse the sort order.')
+@configuration
+def list(sort_size, reverse):
+    "List queues."
+
+    from sentry.celery import app
+    from sentry.monitoring.queues import get_backend_for_celery
+
+    try:
+        backend = get_backend_for_celery(app)
+    except KeyError as e:
+        raise click.ClickException('unknown broker type: %r' % e.message)
+
+    queues = backend.bulk_get_sizes(app.conf.CELERY_QUEUES)
+
+    if sort_size:
+        queues = sorted(queues, key=lambda q: (-q[1], q[0]), reverse=reverse)
+    else:
+        queues = sorted(queues, reverse=reverse)
+
+    for queue in queues:
+        click.echo('%s %d' % queue)
+
+
+@queues.command()
+@click.option('-f', '--force', default=False, is_flag=True, help='Do not prompt for confirmation.')
+@click.argument('queue')
+@configuration
+def purge(force, queue):
+    from sentry.celery import app
+    for q in app.conf.CELERY_QUEUES:
+        if q.name == queue:
+            queue = q
+            break
+    else:
+        raise click.ClickException('unknown queue: %r' % queue)
+
+    from sentry.monitoring.queues import get_backend_for_celery
+
+    try:
+        backend = get_backend_for_celery(app)
+    except KeyError as e:
+        raise click.ClickException('unknown broker type: %r' % e.message)
+
+    size = backend.get_size(queue)
+
+    if size == 0:
+        click.echo('Queue is empty, nothing to purge', err=True)
+        return
+
+    if not force:
+        click.confirm('Are you sure you want to purge %d messages from the queue %r?' % (size, queue.name), abort=True)
+
+    click.echo('Poof, %d messages deleted' % backend.purge_queue(queue), err=True)


### PR DESCRIPTION
This is first step for GH-2809

This provides commands like:

```
$ sentry queues list -S
```

To view queues sorted by size. This should be easily machine readable, so if another tool, such as Diamond or collectd, wanted to ping Sentry for this information, it could run this command and easily parse the output.

Also adds:

```
$ sentry queues purge <queue>
```

This way there's an easy way from the command line to purge a queue. We currently don't surface this anywhere.
