### PR TITLE
Toggle between original/minified code in exception interface

### DIFF
--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -53,6 +53,15 @@ class SingleException(Interface):
         else:
             stacktrace = None
 
+        if data.get('raw_stacktrace') and data['raw_stacktrace'].get('frames'):
+            raw_stacktrace = Stacktrace.to_python(
+                data['raw_stacktrace'],
+                has_system_frames=has_system_frames,
+                slim_frames=slim_frames,
+            )
+        else:
+            raw_stacktrace = None
+
         type = data.get('type')
         value = data.get('value')
         if not type and ':' in value.split(' ', 1)[0]:
@@ -69,6 +78,7 @@ class SingleException(Interface):
             'value': value,
             'module': trim(data.get('module'), 128),
             'stacktrace': stacktrace,
+            'raw_stacktrace': raw_stacktrace,
         }
 
         return cls(**kwargs)
@@ -79,11 +89,17 @@ class SingleException(Interface):
         else:
             stacktrace = None
 
+        if self.raw_stacktrace:
+            raw_stacktrace = self.raw_stacktrace.to_json()
+        else:
+            raw_stacktrace = None
+
         return {
             'type': self.type,
             'value': self.value,
             'module': self.module,
             'stacktrace': stacktrace,
+            'raw_stacktrace': raw_stacktrace,
         }
 
     def get_api_context(self, is_public=False):
@@ -92,11 +108,17 @@ class SingleException(Interface):
         else:
             stacktrace = None
 
+        if self.raw_stacktrace:
+            raw_stacktrace = self.raw_stacktrace.get_api_context(is_public=is_public)
+        else:
+            raw_stacktrace = None
+
         return {
             'type': self.type,
             'value': unicode(self.value) if self.value else None,
             'module': self.module,
             'stacktrace': stacktrace,
+            'rawStacktrace': raw_stacktrace,
         }
 
     def get_alias(self):

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -616,8 +616,9 @@ class SourceProcessor(object):
                 # Store original data in annotation
                 # HACK(dcramer): we stuff things into raw which gets popped off
                 # later when adding the raw_stacktrace attribute.
+                raw_frame = frame.to_json()
                 frame.data = {
-                    'raw': frame.to_json(),
+                    'raw': raw_frame,
                     'sourcemap': sourcemap_label,
                 }
 
@@ -671,6 +672,9 @@ class SourceProcessor(object):
                         # And conversely, local dependencies start with './'
                         elif filename.startswith('./'):
                             frame.in_app = True
+
+                        # Update 'raw' copy to have same in_app status
+                        raw_frame['in_app'] = frame.in_app
 
                         # We want to explicitly generate a webpack module name
                         frame.module = generate_module(filename)

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -54,6 +54,7 @@ const ExceptionInterface = React.createClass({
     let stackType = this.state.stackType;
     let newestFirst = this.state.newestFirst;
 
+    // at least one stack trace contains raw/minified code
     let hasMinified = data.values.find(x => !!x.rawStacktrace);
 
     let title = (
@@ -67,10 +68,10 @@ const ExceptionInterface = React.createClass({
         </div>
         <div className="btn-group">
           {hasMinified &&
-            <span>
-              <a className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'original'})}>{t('Original')}</a>
-              <a className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'minified'})}>{t('Minified')}</a>
-            </span>
+            [
+              <a key="original" className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'original'})}>{t('Original')}</a>,
+              <a key="minified" className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'minified'})}>{t('Minified')}</a>
+            ]
           }
         </div>
         <h3>

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -45,6 +45,7 @@ const ExceptionInterface = React.createClass({
     });
   },
 
+
   render() {
     let group = this.props.group;
     let evt = this.props.event;
@@ -52,6 +53,8 @@ const ExceptionInterface = React.createClass({
     let stackView = this.state.stackView;
     let stackType = this.state.stackType;
     let newestFirst = this.state.newestFirst;
+
+    let hasMinified = data.values.find(x => !!x.rawStacktrace);
 
     let title = (
       <div>
@@ -63,8 +66,12 @@ const ExceptionInterface = React.createClass({
           <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'raw')}>{t('Text')}</a>
         </div>
         <div className="btn-group">
-          <a className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'minified'})}>{t('Minified')}</a>
-          <a className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'original'})}>{t('Original')}</a>
+          {hasMinified &&
+            <span>
+              <a className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'original'})}>{t('Original')}</a>
+              <a className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'minified'})}>{t('Minified')}</a>
+            </span>
+          }
         </div>
         <h3>
           {t('Exception')}

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -64,7 +64,7 @@ const ExceptionInterface = React.createClass({
             <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'app')}>{t('App Only')}</a>
           }
           <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'full')}>{t('Full')}</a>
-          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'raw')}>{t('Text')}</a>
+          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'raw')}>{t('Raw')}</a>
         </div>
         <div className="btn-group">
           {hasMinified &&
@@ -94,15 +94,14 @@ const ExceptionInterface = React.createClass({
           type={this.props.type}
           title={title}
           wrapTitle={false}>
-        {/*stackType === 'original' ?
-        */}
         {stackView === 'raw' ?
           <RawExceptionContent
+            type={stackType}
             values={data.values}
             platform={evt.platform}/> :
 
           <ExceptionContent
-            type={this.state.stackType}
+            type={stackType}
             view={stackView}
             values={data.values}
             platform={evt.platform}

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -34,11 +34,12 @@ const ExceptionInterface = React.createClass({
 
     return {
       stackView: (this.props.data.hasSystemFrames ? 'app' : 'full'),
+      stackType: 'original',
       newestFirst: newestFirst
     };
   },
 
-  toggleStack(value) {
+  toggleStackView(value) {
     this.setState({
       stackView: value
     });
@@ -49,16 +50,21 @@ const ExceptionInterface = React.createClass({
     let evt = this.props.event;
     let data = this.props.data;
     let stackView = this.state.stackView;
+    let stackType = this.state.stackType;
     let newestFirst = this.state.newestFirst;
 
     let title = (
       <div>
-        <div className="btn-group">
+        <div className="btn-group" style={{marginLeft:'10px'}}>
           {data.hasSystemFrames &&
-            <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'app')}>{t('App Only')}</a>
+            <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'app')}>{t('App Only')}</a>
           }
-          <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'full')}>{t('Full')}</a>
-          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'raw')}>{t('Raw')}</a>
+          <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'full')}>{t('Full')}</a>
+          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'raw')}>{t('Text')}</a>
+        </div>
+        <div className="btn-group">
+          <a className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'minified'})}>{t('Minified')}</a>
+          <a className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'original'})}>{t('Original')}</a>
         </div>
         <h3>
           {t('Exception')}
@@ -80,12 +86,15 @@ const ExceptionInterface = React.createClass({
           type={this.props.type}
           title={title}
           wrapTitle={false}>
+        {/*stackType === 'original' ?
+        */}
         {stackView === 'raw' ?
           <RawExceptionContent
             values={data.values}
             platform={evt.platform}/> :
 
           <ExceptionContent
+            type={this.state.stackType}
             view={stackView}
             values={data.values}
             platform={evt.platform}

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -45,7 +45,6 @@ const ExceptionInterface = React.createClass({
     });
   },
 
-
   render() {
     let group = this.props.group;
     let evt = this.props.event;
@@ -69,8 +68,8 @@ const ExceptionInterface = React.createClass({
         <div className="btn-group">
           {hasMinified &&
             [
-              <a key="original" className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'original'})}>{t('Original')}</a>,
-              <a key="minified" className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setState.bind(this, {stackType: 'minified'})}>{t('Minified')}</a>
+              <a key="original" className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={() => this.setState({stackType: 'original'})}>{t('Original')}</a>,
+              <a key="minified" className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={() => this.setState({stackType: 'minified'})}>{t('Minified')}</a>
             ]
           }
         </div>

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
@@ -5,6 +5,7 @@ import StacktraceContent from './stacktraceContent';
 
 const ExceptionContent = React.createClass({
   propTypes: {
+    type: React.PropTypes.string,
     values: React.PropTypes.array.isRequired,
     view: React.PropTypes.string.isRequired,
     platform: React.PropTypes.string,
@@ -24,7 +25,7 @@ const ExceptionContent = React.createClass({
           }
           {defined(exc.stacktrace) &&
             <StacktraceContent
-                data={exc.stacktrace}
+                data={this.props.type === 'original' ? exc.stacktrace : exc.rawStacktrace}
                 includeSystemFrames={stackView === 'full'}
                 platform={this.props.platform}
                 newestFirst={this.props.newestFirst} />

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
@@ -5,7 +5,7 @@ import StacktraceContent from './stacktraceContent';
 
 const ExceptionContent = React.createClass({
   propTypes: {
-    type: React.PropTypes.string,
+    type: React.PropTypes.oneOf(['original', 'minified']),
     values: React.PropTypes.array.isRequired,
     view: React.PropTypes.string.isRequired,
     platform: React.PropTypes.string,

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -3,15 +3,17 @@ import rawStacktraceContent from './rawStacktraceContent';
 
 const RawExceptionContent = React.createClass({
   propTypes: {
+    type: React.PropTypes.string,
     platform: React.PropTypes.string,
     values: React.PropTypes.array.isRequired,
   },
 
   render() {
+    let {type} = this.props;
     let children = this.props.values.map((exc, excIdx) => {
       return (
         <pre key={excIdx} className="traceback plain">
-          {exc.stacktrace && rawStacktraceContent(exc.stacktrace, this.props.platform, exc)}
+          {exc.stacktrace && rawStacktraceContent(type === 'original' ? exc.stacktrace : exc.rawStacktrace, this.props.platform, exc)}
         </pre>
       );
     });

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -3,7 +3,7 @@ import rawStacktraceContent from './rawStacktraceContent';
 
 const RawExceptionContent = React.createClass({
   propTypes: {
-    type: React.PropTypes.string,
+    type: React.PropTypes.oneOf(['original', 'minified']),
     platform: React.PropTypes.string,
     values: React.PropTypes.array.isRequired,
   },

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -938,8 +938,8 @@
   }
 
   .original-src {
+    font-size: 12px;
     padding-left: 3px;
-    font-size: 13px;
     position: relative;
     top: 1px;
   }
@@ -951,13 +951,7 @@
     position: relative;
     top: 1px;
   }
-
-  .icon-question {
-    font-size: 15px;
-    position: relative;
-    top: 1px;
-  }
-
+  
   .in-at {
     opacity: .8;
     margin: 0 2px;

--- a/tests/js/spec/components/events/interfaces/frame.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame.spec.jsx
@@ -28,38 +28,11 @@ describe('Frame', function () {
       };
     });
 
-    it('should render the original source information as a HTML string', function () {
+    it('should render the source map information as a HTML string', function () {
       let frame = TestUtils.renderIntoDocument(<Frame data={this.data} />);
 
       // NOTE: indentation/whitespace intentional to match output string
-      expect(frame.renderOriginalSourceInfo()).to.eql(`
-    <div>
-      <strong>Original Filename</strong><br/>
-      <a href="https://beta.getsentry.com/_static/sentry/dist/vendor.js">https://beta.getsentry.com/_static/sentry/dist/vendor.js</a><br/>
-      <strong>Line Number</strong><br/>
-      419<br/>
-      <strong>Column Number</strong><br/>
-      2503<br/>
-      <strong>Function</strong><br/>
-      T._updateRenderedComponent<br/>
-      <strong>Source Map</strong><br/><a href="https://beta.getsentry.com/_static/sentry/dist/vendor.js.map">vendor.js.map<br/></div>`);
-    });
-
-    it('should omit a source map <a> tag if no mapUrl is provided', function () {
-      delete this.data.mapUrl;
-
-      let frame = TestUtils.renderIntoDocument(<Frame data={this.data} />);
-      expect(frame.renderOriginalSourceInfo()).to.eql(`
-    <div>
-      <strong>Original Filename</strong><br/>
-      <a href="https://beta.getsentry.com/_static/sentry/dist/vendor.js">https://beta.getsentry.com/_static/sentry/dist/vendor.js</a><br/>
-      <strong>Line Number</strong><br/>
-      419<br/>
-      <strong>Column Number</strong><br/>
-      2503<br/>
-      <strong>Function</strong><br/>
-      T._updateRenderedComponent<br/>
-      <strong>Source Map</strong><br/>vendor.js.map<br/></div>`);
+      expect(frame.renderOriginalSourceInfo()).to.eql(`\n    <div>\n      <strong>Source Map</strong><br/>https://beta.getsentry.com/_static/sentry/dist/vendor.js.map<br/></div>`);
     });
   });
 });

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -174,6 +174,7 @@ class SingleExceptionTest(TestCase):
             'value': self.interface.value,
             'module': self.interface.module,
             'stacktrace': None,
+            'raw_stacktrace': None,
         }
 
     def test_get_hash(self):


### PR DESCRIPTION
_Comments below are by @bentlegen_

**Summary of changes:**
- JavaScript event processor now adds a `raw_stacktrace` to exception objects when a source map was applied _to at least one frame_
- `raw_stacktrace` frames do not have source maps applied; they contain frame data representing the original, minified code
- if `raw_stacktrace` is present for an exception, user can now toggle between "Minified" and "Original" frames
- "App Only", "Full", and "Raw" use data from the currently active stack trace representation

**Screenshots**

![image](https://cloud.githubusercontent.com/assets/2153/15593911/622e386c-2365-11e6-9e37-76a4cae358b5.png)

![image](https://cloud.githubusercontent.com/assets/2153/15593918/68c2b536-2365-11e6-846f-28e2d527b390.png)
