### PR TITLE
Parse a simple timestamp like 2016-01-01 00:00:00

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -297,8 +297,10 @@ class ClientApiHelper(object):
                 ts_bits = value.split('.', 1)
                 value = '%s.%s' % (ts_bits[0], ts_bits[1][:2])
                 fmt = '%Y-%m-%dT%H:%M:%S.%f'
-            else:
+            elif 'T' in value:
                 fmt = '%Y-%m-%dT%H:%M:%S'
+            else:
+                fmt = '%Y-%m-%d %H:%M:%S'
             try:
                 value = datetime.strptime(value, fmt)
             except Exception:

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -140,6 +140,14 @@ class ProcessDataTimestampTest(BaseAPITest):
         self.assertTrue('timestamp' in data)
         self.assertEquals(data['timestamp'], 1325413845.0)
 
+    def test_simple_timestamp(self):
+        d = datetime(2012, 01, 01, 10, 30, 45)
+        data = self.helper._process_data_timestamp({
+            'timestamp': '2012-01-01 10:30:45'
+        }, current_datetime=d)
+        self.assertTrue('timestamp' in data)
+        self.assertEquals(data['timestamp'], 1325413845.0)
+
     def test_invalid_timestamp(self):
         self.assertRaises(InvalidTimestamp, self.helper._process_data_timestamp, {
             'timestamp': 'foo'


### PR DESCRIPTION
I found while sending logs that Sentry wouldn't parse a timestamp like `2016-01-01 00:00:00`. This PR adds that functionality.

<img width="450" alt="screen shot 2016-05-17 at 6 34 53 am" src="https://cloud.githubusercontent.com/assets/1160090/15321023/91119002-1bf9-11e6-9e4a-d29377afc59f.png">
