### PR TITLE
Create an init --dev option for generating settings that are more friendly for localdev.

### DIFF
--- a/src/sentry/runner/commands/init.py
+++ b/src/sentry/runner/commands/init.py
@@ -12,7 +12,7 @@ import click
 
 
 @click.command()
-@click.option('--dev/--no-dev', default=False, help='Use settings more conducive to local development.')
+@click.option('--dev', default=False, is_flag=True, help='Use settings more conducive to local development.')
 @click.argument('directory', required=False)
 @click.pass_context
 def init(ctx, dev, directory):

--- a/src/sentry/runner/commands/init.py
+++ b/src/sentry/runner/commands/init.py
@@ -12,9 +12,10 @@ import click
 
 
 @click.command()
+@click.option('--dev/--no-dev', default=False, help='Use settings more conducive to local development.')
 @click.argument('directory', required=False)
 @click.pass_context
-def init(ctx, directory):
+def init(ctx, dev, directory):
     "Initialize new configuration directory."
     from sentry.runner.settings import discover_configs, generate_settings
     if directory is not None:
@@ -34,7 +35,7 @@ def init(ctx, directory):
     if directory and not os.path.exists(directory):
         os.makedirs(directory)
 
-    py_contents, yaml_contents = generate_settings()
+    py_contents, yaml_contents = generate_settings(dev)
 
     if os.path.isfile(yaml):
         click.confirm("File already exists at '%s', overwrite?" % click.format_filename(yaml), abort=True)

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -48,6 +48,7 @@ SENTRY_USE_BIG_INTS = True
 # Instruct Sentry that this install intends to be run by a single organization
 # and thus various UI optimizations should be enabled.
 SENTRY_SINGLE_ORGANIZATION = True
+DEBUG = %(debug_flag)s
 
 #########
 # Cache #
@@ -178,7 +179,7 @@ YAML_CONFIG_TEMPLATE = u"""\
 # Mail Server #
 ###############
 
-# mail.backend: 'smtp'  # Use dummy if you want to disable email entirely
+# mail.backend: '%(mail.backend)s'  # Use dummy if you want to disable email entirely
 # mail.host: 'localhost'
 # mail.port: 25
 # mail.username: ''
@@ -210,13 +211,18 @@ def generate_secret_key():
     return get_random_string(50, chars)
 
 
-def generate_settings():
+def generate_settings(dev=False):
     """
     This command is run when ``default_path`` doesn't exist, or ``init`` is
     run and returns a string representing the default data to put into their
     settings file.
     """
-    context = {'secret_key': generate_secret_key()}
+    context = {
+        'secret_key': generate_secret_key(),
+        'debug_flag': dev,
+        'mail.backend': 'console' if dev else 'smtp',
+    }
+
     py = PY_CONFIG_TEMPLATE % context
     yaml = YAML_CONFIG_TEMPLATE % context
     return py, yaml


### PR DESCRIPTION
Just has `DEBUG = True` and a commented out `mail.backend = console` as of now.

Fixes #3073.

@getsentry/infrastructure 
