### PR TITLE
Add documentation for new warnings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ running on your own infrastructure.
    monitoring
    beacon
    plugins
+   warnings
    faq
 
 .. sentry:edition:: self, on-premise

--- a/docs/warnings.rst
+++ b/docs/warnings.rst
@@ -1,0 +1,109 @@
+System Warnings
+===============
+
+Deprecated Settings
+-------------------
+
+Beginning with Sentry 8.0 configuration settings have started migrating from
+the original ``sentry.conf.py`` over into a new format ``config.yml``. We refer
+to the new format as ``SENTRY_OPTIONS``.
+
+For example, ``SENTRY_OPTIONS["system.admin-email"]`` means, put
+``system.admin-email`` into ``config.yml``.
+
+In Sentry 8.3, we have begun deprecating some settings from the old ``sentry.conf.py``
+and will soon be only accepting the new values from the new ``config.yml`` file.
+
+Historically, ``SENTRY_CONF`` or ``--config`` was pointed directly to your
+``sentry.conf.py``, such as::
+
+    $ SENTRY_CONF=/etc/sentry/sentry.conf.py sentry start
+
+Now, ``SENTRY_CONF`` should be pointed to the parent directory that contains both
+the python file and the yaml file. ``sentry init`` will generate the right
+structure needed for the future.::
+
+    $ SENTRY_CONF=/etc/sentry sentry start
+
+The following will be a simple mapping of old (``sentry.conf.py``) keys to new
+(``config.yml``). Old settings should be completely removed.
+
+General
+~~~~~~~
+
+.. describe:: SENTRY_ADMIN_EMAIL
+
+    ::
+
+        system.admin-email: 'sentry@example.com'
+
+.. describe:: SENTRY_URL_PREFIX
+
+    ::
+
+        system.url-prefix: 'http://example.com'
+
+.. describe:: SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE
+
+    ::
+
+        system.rate-limit: 10
+
+.. describe:: SECRET_KEY
+
+    ::
+
+        system.secret-key: 'abc123'
+
+
+Mail
+~~~~
+
+.. describe:: EMAIL_BACKEND
+
+    ::
+
+        mail.backend: 'smtp'
+
+
+.. describe:: EMAIL_HOST
+
+    ::
+
+        mail.host: 'localhost'
+
+.. describe:: EMAIL_PORT
+
+    ::
+
+        mail.port: 25
+
+.. describe:: EMAIL_HOST_USER
+
+    ::
+
+        mail.username: 'sentry'
+
+.. describe:: EMAIL_HOST_PASSWORD
+
+    ::
+
+        mail.password: 'nobodywillguessthisone'
+
+.. describe:: EMAIL_USE_TLS
+
+    ::
+
+        mail.use-tls: true
+
+.. describe:: SERVER_EMAIL
+
+    ::
+
+        mail.from: 'sentry@example.com'
+
+.. describe:: EMAIL_SUBJECT_PREFIX
+
+    ::
+
+        mail.subject-prefix: '[Sentry] '

--- a/src/sentry/templates/sentry/admin/status/warnings.html
+++ b/src/sentry/templates/sentry/admin/status/warnings.html
@@ -10,6 +10,7 @@
 {% block main %}
     <h3>System Warnings</h3>
     {% if groups or warnings %}
+        <p><a href="https://docs.getsentry.com/on-premise/server/warnings/">Check out our guide</a> for more information on how to resolve these issues.</p>
         {% for group, items in groups %}
             <h4>{{ group }}</h4>
             <ul>


### PR DESCRIPTION
See GH-2911

Changes proposed in this pull request:
- Adds System Warnings page to docs
- Links to page from warnings page

I've punted on changing verbiage around usage of `SENTRY_OPTIONS` and just opted to explaining it in the documentation which should make it pretty clear. If there are questions, we can update.

After getting this out there, we can always improve the docs after release.

@tkaemming 
