### PR TITLE
Add API tokens management

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+from operator import or_
+from rest_framework import serializers
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.fields import MultipleChoiceField
+from sentry.api.serializers import serialize
+from sentry.models import ApiToken
+
+
+class ApiTokenSerializer(serializers.Serializer):
+    scopes = MultipleChoiceField(
+        required=True,
+        choices=ApiToken.scopes.keys(),
+    )
+
+
+class ApiTokensEndpoint(Endpoint):
+    authentication_classes = (
+        SessionAuthentication,
+    )
+    permission_classes = (
+        IsAuthenticated,
+    )
+
+    def get(self, request):
+        token_list = list(ApiToken.objects.filter(
+            user=request.user,
+        ))
+
+        return Response(serialize(token_list, request.user))
+
+    def post(self, request):
+        serializer = ApiTokenSerializer(data=request.DATA)
+
+        if serializer.is_valid():
+            result = serializer.object
+
+            token = ApiToken.objects.create(
+                user=request.user,
+                scopes=reduce(or_, (
+                    getattr(ApiToken.scopes, k) for k in result['scopes']
+                )),
+            )
+
+            return Response(serialize(token, request.user), status=201)
+        return Response(serializer.errors, status=400)
+
+    def delete(self, request):
+        token = request.DATA.get('token')
+        print(request.DATA)
+        if not token:
+            return Response({'token': ''}, status=400)
+
+        ApiToken.objects.filter(
+            user=request.user,
+            token=token,
+        ).delete()
+
+        return Response(status=204)

--- a/src/sentry/api/fields/multiplechoice.py
+++ b/src/sentry/api/fields/multiplechoice.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+
+
+class MultipleChoiceField(serializers.WritableField):
+    error_messages = {
+        'invalid_choice': ('Select a valid choice. {value} is not one of '
+                           'the available choices.'),
+    }
+
+    def from_native(self, data):
+        if isinstance(data, list):
+            for item in data:
+                if item not in self.choices:
+                    raise serializers.ValidationError(self.error_messages['invalid_choice'].format(
+                        value=item,
+                    ))
+            return data
+        raise serializers.ValidationError('Please provide a valid list.')
+
+    def to_native(self, value):
+        return value
+
+    def __init__(self, choices=None, *args, **kwargs):
+        self.choices = set(choices or ())
+        super(MultipleChoiceField, self).__init__(*args, **kwargs)

--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import ApiToken
+
+
+@register(ApiToken)
+class ApiTokenSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            'token': obj.token,
+            'scopes': [k for k, v in obj.scopes.iteritems() if v],
+            'dateCreated': obj.date_added,
+        }

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -4,6 +4,7 @@ from sentry.app import quotas
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.auth import access
 from sentry.models import (
+    ApiKey,
     Organization,
     OrganizationAccessRequest,
     OrganizationOnboardingTask,
@@ -59,8 +60,11 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         if features.has('organizations:callsigns', obj, actor=user):
             feature_list.append('callsigns')
         if features.has('organizations:onboarding', obj, actor=user) and \
-           not OrganizationOption.objects.filter(organization=obj).exists():
+                not OrganizationOption.objects.filter(organization=obj).exists():
             feature_list.append('onboarding')
+        if features.has('organizations:api-keys', obj, actor=user) or \
+                ApiKey.objects.filter(organization=obj).exists():
+            feature_list.append('api-keys')
 
         if getattr(obj.flags, 'allow_joinleave'):
             feature_list.append('open-membership')

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 from django.conf.urls import patterns, url
 
+from .endpoints.api_tokens import ApiTokensEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.broadcast_index import BroadcastIndexEndpoint
 from .endpoints.catchall import CatchallEndpoint
@@ -83,6 +84,11 @@ from .endpoints.user_organizations import UserOrganizationsEndpoint
 
 urlpatterns = patterns(
     '',
+
+    # Api Tokens
+    url(r'^api-tokens/$',
+        ApiTokensEndpoint.as_view(),
+        name='sentry-api-0-api-tokens'),
 
     # Auth
     url(r'^auth/$',

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -620,6 +620,7 @@ SENTRY_CLIENT = 'sentry.utils.raven.SentryInternalClient'
 
 SENTRY_FEATURES = {
     'auth:register': True,
+    'organizations:api-keys': True,
     'organizations:create': True,
     'organizations:sso': True,
     'organizations:callsigns': False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -7,6 +7,7 @@ from .manager import *  # NOQA
 
 default_manager = FeatureManager()
 default_manager.add('auth:register')
+default_manager.add('organizations:api-keys', OrganizationFeature)
 default_manager.add('organizations:create')
 default_manager.add('organizations:sso', OrganizationFeature)
 default_manager.add('organizations:onboarding', OrganizationFeature)

--- a/src/sentry/static/sentry/app/components/forms/index.jsx
+++ b/src/sentry/static/sentry/app/components/forms/index.jsx
@@ -1,6 +1,15 @@
+const FormState = {
+  READY: 'Ready',
+  SAVING: 'Saving',
+  ERROR: 'Error',
+};
+
+export {default as BooleanField} from './booleanField';
 export {default as CheckboxField} from './checkboxField';
 export {default as Form} from './form';
 export {default as EmailField} from './emailField';
+export {default as MultipleCheckboxField} from './multipleCheckboxField';
 export {default as TextField} from './textField';
-export {default as BooleanField} from './booleanField';
 export {default as TextareaField} from './textareaField';
+
+export {FormState as FormState};

--- a/src/sentry/static/sentry/app/components/forms/multipleCheckboxField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/multipleCheckboxField.jsx
@@ -1,0 +1,80 @@
+import jQuery from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import FormField from './formField';
+
+export default class MultipleCheckboxField extends FormField {
+  constructor(props) {
+    super(props);
+
+    this.state.value = new Set(props.value || []);
+  }
+
+  // XXX(dcramer): this comes from TooltipMixin
+  componentDidMount() {
+    this.attachTooltips();
+  }
+
+  componentWillUnmount() {
+    this.removeTooltips();
+    jQuery(ReactDOM.findDOMNode(this)).unbind();
+  }
+
+  attachTooltips() {
+    jQuery('.tip', ReactDOM.findDOMNode(this))
+      .tooltip();
+  }
+
+  removeTooltips() {
+    jQuery('.tip', ReactDOM.findDOMNode(this))
+      .tooltip('destroy');
+  }
+
+  onChange(value, e) {
+    if (e.target.checked)
+      this.state.value.add(value);
+    else
+      this.state.value.delete(value);
+    this.setState({
+      value: this.state.value,
+    }, () => {
+      this.props.onChange(Array.from(this.state.value.keys()));
+    });
+  }
+
+  render() {
+    let className = 'control-group';
+    if (this.props.error) {
+      className += ' has-error';
+    }
+    return (
+      <div className={className}>
+        <label className="control-label">
+          {this.props.label}
+          {this.props.disabled && this.props.disabledReason &&
+            <span className="disabled-indicator tip" title={this.props.disabledReason}>
+              <span className="icon-question" />
+            </span>
+          }
+        </label>
+        {this.props.help &&
+          <p className="help-block">{this.props.help}</p>
+        }
+        <div className="controls control-list">
+          {this.props.choices.map((choice) => {
+            return (
+              <label className="checkbox" key={choice[0]}>
+                <input type="checkbox"
+                       value={choice[0]}
+                       onChange={this.onChange.bind(this, choice[0])}
+                       disabled={this.props.disabled}
+                       checked={this.state.value.has(choice[0])} />
+                {choice[1]}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/components/header/index.jsx
+++ b/src/sentry/static/sentry/app/components/header/index.jsx
@@ -59,7 +59,7 @@ function getFirstRequiredAdminAction(org) {
 
 const Header = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired
+    orgId: React.PropTypes.string
   },
 
   mixins: [ApiMixin, OrganizationState],

--- a/src/sentry/static/sentry/app/components/header/userNav.jsx
+++ b/src/sentry/static/sentry/app/components/header/userNav.jsx
@@ -29,6 +29,7 @@ const UserNav = React.createClass({
           menuClasses="dropdown-menu-right"
           title={title}>
         <MenuItem href={urlPrefix + '/account/settings/'}>{t('Account')}</MenuItem>
+        <MenuItem to="/api/">{t('API')}</MenuItem>
         {user.isSuperuser &&
           <MenuItem to="/manage/">{t('Admin')}</MenuItem>
         }

--- a/src/sentry/static/sentry/app/components/narrowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.jsx
@@ -1,0 +1,34 @@
+import jQuery from 'jquery';
+import React from 'react';
+
+import Footer from '../components/footer';
+import Header from '../components/header';
+
+const NarryLayout = React.createClass({
+  componentWillMount() {
+    jQuery(document.body).addClass('narrow');
+  },
+
+  componentWillUnmount() {
+    jQuery(document.body).removeClass('narrow');
+  },
+
+  render() {
+    return (
+      <div className="app">
+        <Header />
+        <div className="container">
+          <div className="box">
+            <div className="box-content with-padding">
+              {this.props.children}
+            </div>
+          </div>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+});
+
+export default NarryLayout;
+

--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -73,7 +73,7 @@ const HomeSidebar = React.createClass({
               {features.has('sso') && access.has('org:write') &&
                 <li><a href={urlPrefix + '/auth/'}>{t('Auth')}</a></li>
               }
-              {access.has('org:delete') &&
+              {access.has('org:delete') && features.has('api-keys') &&
                 <li><a href={urlPrefix + '/api-keys/'}>{t('API Keys')}</a></li>
               }
               {access.has('org:write') &&

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Redirect, Route, IndexRoute} from 'react-router';
 
+import ApiDashboard from './views/apiDashboard';
+import ApiNewToken from './views/apiNewToken';
 import Admin from './views/admin';
 import AdminBuffer from './views/adminBuffer';
 import AdminOrganizations from './views/adminOrganizations';
@@ -63,6 +65,9 @@ function appendTrailingSlash(nextState, replaceState) {
 
 let routes = (
   <Route path="/" component={errorHandler(App)}>
+    <Route path="/api/" component={errorHandler(ApiDashboard)} />
+    <Route path="/api/new-token/" component={errorHandler(ApiNewToken)} />
+
     <Route path="/manage/" component={errorHandler(Admin)}>
       <IndexRoute component={errorHandler(AdminOverview)} />
       <Route path="buffer/" component={errorHandler(AdminBuffer)} />

--- a/src/sentry/static/sentry/app/views/apiDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/apiDashboard.jsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import DocumentTitle from 'react-document-title';
+import {Link} from 'react-router';
+
+import ApiMixin from '../mixins/apiMixin';
+import AutoSelectText from '../components/autoSelectText';
+import IndicatorStore from '../stores/indicatorStore';
+import ListLink from '../components/listLink';
+import LoadingError from '../components/loadingError';
+import LoadingIndicator from '../components/loadingIndicator';
+import NarrowLayout from '../components/narrowLayout';
+import {t, tct} from '../locale';
+
+const ApiTokenRow = React.createClass({
+  propTypes: {
+    token: React.PropTypes.object.isRequired,
+    onRemove: React.PropTypes.func.isRequired
+  },
+
+  mixins: [ApiMixin],
+
+  getInitialState() {
+    return {
+      loading: false,
+    };
+  },
+
+  onRemove() {
+    if (this.state.loading) return;
+
+    let token = this.props.token;
+
+    this.setState({
+      loading: true,
+    }, () => {
+      let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+      this.api.request('/api-tokens/', {
+        method: 'DELETE',
+        data: {token: token.token},
+        success: (data) => {
+          this.props.onRemove();
+        },
+        complete: () => {
+          IndicatorStore.remove(loadingIndicator);
+        }
+      });
+    });
+  },
+
+  render() {
+    let token = this.props.token;
+
+    let btnClassName = 'btn btn-default';
+    if (this.state.loading)
+      btnClassName += ' disabled';
+
+    return (
+      <tr>
+        <td>
+          <small><AutoSelectText>{token.token}</AutoSelectText></small>
+          <small style={{color: '#999'}}>{token.scopes.join(', ')}</small>
+        </td>
+        <td style={{width: 32}}>
+          <a onClick={this.onRemove.bind(this, token)}
+             className={btnClassName}
+             disabled={this.state.loading}>
+            <span className="icon icon-trash" />
+          </a>
+        </td>
+      </tr>
+    );
+  }
+});
+
+const ApiDashboard = React.createClass({
+  mixins: [ApiMixin],
+
+  getInitialState() {
+    return {
+      loading: true,
+      error: false,
+      tokenList: [],
+    };
+  },
+
+  componentWillMount() {
+    this.fetchData();
+  },
+
+  remountComponent() {
+    this.setState(this.getInitialState(), this.fetchData);
+  },
+
+  fetchData() {
+    this.setState({
+      loading: true,
+    });
+
+    this.api.request('/api-tokens/', {
+      success: (data, _, jqXHR) => {
+        this.setState({
+          loading: false,
+          error: false,
+          tokenList: data
+        });
+      },
+      error: () => {
+        this.setState({
+          loading: false,
+          error: true,
+        });
+      }
+    });
+  },
+
+  onRemoveToken(token) {
+    this.setState({
+      tokenList: this.state.tokenList.filter((tk) => tk.token !== token.token),
+    });
+  },
+
+  renderResults() {
+    if (this.state.tokenList.length === 0) {
+      return (
+        <tr colSpan="2">
+          <td className="blankslate well">
+            {t('You haven\'t created any authentication tokens yet.')}
+          </td>
+        </tr>
+      );
+    }
+
+    return this.state.tokenList.map((token) => {
+      return (
+        <ApiTokenRow
+          key={token.token}
+          token={token}
+          onRemove={this.onRemoveToken.bind(this, token)} />
+      );
+    });
+  },
+
+  getTitle() {
+    return 'Sentry API';
+  },
+
+  render() {
+    return (
+      <DocumentTitle title={this.getTitle()}>
+        <NarrowLayout>
+          <h3>{t('Sentry Web API')}</h3>
+          <ul className="nav nav-tabs border-bottom">
+            <ListLink to="/api/">{t('Auth Tokens')}</ListLink>
+          </ul>
+          <p>{t('Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They\'re the easiest way to get started using the API.')}</p>
+          <p>{tct('For more information on how to use the web API, see our [link:documentation].', {
+            link: <a href="https://docs.getsentry.com/hosted/api/" />
+          })}</p>
+
+          <p><small>psst. Looking for the <strong>DSN</strong> for an SDK? You'll find that under <strong>[Project] &raquo; Settings &raquo; Client Keys</strong>.</small></p>
+
+          <table className="table">
+            <tbody>
+              {(this.state.loading ?
+                <tr><td colSpan="2"><LoadingIndicator /></td></tr>
+              : (this.state.error ?
+                <tr><td colSpan="2"><LoadingError onRetry={this.fetchData} /></td></tr>
+              :
+                this.renderResults()
+              ))}
+            </tbody>
+          </table>
+
+          <div className="form-actions" style={{textAlign: 'right'}}>
+            <Link to="/api/new-token/" className="btn btn-primary">{t('Create New Token')}</Link>
+          </div>
+        </NarrowLayout>
+      </DocumentTitle>
+    );
+  }
+});
+
+export default ApiDashboard;
+

--- a/src/sentry/static/sentry/app/views/apiNewToken.jsx
+++ b/src/sentry/static/sentry/app/views/apiNewToken.jsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import DocumentTitle from 'react-document-title';
+import {History} from 'react-router';
+
+import ApiMixin from '../mixins/apiMixin';
+import IndicatorStore from '../stores/indicatorStore';
+import NarrowLayout from '../components/narrowLayout';
+import {FormState, MultipleCheckboxField} from '../components/forms';
+import {t, tct} from '../locale';
+
+const SCOPES = new Set([
+  'project:read',
+  'project:write',
+  'project:delete',
+  'team:read',
+  'team:write',
+  'team:delete',
+  'event:read',
+  'event:write',
+  'event:delete',
+  'org:read',
+  'org:write',
+  'org:delete',
+  'member:read',
+  'member:write',
+  'member:delete'
+]);
+
+const DEFAULT_SCOPES = new Set([
+  'event:read',
+  'event:write',
+  'project:read',
+  'project:write',
+  'org:read',
+  'team:read',
+  'member:read',
+]);
+
+const TokenForm = React.createClass({
+  propTypes: {
+    initialData: React.PropTypes.object,
+    onSave: React.PropTypes.func.isRequired,
+    onCancel: React.PropTypes.func.isRequired
+  },
+
+  mixins: [ApiMixin],
+
+  getInitialState() {
+    return {
+      formData: Object.assign({}, this.props.initialData),
+      errors: {},
+    };
+  },
+
+  onFieldChange(name, value) {
+    let formData = this.state.formData;
+    formData[name] = value;
+    this.setState({
+      formData: formData,
+    });
+  },
+
+  onSubmit(e) {
+    e.preventDefault();
+
+    if (this.state.state == FormState.SAVING) {
+      return;
+    }
+    this.setState({
+      state: FormState.SAVING,
+    }, () => {
+      let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+      this.api.request('/api-tokens/', {
+        method: 'POST',
+        data: this.state.formData,
+        success: (data) => {
+          this.setState({
+            state: FormState.READY,
+            errors: {},
+          });
+          IndicatorStore.remove(loadingIndicator);
+          this.props.onSave(data);
+        },
+        error: (error) => {
+          this.setState({
+            state: FormState.ERROR,
+            errors: error.responseJSON,
+          });
+          IndicatorStore.remove(loadingIndicator);
+        }
+      });
+    });
+  },
+
+  render() {
+    let isSaving = this.state.state === FormState.SAVING;
+    let errors = this.state.errors;
+
+    return (
+      <form onSubmit={this.onSubmit} className="form-stacked api-new-token">
+        {this.state.state === FormState.ERROR &&
+          <div className="alert alert-error alert-block">
+            {t('Unable to save your changes. Please ensure all fields are valid and try again.')}
+          </div>
+        }
+        <fieldset>
+          <MultipleCheckboxField
+            key="scopes"
+            choices={Array.from(SCOPES.keys()).map((s) => [s, s])}
+            label={t('Scopes')}
+            value={this.state.formData.scopes}
+            required={true}
+            error={errors.scopes}
+            onChange={this.onFieldChange.bind(this, 'scopes')} />
+       </fieldset>
+        <fieldset className="form-actions">
+          <button className="btn btn-default"
+                  disabled={isSaving} onClick={this.props.onCancel}>{t('Cancel')}</button>
+          <button type="submit" className="btn btn-primary pull-right"
+                  disabled={isSaving}>{t('Save Changes')}</button>
+        </fieldset>
+      </form>
+    );
+  }
+});
+
+const ApiNewToken = React.createClass({
+  mixins: [ApiMixin, History],
+
+  getInitialState() {
+    return {
+      loading: true,
+      error: false,
+    };
+  },
+
+  getTitle() {
+    return 'Sentry API';
+  },
+
+  onCancel() {
+    this.history.pushState(null, '/api/');
+  },
+
+  onSave() {
+    this.history.pushState(null, '/api/');
+  },
+
+  render() {
+    let defaultScopes = Array.from(DEFAULT_SCOPES);
+    defaultScopes.sort();
+
+    return (
+      <DocumentTitle title={this.getTitle()}>
+        <NarrowLayout>
+          <h3>{t('Create New Token')}</h3>
+
+          <hr />
+
+          <p>{t('Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They\'re the easiest way to get started using the API.')}</p>
+          <p>{tct('For more information on how to use the web API, see our [link:documentation].', {
+            link: <a href="https://docs.getsentry.com/hosted/api/" />
+          })}</p>
+
+          <TokenForm
+            initialData={{
+              scopes: defaultScopes,
+            }}
+            onCancel={this.onCancel}
+            onSave={this.onSave} />
+
+        </NarrowLayout>
+      </DocumentTitle>
+    );
+  }
+});
+
+export default ApiNewToken;
+

--- a/src/sentry/static/sentry/app/views/teamSettings.jsx
+++ b/src/sentry/static/sentry/app/views/teamSettings.jsx
@@ -2,14 +2,8 @@ import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
 import IndicatorStore from '../stores/indicatorStore';
-import {TextField} from '../components/forms';
+import {FormState, TextField} from '../components/forms';
 import {t} from '../locale';
-
-const FormState = {
-  READY: 'Ready',
-  SAVING: 'Saving',
-  ERROR: 'Error',
-};
 
 const TeamSettingsForm = React.createClass({
   propTypes: {

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -23,7 +23,7 @@ body.narrow {
   background: #fff;
 
   .container {
-    max-width: 660px !important;
+    max-width: 760px !important;
   }
 }
 

--- a/src/sentry/static/sentry/less/organization.less
+++ b/src/sentry/static/sentry/less/organization.less
@@ -442,34 +442,37 @@ table.project-list {
   }
 }
 
-.api-key-detail {
-  .scopes {
-    padding-bottom: 20px;
-    .clearfix();
+.api-key-detail .scopes {
+  padding-bottom: 20px;
+}
 
-    label {
+
+.api-key-detail .scopes,
+.control-group .control-list {
+  .clearfix();
+
+  label {
+    display: block;
+    width: 25%;
+    padding: 0 20px 0 30px;
+    float: left;
+    position: relative;
+
+    &.control-label {
+      font-size: 14px;
+      padding: 0 0 10px;
+      margin-bottom: 20px;
       display: block;
-      width: 25%;
-      padding: 0 20px 0 30px;
-      float: left;
-      position: relative;
-
-      &.control-label {
-        font-size: 14px;
-        padding: 0 0 10px;
-        margin-bottom: 20px;
-        display: block;
-        width: 100%;
-        float: none;
-        border-bottom: 1px solid lighten(@trim, 6);
-      }
+      width: 100%;
+      float: none;
+      border-bottom: 1px solid lighten(@trim, 6);
     }
-
-    .checkbox, .checkbox + .checkbox {
-      margin: 0 0 15px;
-    }
-
   }
+
+  .checkbox, .checkbox + .checkbox {
+    margin: 0 0 15px;
+  }
+
 }
 
 /**

--- a/src/sentry/templates/sentry/bases/organization.html
+++ b/src/sentry/templates/sentry/bases/organization.html
@@ -63,11 +63,13 @@
       {% endfeature %}
     {% endif %}
     {% if ACCESS.org_delete %}
-      <li class="{% block org_apikeys_nav %}{% endblock %}">
-        <a href="{% url 'sentry-organization-api-keys' organization.slug %}">
-          {% trans "API Keys" %}
-        </a>
-      </li>
+      {% feature organizations:api-keys organization %}
+        <li class="{% block org_apikeys_nav %}{% endblock %}">
+          <a href="{% url 'sentry-organization-api-keys' organization.slug %}">
+            {% trans "API Keys" %}
+          </a>
+        </li>
+      {% endfeature %}
     {% endif %}
     {% if ACCESS.org_write %}
       <li><a href="{% absolute_uri '/organizations/{}/audit-log/' organization.slug %}">{% trans "Audit Log" %}</a></li>

--- a/src/sentry/templates/sentry/organization-api-keys.html
+++ b/src/sentry/templates/sentry/organization-api-keys.html
@@ -21,39 +21,43 @@
 
   <p>API keys grant access to the <a href="https://docs.getsentry.com/hosted/api/">developer web API</a>. If you're looking to configure a Sentry client, you'll need a client key which is available in your project settings.</p>
 
-      {% if key_list %}
-      <table class="table api-key-list">
-        <colgroup>
-          <col style="width: 40%"></col>
-          <col style="width: 40%"></col>
-          <col style="width: 20%"></col>
-        </colgroup>
-        <tbody>
-        {% for key in key_list %}
-          <tr>
-            <td>
-              <h5><a href="{% url 'sentry-organization-api-key-settings' organization.slug key.id %}">{{ key.label }}</a></h5>
-            </td>
-            <td>
-              <div class="form-control disabled auto-select">{{ key.key }}</div>
-            </td>
-            <td class="align-right">
-              <a href="{% url 'sentry-organization-api-key-settings' organization.slug key.id %}" class="btn btn-default btn-sm" style="margin-right: 4px">Edit Key</a>
-              <form class="pull-right" method="POST" action="" onsubmit="return confirm('Are you sure you want to remove this API key?');">
-                {% csrf_token %}
-                <input type="hidden" name="op" value="removekey" />
-                <input type="hidden" name="kid" value="{{ key.id }}" />
-                <button class="btn btn-default btn-sm"><span class="icon-trash"></span></button>
-              </form>
-            </td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-      {% else %}
-        <div class="blankslate well">
-          There are no API keys for this organization.
-        </div>
-      {% endif %}
+  <div class="alert alert-block alert-info">
+    psst. Until Sentry supports OAuth, you might want to switch to using <a href="{% absolute_uri '/api/' %}">Auth Tokens</a> instead.
+  </div>
+
+  {% if key_list %}
+  <table class="table api-key-list">
+    <colgroup>
+      <col style="width: 40%"></col>
+      <col style="width: 40%"></col>
+      <col style="width: 20%"></col>
+    </colgroup>
+    <tbody>
+    {% for key in key_list %}
+      <tr>
+        <td>
+          <h5><a href="{% url 'sentry-organization-api-key-settings' organization.slug key.id %}">{{ key.label }}</a></h5>
+        </td>
+        <td>
+          <div class="form-control disabled auto-select">{{ key.key }}</div>
+        </td>
+        <td class="align-right">
+          <a href="{% url 'sentry-organization-api-key-settings' organization.slug key.id %}" class="btn btn-default btn-sm" style="margin-right: 4px">Edit Key</a>
+          <form class="pull-right" method="POST" action="" onsubmit="return confirm('Are you sure you want to remove this API key?');">
+            {% csrf_token %}
+            <input type="hidden" name="op" value="removekey" />
+            <input type="hidden" name="kid" value="{{ key.id }}" />
+            <button class="btn btn-default btn-sm"><span class="icon-trash"></span></button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <div class="blankslate well">
+      There are no API keys for this organization.
+    </div>
+  {% endif %}
 
 {% endblock %}

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -239,12 +239,12 @@ urlpatterns += patterns(
     url(r'^docs/?$',
         RedirectView.as_view(url='https://docs.getsentry.com/hosted/', permanent=False),
         name='sentry-docs-redirect'),
-    url(r'^api/?$',
-        RedirectView.as_view(url='https://docs.getsentry.com/hosted/api/', permanent=False),
-        name='sentry-api-docs-redirect'),
     url(r'^docs/api/?$',
         RedirectView.as_view(url='https://docs.getsentry.com/hosted/api/', permanent=False),
         name='sentry-api-docs-redirect'),
+
+    url(r'^api/?$', react_page_view, name='sentry-api'),
+    url(r'^api/new-token/$', react_page_view),
 
     # Organizations
     url(r'^(?P<organization_slug>[\w_-]+)/$', react_page_view,

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import ApiToken
+from sentry.testutils import APITestCase
+
+
+class ApiTokensListTest(APITestCase):
+    def test_simple(self):
+        ApiToken.objects.create(user=self.user, scopes=getattr(ApiToken.scopes, 'event:read'))
+        ApiToken.objects.create(user=self.user, scopes=getattr(ApiToken.scopes, 'event:read'))
+
+        self.login_as(self.user)
+        url = reverse('sentry-api-0-api-tokens')
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+
+
+class ApiTokensCreateTest(APITestCase):
+    def test_no_scopes(self):
+        self.login_as(self.user)
+        url = reverse('sentry-api-0-api-tokens')
+        response = self.client.post(url)
+        assert response.status_code == 400
+
+    def test_simple(self):
+        self.login_as(self.user)
+        url = reverse('sentry-api-0-api-tokens')
+        response = self.client.post(url, data={'scopes': ['event:read']})
+        assert response.status_code == 201
+        token = ApiToken.objects.get(
+            user=self.user,
+        )
+        scopes = [k for k, v in token.scopes.iteritems() if v]
+        assert scopes == ['event:read']
+
+
+class ApiTokensDeleteTest(APITestCase):
+    def test_simple(self):
+        token = ApiToken.objects.create(user=self.user)
+        self.login_as(self.user)
+        url = reverse('sentry-api-0-api-tokens')
+        response = self.client.delete(url, data={'token': token.token})
+        assert response.status_code == 204
+        assert not ApiToken.objects.filter(id=token.id).exists()


### PR DESCRIPTION
This adds the UI and endpoints for managing API tokens.

Blocked on adding messaging to API Keys pages so people understand what these are, why they should use them, etc.

![screenshot 2016-05-13 16 52 37](https://cloud.githubusercontent.com/assets/23610/15264706/1f5f72ce-192b-11e6-92ea-e6eeedc26ff4.png)

@getsentry/api 
