### PR TITLE
Fix console warnings output during karma/mocha tests

### DIFF
--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -5,7 +5,7 @@ import {t} from '../locale';
 
 const Pagination = React.createClass({
   propTypes: {
-    pageLinks: React.PropTypes.string.isRequired,
+    pageLinks: React.PropTypes.string,
     to: React.PropTypes.string
   },
 

--- a/tests/js/spec/views/stream/actions.spec.jsx
+++ b/tests/js/spec/views/stream/actions.spec.jsx
@@ -21,6 +21,7 @@ describe('StreamActions', function() {
     beforeEach(function() {
       this.actions = shallow(
           <StreamActions
+            query=""
             orgId="1337"
             projectId="1"
             groupIds={[1,2,3]}

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
 import {shallow, mount} from 'enzyme';
 
 import {Client} from 'app/api';
@@ -114,19 +112,15 @@ describe('SearchBar', function() {
   describe('onKeyUp()', function () {
     describe('escape', function () {
       it('blurs the input', function () {
-        // needs to be rendered into document.body or cannot query document.activeElement
-        let searchBar = ReactDOM.render(<SearchBar orgId="123" projectId="456"/>, document.body);
-        searchBar.state.dropdownVisible = true;
+        let wrapper = shallow(<SearchBar orgId="123" projectId="456"/>);
+        wrapper.setState({dropdownVisible: true});
 
-        let input = ReactDOM.findDOMNode(searchBar.refs.searchInput);
+        let instance = wrapper.instance();
+        this.sandbox.stub(instance, 'blur');
 
-        input.focus();
+        wrapper.find('input').simulate('keyup', {key: 'Escape', keyCode: '27'});
 
-        expect(document.activeElement).to.eql(input);
-
-        TestUtils.Simulate.keyUp(input, {key: 'Escape', keyCode: '27'});
-
-        expect(document.activeElement).to.not.eql(input);
+        expect(instance.blur.calledOnce).to.be.ok;
       });
     });
   });


### PR DESCRIPTION
Before:

```
................................................................................
...................................
ERROR: 'Warning: Each child in an array or iterator should have a unique "key" prop. Check the top-level render call using <LanguageNav>. See https://fb.me/react-warning-keys for more information.'
ERROR: 'Warning: Each child in an array or iterator should have a unique "key" prop. Check the top-level render call using <div>. See https://fb.me/react-warning-keys for more information.'
......
ERROR: 'Warning: Failed propType: Required prop `pageLinks` was not specified in `Pagination`.'
.......................
ERROR: 'Warning: Failed propType: Required prop `query` was not specified in `StreamActions`.'
.........
ERROR: 'Warning: render(): Rendering components directly into document.body is discouraged, since its children are often manipulated by third-party scripts and browser extensions. This may lead to subtle reconciliation issues. Try rendering into a container element created for your app.'
........
PhantomJS 1.9.8 (Mac OS X 0.0.0): Executed 161 of 161 SUCCESS (0.29 secs / 0.205 secs)
```

After (this patch and #2999):

```
................................................................................
................................................................................
.
PhantomJS 1.9.8 (Mac OS X 0.0.0): Executed 161 of 161 SUCCESS (0.221 secs / 0.155 secs)
```

cc @getsentry/ui 
