### PR TITLE
Read csrf cookie on every API request since the value may change

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -17,8 +17,6 @@ function getCookie(name) {
   return cookieValue;
 }
 
-let csrftoken = getCookie('csrf');
-
 function csrfSafeMethod(method) {
   // these HTTP methods do not require CSRF protection
   return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
@@ -26,7 +24,7 @@ function csrfSafeMethod(method) {
 jQuery.ajaxSetup({
   beforeSend: function(xhr, settings) {
     if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-      xhr.setRequestHeader('X-CSRFToken', csrftoken);
+      xhr.setRequestHeader('X-CSRFToken', getCookie('csrf'));
     }
   }
 });


### PR DESCRIPTION
During subsequent requests, it's possible for the server to send back a
new value. This may happen if cookies are cleared or any other way that
the csrf cookie disappears causing the server to regenerate a new one.

Since we have a single page app, the actual page doesn't refresh,
causing this cached value to never be updated.

Refs: SENTRY-HP

/cc @getsentry/ui
