### PR TITLE
Return a proper 401 response from unauthorized API calls

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.contrib.auth.models import AnonymousUser
 from django.utils.crypto import constant_time_compare
 from rest_framework.authentication import (
-    BaseAuthentication, BasicAuthentication, get_authorization_header
+    BasicAuthentication, get_authorization_header
 )
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -43,7 +43,7 @@ class ApiKeyAuthentication(QuietBasicAuthentication):
         return (AnonymousUser(), key)
 
 
-class TokenAuthentication(BaseAuthentication):
+class TokenAuthentication(QuietBasicAuthentication):
     def authenticate(self, request):
         auth = get_authorization_header(request).split()
 

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -32,9 +32,9 @@ class SystemOptionsTest(APITestCase):
 
     def test_not_logged_in(self):
         response = self.client.get(self.url)
-        assert response.status_code == 403
+        assert response.status_code == 401
         response = self.client.put(self.url)
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     def test_disabled_smtp(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
DRF checks for a `authenticate_header` from the first
`authentication_classes`. In our case, this is now `TokenAuthenticator`,
which was subclassing `BaseAuthentication`. `BaseAuthentication` doesn't
provide this method, so DRF coerces it to a 403 response. Subclassing
`QuietBasicAuthentication` provides a fake `authenticate_header` used to
trick DRF into sending back the sweet sweet 401.

@getsentry/api @benvinegar 

Looks like this behavior was broken with 60bc9e05a43e297c58b1daddbdcbbdd526d24a2f by adding in the new `TokenAuthentication`.
