### PR TITLE
Do not fail on empty package in ios stack rendering

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -8,6 +8,9 @@ import FrameVariables from './frameVariables';
 import {t} from '../../../locale';
 
 function trimPackage(pkg) {
+  if (!pkg) {
+    return '';
+  }
   let pieces = pkg.split(/\//g);
   let rv = pieces[pieces.length - 1] || pieces[pieces.length - 2] || pkg;
   let match = rv.match(/^(.*?)\.(dylib|so|a)$/);
@@ -237,7 +240,7 @@ const Frame = React.createClass({
     let className = 'stacktrace-table';
     return (
       <div className={className}>
-        <div className="trace-col package" title={data.package}>
+        <div className="trace-col package" title={data.package || ''}>
           {trimPackage(data.package)}
         </div>
         <div className="trace-col address">

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -8,9 +8,6 @@ import FrameVariables from './frameVariables';
 import {t} from '../../../locale';
 
 function trimPackage(pkg) {
-  if (!pkg) {
-    return '';
-  }
   let pieces = pkg.split(/\//g);
   let rv = pieces[pieces.length - 1] || pieces[pieces.length - 2] || pkg;
   let match = rv.match(/^(.*?)\.(dylib|so|a)$/);
@@ -240,9 +237,15 @@ const Frame = React.createClass({
     let className = 'stacktrace-table';
     return (
       <div className={className}>
-        <div className="trace-col package" title={data.package || ''}>
-          {trimPackage(data.package)}
-        </div>
+        {defined(data.package)
+          ? (
+            <div className="trace-col package" title={data.package}>
+              {trimPackage(data.package)}
+            </div>
+          ) : (
+            <div className="trace-col package"/>
+          )
+        }
         <div className="trace-col address">
           {data.instructionAddr}
         </div>


### PR DESCRIPTION
This makes sure the UI can deal with packages not being set for stacktraces.

@getsentry/ui needs review.
