### PR TITLE
Fixes to Rules editor

### DIFF
--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -8,15 +8,17 @@ sentry.rules.conditions.minimum_level
 
 from __future__ import absolute_import
 
+from collections import OrderedDict
+
 from django import forms
 from sentry.constants import LOG_LEVELS
 
 from sentry.rules.conditions.base import EventCondition
 
-LEVEL_CHOICES = [
+LEVEL_CHOICES = OrderedDict([
     ("{0}".format(k), "{0}".format(v.capitalize()))
     for k, v in sorted(LOG_LEVELS.items(), key=lambda x: x[0], reverse=True)
-]
+])
 
 
 class LevelMatchType(object):
@@ -27,7 +29,7 @@ class LevelMatchType(object):
 
 class LevelEventForm(forms.Form):
     level = forms.ChoiceField(
-        choices=LEVEL_CHOICES,
+        choices=LEVEL_CHOICES.items(),
         initial=30)
     match = forms.ChoiceField(
         choices=(
@@ -40,6 +42,13 @@ class LevelEventForm(forms.Form):
 class LevelCondition(EventCondition):
     form_cls = LevelEventForm
     label = 'An event\'s level is {match} {level}'
+
+    def render_label(self):
+        data = {
+            'match': self.data['match'],
+            'level': LEVEL_CHOICES[self.data['level']],
+        }
+        return self.label.format(**data)
 
     def passes(self, event, state, **kwargs):
         desired_level = self.get_option('level')

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
@@ -12,7 +12,7 @@ const RuleNodeList = React.createClass({
   getInitialState() {
     let counter = 0;
     let initialItems = (this.props.initialItems || []).map(item => {
-      return {...item, key: counter++};
+      return {...item, key_attr: counter++};
     });
 
     return {
@@ -41,7 +41,7 @@ const RuleNodeList = React.createClass({
       // need to make sure elements aren't accidentally re-rendered. So, give each
       // row a consistent key using a counter that initializes at 0 when RuleNodeList
       // is mounted.
-      key: this.state.counter
+      key_attr: this.state.counter
     });
     this.setState({
       items: this.state.items,
@@ -69,7 +69,7 @@ const RuleNodeList = React.createClass({
           <tbody>
             {this.state.items.map((item, idx) => {
               return (
-                <RuleNode key={item.key}
+                <RuleNode key={item.key_attr}
                   node={this.getNode(item.id)}
                   onDelete={this.onDeleteRow.bind(this, idx)}
                   data={item} />

--- a/tests/js/spec/views/ruleEditor/ruleNodeList.spec.jsx
+++ b/tests/js/spec/views/ruleEditor/ruleNodeList.spec.jsx
@@ -22,7 +22,7 @@ describe('RuleNodeList', function() {
   });
 
   describe('getInitialItems()', function () {
-    it('should give each initial item a unique incremented key, and set state.counter', function () {
+    it('should give each initial item a unique incremented key_attr, and set state.counter', function () {
       let initialItems = [
         {
           id: 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
@@ -36,14 +36,14 @@ describe('RuleNodeList', function() {
 
       let wrapper = shallow(<RuleNodeList nodes={this.sampleNodes} initialItems={initialItems}/>);
 
-      expect(wrapper.state('items')[0]).to.have.property('key', 0);
-      expect(wrapper.state('items')[1]).to.have.property('key', 1);
+      expect(wrapper.state('items')[0]).to.have.property('key_attr', 0);
+      expect(wrapper.state('items')[1]).to.have.property('key_attr', 1);
       expect(wrapper.state('counter')).to.equal(2);
     });
   });
 
   describe('onAddRow()', function() {
-    it('should add a new item with key value equal to state.counter, and increment state.counter', function () {
+    it('should add a new item with key_attr value equal to state.counter, and increment state.counter', function () {
       let wrapper = shallow(<RuleNodeList nodes={this.sampleNodes} />);
 
       wrapper.setState({
@@ -58,7 +58,7 @@ describe('RuleNodeList', function() {
 
       expect(wrapper.state('items')[0]).to.eql({
         id: 'sentry.rules.conditions.every_event.EveryEventCondition',
-        key: 5
+        key_attr: 5
       });
       expect(wrapper.state('counter')).to.equal(6);
     });


### PR DESCRIPTION
- Level was displaying integer form on list view.
- When Adding/Editing rules for matching tags, the key value was
  conflicting with the React "key" causing it to render an integer
  instead of the actual value. Fixes GH-3139

@getsentry/ui 
