### PR TITLE
Ellipsize box header overflow

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1769,6 +1769,8 @@ table.integrations {
       padding-bottom: 5px;
       max-width: 80%;
       line-height: 1.2;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
       small {
         color: @gray-dark;


### PR DESCRIPTION
This is especially useful for the "URL type" box, where the header contains the full HTTP Reques.
Very long URLs overflow the box and are currently simply displayed on top of the right column with tag info and stuff.
The hidden overflow doesn't loose you any infomation as the full URL can be found in the box content right below where the fields (in case of rich mode) or the box itself (in case of curl mode) have a scrolling overflow.

It might be worth looking for other places where the box header might be able to overflow.
