### PR TITLE
Validate data internally for the raven client as validate also normalizes.

### DIFF
--- a/src/sentry/utils/raven.py
+++ b/src/sentry/utils/raven.py
@@ -96,7 +96,8 @@ class SentryInternalClient(DjangoClient):
 
         kwargs['project'] = project.id
         try:
-            manager = EventManager(kwargs)
+            data = helper.validate_data(project, kwargs)
+            manager = EventManager(data)
             data = manager.normalize()
             tsdb.incr_multi([
                 (tsdb.models.project_total_received, project.id),


### PR DESCRIPTION
This is required so that submission of breadcrumbs internally works
which uses the non normalized form of submitting a list.
