### PR TITLE
Fix bad width on all/any/none dropdown in rule editor (fixes #3066)

### DIFF
--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -129,6 +129,7 @@ const RuleEditor = React.createClass({
                   <SelectInput ref="actionMatch"
                         className={(this.hasError('actionMatch') ? ' error' : '')}
                         value={actionMatch}
+                        style={{width:80}}
                         required={true}>
                     <option value="all">{t('all')}</option>
                     <option value="any">{t('any')}</option>


### PR DESCRIPTION
select2 seems not to be picking a good width for this element, possible because they are so small / bleed into the down arrow icon.

Before: 

![image](https://cloud.githubusercontent.com/assets/2153/14625071/be5a4426-0594-11e6-8595-fb4c63c02807.png)

After:

![image](https://cloud.githubusercontent.com/assets/2153/14658297/920e4a8a-0647-11e6-8173-11bd326cbe75.png)

Note 80px is the smallest I can make this without select2 intentionally clipping the values with ellipses.

/cc @getsentry/ui
