### PR TITLE
Change Reply-To behaviour to only contain `mail.from`

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -286,9 +286,7 @@ class MessageBuilder(object):
         if options.get('mail.enable-replies') and 'X-Sentry-Reply-To' in headers:
             reply_to = headers['X-Sentry-Reply-To']
         else:
-            reply_to = set(reply_to or ())
-            reply_to.remove(to)
-            reply_to = ', '.join(reply_to)
+            reply_to = reply_to or self.from_email
 
         if reply_to:
             headers.setdefault('Reply-To', reply_to)
@@ -337,7 +335,7 @@ class MessageBuilder(object):
     def get_built_messages(self, to=None, bcc=None):
         send_to = set(to or ())
         send_to.update(self._send_to)
-        results = [self.build(to=email, reply_to=send_to, bcc=bcc) for email in send_to]
+        results = [self.build(to=email, reply_to=self.from_email, bcc=bcc) for email in send_to]
         if not results:
             logger.debug('Did not build any messages, no users to send to.')
         return results


### PR DESCRIPTION
Current behaviour is causing Postmark to reject emails because of limit to the size of Reply-To field (255 characters max). If there are multiple members of the team who are receiving emails (i.e. error notifications) then Reply-To can exceed 255 characters.

Changed by setting Reply-To to `mail.from`.

This change does not affect scenario when `mail.enable-replies` is set to `True`.

/cc @getsentry/team
