### PR TITLE
Restrict the object_path index length for mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 services:
   - memcached
+  - mysql
   - riak
   - postgresql
   - redis-server
@@ -17,6 +18,7 @@ env:
   matrix:
     - TEST_SUITE=sqlite DB=sqlite
     - TEST_SUITE=postgres DB=postgres
+    - TEST_SUITE=mysql DB=mysql
     - TEST_SUITE=js
     - TEST_SUITE=cli
     - TEST_SUITE=dist

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,9 @@ travis-noop:
 travis-install-sqlite: travis-install-python
 travis-install-postgres: travis-install-python dev-postgres
 	psql -c 'create database sentry;' -U postgres
+travis-install-mysql: travis-install-python
+	pip install mysqlclient
+	echo 'create database sentry;' | mysql -uroot
 travis-install-js: install-npm
 travis-install-cli: travis-install-python
 travis-install-dist: travis-noop
@@ -169,19 +172,21 @@ travis-install-dist: travis-noop
 # Lint steps
 travis-lint-sqlite: lint-python
 travis-lint-postgres: lint-python
+travis-lint-mysql: lint-python
 travis-lint-js: lint-js
 travis-lint-cli: travis-noop
 travis-lint-dist: travis-noop
 
-.PHONY: travis-lint-sqlite travis-lint-postgres travis-lint-js travis-lint-cli travis-lint-dist
+.PHONY: travis-lint-sqlite travis-lint-postgres travis-lint-mysql travis-lint-js travis-lint-cli travis-lint-dist
 
 # Test steps
 travis-test-sqlite: test-python-coverage
 travis-test-postgres: test-python-coverage
+travis-test-mysql: test-python-coverage
 travis-test-js: test-js
 travis-test-ci: test-ci
 travis-test-dist:
 	SENTRY_BUILD=$(TRAVIS_COMMIT) SENTRY_LIGHT_BUILD=0 python setup.py sdist bdist_wheel
 	@ls -lh dist/
 
-.PHONY: travis-test-sqlite travis-test-postgres travis-test-js travis-test-cli travis-test-dist
+.PHONY: travis-test-sqlite travis-test-postgres travis-test-mysql travis-test-js travis-test-cli travis-test-dist

--- a/src/sentry/utils/pytest.py
+++ b/src/sentry/utils/pytest.py
@@ -24,6 +24,8 @@ def pytest_configure(config):
                 'NAME': 'sentry',
                 'USER': 'root',
             })
+            # mysql requires running full migration all the time
+            settings.SOUTH_TESTS_MIGRATE = True
         elif test_db == 'postgres':
             settings.DATABASES['default'].update({
                 'ENGINE': 'sentry.db.postgres',


### PR DESCRIPTION
Not exactly the nicest way to do it but it works.

This fixes #3173
