### PR TITLE
Support persistent dismissal of non-ephemeral alerts.

### DIFF
--- a/src/sentry/api/endpoints/system_health.py
+++ b/src/sentry/api/endpoints/system_health.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import itertools
+from hashlib import md5
 
 from rest_framework.response import Response
 
@@ -17,6 +18,7 @@ class SystemHealthEndpoint(Endpoint):
         return Response({
             'problems': map(
                 lambda problem: {
+                    'id': md5(problem.message).hexdigest(),
                     'message': problem.message,
                     'severity': problem.severity,
                     'url': problem.url,

--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -5,23 +5,28 @@ import {t} from '../locale';
 
 const AlertMessage = React.createClass({
   propTypes: {
-    className: React.PropTypes.string,
-    id: React.PropTypes.number.isRequired,
-    message: React.PropTypes.string.isRequired,
-    type: React.PropTypes.string,
-    url: React.PropTypes.string
+    alert: React.PropTypes.shape({
+      id: React.PropTypes.string,
+      message: React.PropTypes.string.isRequired,
+      type: React.PropTypes.oneOf([
+        'success',
+        'error',
+        'warning'
+      ]),
+      url: React.PropTypes.string
+    })
   },
 
   mixins: [PureRenderMixin],
 
   closeAlert: function() {
-    AlertActions.closeAlert(this.props.id);
+    AlertActions.closeAlert(this.props.alert);
   },
 
   render: function() {
-    let className = this.props.className || 'alert';
-    if (this.props.type !== '') {
-      className += ' alert-' + this.props.type;
+    let className = 'alert';
+    if (this.props.alert.type !== '') {
+      className += ' alert-' + this.props.alert.type;
     }
 
     return (
@@ -32,9 +37,9 @@ const AlertMessage = React.createClass({
             <span aria-hidden="true">&times;</span>
           </button>
           <span className="icon"></span>
-          {this.props.url
-            ? <a href={this.props.url}>{this.props.message}</a>
-            : this.props.message}
+          {this.props.alert.url
+            ? <a href={this.props.alert.url}>{this.props.alert.message}</a>
+            : this.props.alert.message}
         </div>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/alerts.jsx
+++ b/src/sentry/static/sentry/app/components/alerts.jsx
@@ -20,8 +20,8 @@ const Alerts = React.createClass({
   render() {
     return (
       <div {...this.props}>
-        {this.state.alerts.map(function(alert, key) {
-           return <AlertMessage id={alert.id} key={key} type={alert.type} message={alert.message} url={alert.url} />;
+        {this.state.alerts.map(function(alert) {
+           return <AlertMessage alert={alert} key={alert.key} />;
         })}
       </div>
     );

--- a/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
@@ -4,8 +4,6 @@ import AlertActions from '../actions/alertActions';
 import ApiMixin from '../mixins/apiMixin';
 import {t} from '../locale';
 
-const ERR_JOIN = 'There was an error while trying to join the team.';
-
 const MissingProjectMembership = React.createClass({
   propTypes: {
     organization: React.PropTypes.object.isRequired,
@@ -43,7 +41,10 @@ const MissingProjectMembership = React.createClass({
           loading: false,
           error: true
         });
-        AlertActions.addAlert(ERR_JOIN, 'error');
+        AlertActions.addAlert({
+            message: 'There was an error while trying to join the team.',
+            type: 'error'
+        });
       }
     });
   },

--- a/src/sentry/static/sentry/app/stores/alertStore.jsx
+++ b/src/sentry/static/sentry/app/stores/alertStore.jsx
@@ -1,5 +1,6 @@
 import Reflux from 'reflux';
 import AlertActions from '../actions/alertActions';
+import {getItem, setItem} from '../utils/localStorage';
 
 const AlertStore = Reflux.createStore({
   listenables: AlertActions,
@@ -9,34 +10,43 @@ const AlertStore = Reflux.createStore({
     this.count = 0;
   },
 
-  onAddAlert(message, type, expireAfter, url) {
+  getMutedKey(alert) {
+    return `alerts:${alert.id}:muted`;
+  },
+
+  onAddAlert(alert) {
+    if (alert.id !== void 0) {
+      if (getItem(this.getMutedKey(alert)) !== null) {
+        return;
+      }
+    } else {
+      if (alert.expireAfter === void 0) {
+        alert.expireAfter = 5000;
+      }
+    }
+
+    if (alert.expireAfter) {
+      window.setTimeout(() => {
+        this.onCloseAlert(alert);
+      }, alert.expireAfter);
+    }
+
+    alert.key = this.count++;
+
     // intentionally recreate array via concat because of Reflux
     // "bug" where React components are given same reference to tracked
     // data objects, and don't *see* that values have changed
-    let alertId = this.count++;
-
-    this.alerts = this.alerts.concat([{
-      id: alertId,
-      message: message,
-      type: type,
-      url: url
-    }]);
-
-    if (typeof expireAfter === 'undefined') {
-      expireAfter = 5000;
-    }
-    if (expireAfter) {
-      window.setTimeout(() => {
-        this.onCloseAlert(alertId);
-      }, expireAfter);
-    }
-
+    this.alerts = this.alerts.concat([alert]);
     this.trigger(this.alerts);
   },
 
-  onCloseAlert(id) {
+  onCloseAlert(alert) {
+    if (alert.id !== void 0) {
+      setItem(this.getMutedKey(alert), +new Date());
+    }
+
     // TODO(dcramer): we need some animations here for closing alerts
-    this.alerts = this.alerts.filter(item => item.id !== id);
+    this.alerts = this.alerts.filter(item => alert !== item);
     this.trigger(this.alerts);
   },
 });

--- a/src/sentry/static/sentry/app/stores/alertStore.jsx
+++ b/src/sentry/static/sentry/app/stores/alertStore.jsx
@@ -1,6 +1,7 @@
 import Reflux from 'reflux';
 import AlertActions from '../actions/alertActions';
 import {getItem, setItem} from '../utils/localStorage';
+import {defined} from '../utils';
 
 const AlertStore = Reflux.createStore({
   listenables: AlertActions,
@@ -10,17 +11,27 @@ const AlertStore = Reflux.createStore({
     this.count = 0;
   },
 
-  getMutedKey(alert) {
-    return `alerts:${alert.id}:muted`;
-  },
-
   onAddAlert(alert) {
-    if (alert.id !== void 0) {
-      if (getItem(this.getMutedKey(alert)) !== null) {
-        return;
+    if (defined(alert.id)) {
+      let expirations = getItem('alerts:muted');
+      if (defined(expirations)) {
+        expirations = JSON.parse(expirations);
+
+        // Remove any objects that have passed their mute duration.
+        let now = Math.floor(new Date() / 1000);
+        for (let key in expirations) {
+          if (expirations.hasOwnProperty(key) && expirations[key] < now) {
+            delete expirations[key];
+          }
+        }
+        setItem('alerts:muted', JSON.stringify(expirations));
+
+        if (expirations.hasOwnProperty(alert.id)) {
+          return;
+        }
       }
     } else {
-      if (alert.expireAfter === void 0) {
+      if (defined(alert.expireAfter)) {
         alert.expireAfter = 5000;
       }
     }
@@ -40,9 +51,17 @@ const AlertStore = Reflux.createStore({
     this.trigger(this.alerts);
   },
 
-  onCloseAlert(alert) {
-    if (alert.id !== void 0) {
-      setItem(this.getMutedKey(alert), +new Date());
+  onCloseAlert(alert, duration = 60 * 60 * 7 * 24) {
+    if (defined(alert.id) && defined(duration)) {
+      let expiry = Math.floor(new Date() / 1000) + duration;
+      let expirations = getItem('alerts:muted');
+      if (defined(expirations)) {
+        expirations = JSON.parse(expirations);
+      } else {
+        expirations = {};
+      }
+      expirations[alert.id] = expiry;
+      setItem('alerts:muted', JSON.stringify(expirations));
     }
 
     // TODO(dcramer): we need some animations here for closing alerts

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -134,7 +134,10 @@ const AdminSettings = React.createClass({
         this.setState({
           submitInProgress: false,
         });
-        AlertActions.addAlert(t('Your changes were saved, and will propagate to services shortly.'), 'success');
+        AlertActions.addAlert({
+            message: t('Your changes were saved, and will propagate to services shortly.'),
+            type: 'success'
+        });
       },
       error: () => {
         this.setState({

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -54,12 +54,12 @@ const App = React.createClass({
       success: (data) => {
         if (data && data.problems) {
           data.problems.forEach(problem => {
-            AlertActions.addAlert(
-              problem.message,
-              getAlertTypeForProblem(problem),
-              0,
-              problem.url
-            );
+            AlertActions.addAlert({
+              id: problem.id,
+              message: problem.message,
+              type: getAlertTypeForProblem(problem),
+              url: problem.url
+            });
           });
         }
       },
@@ -67,7 +67,10 @@ const App = React.createClass({
     });
 
     ConfigStore.get('messages').forEach((msg) => {
-      AlertActions.addAlert(msg.message, msg.level);
+      AlertActions.addAlert({
+        message: msg.message,
+        type: msg.level
+      });
     });
   },
 

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
@@ -46,10 +46,10 @@ const AllTeamsRow = React.createClass({
           loading: false,
           error: true
         });
-        AlertActions.addAlert(
-          t('There was an error while trying to join the team.'),
-          'error'
-        );
+        AlertActions.addAlert({
+          message: t('There was an error while trying to join the team.'),
+          type: 'error'
+        });
       }
     });
   },
@@ -74,10 +74,10 @@ const AllTeamsRow = React.createClass({
           loading: false,
           error: true
         });
-        AlertActions.addAlert(
-          t('There was an error while trying to leave the team.'),
-          'error'
-        );
+        AlertActions.addAlert({
+          message: t('There was an error while trying to leave the team.'),
+          type: 'error'
+        });
       }
     });
   },

--- a/tests/js/spec/stores/alertStore.spec.js
+++ b/tests/js/spec/stores/alertStore.spec.js
@@ -7,7 +7,7 @@ describe('AlertStore', function () {
   });
 
   describe('onAddAlert()', function () {
-    it('should add a new alert with incrementing id', function () {
+    it('should add a new alert with incrementing key', function () {
       AlertStore.onAddAlert({
         message: 'Bzzzzzzp *crash*',
         type: 'error'
@@ -19,24 +19,30 @@ describe('AlertStore', function () {
       });
 
       expect(AlertStore.alerts.length).to.eql(2);
-      expect(AlertStore.alerts[0].id).to.eql(0);
-      expect(AlertStore.alerts[1].id).to.eql(1);
+      expect(AlertStore.alerts[0].key).to.eql(0);
+      expect(AlertStore.alerts[1].key).to.eql(1);
     });
   });
 
   describe('onCloseAlert()', function () {
-    it('should remove alert with given id', function () {
+    it('should remove alert', function () {
       AlertStore.alerts = [
-        {id: 1, message: 'foo', type: 'error '},
-        {id: 2, message: 'bar', type: 'error '},
-        {id: 3, message: 'baz', type: 'error '},
+        {key: 1, message: 'foo', type: 'error'},
+        {key: 2, message: 'bar', type: 'error'},
+        {key: 3, message: 'baz', type: 'error'},
       ];
 
-      AlertStore.onCloseAlert(2);
+      AlertStore.onCloseAlert(AlertStore.alerts[1]);
 
       expect(AlertStore.alerts.length).to.eql(2);
-      expect(AlertStore.alerts[0].id).to.eql(1);
-      expect(AlertStore.alerts[1].id).to.eql(3);
+      expect(AlertStore.alerts[0].key).to.eql(1);
+      expect(AlertStore.alerts[1].key).to.eql(3);
+    });
+    it('should persist removal of persistent alerts', function () {
+      let alert = {key: 1, id: 'test', message: 'foo', type: 'error'};
+      AlertStore.onCloseAlert(alert);
+      AlertStore.onAddAlert(alert);
+      expect(AlertStore.alerts.length).to.eql(0);
     });
   });
 });


### PR DESCRIPTION
References GH-2911.

This adds the `id` attribute to problems returned by the system health endpoint, which is then associated with the alert rendered for that problem. When the alert for a problem is dismissed, the ID is stored in local storage and prevents the alert from being admitted to the `AlertStore` again.

@getsentry/ui  
