### PR TITLE
Invite status and 2FA status on same column on member page

### DIFF
--- a/src/sentry/templates/sentry/organization-members.html
+++ b/src/sentry/templates/sentry/organization-members.html
@@ -55,11 +55,17 @@
 
   <table class="table member-list">
     <colgroup>
+      {% if can_remove_members or members_can_leave %}
+      <!-- 4 column -->
+      <col width="45%"/>
       <col width="15%"/>
-      <col width="5%"/>
-      <col width="5%"/>
-      {% if can_remove_members or member_can_leave %}
-        <col width="10%"/>
+      <col width="15%"/>
+      <col width="25%"/>
+      {% else %}
+      <!-- 3 column -->
+      <col width="60%"/>
+      <col width="20%"/>
+      <col width="20%"/>
       {% endif %}
     </colgroup>
     <thead>

--- a/src/sentry/templates/sentry/organization-members.html
+++ b/src/sentry/templates/sentry/organization-members.html
@@ -56,9 +56,6 @@
   <table class="table member-list">
     <colgroup>
       <col width="15%"/>
-      {% feature auth:twofactor %}
-        <col width="1%"/>
-      {% endfeature %}
       <col width="5%"/>
       <col width="5%"/>
       {% if can_remove_members or member_can_leave %}
@@ -68,9 +65,6 @@
     <thead>
       <tr>
         <th>{% trans "Member" %}</th>
-        {% feature auth:twofactor %}
-          <th class="squash">&nbsp;</th>
-        {% endfeature %}
         <th>&nbsp;</th>
         <th class="squash">{% trans "Role" %}</th>
         {% if can_remove_members or member_can_leave %}
@@ -96,9 +90,6 @@
             {{ member.get_email }}
             <br />
           </td>
-          {% feature auth:twofactor %}
-            <td class="squash">{% if not has_2fa %}<span style="color: #B64236" class="icon-exclamation tip pull-right" title="{% trans "Two-factor auth not enabled" %}"></span>{% endif %}</td>
-          {% endfeature %}
           <td class="status">
             {% if needs_sso or member.is_pending %}
               {% if member.is_pending %}
@@ -110,6 +101,10 @@
               {% if can_add_members %}
               <a href="javascript:void(0)" class="resend-invite btn btn-sm btn-primary" data-member-id="{{ member.id }}" style="padding: 0 4px; margin-top: 2px">Resend invite</a>
               {% endif %}
+            {% elif not has_2fa %}
+              {% feature auth:twofactor %}
+              <span style="color:#B64236;" class="icon-exclamation tip" title="{% trans "Two-factor auth not enabled" %}"></span>
+              {% endfeature %}
             {% endif %}
           </td>
           <td class="squash">{{ member.get_role_display }}</td>


### PR DESCRIPTION
With admin privilege + 2 factor auth:

![image](https://cloud.githubusercontent.com/assets/2153/15485027/e140695c-20f1-11e6-8e37-2af19b839a78.png)

Without admin privilege:

![image](https://cloud.githubusercontent.com/assets/2153/15485015/d517218e-20f1-11e6-9701-a09ae4048499.png)
