### PR TITLE
Add the ability to refresh recent activity

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -196,11 +196,21 @@ const Activity = React.createClass({
     return `/organizations/${this.props.params.orgId}/activity/`;
   },
 
+  refresh() {
+    this.refs.activityFeed.remountComponent();
+  },
+
   render() {
     return (
       <div>
+        <div className="pull-right">
+          <a className="btn btn-sm btn-default" style={{marginLeft: 5}}
+             onClick={this.refresh}>
+            <span className="icon icon-refresh" />
+          </a>
+        </div>
         <h4>Recent activity</h4>
-        <ActivityFeed endpoint={this.getEndpoint()} query={{
+        <ActivityFeed ref="activityFeed" endpoint={this.getEndpoint()} query={{
           per_page: 10,
         }} pagination={false} {...this.props} />
       </div>


### PR DESCRIPTION
Adds a refresh button to the activity block on the org dashboard.

![screen shot 2016-05-03 at 4 14 27 pm](https://cloud.githubusercontent.com/assets/30713/15001166/26baeff0-114a-11e6-8a81-67bbdee826e4.png)

cc @getsentry/ui 
