### PR TITLE
Don't render pre/post frame context until expanded

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/contextLine.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/contextLine.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {defined} from '../../../utils';
+
+const ContextLine = function(props) {
+  let {line, isActive} = props;
+  let liClassName = 'expandable';
+  if (isActive) {
+    liClassName += ' active';
+  }
+
+  let lineWs = '';
+  let lineCode = '';
+  if (defined(line[1]) && line[1].match) {
+    [, lineWs, lineCode] = line[1].match(/^(\s*)(.*?)$/m);
+  }
+
+  return (
+    <li className={liClassName} key={line[0]}>
+      <span className="ws">{lineWs}</span><span className="contextline">{lineCode}</span>
+    </li>
+  );
+};
+
+ContextLine.propTypes = {
+  line: React.PropTypes.array.isRequired,
+  isActive: React.PropTypes.number,
+};
+
+export default ContextLine;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -5,6 +5,7 @@ import {defined, objectIsEmpty, isUrl} from '../../../utils';
 
 import TooltipMixin from '../../../mixins/tooltip';
 import FrameVariables from './frameVariables';
+import ContextLine from './contextLine';
 import {t} from '../../../locale';
 
 function trimPackage(pkg) {
@@ -158,15 +159,20 @@ const Frame = React.createClass({
   renderContext() {
     let data = this.props.data;
     let context = '';
+    let {isExpanded} = this.state;
 
     let outerClassName = 'context';
-    if (this.state.isExpanded) {
+    if (isExpanded) {
       outerClassName += ' expanded';
     }
 
     let hasContextSource = this.hasContextSource();
     let hasContextVars = this.hasContextVars();
     let expandable = this.isExpandable();
+
+    let contextLines = isExpanded
+      ? data.context
+      : data.context && data.context.filter(l => l[0] === data.lineNo);
 
     if (hasContextSource || hasContextVars) {
       let startLineNo = hasContextSource ? data.context[0][0] : '';
@@ -177,27 +183,8 @@ const Frame = React.createClass({
           <li className={expandable ? 'expandable error' : 'error'}
               key="errors">{data.errors.join(', ')}</li>
           }
-          {(data.context || []).map((line) => {
-            let liClassName = 'expandable';
-            if (line[0] === data.lineNo) {
-              liClassName += ' active';
-            }
-
-            let lineWs;
-            let lineCode;
-            if (defined(line[1]) && line[1].match) {
-              [, lineWs, lineCode] = line[1].match(/^(\s*)(.*?)$/m);
-            } else {
-              lineWs = '';
-              lineCode = '';
-            }
-            return (
-              <li className={liClassName} key={line[0]}>
-                <span className="ws">{
-                lineWs}</span><span className="contextline">{lineCode
-                }</span>
-              </li>
-            );
+          {data.context && contextLines.map((line, index) => {
+            return <ContextLine key={index} line={line} isActive={data.lineNo === line[0]}/>;
           })}
 
           {hasContextVars &&


### PR DESCRIPTION
While working on #3316, it occurred to me from quickly switching between minified/original stack traces that frame rendering is kind of slow (there's a noticeable browser "freeze").

This improves stack trace frame rendering by only rendering the "active" line by default, rendering the pre/post context frames if the user manually expands the frame.

On a page with ~40 frames, with each frame having 5 pre/post context lines, and each context line composed of 3 DOM elements (1 `li`, 2 `span`), this prevents rendering of 1200 DOM elements when the page first loads. The result is a noticeable reduction in browser "freeze" when switching between tabs in #3316.
