### PR TITLE
Fix error email tag links

### DIFF
--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -52,8 +52,8 @@
               <strong>{{ tag_key }}</strong>
               <em>=</em>
               <span>
-              {% with query_string=tag_key|add:":"|add:tag_value %}
-                <a href="{% absolute_uri project_link %}?query={{ query_string|urlencode }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
+              {% with query=tag_key|add:":\""|add:tag_value|add:"\""|urlencode %}
+                <a href="{% absolute_uri project_link %}?query={{ query }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
               {% endwith %}
               </span>
           </li>

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -51,7 +51,11 @@
           <li>
               <strong>{{ tag_key }}</strong>
               <em>=</em>
-              <span><a href="{% absolute_uri project_link %}?{{ tag_key }}={{ tag_value }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}</span>
+              <span>
+              {% with query_string=tag_key|add:":"|add:tag_value %}
+                <a href="{% absolute_uri project_link %}?query={{ query_string|urlencode }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
+              {% endwith %}
+              </span>
           </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
The querystring is built up incorrectly.

**Before:**
`?tag_key=tag_value`
**After:**
`?query=tag_key:"tag_value"`
