### PR TITLE
Use tag value ids for React keys in TagDistributionMeter ...

### DIFF
--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -90,7 +90,7 @@ const TagDistributionMeter = React.createClass({
 
           return (
             <Link
-                key={value.value}
+                key={value.id}
                 className="segment" style={{width: pct + '%'}}
                 to={`/${orgId}/${projectId}/issues/${this.props.group.id}/tags/${this.props.tag}/`}
                 title={'<div class="truncate">' + escape(value.name) + '</div>' + pctLabel + '%'}>


### PR DESCRIPTION
... possible after 80ec90aeaa478ede29130d5a30a569a905e65e03

cc @mattrobenolt 
