### PR TITLE
Add basic CLI tool for querying TSDB.

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -46,14 +46,14 @@ def cli(ctx, config):
 
 # TODO(mattrobenolt): Autodiscover commands?
 map(lambda cmd: cli.add_command(import_string(cmd)), (
+    'sentry.runner.commands.backup.export',
+    'sentry.runner.commands.backup.import_',
     'sentry.runner.commands.cleanup.cleanup',
     'sentry.runner.commands.config.config',
     'sentry.runner.commands.createuser.createuser',
     'sentry.runner.commands.devserver.devserver',
     'sentry.runner.commands.django.django',
-    'sentry.runner.commands.backup.export',
     'sentry.runner.commands.help.help',
-    'sentry.runner.commands.backup.import_',
     'sentry.runner.commands.init.init',
     'sentry.runner.commands.plugins.plugins',
     'sentry.runner.commands.queues.queues',

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -59,6 +59,7 @@ map(lambda cmd: cli.add_command(import_string(cmd)), (
     'sentry.runner.commands.queues.queues',
     'sentry.runner.commands.repair.repair',
     'sentry.runner.commands.start.start',
+    'sentry.runner.commands.tsdb.tsdb',
     'sentry.runner.commands.upgrade.upgrade',
 ))
 

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -1,0 +1,118 @@
+from __future__ import absolute_import
+
+from collections import OrderedDict
+from datetime import datetime, timedelta
+
+import click
+import pytz
+from dateutil.parser import parse
+
+from sentry.runner.decorators import configuration
+from sentry.utils.iterators import chunked
+
+
+class DateTimeParamType(click.ParamType):
+    name = 'datetime'
+
+    def convert(self, context, option, value):
+        if value is None:
+            return value
+        elif isinstance(value, datetime):
+            return value
+
+        try:
+            result = parse(value)
+        except Exception:
+            self.fail(
+                '{!r} is not a valid datetime'.format(value),
+                option,
+                context,
+            )
+
+        if result.tzinfo is None:
+            # TODO: We should probably warn about this? Also note that this
+            # doesn't use the Django specified timezone, since settings haven't
+            # been configured yet.
+            result = result.replace(tzinfo=pytz.utc)
+
+        return result
+
+
+@click.group()
+def tsdb():
+    """Tools for interacting with the time series database."""
+    pass
+
+
+@tsdb.group()
+def query():
+    """Execute queries against the time series database."""
+    pass
+
+
+@query.command()
+@click.argument(
+    'metrics',
+    nargs=-1,
+    type=click.Choice([
+        'organization_total_received',
+        'organization_total_rejected',
+        'organization_total_blacklisted',
+    ]),
+)
+@click.option('--since', callback=DateTimeParamType())
+@click.option('--until', callback=DateTimeParamType())
+@configuration
+def organizations(metrics, since, until):
+    """
+    Fetch metrics for organizations.
+    """
+    from django.utils import timezone
+    from sentry.app import tsdb
+    from sentry.models import Organization
+
+    stdout = click.get_text_stream('stdout')
+    stderr = click.get_text_stream('stderr')
+    aggregate = lambda series: sum(value for timestamp, value in series)
+
+    metrics = OrderedDict((name, getattr(tsdb.models, name)) for name in metrics)
+    if not metrics:
+        return
+
+    if until is None:
+        until = timezone.now()
+
+    if since is None:
+        since = until - timedelta(minutes=60)
+
+    assert until >= since
+
+    stderr.write(
+        'Dumping {} from {} to {}...\n'.format(
+            ', '.join(metrics.keys()),
+            since,
+            until,
+        ),
+    )
+
+    objects = Organization.objects.all()
+
+    for chunk in chunked(objects, 100):
+        instances = OrderedDict((instance.pk, instance) for instance in chunk)
+
+        results = {}
+        for metric in metrics.values():
+            results[metric] = tsdb.get_range(metric, instances.keys(), since, until)
+
+        for key, instance in instances.iteritems():
+            values = []
+            for metric in metrics.values():
+                values.append(aggregate(results[metric][key]))
+
+            stdout.write(
+                '{} {} {}\n'.format(
+                    instance.id,
+                    instance.slug,
+                    ' '.join(map(str, values)),
+                ),
+            )

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -1,0 +1,8 @@
+def chunked(iterator, size):
+    chunk = []
+    for item in iterator:
+        chunk.append(item)
+        if len(chunk) == size:
+            yield chunk
+            del chunk[:]
+    yield chunk


### PR DESCRIPTION
To run, try this: `sentry tsdb query organizations --since "10 AM PST" --until "12 PM PST" organization_total_received organization_total_rejected`

Right now this is limited to organization statistics.

This could fairly easily support projects or other entities with a bit of cleanup, as well as different aggregation methods.

@getsentry/infrastructure @mattrobenolt 
