### PR TITLE
Display errors for javascript frames without a line of context

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -653,6 +653,14 @@ class SourceProcessor(object):
             # TODO: theoretically a minified source could point to another mapped, minified source
             frame.pre_context, frame.context_line, frame.post_context = get_source_context(
                 source=source, lineno=frame.lineno, colno=frame.colno or 0)
+
+            if not frame.context_line:
+                all_errors.append({
+                    'type': EventError.JS_INVALID_SOURCEMAP_LOCATION,
+                    'column': frame.colno,
+                    'row': frame.lineno,
+                    'source': frame.abs_path,
+                })
         return all_errors
 
     def get_source(self, filename, release):


### PR DESCRIPTION
At this point, we got valid line/column number according to the sourcemap itself, but it was likely mapped to the wrong source file since this doesn't actually exist in the file.

Fixes GH-2858
