### PR TITLE
Add `__str__`/`__repr__` to `RetryException`.

### DIFF
--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -5,6 +5,9 @@ import logging
 import random
 import time
 
+from django.utils.encoding import force_bytes
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,10 +17,10 @@ class RetryException(Exception):
         self.exception = exception
 
     def __str__(self):
-        return '{}'.format(self.message)
+        return force_bytes(self.message, errors='replace')
 
     def __repr__(self):
-        return '<{}: {!r}>'.format(
+        return u'<{}: {!r}>'.format(
             type(self).__name__,
             self.message,
         )

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -13,6 +13,15 @@ class RetryException(Exception):
         self.message = message
         self.exception = exception
 
+    def __str__(self):
+        return '{}'.format(self.message)
+
+    def __repr__(self):
+        return '<{}: {!r}>'.format(
+            type(self).__name__,
+            self.message,
+        )
+
 
 class RetryPolicy(object):
     def __call__(self, function):


### PR DESCRIPTION
Improves messaging when the callable doesn't successfully execute. For example: https://app.getsentry.com/sentry/sentry/issues/131657338/
