### PR TITLE
Disable internal raven normalize

### DIFF
--- a/src/sentry/utils/raven.py
+++ b/src/sentry/utils/raven.py
@@ -96,7 +96,11 @@ class SentryInternalClient(DjangoClient):
 
         kwargs['project'] = project.id
         try:
-            data = helper.validate_data(project, kwargs)
+            # This in theory is the right way to do it because validate
+            # also normalizes currently, but we just send in data already
+            # normalised in the raven client now.
+            # data = helper.validate_data(project, kwargs)
+            data = kwargs
             manager = EventManager(data)
             data = manager.normalize()
             tsdb.incr_multi([


### PR DESCRIPTION
Turns out we have some issues with actually passing validation and it causes
recursive failures in some circumstances.  Disable it for now and make sure
that raven python always sends noramlized data.
