### PR TITLE
Bump version of kombu to fix work with sockets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ install_requires = [
     'exam>=0.5.1',
     'hiredis>=0.1.0,<0.2.0',
     'ipaddr>=2.1.11,<2.2.0',
-    'kombu==3.0.30',
+    'kombu==3.0.34',
     'lxml>=3.4.1',
     'mock>=0.8.0,<1.1',
     'petname>=1.7,<1.8',


### PR DESCRIPTION
Sentry not working with kombu 3.0.30 with Linux sockets. From [changelog kombu](https://github.com/celery/kombu/blob/master/Changelog#L120):

> 3.0.31
> - Redis: Fixed bug introduced in 3.0.30 where socket was prematurely
>   disconnected.
> 
> 3.0.32
> - Redis: Fixed bug introduced in 3.0.31 where the redis transport always
>   connects to localhost, regardless of host setting.\
> 
> 3.0.34
> - Redis: Connection.as_uri() returned malformed URLs when the
>   `redis+socket` scheme was ised (Issue celery/celery#2995).

Changes proposed in this pull request:
- Bump version of kombu to 3.0.34

@getsentry/team
