### PR TITLE
Add `has_scopes` method to ApiKey

### DIFF
--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -97,6 +97,9 @@ class ApiKey(Model):
     def get_scopes(self):
         return self.scopes.keys()
 
+    def has_scope(self, scope):
+        return scope in self.scopes
+
 
 class SystemKey(object):
     is_active = True


### PR DESCRIPTION
Fixes SENTRY-10P

/cc @dcramer since you introduced this bug with GH-2965
