### PR TITLE
Make sure InvalidFrame contains all the methods that exist on a regular Frame

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -199,10 +199,31 @@ def handle_nan(value):
 
 class InvalidFrame(Interface):
     def __init__(self, reason):
-        self._data = {'errors': [reason]}
+        self._data = {
+            'in_app': False,
+            'vars': None,
+            'pre_context': None,
+            'post_context': None,
+            'errors': [reason],
+        }
 
     def get_hash(self):
         return ['<invalid_frame>']
+
+    def get_culprit_string(self, platform=None):
+        return ''
+
+    def is_url(self):
+        return False
+
+    def is_caused_by(self):
+        return False
+
+    def is_unhashable_module(self):
+        return False
+
+    def is_unhashable_function(self):
+        return False
 
 
 class Frame(Interface):

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -434,6 +434,15 @@ class StacktraceTest(TestCase):
             {'x': '<nan>'},
         )
 
+    def test_invalid_frame_looks_like_frame(self):
+        frame = InvalidFrame('oops')
+        assert frame.get_hash() == ['<invalid_frame>']
+        assert frame.get_culprit_string() == ''
+        assert frame.is_url() is False
+        assert frame.is_caused_by() is False
+        assert frame.is_unhashable_module() is False
+        assert frame.is_unhashable_function() is False
+
 
 class SlimFrameDataTest(TestCase):
     def test_under_max(self):

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -564,6 +564,15 @@ class EventManagerTest(TransactionTestCase):
             'message': "Blocked 'script' from 'example.com'",
         }
 
+    def test_invalid_frame(self):
+        manager = EventManager(self.make_event(**{
+            'sentry.interfaces.Stacktrace': {
+                'frames': [{}],
+            },
+        }))
+        manager.normalize()
+        manager.save(self.project.id)
+
 
 class GetHashesFromEventTest(TestCase):
     @patch('sentry.interfaces.stacktrace.Stacktrace.compute_hashes')


### PR DESCRIPTION
Fixes SENTRY-10B

https://app.getsentry.com/sentry/sentry/issues/120372018/

Also backfilled an integration test that surfaced this bug. :(

@getsentry/infrastructure 
