### PR TITLE
Infinite loop in sqlquerycount for MySQL #3185

### DIFF
--- a/src/sentry/debug/utils/patch_context.py
+++ b/src/sentry/debug/utils/patch_context.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from threading import Lock
+from threading import RLock
 from sentry.utils.imports import import_string
 
 
@@ -11,7 +11,7 @@ class PatchContext(object):
         self.target = target
         self.attr = attr
         self.callback = callback
-        self._lock = Lock()
+        self._lock = RLock()
         with self._lock:
             self.func = getattr(target, attr)
 


### PR DESCRIPTION
This relates to #3185, which is not MySQL related.

Using a re-entrant Lock is behaving better than using a standard Lock so far (after a couple hours of uptime).

https://docs.python.org/2/library/threading.html#rlock-objects
http://stackoverflow.com/questions/16567958/when-and-how-to-use-pythons-rlock
