### PR TITLE
ES6 classes in React don't autobind (fix saved searches)

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -52,7 +52,7 @@ export default class InputField extends FormField {
           type={this.getType()}
           className="form-control"
           placeholder={this.props.placeholder}
-          onChange={this.onChange}
+          onChange={this.onChange.bind(this)}
           disabled={this.props.disabled}
           value={this.state.value} />
     );


### PR DESCRIPTION
@mattrobenolt @macqueen
