### PR TITLE
Fix inconsistent field type declaration for `Counter.value`.

### DIFF
--- a/src/sentry/migrations/0241_auto__add_counter__add_unique_counter_project_ident__add_field_group_s.py
+++ b/src/sentry/migrations/0241_auto__add_counter__add_unique_counter_project_ident__add_field_group_s.py
@@ -168,7 +168,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'Counter', 'db_table': "'sentry_projectcounter'"},
             'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
             'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'unique': True}),
-            'value': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+            'value': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
         },
         'sentry.event': {
             'Meta': {'unique_together': "(('project_id', 'event_id'),)", 'object_name': 'Event', 'db_table': "'sentry_message'", 'index_together': "(('group_id', 'datetime'),)"},

--- a/src/sentry/migrations/0242_auto__add_field_project_forced_color.py
+++ b/src/sentry/migrations/0242_auto__add_field_project_forced_color.py
@@ -103,7 +103,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'Counter', 'db_table': "'sentry_projectcounter'"},
             'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
             'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'unique': True}),
-            'value': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+            'value': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
         },
         'sentry.event': {
             'Meta': {'unique_together': "(('project_id', 'event_id'),)", 'object_name': 'Event', 'db_table': "'sentry_message'", 'index_together': "(('group_id', 'datetime'),)"},


### PR DESCRIPTION
The model and original migration uses `BoundedBigIntegerField`, but
model state dumps defined `BoundedPositiveIntegerField`.
