### PR TITLE
Vertically align default event types in stream

### DIFF
--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -297,6 +297,16 @@
       }
     }
 
+    &.type-default {
+      .event-assignee, .group-list, .event-graph {
+        padding-top: 20px;
+      }
+
+      .event-count, .event-users {
+        padding-top: 22px;
+      }
+    }
+
     &:first-child {
       .event-cell{
         border-top: 0;

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -1194,6 +1194,12 @@
     padding-top: 33px !important;
   }
 
+  .type-default {
+    .event-users, .event-count {
+      padding-top: 22px !important;
+    }
+  }
+
   .search {
     width: 100% !important;
   }


### PR DESCRIPTION
Vertically aligns default 'event-type' items (the ones without messages).

![screen shot 2016-03-30 at 5 48 35 pm](https://cloud.githubusercontent.com/assets/30713/14162303/b1c655d2-f69f-11e5-8ce5-351c2953f66b.png)

cc @dcramer @getsentry/ui
