### PR TITLE
Reload the current page (and redirect to /login) if XHR returns 401

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -189,7 +189,7 @@ OK_PLUGIN_DISABLED = _("The {name} integration has been disabled.")
 
 OK_PLUGIN_SAVED = _('Configuration for the {name} integration has been saved.')
 
-WARN_SESSION_EXPIRED = _('Your session has expired.')
+WARN_SESSION_EXPIRED = 'Your session has expired.'  # TODO: translate this
 
 # Key to use when ordering a list of events manually
 EVENT_ORDERING_KEY = attrgetter('datetime', 'id')

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -189,6 +189,8 @@ OK_PLUGIN_DISABLED = _("The {name} integration has been disabled.")
 
 OK_PLUGIN_SAVED = _('Configuration for the {name} integration has been saved.')
 
+WARN_SESSION_EXPIRED = _('Your session has expired.')
+
 # Key to use when ordering a list of events manually
 EVENT_ORDERING_KEY = attrgetter('datetime', 'id')
 

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import $ from 'jquery';
+
 import ApiMixin from '../mixins/apiMixin';
 import Alerts from '../components/alerts';
 import AlertActions from '../actions/alertActions.jsx';
@@ -71,6 +73,16 @@ const App = React.createClass({
         message: msg.message,
         type: msg.level
       });
+    });
+
+    $(document).ajaxError(function (evt, jqXHR) {
+      if (jqXHR && jqXHR.status === 401) {
+        // User has become unauthenticated; reload URL, and let Django
+        // redirect to login page
+        // NOTE: This presumes that React application is ONLY for
+        //       authenticated users.
+        window.location.reload();
+      }
     });
   },
 

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import $ from 'jquery';
+import Cookies from 'js-cookie';
 
 import ApiMixin from '../mixins/apiMixin';
 import Alerts from '../components/alerts';
@@ -77,6 +78,7 @@ const App = React.createClass({
 
     $(document).ajaxError(function (evt, jqXHR) {
       if (jqXHR && jqXHR.status === 401) {
+        Cookies.set('session_expired', 1);
         // User has become unauthenticated; reload URL, and let Django
         // redirect to login page
         // NOTE: This presumes that React application is ONLY for

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import, print_function
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import transaction
+from django.utils.translation import ugettext as _
 from django.views.decorators.cache import never_cache
+from django.contrib import messages
 
 from sentry import features
 from sentry.auth.helper import AuthHelper
@@ -12,6 +14,8 @@ from sentry.models import AuthProvider, Organization, OrganizationStatus
 from sentry.utils import auth
 from sentry.web.forms.accounts import AuthenticationForm, RegistrationForm
 from sentry.web.frontend.base import BaseView
+
+ERR_EXPIRED = _('Your session has expired.')
 
 
 class AuthOrganizationLoginView(BaseView):
@@ -136,6 +140,13 @@ class AuthOrganizationLoginView(BaseView):
         except AuthProvider.DoesNotExist:
             auth_provider = None
 
+        if request.COOKIES.get('session_expired'):
+            messages.add_message(request, messages.WARNING, ERR_EXPIRED)
+
         if not auth_provider:
-            return self.handle_basic_auth(request, organization)
-        return self.handle_sso(request, organization, auth_provider)
+            response = self.handle_basic_auth(request, organization)
+        else:
+            response = self.handle_sso(request, organization, auth_provider)
+
+        response.delete_cookie('session_expired')
+        return response

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -19,6 +19,14 @@ class AuthLoginTest(TestCase):
         assert resp.status_code == 200
         self.assertTemplateUsed('sentry/login.html')
 
+    def test_renders_session_expire_message(self):
+        self.client.cookies['session_expired'] = '1'
+        resp = self.client.get(self.path)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/login.html')
+        assert len(resp.context['messages']) == 1
+
     def test_login_invalid_password(self):
         # load it once for test cookie
         self.client.get(self.path)

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -25,6 +25,17 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert 'provider_key' not in resp.context
         assert resp.context['CAN_REGISTER']
 
+    def test_renders_session_expire_message(self):
+        organization = self.create_organization(name='foo', owner=self.user)
+        path = reverse('sentry-auth-organization', args=[organization.slug])
+
+        self.client.cookies['session_expired'] = '1'
+        resp = self.client.get(path)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/organization-login.html')
+        assert len(resp.context['messages']) == 1
+
     def test_flow_as_anonymous(self):
         organization = self.create_organization(name='foo', owner=self.user)
         auth_provider = AuthProvider.objects.create(


### PR DESCRIPTION
Fixes #2331 since broadcast polling will also return 401 / force user to re-authenticate.

/cc @getsentry/ui
