### PR TITLE
Disable transaction when resolving plugins.for_project

### DIFF
--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -39,7 +39,8 @@ class PluginManager(InstanceManager):
 
     def for_project(self, project, version=1):
         for plugin in self.all(version=version):
-            if not safe_execute(plugin.is_enabled, project):
+            if not safe_execute(plugin.is_enabled, project,
+                                _with_transaction=False):
                 continue
             yield plugin
 


### PR DESCRIPTION
This is called O(n) times in places like the GroupSerializer, and is
generally called, which in turn calls it O(n) times for each plugin to
check if it's enabled. This can end up being a lot of network traffic
with just transaction management and it's unlikely that any
plugin.is_enabled() call will try to cause a database mutation.

/cc @drcapulet @dcramer 

Also worth noting that the other call, `plugins.configurable_for_project` already disables transactions in it's `safe_execute` call.
