### PR TITLE
Handle race-condition in LevelCondition

### DIFF
--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -19,6 +19,7 @@ LEVEL_CHOICES = OrderedDict([
     ("{0}".format(k), "{0}".format(v.capitalize()))
     for k, v in sorted(LOG_LEVELS.items(), key=lambda x: x[0], reverse=True)
 ])
+LOG_LEVEL_REVERSE_MAP = dict((v, k) for k, v in LOG_LEVELS.iteritems())
 
 
 class LevelMatchType(object):
@@ -58,7 +59,12 @@ class LevelCondition(EventCondition):
             return False
 
         desired_level = int(desired_level)
-        level = int(event.group.level)
+        # Fetch the event level from the tags since event.level is
+        # event.group.level which may have changed
+        try:
+            level = LOG_LEVEL_REVERSE_MAP[event.get_tag('level')]
+        except KeyError:
+            return False
 
         if desired_match == LevelMatchType.EQUAL:
             return level == desired_level


### PR DESCRIPTION
Relying on `event.level` and `event.group.level` can be dangerous - this makes the `LevelCondition` read directly of the specific event object, falling back to the old behavior.
