### PR TITLE
Fixed exception messages not wrapping correctly

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -943,6 +943,7 @@
 .exc-message {
   margin: 15px 0;
   word-wrap: break-word;
+  white-space: pre-wrap;
   color: @gray-darker;
   padding: 0;
   background: none;


### PR DESCRIPTION
This fixes exception messages not wrapping correctly in the stacktrace.
It's caused by pre elements requireing a different whitespace setting
in css.  I checked for similar cases in our files and I think this is
the only one that needs changing.
