### PR TITLE
Make Redis recommended version more conservative.

### DIFF
--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -105,6 +105,7 @@ class RedisTSDB(BaseTSDB):
         check_cluster_versions(
             self.cluster,
             version,
+            recommended=Version((2, 8, 18)),
             label='TSDB',
         )
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -118,7 +118,7 @@ def get_cluster_from_options(setting, options, cluster_manager=clusters):
     return cluster, options
 
 
-def check_cluster_versions(cluster, required, recommended=Version((3, 0, 4)), label=None):
+def check_cluster_versions(cluster, required, recommended=None, label=None):
     try:
         with cluster.all() as client:
             results = client.info()


### PR DESCRIPTION
This _removes_ the global recommendation of 3.0.4 (which was the latest at
the time this was written) that wasn't based on any feature necessity
(that I can remember, at least.)

This _adds_ the recommendation of 2.8.18 to the Redis TSDB backend,
since that adds the Lua `bit` module which will be required for features
in the future.

References GH-2983.

@getsentry/infrastructure 
