### PR TITLE
Add missing key declarations in platformLink, sidebar lists

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -77,6 +77,7 @@ const ProjectInstallPlatform = React.createClass({
     let {orgId, projectId} = this.props.params;
     return (
       <Link
+        key={platform}
         to={`/${orgId}/${projectId}/settings/install/${platform}/`}
         className="list-group-item">
           {display || platform}
@@ -90,7 +91,7 @@ const ProjectInstallPlatform = React.createClass({
       <div className="install-sidebar col-md-2">
         {this.props.platformData.platforms.map((p_item) => {
           return (
-            <LanguageNav name={p_item.name} active={platform && platform.id === p_item.id}>
+            <LanguageNav key={p_item.id} name={p_item.name} active={platform && platform.id === p_item.id}>
               {p_item.integrations.map((i_item) => {
                 return this.getPlatformLink(i_item.id, (i_item.id === p_item.id ? t('Generic') : i_item.name));
               })}


### PR DESCRIPTION
I noticed warnings about this when running tests.

```
ERROR: 'Warning: Each child in an array or iterator should have a unique "key" prop. Check the top-level render call using <LanguageNav>. See https://fb.me/react-warning-keys for more information.'
ERROR: 'Warning: Each child in an array or iterator should have a unique "key" prop. Check the top-level render call using <div>. See https://fb.me/react-warning-keys for more information.'
```

cc @macqueen 
