### PR TITLE
Detect if the worker issue is actually because of backlog or not

### DIFF
--- a/src/sentry/status_checks/celery_alive.py
+++ b/src/sentry/status_checks/celery_alive.py
@@ -15,9 +15,22 @@ class CeleryAliveCheck(StatusCheck):
         last_ping = options.get('sentry:last_worker_ping') or 0
         if last_ping >= time() - 300:
             return []
+
+        backlogged, size = None, 0
+        from sentry.monitoring.queues import backend
+        if backend is not None:
+            size = backend.get_size('default')
+            backlogged = size > 0
+
+        message = "Background workers haven't checked in recently. "
+        if backlogged:
+            message += "It seems that you have a backlog of %d tasks. Either your workers aren't running or you need more capacity." % size
+        else:
+            message += "This is likely an issue with your configuration or the workers aren't running."
+
         return [
             Problem(
-                "Background workers haven't checked in recently. This can mean an issue with your configuration or a serious backlog in tasks.",
+                message,
                 url=absolute_uri(reverse('sentry-admin-queue')),
             ),
         ]


### PR DESCRIPTION
:tada: 

![image](https://cloud.githubusercontent.com/assets/375744/13863998/52b0c17a-ec5b-11e5-8589-72a7d9492f62.png)
![image](https://cloud.githubusercontent.com/assets/375744/13864006/6f02a00a-ec5b-11e5-9697-174b27842158.png)

tbh I don't know if this is overly useful, but this is leveraging the internal queue monitoring.

/cc @dcramer 
