### PR TITLE
Point pushover plugin to getsentry

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -51,7 +51,7 @@ The following extensions are available and maintained by members of the Sentry c
 * `sentry-notifico <https://github.com/lukegb/sentry-notifico>`_
 * `sentry-phabricator <https://github.com/getsentry/sentry-phabricator>`_
 * `sentry-pivotal <https://github.com/getsentry/sentry-pivotal>`_
-* `sentry-pushover <https://github.com/dz0ny/sentry-pushover>`_
+* `sentry-pushover <https://github.com/getsentry/sentry-pushover>`_
 * `sentry-searchbutton <https://github.com/timmyomahony/sentry-searchbutton>`_
 * `sentry-sprintly <https://github.com/mattrobenolt/sentry-sprintly>`_
 * `sentry-statsd <https://github.com/dreadatour/sentry-statsd>`_


### PR DESCRIPTION
The pushover plugin mentioned in your documentation by [dz0ny](/dz0ny/sentry-pushover) is horribly outdated and doesn't work with sentry > 6.4
Instead link to the [fork in your own organization](/getsentry/sentry-pushover), which is better maintained.
