### PR TITLE
Fix bad proptype in Frame

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -11,7 +11,7 @@ import {t} from '../../../locale';
 const Frame = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired,
-    nextFrameInApp: React.PropTypes.object.bool,
+    nextFrameInApp: React.PropTypes.bool,
     platform: React.PropTypes.string,
     isExpanded: React.PropTypes.bool,
   },


### PR DESCRIPTION
```
Warning: Frame: prop type `nextFrameInApp` is invalid; it must be a function, usually from React.PropTypes.
```

/cc @benvinegar @mitsuhiko 
