### PR TITLE
Union merge changelog by default.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG merge=union


### PR DESCRIPTION
The idea is basically to make sure that the changelog file does not merge conflict. That way we can probably add the items on the branches.
