### PR TITLE
Refactor some 2fa flows to be more efficient

### DIFF
--- a/src/sentry/utils/decorators.py
+++ b/src/sentry/utils/decorators.py
@@ -1,0 +1,14 @@
+
+
+# Vendored from newer Django:
+# https://github.com/django/django/blob/1.9.6/django/utils/decorators.py#L188-L197
+class classproperty(object):
+    def __init__(self, method=None):
+        self.fget = method
+
+    def __get__(self, instance, owner):
+        return self.fget(owner)
+
+    def getter(self, method):
+        self.fget = method
+        return self

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -153,7 +153,7 @@ def twofactor_settings(request):
     context = csrf(request)
     context.update({
         'page': 'settings',
-        'has_2fa': any(x.is_enrolled for x in interfaces),
+        'has_2fa': any(x.is_enrolled and not x.is_backup_interface for x in interfaces),
         'interfaces': interfaces,
     })
     return render_to_response('sentry/account/twofactor.html', context, request)

--- a/src/sentry/web/frontend/accounts_twofactor.py
+++ b/src/sentry/web/frontend/accounts_twofactor.py
@@ -96,8 +96,7 @@ class TwoFactorSettingsView(BaseView):
         # enrolling a backup interface when we already had a primary one.
         if not insecure \
            or (interface.is_backup_interface and
-               Authenticator.objects.user_has_2fa(request.user,
-                                                  ignore_backup=True)):
+               Authenticator.objects.user_has_2fa(request.user)):
             interface.enroll(request.user)
             if Authenticator.objects.auto_add_recovery_codes(request.user):
                 next = reverse('sentry-account-settings-2fa-recovery')

--- a/tests/sentry/models/test_authenticator.py
+++ b/tests/sentry/models/test_authenticator.py
@@ -12,12 +12,10 @@ class AuthenticatorTest(TestCase):
 
         RecoveryCodeInterface().enroll(user)
 
-        assert Authenticator.objects.user_has_2fa(user) is True
-        assert Authenticator.objects.user_has_2fa(user, ignore_backup=True) is False
+        assert Authenticator.objects.user_has_2fa(user) is False
         assert Authenticator.objects.filter(user=user).count() == 1
 
         TotpInterface().enroll(user)
 
         assert Authenticator.objects.user_has_2fa(user) is True
-        assert Authenticator.objects.user_has_2fa(user, ignore_backup=True) is True
         assert Authenticator.objects.filter(user=user).count() == 2


### PR DESCRIPTION
- Query for available interfaces only instead of querying all and
  checking each of them.

This opens the door a bit easier to bulk fetch for multiple users'
2fa statuses.

@mitsuhiko 
