### PR TITLE
Add Early Adopter flag

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -21,6 +21,7 @@ class OrganizationSerializer(Serializer):
             'slug': obj.slug,
             'name': obj.name,
             'dateCreated': obj.date_added,
+            'isEarlyAdopter': bool(obj.flags.early_adopter),
         }
 
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -60,7 +60,7 @@ class ProjectSerializer(Serializer):
         from sentry import features
 
         feature_list = []
-        for feature in ('breadcrumbs', 'csp', 'global-events', 'user-reports', 'dsym'):
+        for feature in ('breadcrumbs', 'global-events', 'user-reports'):
             if features.has('projects:' + feature, obj, actor=user):
                 feature_list.append(feature)
 
@@ -111,7 +111,7 @@ class SharedProjectSerializer(Serializer):
         from sentry import features
 
         feature_list = []
-        for feature in ('global-events', 'user-reports', 'dsym'):
+        for feature in ('global-events', 'user-reports'):
             if features.has('projects:' + feature, obj, actor=user):
                 feature_list.append(feature)
 

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -16,8 +16,6 @@ default_manager.add('projects:global-events', ProjectFeature)
 default_manager.add('projects:quotas', ProjectFeature)
 default_manager.add('projects:user-reports', ProjectFeature)
 default_manager.add('projects:plugins', ProjectPluginFeature)
-default_manager.add('projects:csp', ProjectFeature)
-default_manager.add('projects:dsym', ProjectFeature)
 
 
 # expose public api

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -83,6 +83,7 @@ class Organization(Model):
         ('allow_joinleave', 'Allow members to join and leave teams without requiring approval.'),
         ('enhanced_privacy', 'Enable enhanced privacy controls to limit personally identifiable information (PII) as well as source code in things like notifications.'),
         ('disable_shared_issues', 'Disable sharing of limited details on issues to anonymous users.'),
+        ('early_adopter', 'Enable early adopter status, gaining access to features prior to public release.'),
     ), default=1)
 
     objects = OrganizationManager(cache_fields=(

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -13,7 +13,8 @@ const ProjectSettings = React.createClass({
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: React.PropTypes.object,
+    organization: React.PropTypes.object,
   },
 
   mixins: [
@@ -77,6 +78,7 @@ const ProjectSettings = React.createClass({
     let project = this.state.project;
     let features = new Set(project.features);
     let rootInstallPath = `/${orgId}/${projectId}/settings/install/`;
+    let isEarlyAdopter = this.context.organization.isEarlyAdopter;
 
     return (
       <div className="row">
@@ -93,8 +95,7 @@ const ProjectSettings = React.createClass({
             <li><a href={`${settingsUrlRoot}/issue-tracking/`}>{t('Issue Tracking')}</a></li>
             <li><a href={`${settingsUrlRoot}/release-tracking/`}>{t('Release Tracking')}</a></li>
             <ListLink to={`/${orgId}/${projectId}/settings/saved-searches/`}>{t('Saved Searches')}</ListLink>
-
-            {features.has('dsym') &&
+            {isEarlyAdopter &&
               <ListLink to={`/${orgId}/${projectId}/settings/debug-symbols/`}>{t('Debug Symbols')}</ListLink>
             }
           </ul>
@@ -106,7 +107,7 @@ const ProjectSettings = React.createClass({
               // Because react-router 1.0 removes router.isActive(route)
               return pathname === rootInstallPath || /install\/[\w\-]+\/$/.test(pathname);
             }.bind(this)}>{t('Error Tracking')}</ListLink>
-            {features.has('csp') &&
+            {isEarlyAdopter &&
               <ListLink to={`/${orgId}/${projectId}/settings/csp/`}>{t('CSP Reports')}</ListLink>
             }
             {features.has('user-reports') &&

--- a/src/sentry/templates/sentry/organization-settings.html
+++ b/src/sentry/templates/sentry/organization-settings.html
@@ -23,6 +23,7 @@
 
         {{ form.name|as_crispy_field }}
         {{ form.slug|as_crispy_field }}
+        {{ form.early_adopter|as_crispy_field }}
 
         <legend>Membership</legend>
 

--- a/src/sentry/templates/sentry/projects/keys.html
+++ b/src/sentry/templates/sentry/projects/keys.html
@@ -2,7 +2,6 @@
 
 {% load i18n %}
 {% load sentry_helpers %}
-{% load sentry_features %}
 
 {% block title %}{% trans "Client Keys" %} | {{ block.super }}{% endblock %}
 
@@ -61,13 +60,13 @@
             <div class="help-block">{% blocktrans with 'https://github.com/getsentry/raven-js' as link %}Use your public DSN with browser-based clients such as <a href="{{ link }}">raven-js</a>.{% endblocktrans %}</div>
           </div>
 
-          {% feature projects:csp project %}
+          {% if organization.flags.early_adopter %}
           <div class="form-group">
             <label>{% trans "CSP Endpoint" %}</label>
             <div class="form-control disabled auto-select">{{ key.csp_endpoint }}</div>
             <div class="help-block">{% blocktrans %}Use your CSP endpoint in the <code>report-uri</code> directive in your <code>Content-Security-Policy</code> header.{% endblocktrans %}</div>
           </div>
-          {% endfeature %}
+          {% endif %}
         </div>
       {% endfor %}
     </div>

--- a/src/sentry/templates/sentry/projects/manage.html
+++ b/src/sentry/templates/sentry/projects/manage.html
@@ -191,22 +191,22 @@
     <li>
         <a href="{% absolute_uri '/{}/{}/settings/saved-searches/' project.organization.slug project.slug %}">{% trans "Saved Searches" %}</a>
     </li>
-    {% feature projects:dsym project %}
+    {% if organization.flags.early_adopter %}
     <li>
         <a href="{% absolute_uri '/{}/{}/settings/debug-symbols/' project.organization.slug project.slug %}">{% trans "Debug Symbols" %}</a>
     </li>
-    {% endfeature %}
+    {% endif %}
   </ul>
   <h6 class="nav-header">{% trans "Data" %}</h6>
   <ul class="nav nav-stacked">
     <li>
         <a href="{% absolute_uri '/{}/{}/settings/install/' project.organization.slug project.slug %}">{% trans "Error Tracking" %}</a>
     </li>
-    {% feature projects:csp project %}
+    {% if organization.flags.early_adopter %}
     <li>
         <a href="{% absolute_uri '/{}/{}/settings/csp/' project.organization.slug project.slug %}">{% trans "CSP Reports" %}</a>
     </li>
-    {% endfeature %}
+    {% endif %}
     {% feature projects:user-reports project %}
     <li>
         <a href="{% absolute_uri '/{}/{}/settings/user-feedback/' project.organization.slug project.slug %}">{% trans "User Feedback" %}</a>

--- a/src/sentry/web/frontend/organization_settings.py
+++ b/src/sentry/web/frontend/organization_settings.py
@@ -66,6 +66,11 @@ class OrganizationSettingsForm(forms.ModelForm):
         help_text=_('Preventing IP addresses from being stored for new events on all projects.'),
         required=False
     )
+    early_adopter = forms.BooleanField(
+        label=_('Early Adopter'),
+        help_text=_('Opt-in to new features before they\'re released to the public.'),
+        required=False
+    )
 
     class Meta:
         fields = ('name', 'slug', 'default_role')
@@ -95,6 +100,7 @@ class OrganizationSettingsView(OrganizationView):
                 'require_scrub_defaults': bool(organization.get_option('sentry:require_scrub_defaults', False)),
                 'sensitive_fields': '\n'.join(organization.get_option('sentry:sensitive_fields', None) or []),
                 'require_scrub_ip_address': bool(organization.get_option('sentry:require_scrub_ip_address', False)),
+                'early_adopter': bool(organization.flags.early_adopter),
             }
         )
 
@@ -105,6 +111,7 @@ class OrganizationSettingsView(OrganizationView):
             organization.flags.allow_joinleave = form.cleaned_data['allow_joinleave']
             organization.flags.enhanced_privacy = form.cleaned_data['enhanced_privacy']
             organization.flags.disable_shared_issues = not form.cleaned_data['allow_shared_issues']
+            organization.flags.early_adopter = form.cleaned_data['early_adopter']
             organization.save()
 
             for opt in (


### PR DESCRIPTION
- Allow orgs to opt-in via Settings
- Move CSP and DSYM behind early adopter

/cc @getsentry/team

![screenshot 2016-04-20 17 40 54](https://cloud.githubusercontent.com/assets/23610/14694628/0f8da848-071f-11e6-830d-afb36bcf991a.png)
