### PR TITLE
Fix status code '0' being appended to url in http breadcrumbs

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRenderer.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbComponents/httpRenderer.jsx
@@ -26,7 +26,7 @@ const HttpRenderer = React.createClass({
           <code>
             {method && <strong>{method} </strong>}
             {url && this.renderUrl(url)}
-            {status_code && (' [' + status_code + ']')}
+            {status_code !== undefined ? <span>{' [' + status_code + ']'}</span> : ''}
           </code>
         </pre>
       </SummaryLine>

--- a/tests/js/spec/components/events/interfaces/breadcrumbComponents/httpRenderer.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbComponents/httpRenderer.spec.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import HttpRenderer from 'app/components/events/interfaces/breadcrumbComponents/httpRenderer';
+
+describe('HttpRenderer', function() {
+  describe('render()', function() {
+    it('should work', function () {
+      let httpRendererWrapper = shallow(<HttpRenderer crumb={{
+        data: {
+          method: 'POST',
+          url: 'http://example.com/foo',
+          // status_code 0 is possible via broken client-side XHR; should still render as '[0]'
+          status_code: 0
+        }
+      }}/>);
+
+      let summaryLine = httpRendererWrapper.prop('summary');
+
+      let summaryLineWrapper = shallow(summaryLine);
+      expect(summaryLineWrapper.find('strong').text()).to.eql('POST ');
+      expect(summaryLineWrapper.find('a').text().trim()).to.eql('http://example.com/foo');
+      expect(summaryLineWrapper.find('span').text()).to.eql(' [0]');
+    });
+  });
+});


### PR DESCRIPTION
Before:

```
POST http://example.com/foo/0
```

After:

```
POST http://example.com/foo [0]
```

Non-zero status codes (e.g. `200`) were unaffected.

/cc @getsentry/ui
