### PR TITLE
Leverage uwsgi caching for optionsstore

### DIFF
--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -87,6 +87,7 @@ class SentryHTTPServer(Service):
         options['enable-threads'] = True
         options['lazy-apps'] = True
         options['single-interpreter'] = True
+        options['cache2'] = 'name=options,items=100,purge_lru=true'
 
         if workers:
             options['workers'] = workers


### PR DESCRIPTION
This gives a per-machine cache as opposed to a per-process cache
increasing cache hits drastically in active machines.

Since we rely on optionsstore a lot and make multiple requests for
options per request, this is pretty valuable to prevent rount trips
talking to memcache, since for getsentry, we run 10+ processes per
machine, so this should increase cache hits by 10x in local process.

uwsgi also has the ability to persist to disk asynchronously, so will
want to leverage that next so cache can persist between restarts.

@getsentry/infrastructure 
