### PR TITLE
Use devtool: cheap-module-eval-source-map in development ...

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -929,7 +929,7 @@ SENTRY_API_RESPONSE_DELAY = 0
 # XXX(dcramer): this doesn't work outside of a source distribution as the
 # webpack.config.js is not part of Sentry's datafiles
 SENTRY_WATCHERS = (
-    ('webpack', [os.path.join(NODE_MODULES_ROOT, '.bin', 'webpack'), '-d', '--watch',
+    ('webpack', [os.path.join(NODE_MODULES_ROOT, '.bin', 'webpack'), '--output-pathinfo', '--watch',
      "--config={}".format(os.path.normpath(os.path.join(PROJECT_ROOT, os.pardir, os.pardir, "webpack.config.js")))]),
 )
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,8 @@ if (process.env.SENTRY_STATIC_DIST_PATH) {
     distPath = process.env.SENTRY_STATIC_DIST_PATH;
 }
 
+var IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
 var babelQuery = {
   plugins: [],
   extra: {}
@@ -174,13 +176,15 @@ var config = {
     library: 'exports',
     sourceMapFilename: '[name].js.map',
   },
-  devtool: 'source-map'
+  devtool: IS_PRODUCTION ?
+    'source-map' :
+    'cheap-module-eval-source-map'
 };
 
 // This compression-webpack-plugin generates pre-compressed files
 // ending in .gz, to be picked up and served by our internal static media
 // server as well as nginx when paired with the gzip_static module.
-if (process.env.NODE_ENV === 'production') {
+if (IS_PRODUCTION) {
   config.plugins.push(new (require('compression-webpack-plugin'))({
     // zopfli gives us a better gzip compression
     // See: http://googledevelopers.blogspot.com/2013/02/compress-data-more-densely-with-zopfli.html


### PR DESCRIPTION
- It's becoming the default in webpack 2.0 (currently in beta)
- It fixes Chrome's source map caching issue (since source maps are evaled as part of app.js)
- It should rebuild faster according to webpack docs: https://webpack.github.io/docs/configuration.html#devtool

Rebuild times after a 1 line change to the same, single file:

|  | Before | After |
| --- | --- | --- |
| 1 | 4266ms | 2967ms |
| 2 | 2087ms | 2186ms |
| 3 | 3164ms | 1714ms |
| **Avg** | **3172ms** | **2289ms** |

^There's some pretty big variance here, but ... it did have the lowest ever generation time (1714ms), and the lowest max time (2967ms).
