### PR TITLE
Reduce transaction savepoints in safe_execute calls

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -100,7 +100,8 @@ class GroupDetailsEndpoint(GroupEndpoint):
 
         action_list = []
         for plugin in plugins.for_project(project, version=1):
-            results = safe_execute(plugin.actions, request, group, action_list)
+            results = safe_execute(plugin.actions, request, group, action_list,
+                                   _with_transaction=False)
 
             if not results:
                 continue
@@ -108,7 +109,8 @@ class GroupDetailsEndpoint(GroupEndpoint):
             action_list = results
 
         for plugin in plugins.for_project(project, version=2):
-            for action in (safe_execute(plugin.get_actions, request, group) or ()):
+            for action in (safe_execute(plugin.get_actions, request, group,
+                                        _with_transaction=False) or ()):
                 action_list.append(action)
 
         return action_list

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -72,9 +72,11 @@ class GroupSerializer(Serializer):
 
             annotations = []
             for plugin in plugins.for_project(project=item.project, version=1):
-                safe_execute(plugin.tags, None, item, annotations)
+                safe_execute(plugin.tags, None, item, annotations,
+                             _with_transaction=False)
             for plugin in plugins.for_project(project=item.project, version=2):
-                annotations.extend(safe_execute(plugin.get_annotations, group=item) or ())
+                annotations.extend(safe_execute(plugin.get_annotations, group=item,
+                                                _with_transaction=False) or ())
 
             result[item] = {
                 'assigned_to': serialize(assignees.get(item.id)),

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -140,7 +140,8 @@ class Event(Model):
             except ValueError:
                 continue
 
-            value = safe_execute(cls.to_python, data)
+            value = safe_execute(cls.to_python, data,
+                                 _with_transaction=False)
             if not value:
                 continue
 

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -41,7 +41,7 @@ class IssueTrackingPlugin(Plugin):
     def _get_group_body(self, request, group, event, **kwargs):
         result = []
         for interface in event.interfaces.itervalues():
-            output = safe_execute(interface.to_string, event)
+            output = safe_execute(interface.to_string, event, _with_transaction=False)
             if output:
                 result.append(output)
         return '\n\n'.join(result)

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -80,4 +80,4 @@ class WebHooksPlugin(notify.NotificationPlugin):
     def notify_users(self, group, event, fail_silently=False):
         payload = self.get_group_data(group, event)
         for url in self.get_webhook_urls(group.project):
-            safe_execute(self.send_webhook, url, payload)
+            safe_execute(self.send_webhook, url, payload, _with_transaction=False)

--- a/src/sentry/rules/__init__.py
+++ b/src/sentry/rules/__init__.py
@@ -23,7 +23,7 @@ def init_registry():
         cls = import_string(rule)
         registry.add(cls)
     for plugin in plugins.all(version=2):
-        for cls in (safe_execute(plugin.get_rules) or ()):
+        for cls in (safe_execute(plugin.get_rules, _with_transaction=False) or ()):
             registry.add(cls)
 
     return registry

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -27,7 +27,7 @@ class NotifyEventAction(EventAction):
             results.append(plugin)
 
         for plugin in plugins.for_project(self.project, version=2):
-            for notifier in (safe_execute(plugin.get_notifiers) or ()):
+            for notifier in (safe_execute(plugin.get_notifiers, _with_transaction=False) or ()):
                 results.append(notifier)
 
         return results
@@ -36,7 +36,7 @@ class NotifyEventAction(EventAction):
         group = event.group
 
         for plugin in self.get_plugins():
-            if not safe_execute(plugin.should_notify, group=group, event=event):
+            if not safe_execute(plugin.should_notify, group=group, event=event, _with_transaction=False):
                 continue
 
             metrics.incr('notifications.sent', instance=plugin.slug)

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -66,7 +66,7 @@ class NotifyEventServiceAction(EventAction):
             results.append(plugin)
 
         for plugin in plugins.for_project(self.project, version=2):
-            for notifier in (safe_execute(plugin.get_notifiers) or ()):
+            for notifier in (safe_execute(plugin.get_notifiers, _with_transaction=False) or ()):
                 results.append(notifier)
 
         return results

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -56,7 +56,8 @@ class RuleProcessor(object):
             return
 
         condition_inst = condition_cls(self.project, data=condition, rule=rule)
-        return safe_execute(condition_inst.passes, self.event, state)
+        return safe_execute(condition_inst.passes, self.event, state,
+                            _with_transaction=False)
 
     def get_state(self, rule_status):
         return EventState(
@@ -131,7 +132,8 @@ class RuleProcessor(object):
                 continue
 
             action_inst = action_cls(self.project, data=action, rule=rule)
-            results = safe_execute(action_inst.after, event=self.event, state=state)
+            results = safe_execute(action_inst.after, event=self.event, state=state,
+                                   _with_transaction=False)
             if results is None:
                 self.logger.warn('Action %s did not return any futures', action['id'])
                 continue

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -26,7 +26,7 @@ def get_activity_notifiers(project):
             results.append(plugin)
 
     for plugin in plugins.for_project(project, version=2):
-        for notifier in (safe_execute(plugin.get_notifiers) or ()):
+        for notifier in (safe_execute(plugin.get_notifiers, _with_transaction=False) or ()):
             results.append(notifier)
 
     return results

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -85,7 +85,7 @@ def record_additional_tags(event):
 
     added_tags = []
     for plugin in plugins.for_project(event.project, version=2):
-        added_tags.extend(safe_execute(plugin.get_tags, event) or ())
+        added_tags.extend(safe_execute(plugin.get_tags, event, _with_transaction=False) or ())
     if added_tags:
         Group.objects.add_tags(event.group, added_tags)
 

--- a/src/sentry/templatetags/sentry_plugins.py
+++ b/src/sentry/templatetags/sentry_plugins.py
@@ -21,7 +21,8 @@ def get_actions(group, request):
 
     action_list = []
     for plugin in plugins.for_project(project, version=1):
-        results = safe_execute(plugin.actions, request, group, action_list)
+        results = safe_execute(plugin.actions, request, group, action_list,
+                               _with_transaction=False)
 
         if not results:
             continue
@@ -29,7 +30,8 @@ def get_actions(group, request):
         action_list = results
 
     for plugin in plugins.for_project(project, version=2):
-        for action in (safe_execute(plugin.get_actions, request, group) or ()):
+        for action in (safe_execute(plugin.get_actions, request, group,
+                                    _with_transaction=False) or ()):
             action_list.append(action)
 
     return [(a[0], a[1], request.path == a[1]) for a in action_list]
@@ -41,7 +43,8 @@ def get_panels(group, request):
 
     panel_list = []
     for plugin in plugins.for_project(project):
-        results = safe_execute(plugin.panels, request, group, panel_list)
+        results = safe_execute(plugin.panels, request, group, panel_list,
+                               _with_transaction=False)
 
         if not results:
             continue
@@ -56,7 +59,8 @@ def get_widgets(group, request):
     project = group.project
 
     for plugin in plugins.for_project(project):
-        resp = safe_execute(plugin.widget, request, group)
+        resp = safe_execute(plugin.widget, request, group,
+                            _with_transaction=False)
 
         if resp:
             yield resp.render(request)
@@ -68,7 +72,8 @@ def get_legacy_annotations(group, request=None):
 
     annotation_list = []
     for plugin in plugins.for_project(project, version=1):
-        results = safe_execute(plugin.tags, request, group, annotation_list)
+        results = safe_execute(plugin.tags, request, group, annotation_list,
+                               _with_transaction=False)
 
         if not results:
             continue
@@ -84,8 +89,8 @@ def get_annotations(group, request=None):
 
     annotation_list = []
     for plugin in plugins.for_project(project, version=2):
-        for value in (safe_execute(plugin.get_annotations, group=group) or ()):
-            annotation = safe_execute(Annotation, **value)
+        for value in (safe_execute(plugin.get_annotations, group=group, _with_transaction=False) or ()):
+            annotation = safe_execute(Annotation, _with_transaction=False, **value)
             if annotation:
                 annotation_list.append(annotation)
 
@@ -125,6 +130,6 @@ def get_plugins(project):
 @register.filter
 def get_plugins_with_status(project):
     return [
-        (plugin, safe_execute(plugin.is_enabled, project))
+        (plugin, safe_execute(plugin.is_enabled, project, _with_transaction=False))
         for plugin in plugins.configurable_for_project(project, version=None)
     ]

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -229,8 +229,9 @@ def notification_settings(request):
 
     ext_forms = []
     for plugin in plugins.all():
-        for form in safe_execute(plugin.get_notification_forms) or ():
-            form = safe_execute(form, plugin, request.user, request.POST or None, prefix=plugin.slug)
+        for form in safe_execute(plugin.get_notification_forms, _with_transaction=False) or ():
+            form = safe_execute(form, plugin, request.user, request.POST or None, prefix=plugin.slug,
+                                _with_transaction=False)
             if not form:
                 continue
             ext_forms.append(form)


### PR DESCRIPTION
This is mostly a bunch of little performance adjustments.

I quickly audited all of the calls we make to `safe_execute()` and most of them don't require transaction safety, and many of these calls are done within tight loops, especially around dealing with plugins, which means the loops require multiple round trips to the database with no value.

@getsentry/infrastructure 
