### PR TITLE
Catch all exceptions that may bubble up from trying to parse sourcemap

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -13,7 +13,6 @@ from django.utils.encoding import force_bytes, force_text
 from collections import namedtuple
 from os.path import splitext
 from requests.exceptions import RequestException
-from simplejson import JSONDecodeError
 from urlparse import urlparse, urljoin, urlsplit
 
 # In case SSL is unavailable (light builds) we can't import this here.
@@ -379,7 +378,7 @@ def fetch_sourcemap(url, project=None, release=None, allow_scraping=True):
 
     try:
         return sourcemap_to_index(body)
-    except (JSONDecodeError, ValueError, AssertionError) as exc:
+    except Exception as exc:
         logger.warn(unicode(exc))
         raise UnparseableSourcemap({
             'url': url,


### PR DESCRIPTION
Lately, this has been from a KeyError, so rather than adding more
exceptions here, just catch them all.

The effect of this is the entire process gets aborted without an error shown to the user, when they've supplied an invalid sourcemap format.

@getsentry/infrastructure @benvinegar 
