### PR TITLE
Signup flow

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
@@ -17,11 +17,11 @@ const ProjectInstallOverview = React.createClass({
 
   getIntegrationLink(root, platform, display) {
     let {orgId, projectId} = this.props.params;
-    let onboarding = this.props.location.query.onboarding ? '?onboarding=1' : '';
+    let signup = this.props.location.query.hasOwnProperty('signup') ? '?signup' : '';
     return (
       <li className={`${root} ${platform}`} key={platform}>
         <span className={`platformicon platformicon-${platform}`}/>
-        <Link to={`/${orgId}/${projectId}/settings/install/${platform}/${onboarding}`}>
+        <Link to={`/${orgId}/${projectId}/settings/install/${platform}/${signup}`}>
           {display}
         </Link>
       </li>

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -142,13 +142,15 @@ const ProjectInstallPlatform = React.createClass({
             <div dangerouslySetInnerHTML={{__html: this.state.html}}/>
           )}
 
-          {queryParams.onboarding ?
+          {queryParams.hasOwnProperty('signup') ?
             <p>
-              <Link
-                to={`/${orgId}/${projectId}/?onboarding=1#welcome`}
+              // Using <a /> instead of <Link /> as hashchange events are not
+              // triggered when switching views within React Router
+              <a
+                href={`/${orgId}/${projectId}/#welcome`}
                 className="btn btn-primary btn-lg">
-                  Got it! Take me to the Issue Stream.
-              </Link>
+                  {t('Got it! Take me to the Issue Stream.')}
+              </a>
             </p>
           :
             null

--- a/src/sentry/web/frontend/create_project.py
+++ b/src/sentry/web/frontend/create_project.py
@@ -78,10 +78,15 @@ class CreateProjectView(OrganizationView):
         if form.is_valid():
             project = form.save(request.user, request.META['REMOTE_ADDR'])
 
-            return self.redirect(absolute_uri('/{}/{}/settings/install/'.format(
+            install_uri = absolute_uri('/{}/{}/settings/install/'.format(
                 organization.slug,
                 project.slug,
-            )))
+            ))
+
+            if 'signup' in request.GET:
+                install_uri += '?signup'
+
+            return self.redirect(install_uri)
 
         context = {
             'form': form,


### PR DESCRIPTION
Changes proposed in this pull request:
- adding "?signup" param when new organizations are created, for on-boarding flow
- also changed <Link> to <a> to ensure reloading of page in the platform.jsx page (hashchange isn't triggered otherwise)

@getsentry/team
