### PR TITLE
Order breadcrumbs below exception

### DIFF
--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -67,8 +67,8 @@ class Breadcrumbs(Interface):
     >>>     }
     >>> ], ...}
     """
-    display_score = 5000
-    score = 100
+    display_score = 1100
+    score = 800
 
     @classmethod
     def to_python(cls, data):


### PR DESCRIPTION
Exception interface has `display_score` 1200, `score` 900.

/cc @getsentry/ui @dcramer 
