### PR TITLE
[GH-3242] Create the MessagePack formatter.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ install_requires = [
     'ipaddr>=2.1.11,<2.2.0',
     'kombu==3.0.30',
     'lxml>=3.4.1',
+    'msgpack-python>=0.4,<0.5',
     'mock>=0.8.0,<1.1',
     'petname>=1.7,<1.8',
     'Pillow>=3.2.0,<3.3.0',

--- a/src/sentry/logging/__init__.py
+++ b/src/sentry/logging/__init__.py
@@ -1,0 +1,8 @@
+"""
+sentry.logging
+~~~~~~~~~~~~~~
+:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import

--- a/src/sentry/logging/formatters.py
+++ b/src/sentry/logging/formatters.py
@@ -1,0 +1,31 @@
+"""
+sentry.logging.formatters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from logging import Formatter
+from traceback import format_tb
+
+from django.utils.encoding import force_bytes
+from msgpack import packb
+
+
+class MessagePackFormatter(Formatter):
+    """
+    Return a packed dictionary.
+
+    Will pack the dictionary or the String representation of the message.
+    """
+    def format(self, record):
+        pack = record.msg if isinstance(record.msg, dict) else {
+            'msg': force_bytes(record.msg, errors='replace')
+        }
+        pack['levelname'] = record.levelname
+        if record.exc_info:
+            pack['traceback'] = format_tb(record.exc_info[-1])
+
+        return packb(pack)


### PR DESCRIPTION
Fixes #3242.

Will not change anything as it stands, but will output messages in the [MessagePack](http://msgpack.org/index.html) format if `SENTRY_LOGGING_FORMAT` is set to `msgpack`.

@getsentry/infrastructure 
