### PR TITLE
Guard against forwarded-for with port numbers

### DIFF
--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import re
 
 
 class SetRemoteAddrFromForwardedFor(object):
@@ -11,6 +12,9 @@ class SetRemoteAddrFromForwardedFor(object):
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
             # Take just the first one.
             real_ip = real_ip.split(",")[0]
+            if real_ip.count(':') == 1:
+                # if the count > 1 it's ipv6 and count < 1 there's no port
+                real_ip = re.sub(r':\d+$', '', real_ip)
             request.META['REMOTE_ADDR'] = real_ip
 
 

--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import re
 
 
 class SetRemoteAddrFromForwardedFor(object):
@@ -12,9 +11,8 @@ class SetRemoteAddrFromForwardedFor(object):
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
             # Take just the first one.
             real_ip = real_ip.split(",")[0]
-            if real_ip.count(':') == 1:
-                # if the count > 1 it's ipv6 and count < 1 there's no port
-                real_ip = re.sub(r':\d+$', '', real_ip)
+            if ':' in real_ip:
+                real_ip = real_ip.split(':', 1)[0]
             request.META['REMOTE_ADDR'] = real_ip
 
 


### PR DESCRIPTION
### What

Updated `SetRemoteAddrFromForwardedFor` to remove any port-number found; this change is for IPv4 addresses only (since I don't know what an IPv6 forwarded-for with a port number would look like and didn't readily find any examples online).
### Why

Our internal proxy service has a bug wherein it sends along the remote IP _and_ its port number in the `X-Forwarded-For` header, which causes any module in Sentry that tries to use the `AuditLogEntry` (such as [project_settings](https://github.com/getsentry/sentry/blob/8.4.0/src/sentry/web/frontend/project_settings.py#L226)) to attempt to insert `1.2.3.4:80` into an `inet` column in Postgres, and :bomb:

```
DataError: invalid input syntax for type inet: "10.1.2.3:88"
LINE 1: ...ALUES (1, 'root@localhost', 1, NULL, 2, NULL, 31, '10.1.2.3:...
```

While it may very well be true that it's our problem, it also seems like something which is reasonable and inexpensive to guard against
### Verify Old Behavior

``` sh
curl -v -X POST -H 'X-Forwarded-For: 10.1.2.3:80' ...cookie args,etc http://127.0.0.1:9000/sentry/internal/settings/
# observe the internal server error
```
### Verify Fixed Behavior

``` sh
curl -v -X POST -H 'X-Forwarded-For: 10.1.2.3:80' ...cookie args,etc http://127.0.0.1:9000/sentry/internal/settings/
# observe the "302 Found" response
psql -U sentry -d sentry -c 'select ip_address from sentry_auditlogentry'
# observe the 10.1.2.3 entry present
```

For more good sport, repeat that exercise with an IPv6 XFF address (sans port number, unless you know the format for such a thing, in which case by all means try it) and observe that the IPv6 appears in the `sentry_auditlogentry` table, too
