### PR TITLE
Better systemd compatibility: killing sentry by SIGTERM

### DIFF
--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -65,6 +65,7 @@ class SentryHTTPServer(Service):
         options.setdefault('ignore-write-errors', True)
         options.setdefault('disable-write-exception', True)
         options.setdefault('virtualenv', sys.prefix)
+        options.setdefault('die-on-term', True)
         options.setdefault('log-format', '%(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"')
 
         options.setdefault('%s-socket' % options['protocol'], '%s:%s' % (host, port))


### PR DESCRIPTION
See #2845 and the [uWSGI docs on `die-on-term`](http://uwsgi-docs.readthedocs.org/en/latest/Options.html?highlight=die-on-term#die-on-term)
