### PR TITLE
Strip search filter queries from extraneous whitespace

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -184,7 +184,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             # disable stats
             stats_period = None
 
-        query = request.GET.get('query')
+        query = request.GET.get('query', '').strip()
         if query:
             matching_group = None
             if len(query) == 32:

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -304,7 +304,7 @@ const Stream = React.createClass({
     let url = this.getGroupListEndpoint();
 
     let requestParams = {
-      query: this.state.query,
+      query: this.state.query.replace(/^\s+|\s+$/g, ''),
       limit: this.props.maxItems,
       sort: this.state.sort,
       statsPeriod: this.state.statsPeriod,


### PR DESCRIPTION
This mostly affected an exact event id search, which has extra
whitespace, it wasn't getting matched.

I'm doing this on both the frontend and backend. Frontend seemed like
the more appropriate place to strip before sending over the wire, but
it's also possible to make an API request directly, so just sanitizing
in both place.

I'm also open to only applying the change on the backend and let the frontend send garbage.

@getsentry/ui 
