### PR TITLE
Fix broken snooze forever button on org dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "babel-gettext-extractor": "^1.0.2",
     "babel-loader": "5.3.3",
     "chai": "3.4.1",
-    "enzyme": "^1.1.0",
+    "enzyme": "2.1.0",
     "eslint": "1.9.0",
     "eslint-plugin-getsentry": "1.0.0",
     "eslint-plugin-react": "3.11.2",

--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -1,82 +1,14 @@
 import React from 'react';
 import Reflux from 'reflux';
 import {Link} from 'react-router';
-import Modal from 'react-bootstrap/lib/Modal';
 
 import ApiMixin from '../mixins/apiMixin';
 import IndicatorStore from '../stores/indicatorStore';
 import DropdownLink from './dropdownLink';
+import SnoozeAction from './issues/snoozeAction';
 import GroupChart from './stream/groupChart';
 import GroupStore from '../stores/groupStore';
 import {t} from '../locale';
-
-const Snooze = {
-  // all values in minutes
-  '30MINUTES': 30,
-  '2HOURS': 60 * 2,
-  '24HOURS': 60 * 24,
-};
-
-
-const SnoozeAction = React.createClass({
-  propTypes: {
-    disabled: React.PropTypes.bool,
-    onSnooze: React.PropTypes.func.isRequired,
-    tooltip: React.PropTypes.string
-  },
-
-  getInitialState() {
-    return {
-      isModalOpen: false
-    };
-  },
-
-  toggleModal() {
-    if (this.props.disabled) {
-      return;
-    }
-    this.setState({
-      isModalOpen: !this.state.isModalOpen
-    });
-  },
-
-  closeModal() {
-    this.setState({isModalOpen: false});
-  },
-
-  onSnooze(duration) {
-    this.props.onSnooze(duration);
-    this.closeModal();
-  },
-
-  render(){
-    return (
-      <a title={this.props.tooltip}
-         className={this.props.className}
-         disabled={this.props.disabled}
-         onClick={this.toggleModal}>
-        <span>{t('zZz')}</span>
-
-        <Modal show={this.state.isModalOpen} title={t('Please confirm')} animation={false}
-               onHide={this.closeModal} bsSize="sm">
-          <div className="modal-body">
-            <h5>{t('How long should we snooze this issue?')}</h5>
-            <ul className="nav nav-stacked nav-pills">
-              <li><a onClick={this.onSnooze.bind(this, Snooze['30MINUTES'])}>{t('30 minutes')}</a></li>
-              <li><a onClick={this.onSnooze.bind(this, Snooze['2HOURS'])}>{t('2 hours')}</a></li>
-              <li><a onClick={this.onSnooze.bind(this, Snooze['24HOURS'])}>{t('24 hours')}</a></li>
-              <li><a onClick={this.onSnooze}>{t('Forever')}</a></li>
-            </ul>
-          </div>
-          <div className="modal-footer">
-            <button type="button" className="btn btn-default"
-                    onClick={this.closeModal}>{t('Cancel')}</button>
-          </div>
-        </Modal>
-      </a>
-    );
-  }
-});
 
 const CompactIssueHeader = React.createClass({
   propTypes: {
@@ -193,10 +125,14 @@ const CompactIssue = React.createClass({
   },
 
   onSnooze(duration) {
-    this.onUpdate({
-      status: 'muted',
-      snoozeDuration: duration,
-    });
+    let data = {
+      status: 'muted'
+    };
+
+    if (duration)
+      data.snoozeDuration = duration;
+
+    this.onUpdate(data);
   },
 
   onUpdate(data) {

--- a/src/sentry/static/sentry/app/components/issues/snoozeAction.jsx
+++ b/src/sentry/static/sentry/app/components/issues/snoozeAction.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import Modal from 'react-bootstrap/lib/Modal';
+import {t} from '../../locale';
+
+const Snooze = {
+  // all values in minutes
+  '30MINUTES': 30,
+  '2HOURS': 60 * 2,
+  '24HOURS': 60 * 24,
+};
+
+const SnoozeAction = React.createClass({
+  propTypes: {
+    disabled: React.PropTypes.bool,
+    onSnooze: React.PropTypes.func.isRequired,
+    tooltip: React.PropTypes.string
+  },
+
+  getInitialState() {
+    return {
+      isModalOpen: false
+    };
+  },
+
+  toggleModal() {
+    if (this.props.disabled) {
+      return;
+    }
+    this.setState({
+      isModalOpen: !this.state.isModalOpen
+    });
+  },
+
+  closeModal() {
+    this.setState({isModalOpen: false});
+  },
+
+  onSnooze(duration) {
+    this.props.onSnooze(duration);
+    this.closeModal();
+  },
+
+  render(){
+    return (
+      <a title={this.props.tooltip}
+         className={this.props.className}
+         disabled={this.props.disabled}
+         onClick={this.toggleModal}>
+        <span>{t('zZz')}</span>
+
+        <Modal show={this.state.isModalOpen} title={t('Please confirm')} animation={false}
+               onHide={this.closeModal} bsSize="sm">
+          <div className="modal-body">
+            <h5>{t('How long should we snooze this issue?')}</h5>
+            <ul className="nav nav-stacked nav-pills">
+              <li><a onClick={this.onSnooze.bind(this, Snooze['30MINUTES'])}>{t('30 minutes')}</a></li>
+              <li><a onClick={this.onSnooze.bind(this, Snooze['2HOURS'])}>{t('2 hours')}</a></li>
+              <li><a onClick={this.onSnooze.bind(this, Snooze['24HOURS'])}>{t('24 hours')}</a></li>
+              {/* override click event object w/ undefined to indicate "no duration" */}
+              <li><a onClick={this.onSnooze.bind(this, undefined)}>{t('Forever')}</a></li>
+            </ul>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-default"
+                    onClick={this.closeModal}>{t('Cancel')}</button>
+          </div>
+        </Modal>
+      </a>
+    );
+  }
+});
+
+export default SnoozeAction;

--- a/tests/js/spec/components/issues/snoozeAction.spec.jsx
+++ b/tests/js/spec/components/issues/snoozeAction.spec.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import SnoozeAction from 'app/components/issues/snoozeAction';
+
+describe('SnoozeAction', function() {
+  beforeEach(function () {
+    this.sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    this.sandbox.restore();
+  });
+
+  describe('render()', function() {
+    it('should show a gravatar when avatar type is gravatar', function () {
+      let wrapper = shallow(<SnoozeAction onSnooze={function(){}}/>);
+      expect(wrapper.find('h5').text()).to.equal('How long should we snooze this issue?');
+    });
+  });
+
+  describe('click handlers', function () {
+    it('30m link should call prop w/ value 30', function (done) {
+      let wrapper = shallow(<SnoozeAction onSnooze={function(duration){
+        expect(duration).to.equal(30);
+        done();
+      }}/>);
+
+      wrapper.find('ul').childAt(0).find('a').simulate('click');
+    });
+
+    it('forever link should call prop w/ value undefined', function (done) {
+      let wrapper = shallow(<SnoozeAction onSnooze={function(duration){
+        expect(duration).to.equal(undefined);
+        done();
+      }}/>);
+
+      wrapper.find('ul').childAt(3).find('a').simulate('click');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3178

When clicking "Forever", we were passing a `MouseEvent` instance for `snoozeDuration`, which blew up during JSON serialization when preparing the outbound XHR PUT.

This patch omits `snoozeDuration` entirely when "Forever" is selected, which should be the correct behavior [according to](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/group_details.py#L277) `api.endpoints.group_details`.

/cc @getsentry/ui 
