### PR TITLE
Make breadcrumb UI way smaller

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/error.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/error.jsx
@@ -6,8 +6,7 @@ function Error(props) {
   let {type, value, message, eventId} = props.data;
 
   let list = [];
-  if (type && value) {
-    list.push(['type', type]);
+  if (value) {
     list.push(['message', value]);
   }
   if (message) {
@@ -19,7 +18,7 @@ function Error(props) {
 
   return (
     <div>
-      <h5>Error</h5>
+      <h5>{type || 'Error'}</h5>
       <KeyValueList data={list} isSorted={false} />
     </div>
   );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
@@ -24,7 +24,9 @@ const HttpRequestCrumbComponent = React.createClass({
 
     return (
       <div>
-        <h5>HTTP Request ({data.method || "Unknown"}) <Classifier value={data.classifier} title="%s request" /></h5>
+        <h5>HTTP Request ({data.method || "Unknown"})
+          {data.classifier ? <Classifier value={data.classifier} title="%s request"/> : null}
+        </h5>
         <KeyValueList data={list} isSorted={false} />
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
@@ -16,7 +16,7 @@ const HttpRequestCrumbComponent = React.createClass({
     let data = this.props.data;
 
     let list = [];
-    list.push(['url', data.url]);
+    list.push([data.method, data.url]);
 
     if(data.response) {
       list.push(['response', data.response.statusCode]);
@@ -24,7 +24,7 @@ const HttpRequestCrumbComponent = React.createClass({
 
     return (
       <div>
-        <h5>HTTP Request ({data.method || "Unknown"})
+        <h5>HTTP Request
           <Classifier value={data.classifier} title="%s request" hideIfEmpty={true}/>
         </h5>
         <KeyValueList data={list} isSorted={false} />

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
@@ -25,7 +25,7 @@ const HttpRequestCrumbComponent = React.createClass({
     return (
       <div>
         <h5>HTTP Request ({data.method || "Unknown"})
-          {data.classifier ? <Classifier value={data.classifier} title="%s request"/> : null}
+          <Classifier value={data.classifier} title="%s request" hideIfEmpty={true}/>
         </h5>
         <KeyValueList data={list} isSorted={false} />
       </div>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRequest.jsx
@@ -16,7 +16,6 @@ const HttpRequestCrumbComponent = React.createClass({
     let data = this.props.data;
 
     let list = [];
-    list.push(['method', data.method]);
     list.push(['url', data.url]);
 
     if(data.response) {
@@ -25,7 +24,7 @@ const HttpRequestCrumbComponent = React.createClass({
 
     return (
       <div>
-        <h5>HTTP Request <Classifier value={data.classifier} title="%s request" /></h5>
+        <h5>HTTP Request ({data.method || "Unknown"}) <Classifier value={data.classifier} title="%s request" /></h5>
         <KeyValueList data={list} isSorted={false} />
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/message.jsx
@@ -14,7 +14,7 @@ const MessageCrumbComponent = React.createClass({
     return (
       <p>
         {data.level ? <span className={levelClasses}>{data.level}</span> : null}
-        {' ' + data.message + ' '}
+        <span className="message-text">{' ' + data.message + ' '}</span>
         {data.logger ? <span className="logger">[{data.logger}]</span> : null}
         <Classifier value={data.classifier} title="%s" hideIfEmpty={true}/>
       </p>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
@@ -17,7 +17,7 @@ const UiEventComponent = React.createClass({
     return (
       <div>
         <h5>{data.type || 'UI Event'}
-          {data.classifier ? <Classifier value={data.classifier} title="%s call"/> : null}
+          <Classifier value={data.classifier} title="%s call" hideIfEmpty={true}/>
         </h5>
         <KeyValueList data={list} isSorted={false} />
       </div>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
@@ -12,12 +12,11 @@ const UiEventComponent = React.createClass({
     let data = this.props.data;
 
     let list = [];
-    list.push(['type', data.type || 'undefined type']);
     list.push(['element', data.target || 'undefined target']);
 
     return (
       <div>
-        <h5>{data.event || 'UI Event'} <Classifier value={data.classifier} title="%s call"/></h5>
+        <h5>{data.type || 'UI Event'} <Classifier value={data.classifier} title="%s call"/></h5>
         <KeyValueList data={list} isSorted={false} />
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
@@ -16,7 +16,9 @@ const UiEventComponent = React.createClass({
 
     return (
       <div>
-        <h5>{data.type || 'UI Event'} <Classifier value={data.classifier} title="%s call"/></h5>
+        <h5>{data.type || 'UI Event'}
+          {data.classifier ? <Classifier value={data.classifier} title="%s call"/> : null}
+        </h5>
         <KeyValueList data={list} isSorted={false} />
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/uiEvent.jsx
@@ -12,11 +12,11 @@ const UiEventComponent = React.createClass({
     let data = this.props.data;
 
     let list = [];
-    list.push(['element', data.target || 'undefined target']);
+    list.push([data.type, data.target || 'undefined target']);
 
     return (
       <div>
-        <h5>{data.type || 'UI Event'}
+        <h5>UI Event
           <Classifier value={data.classifier} title="%s call" hideIfEmpty={true}/>
         </h5>
         <KeyValueList data={list} isSorted={false} />

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1576,9 +1576,9 @@ ul.crumbs {
     border-left: 1px solid transparent;
     border-right: 1px solid transparent;
     border-bottom: 1px solid lighten(@trim, 6);
-    padding: 10px 20px 10px 70px;
+    padding: 6px 20px 6px 60px;
     position: relative;
-    min-height: 46px;
+    min-height: 39px;
 
     &:before {
       display: block;
@@ -1586,7 +1586,7 @@ ul.crumbs {
       width: 2px;
       top: 0;
       bottom: 0;
-      left: 35px;
+      left: 30px;
       background: #E7EAEF;
       position: absolute;
     }
@@ -1608,22 +1608,28 @@ ul.crumbs {
       padding: 0;
     }
 
+    .message-text {
+      font-size: 15px;
+      padding-top: 2px;
+    }
+
     .icon-container {
       display: block;
-      .square(32px);
+      .square(26px);
       background: #fff;
       border: 1px solid @gray-lighter;
       box-shadow: 0 1px 2px rgba(0, 0, 0, .08);
       border-radius: 32px;
       position: absolute;
-      top: 7px;
-      left: 19px;
+      top: 6px;
+      left: 18px;
+      z-index: 1;
 
       .icon {
-        font-size: 16px;
+        font-size: 14px;
         position: absolute;
-        left: 8px;
-        top: 6px;
+        left: 5px;
+        top: 4px;
         font-family: 'sentry-simple';
         speak: none;
         font-style: normal;
@@ -1682,18 +1688,23 @@ ul.crumbs {
       box-shadow: inset 0 -1px 2px rgba(0,0,0, .03);
 
       &:before {
-        left: 34px;
+        left: 29px;
+      }
+
+      .icon-container {
+        left: 17px;
       }
 
       .icon {
         color: @gray;
-        top: 8px;
+        top: 6px;
       }
 
       a {
         color: @gray-dark;
         display: block;
-        padding: 6px 0 5px;
+        font-size: 15px;
+        padding: 7px 0 5px;
         margin: -5px 0;
 
         &:hover {
@@ -1726,7 +1737,7 @@ ul.crumbs {
         border-color: @yellow-orange-dark;
 
         .icon {
-          top: 7px;
+          top: 5px;
           color: darken(@yellow-orange, 5);
           &:before {content: "\e61d";}
         }
@@ -1738,7 +1749,7 @@ ul.crumbs {
         border-color: @green-dark;
 
         .icon {
-          top: 7px;
+          top: 5px;
           color: @green;
           &:before {
             content: "\e908";
@@ -1748,14 +1759,15 @@ ul.crumbs {
     }
 
     &.crumb-message {
-      padding-top: 11px;
+      padding-top: 7px;
+      clear: both;
 
       & + .crumb-message {
-        margin-top: -6px;
+        margin-top: -9px;
         background: #fff;
         min-height: 0;
         padding-top: 0;
-        padding-bottom: 10px;
+        padding-bottom: 6px;
         border-left: 1px solid @trim;
         border-right: 1px solid @trim;
 
@@ -1770,7 +1782,7 @@ ul.crumbs {
 
       .icon {
         color: @blue;
-        top: 7px;
+        top: 5px;
 
         &:before {
           content: "\e909";
@@ -1785,7 +1797,7 @@ ul.crumbs {
         color: @gray-dark;
         border-radius: 2px;
         display: inline-block;
-        padding: 4px 0;
+        padding: 3px 0;
         margin-right: 6px;
         line-height: 1;
         position: relative;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1600,6 +1600,7 @@ ul.crumbs {
       font-size: 15px;
       margin-bottom: 3px;
       line-height: 24px;
+      text-transform: capitalize;
     }
 
     p {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1671,7 +1671,7 @@ ul.crumbs {
       }
 
       .key {
-        width: 126px;
+        width: 110px;
         color: @gray-dark;
       }
 


### PR DESCRIPTION
#### Condenses this:

![screen shot 2016-04-11 at 4 19 28 pm](https://cloud.githubusercontent.com/assets/30713/14445398/81e409a2-0001-11e6-961b-4342fcc80ca6.png)
#### Into this:

![screen shot 2016-04-11 at 5 02 07 pm](https://cloud.githubusercontent.com/assets/30713/14446098/2d7cb2e6-0007-11e6-8df4-8c508e81bd95.png)

cc @getsentry/ui 
