### PR TITLE
Improve design for query breadcrumbs

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1720,10 +1720,16 @@ ul.crumbs {
     &.crumb-query {
       background: lighten(@orange, 42);
       code {
-        white-space: pre;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        background: transparent;
+        font-size: 13px;
+
+        span {
+          display: inline;
+        }
 
         span.param {
-          display: inline;
           color: @blue;
           padding: 0 3px;
           background: white;


### PR DESCRIPTION
What it looks like:

<img width="931" alt="screen shot 2016-04-22 at 23 28 36" src="https://cloud.githubusercontent.com/assets/7396/14755381/1f4b6896-08e2-11e6-81a0-68298771b717.png">
