### PR TITLE
Provide short aliases for email backends

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -709,6 +709,12 @@ SENTRY_INTERFACES = {
     'sentry.interfaces.Breadcrumbs': 'sentry.interfaces.breadcrumbs.Breadcrumbs',
 }
 
+SENTRY_EMAIL_BACKEND_ALIASES = {
+    'smtp': 'django.core.mail.backends.smtp.EmailBackend',
+    'dummy': 'django.core.mail.backends.dummy.EmailBackend',
+    'console': 'django.core.mail.backends.console.EmailBackend',
+}
+
 # Should users without superuser permissions be allowed to
 # make projects public
 SENTRY_ALLOW_PUBLIC_PROJECTS = True

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -49,7 +49,7 @@ register('dsym.llvm-symbolizer-path', type=String)
 register('dsym.cache-path', type=String, default='/tmp/sentry-dsym-cache')
 
 # Mail
-register('mail.backend', default='django.core.mail.backends.smtp.EmailBackend', flags=FLAG_NOSTORE)
+register('mail.backend', default='smtp', flags=FLAG_NOSTORE)
 register('mail.host', default='localhost', flags=FLAG_PRIORITIZE_DISK)
 register('mail.port', default=25, flags=FLAG_PRIORITIZE_DISK)
 register('mail.username', flags=FLAG_PRIORITIZE_DISK)

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -177,6 +177,7 @@ YAML_CONFIG_TEMPLATE = u"""\
 # Mail Server #
 ###############
 
+# mail.backend: 'smtp'  # Use dummy if you want to disable email entirely
 # mail.host: 'localhost'
 # mail.port: 25
 # mail.username: ''

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -358,12 +358,20 @@ def send_messages(messages, fail_silently=False):
     return connection.send_messages(messages)
 
 
+def get_mail_backend():
+    backend = options.get('mail.backend')
+    try:
+        return settings.SENTRY_EMAIL_BACKEND_ALIASES[backend]
+    except KeyError:
+        return backend
+
+
 def get_connection(fail_silently=False):
     """
     Gets an SMTP connection using our OptionsStore
     """
     return _get_connection(
-        backend=options.get('mail.backend'),
+        backend=get_mail_backend(),
         host=options.get('mail.host'),
         port=options.get('mail.port'),
         username=options.get('mail.username'),

--- a/tests/sentry/utils/email/tests.py
+++ b/tests/sentry/utils/email/tests.py
@@ -11,7 +11,7 @@ from sentry.models import GroupEmailThread, User, UserOption
 from sentry.testutils import TestCase
 from sentry.utils.email import (
     ListResolver, MessageBuilder, default_list_type_handlers,
-    get_from_email_domain
+    get_from_email_domain, get_mail_backend,
 )
 
 
@@ -310,3 +310,16 @@ class MiscTestCase(TestCase):
 
         with self.options({'mail.from': 'garbage'}):
             assert get_from_email_domain() == 'garbage'
+
+    def test_get_mail_backend(self):
+        with self.options({'mail.backend': 'smtp'}):
+            assert get_mail_backend() == 'django.core.mail.backends.smtp.EmailBackend'
+
+        with self.options({'mail.backend': 'dummy'}):
+            assert get_mail_backend() == 'django.core.mail.backends.dummy.EmailBackend'
+
+        with self.options({'mail.backend': 'console'}):
+            assert get_mail_backend() == 'django.core.mail.backends.console.EmailBackend'
+
+        with self.options({'mail.backend': 'something.else'}):
+            assert get_mail_backend() == 'something.else'


### PR DESCRIPTION
Changes proposed in this pull request:
- Provides short aliases for email backends to separate from Django in our docs

@getsentry/infrastructure 
