### PR TITLE
Better guard against invalid auth headers

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -174,16 +174,16 @@ class ClientApiHelper(object):
         self.log = ClientLogHelper(self.context)
 
     def auth_from_request(self, request):
-        if request.META.get('HTTP_X_SENTRY_AUTH', '').startswith('Sentry'):
+        if request.META.get('HTTP_X_SENTRY_AUTH', '')[:7].lower() == 'sentry ':
             result = parse_auth_header(request.META['HTTP_X_SENTRY_AUTH'])
-        elif request.META.get('HTTP_AUTHORIZATION', '').startswith('Sentry'):
+        elif request.META.get('HTTP_AUTHORIZATION', '')[:7].lower() == 'sentry ':
             result = parse_auth_header(request.META['HTTP_AUTHORIZATION'])
         else:
-            result = dict(
-                (k, request.GET[k])
+            result = {
+                k: request.GET[k]
                 for k in request.GET.iterkeys()
-                if k.startswith('sentry_')
-            )
+                if k[:7] == 'sentry_'
+            }
         if not result:
             raise APIUnauthorized('Unable to find authentication information')
 

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -19,8 +19,15 @@ from sentry.models import User
 logger = logging.getLogger('sentry.auth')
 
 
+def _make_key_value(val):
+    return val.strip().split('=', 1)
+
+
 def parse_auth_header(header):
-    return dict(map(lambda x: x.strip().split('='), header.split(' ', 1)[1].split(',')))
+    try:
+        return dict(map(_make_key_value, header.split(' ', 1)[1].split(',')))
+    except Exception:
+        return {}
 
 
 def get_auth_providers():


### PR DESCRIPTION
Refs: SENTRY-11K SENTRY-SZ

/cc @getsentry/infrastructure
