### PR TITLE
Move celery commands to `sentry run` and deprecate `sentry celery`

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -17,6 +17,51 @@ if not settings.configured:
 from sentry.utils import metrics
 
 
+DB_SHARED_THREAD = """\
+DatabaseWrapper objects created in a thread can only \
+be used in that same thread.  The object with alias '%s' \
+was created in thread id %s and this is thread id %s.\
+"""
+
+
+def patch_thread_ident():
+    # monkey patch django.
+    # This patch make sure that we use real threads to get the ident which
+    # is going to happen if we are using gevent or eventlet.
+    # -- patch taken from gunicorn
+    if getattr(patch_thread_ident, 'called', False):
+        return
+    try:
+        from django.db.backends import BaseDatabaseWrapper, DatabaseError
+
+        if 'validate_thread_sharing' in BaseDatabaseWrapper.__dict__:
+            import thread
+            _get_ident = thread.get_ident
+
+            __old__init__ = BaseDatabaseWrapper.__init__
+
+            def _init(self, *args, **kwargs):
+                __old__init__(self, *args, **kwargs)
+                self._thread_ident = _get_ident()
+
+            def _validate_thread_sharing(self):
+                if (not self.allow_thread_sharing
+                        and self._thread_ident != _get_ident()):
+                    raise DatabaseError(
+                        DB_SHARED_THREAD % (
+                            self.alias, self._thread_ident, _get_ident()),
+                    )
+
+            BaseDatabaseWrapper.__init__ = _init
+            BaseDatabaseWrapper.validate_thread_sharing = \
+                _validate_thread_sharing
+
+        patch_thread_ident.called = True
+    except ImportError:
+        pass
+patch_thread_ident()
+
+
 class Celery(celery.Celery):
     def on_configure(self):
         from raven.contrib.django.models import client
@@ -49,7 +94,3 @@ app.Task = SentryTask
 # pickle the object when using Windows.
 app.config_from_object(settings)
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
-
-
-if __name__ == '__main__':
-    app.start()

--- a/src/sentry/management/commands/celery.py
+++ b/src/sentry/management/commands/celery.py
@@ -11,12 +11,23 @@ base = celery.CeleryCommand(app=app)
 # this is a reimplementation of the djcelery 'celery' command
 class Command(CeleryCommand):
     """The celery command."""
-    help = 'celery commands, see celery help'
+    help = 'DEPRECATED see `sentry run {worker,cron} instead.'
     options = (CeleryCommand.options
                + base.get_options()
                + base.preload_options)
 
     def run_from_argv(self, argv):
+        from sentry.runner.initializer import show_big_error
+        if 'worker' in argv:
+            show_big_error([
+                '`sentry celery worker` is deprecated.',
+                'Use `sentry run worker` instead.',
+            ])
+        elif 'beat' in argv:
+            show_big_error([
+                '`sentry celery beat` is deprecated.',
+                'Use `sentry run cron` instead.',
+            ])
         argv = self.handle_default_options(argv)
         if self.requires_model_validation:
             self.validate()

--- a/src/sentry/queue/command.py
+++ b/src/sentry/queue/command.py
@@ -6,50 +6,6 @@ import sys
 
 from django.core.management.base import BaseCommand
 
-DB_SHARED_THREAD = """\
-DatabaseWrapper objects created in a thread can only \
-be used in that same thread.  The object with alias '%s' \
-was created in thread id %s and this is thread id %s.\
-"""
-
-
-def patch_thread_ident():
-    # monkey patch django.
-    # This patch make sure that we use real threads to get the ident which
-    # is going to happen if we are using gevent or eventlet.
-    # -- patch taken from gunicorn
-    if getattr(patch_thread_ident, 'called', False):
-        return
-    try:
-        from django.db.backends import BaseDatabaseWrapper, DatabaseError
-
-        if 'validate_thread_sharing' in BaseDatabaseWrapper.__dict__:
-            import thread
-            _get_ident = thread.get_ident
-
-            __old__init__ = BaseDatabaseWrapper.__init__
-
-            def _init(self, *args, **kwargs):
-                __old__init__(self, *args, **kwargs)
-                self._thread_ident = _get_ident()
-
-            def _validate_thread_sharing(self):
-                if (not self.allow_thread_sharing
-                        and self._thread_ident != _get_ident()):
-                    raise DatabaseError(
-                        DB_SHARED_THREAD % (
-                            self.alias, self._thread_ident, _get_ident()),
-                    )
-
-            BaseDatabaseWrapper.__init__ = _init
-            BaseDatabaseWrapper.validate_thread_sharing = \
-                _validate_thread_sharing
-
-        patch_thread_ident.called = True
-    except ImportError:
-        pass
-patch_thread_ident()
-
 
 class CeleryCommand(BaseCommand):
     options = BaseCommand.option_list

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -90,7 +90,7 @@ def make_django_command(name, django_command=None, help=None):
 
 map(cli.add_command, (
     make_django_command('shell', help='Run a Python interactive interpreter.'),
-    make_django_command('celery', help='Start background workers.'),
+    make_django_command('celery', help='DEPRECATED see `sentry run` instead.'),
 ))
 
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -51,8 +51,8 @@ def devserver(reload, watchers, workers, bind):
             raise click.ClickException('Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers.')
 
         daemons += [
-            ('worker', ['sentry', 'celery', 'worker', '-c', '1', '-l', 'INFO']),
-            ('beat', ['sentry', 'celery', 'beat', '-l', 'INFO']),
+            ('worker', ['sentry', 'run', 'worker', '-c', '1', '-l', 'INFO', '--autoreload']),
+            ('cron', ['sentry', 'run', 'cron', '-l', 'INFO', '--autoreload']),
         ]
 
     # A better log-format for local dev when running through honcho,

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -7,9 +7,14 @@ sentry.runner.commands.run
 """
 from __future__ import absolute_import, print_function
 
+import sys
+from multiprocessing import cpu_count
+
 import click
 
 from sentry.runner.decorators import configuration
+
+CELERY_LOG_LEVELS = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'FATAL')
 
 
 class AddressParamType(click.ParamType):
@@ -29,8 +34,23 @@ class AddressParamType(click.ParamType):
             port = None
         return host, port
 
+Address = AddressParamType()
 
-ADDRESS = AddressParamType()
+
+class CaseInsensitiveChoice(click.Choice):
+    def convert(self, value, param, ctx):
+        return super(CaseInsensitiveChoice, self).convert(value.upper(), param, ctx)
+
+
+class SetType(click.ParamType):
+    name = 'text'
+
+    def convert(self, value, param, ctx):
+        if value is None:
+            return None
+        return frozenset(value.split(','))
+
+Set = SetType()
 
 
 @click.group()
@@ -39,7 +59,7 @@ def run():
 
 
 @run.command()
-@click.option('--bind', '-b', default=None, help='Bind address.', type=ADDRESS)
+@click.option('--bind', '-b', default=None, help='Bind address.', type=Address)
 @click.option('--workers', '-w', default=0, help='The number of worker processes for handling requests.')
 @click.option('--upgrade', default=False, is_flag=True, help='Upgrade before starting.')
 @click.option('--noinput', default=False, is_flag=True, help='Do not prompt the user for input of any kind.')
@@ -63,7 +83,7 @@ def web(bind, workers, upgrade, noinput):
 
 
 @run.command()
-@click.option('--bind', '-b', default=None, help='Bind address.', type=ADDRESS)
+@click.option('--bind', '-b', default=None, help='Bind address.', type=Address)
 @click.option('--upgrade', default=False, is_flag=True, help='Upgrade before starting.')
 @click.option('--noinput', default=False, is_flag=True, help='Do not prompt the user for input of any kind.')
 @configuration
@@ -81,4 +101,77 @@ def smtp(bind, upgrade, noinput):
     SentrySMTPServer(
         host=bind[0],
         port=bind[1],
+    ).run()
+
+
+@run.command()
+@click.option('--hostname', '-n', help=(
+    'Set custom hostname, e.g. \'w1.%h\'. Expands: %h'
+    '(hostname), %n (name) and %d, (domain).'))
+@click.option('--queues', '-Q', type=Set, help=(
+    'List of queues to enable for this worker, separated by '
+    'comma. By default all configured queues are enabled. '
+    'Example: -Q video,image'))
+@click.option('--exclude-queues', '-X', type=Set)
+@click.option('--concurrency', '-c', default=cpu_count(), help=(
+    'Number of child processes processing the queue. The '
+    'default is the number of CPUs available on your '
+    'system.'))
+@click.option('--loglevel', '-l', default='WARNING', help='Logging level.',
+    type=CaseInsensitiveChoice(CELERY_LOG_LEVELS))
+@click.option('--logfile', '-f', help=(
+    'Path to log file. If no logfile is specified, stderr is used.'))
+@click.option('--quiet', '-q', is_flag=True, default=False)
+@click.option('--no-color', is_flag=True, default=False)
+@click.option('--autoreload', is_flag=True, default=False, help='Enable autoreloading.')
+@configuration
+def worker(**options):
+    "Run background worker instance."
+    from django.conf import settings
+    if settings.CELERY_ALWAYS_EAGER:
+        raise click.ClickException('Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers.')
+
+    from sentry.celery import app
+    worker = app.Worker(
+        without_gossip=True,
+        without_mingle=True,
+        without_heartbeat=True,
+        pool_cls='prefork',
+        **options
+    )
+    worker.start()
+    try:
+        sys.exit(worker.exitcode)
+    except AttributeError:
+        # `worker.exitcode` was added in a newer version of Celery:
+        # https://github.com/celery/celery/commit/dc28e8a5
+        # so this is an attempt to be forwards compatible
+        pass
+
+
+@run.command()
+@click.option('--pidfile', help=(
+    'Optional file used to store the process pid. The '
+    'program will not start if this file already exists and '
+    'the pid is still alive.'))
+@click.option('--loglevel', '-l', default='WARNING', help='Logging level.',
+    type=CaseInsensitiveChoice(CELERY_LOG_LEVELS))
+@click.option('--logfile', '-f', help=(
+    'Path to log file. If no logfile is specified, stderr is used.'))
+@click.option('--quiet', '-q', is_flag=True, default=False)
+@click.option('--no-color', is_flag=True, default=False)
+@click.option('--autoreload', is_flag=True, default=False, help='Enable autoreloading.')
+@configuration
+def cron(**options):
+    "Run periodic task dispatcher."
+    from django.conf import settings
+    if settings.CELERY_ALWAYS_EAGER:
+        raise click.ClickException('Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers.')
+
+    from sentry.celery import app
+    app.Beat(
+        without_gossip=True,
+        without_mingle=True,
+        without_heartbeat=True,
+        **options
     ).run()


### PR DESCRIPTION
For sake of further unification of all sentry subprocesses under `sentry
run`, this is moving `sentry celery {worker,beat}`.

In doing so, this restricts the functionality of celery greatly (in a
good way). Celery provides ton of features that are extremely daunting
and confusing to a user. None of which we use, so exposing command line
configuration for them doesn't make sense. We can further dictate our
recommended configuration. We also want to loosen our ties to Celery
because in the future we're likely to replace it with something else. So
exposing the advanced configurations and utilizing advanced Celery
features is only going to prolong breaking away.

@getsentry/infrastructure 
