### PR TITLE
Add latency to the event timestamp tooltip.

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -9,10 +9,11 @@ import FileSize from '../../components/fileSize';
 import TooltipMixin from '../../mixins/tooltip';
 import {t} from '../../locale';
 
-let formatDuration = (duration) => {
-  let hours = Math.floor(+duration / (60 * 60 * 1000)),
-      minutes = duration.minutes(),
-      results = [];
+let formatDateDelta = (reference, observed) => {
+  let duration = moment.duration(Math.abs(+observed - +reference));
+  let hours = Math.floor(+duration / (60 * 60 * 1000));
+  let minutes = duration.minutes();
+  let results = [];
 
   if (hours) {
     results.push(`${hours} hour${hours != 1 ? 's' : ''}`);
@@ -65,7 +66,7 @@ let GroupEventToolbar  = React.createClass({
         '<dd>' + dateReceived.format('ll') + '<br />' +
           dateReceived.format(format) + '</dd>' +
         '<dt>Latency</dt>' +
-        '<dd>' + formatDuration(moment.duration(dateReceived.diff(dateCreated))) + '</dd>'
+        '<dd>' + formatDateDelta(dateCreated, dateReceived) + '</dd>'
       );
     }
     return resp + '</dl>';

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -1,7 +1,6 @@
 import {Link} from 'react-router';
 import moment from 'moment';
 import React from 'react';
-import {sprintf} from 'sprintf-js';
 
 import ConfigStore from '../../stores/configStore';
 import PropTypes from '../../proptypes';
@@ -9,6 +8,26 @@ import DateTime from '../../components/dateTime';
 import FileSize from '../../components/fileSize';
 import TooltipMixin from '../../mixins/tooltip';
 import {t} from '../../locale';
+
+let formatDuration = (duration) => {
+  let hours = Math.floor(+duration / (60 * 60 * 1000)),
+      minutes = duration.minutes(),
+      results = [];
+
+  if (hours) {
+    results.push(`${hours} hour${hours != 1 ? 's' : ''}`);
+  }
+
+  if (minutes) {
+    results.push(`${minutes} minute${minutes != 1 ? 's' : ''}`);
+  }
+
+  if (results.length == 0) {
+    results.push('a few seconds');
+  }
+
+  return results.join(', ');
+}
 
 let GroupEventToolbar  = React.createClass({
   propTypes: {
@@ -40,21 +59,13 @@ let GroupEventToolbar  = React.createClass({
           dateCreated.format(format) + '</dd>'
     );
     if (evt.dateReceived) {
-      let dateReceived = moment(evt.dateReceived),
-          latency = moment.duration(dateReceived.diff(dateCreated));
-
+      let dateReceived = moment(evt.dateReceived);
       resp += (
         '<dt>Received</dt>' +
         '<dd>' + dateReceived.format('ll') + '<br />' +
           dateReceived.format(format) + '</dd>' +
         '<dt>Latency</dt>' +
-        '<dd>' + sprintf(
-          '%u:%02u:%02u',
-          Math.floor(+latency / (60 * 60 * 1000)),
-          latency.minutes(),
-          latency.seconds()
-        ) +
-        '</dd>'
+        '<dd>' + formatDuration(moment.duration(dateReceived.diff(dateCreated))) + '</dd>'
       );
     }
     return resp + '</dl>';

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -131,6 +131,9 @@ let GroupEventToolbar  = React.createClass({
       paddingBottom: '5px'
     };
 
+    let latencyThreshold = 30 * 60 * 1000;  // 30 minutes
+    let isOverLatencyThreshold = evt.dateReceived && Math.abs(+moment(evt.dateReceived) - +moment(evt.dateCreated)) > latencyThreshold;
+
     return (
       <div className="event-toolbar">
         <div className="pull-right">
@@ -140,8 +143,10 @@ let GroupEventToolbar  = React.createClass({
         </div>
         <h4>{t('Event %s', evt.eventID)}</h4>
         <span>
-          <DateTime date={evt.dateCreated} className="tip" data-title={this.getDateTooltip()}
-                    style={style} />
+          <span className="tip" data-title={this.getDateTooltip()}>
+            <DateTime date={evt.dateCreated} style={style} />
+            {isOverLatencyThreshold ? <span className="icon-alert" /> : ''}
+          </span>
           <a href={jsonUrl} target="_blank" className="json-link">{'JSON'} &#40;<FileSize bytes={evt.size} />&#41;</a>
         </span>
       </div>

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -145,7 +145,7 @@ let GroupEventToolbar  = React.createClass({
         <span>
           <span className="tip" data-title={this.getDateTooltip()}>
             <DateTime date={evt.dateCreated} style={style} />
-            {isOverLatencyThreshold ? <span className="icon-alert" /> : ''}
+            {isOverLatencyThreshold && <span className="icon-alert" />}
           </span>
           <a href={jsonUrl} target="_blank" className="json-link">{'JSON'} &#40;<FileSize bytes={evt.size} />&#41;</a>
         </span>

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -1,6 +1,7 @@
 import {Link} from 'react-router';
 import moment from 'moment';
 import React from 'react';
+import {sprintf} from 'sprintf-js';
 
 import ConfigStore from '../../stores/configStore';
 import PropTypes from '../../proptypes';
@@ -39,12 +40,21 @@ let GroupEventToolbar  = React.createClass({
           dateCreated.format(format) + '</dd>'
     );
     if (evt.dateReceived) {
-      let dateReceived = moment(evt.dateReceived);
+      let dateReceived = moment(evt.dateReceived),
+          latency = moment.duration(dateReceived.diff(dateCreated));
 
       resp += (
         '<dt>Received</dt>' +
         '<dd>' + dateReceived.format('ll') + '<br />' +
-          dateReceived.format(format) + '</dd>'
+          dateReceived.format(format) + '</dd>' +
+        '<dt>Latency</dt>' +
+        '<dd>' + sprintf(
+          '%u:%02u:%02u',
+          Math.floor(+latency / (60 * 60 * 1000)),
+          latency.minutes(),
+          latency.seconds()
+        ) +
+        '</dd>'
       );
     }
     return resp + '</dl>';

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -28,7 +28,7 @@ let formatDateDelta = (reference, observed) => {
   }
 
   return results.join(', ');
-}
+};
 
 let GroupEventToolbar  = React.createClass({
   propTypes: {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -711,6 +711,12 @@
     color: @gray-dark;
   }
 
+  .icon-alert {
+    margin-left: 5px;
+    color: @yellow-orange;
+    font-size: 14px;
+  }
+
   .json-link {
     margin-left: 8px;
     padding-left: 8px;


### PR DESCRIPTION
![screenshot 2016-05-25 12 16 11](https://cloud.githubusercontent.com/assets/65315/15553052/310ddfec-2272-11e6-822b-e90aa67b44d8.png)

Fixes GH-3283.

@getsentry/ui @getsentry/javascript 
