### PR TITLE
Initial acceptance testing setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ extract-api-docs:
 	cd api-docs; python generator.py
 
 
-.PHONY: develop dev-postgres dev-docs setup-git build clean locale update-transifex update-submodules test testloop test-cli test-js test-python test-python-coverage lint lint-python lint-js coverage publish
+.PHONY: develop dev-postgres dev-docs setup-git build clean locale update-transifex update-submodules test testloop test-cli test-js test-python test-acceptance test-python-coverage lint lint-python lint-js coverage publish
 
 
 ############################

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-acceptance:
 
 test-python-coverage:
 	@echo "--> Running Python tests"
-	coverage run --source=src/sentry,tests -m py.test tests
+	coverage run --source=src/sentry -m py.test tests/integration tests/sentry
 	@echo ""
 
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,12 @@ test-js:
 
 test-python:
 	@echo "--> Running Python tests"
-	py.test tests || exit 1
+	py.test tests/integration tests/sentry || exit 1
+	@echo ""
+
+test-acceptance:
+	@echo "--> Running acceptance tests"
+	py.test tests/acceptance || exit 1
 	@echo ""
 
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "karma-sourcemap-loader": "0.3.6",
     "karma-webpack": "1.7.0",
     "mocha": "2.3.4",
+    "phantomjs-prebuilt": "^2.1.7",
     "platformicons": "0.0.14",
     "po-catalog-loader": "^1.2.0",
     "sinon": "1.17.2",

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ tests_require = [
     'pytest-xdist>=1.11.0,<1.12.0',
     'python-coveralls',
     'responses',
+    'selenium',
 ]
 
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 __all__ = (
     'TestCase', 'TransactionTestCase', 'APITestCase', 'AuthProviderTestCase',
-    'RuleTestCase', 'PermissionTestCase', 'PluginTestCase', 'CliTestCase',
+    'RuleTestCase', 'PermissionTestCase', 'PluginTestCase', 'CliTestCase', 'LiveServerTestCase',
 )
 
 import base64
@@ -24,10 +24,11 @@ from django.contrib.auth import login
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.http import HttpRequest
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase, TransactionTestCase, LiveServerTestCase
 from django.utils.importlib import import_module
-from exam import before, fixture, Exam
+from exam import before, after, fixture, Exam
 from rest_framework.test import APITestCase as BaseAPITestCase
+from selenium import webdriver
 
 from sentry import auth
 from sentry.auth.providers.dummy import DummyProvider
@@ -237,6 +238,16 @@ class TestCase(BaseTestCase, TestCase):
 
 class TransactionTestCase(BaseTestCase, TransactionTestCase):
     pass
+
+
+class LiveServerTestCase(BaseTestCase, LiveServerTestCase):
+    @before
+    def setup_browser(self):
+        self.browser = webdriver.PhantomJS()
+
+    @after
+    def teardown_browser(self):
+        self.browser.close()
 
 
 class APITestCase(BaseTestCase, BaseAPITestCase):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -15,6 +15,7 @@ __all__ = (
 
 import base64
 import os.path
+import signal
 import urllib
 from contextlib import contextmanager
 
@@ -255,6 +256,9 @@ class LiveServerTestCase(BaseTestCase, LiveServerTestCase):
     @after
     def teardown_browser(self):
         self.browser.close()
+        # TODO: remove this when fixed in: https://github.com/seleniumhq/selenium/issues/767
+        self.browser.service.process.send_signal(signal.SIGTERM)
+        self.browser.quit()
 
 
 class APITestCase(BaseTestCase, BaseAPITestCase):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -243,7 +243,14 @@ class TransactionTestCase(BaseTestCase, TransactionTestCase):
 class LiveServerTestCase(BaseTestCase, LiveServerTestCase):
     @before
     def setup_browser(self):
-        self.browser = webdriver.PhantomJS()
+        # NOTE: this relies on the phantomjs-prebuilt dependency in package.json.
+        phantomjs_path = os.path.join(
+            settings.NODE_MODULES_ROOT,
+            'phantomjs-prebuilt',
+            'bin',
+            'phantomjs',
+        )
+        self.browser = webdriver.PhantomJS(executable_path=phantomjs_path)
 
     @after
     def teardown_browser(self):

--- a/tests/acceptance/test_static.py
+++ b/tests/acceptance/test_static.py
@@ -1,0 +1,6 @@
+from sentry.testutils import LiveServerTestCase
+
+
+class StaticAcceptanceTest(LiveServerTestCase):
+    def test_static(self):
+        self.browser.get(self.live_server_url)


### PR DESCRIPTION
Added:
- `tests/acceptance` folder
- `test-acceptance` Makefile endpoint, and modified `test-python` to avoid running acceptance tests until you're ready to integrate that into your full testing workflow.
- `LiveServerTestCase` utilities

@dcramer 
