### PR TITLE
Added flags to disable problematic features in migration execution

### DIFF
--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -10,6 +10,7 @@ from functools import wraps
 from pkg_resources import parse_version as Version
 
 from sentry import options
+from sentry import south_migrations
 from sentry.models import (
     Organization, OrganizationMember, Project, User,
     Team, ProjectKey, TagKey, TagValue, GroupTagValue, GroupTagKey
@@ -36,6 +37,11 @@ def handle_db_failure(func):
 
 
 def create_default_projects(created_models, verbosity=2, **kwargs):
+    # If we're running migrations with safety we do not want to create the
+    # default projects because that might not work
+    if south_migrations.MIGRATION_SAFETY:
+        return
+
     if Project not in created_models:
         return
 

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -20,6 +20,11 @@ from sentry.runner.decorators import configuration
 def upgrade(ctx, verbosity, traceback, noinput):
     "Perform any pending database migrations and upgrades."
 
+    # Turn on sentry migration safety.  This flips some flags internally
+    # that might conflict with migration error reporting.
+    from sentry import south_migrations
+    south_migrations.MIGRATION_SAFETY = True
+
     from django.core.management import call_command as dj_call_command
     dj_call_command(
         'syncdb',

--- a/src/sentry/south_migrations/__init__.py
+++ b/src/sentry/south_migrations/__init__.py
@@ -1,0 +1,1 @@
+MIGRATION_SAFETY = False

--- a/src/sentry/utils/raven.py
+++ b/src/sentry/utils/raven.py
@@ -46,6 +46,11 @@ class SentryInternalClient(DjangoClient):
         return super(SentryInternalClient, self).capture(*args, **kwargs)
 
     def send(self, **kwargs):
+        # If we're running migrations with safety we do not want to report
+        # to internal sentry as this might fail.
+        if south_migrations.MIGRATION_SAFETY:
+            return
+
         # TODO(dcramer): this should respect rate limits/etc and use the normal
         # pipeline
 
@@ -121,3 +126,6 @@ class SentryInternalFilter(logging.Filter):
         # TODO(mattrobenolt): handle an upstream Sentry
         metrics.incr('internal.uncaptured.logs')
         return is_current_event_safe()
+
+
+import sentry.south_migrations as south_migrations


### PR DESCRIPTION
This primarily helps debugging broken migrations on sqlite and mysql
because there the lack of transaction safety makes failing migrations
fail so very hard that the original failure cannot be seen.
