### PR TITLE
Various improvements for crumb rendering.

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/category.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/category.jsx
@@ -22,7 +22,7 @@ const Category = React.createClass({
       title = value;
     }
     return (
-      <span className="crumb-category">{title}</span>
+      <span className="crumb-category" title={title}>{title}</span>
     );
   }
 });

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRenderer.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRenderer.jsx
@@ -9,13 +9,25 @@ const HttpRenderer = React.createClass({
     crumb: React.PropTypes.object.isRequired,
   },
 
+  renderUrl(url) {
+    return (
+      url.match(/^https?:\/\//)
+        ? <a href={url}>{url}</a>
+        : <em>{url}</em>
+    );
+  },
+
   render() {
     let {crumb} = this.props;
     let {method, status_code, reason, url, ...extra} = crumb.data;
     let summary = (
       <SummaryLine crumb={crumb}>
         <pre>
-          <code>{method + ' ' + url + ' [' + status_code + ']'}</code>
+          <code>
+            {method && <strong>{method} </strong>}
+            {url && this.renderUrl(url)}
+            {status_code && (' [' + status_code + ']')}
+          </code>
         </pre>
       </SummaryLine>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/summaryLine.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/summaryLine.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 
 function isOverflowing(el) {
-  return el.clientHeight < el.scrollHeight;
+  // XXX(mitsuhiko): subtract one because of reasons. Not sure which ones.
+  return el.offsetHeight < el.scrollHeight - 1;
 }
 
 const SummaryLine = React.createClass({


### PR DESCRIPTION
<img width="929" alt="screen shot 2016-05-04 at 17 59 30" src="https://cloud.githubusercontent.com/assets/7396/15020353/fcdf7754-1221-11e6-9fb8-5f5db04e2dd2.png">
- improved overflow
- rendering of http crumbs improved
- allow long categories to have titles shown
