### PR TITLE
Only look up active accounts when linking SSO

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -367,7 +367,7 @@ class AuthHelper(object):
         op = request.POST.get('op')
         if not request.user.is_authenticated():
             try:
-                existing_user = auth.find_users(identity['email'])[0]
+                existing_user = auth.find_users(identity['email'], is_active=True)[0]
             except IndexError:
                 existing_user = None
             login_form = self._get_login_form(existing_user)

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -81,12 +81,16 @@ def get_login_redirect(request, default=None):
     return login_url
 
 
-def find_users(username, with_valid_password=True):
+def find_users(username, with_valid_password=True, is_active=None):
     """
     Return a list of users that match a username
     and falling back to email
     """
     qs = User.objects
+
+    if is_active is not None:
+        qs = qs.filter(is_active=is_active)
+
     if with_valid_password:
         qs = qs.exclude(password='!')
 


### PR DESCRIPTION
From a quick glance, this seems like a safe assumption to apply everywhere, but not sure if there are cases where we are explicitly looking for inactive accounts with this.

@getsentry/infrastructure 
