### PR TITLE
Fix sudo flow for password

### DIFF
--- a/src/sentry/web/frontend/sudo.py
+++ b/src/sentry/web/frontend/sudo.py
@@ -10,17 +10,23 @@ class SudoView(BaseSudoView):
     template_name = 'sentry/account/sudo.html'
 
     def handle_sudo(self, request, redirect_to, context):
+        if BaseSudoView.handle_sudo(self, request, redirect_to, context):
+            return True
+
         interface = Authenticator.objects.get_interface(request.user, 'u2f')
 
         if interface.is_available and interface.is_enrolled:
             challenge = interface.activate(request).challenge
             if request.method == 'POST':
-                if 'challenge' in request.POST:
-                    challenge = json.loads(request.POST['challenge'])
-                if 'response' in request.POST:
-                    response = json.loads(request.POST['response'])
-                    if interface.validate_response(request, challenge, response):
-                        return True
+                if 'challenge' in request.POST and 'response' in request.POST:
+                    try:
+                        challenge = json.loads(request.POST['challenge'])
+                        response = json.loads(request.POST['response'])
+                    except ValueError:
+                        pass
+                    else:
+                        if interface.validate_response(request, challenge, response):
+                            return True
             context['u2f_challenge'] = challenge
 
-        return BaseSudoView.handle_sudo(self, request, redirect_to, context)
+        return False


### PR DESCRIPTION
This flow was assuming that U2F was the only way to sudo through. If the case of entering in a password, it didn't work and errored on the U2F assumption.

This changes the flow to first check password, and if we fail there, _then_ check U2F flow, and guard against JSON decode failures.

@getsentry/infrastructure @mitsuhiko 
