### PR TITLE
Visual tweaks to event types

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -75,11 +75,7 @@ const StreamGroupHeader = React.createClass({
       <div>
         <h3 className="truncate">
           <Link to={`/${orgId}/${projectId}/issues/${data.id}/`}>
-            {this.props.hasEventTypes ?
-              <span className="event-type truncate">{data.type}</span>
-            :
-              <span className="error-level truncate">{data.level}</span>
-            }
+            <span className="error-level truncate">{data.level}</span>
             <span className="icon icon-soundoff" />
             <span className="icon icon-star-solid" />
             {this.getTitle()}

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -153,11 +153,7 @@ const GroupHeader = React.createClass({
               {this.getTitle(hasEventTypes)}
             </h3>
             <div className="event-message">
-              {hasEventTypes ?
-                <span className="event-type">{group.type}</span>
-              :
-                <span className="error-level">{group.level}</span>
-              }
+              <span className="error-level">{group.level}</span>
               {group.shortId &&
                 <ShortId shortId={group.shortId} />
               }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -17,6 +17,11 @@
     white-space: nowrap;
     overflow: hidden;
     line-height: 1.1;
+
+    em {
+      font-style: normal;
+    }
+
   }
 
   .short-id {

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -369,6 +369,10 @@
         margin-right: 5px;
       }
 
+      em {
+        font-style: normal;
+      }
+
       a {
         color: @gray-darker;
 
@@ -705,6 +709,10 @@
         width: auto;
         overflow: hidden;
         padding-left: 1px;
+      }
+
+      em {
+        font-style: normal;
       }
     }
 


### PR DESCRIPTION
- Revert to rendering event level
- Remove italicized text from culprits

![screenshot 2016-03-31 11 46 30](https://cloud.githubusercontent.com/assets/23610/14187114/4f68752c-f736-11e5-9b1a-5706b5a758d8.png)
![screenshot 2016-03-31 11 46 54](https://cloud.githubusercontent.com/assets/23610/14187116/5077afbe-f736-11e5-97f0-bb86c71dd108.png)

@getsentry/ui
