### PR TITLE
Show user's email sub status on project notification page

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -256,3 +256,14 @@ class Project(Model):
         if self.team.name not in self.name:
             return '%s %s' % (self.team.name, self.name)
         return self.name
+
+    def is_user_subscribed_to_mail_alerts(self, user):
+        from sentry.models import UserOption
+        is_enabled = UserOption.objects.get_value(
+            user, self, 'mail:alert', None)
+        if is_enabled is None:
+            is_enabled = UserOption.objects.get_value(
+                user, None, 'subscribe_by_default', '1') == '1'
+        else:
+            is_enabled = bool(is_enabled)
+        return is_enabled

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -119,3 +119,14 @@ class UserOption(Model):
         unique_together = (('user', 'project', 'key',),)
 
     __repr__ = sane_repr('user_id', 'project_id', 'key', 'value')
+
+    @classmethod
+    def is_user_subscribed_to_mail_alerts(cls, user, project):
+        is_enabled = cls.objects.get_value(
+            user, project, 'mail:alert', None)
+        if is_enabled is None:
+            is_enabled = cls.objects.get_value(
+                user, None, 'subscribe_by_default', '1') == '1'
+        else:
+            is_enabled = bool(is_enabled)
+        return is_enabled

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -119,14 +119,3 @@ class UserOption(Model):
         unique_together = (('user', 'project', 'key',),)
 
     __repr__ = sane_repr('user_id', 'project_id', 'key', 'value')
-
-    @classmethod
-    def is_user_subscribed_to_mail_alerts(cls, user, project):
-        is_enabled = cls.objects.get_value(
-            user, project, 'mail:alert', None)
-        if is_enabled is None:
-            is_enabled = cls.objects.get_value(
-                user, None, 'subscribe_by_default', '1') == '1'
-        else:
-            is_enabled = bool(is_enabled)
-        return is_enabled

--- a/src/sentry/templates/sentry/project-notifications.html
+++ b/src/sentry/templates/sentry/project-notifications.html
@@ -13,6 +13,15 @@
     {% csrf_token %}
     <input type="hidden" name="op" value="save-settings" />
 
+    {% if not is_user_subbed %}
+    <div class="box" style="border:0">
+      <div class="alert">
+        {% url 'sentry-account-settings-notifications' as account_notification_url %}
+        <p>You are currently not subscribed to this project. To subscribe, go to <a href="{{ account_notification_url }}">Account Notifications</a>.</p>
+      </div>
+    </div>
+    {% endif %}
+
     <div class="box">
       <div class="box-header">
         <h3>{% trans "Rules" %}</h3>
@@ -21,10 +30,6 @@
         {% url 'sentry-project-rules' organization.slug project.slug as link %}
         <p>{% blocktrans %}Sentry will notify users subscribed to this project based on the <a href="{{ link }}">rules configured for this project</a>.{% endblocktrans %}</p>
 
-        {% if not is_user_subbed %}
-        {% url 'sentry-account-settings-notifications' as account_notification_url %}
-        <p style="font-style:italic">You are currently not subscribed to this project. To subscribe, go to <a href="{{ account_notification_url }}">Account Notifications</a>.</p>
-        {% endif %}
       </div>
     </div>
 

--- a/src/sentry/templates/sentry/project-notifications.html
+++ b/src/sentry/templates/sentry/project-notifications.html
@@ -19,7 +19,12 @@
       </div>
       <div class="box-content with-padding">
         {% url 'sentry-project-rules' organization.slug project.slug as link %}
-        <p>{% blocktrans %}Sentry will notify you based on the <a href="{{ link }}">rules configured for this project</a>.{% endblocktrans %}</p>
+        <p>{% blocktrans %}Sentry will notify users subscribed to this project based on the <a href="{{ link }}">rules configured for this project</a>.{% endblocktrans %}</p>
+
+        {% if not is_user_subbed %}
+        {% url 'sentry-account-settings-notifications' as account_notification_url %}
+        <p style="font-style:italic">You are currently not subscribed to this project. To subscribe, go to <a href="{{ account_notification_url }}">Account Notifications</a>.</p>
+        {% endif %}
       </div>
     </div>
 

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -388,7 +388,7 @@ class ProjectEmailOptionsForm(forms.Form):
 
         super(ProjectEmailOptionsForm, self).__init__(*args, **kwargs)
 
-        is_enabled = UserOption.is_user_subscribed_to_mail_alerts(user, project)
+        is_enabled = project.is_user_subscribed_to_mail_alerts(user)
 
         self.fields['alert'].initial = is_enabled
         self.fields['email'].initial = UserOption.objects.get_value(

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -388,13 +388,7 @@ class ProjectEmailOptionsForm(forms.Form):
 
         super(ProjectEmailOptionsForm, self).__init__(*args, **kwargs)
 
-        is_enabled = UserOption.objects.get_value(
-            user, project, 'mail:alert', None)
-        if is_enabled is None:
-            is_enabled = UserOption.objects.get_value(
-                user, None, 'subscribe_by_default', '1') == '1'
-        else:
-            is_enabled = bool(is_enabled)
+        is_enabled = UserOption.is_user_subscribed_to_mail_alerts(user, project)
 
         self.fields['alert'].initial = is_enabled
         self.fields['email'].initial = UserOption.objects.get_value(

--- a/src/sentry/web/frontend/project_notifications.py
+++ b/src/sentry/web/frontend/project_notifications.py
@@ -47,14 +47,6 @@ class ProjectNotificationsView(ProjectView):
         )
 
     def handle(self, request, organization, team, project):
-        is_user_subbed = UserOption.objects.get_value(
-            request.user, project, 'mail:alert', None)
-        if is_user_subbed is None:
-            is_user_subbed = UserOption.objects.get_value(
-                request.user, None, 'subscribe_by_default', '1') == '1'
-        else:
-            is_user_subbed = bool(is_user_subbed)
-
         op = request.POST.get('op')
         if op == 'enable':
             self._handle_enable_plugin(request, project)
@@ -147,6 +139,8 @@ class ProjectNotificationsView(ProjectView):
                     enabled_plugins.append((plugin, mark_safe(content)))
             elif plugin.can_configure_for_project(project):
                 other_plugins.append(plugin)
+
+        is_user_subbed = UserOption.is_user_subscribed_to_mail_alerts(request.user, project)
 
         context = {
             'page': 'notifications',

--- a/src/sentry/web/frontend/project_notifications.py
+++ b/src/sentry/web/frontend/project_notifications.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext_lazy as _
 from sentry import constants
 from sentry import options
 from sentry.app import digests
-from sentry.models import UserOption
 from sentry.digests import get_option_key as get_digest_option_key
 from sentry.plugins import plugins, NotificationPlugin
 from sentry.web.forms.projects import (
@@ -140,7 +139,7 @@ class ProjectNotificationsView(ProjectView):
             elif plugin.can_configure_for_project(project):
                 other_plugins.append(plugin)
 
-        is_user_subbed = UserOption.is_user_subscribed_to_mail_alerts(request.user, project)
+        is_user_subbed = project.is_user_subscribed_to_mail_alerts(request.user)
 
         context = {
             'page': 'notifications',


### PR DESCRIPTION
This is designed to reduce confusion where users aren't seeing notifications coming from a project – because they may be unsubscribed, which is configured on an entirely different page.

---

![image](https://cloud.githubusercontent.com/assets/2153/15551461/f83a51c0-226a-11e6-9957-1d85ea08dc9c.png)
- @mattrobenolt – where would you put this copy/pasted code about determining sub status?
- @ckj – any thoughts on how to make this not terrible, design wise

/cc @getsentry/ui
