### PR TITLE
Include the last frame from non app code in stacktrace.

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -11,6 +11,7 @@ import {t} from '../../../locale';
 const Frame = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired,
+    nextFrameInApp: React.PropTypes.object.bool,
     platform: React.PropTypes.string,
     isExpanded: React.PropTypes.bool,
   },
@@ -227,9 +228,6 @@ const Frame = React.createClass({
   renderCocoaLine() {
     let data = this.props.data;
     let className = 'stacktrace-table';
-    if (data.inApp) {
-      className += ' in-app';
-    }
     return (
       <div className={className}>
         <div className="trace-col package">
@@ -268,6 +266,7 @@ const Frame = React.createClass({
       'frame': true,
       'system-frame': !data.inApp,
       'frame-errors': data.errors,
+      'leads-to-app': !data.inApp && this.props.nextFrameInApp
     });
     let props = {className: className};
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -31,10 +31,17 @@ const StacktraceContent = React.createClass({
     return <li {...props}>{text}</li>;
   },
 
+  frameIsVisible(frame, nextFrame) {
+    return (
+      this.props.includeSystemFrames ||
+      frame.inApp ||
+      (nextFrame && nextFrame.inApp)
+    );
+  },
+
   render() {
     let data = this.props.data;
     let firstFrameOmitted, lastFrameOmitted;
-    let includeSystemFrames = this.props.includeSystemFrames;
 
     if (data.framesOmitted) {
       firstFrameOmitted = data.framesOmitted[0];
@@ -46,11 +53,13 @@ const StacktraceContent = React.createClass({
 
     let frames = [];
     data.frames.forEach((frame, frameIdx) => {
-      if (includeSystemFrames || frame.inApp) {
+      let nextFrame = data.frames[frameIdx + 1];
+      if (this.frameIsVisible(frame, nextFrame)) {
         frames.push(
           <Frame
             key={frameIdx}
             data={frame}
+            nextFrameInApp={nextFrame && nextFrame.inApp}
             platform={this.props.platform} />
         );
       }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1270,11 +1270,11 @@ ol.context-line {
 }
 
 .system-frame .stacktrace-table {
-  background: lighten(@blue-light, 25);
+  background-color: #f6f7f8;
 }
 
 .leads-to-app .stacktrace-table {
-  background: lighten(@green-light, 28);
+  background: lighten(@blue-light, 28);
 }
 
 #full-message {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -965,6 +965,8 @@
 
   &.system-frame {}
 
+  &.leads-to-app {}
+
   h3 {
     font-size: 22px;
   }
@@ -1230,11 +1232,6 @@ ol.context-line {
 }
 
 .stacktrace-table {
-  background: lighten(@blue-light, 25);
-
-  &.in-app {
-    background: white;
-  }
 
   .trace-col {
     display: inline-block;
@@ -1270,6 +1267,14 @@ ol.context-line {
       padding-left: 10px;
     }
   }
+}
+
+.system-frame .stacktrace-table {
+  background: lighten(@blue-light, 25);
+}
+
+.leads-to-app .stacktrace-table {
+  background: lighten(@green-light, 28);
 }
 
 #full-message {


### PR DESCRIPTION
This commit includes the last frame in system code in the stacktrace
when only the app code is shown.  This significantly improves the
understanding of stacktraces, particularly for iOS.

Currently only the cocoa stack colors this line, the traditional
stacktrace rendering does not try to color code that line.
## Collapsed View

<img width="926" alt="screen shot 2016-03-26 at 01 36 44" src="https://cloud.githubusercontent.com/assets/7396/14056929/43fd936c-f2f3-11e5-8554-21e6c810901e.png">
## Full Traceback

<img width="928" alt="screen shot 2016-03-26 at 01 36 50" src="https://cloud.githubusercontent.com/assets/7396/14056931/492911ea-f2f3-11e5-8ac7-7f8d8d7a9cf3.png">
