### PR TITLE
Refactor settings initialization

### DIFF
--- a/api-docs/sentry.conf.py
+++ b/api-docs/sentry.conf.py
@@ -49,14 +49,13 @@ SENTRY_WEB_OPTIONS = {
     'secure_scheme_headers': {'X-FORWARDED-PROTO': 'https'},
 }
 
-SECRET_KEY = 'super secret secret key'
-
 SENTRY_OPTIONS.update({
     'redis.clusters': {
         'default': {
             'hosts': {i: {'port': SENTRY_APIDOCS_REDIS_PORT} for i in xrange(0, 4)},
         },
     },
+    'system.secret-key': 'super secret secret key',
     'system.admin-email': 'admin@getsentry.com',
     'system.url-prefix': SENTRY_URL_PREFIX,
     'mail.backend': 'django.core.mail.backends.smtp.EmailBackend',

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -25,9 +25,6 @@ import sentry
 
 gettext_noop = lambda s: s
 
-# A marker for indicating builtin Django settings that are to not be used
-DEAD = object()
-
 socket.setdefaulttimeout(5)
 
 DEBUG = False
@@ -188,8 +185,6 @@ USE_L10N = True
 
 USE_TZ = True
 
-# Make this unique, and don't share it with anybody.
-SECRET_KEY = hashlib.md5(socket.gethostname() + ')*)&8a36)6%74e@-ne5(-!8a(vv#tkv)(eyg&@0=zd^pl!7=y@').hexdigest()
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
@@ -687,10 +682,6 @@ SENTRY_SMTP_HOSTNAME = 'localhost'
 SENTRY_SMTP_HOST = 'localhost'
 SENTRY_SMTP_PORT = 1025
 
-SERVER_EMAIL = DEAD
-DEFAULT_FROM_EMAIL = DEAD
-EMAIL_SUBJECT_PREFIX = DEAD
-
 SENTRY_INTERFACES = {
     'exception': 'sentry.interfaces.exception.Exception',
     'logentry': 'sentry.interfaces.message.Message',
@@ -912,7 +903,18 @@ SENTRY_ROLES = (
 )
 
 # See sentry/options/__init__.py for more information
-SENTRY_OPTIONS = {}
+SENTRY_OPTIONS = {
+    'mail.backend': 'django.core.mail.backends.smtp.EmailBackend',
+    'mail.host': 'localhost',
+    'mail.port': 25,
+    'mail.username': '',
+    'mail.password': '',
+    'mail.use-tls': False,
+    'mail.subject-prefix': '[Sentry] ',
+    'mail.from': 'root@localhost',
+    # Make this unique, and don't share it with anybody.
+    'system.secret-key': hashlib.md5(socket.gethostname() + ')*)&8a36)6%74e@-ne5(-!8a(vv#tkv)(eyg&@0=zd^pl!7=y@').hexdigest(),
+}
 
 # You should not change this setting after your database has been created
 # unless you have altered all schemas first
@@ -944,3 +946,18 @@ def get_raven_config():
     }
 
 RAVEN_CONFIG = get_raven_config()
+
+# Config options that are explicitly disabled from Django
+DEAD = object()
+
+# This will eventually get set from values in SENTRY_OPTIONS during
+# sentry.runner.initializer:bootstrap_options
+SECRET_KEY = DEAD
+EMAIL_BACKEND = DEAD
+EMAIL_HOST = DEAD
+EMAIL_PORT = DEAD
+EMAIL_HOST_USER = DEAD
+EMAIL_HOST_PASSWORD = DEAD
+EMAIL_USE_TLS = DEAD
+SERVER_EMAIL = DEAD
+EMAIL_SUBJECT_PREFIX = DEAD

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -13,13 +13,13 @@ from sentry.options import (
 from sentry.utils.types import Dict, String
 
 # Cache
-register('cache.backend', flags=FLAG_NOSTORE)
-register('cache.options', type=Dict, flags=FLAG_NOSTORE)
+# register('cache.backend', flags=FLAG_NOSTORE)
+# register('cache.options', type=Dict, flags=FLAG_NOSTORE)
 
 # System
 register('system.admin-email', flags=FLAG_REQUIRED)
 register('system.databases', type=Dict, flags=FLAG_NOSTORE)
-register('system.debug', default=False, flags=FLAG_NOSTORE)
+# register('system.debug', default=False, flags=FLAG_NOSTORE)
 register('system.rate-limit', default=0, flags=FLAG_PRIORITIZE_DISK)
 register('system.secret-key', flags=FLAG_NOSTORE)
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
@@ -57,5 +57,5 @@ register('mail.password', flags=FLAG_PRIORITIZE_DISK)
 register('mail.use-tls', default=False, flags=FLAG_PRIORITIZE_DISK)
 register('mail.subject-prefix', default='[Sentry] ', flags=FLAG_PRIORITIZE_DISK)
 register('mail.from', default='root@localhost', flags=FLAG_PRIORITIZE_DISK)
-register('mail.enable-replies', default=False, flags=FLAG_PRIORITIZE_DISK)
+# register('mail.enable-replies', default=False, flags=FLAG_PRIORITIZE_DISK)
 register('mail.list-namespace', type=String, default='localhost', flags=FLAG_NOSTORE)

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -185,8 +185,9 @@ YAML_CONFIG_TEMPLATE = u"""\
 # The email address to send on behalf of
 # mail.from: 'root@localhost'
 
-# If this file ever becomes compromised, it's important to regenerate your SECRET_KEY
-# Changing this value will result in all current sessions being invalidated
+# If this file ever becomes compromised, it's important to regenerate your a new key
+# Changing this value will result in all current sessions being invalidated.
+# A new key can be generated with `$ sentry config generate-secret-key`
 system.secret-key: '%(secret_key)s'
 
 # The ``redis.clusters`` setting is used, unsurprisingly, to configure Redis

--- a/src/sentry/utils/pytest.py
+++ b/src/sentry/utils/pytest.py
@@ -64,8 +64,6 @@ def pytest_configure(config):
     middleware[sudo] = 'sentry.testutils.middleware.SudoMiddleware'
     settings.MIDDLEWARE_CLASSES = tuple(middleware)
 
-    settings.SENTRY_OPTIONS['system.url-prefix'] = 'http://testserver'
-
     # enable draft features
     settings.SENTRY_ENABLE_EMAIL_REPLIES = True
 
@@ -106,6 +104,7 @@ def pytest_configure(config):
             },
         },
         'mail.backend': 'django.core.mail.backends.locmem.EmailBackend',
+        'system.url-prefix': 'http://testserver',
     })
 
     # django mail uses socket.getfqdn which doesn't play nice if our
@@ -113,8 +112,10 @@ def pytest_configure(config):
     patcher = mock.patch('socket.getfqdn', return_value='localhost')
     patcher.start()
 
-    from sentry.runner.initializer import initialize_receivers, fix_south, bind_cache_to_option_store
+    from sentry.runner.initializer import (
+        bootstrap_options, initialize_receivers, fix_south, bind_cache_to_option_store)
 
+    bootstrap_options(settings)
     fix_south(settings)
 
     bind_cache_to_option_store()

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -15,7 +15,6 @@ class SystemOptionsTest(APITestCase):
         assert 'system.secret-key' in response.data
         assert 'system.url-prefix' in response.data
         assert 'system.admin-email' in response.data
-        assert 'cache.backend' in response.data
 
     def test_bad_query(self):
         self.login_as(user=self.user)

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -1,0 +1,177 @@
+from __future__ import absolute_import
+
+import pytest
+from sentry.runner.importer import ConfigurationError
+from sentry.runner.initializer import bootstrap_options, apply_legacy_settings
+
+
+@pytest.fixture
+def settings():
+    class Settings(object):
+        pass
+
+    s = Settings()
+    s.TIME_ZONE = 'UTC'
+    s.ALLOWED_HOSTS = []
+    s.SENTRY_FEATURES = {}
+    s.SENTRY_OPTIONS = {}
+    return s
+
+
+@pytest.fixture
+def config_yml(tmpdir):
+    return tmpdir.join('config.yml')
+
+
+def test_bootstrap_options_simple(settings, config_yml):
+    "Config options are specified in both places, but config.yml should prevail"
+    settings.SECRET_KEY = 'xxx'
+    settings.EMAIL_BACKEND = 'xxx'
+    settings.EMAIL_HOST = 'xxx'
+    settings.EMAIL_PORT = 6969
+    settings.EMAIL_HOST_USER = 'xxx'
+    settings.EMAIL_HOST_PASSWORD = 'xxx'
+    settings.EMAIL_USE_TLS = False
+    settings.SERVER_EMAIL = 'xxx'
+    settings.EMAIL_SUBJECT_PREFIX = 'xxx'
+    settings.SENTRY_OPTIONS = {'something.else': True}
+
+    config_yml.write("""\
+foo.bar: my-foo-bar
+system.secret-key: my-system-secret-key
+mail.backend: my-mail-backend
+mail.host: my-mail-host
+mail.port: 123
+mail.username: my-mail-username
+mail.password: my-mail-password
+mail.use-tls: true
+mail.from: my-mail-from
+mail.subject-prefix: my-mail-subject-prefix
+""")
+
+    bootstrap_options(settings, str(config_yml))
+    assert settings.SENTRY_OPTIONS == {
+        'something.else': True,
+        'foo.bar': 'my-foo-bar',
+        'system.secret-key': 'my-system-secret-key',
+        'mail.backend': 'my-mail-backend',
+        'mail.host': 'my-mail-host',
+        'mail.port': 123,
+        'mail.username': 'my-mail-username',
+        'mail.password': 'my-mail-password',
+        'mail.use-tls': True,
+        'mail.from': 'my-mail-from',
+        'mail.subject-prefix': 'my-mail-subject-prefix',
+    }
+    assert settings.SECRET_KEY == 'my-system-secret-key'
+    assert settings.EMAIL_BACKEND == 'my-mail-backend'
+    assert settings.EMAIL_HOST == 'my-mail-host'
+    assert settings.EMAIL_PORT == 123
+    assert settings.EMAIL_HOST_USER == 'my-mail-username'
+    assert settings.EMAIL_HOST_PASSWORD == 'my-mail-password'
+    assert settings.EMAIL_USE_TLS is True
+    assert settings.SERVER_EMAIL == 'my-mail-from'
+    assert settings.EMAIL_SUBJECT_PREFIX == 'my-mail-subject-prefix'
+
+
+def test_bootstrap_options_malformed_yml(settings, config_yml):
+    config_yml.write('1')
+    with pytest.raises(ConfigurationError):
+        bootstrap_options(settings, str(config_yml))
+
+    config_yml.write('{{{')
+    with pytest.raises(ConfigurationError):
+        bootstrap_options(settings, str(config_yml))
+
+
+def test_bootstrap_options_no_config(settings):
+    "No config file should gracefully extract values out of settings"
+    settings.SECRET_KEY = 'my-system-secret-key'
+    settings.EMAIL_BACKEND = 'my-mail-backend'
+    settings.EMAIL_HOST = 'my-mail-host'
+    settings.EMAIL_PORT = 123
+    settings.EMAIL_HOST_USER = 'my-mail-username'
+    settings.EMAIL_HOST_PASSWORD = 'my-mail-password'
+    settings.EMAIL_USE_TLS = True
+    settings.SERVER_EMAIL = 'my-mail-from'
+    settings.EMAIL_SUBJECT_PREFIX = 'my-mail-subject-prefix'
+    settings.FOO_BAR = 'lol'
+
+    bootstrap_options(settings)
+    assert settings.SENTRY_OPTIONS == {
+        'system.secret-key': 'my-system-secret-key',
+        'mail.backend': 'my-mail-backend',
+        'mail.host': 'my-mail-host',
+        'mail.port': 123,
+        'mail.username': 'my-mail-username',
+        'mail.password': 'my-mail-password',
+        'mail.use-tls': True,
+        'mail.from': 'my-mail-from',
+        'mail.subject-prefix': 'my-mail-subject-prefix',
+    }
+
+
+def test_bootstrap_options_no_config_only_sentry_options(settings):
+    "SENTRY_OPTIONS is only declared, but should be promoted into settings"
+    settings.SENTRY_OPTIONS = {
+        'system.secret-key': 'my-system-secret-key',
+        'mail.backend': 'my-mail-backend',
+        'mail.host': 'my-mail-host',
+        'mail.port': 123,
+        'mail.username': 'my-mail-username',
+        'mail.password': 'my-mail-password',
+        'mail.use-tls': True,
+        'mail.from': 'my-mail-from',
+        'mail.subject-prefix': 'my-mail-subject-prefix',
+    }
+
+    bootstrap_options(settings)
+    assert settings.SECRET_KEY == 'my-system-secret-key'
+    assert settings.EMAIL_BACKEND == 'my-mail-backend'
+    assert settings.EMAIL_HOST == 'my-mail-host'
+    assert settings.EMAIL_PORT == 123
+    assert settings.EMAIL_HOST_USER == 'my-mail-username'
+    assert settings.EMAIL_HOST_PASSWORD == 'my-mail-password'
+    assert settings.EMAIL_USE_TLS is True
+    assert settings.SERVER_EMAIL == 'my-mail-from'
+    assert settings.EMAIL_SUBJECT_PREFIX == 'my-mail-subject-prefix'
+
+
+def test_bootstrap_options_missing_file(settings):
+    bootstrap_options(settings, 'this-file-does-not-exist-xxxxxxxxxxxxxx.yml')
+    assert settings.SENTRY_OPTIONS == {}
+
+
+def test_bootstrap_options_empty_file(settings, config_yml):
+    config_yml.write('')
+    bootstrap_options(settings, str(config_yml))
+    assert settings.SENTRY_OPTIONS == {}
+
+
+def test_apply_legacy_settings(settings):
+    settings.SENTRY_USE_QUEUE = True
+    settings.SENTRY_ALLOW_REGISTRATION = True
+    settings.SENTRY_ADMIN_EMAIL = 'admin-email'
+    settings.SENTRY_URL_PREFIX = 'http://url-prefix'
+    settings.SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE = 10
+    settings.SENTRY_REDIS_OPTIONS = {'foo': 'bar'}
+    settings.SENTRY_OPTIONS = {
+        'mail.from': 'mail-from',
+    }
+    apply_legacy_settings(settings)
+    assert settings.CELERY_ALWAYS_EAGER is False
+    assert settings.SENTRY_FEATURES['auth:register'] is True
+    assert settings.SENTRY_OPTIONS == {
+        'system.admin-email': 'admin-email',
+        'system.url-prefix': 'http://url-prefix',
+        'system.rate-limit': 10,
+        'redis.clusters': {'default': {'foo': 'bar'}},
+        'mail.from': 'mail-from',
+    }
+    assert settings.DEFAULT_FROM_EMAIL == 'mail-from'
+
+
+def test_initialize_app(settings):
+    "Just a sanity check of the full initialization process"
+    bootstrap_options(settings)
+    apply_legacy_settings(settings)


### PR DESCRIPTION
Problems:
- When introducing the new SMTP configuration options that directly
  replaced direct Django settings, the default option values were
  never being applied back into settings, so Django could break if
  something tried to read the original values.
- When no config.yml file was present and _only_ SENTRY_OPTIONS was
  used, none of these values got applied back into django settings
  because bootstrap_options was entirely skipped. This was just an
  oversight since it was assumed that a config.yml would always exist,
  but in getsentry case, we only use SENTRY_OPTIONS which caused a bad
  deploy.

This now duplicates efforts from the options default values, and moves
them also into SENTRY_OPTIONS, so they always exist, while always
running through bootstrap_options. This is a temporary hack to work
around the problem at the moment.
