### PR TITLE
bin/load-mocks adds breadcrumbs again, inserts "error" crumb

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -116,6 +116,78 @@ def milliseconds_ago(now, milliseconds):
     return (ago - epoch).total_seconds()
 
 
+def get_sample_breadcrumbs(prior_event_id=None):
+    now = datetime.now()
+    sample_breadcrumbs = {
+        "values": [
+            {
+                "type": "navigation",
+                "timestamp": milliseconds_ago(now, 5200),
+                "data": {
+                    "to": "http://example.com/dashboard/",
+                    "from": "http://example.com/login/"
+                }
+            },
+            {
+                "type": "message",
+                "timestamp": milliseconds_ago(now, 4000),
+                "data": {
+                    "message": "This is a message breadcrumb",
+                    "level": "info"
+                }
+            },
+            {
+                "type": "message",
+                "timestamp": milliseconds_ago(now, 3300),
+                "data": {
+                    "message": "This is a warning message",
+                    "level": "warning"
+                }
+            },
+            {
+                "type": "message",
+                "timestamp": milliseconds_ago(now, 2700),
+                "data": {
+                    "message": "This is an error message",
+                    "level": "error"
+                }
+            },
+            {
+                "type": "http_request",
+                "timestamp": milliseconds_ago(now, 1300),
+                "data": {
+                    "url": "http://example.com/foo",
+                    "status_code": 200,
+                    "method": "POST",
+                    "headers": {
+                        "Referer": "http://example.com",
+                        "Content-Type": "application/json"
+                    }
+                }
+            },
+            {
+                "type": "ui_event",
+                "timestamp": milliseconds_ago(now, 1000),
+                "data": {
+                    "type": "click",
+                    "target": "<button name=\"submit\" class=\"btn btn-small\"/>"
+                }
+            }
+        ]
+    }
+
+    if prior_event_id:
+        sample_breadcrumbs["values"].insert(2, {
+            "type": "error",
+            "timestamp": milliseconds_ago(now, 3000),
+            "data": {
+                "message": "TypeError: something broke earlier",
+                "event_id": prior_event_id
+            }
+        })
+
+    return sample_breadcrumbs
+
 def main(num_events=1):
     user = User.objects.filter(is_superuser=True)[0]
 
@@ -160,71 +232,6 @@ def main(num_events=1):
             'role': roles.get_default().id,
         }
     )
-
-    now = datetime.now()
-    sample_breadcrumbs = {
-        "values": [
-            {
-                "type": "navigation",
-                "dt": 8200,
-                "timestamp": milliseconds_ago(now, 5200),
-                "data": {
-                    "to": "http://example.com/dashboard/",
-                    "from": "http://example.com/login/"
-                }
-            },
-            {
-                "type": "message",
-                "dt": 5000,
-                "timestamp": milliseconds_ago(now, 4000),
-                "data": {
-                    "message": "This is a message breadcrumb",
-                    "level": "info"
-                }
-            },
-            {
-                "type": "message",
-                "dt": 4000,
-                "timestamp": milliseconds_ago(now, 3300),
-                "data": {
-                    "message": "This is a warning message",
-                    "level": "warning"
-                }
-            },
-            {
-                "type": "message",
-                "dt": 3500,
-                "timestamp": milliseconds_ago(now, 2700),
-                "data": {
-                    "message": "This is an error message",
-                    "level": "error"
-                }
-            },
-            {
-                "type": "http_request",
-                "dt": 3000,
-                "timestamp": milliseconds_ago(now, 1300),
-                "data": {
-                    "url": "http://example.com/foo",
-                    "statusCode": 200,
-                    "method": "POST",
-                    "headers": {
-                        "Referer": "http://example.com",
-                        "Content-Type": "application/json"
-                    }
-                }
-            },
-            {
-                "type": "ui_event",
-                "dt": 1500,
-                "timestamp": milliseconds_ago(now, 1000),
-                "data": {
-                    "type": "click",
-                    "target": "<button name=\"submit\" class=\"btn btn-small\"/>"
-                }
-            }
-        ]
-    }
 
     for team_name, project_names in mocks:
         print('> Mocking team {}'.format(team_name))
@@ -272,16 +279,18 @@ def main(num_events=1):
             )
 
             # Add a bunch of additional dummy events to support pagination
+            last_event = None
             for _ in range(45):
                 platform = PLATFORMS.next()
-                create_sample_event(
+
+                last_event = create_sample_event(
                     project=project,
                     platform=platform,
                     release=release.version,
                     level=LEVELS.next(),
                     message='This is a mostly useless example %s exception' % platform,
                     checksum=md5(platform + str(_)).hexdigest(),
-                    breadcrumbs=sample_breadcrumbs,
+                    breadcrumbs=get_sample_breadcrumbs(prior_event_id=last_event.id if last_event else None),
                 )
 
             for _ in range(num_events):
@@ -295,7 +304,7 @@ def main(num_events=1):
                     project=project,
                     platform='javascript',
                     release=release.version,
-                    breadcrumbs=sample_breadcrumbs,
+                    breadcrumbs=get_sample_breadcrumbs(prior_event_id=event1.event_id),
                 )
 
                 event3 = create_sample_event(project, 'java')

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -108,6 +108,14 @@ def create_sample_time_series(event):
         now = now - timedelta(hours=1)
 
 
+epoch = datetime.utcfromtimestamp(0)
+
+
+def milliseconds_ago(now, milliseconds):
+    ago = (now - timedelta(milliseconds=milliseconds))
+    return (ago - epoch).total_seconds()
+
+
 def main(num_events=1):
     user = User.objects.filter(is_superuser=True)[0]
 
@@ -152,6 +160,71 @@ def main(num_events=1):
             'role': roles.get_default().id,
         }
     )
+
+    now = datetime.now()
+    sample_breadcrumbs = {
+        "values": [
+            {
+                "type": "navigation",
+                "dt": 8200,
+                "timestamp": milliseconds_ago(now, 5200),
+                "data": {
+                    "to": "http://example.com/dashboard/",
+                    "from": "http://example.com/login/"
+                }
+            },
+            {
+                "type": "message",
+                "dt": 5000,
+                "timestamp": milliseconds_ago(now, 4000),
+                "data": {
+                    "message": "This is a message breadcrumb",
+                    "level": "info"
+                }
+            },
+            {
+                "type": "message",
+                "dt": 4000,
+                "timestamp": milliseconds_ago(now, 3300),
+                "data": {
+                    "message": "This is a warning message",
+                    "level": "warning"
+                }
+            },
+            {
+                "type": "message",
+                "dt": 3500,
+                "timestamp": milliseconds_ago(now, 2700),
+                "data": {
+                    "message": "This is an error message",
+                    "level": "error"
+                }
+            },
+            {
+                "type": "http_request",
+                "dt": 3000,
+                "timestamp": milliseconds_ago(now, 1300),
+                "data": {
+                    "url": "http://example.com/foo",
+                    "statusCode": 200,
+                    "method": "POST",
+                    "headers": {
+                        "Referer": "http://example.com",
+                        "Content-Type": "application/json"
+                    }
+                }
+            },
+            {
+                "type": "ui_event",
+                "dt": 1500,
+                "timestamp": milliseconds_ago(now, 1000),
+                "data": {
+                    "type": "click",
+                    "target": "<button name=\"submit\" class=\"btn btn-small\"/>"
+                }
+            }
+        ]
+    }
 
     for team_name, project_names in mocks:
         print('> Mocking team {}'.format(team_name))
@@ -208,6 +281,7 @@ def main(num_events=1):
                     level=LEVELS.next(),
                     message='This is a mostly useless example %s exception' % platform,
                     checksum=md5(platform + str(_)).hexdigest(),
+                    breadcrumbs=sample_breadcrumbs,
                 )
 
             for _ in range(num_events):
@@ -221,6 +295,7 @@ def main(num_events=1):
                     project=project,
                     platform='javascript',
                     release=release.version,
+                    breadcrumbs=sample_breadcrumbs,
                 )
 
                 event3 = create_sample_event(project, 'java')

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -89,7 +89,7 @@ def validate_rpc(payload):
 @typevalidator('http_request')
 def validate_http_request(payload):
     rv = {}
-    for key in 'statusCode', 'reason', 'method', 'url', 'headers', \
+    for key in 'status_code', 'reason', 'method', 'url', 'headers', \
                'response', 'classifier':
         value = payload.get(key)
         if value is not None:
@@ -133,6 +133,16 @@ def validate_navigation(payload):
     if 'to' not in rv:
         raise InterfaceValidationError("Location not provided for 'navigation' "
                                        "breadcrumb.")
+    return rv
+
+
+@typevalidator('error')
+def validate_error(payload):
+    rv = {}
+    for key in 'type', 'message', 'event_id':
+        value = payload.get(key)
+        if value is not None:
+            rv[key] = trim(value, 1024)
     return rv
 
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/error.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/error.jsx
@@ -3,11 +3,19 @@ import React from 'react';
 import KeyValueList from '../keyValueList';
 
 function Error(props) {
-  let {type, value} = props.data;
+  let {type, value, message, eventId} = props.data;
 
   let list = [];
-  list.push(['type', type]);
-  list.push(['message', value]);
+  if (type && value) {
+    list.push(['type', type]);
+    list.push(['message', value]);
+  }
+  if (message) {
+    list.push(['message', message]);
+  }
+  if (eventId) {
+    list.push(['event_id', eventId]);
+  }
 
   return (
     <div>

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -8,18 +8,10 @@ sentry.utils.samples
 from __future__ import absolute_import
 
 import os.path
-from datetime import datetime, timedelta
 
 from sentry.constants import DATA_ROOT
 from sentry.event_manager import EventManager
 from sentry.utils import json
-
-epoch = datetime.utcfromtimestamp(0)
-
-
-def milliseconds_ago(now, milliseconds):
-    ago = (now - timedelta(milliseconds=milliseconds))
-    return (ago - epoch).total_seconds()
 
 
 def load_data(platform, default=None):
@@ -31,8 +23,6 @@ def load_data(platform, default=None):
     #     event so it's not an empty project.
     #   * When a user clicks Test Configuration from notification plugin settings page,
     #     a fake event is generated to go through the pipeline.
-
-    # now = datetime.now()
 
     data = None
     for platform in (platform, default):
@@ -90,73 +80,6 @@ def load_data(platform, default=None):
         "data": '{"hello": "world"}',
         "method": "GET"
     }
-
-    # We can't send Breadcrumb data as a part of the sample event.
-    # This gets used for all new projects as the "starter" event.
-    #
-    # data['sentry.interfaces.Breadcrumbs'] = {
-    #     "values": [
-    #         {
-    #             "type": "navigation",
-    #             "dt": 8200,
-    #             "timestamp": milliseconds_ago(now, 5200),
-    #             "data": {
-    #                 "to": "http://example.com/dashboard/",
-    #                 "from": "http://example.com/login/"
-    #             }
-    #         },
-    #         {
-    #             "type": "message",
-    #             "dt": 5000,
-    #             "timestamp": milliseconds_ago(now, 4000),
-    #             "data": {
-    #                 "message": "This is a message breadcrumb",
-    #                 "level": "info"
-    #             }
-    #         },
-    #         {
-    #             "type": "message",
-    #             "dt": 4000,
-    #             "timestamp": milliseconds_ago(now, 3300),
-    #             "data": {
-    #                 "message": "This is a warning message",
-    #                 "level": "warning"
-    #             }
-    #         },
-    #         {
-    #             "type": "message",
-    #             "dt": 3500,
-    #             "timestamp": milliseconds_ago(now, 2700),
-    #             "data": {
-    #                 "message": "This is an error message",
-    #                 "level": "error"
-    #             }
-    #         },
-    #         {
-    #             "type": "http_request",
-    #             "dt": 3000,
-    #             "timestamp": milliseconds_ago(now, 1300),
-    #             "data": {
-    #                 "url": "http://example.com/foo",
-    #                 "statusCode": 200,
-    #                 "method": "POST",
-    #                 "headers": {
-    #                     "Referer": "http://example.com",
-    #                     "Content-Type": "application/json"
-    #                 }
-    #             }
-    #         },
-    #         {
-    #             "type": "ui_event",
-    #             "dt": 1500,
-    #             "timestamp": milliseconds_ago(now, 1000),
-    #             "data": {
-    #                 "type": "click",
-    #                 "target": "<button name=\"submit\" class=\"btn btn-small\"/>"
-    #             }
-    #         }
-    #     ]
-    # }
 
     return data
 


### PR DESCRIPTION
Also changes `sentry.interfaces.Breadcrumbs` to use underscored param names, e.g. `status_code` instead of `statusCode` ... but one thing I notice is that, unlike other interfaces, breadcrumb keys are not converted to camelCase when fetched via the API.

For example, in the `Request` interface, `query_string` gets converted to ~~`queryString`~~ _my bad, it's actually converted to `query`, so maybe this is manual_.

But right now, in the `Breadcrumbs` interface, `status_code` remains `status_code`.

How do I fix this?

@mattrobenolt @mitsuhiko 
