### PR TITLE
Added platform to stacks

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -438,8 +438,6 @@ class Frame(Interface):
         }).strip('\n')
 
     def get_culprit_string(self, platform=None):
-        if self.platform is not None:
-            platform = self.platform
         if platform in ('objc', 'cocoa'):
             return '%s (%s)' % (
                 self.function or '?',

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -630,6 +630,7 @@ class Stacktrace(Interface):
             'frames': frame_list,
             'framesOmitted': self.frames_omitted,
             'hasSystemFrames': self.has_system_frames,
+            'platform': self.platform,
         }
 
     def to_json(self):
@@ -637,6 +638,7 @@ class Stacktrace(Interface):
             'frames': [f.to_json() for f in self.frames],
             'frames_omitted': self.frames_omitted,
             'has_system_frames': self.has_system_frames,
+            'platform': self.platform,
         }
 
     def get_path(self):

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -20,7 +20,7 @@ const StacktraceInterface = React.createClass({
     let user = ConfigStore.get('user');
     // user may not be authenticated
     let options = user ? user.options : {};
-    let platform = this.props.event.platform;
+    let platform = this.getPlatform();
     let newestFirst;
     switch (options.stacktraceOrder) {
       case 'newestFirst':
@@ -36,8 +36,16 @@ const StacktraceInterface = React.createClass({
 
     return {
       stackView: (this.props.data.hasSystemFrames ? 'app' : 'full'),
+      // if our stacktrace has a platform information itself we can use it,
+      // otherwise we call back to the platform that we were told we're
+      // using (the one from the props).
       newestFirst: newestFirst
     };
+  },
+
+  getPlatform() {
+    return this.props.data.platform ||
+      this.props.platform || this.props.event.platform;
   },
 
   toggleStack(value) {
@@ -82,13 +90,13 @@ const StacktraceInterface = React.createClass({
           wrapTitle={false}>
         {stackView === 'raw' ?
           <pre className="traceback plain">
-            {rawStacktraceContent(data, this.props.platform)}
+            {rawStacktraceContent(data, this.getPlatform())}
           </pre>
         :
           <StacktraceContent
               data={data}
               includeSystemFrames={stackView === 'full'}
-              platform={evt.platform}
+              platform={this.getPlatform()}
               newestFirst={newestFirst} />
         }
       </GroupEventDataSection>

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -17,8 +17,13 @@ const StacktraceContent = React.createClass({
     };
   },
 
+  getPlatform() {
+    return this.props.data.platform || this.props.platform;
+  },
+
   shouldRenderAsTable() {
-    return this.props.platform === 'cocoa';
+    const platform = this.getPlatform();
+    return platform === 'cocoa' || platform === 'objc';
   },
 
   renderOmittedFrames(firstFrameOmitted, lastFrameOmitted) {
@@ -60,7 +65,7 @@ const StacktraceContent = React.createClass({
             key={frameIdx}
             data={frame}
             nextFrameInApp={nextFrame && nextFrame.inApp}
-            platform={this.props.platform} />
+            platform={this.getPlatform()} />
         );
       }
       if (frameIdx === firstFrameOmitted) {


### PR DESCRIPTION
The idea behind this is that we can set the platform on a per stackframe/exception basis. This way we can combine stacktraces of different languages. In the case I have in mind we have cocoa and .NET stacktraces in one event. 
