### PR TITLE
Fetch JavaScript SourceMap files with http and https switching

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -240,6 +240,17 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
     """
     if release:
         result = fetch_release_file(url, release)
+
+        if result is None:
+            # Refetch release files when a site has http and https both online.
+            if url.startswith('http:'):
+                result = fetch_release_file(
+                    url.replace('http:', 'https:'), release
+                )
+            elif url.startswith('https:'):
+                result = fetch_release_file(
+                    url.replace('https:', 'http:'), release
+                )
     else:
         result = None
 


### PR DESCRIPTION
A site may have http and https both online. We usually upload `https` files to releases, but users may hit the http URL. In this case, sentry will report no source map found.
