### PR TITLE
Make sure react_page ends with a trailing slash

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -260,7 +260,7 @@ urlpatterns += patterns(
         RedirectView.as_view(url='https://docs.getsentry.com/hosted/api/', permanent=False),
         name='sentry-api-docs-redirect'),
 
-    url(r'^api/?$', react_page_view, name='sentry-api'),
+    url(r'^api/$', react_page_view, name='sentry-api'),
     url(r'^api/new-token/$', react_page_view),
 
     # Organizations
@@ -419,5 +419,5 @@ urlpatterns += patterns(
         name='sentry-group-plugin-action'),
 
     # Legacy
-    url(r'', react_page_view),
+    url(r'/$', react_page_view),
 )


### PR DESCRIPTION
This allows Django's default behavior of APPEND_SLASHES to kick in and
we issue a real redirect from no-slash to trailing-slash. All of our
React pages are expected to have a trailing slash, and this solves the
problem of hitting a 404 on a Django page, to fall back to a React page,
which would then need to get served by Django again.

@getsentry/ui @getsentry/infrastructure 
