### PR TITLE
Split `sentry start` into `sentry run`

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -58,6 +58,7 @@ map(lambda cmd: cli.add_command(import_string(cmd)), (
     'sentry.runner.commands.plugins.plugins',
     'sentry.runner.commands.queues.queues',
     'sentry.runner.commands.repair.repair',
+    'sentry.runner.commands.run.run',
     'sentry.runner.commands.start.start',
     'sentry.runner.commands.tsdb.tsdb',
     'sentry.runner.commands.upgrade.upgrade',

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -1,0 +1,83 @@
+"""
+sentry.runner.commands.run
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+from __future__ import absolute_import, print_function
+
+import click
+from sentry.runner.decorators import configuration
+
+
+class AddressParamType(click.ParamType):
+    name = 'address'
+
+    def __call__(self, value, param=None, ctx=None):
+        if value is None:
+            return (None, None)
+        return self.convert(value, param, ctx)
+
+    def convert(self, value, param, ctx):
+        if ':' in value:
+            host, port = value.split(':', 1)
+            port = int(port)
+        else:
+            host = value
+            port = None
+        return host, port
+
+
+ADDRESS = AddressParamType()
+
+
+@click.group()
+def run():
+    "Run a service."
+
+
+@run.command()
+@click.option('--bind', '-b', default=None, help='Bind address.', type=ADDRESS)
+@click.option('--workers', '-w', default=0, help='The number of worker processes for handling requests.')
+@click.option('--upgrade', default=False, is_flag=True, help='Upgrade before starting.')
+@click.option('--noinput', default=False, is_flag=True, help='Do not prompt the user for input of any kind.')
+@configuration
+def web(bind, workers, upgrade, noinput):
+    "Run web service."
+    if upgrade:
+        click.echo('Performing upgrade before service startup...')
+        from sentry.runner import call_command
+        call_command(
+            'sentry.runner.commands.upgrade.upgrade',
+            verbosity=0, noinput=noinput,
+        )
+
+    from sentry.services.http import SentryHTTPServer
+    SentryHTTPServer(
+        host=bind[0],
+        port=bind[1],
+        workers=workers,
+    ).run()
+
+
+@run.command()
+@click.option('--bind', '-b', default=None, help='Bind address.', type=ADDRESS)
+@click.option('--upgrade', default=False, is_flag=True, help='Upgrade before starting.')
+@click.option('--noinput', default=False, is_flag=True, help='Do not prompt the user for input of any kind.')
+@configuration
+def smtp(bind, upgrade, noinput):
+    "Run inbound email service."
+    if upgrade:
+        click.echo('Performing upgrade before service startup...')
+        from sentry.runner import call_command
+        call_command(
+            'sentry.runner.commands.upgrade.upgrade',
+            verbosity=0, noinput=noinput,
+        )
+
+    from sentry.services.smtp import SentrySMTPServer
+    SentrySMTPServer(
+        host=bind[0],
+        port=bind[1],
+    ).run()

--- a/src/sentry/runner/commands/start.py
+++ b/src/sentry/runner/commands/start.py
@@ -7,6 +7,7 @@ sentry.runner.commands.start
 """
 from __future__ import absolute_import, print_function
 
+import sys
 import click
 from sentry.runner.decorators import configuration
 
@@ -25,7 +26,14 @@ SERVICES = {
 @configuration
 @click.pass_context
 def start(ctx, service, bind, workers, upgrade, noinput):
-    "Start running a service."
+    "DEPRECATED see `sentry run` instead."
+
+    from sentry.runner.initializer import show_big_error
+    show_big_error([
+        '`sentry start%s` is deprecated.' % (' ' + service if 'http' in sys.argv else ''),
+        'Use `sentry run %s` instead.' % {'http': 'web'}.get(service, service),
+    ])
+
     if bind:
         if ':' in bind:
             host, port = bind.split(':', 1)
@@ -49,7 +57,6 @@ def start(ctx, service, bind, workers, upgrade, noinput):
     # remove command line arguments to avoid optparse failures with service code
     # that calls call_command which reparses the command line, and if --noupgrade is supplied
     # a parse error is thrown
-    import sys
     sys.argv = sys.argv[:1]
 
     from sentry.utils.imports import import_string

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -251,10 +251,16 @@ def bind_cache_to_option_store():
 
 
 def show_big_error(message):
+    if isinstance(message, basestring):
+        lines = message.splitlines()
+    else:
+        lines = message
+    maxline = max(map(len, lines))
     click.echo('', err=True)
-    click.secho('!! %s !!' % ('!' * min(len(message), 80),), err=True, fg='red')
-    click.secho('!! %s !!' % message, err=True, fg='red')
-    click.secho('!! %s !!' % ('!' * min(len(message), 80),), err=True, fg='red')
+    click.secho('!! %s !!' % ('!' * min(maxline, 80),), err=True, fg='red')
+    for line in lines:
+        click.secho('!! %s !!' % line.center(maxline), err=True, fg='red')
+    click.secho('!! %s !!' % ('!' * min(maxline, 80),), err=True, fg='red')
     click.echo('', err=True)
 
 


### PR DESCRIPTION
This deprecates `sentry start`. This change allows each service to
be a dedicated subcommand so that each service may expose its own
options and args. We need to do this if we wish to expand `sentry run`
into more than what we're using it for today.

We can also now easily expand this to do like: `sentry run worker` and `sentry run cron` to deprecate `sentry celery`. But that's for future.

@getsentry/infrastructure 
