### PR TITLE
Make avatars square again

### DIFF
--- a/src/sentry/static/sentry/less/organization.less
+++ b/src/sentry/static/sentry/less/organization.less
@@ -88,7 +88,7 @@
 
     .activity-item {
       margin: 0;
-      padding: 10px 15px 10px 62px;
+      padding: 10px 15px 10px 60px;
       border-bottom: 1px solid lighten(@trim, 5);
       line-height: 1.4;
       font-size: 15px;
@@ -146,7 +146,7 @@
       .avatar {
         position: absolute;
         .square(36px);
-        left: 15px;
+        left: 12px;
         top: 12px;
 
         &.sentry {
@@ -155,7 +155,7 @@
           background: @purple;
           color: #fff;
           line-height: 36px;
-          border-radius: 50%;
+          border-radius: 3px;
         }
       }
 


### PR DESCRIPTION
Makes the round sentry avatars square, and fixes a minor padding issue:

**from:**

![screen shot 2016-04-26 at 11 21 10 am](https://cloud.githubusercontent.com/assets/30713/14829619/3ef25c06-0ba1-11e6-8af8-b4853b53cfc4.png)

**to:**

![screen shot 2016-04-26 at 11 21 55 am](https://cloud.githubusercontent.com/assets/30713/14829612/35383c62-0ba1-11e6-8b64-74b28b74712f.png)

@getsentry/ui 
