### PR TITLE
Support tag queries on group events

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import
 
+from django.db.models import Q
+from operator import or_
+
 from sentry.api.base import DocSection
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.paginator import DateTimePaginator
-from sentry.models import Event, Group
+from sentry.models import Event, EventTag, Group, TagKey, TagValue
+from sentry.search.utils import parse_query
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -19,6 +23,52 @@ def list_available_samples_scenario(runner):
 
 class GroupEventsEndpoint(GroupEndpoint):
     doc_section = DocSection.EVENTS
+
+    def _tags_to_filter(self, project, tags):
+        tagkeys = dict(TagKey.objects.filter(
+            project=project,
+            key__in=tags.keys(),
+        ).values_list('key', 'id'))
+
+        tagvalues = {
+            (t[1], t[2]): t[0]
+            for t in TagValue.objects.filter(
+                reduce(or_, (Q(key=k, value=v) for k, v in tags.iteritems())),
+                project=project,
+            ).values_list('id', 'key', 'value')
+        }
+
+        try:
+            tag_lookups = [
+                (tagkeys[k], tagvalues[(k, v)])
+                for k, v in tags.iteritems()
+            ]
+        except KeyError:
+            # one or more tags were invalid, thus the result should be an empty
+            # set
+            return []
+
+        # Django doesnt support union, so we limit results and try to find
+        # reasonable matches
+
+        # get initial matches to start the filter
+        k, v = tag_lookups.pop()
+        matches = list(EventTag.objects.filter(
+            key_id=k,
+            value_id=v,
+            project_id=project.id,
+        ).values_list('event_id', flat=True)[:1000])
+
+        # for each remaining tag, find matches contained in our
+        # existing set, pruning it down each iteration
+        for k, v in tag_lookups:
+            matches = list(EventTag.objects.filter(
+                key_id=k,
+                value_id=v,
+                event_id__in=matches,
+                project_id=project.id,
+            ).values_list('event_id', flat=True)[:1000])
+        return matches
 
     @attach_scenarios([list_available_samples_scenario])
     def get(self, request, group):
@@ -38,9 +88,17 @@ class GroupEventsEndpoint(GroupEndpoint):
 
         query = request.GET.get('query')
         if query:
-            events = events.filter(
-                message__icontains=query,
-            )
+            query_kwargs = parse_query(group.project, query, request.user)
+
+            if query_kwargs['query']:
+                events = events.filter(
+                    message__icontains=query_kwargs['query'],
+                )
+
+            if query_kwargs['tags']:
+                events = events.filter(
+                    id__in=self._tags_to_filter(group.project, query_kwargs['tags']),
+                )
 
         return self.paginate(
             request=request,

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -219,7 +219,7 @@ const GroupEvents = React.createClass({
       <div>
         <div style={{marginBottom: 20}}>
           <SearchBar defaultQuery=""
-            placeholder="search event message"
+            placeholder="search event message or tags"
             query={this.state.query}
             onSearch={this.onSearch} />
         </div>

--- a/tests/sentry/api/endpoints/test_group_events.py
+++ b/tests/sentry/api/endpoints/test_group_events.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.models import EventTag, TagKey, TagValue
 from sentry.testutils import APITestCase
 
 
@@ -20,3 +21,79 @@ class GroupEventsTest(APITestCase):
             str(event_1.id),
             str(event_2.id),
         ])
+
+    def test_tags(self):
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+        event_1 = self.create_event('a' * 32, group=group)
+        event_2 = self.create_event('b' * 32, group=group)
+
+        tagkey_1 = TagKey.objects.create(project=group.project, key='foo')
+        tagkey_2 = TagKey.objects.create(project=group.project, key='bar')
+        tagvalue_1 = TagValue.objects.create(project=group.project, key='foo', value='baz')
+        tagvalue_2 = TagValue.objects.create(project=group.project, key='bar', value='biz')
+        tagvalue_3 = TagValue.objects.create(project=group.project, key='bar', value='buz')
+
+        EventTag.objects.create(
+            project_id=group.project_id,
+            event_id=event_1.id,
+            key_id=tagkey_1.id,
+            value_id=tagvalue_1.id,
+        )
+        EventTag.objects.create(
+            project_id=group.project_id,
+            event_id=event_2.id,
+            key_id=tagkey_2.id,
+            value_id=tagvalue_2.id,
+        )
+        EventTag.objects.create(
+            project_id=group.project_id,
+            event_id=event_1.id,
+            key_id=tagkey_2.id,
+            value_id=tagvalue_3.id,
+        )
+
+        url = '/api/0/issues/{}/events/'.format(group.id)
+        response = self.client.get(url + '?query=foo:baz', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == str(event_1.id)
+
+        response = self.client.get(url + '?query=bar:biz', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == str(event_2.id)
+
+        response = self.client.get(url + '?query=bar:biz%20foo:baz', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
+        response = self.client.get(url + '?query=bar:buz%20foo:baz', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == str(event_1.id)
+
+        response = self.client.get(url + '?query=bar:baz', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
+        response = self.client.get(url + '?query=a:b', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
+        response = self.client.get(url + '?query=bar:b', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
+        response = self.client.get(url + '?query=bar:baz', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0


### PR DESCRIPTION
This allows searching of individual events based on tags on the "Related Events" tab.

@getsentry/api
