### PR TITLE
Remove unused showAllTeams prop on ExpandedTeamList

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -17,7 +17,6 @@ const ExpandedTeamList = React.createClass({
     organization: PropTypes.Organization.isRequired,
     teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
     projectStats: React.PropTypes.object,
-    showAllTeams: React.PropTypes.func.isRequired,
     hasTeams: React.PropTypes.bool
   },
 


### PR DESCRIPTION
@benvinegar I couldn't see this being used and was throwing a React warning.

```
Warning: Failed propType: Required prop `showAllTeams` was not specified in `ExpandedTeamList`. Check the render method of `OrganizationTeams`.
```

This is a PR since I wasn't sure if it was intended to be used where I should pass in the value instead, or if this is just not needed.
