### PR TITLE
Remove use of get_task_logger

### DIFF
--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, print_function
 
-from celery.utils.log import get_task_logger
+import logging
 
 from sentry.models import Organization, OrganizationMember
 from sentry.tasks.base import instrumented_task
 
-logger = get_task_logger(__name__)
+logger = logging.getLogger('sentry.auth')
 
 
 @instrumented_task(name='sentry.tasks.send_sso_link_emails', queue='auth')

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -8,14 +8,14 @@ sentry.tasks.deletion
 
 from __future__ import absolute_import
 
-from celery.utils.log import get_task_logger
+import logging
 
 from sentry.exceptions import DeleteAborted
 from sentry.signals import pending_delete
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.query import bulk_delete_objects
 
-logger = get_task_logger(__name__)
+logger = logging.getLogger('sentry.deletions')
 
 
 @instrumented_task(name='sentry.tasks.deletion.delete_organization', queue='cleanup',

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -8,14 +8,17 @@ sentry.tasks.merge
 
 from __future__ import absolute_import
 
-from celery.utils.log import get_task_logger
+import logging
+
 from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
 
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.deletion import delete_group
 
-logger = get_task_logger(__name__)
+# TODO(dcramer): probably should have a new logger for this, but it removes data
+# so lets bundle under deletions
+logger = logging.getLogger('sentry.deletions')
 
 
 @instrumented_task(name='sentry.tasks.merge.merge_group', queue='merge',

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -8,7 +8,8 @@ sentry.tasks.post_process
 
 from __future__ import absolute_import, print_function
 
-from celery.utils.log import get_task_logger
+import logging
+
 from django.db import IntegrityError, router, transaction
 from raven.contrib.django.models import client as Raven
 
@@ -18,7 +19,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
-logger = get_task_logger(__name__)
+logger = logging.getLogger('sentry')
 
 
 def _capture_stats(event, is_new):

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -8,7 +8,8 @@ sentry.tasks.store
 
 from __future__ import absolute_import
 
-from celery.utils.log import get_task_logger
+import logging
+
 from raven.contrib.django.models import client as Raven
 from time import time
 
@@ -17,7 +18,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
-logger = get_task_logger(__name__)
+logger = logging.getLogger('sentry')
 
 
 @instrumented_task(


### PR DESCRIPTION
In at least some situations these weren't propagating correctly to Sentry.

@getsentry/infrastructure
