### PR TITLE
Switch to `#` prefixes for source mapping URLs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,8 +177,8 @@ var config = {
     sourceMapFilename: '[name].js.map',
   },
   devtool: IS_PRODUCTION ?
-    'source-map' :
-    'cheap-module-eval-source-map'
+    '#source-map' :
+    '#cheap-module-eval-source-map'
 };
 
 // This compression-webpack-plugin generates pre-compressed files


### PR DESCRIPTION
This changes @sourceMappingURL to #sourceMappingURL.

It's necessary to do this change or we get spammed to hell and back
in newer chrome versions.
