### PR TITLE
Fetch the members from the organization as people can leave teams

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectDetails.jsx
@@ -151,7 +151,7 @@ const ProjectDetails = React.createClass({
 
   getMemberListEndpoint() {
     let params = this.props.params;
-    return '/projects/' + params.orgId + '/' + params.projectId + '/members/';
+    return '/organizations/' + params.orgId + '/members/';
   },
 
   setProjectNavSection(section) {


### PR DESCRIPTION
Looks like a work around for the exception was fixed in https://github.com/getsentry/sentry/commit/c30d61c7aff3146e72bc1076ecf7a0603f22822b, but we can just fetch the members of the org instead.

Changes proposed in this pull request:
- When looking at the activity feeds, if the issue was assigned to someone who was since left the team it would crash pre 8.2, post 8.2 it would appear as `X assigned this event to an unknown user`. Now it'll properly show the user.

That endpoint requires `member:read` which is in every default role so I don't forsee permissions being a problem.

@getsentry/team
