### PR TITLE
When updating an existing ReleaseFile, make sure we keep ident in sync

### DIFF
--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -40,6 +40,12 @@ class ReleaseFile(Model):
             self.ident = type(self).get_ident(self.name)
         return super(ReleaseFile, self).save(*args, **kwargs)
 
+    def update(self, *args, **kwargs):
+        # If our name is changing, we must also change the ident
+        if 'name' in kwargs and 'ident' not in kwargs:
+            kwargs['ident'] = self.ident = type(self).get_ident(kwargs['name'])
+        return super(ReleaseFile, self).update(*args, **kwargs)
+
     @classmethod
     def get_ident(cls, name):
         return sha1(name).hexdigest()

--- a/tests/sentry/api/endpoints/test_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_release_file_details.py
@@ -77,6 +77,7 @@ class ReleaseFileUpdateTest(APITestCase):
 
         releasefile = ReleaseFile.objects.get(id=releasefile.id)
         assert releasefile.name == 'foobar'
+        assert releasefile.ident == ReleaseFile.get_ident('foobar')
 
 
 class ReleaseFileDeleteTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_release_files.py
+++ b/tests/sentry/api/endpoints/test_release_files.py
@@ -69,6 +69,7 @@ class ReleaseFileCreateTest(APITestCase):
 
         releasefile = ReleaseFile.objects.get(release=release)
         assert releasefile.name == 'http://example.com/application.js'
+        assert releasefile.ident == ReleaseFile.get_ident('http://example.com/application.js')
         assert releasefile.file.headers == {
             'Content-Type': 'application/javascript',
             'X-SourceMap': 'http://example.com',


### PR DESCRIPTION
If someone renames a file through the API, it's then impossible to look
up during sourcemaps since we only query using the ident. The ident is
then wrong and doesn't match what they renamed to.

@getsentry/infrastructure 
