### PR TITLE
Add documentation around queue monitoring

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ running on your own infrastructure.
    internal-metrics
    performance
    cli/index
-   health-checks
+   monitoring
    beacon
    plugins
    faq

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -38,3 +38,32 @@ That said, we also expose additional checks via the same endpoint by passing
          with your configuration or a serious backlog in tasks."
       ]
     }
+
+
+Queue Monitoring
+================
+
+The health of Sentry relies very heavily on passing messages through our queue
+and if the queue is backlogged, we will notify you through a message in the UI
+if you are a superuser.
+
+To monitor the health actively with an external tool such as collectd or Diamond,
+Sentry provides a CLI tool that returns machine parsable output.
+
+.. code-block:: bash
+
+    $ sentry queues list
+    alerts 0
+    auth 0
+    cleanup 0
+    counters-0 0
+    default 0
+    digests.delivery 0
+    digests.scheduling 0
+    email 0
+    events 34
+    merge 0
+    options 0
+    search 0
+    triggers-0 0
+    update 0


### PR DESCRIPTION
See GH-2809

Changes proposed in this pull request:
- Add documentation to support the current iteration of queue monitoring
- Moves `docs/health-check` into a more general, `docs/monitoring`

@getsentry/infrastructure 
