### PR TITLE
Remove zip usage in serializers

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -54,13 +54,15 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
                 team__in=team_list,
             ).order_by('name'))
 
-        team_map = dict(
-            (t.id, c) for (t, c) in zip(team_list, serialize(team_list, request.user)),
-        )
+        team_map = {
+            d['id']: d
+            for d in serialize(team_list, request.user)
+        }
 
         context = []
         for project, pdata in zip(project_list, serialize(project_list, request.user)):
-            pdata['team'] = team_map[project.team_id]
+            assert str(project.id) == pdata['id']
+            pdata['team'] = team_map[str(project.team_id)]
             context.append(pdata)
 
         return Response(context)

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -12,7 +12,9 @@ def serialize(objects, user=None, serializer=None):
 
     if not objects:
         return objects
-    elif not isinstance(objects, (list, tuple)):
+    # sets aren't predictable, so generally you should use a list, but it's
+    # supported out of convenience
+    elif not isinstance(objects, (list, tuple, set, frozenset)):
         return serialize([objects], user=user, serializer=serializer)[0]
 
     # elif isinstance(obj, dict):

--- a/src/sentry/api/serializers/models/groupseen.py
+++ b/src/sentry/api/serializers/models/groupseen.py
@@ -7,16 +7,15 @@ from sentry.models import GroupSeen
 @register(GroupSeen)
 class GroupSeenSerializer(Serializer):
     def get_attrs(self, item_list, user):
-        user_list = [i.user for i in item_list]
         user_map = {
-            u: d
-            for u, d in zip(user_list, serialize(user_list, user))
+            d['id']: d
+            for d in serialize(set(i.user for i in item_list), user)
         }
 
         result = {}
         for item in item_list:
             result[item] = {
-                'user': user_map[item.user],
+                'user': user_map[str(item.user_id)],
             }
         return result
 

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -16,17 +16,15 @@ class ReleaseSerializer(Serializer):
             )
         }
         owners = {
-            k: v
-            for k, v in zip(
-                item_list, serialize([i.owner for i in item_list], user)
-            )
+            d['id']: d
+            for d in serialize(set(i.owner for i in item_list if i.owner_id), user)
         }
 
         result = {}
         for item in item_list:
             result[item] = {
                 'tag': tags.get(item.version),
-                'owner': owners[item],
+                'owner': owners[str(item.owner_id)] if item.owner_id else None,
             }
         return result
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -22,14 +22,16 @@ class UserReportSerializer(Serializer):
 class ProjectUserReportSerializer(UserReportSerializer):
     def get_attrs(self, item_list, user):
         # TODO(dcramer); assert on relations
-        groups = dict(zip(
-            item_list,
-            serialize([i.group for i in item_list], user)
-        ))
+        groups = {
+            d['id']: d
+            for d in serialize(set(i.group for i in item_list if i.group_id), user)
+        }
 
         attrs = {}
         for item in item_list:
-            attrs[item] = {'group': groups[item]}
+            attrs[item] = {
+                'group': groups[str(item.group_id)] if item.group_id else None,
+            }
         return attrs
 
     def serialize(self, obj, attrs, user):


### PR DESCRIPTION
This simplifies some code/memory overhead.

@getsentry/api @getsentry/infrastructure
