### PR TITLE
Re-bind Group/Project to Event in post_process_group

### DIFF
--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -58,7 +58,7 @@ class LevelCondition(EventCondition):
             return False
 
         desired_level = int(desired_level)
-        level = int(event.level)
+        level = int(event.group.level)
 
         if desired_match == LevelMatchType.EQUAL:
             return level == desired_level


### PR DESCRIPTION
It's possible to have a race condition if the Group/Project changes
while the job is in the queue because we are serializing these fields
onto the Event. Then when a plugin checks event.group, it may be stale.

@getsentry/infrastructure 
