### PR TITLE
Remove insecure fallback system.secret-key

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -13,7 +13,6 @@ from django.conf.global_settings import *  # NOQA
 
 from datetime import timedelta
 
-import hashlib
 import os
 import os.path
 import socket
@@ -935,10 +934,7 @@ SENTRY_ROLES = (
 
 # See sentry/options/__init__.py for more information
 SENTRY_OPTIONS = {}
-SENTRY_DEFAULT_OPTIONS = {
-    # Make this unique, and don't share it with anybody.
-    'system.secret-key': hashlib.md5(socket.gethostname() + ')*)&8a36)6%74e@-ne5(-!8a(vv#tkv)(eyg&@0=zd^pl!7=y@').hexdigest(),
-}
+SENTRY_DEFAULT_OPTIONS = {}
 
 # You should not change this setting after your database has been created
 # unless you have altered all schemas first

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -335,6 +335,14 @@ def apply_legacy_settings(settings):
     settings.DEFAULT_FROM_EMAIL = settings.SENTRY_OPTIONS.get(
         'mail.from', settings.SENTRY_DEFAULT_OPTIONS.get('mail.from'))
 
+    # HACK(mattrobenolt): This is a one-off assertion for a system.secret-key value.
+    # If this becomes a pattern, we could add another flag to the OptionsManager to cover this, but for now
+    # this is the only value that should prevent the app from booting up. Currently FLAG_REQUIRED is used to
+    # trigger the Installation Wizard, not abort startup.
+    if not settings.SENTRY_OPTIONS.get('system.secret-key'):
+        from .importer import ConfigurationError
+        raise ConfigurationError("`system.secret-key` MUST be set. Use 'sentry config generate-secret-key' to get one.")
+
 
 def skip_migration_if_applied(settings, app_name, table_name,
                               name='0001_initial'):

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -170,6 +170,7 @@ def test_apply_legacy_settings(settings):
     settings.SENTRY_SMTP_HOSTNAME = 'reply-hostname'
     settings.MAILGUN_API_KEY = 'mailgun-api-key'
     settings.SENTRY_OPTIONS = {
+        'system.secret-key': 'secret-key',
         'mail.from': 'mail-from',
     }
     apply_legacy_settings(settings)
@@ -179,6 +180,7 @@ def test_apply_legacy_settings(settings):
         'system.admin-email': 'admin-email',
         'system.url-prefix': 'http://url-prefix',
         'system.rate-limit': 10,
+        'system.secret-key': 'secret-key',
         'redis.clusters': {'default': {'foo': 'bar'}},
         'mail.from': 'mail-from',
         'mail.enable-replies': True,
@@ -191,5 +193,12 @@ def test_apply_legacy_settings(settings):
 
 def test_initialize_app(settings):
     "Just a sanity check of the full initialization process"
+    settings.SENTRY_OPTIONS = {'system.secret-key': 'secret-key'}
     bootstrap_options(settings)
     apply_legacy_settings(settings)
+
+
+def test_require_secret_key(settings):
+    assert 'system.secret-key' not in settings.SENTRY_OPTIONS
+    with pytest.raises(ConfigurationError):
+        apply_legacy_settings(settings)


### PR DESCRIPTION
Having a fallback here makes it significantly more likely for two
installs to be sharing the same value, which would be highly insecure.
Removing this fallback makes it mandatory to define in your own config.

Also enforce strictly and yield a useful error message on how to correct
the issue.

@getsentry/infrastructure 
