### PR TITLE
Handle group refreshing in post_process when group has been merged

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -58,23 +58,21 @@ def get_group_with_redirect(id, queryset=None):
     Retrieve a group by ID, checking the redirect table if the requested group
     does not exist. Returns a two-tuple of ``(object, redirected)``.
     """
-    from sentry.models import GroupRedirect
-
     if queryset is None:
         queryset = Group.objects.all()
+        # When not passing a queryset, we want to read from cache
+        getter = Group.objects.get_from_cache
+    else:
+        getter = queryset.get
 
     try:
-        return queryset.get(id=id), False
+        return getter(id=id), False
     except Group.DoesNotExist as error:
+        from sentry.models import GroupRedirect
+        qs = GroupRedirect.objects.filter(previous_group_id=id).values_list('group_id', flat=True)
         try:
-            redirect = GroupRedirect.objects.get(previous_group_id=id)
-        except GroupRedirect.DoesNotExist:
-            raise error  # raise original `DoesNotExist`
-
-        try:
-            return queryset.get(id=redirect.group_id), True
+            return queryset.get(id=qs), True
         except Group.DoesNotExist:
-            logger.warning('%r redirected to group that does not exist!', redirect, exc_info=True)
             raise error  # raise original `DoesNotExist`
 
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -48,12 +48,14 @@ def post_process_group(event, is_new, is_regression, is_sample, **kwargs):
     # NOTE: we must pass through the full Event object, and not an
     # event_id since the Event object may not actually have been stored
     # in the database due to sampling.
-    from sentry.models import Project, Group
+    from sentry.models import Project
+    from sentry.models.group import get_group_with_redirect
     from sentry.rules.processor import RuleProcessor
 
     # Re-bind Group since we're pickling the whole Event object
     # which may contain a stale Group.
-    event.group = Group.objects.get_from_cache(id=event.group_id)
+    event.group, _ = get_group_with_redirect(event.group_id)
+    event.group_id = event.group.id
 
     project_id = event.group.project_id
     Raven.tags_context({

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -6,6 +6,7 @@ from mock import Mock, patch
 
 from sentry.models import EventTag, TagKey, TagValue
 from sentry.testutils import TestCase
+from sentry.tasks.merge import merge_group
 from sentry.tasks.post_process import index_event_tags, post_process_group
 
 
@@ -34,6 +35,36 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.assert_called_once_with()
 
         mock_callback.assert_called_once_with(event, mock_futures)
+
+    @patch('sentry.tasks.post_process.record_affected_user', Mock())
+    @patch('sentry.rules.processor.RuleProcessor')
+    def test_group_refresh(self, mock_processor):
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        event = self.create_event(group=group1)
+
+        assert event.group_id == group1.id
+        assert event.group == group1
+
+        with self.tasks():
+            merge_group(group1.id, group2.id)
+
+        mock_callback = Mock()
+        mock_futures = [Mock()]
+
+        mock_processor.return_value.apply.return_value = [
+            (mock_callback, mock_futures),
+        ]
+
+        post_process_group(
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_sample=False,
+        )
+
+        assert event.group == group2
+        assert event.group_id == group2.id
 
 
 class IndexEventTagsTest(TestCase):


### PR DESCRIPTION
This also optimizes the `get_group_with_redirect` path to use caching
and reduce the number of queries from 3 to 2.

Fixes SENTRY-1CF

@getsentry/infrastructure @tkaemming 
