### PR TITLE
Handle GroupTagKey and GroupTagValue when merging issues

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -153,13 +153,15 @@ def _rehash_group_events(group, limit=100):
 
 def merge_objects(models, group, new_group, limit=1000,
                   logger=None):
+    from sentry.models import GroupTagKey, GroupTagValue
 
     has_more = False
     for model in models:
         if logger is not None:
             logger.info('Merging %r objects where %r into %r', model, group,
                         new_group)
-        has_group = 'group' in model._meta.get_all_field_names()
+        all_fields = model._meta.get_all_field_names()
+        has_group = 'group' in all_fields
         if has_group:
             queryset = model.objects.filter(group=group)
         else:
@@ -179,7 +181,26 @@ def merge_objects(models, group, new_group, limit=1000,
                 delete = True
             else:
                 delete = False
+
             if delete:
+                # Before deleting, we want to merge in counts
+                try:
+                    if model == GroupTagKey:
+                        with transaction.atomic(using=router.db_for_write(model)):
+                            model.objects.filter(
+                                group=new_group,
+                                key=obj.key,
+                            ).update(values_seen=F('values_seen') + obj.values_seen)
+                    elif model == GroupTagValue:
+                        with transaction.atomic(using=router.db_for_write(model)):
+                            model.objects.filter(
+                                group=new_group,
+                                key=obj.key,
+                                value=obj.value,
+                            ).update(times_seen=F('times_seen') + obj.times_seen)
+                except DataError:
+                    # it's possible to hit an out of range value for counters
+                    pass
                 obj.delete()
             has_more = True
 

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.tasks.merge import merge_group, rehash_group_events
-from sentry.models import Event, Group, GroupRedirect, GroupTagKey
+from sentry.models import Event, Group, GroupRedirect, GroupTagKey, GroupTagValue
 from sentry.testutils import TestCase
 
 
@@ -68,17 +68,43 @@ class MergeGroupTest(TestCase):
                 key='foo',
                 values_seen=5,
             )
+            GroupTagValue.objects.create(
+                project=project,
+                group=group,
+                key='key1',
+                times_seen=1,
+            )
+            GroupTagValue.objects.create(
+                project=project,
+                group=group,
+                key='key2',
+                times_seen=5,
+            )
 
         with self.tasks():
             merge_group(groups[0].id, groups[1].id)
 
         assert not Group.objects.filter(id=groups[0].id).exists()
         assert not GroupTagKey.objects.filter(group_id=groups[0].id).exists()
+        assert not GroupTagValue.objects.filter(group_id=groups[0].id).exists()
 
         assert GroupTagKey.objects.get(
             group_id=groups[1].id,
             key='sentry:user',
         ).values_seen == 2
+        assert GroupTagKey.objects.get(
+            group_id=groups[1].id,
+            key='foo',
+        ).values_seen == 10
+
+        assert GroupTagValue.objects.get(
+            group_id=groups[1].id,
+            key='key1',
+        ).times_seen == 2
+        assert GroupTagValue.objects.get(
+            group_id=groups[1].id,
+            key='key2',
+        ).times_seen == 10
 
 
 class RehashGroupEventsTest(TestCase):

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.tasks.merge import merge_group, rehash_group_events
-from sentry.models import Event, Group, GroupRedirect
+from sentry.models import Event, Group, GroupRedirect, GroupTagKey
 from sentry.testutils import TestCase
 
 
@@ -50,6 +50,35 @@ class MergeGroupTest(TestCase):
         assert GroupRedirect.objects.filter(
             group_id=groups[2].id,
         ).count() == 2
+
+    def test_merge_updates_tag_values_seen(self):
+        project = self.create_project()
+        groups = [self.create_group(project) for _ in xrange(0, 2)]
+
+        for group in groups:
+            GroupTagKey.objects.create(
+                project=project,
+                group=group,
+                key='sentry:user',
+                values_seen=1,
+            )
+            GroupTagKey.objects.create(
+                project=project,
+                group=group,
+                key='foo',
+                values_seen=5,
+            )
+
+        with self.tasks():
+            merge_group(groups[0].id, groups[1].id)
+
+        assert not Group.objects.filter(id=groups[0].id).exists()
+        assert not GroupTagKey.objects.filter(group_id=groups[0].id).exists()
+
+        assert GroupTagKey.objects.get(
+            group_id=groups[1].id,
+            key='sentry:user',
+        ).values_seen == 2
 
 
 class RehashGroupEventsTest(TestCase):


### PR DESCRIPTION
Fixes GH-2804

This reverts commit ef9986a9563a6cc44f9a7c3aca15cc3e67dfb404.

@getsentry/api 
