### PR TITLE
Improved in_app detection for cocoa

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -7,6 +7,13 @@ import TooltipMixin from '../../../mixins/tooltip';
 import FrameVariables from './frameVariables';
 import {t} from '../../../locale';
 
+function trimPackage(pkg) {
+  let pieces = pkg.split(/\//g);
+  let rv = pieces[pieces.length - 1] || pieces[pieces.length - 2] || pkg;
+  let match = rv.match(/^(.*?)\.(dylib|so|a)$/);
+  return match && match[1] || rv;
+}
+
 
 const Frame = React.createClass({
   propTypes: {
@@ -131,7 +138,7 @@ const Frame = React.createClass({
 
     if (defined(data.package)) {
       title.push(<span className="within" key="within"> {t('within')} </span>);
-      title.push(<code>{data.package}</code>);
+      title.push(<code title={data.package}>{trimPackage(data.package)}</code>);
     }
 
     if (defined(data.origAbsPath)) {
@@ -230,8 +237,8 @@ const Frame = React.createClass({
     let className = 'stacktrace-table';
     return (
       <div className={className}>
-        <div className="trace-col package">
-          {data.package}
+        <div className="trace-col package" title={data.package}>
+          {trimPackage(data.package)}
         </div>
         <div className="trace-col address">
           {data.instructionAddr}

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1206,15 +1206,16 @@ ol.context-line {
     code {
       background: transparent;
       color: @blue-dark;
+      padding-right: 5px;
     }
 
     span.offset {
       font-weight: bold;
+      padding-right: 10px;
     }
 
     span.filename {
       color: @purple;
-      padding-left: 10px;
 
       &:before {
         content: "(";

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1177,9 +1177,13 @@ ol.context-line {
 
 .stacktrace-table {
   display: flex;
+  align-items: baseline;
+  line-height: 16px;
+  box-shadow: inset 0 1px 0 #E6EEF4;
 
   .trace-col {
-    padding: 0 6px;
+    padding: 6px 5px 3px;
+    font-size: 12px;
   }
 
   .package {
@@ -1197,18 +1201,15 @@ ol.context-line {
 
   .symbol {
     code {
-      font-size: 12px;
       background: transparent;
       color: @blue-dark;
     }
 
     span.offset {
-      font-size: 12px;
       font-weight: bold;
     }
 
     span.filename {
-      font-size: 12px;
       color: @purple;
       padding-left: 10px;
 
@@ -1227,7 +1228,7 @@ ol.context-line {
 }
 
 .leads-to-app .stacktrace-table {
-  background: lighten(@blue-light, 28);
+  background: lighten(@blue-light, 30);
 }
 
 #full-message {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1176,10 +1176,10 @@ ol.context-line {
 }
 
 .stacktrace-table {
+  display: flex;
 
   .trace-col {
-    display: inline-block;
-    padding: 0 5px;
+    padding: 0 6px;
   }
 
   .package {
@@ -1187,34 +1187,37 @@ ol.context-line {
     font-size: 13px;
     font-weight: bold;
   }
+
   .address {
-    width: 10%;
     font-family: @font-family-code;
     font-size: 11px;
     color: @gray-dark;
     letter-spacing: -0.25px;
   }
+
   .symbol {
-    width: 75%;
     code {
       font-size: 12px;
       background: transparent;
       color: @blue-dark;
     }
+
     span.offset {
       font-size: 12px;
       font-weight: bold;
     }
+
     span.filename {
+      font-size: 12px;
+      color: @purple;
+      padding-left: 10px;
+
       &:before {
         content: "(";
       }
       &:after {
         content: ")";
       }
-      font-size: 12px;
-      color: @purple;
-      padding-left: 10px;
     }
   }
 }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1190,6 +1190,9 @@ ol.context-line {
     width: 15%;
     font-size: 13px;
     font-weight: bold;
+    .truncate;
+    flex-grow: 0;
+    flex-shrink: 0;
   }
 
   .address {
@@ -1228,7 +1231,7 @@ ol.context-line {
 }
 
 .leads-to-app .stacktrace-table {
-  background: lighten(@blue-light, 30);
+  background: lighten(@blue-light, 31);
 }
 
 #full-message {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1227,11 +1227,11 @@ ol.context-line {
 }
 
 .system-frame .stacktrace-table {
-  background-color: #f6f7f8;
+  background-color: @white-dark;
 }
 
 .leads-to-app .stacktrace-table {
-  background: lighten(@blue-light, 31);
+  background: lighten(@blue-light, 30);
 }
 
 #full-message {


### PR DESCRIPTION
This now detects any image below the private container path as belonging to the
application.  This unfortunately now also means that third party frameworks
are detected as app but I don't have a better solution for now.

I would like to merge this for now because without this change many stacks are
completely unreadable by default.

I will figure out better ways to detect app vs third party bundles later.

This fixes #3325
