### PR TITLE
Rework our simplejson implementation for performance

### DIFF
--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -9,7 +9,7 @@ sentry.utils.json
 # Avoid shadowing the standard library json module
 from __future__ import absolute_import
 
-import simplejson
+from simplejson import JSONEncoder, JSONEncoderForHTML, _default_decoder
 import datetime
 import uuid
 import decimal
@@ -17,36 +17,57 @@ import decimal
 from django.utils.timezone import is_aware
 
 
-class BetterJSONEncoder(simplejson.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, uuid.UUID):
-            return o.hex
-        elif isinstance(o, datetime.datetime):
-            return o.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-        elif isinstance(o, datetime.date):
-            return o.isoformat()
-        elif isinstance(o, datetime.time):
-            if is_aware(o):
-                raise ValueError("JSON can't represent timezone-aware times.")
-            r = o.isoformat()
-            if o.microsecond:
-                r = r[:12]
-            return r
-        elif isinstance(o, (set, frozenset)):
-            return list(o)
-        elif isinstance(o, decimal.Decimal):
-            return str(o)
-        return super(BetterJSONEncoder, self).default(o)
+def better_default_encoder(o):
+    if isinstance(o, uuid.UUID):
+        return o.hex
+    elif isinstance(o, datetime.datetime):
+        return o.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    elif isinstance(o, datetime.date):
+        return o.isoformat()
+    elif isinstance(o, datetime.time):
+        if is_aware(o):
+            raise ValueError("JSON can't represent timezone-aware times.")
+        r = o.isoformat()
+        if o.microsecond:
+            r = r[:12]
+        return r
+    elif isinstance(o, (set, frozenset)):
+        return list(o)
+    elif isinstance(o, decimal.Decimal):
+        return str(o)
+    raise TypeError(repr(o) + ' is not JSON serializable')
+
+
+_default_encoder = JSONEncoder(
+    separators=(',', ':'),
+    ignore_nan=True,
+    skipkeys=False,
+    ensure_ascii=True,
+    check_circular=True,
+    allow_nan=True,
+    indent=None,
+    encoding='utf-8',
+    default=better_default_encoder,
+)
+
+_default_escaped_encoder = JSONEncoderForHTML(
+    separators=(',', ':'),
+    ignore_nan=True,
+    skipkeys=False,
+    ensure_ascii=True,
+    check_circular=True,
+    allow_nan=True,
+    indent=None,
+    encoding='utf-8',
+    default=better_default_encoder,
+)
 
 
 def dumps(value, escape=False, **kwargs):
-    kwargs.setdefault('separators', (',', ':'))
-    kwargs.setdefault('ignore_nan', True)
-    rv = simplejson.dumps(value, cls=BetterJSONEncoder, **kwargs)
     if escape:
-        rv = rv.replace('</', '<\/')
-    return rv
+        return _default_escaped_encoder.encode(value)
+    return _default_encoder.encode(value)
 
 
 def loads(value, **kwargs):
-    return simplejson.loads(value)
+    return _default_decoder.decode(value)

--- a/tests/sentry/utils/json/tests.py
+++ b/tests/sentry/utils/json/tests.py
@@ -30,7 +30,7 @@ class JSONTest(TestCase):
     def test_escape(self):
         res = '<script>alert(1);</script>'
         assert json.dumps(res) == '"<script>alert(1);</script>"'
-        assert json.dumps(res, escape=True) == '"<script>alert(1);<\/script>"'
+        assert json.dumps(res, escape=True) == '"\\u003cscript\\u003ealert(1);\\u003c/script\\u003e"'
 
     def test_inf(self):
         res = float('inf')


### PR DESCRIPTION
Following the simplejson source and their documentation, using a default
kwarg is a bit faster than implementing a subclass of JSONEncoder. We
also cache an instance of our encoder instance to prevent simplejson
from taking the slow path and creating a new encoder object on every
cycle.

This brings performance of `sentry.utils.json` on par with `simplejson`
out of the box. Before this change, our performance was twice as slow.

Before:

```
$ python -m timeit -s 'from sentry.utils import json' -s "data={'foo':'bar'}" 'json.dumps(data)'
100000 loops, best of 3: 6.99 usec per loop
```

After:

```
$ python -m timeit -s 'import simplejson as json' -s "data={'foo':'bar'}" 'json.dumps(data)'
100000 loops, best of 3: 3.96 usec per loop
$ python -m timeit -s 'from sentry.utils import json' -s "data={'foo': 'bar'}" 'json.dumps(data)'
100000 loops, best of 3: 3.81 usec per loop
```

Lastly, while in here, simplejson has a built in HTML encoder version to
properly escape output with JSONEncoderForHTML.
