### PR TITLE
Send along docker info with beacon

### DIFF
--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -48,6 +48,14 @@ def get_version():
         return '%s.%s' % (__version__, __build__)
     return __version__
 
+
+def is_docker():
+    # One of these environment variables are guaranteed to exist
+    # from our official docker images.
+    # SENTRY_VERSION is from a tagged release, and SENTRY_BUILD is from a
+    # a git based image.
+    return 'SENTRY_VERSION' in os.environ or 'SENTRY_BUILD' in os.environ
+
 __version__ = VERSION
 __build__ = get_revision()
 __docformat__ = 'restructuredtext en'

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -59,6 +59,7 @@ def send_beacon():
     payload = {
         'install_id': install_id,
         'version': sentry.get_version(),
+        'docker': sentry.is_docker(),
         'admin_email': options.get('system.admin-email'),
         'data': {
             # TODO(dcramer): we'd also like to get an idea about the throughput

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -33,6 +33,7 @@ class SendBeaconTest(TestCase):
         safe_urlopen.assert_called_once_with(BEACON_URL, json={
             'install_id': install_id,
             'version': sentry.get_version(),
+            'docker': sentry.is_docker(),
             'data': {
                 'organizations': 1,
                 'users': 0,


### PR DESCRIPTION
It'd be nice to know on the beacon if this install is docker based or not to track adoption.

@getsentry/infrastructure 
