### PR TITLE
Remove Admin link from footer

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -183,9 +183,6 @@
       <div class="container">
         {% block footer %}
         <div class="pull-right">
-          {% if request.is_superuser %}
-          <a href="{% url 'sentry-admin-status' %}">{% trans "Admin" %}</a>
-          {% endif %}
           {% block support_link %}{% endblock %}
           <a href="https://docs.getsentry.com/hosted/api/">{% trans "API" %}</a>
           <a href="https://docs.getsentry.com">{% trans "Docs" %}</a>


### PR DESCRIPTION
This is shown in HTML pages, but wasn't shown on React pages.

~~Alternatively, we can just 100% remove this from the footer? Not sure which is preferrable~~ I removed it from HTML.

@getsentry/ui @dcramer 
