### PR TITLE
Fix SDK event interface header font weight

### DIFF
--- a/src/sentry/static/sentry/app/components/events/sdk.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdk.jsx
@@ -13,13 +13,14 @@ const EventSdk = React.createClass({
   render() {
     let {group, event} = this.props;
     let data = event.sdk;
+
     return (
       <GroupEventDataSection
           group={group}
           event={event}
           type="sdk"
           title={t('SDK')}
-          wrapTitle={false}>
+          wrapTitle={true}>
         <table className="table key-value">
           <tbody>
             <tr key="name">


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/2153/14759199/36ba31ba-08ce-11e6-9a34-678e090a508d.png)

After:

![image](https://cloud.githubusercontent.com/assets/2153/14759198/2c9e10b6-08ce-11e6-8d47-f865f8e72986.png)

(This was bothering me.)

/cc @getsentry/ui
