### PR TITLE
Don't require SMTP keys to be set when backend doesn't require them

### DIFF
--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 import sentry
 from sentry import options
-from sentry.utils.email import get_mail_backend
+from sentry.utils.email import is_smtp_enabled
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SuperuserPermission
 
@@ -23,17 +23,7 @@ class SystemOptionsEndpoint(Endpoint):
         else:
             option_list = options.all()
 
-        # This is a fragile, hardcoded list of mail backends, but the likelihood of
-        # someone using something custom here is slim, and even if they did, the worst
-        # is they'd be prompted for SMTP information. These backends are guaranteed
-        # to not need SMTP information.
-        smtp_disabled = get_mail_backend() in (
-            'django.core.mail.backends.dummy.EmailBackend',
-            'django.core.mail.backends.console.EmailBackend',
-            'django.core.mail.backends.locmem.EmailBackend',
-            'django.core.mail.backends.filebased.EmailBackend',
-            'sentry.utils.email.PreviewBackend',
-        )
+        smtp_disabled = not is_smtp_enabled()
 
         results = {}
         for k in option_list:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -715,6 +715,18 @@ SENTRY_EMAIL_BACKEND_ALIASES = {
     'console': 'django.core.mail.backends.console.EmailBackend',
 }
 
+# set of backends that do not support needing SMTP mail.* settings
+# This list is a bit fragile and hardcoded, but it's unlikely that
+# a user will be using a different backend that also mandates SMTP
+# credentials.
+SENTRY_SMTP_DISABLED_BACKENDS = frozenset((
+    'django.core.mail.backends.dummy.EmailBackend',
+    'django.core.mail.backends.console.EmailBackend',
+    'django.core.mail.backends.locmem.EmailBackend',
+    'django.core.mail.backends.filebased.EmailBackend',
+    'sentry.utils.email.PreviewBackend',
+))
+
 # Should users without superuser permissions be allowed to
 # make projects public
 SENTRY_ALLOW_PUBLIC_PROJECTS = True

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -394,6 +394,15 @@ def send_mail(subject, message, from_email, recipient_list, fail_silently=False)
     )
 
 
+def is_smtp_enabled(backend=None):
+    """
+    Check if the current backend is SMTP based.
+    """
+    if backend is None:
+        backend = get_mail_backend()
+    return backend not in settings.SENTRY_SMTP_DISABLED_BACKENDS
+
+
 class PreviewBackend(BaseEmailBackend):
     """
     Email backend that can be used in local development to open messages in the


### PR DESCRIPTION
Fixes GH-2970

@getsentry/infrastructure @tkaemming 
