### PR TITLE
Hide HTTP in public

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -19,8 +19,13 @@ class EventSerializer(Serializer):
             if key in self._reserved_keys:
                 continue
 
+            data = interface.get_api_context(is_public=is_public)
+            # data might not be returned for e.g. a public HTTP repr
+            if not data:
+                continue
+
             entry = {
-                'data': interface.get_api_context(is_public=is_public),
+                'data': data,
                 'type': interface.get_alias(),
             }
             interface_list.append((interface, entry))

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -213,6 +213,9 @@ class Http(Interface):
         return _('Request')
 
     def get_api_context(self, is_public=False):
+        if is_public:
+            return {}
+
         data = self.data
         if isinstance(data, dict):
             data = json.dumps(data)
@@ -232,10 +235,7 @@ class Http(Interface):
             'fragment': self.fragment,
             'data': data,
             'headers': headers,
+            'cookies': cookies,
+            'env': self.env or None,
         }
-        if not is_public:
-            data.update({
-                'cookies': cookies,
-                'env': self.env or None,
-            })
         return data


### PR DESCRIPTION
This will remove HTTP data entirely from public views. In many cases (Sentry included), even the minor data remaining would contain PII. For example, the URL may contain the customer name.

@getsentry/api 
