### PR TITLE
Allow overriding the clock used by `TimedRetryPolicy`.

### DIFF
--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -35,15 +35,16 @@ class TimedRetryPolicy(RetryPolicy):
         self.timeout = timeout
         self.delay = delay
         self.exceptions = exceptions
+        self.clock = time
 
     def __call__(self, function):
-        start = time.time()
+        start = self.clock.time()
         for i in itertools.count(1):
             try:
                 return function()
             except self.exceptions as error:
                 delay = self.delay(i)
-                now = time.time()
+                now = self.clock.time()
                 if (now + delay) > (start + self.timeout):
                     raise RetryException(
                         'Could not successfully execute %r within %.3f seconds (%s attempts.)' % (function, now - start, i),
@@ -57,4 +58,4 @@ class TimedRetryPolicy(RetryPolicy):
                         i,
                         delay,
                     )
-                    time.sleep(delay)
+                    self.clock.sleep(delay)

--- a/tests/sentry/utils/test_retries.py
+++ b/tests/sentry/utils/test_retries.py
@@ -1,7 +1,7 @@
 import mock
 
-from sentry.utils.retries import TimedRetryPolicy, RetryException
 from sentry.testutils import TestCase
+from sentry.utils.retries import TimedRetryPolicy, RetryException
 
 
 class TimedRetryPolicyTestCase(TestCase):
@@ -10,21 +10,27 @@ class TimedRetryPolicyTestCase(TestCase):
         callable = mock.MagicMock(side_effect=[bomb, mock.sentinel.OK])
 
         retry = TimedRetryPolicy(30, delay=lambda i: 10)
-        with mock.patch('time.sleep'), mock.patch('time.time', side_effect=[0, 15]):
-            assert retry(callable) is mock.sentinel.OK
-            assert callable.call_count == 2
+        retry.clock = mock.Mock()
+        retry.clock.sleep = mock.MagicMock()
+        retry.clock.time = mock.MagicMock(side_effect=[0, 15])
+
+        assert retry(callable) is mock.sentinel.OK
+        assert callable.call_count == 2
 
     def test_policy_failure(self):
         bomb = Exception('Boom!')
         callable = mock.MagicMock(side_effect=bomb)
 
         retry = TimedRetryPolicy(30, delay=lambda i: 10)
-        with mock.patch('time.sleep'), mock.patch('time.time', side_effect=[0, 15, 25]):
-            try:
-                retry(callable)
-            except RetryException as exception:
-                assert exception.exception is bomb
-            else:
-                self.fail('Expected {!r}!'.format(RetryException))
+        retry.clock = mock.Mock()
+        retry.clock.sleep = mock.MagicMock()
+        retry.clock.time = mock.MagicMock(side_effect=[0, 15, 25])
 
-            assert callable.call_count == 2
+        try:
+            retry(callable)
+        except RetryException as exception:
+            assert exception.exception is bomb
+        else:
+            self.fail('Expected {!r}!'.format(RetryException))
+
+        assert callable.call_count == 2


### PR DESCRIPTION
This is intended to allow isolating the mocked clock used by
`TimedRetryPolicyTestCase` to avoid failures when these tests are ran in
environments that are also accessing clock methods like `time.time`.

@getsentry/infrastructure 
