### PR TITLE
Report a per-frame failure for symbolizer errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ install_requires = [
 ]
 
 dsym_requires = [
-    'symsynd>=0.6.1,<1.0.0',
+    'symsynd>=0.7.0,<1.0.0',
 ]
 
 

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -20,6 +20,7 @@ class EventError(object):
 
     NATIVE_NO_CRASHED_THREAD = 'native_no_crashed_thread'
     NATIVE_INTERNAL_FAILURE = 'native_internal_failure'
+    NATIVE_NO_SYMSYND = 'native_no_symsynd'
 
     _messages = {
         INVALID_DATA: 'Discarded invalid value for parameter \'{name}\'',
@@ -38,6 +39,7 @@ class EventError(object):
         JS_INVALID_SOURCEMAP_LOCATION: 'Invalid location in sourcemap: ({column}, {row})',
         NATIVE_NO_CRASHED_THREAD: 'No crashed thread found in crash report',
         NATIVE_INTERNAL_FAILURE: 'Internal failure when attempting to symbolicate: {error}',
+        NATIVE_NO_SYMSYND: 'The symbolizer is not configured for this system.',
     }
 
     @classmethod


### PR DESCRIPTION
This now lets the symbolizer report failures on a per-frame basis which
greatly increases the debuggability.  Together with the symsynd update
this now also recovers if the symbolizer crashes.
