### PR TITLE
Call plugin.configure with kwargs

### DIFF
--- a/src/sentry/web/frontend/admin.py
+++ b/src/sentry/web/frontend/admin.py
@@ -42,7 +42,7 @@ def configure_plugin(request, slug):
     if not plugin.has_site_conf():
         return HttpResponseRedirect(reverse('sentry'))
 
-    view = plugin.configure(request)
+    view = plugin.configure(request=request)
     if isinstance(view, HttpResponse):
         return view
 

--- a/src/sentry/web/frontend/project_issue_tracking.py
+++ b/src/sentry/web/frontend/project_issue_tracking.py
@@ -56,7 +56,7 @@ class ProjectIssueTrackingView(ProjectView):
 
                 form = plugin.project_conf_form
                 if form is not None:
-                    view = plugin.configure(request, project=project)
+                    view = plugin.configure(request=request, project=project)
                     if isinstance(view, HttpResponse):
                         return view
                 elif content:

--- a/src/sentry/web/frontend/project_notifications.py
+++ b/src/sentry/web/frontend/project_notifications.py
@@ -130,7 +130,7 @@ class ProjectNotificationsView(ProjectView):
 
                 form = plugin.project_conf_form
                 if form is not None:
-                    view = plugin.configure(request, project=project)
+                    view = plugin.configure(request=request, project=project)
                     if isinstance(view, HttpResponse):
                         return view
                     enabled_plugins.append((plugin, mark_safe(content + view)))

--- a/src/sentry/web/frontend/project_plugin_configure.py
+++ b/src/sentry/web/frontend/project_plugin_configure.py
@@ -19,7 +19,7 @@ class ProjectPluginConfigureView(ProjectView):
         if not plugin.can_configure_for_project(project):
             return self.redirect(reverse('sentry-manage-project', args=[project.organization.slug, project.slug]))
 
-        view = plugin.configure(request, project=project)
+        view = plugin.configure(request=request, project=project)
         if isinstance(view, HttpResponse):
             return view
 


### PR DESCRIPTION
v1 and v2 of plugins have a different order of arguments, so avoid this
issue by always calling with kwargs.

Fixes SENTRY-1CH

@getsentry/infrastructure 
