### PR TITLE
Expand install wizard to prompt SMTP options

### DIFF
--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -54,7 +54,6 @@ class SystemOptionsEndpoint(Endpoint):
                     'disabledReason': disabled_reason,
                     'isSet': options.isset(k.name),
                     'allowEmpty': bool(k.flags & options.FLAG_ALLOW_EMPTY),
-
                 }
             }
 

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 import sentry
 from sentry import options
+from sentry.utils.email import get_mail_backend
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SuperuserPermission
 
@@ -22,10 +23,26 @@ class SystemOptionsEndpoint(Endpoint):
         else:
             option_list = options.all()
 
+        # This is a fragile, hardcoded list of mail backends, but the likelihood of
+        # someone using something custom here is slim, and even if they did, the worst
+        # is they'd be prompted for SMTP information. These backends are guaranteed
+        # to not need SMTP information.
+        smtp_disabled = get_mail_backend() in (
+            'django.core.mail.backends.dummy.EmailBackend',
+            'django.core.mail.backends.console.EmailBackend',
+            'django.core.mail.backends.locmem.EmailBackend',
+            'django.core.mail.backends.filebased.EmailBackend',
+        )
+
         results = {}
         for k in option_list:
-            # TODO(mattrobenolt): Expose this as a property on Key.
-            diskPriority = bool(k.flags & options.FLAG_PRIORITIZE_DISK and settings.SENTRY_OPTIONS.get(k.name))
+            disabled, disabled_reason = False, None
+
+            if smtp_disabled and k.name[:5] == 'mail.':
+                disabled_reason, disabled = 'smtpDisabled', True
+            elif bool(k.flags & options.FLAG_PRIORITIZE_DISK and settings.SENTRY_OPTIONS.get(k.name)):
+                # TODO(mattrobenolt): Expose this as a property on Key.
+                disabled_reason, disabled = 'diskPriority', True
 
             # TODO(mattrobenolt): help, placeholder, title, type
             results[k.name] = {
@@ -33,9 +50,8 @@ class SystemOptionsEndpoint(Endpoint):
                 'field': {
                     'default': k.default(),
                     'required': bool(k.flags & options.FLAG_REQUIRED),
-                    # We're disabled if the disk has taken priority
-                    'disabled': diskPriority,
-                    'disabledReason': 'diskPriority' if diskPriority else None,
+                    'disabled': disabled,
+                    'disabledReason': disabled_reason,
                     'isSet': options.isset(k.name),
                     'allowEmpty': bool(k.flags & options.FLAG_ALLOW_EMPTY),
 

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -11,11 +11,11 @@ from .store import OptionsStore
 from .manager import OptionsManager
 from .manager import (  # NOQA
     DEFAULT_FLAGS, FLAG_IMMUTABLE, FLAG_NOSTORE, FLAG_STOREONLY,
-    FLAG_REQUIRED, FLAG_PRIORITIZE_DISK, UnknownOption
+    FLAG_REQUIRED, FLAG_PRIORITIZE_DISK, FLAG_ALLOW_EMPTY, UnknownOption
 )
 
 __all__ = (
-    'get', 'set', 'delete', 'register', 'UnknownOption',
+    'get', 'set', 'delete', 'register', 'isset', 'lookup_key', 'UnknownOption',
 )
 
 # See notes in ``runner.initializer`` regarding lazy cache configuration.
@@ -32,6 +32,7 @@ register = default_manager.register
 all = default_manager.all
 filter = default_manager.filter
 isset = default_manager.isset
+lookup_key = default_manager.lookup_key
 
 
 def load_defaults():

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -8,7 +8,8 @@ sentry.options.defaults
 from __future__ import absolute_import, print_function
 
 from sentry.options import (
-    FLAG_IMMUTABLE, FLAG_NOSTORE, FLAG_PRIORITIZE_DISK, FLAG_REQUIRED, register
+    FLAG_IMMUTABLE, FLAG_NOSTORE, FLAG_PRIORITIZE_DISK, FLAG_REQUIRED, FLAG_ALLOW_EMPTY,
+    register,
 )
 from sentry.utils.types import Dict, String
 
@@ -20,7 +21,7 @@ from sentry.utils.types import Dict, String
 register('system.admin-email', flags=FLAG_REQUIRED)
 register('system.databases', type=Dict, flags=FLAG_NOSTORE)
 # register('system.debug', default=False, flags=FLAG_NOSTORE)
-register('system.rate-limit', default=0, flags=FLAG_PRIORITIZE_DISK)
+register('system.rate-limit', default=0, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register('system.secret-key', flags=FLAG_NOSTORE)
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 register('system.url-prefix', ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
@@ -50,12 +51,12 @@ register('dsym.cache-path', type=String, default='/tmp/sentry-dsym-cache')
 
 # Mail
 register('mail.backend', default='smtp', flags=FLAG_NOSTORE)
-register('mail.host', default='localhost', flags=FLAG_PRIORITIZE_DISK)
-register('mail.port', default=25, flags=FLAG_PRIORITIZE_DISK)
-register('mail.username', flags=FLAG_PRIORITIZE_DISK)
-register('mail.password', flags=FLAG_PRIORITIZE_DISK)
-register('mail.use-tls', default=False, flags=FLAG_PRIORITIZE_DISK)
+register('mail.host', default='localhost', flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
+register('mail.port', default=25, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
+register('mail.username', flags=FLAG_REQUIRED | FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register('mail.password', flags=FLAG_REQUIRED | FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register('mail.use-tls', default=False, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
 register('mail.subject-prefix', default='[Sentry] ', flags=FLAG_PRIORITIZE_DISK)
-register('mail.from', default='root@localhost', flags=FLAG_PRIORITIZE_DISK)
+register('mail.from', default='root@localhost', flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
 # register('mail.enable-replies', default=False, flags=FLAG_PRIORITIZE_DISK)
 register('mail.list-namespace', type=String, default='localhost', flags=FLAG_NOSTORE)

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -36,6 +36,8 @@ FLAG_REQUIRED = 1 << 4
 # If the value is defined on disk, use that and don't attempt to fetch from db.
 # This also make the value immutible to changes from web UI.
 FLAG_PRIORITIZE_DISK = 1 << 5
+# If the value is allowed to be empty to be considered valid
+FLAG_ALLOW_EMPTY = 1 << 6
 
 # How long will a cache key exist in local memory before being evicted
 DEFAULT_KEY_TTL = 10
@@ -220,6 +222,11 @@ class OptionsManager(object):
         if default_value is None:
             default = type
             default_value = default()
+
+        # Boolean values need to be set to ALLOW_EMPTY becaues otherwise, "False"
+        # would be treated as a not valid value
+        if default_value is True or default_value is False:
+            flags |= FLAG_ALLOW_EMPTY
 
         settings.SENTRY_DEFAULT_OPTIONS[key] = default_value
 

--- a/src/sentry/static/sentry/app/components/forms/booleanField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/booleanField.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import InputField from './inputField';
+
+export default class BooleanField extends InputField {
+  onChange(e) {
+    this.setState({
+      value: e.target.checked,
+    }, () => {
+      this.props.onChange(this.state.value);
+    });
+  }
+
+  getField() {
+    return (
+      <input id={this.getId()}
+          type={this.getType()}
+          style={{marginLeft: '10px'}}
+          onChange={this.onChange}
+          disabled={this.props.disabled}
+          defaultChecked={this.state.value} />
+    );
+  }
+
+  getType() {
+    return 'checkbox';
+  }
+}

--- a/src/sentry/static/sentry/app/components/forms/index.jsx
+++ b/src/sentry/static/sentry/app/components/forms/index.jsx
@@ -2,3 +2,4 @@ export {default as CheckboxField} from './checkboxField';
 export {default as Form} from './form';
 export {default as EmailField} from './emailField';
 export {default as TextField} from './textField';
+export {default as BooleanField} from './booleanField';

--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -7,9 +7,11 @@ export default class InputField extends FormField {
   constructor(props) {
     super(props);
 
-    this.state.value = (
-      props.value !== '' ? props.value : (props.defaultValue || '')
-    );
+    this.state.value = this.valueFromProps(props);
+  }
+
+  valueFromProps(props) {
+    return props.value !== '' ? props.value : (props.defaultValue || '');
   }
 
   // XXX(dcramer): this comes from TooltipMixin
@@ -40,6 +42,22 @@ export default class InputField extends FormField {
     });
   }
 
+  getId() {
+    return 'wizard-' + this.props.name;
+  }
+
+  getField() {
+    return (
+      <input id={this.getId()}
+          type={this.getType()}
+          className="form-control"
+          placeholder={this.props.placeholder}
+          onChange={this.onChange}
+          disabled={this.props.disabled}
+          value={this.state.value} />
+    );
+  }
+
   render() {
     let className = 'control-group';
     if (this.props.error) {
@@ -48,18 +66,13 @@ export default class InputField extends FormField {
     return (
       <div className={className}>
         <div className="controls">
-          <label className="control-label">{this.props.label}</label>
+          <label htmlFor={this.getId()} className="control-label">{this.props.label}</label>
           {this.props.disabled && this.props.disabledReason &&
             <span className="disabled-indicator tip" title={this.props.disabledReason}>
               <span className="icon-question" />
             </span>
           }
-          <input type={this.getType()}
-                 className="form-control"
-                 placeholder={this.props.placeholder}
-                 onChange={this.onChange.bind(this)}
-                 disabled={this.props.disabled}
-                 value={this.state.value} />
+          {this.getField()}
           {this.props.help &&
             <p className="help-block">{this.props.help}</p>
           }

--- a/src/sentry/static/sentry/app/options.jsx
+++ b/src/sentry/static/sentry/app/options.jsx
@@ -84,6 +84,7 @@ const definitionsMap = _.indexBy(definitions, 'key');
 
 const disabledReasons = {
   diskPriority: 'This setting is defined in config.yml and may not be changed via the web UI.',
+  smtpDisabled: 'SMTP mail has been disabled, so this option is unavailable',
 };
 
 export function getOption(option) {

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -7,7 +7,7 @@ import ApiMixin from '../mixins/apiMixin';
 import ConfigStore from '../stores/configStore';
 import IndicatorStore from '../stores/indicatorStore';
 import LoadingIndicator from '../components/loadingIndicator';
-import {getOption, getOptionField} from '../options';
+import {getOption, getOptionField, getForm} from '../options';
 
 const InstallWizardSettings = React.createClass({
   propTypes: {
@@ -21,8 +21,7 @@ const InstallWizardSettings = React.createClass({
     let requiredOptions = Object.keys(_.pick(options, (option) => {
       return option.field.required && !option.field.disabled;
     }));
-    let missingOptions = new Set(requiredOptions.filter(option => !options[option].value));
-    let fields = [];
+    let missingOptions = new Set(requiredOptions.filter(option => !options[option].field.isSet));
     // This is to handle the initial installation case.
     // Even if all options are filled out, we want to prompt to confirm
     // them. This is a bit of a hack because we're assuming that
@@ -31,12 +30,17 @@ const InstallWizardSettings = React.createClass({
     if (missingOptions.size === 0) {
       missingOptions = new Set(requiredOptions);
     }
+
+    // A mapping of option name to Field object
+    let fields = {};
+
     for (let key of missingOptions) {
       let option = options[key];
-      if (!option.value) {
-        option.value = getOption(key).defaultValue();
+      if (!option.field.isSet) {
+        let o = getOption(key);
+        option.value = o.defaultValue ? o.defaultValue() : '';
       }
-      fields.push(getOptionField(key, this.onFieldChange.bind(this, key), option.value, option.field));
+      fields[key] = getOptionField(key, this.onFieldChange.bind(this, key), option.value, option.field);
       // options is used for submitting to the server, and we dont submit values
       // that are deleted
       if (option.field.disabled) {
@@ -66,7 +70,7 @@ const InstallWizardSettings = React.createClass({
 
   render() {
     let {fields, required, options} = this.state;
-    let formValid = !required.filter(option => !options[option].value).length;
+    let formValid = !required.filter(option => !options[option].field.allowEmpty && !options[option].value).length;
     let disabled = !formValid || this.props.formDisabled;
 
     return (
@@ -74,7 +78,7 @@ const InstallWizardSettings = React.createClass({
         <p>Welcome to Sentry, yo! Complete setup by filling out the required
           configuration.</p>
 
-        {fields}
+        {getForm(fields)}
 
         <div className="form-actions" style={{marginTop: 25}}>
           <button className="btn btn-primary"

--- a/src/sentry/static/sentry/less/setup-wizard.less
+++ b/src/sentry/static/sentry/less/setup-wizard.less
@@ -5,7 +5,8 @@
 
 body.install-wizard {
   #gradient > .horizontal(#9f73c3 , #6875be);
-  height: 100%;
+
+  background-repeat: repeat-y;
 
   .pattern {
     position: fixed;
@@ -28,10 +29,10 @@ body.install-wizard {
   border-radius: 4px;
   box-shadow: 0 5px 30px rgba(0,0,0, .3);
   position: absolute;
-  top: 50%;
+  top: 50px;
   left: 50%;
   margin-left: -300px;
-  margin-top: -250px;
+  margin-bottom: 50px;
 
   h1 {
     .clearfix;

--- a/src/sentry/utils/types.py
+++ b/src/sentry/utils/types.py
@@ -73,9 +73,9 @@ class BoolType(Type):
 
     def convert(self, value):
         value = value.lower()
-        if value in ('y', 'yes', 't', 'true', '1'):
+        if value in ('y', 'yes', 't', 'true', '1', 'on'):
             return True
-        if value in ('n', 'no', 'f', 'false', '0'):
+        if value in ('n', 'no', 'f', 'false', '0', 'off'):
             return False
 
 

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
+from sentry import options
 from sentry.testutils import APITestCase
 
 
@@ -32,3 +33,37 @@ class SystemOptionsTest(APITestCase):
     def test_not_logged_in(self):
         response = self.client.get(self.url)
         assert response.status_code == 401
+        response = self.client.put(self.url)
+        assert response.status_code == 401
+
+    def test_disabled_smtp(self):
+        self.login_as(user=self.user)
+
+        with self.options({'mail.backend': 'smtp'}):
+            response = self.client.get(self.url)
+            assert response.status_code == 200
+            assert response.data['mail.host']['field']['disabled'] is False
+            assert response.data['mail.host']['field']['disabledReason'] is None
+
+        with self.options({'mail.backend': 'dummy'}):
+            response = self.client.get(self.url)
+            assert response.status_code == 200
+            assert response.data['mail.host']['field']['disabled'] is True
+            assert response.data['mail.host']['field']['disabledReason'] == 'smtpDisabled'
+
+    def test_put_unknown_option(self):
+        self.login_as(user=self.user)
+        response = self.client.put(self.url, {
+            'xxx': 'lol',
+        })
+        assert response.status_code == 400
+        assert response.data['error'] == 'unknown_option'
+
+    def test_put_simple(self):
+        self.login_as(user=self.user)
+        assert options.get('mail.host') != 'lolcalhost'
+        response = self.client.put(self.url, {
+            'mail.host': 'lolcalhost',
+        })
+        assert response.status_code == 200
+        assert options.get('mail.host') == 'lolcalhost'

--- a/tests/sentry/utils/test_types.py
+++ b/tests/sentry/utils/test_types.py
@@ -26,12 +26,14 @@ class OptionsTypesTest(TestCase):
         assert Bool('t') is True
         assert Bool('true') is True
         assert Bool('1') is True
+        assert Bool('on') is True
         assert Bool(False) is False
         assert Bool('n') is False
         assert Bool('NO') is False
         assert Bool('f') is False
         assert Bool('false') is False
         assert Bool('0') is False
+        assert Bool('off') is False
         assert Bool() is False
         assert Bool.test(None) is False
         assert Bool(True) is True


### PR DESCRIPTION
See: GH-2799

Changes proposed in this pull request:
- Adds SMTP information into installation wizard
- Splits "system" configs into a separate group from "mail" visually, and maintains visual order on the frontend to make logical sense.
- Adds an `ALLOW_EMPTY` flag to support values that may be falsey (booleans, empty string, etc)

![image](https://cloud.githubusercontent.com/assets/375744/14157147/9abc1f78-f67e-11e5-91f6-9e98c466fa14.png)

@getsentry/ui @getsentry/infrastructure 
