### PR TITLE
Fix GroupStore removing existing entries on org dashboard

### DIFF
--- a/src/sentry/static/sentry/app/stores/groupStore.jsx
+++ b/src/sentry/static/sentry/app/stores/groupStore.jsx
@@ -52,17 +52,15 @@ const GroupStore = Reflux.createStore({
       itemIds.add(item.id);
     });
 
-    items.forEach((item, idx) => {
+    // See if any existing items are updated by this new set of items
+    this.items.forEach((item, idx) => {
       if (itemsById[item.id]) {
         this.items[idx] = jQuery.extend(true, {}, item, itemsById[item.id]);
-        // HACK(dcramer): work around statusDetails not being consistent
-        if (typeof itemsById[item.id].statusDetails !== undefined) {
-          this.items[idx].statusDetails = itemsById[item.id].statusDetails;
-        }
         delete itemsById[item.id];
       }
     });
 
+    // New items
     for (let itemId in itemsById) {
       this.items.push(itemsById[itemId]);
     }

--- a/tests/js/spec/stores/groupStore.spec.jsx
+++ b/tests/js/spec/stores/groupStore.spec.jsx
@@ -10,6 +10,39 @@ describe('GroupStore', function () {
     this.sandbox.restore();
   });
 
+  describe('add()', function () {
+    it('should add new entries', function () {
+      GroupStore.items = [];
+      GroupStore.add([
+        {id: 1},
+        {id: 2},
+      ]);
+
+      expect(GroupStore.items).to.eql([
+        {id: 1},
+        {id: 2},
+      ]);
+    });
+
+    it('should update matching existing entries', function () {
+      GroupStore.items = [
+        {id: 1},
+        {id: 2},
+      ];
+
+      GroupStore.add([
+        {id: 1, foo: 'bar'},
+        {id: 3},
+      ]);
+
+      expect(GroupStore.items).to.eql([
+        {id: 1, foo: 'bar'},
+        {id: 2},
+        {id: 3},
+      ]);
+    });
+  });
+
   describe('onMergeSuccess()', function () {
     it('should remove the non-parent merged ids', function () {
       GroupStore.items = [


### PR DESCRIPTION
This fixes an exception that fires when you attempt to resolve an issue from the org dashboard (the issue is resolved, but the UI doesn't reflect it – page has to be refreshed).

/cc @getsentry/ui @dcramer 
