### PR TITLE
Provide link to both internal and public issue

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -195,6 +195,9 @@ class Group(Model):
         return absolute_uri(reverse('sentry-group', args=[
             self.organization.slug, self.project.slug, self.id]))
 
+    def get_share_url(self):
+        return absolute_uri('share/issue/%s/' % (self.get_share_id()))
+
     @property
     def qualified_short_id(self):
         if self.project.callsign is not None and \

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -47,7 +47,8 @@ class IssueTrackingPlugin(Plugin):
 
     def _get_group_description(self, request, group, event):
         output = [
-            absolute_uri(group.get_absolute_url()),
+            "[Internal issue](%s)" % (group.get_absolute_url()),
+            "[Public issue](%s)" % (group.get_share_url())
         ]
         body = self._get_group_body(request, group, event)
         if body:


### PR DESCRIPTION
Somewhat related to #2887.
I want random contributors to be able to contribute to projects supported by self-hosted Sentry, so I want them to be able to view Sentry issues. However, I don't want to individually register each one, or add them to a GitHub organization.

This will make the generated issue link to both the internal Sentry issue, and the public one.
![2016-03-23-130250_832x298_scrot](https://cloud.githubusercontent.com/assets/7784737/13984636/ce50faa2-f0f7-11e5-8be8-7988838cd6a9.png)
See an example here: https://github.com/temporary-ou-for-sentry-plugin-testing/temporary-project/issues/3

Of course, I am completely open to changing this PR entirely, if it doesn't meet the code or UI quality standards (I'm a bit of a python skrub :wink:). This is just to open discussion on some guest-focused Sentry features.
