### PR TITLE
Isolate digest partition scheduling/maintenance runs.

### DIFF
--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -188,184 +188,204 @@ class RedisBackend(Backend):
 
             return results[-2 if should_truncate else -1]
 
+    def __schedule_partition(self, host, deadline, chunk):
+        connection = self.cluster.get_local_client(host)
+
+        with Lock('{0}:s:{1}'.format(self.namespace, host), nowait=True, timeout=30):
+            # Prevent a runaway loop by setting a maximum number of
+            # iterations. Note that this limits the total number of
+            # expected items in any specific scheduling interval to chunk *
+            # maximum_iterations.
+            maximum_iterations = 1000
+            for i in xrange(maximum_iterations):
+                items = connection.zrangebyscore(
+                    make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING),
+                    min=0,
+                    max=deadline,
+                    withscores=True,
+                    start=0,
+                    num=chunk,
+                )
+
+                # XXX: Redis will error if we try and execute an empty
+                # transaction. If there are no items to move between states, we
+                # need to exit the loop now. (This can happen on the first
+                # iteration of the loop if there is nothing to do, or on a
+                # subsequent iteration if there was exactly the same number of
+                # items to change states as the chunk size.)
+                if not items:
+                    break
+
+                with connection.pipeline() as pipeline:
+                    pipeline.multi()
+
+                    pipeline.zrem(
+                        make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING),
+                        *[key for key, timestamp in items]
+                    )
+
+                    pipeline.zadd(
+                        make_schedule_key(self.namespace, SCHEDULE_STATE_READY),
+                        *itertools.chain.from_iterable([(timestamp, key) for (key, timestamp) in items])
+                    )
+
+                    for key, timestamp in items:
+                        yield ScheduleEntry(key, timestamp)
+
+                    pipeline.execute()
+
+                # If we retrieved less than the chunk size of items, we don't
+                # need try to retrieve more items.
+                if len(items) < chunk:
+                    break
+            else:
+                raise RuntimeError('loop exceeded maximum iterations (%s)' % (maximum_iterations,))
+
     def schedule(self, deadline, chunk=1000):
         # TODO: This doesn't lead to a fair balancing of workers, ideally each
         # scheduling task would be executed by a different process for each
-        # host. There is also no failure isolation here, so a single shard
-        # failure will cause the remainder of the shards to not be able to be
-        # scheduled.
+        # host.
         for host in self.cluster.hosts:
-            connection = self.cluster.get_local_client(host)
+            try:
+                for entry in self.__schedule_partition(host, deadline, chunk):
+                    yield entry
+            except Exception as error:
+                logger.warning(
+                    'Failed to perform scheduling for partition %r due to error: %r',
+                    host,
+                    error,
+                    exc_info=True
+                )
 
-            with Lock('{0}:s:{1}'.format(self.namespace, host), nowait=True, timeout=30):
-                # Prevent a runaway loop by setting a maximum number of
-                # iterations. Note that this limits the total number of
-                # expected items in any specific scheduling interval to chunk *
-                # maximum_iterations.
-                maximum_iterations = 1000
-                for i in xrange(maximum_iterations):
-                    items = connection.zrangebyscore(
-                        make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING),
-                        min=0,
-                        max=deadline,
-                        withscores=True,
-                        start=0,
-                        num=chunk,
+    def __maintenance_partition(self, host, deadline, chunk):
+        connection = self.cluster.get_local_client(host)
+
+        extra = 0
+        start = 0
+        maximum_iterations = 1000
+        for i in xrange(maximum_iterations):
+            fetch_size = chunk + extra
+            items = connection.zrangebyscore(
+                make_schedule_key(self.namespace, SCHEDULE_STATE_READY),
+                min=start,
+                max=deadline,
+                withscores=True,
+                start=0,
+                num=fetch_size,
+            )
+
+            def try_lock(item):
+                """
+                Attempt to immedately acquire a lock on the timeline at
+                key, returning the lock if it can be acquired, otherwise
+                returning ``None``.
+                """
+                key, timestamp = item
+                lock = Lock(make_timeline_key(self.namespace, key), timeout=5, nowait=True)
+                return lock if lock.acquire() else None, item
+
+            # Try to take out a lock on each item. If we can't acquire the
+            # lock, that means this is currently being digested and cannot
+            # be rescheduled.
+            can_reschedule = {
+                True: [],
+                False: [],
+            }
+
+            for result in map(try_lock, items):
+                can_reschedule[result[0] is not None].append(result)
+
+            logger.debug('Fetched %s items, able to reschedule %s.', len(items), len(can_reschedule[True]))
+
+            # Set the start position for the next query. (If there are no
+            # items, we don't need to worry about this, since there won't
+            # be a next query.) If all items share the same score and are
+            # locked, the iterator will never advance (we will keep trying
+            # to schedule the same locked items over and over) and either
+            # eventually progress slowly as items are unlocked, or hit the
+            # maximum iterations boundary. A possible solution to this
+            # would be to count the number of items that have the maximum
+            # score in this page that we assume we can't acquire (since we
+            # couldn't acquire the lock this iteration) and add that count
+            # to the next query limit. (This unfortunately could also
+            # lead to unbounded growth too, so we have to limit it as well.)
+            if items:
+                start = items[-1][0]  # (This value is (key, timestamp).)
+                extra = min(
+                    ilen(
+                        itertools.takewhile(
+                            lambda (lock, (key, timestamp)): timestamp == start,
+                            can_reschedule[False][::-1],
+                        ),
+                    ),
+                    chunk,
+                )
+
+            # XXX: We need to perform this check before the transaction to
+            # ensure that we don't execute an empty transaction. (We'll
+            # need to perform a similar check after the completion of the
+            # transaction as well.)
+            if not can_reschedule[True]:
+                if len(items) == fetch_size:
+                    # There is nothing to reschedule in this chunk, but we
+                    # need check if there are others after this chunk.
+                    continue
+                else:
+                    # There is nothing to unlock, and we've exhausted all items.
+                    break
+
+            try:
+                with connection.pipeline() as pipeline:
+                    pipeline.multi()
+
+                    pipeline.zrem(
+                        make_schedule_key(self.namespace, SCHEDULE_STATE_READY),
+                        *[key for (lock, (key, timestamp)) in can_reschedule[True]]
                     )
 
-                    # XXX: Redis will error if we try and execute an empty
-                    # transaction. If there are no items to move between states, we
-                    # need to exit the loop now. (This can happen on the first
-                    # iteration of the loop if there is nothing to do, or on a
-                    # subsequent iteration if there was exactly the same number of
-                    # items to change states as the chunk size.)
-                    if not items:
-                        break
+                    pipeline.zadd(
+                        make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING),
+                        *itertools.chain.from_iterable([(timestamp, key) for (lock, (key, timestamp)) in can_reschedule[True]])
+                    )
 
-                    with connection.pipeline() as pipeline:
-                        pipeline.multi()
+                    pipeline.execute()
+            finally:
+                # Regardless of the outcome of the transaction, we should
+                # try to unlock the items for processing.
+                for lock, item in can_reschedule[True]:
+                    try:
+                        lock.release()
+                    except Exception as error:
+                        # XXX: This shouldn't be hit (the ``Lock`` code
+                        # should swallow the exception) but this is here
+                        # for safety anyway.
+                        logger.warning('Could not unlock %r: %s', item, error)
 
-                        pipeline.zrem(
-                            make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING),
-                            *[key for key, timestamp in items]
-                        )
-
-                        pipeline.zadd(
-                            make_schedule_key(self.namespace, SCHEDULE_STATE_READY),
-                            *itertools.chain.from_iterable([(timestamp, key) for (key, timestamp) in items])
-                        )
-
-                        for key, timestamp in items:
-                            yield ScheduleEntry(key, timestamp)
-
-                        pipeline.execute()
-
-                    # If we retrieved less than the chunk size of items, we don't
-                    # need try to retrieve more items.
-                    if len(items) < chunk:
-                        break
-                else:
-                    raise RuntimeError('loop exceeded maximum iterations (%s)' % (maximum_iterations,))
+            # If we retrieved less than the chunk size of items, we don't
+            # need try to retrieve more items.
+            if len(items) < fetch_size:
+                break
+        else:
+            raise RuntimeError('loop exceeded maximum iterations (%s)' % (maximum_iterations,))
 
     def maintenance(self, deadline, chunk=1000):
         # TODO: This needs tests!
 
-        # TODO: This suffers from the same shard isolation issues as
-        # ``schedule``. Ideally, this would also return the number of items
-        # that were rescheduled (and possibly even how late they were at the
-        # point of rescheduling) but that causes a bit of an API issue since in
-        # the case of an error, this can be considered a partial success (but
-        # still should raise an exception.)
+        # TODO: Ideally, this would also return the number of items that were
+        # rescheduled (and possibly even how late they were at the point of
+        # rescheduling) but that causes a bit of an API issue since in the case
+        # of an error, this can be considered a partial success (but still
+        # should raise an exception.)
         for host in self.cluster.hosts:
-            connection = self.cluster.get_local_client(host)
-
-            extra = 0
-            start = 0
-            maximum_iterations = 1000
-            for i in xrange(maximum_iterations):
-                fetch_size = chunk + extra
-                items = connection.zrangebyscore(
-                    make_schedule_key(self.namespace, SCHEDULE_STATE_READY),
-                    min=start,
-                    max=deadline,
-                    withscores=True,
-                    start=0,
-                    num=fetch_size,
+            try:
+                self.__maintenance_partition(host, deadline, chunk)
+            except Exception as error:
+                logger.warning(
+                    'Failed to perform maintenance on digest partition %r due to error: %r',
+                    host,
+                    error,
+                    exc_info=True
                 )
-
-                def try_lock(item):
-                    """
-                    Attempt to immedately acquire a lock on the timeline at
-                    key, returning the lock if it can be acquired, otherwise
-                    returning ``None``.
-                    """
-                    key, timestamp = item
-                    lock = Lock(make_timeline_key(self.namespace, key), timeout=5, nowait=True)
-                    return lock if lock.acquire() else None, item
-
-                # Try to take out a lock on each item. If we can't acquire the
-                # lock, that means this is currently being digested and cannot
-                # be rescheduled.
-                can_reschedule = {
-                    True: [],
-                    False: [],
-                }
-
-                for result in map(try_lock, items):
-                    can_reschedule[result[0] is not None].append(result)
-
-                logger.debug('Fetched %s items, able to reschedule %s.', len(items), len(can_reschedule[True]))
-
-                # Set the start position for the next query. (If there are no
-                # items, we don't need to worry about this, since there won't
-                # be a next query.) If all items share the same score and are
-                # locked, the iterator will never advance (we will keep trying
-                # to schedule the same locked items over and over) and either
-                # eventually progress slowly as items are unlocked, or hit the
-                # maximum iterations boundary. A possible solution to this
-                # would be to count the number of items that have the maximum
-                # score in this page that we assume we can't acquire (since we
-                # couldn't acquire the lock this iteration) and add that count
-                # to the next query limit. (This unfortunately could also
-                # lead to unbounded growth too, so we have to limit it as well.)
-                if items:
-                    start = items[-1][0]  # (This value is (key, timestamp).)
-                    extra = min(
-                        ilen(
-                            itertools.takewhile(
-                                lambda (lock, (key, timestamp)): timestamp == start,
-                                can_reschedule[False][::-1],
-                            ),
-                        ),
-                        chunk,
-                    )
-
-                # XXX: We need to perform this check before the transaction to
-                # ensure that we don't execute an empty transaction. (We'll
-                # need to perform a similar check after the completion of the
-                # transaction as well.)
-                if not can_reschedule[True]:
-                    if len(items) == fetch_size:
-                        # There is nothing to reschedule in this chunk, but we
-                        # need check if there are others after this chunk.
-                        continue
-                    else:
-                        # There is nothing to unlock, and we've exhausted all items.
-                        break
-
-                try:
-                    with connection.pipeline() as pipeline:
-                        pipeline.multi()
-
-                        pipeline.zrem(
-                            make_schedule_key(self.namespace, SCHEDULE_STATE_READY),
-                            *[key for (lock, (key, timestamp)) in can_reschedule[True]]
-                        )
-
-                        pipeline.zadd(
-                            make_schedule_key(self.namespace, SCHEDULE_STATE_WAITING),
-                            *itertools.chain.from_iterable([(timestamp, key) for (lock, (key, timestamp)) in can_reschedule[True]])
-                        )
-
-                        pipeline.execute()
-                finally:
-                    # Regardless of the outcome of the transaction, we should
-                    # try to unlock the items for processing.
-                    for lock, item in can_reschedule[True]:
-                        try:
-                            lock.release()
-                        except Exception as error:
-                            # XXX: This shouldn't be hit (the ``Lock`` code
-                            # should swallow the exception) but this is here
-                            # for safety anyway.
-                            logger.warning('Could not unlock %r: %s', item, error)
-
-                # If we retrieved less than the chunk size of items, we don't
-                # need try to retrieve more items.
-                if len(items) < fetch_size:
-                    break
-            else:
-                raise RuntimeError('loop exceeded maximum iterations (%s)' % (maximum_iterations,))
 
     @contextmanager
     def digest(self, key, minimum_delay=None):

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -250,7 +250,7 @@ class RedisBackend(Backend):
                 for entry in self.__schedule_partition(host, deadline, chunk):
                     yield entry
             except Exception as error:
-                logger.warning(
+                logger.error(
                     'Failed to perform scheduling for partition %r due to error: %r',
                     host,
                     error,
@@ -380,7 +380,7 @@ class RedisBackend(Backend):
             try:
                 self.__maintenance_partition(host, deadline, chunk)
             except Exception as error:
-                logger.warning(
+                logger.error(
                     'Failed to perform maintenance on digest partition %r due to error: %r',
                     host,
                     error,


### PR DESCRIPTION
This ensures that failing to perform scheduling or maintenance on a partition does not cause the remainder of the unprocessed partitions to fail.

Fixes GH-3227.

@getsentry/infrastructure 
