### PR TITLE
Largest value = darkest color in tag distribution charts

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1458,19 +1458,19 @@ table.integrations {
       border-bottom-right-radius: 3px;
     }
 
-    &:nth-child(1) {
+    &:nth-child(4) {
       background-color: rgba(135, 146, 163, 0.2);
     }
 
-    &:nth-child(2) {
+    &:nth-child(3) {
       background-color: rgba(135, 146, 163, 0.4);
     }
 
-    &:nth-child(3) {
+    &:nth-child(2) {
       background-color: rgba(135, 146, 163, 0.6);
     }
 
-    &:nth-child(4) {
+    &:nth-child(1) {
       background-color: rgba(135, 146, 163, 0.8);
     }
   }


### PR DESCRIPTION
Addresses an old concern brought up today by a customer.
### Changes proposed in this pull request:

**From this**

![screen shot 2016-03-31 at 11 51 34 am](https://cloud.githubusercontent.com/assets/30713/14190311/f0377560-f746-11e5-99f2-a09112d2a88c.png)

**to this**

![screen shot 2016-03-31 at 11 51 06 am](https://cloud.githubusercontent.com/assets/30713/14190314/f380cf82-f746-11e5-82e9-be8064dbad36.png)

@getsentry/ui
