### PR TITLE
Separate defined option values from default option values

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -908,15 +908,8 @@ SENTRY_ROLES = (
 )
 
 # See sentry/options/__init__.py for more information
-SENTRY_OPTIONS = {
-    'mail.backend': 'django.core.mail.backends.smtp.EmailBackend',
-    'mail.host': 'localhost',
-    'mail.port': 25,
-    'mail.username': '',
-    'mail.password': '',
-    'mail.use-tls': False,
-    'mail.subject-prefix': '[Sentry] ',
-    'mail.from': 'root@localhost',
+SENTRY_OPTIONS = {}
+SENTRY_DEFAULT_OPTIONS = {
     # Make this unique, and don't share it with anybody.
     'system.secret-key': hashlib.md5(socket.gethostname() + ')*)&8a36)6%74e@-ne5(-!8a(vv#tkv)(eyg&@0=zd^pl!7=y@').hexdigest(),
 }

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -33,4 +33,6 @@ all = default_manager.all
 filter = default_manager.filter
 isset = default_manager.isset
 
-from .defaults import *  # NOQA
+
+def load_defaults():
+    from .defaults import *  # NOQA

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -160,7 +160,10 @@ class OptionsManager(object):
             # default to the hardcoded local configuration for this key
             return settings.SENTRY_OPTIONS[key]
         except KeyError:
-            return opt.default()
+            try:
+                return settings.SENTRY_DEFAULT_OPTIONS[key]
+            except KeyError:
+                return opt.default()
 
     def delete(self, key):
         """
@@ -216,6 +219,9 @@ class OptionsManager(object):
         # value from the type
         if default_value is None:
             default = type
+            default_value = default()
+
+        settings.SENTRY_DEFAULT_OPTIONS[key] = default_value
 
         self.registry[key] = self.store.make_key(key, default, type, flags, ttl, grace)
 

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -15,6 +15,7 @@ def settings():
     s.ALLOWED_HOSTS = []
     s.SENTRY_FEATURES = {}
     s.SENTRY_OPTIONS = {}
+    s.SENTRY_DEFAULT_OPTIONS = {}
     return s
 
 


### PR DESCRIPTION
With everything being shoved into the simple SENTRY_OPTIONS, there was
no longer a way to determine if a key was actually defined with a value
vs falling back to the default value.

This introduces another dict, SENTRY_DEFAULT_OPTIONS. This dict is
managed from within the options manager at registration time.

Before this, it became impossible to do logic needed inside
api/endpoints/system_options.py since anything with a default value +
FLAG_PRIORITIZE_DISK seemed like it was coming from our config file,
when it was just the default value.
