### PR TITLE
Change sms messaging for confirmation setup

### DIFF
--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -373,9 +373,8 @@ class SmsInterface(OtpMixin, AuthenticatorInterface):
         ctx = {'code': self.make_otp().generate_otp()}
 
         if for_enrollment:
-            text = _('You are about to set up two-factor authentication '
-                     'through text messages. Your confirmation code is '
-                     '%(code)s.')
+            text = _('%(code)s is your Sentry two-factor authentication '
+                     'confirmation code.')
         else:
             text = _('%(code)s is your Sentry authentication code.')
 


### PR DESCRIPTION
Because the code was at the end of the message, it's not possible to see in a normal push notification.

![image](https://cloud.githubusercontent.com/assets/375744/15383160/d9358666-1d45-11e6-8545-c4eba86a33d4.png)

@mitsuhiko 
