### PR TITLE
Set the event type to error for apple crash reports

### DIFF
--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -96,7 +96,11 @@ def inject_apple_backtrace(data, frames, diagnosis=None, error=None,
         exc = exception_from_apple_error_or_diagnosis(error, diagnosis)
         if exc is not None:
             exc['stacktrace'] = stacktrace
-            data['sentry.interfaces.Exception'] = exc
+            data['sentry.interfaces.Exception'] = {'values': [exc]}
+            # Since we inject the exception late we need to make sure that
+            # we set the event type to error as it would be set to
+            # 'default' otherwise.
+            data['type'] = 'error'
             return
 
     data['sentry.interfaces.Stacktrace'] = stacktrace


### PR DESCRIPTION
This solves the problem that they are considered to be 'default' due to how
the current detection code works.  As a result culprits were not visible.

Downside is that this is stored with the groups so this bugfix will not
repair the already broken groups of users.

This fixes #3308
