### PR TITLE
Truncate versions if they look like a sha1

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -7,6 +7,8 @@ sentry.models.release
 """
 from __future__ import absolute_import, print_function
 
+import re
+
 from django.db import models
 from django.utils import timezone
 from jsonfield import JSONField
@@ -16,6 +18,8 @@ from sentry.db.models import (
 )
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5
+
+_sha1_re = re.compile(r'^[a-f0-9]{40}$')
 
 
 class Release(Model):
@@ -91,6 +95,6 @@ class Release(Model):
 
     @property
     def short_version(self):
-        if len(self.version) == 40:
+        if _sha1_re.match(self.version):
             return self.version[:12]
         return self.version

--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -17,7 +17,7 @@ const Version = React.createClass({
 
   render() {
     let {orgId, projectId, version} = this.props;
-    let shortVersion = version.length === 40 ? version.substr(0, 12) : version;
+    let shortVersion = version.match(/^[a-f0-9]{40}$/) ? version.substr(0, 12) : version;
 
     if (this.props.anchor) {
       return (

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -30,9 +30,15 @@ class ReleaseSerializerTest(TestCase):
 
         result = serialize(release, user)
         assert result['version'] == release.version
+        assert result['shortVersion'] == release.version
         assert result['newGroups'] == 1
         assert result['firstEvent']
         assert result['lastEvent']
+
+        # Make sure a sha1 value gets truncated
+        release.version = '0' * 40
+        result = serialize(release, user)
+        assert result['shortVersion'] == '0' * 12
 
     def test_no_tag_data(self):
         user = self.create_user()


### PR DESCRIPTION
We were erronously truncating 40 character values, that clearly weren't
git shas which ends up being more confusing and unexpected behavior.
