### PR TITLE
Log failures to `process_pending` task.

### DIFF
--- a/src/sentry/utils/locking/__init__.py
+++ b/src/sentry/utils/locking/__init__.py
@@ -1,0 +1,2 @@
+class UnableToAcquireLock(Exception):
+    """Exception raised when a lock cannot be acquired."""

--- a/src/sentry/utils/locking/backends/redis.py
+++ b/src/sentry/utils/locking/backends/redis.py
@@ -42,8 +42,9 @@ class RedisLockBackend(LockBackend):
 
     def acquire(self, key, duration, routing_key=None):
         client = self.get_client(key, routing_key)
-        if client.set(self.prefix_key(key), self.uuid, ex=duration, nx=True) is not True:
-            raise Exception('Could not acquire lock!')
+        full_key = self.prefix_key(key)
+        if client.set(full_key, self.uuid, ex=duration, nx=True) is not True:
+            raise Exception('Could not set key: {!r}'.format(full_key))
 
     def release(self, key, routing_key=None):
         client = self.get_client(key, routing_key)

--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -1,6 +1,8 @@
 import mock
+import pytest
 
 from sentry.testutils import TestCase
+from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.locking.backends import LockBackend
 from sentry.utils.locking.lock import Lock
 
@@ -26,6 +28,10 @@ class LockTestCase(TestCase):
             key,
             routing_key,
         )
+
+        backend.acquire.side_effect = Exception('Boom!')
+        with pytest.raises(UnableToAcquireLock):
+            lock.acquire()
 
     def test_context_manager_interface(self):
         backend = mock.Mock(spec=LockBackend)


### PR DESCRIPTION
These tasks can run long, and this prevents them from being logged as errors.

Fixes SENTRY-1AQ.

@getsentry/infrastructure 
