### PR TITLE
Add `DeprecatedSettingWarning`.

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -12,6 +12,7 @@ import os
 import click
 
 from sentry.utils import warnings
+from sentry.utils.warnings import DeprecatedSettingWarning
 
 
 def install_plugin_apps(settings):
@@ -224,30 +225,32 @@ def show_big_error(message):
 def apply_legacy_settings(settings):
     # SENTRY_USE_QUEUE used to determine if Celery was eager or not
     if hasattr(settings, 'SENTRY_USE_QUEUE'):
-        warnings.warn('SENTRY_USE_QUEUE is deprecated. Please use CELERY_ALWAYS_EAGER instead. '
-                      'See https://docs.getsentry.com/on-premise/server/queue/ for more information.', DeprecationWarning)
+        warnings.warn(
+            DeprecatedSettingWarning(
+                'SENTRY_USE_QUEUE',
+                'CELERY_ALWAYS_EAGER',
+                'https://docs.getsentry.com/on-premise/server/queue/',
+            )
+        )
         settings.CELERY_ALWAYS_EAGER = (not settings.SENTRY_USE_QUEUE)
 
     if not settings.SENTRY_OPTIONS.get('system.admin-email') and hasattr(settings, 'SENTRY_ADMIN_EMAIL'):
-        warnings.warn('SENTRY_ADMIN_EMAIL is deprecated. '
-                      "Use SENTRY_OPTIONS instead, key 'system.admin-email'", DeprecationWarning)
+        warnings.warn(DeprecatedSettingWarning('SENTRY_ADMIN_EMAIL', 'SENTRY_OPTIONS["system.admin-email"]'))
         settings.SENTRY_OPTIONS['system.admin-email'] = settings.SENTRY_ADMIN_EMAIL
 
     if not settings.SENTRY_OPTIONS.get('system.url-prefix') and hasattr(settings, 'SENTRY_URL_PREFIX'):
-        warnings.warn('SENTRY_URL_PREFIX is deprecated. '
-                      "Use SENTRY_OPTIONS instead, key 'system.url-prefix'", DeprecationWarning)
+        warnings.warn(DeprecatedSettingWarning('SENTRY_URL_PREFIX', 'SENTRY_OPTIONS["system.url-prefix"]'))
         settings.SENTRY_OPTIONS['system.url-prefix'] = settings.SENTRY_URL_PREFIX
 
     if not settings.SENTRY_OPTIONS.get('system.rate-limit') and hasattr(settings, 'SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE'):
-        warnings.warn('SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE is deprecated. '
-                      "Use SENTRY_OPTIONS instead, key 'system.rate-limit'", DeprecationWarning)
+        warnings.warn(DeprecatedSettingWarning('SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE', 'SENTRY_OPTIONS["system.rate-limit"]'))
         settings.SENTRY_OPTIONS['system.rate-limit'] = settings.SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE
 
     if hasattr(settings, 'SENTRY_REDIS_OPTIONS'):
         if 'redis.clusters' in settings.SENTRY_OPTIONS:
             raise Exception("Cannot specify both SENTRY_OPTIONS['redis.clusters'] option and SENTRY_REDIS_OPTIONS setting.")
         else:
-            warnings.warn("SENTRY_REDIS_OPTIONS is deprecated. Use SENTRY_OPTIONS instead, key 'redis.clusters'", DeprecationWarning)
+            warnings.warn(DeprecatedSettingWarning('SENTRY_REDIS_OPTIONS', 'SENTRY_OPTIONS["redis.clusters"]'))
             settings.SENTRY_OPTIONS['redis.clusters'] = {
                 'default': settings.SENTRY_REDIS_OPTIONS,
             }
@@ -278,7 +281,7 @@ def apply_legacy_settings(settings):
         settings.ALLOWED_HOSTS = AllowedHosts()
 
     if hasattr(settings, 'SENTRY_ALLOW_REGISTRATION'):
-        warnings.warn('SENTRY_ALLOW_REGISTRATION is deprecated. Use SENTRY_FEATURES instead.', DeprecationWarning)
+        warnings.warn(DeprecatedSettingWarning('SENTRY_ALLOW_REGISTRATION', 'SENTRY_FEATURES["auth:register"]'))
         settings.SENTRY_FEATURES['auth:register'] = settings.SENTRY_ALLOW_REGISTRATION
 
 

--- a/src/sentry/utils/warnings.py
+++ b/src/sentry/utils/warnings.py
@@ -4,6 +4,29 @@ import collections
 import warnings
 
 
+class DeprecatedSettingWarning(DeprecationWarning):
+    def __init__(self, setting, replacement, url=None):
+        self.setting = setting
+        self.replacement = replacement
+        self.url = url
+        super(DeprecatedSettingWarning, self).__init__(setting, replacement, url)
+
+    def __str__(self):
+        chunks = [
+            'The {} setting is deprecated. Please use {} instead.'.format(
+                self.setting,
+                self.replacement,
+            )
+        ]
+
+        # TODO(tkaemming): This will be removed from the message in the future
+        # when it's added to the API payload separately.
+        if self.url:
+            chunks.append('See {} for more information.'.format(self.url))
+
+        return ' '.join(chunks)
+
+
 class WarningManager(object):
     """
     Transforms warnings into a standard form and invokes handlers.


### PR DESCRIPTION
This is a subclass of `DeprecationWarning` that is specific for settings
that have been moved to new locations. This will get used in the future
to aggregate warnings in the UI and show "Your installation has N
settings that need updating." instead of a bunch of ultra-specific
warnings.
