### PR TITLE
Support indexed sourcemaps

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -768,7 +768,7 @@ class SourceProcessor(object):
             for source in sourcemap_idx.sources:
                 next_filename = urljoin(sourcemap_url, source)
                 if source in sourcemap_idx.content:
-                    cache.add(next_filename, sourcemap_idx.content[source])
+                    self.cache.add(next_filename, sourcemap_idx.content[source])
 
     def populate_source_cache(self, frames, release):
         """

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -758,12 +758,12 @@ class SourceProcessor(object):
         sourcemaps.add(sourcemap_url, sourcemap_idx)
 
         # cache any inlined sources
-        self.cache_sources(sourcemap_url, sourcemap_idx)
+        self.cache_sourcemap_sources(sourcemap_url, sourcemap_idx)
 
-    def cache_sources(self, sourcemap_url, sourcemap_idx):
+    def cache_sourcemap_sources(self, sourcemap_url, sourcemap_idx):
         if isinstance(sourcemap_idx, IndexedSourceMapIndex):
             for map in sourcemap_idx.maps:
-                self.cache_sources(sourcemap_url, map)
+                self.cache_sourcemap_sources(sourcemap_url, map)
         else:
             for source in sourcemap_idx.sources:
                 next_filename = urljoin(sourcemap_url, source)

--- a/src/sentry/lang/javascript/sourcemaps.py
+++ b/src/sentry/lang/javascript/sourcemaps.py
@@ -177,10 +177,19 @@ def find_source(indexed_sourcemap, lineno, colno):
     if isinstance(indexed_sourcemap, IndexedSourceMapIndex):
         map_index = bisect.bisect_right(indexed_sourcemap.offsets, (lineno - 1, colno)) - 1
         offset = indexed_sourcemap.offsets[map_index]
-        return find_source(
+        col_offset = 0 if lineno != offset[0] else offset[1]
+        state = find_source(
             indexed_sourcemap.maps[map_index],
             lineno - offset[0],
-            colno - (0 if lineno != offset[0] else offset[0]),
+            colno - col_offset,
+        )
+        return SourceMap(
+            state.dst_line + offset[0],
+            state.dst_col + col_offset,
+            state.src,
+            state.src_line,
+            state.src_col,
+            state.name
         )
     else:
         return indexed_sourcemap.states[bisect.bisect_right(indexed_sourcemap.keys, (lineno - 1, colno)) - 1]

--- a/src/sentry/lang/javascript/sourcemaps.py
+++ b/src/sentry/lang/javascript/sourcemaps.py
@@ -190,8 +190,8 @@ def get_inline_content_sources(sourcemap_index, sourcemap_url):
     """
     out = []
     if isinstance(sourcemap_index, IndexedSourceMapIndex):
-        for map in sourcemap_index.maps:
-            out += get_inline_content_sources(map, sourcemap_url)
+        for smap in sourcemap_index.maps:
+            out += get_inline_content_sources(smap, sourcemap_url)
     else:
         for source in sourcemap_index.sources:
             next_filename = urljoin(sourcemap_url, source)

--- a/src/sentry/lang/javascript/sourcemaps.py
+++ b/src/sentry/lang/javascript/sourcemaps.py
@@ -173,8 +173,13 @@ def sourcemap_to_index(sourcemap):
         for section in smap.get('sections'):
             offset = section.get('offset')
 
-            offsets.append((offset.get('line'), offset.get('column')))
-            maps.append(_sourcemap_to_index(section.get('map')))
+            # Variant 1: map property (supported)
+            if section.get('map'):
+                offsets.append((offset.get('line'), offset.get('column')))
+                maps.append(_sourcemap_to_index(section.get('map')))
+            else:
+                # Variant 2: url property (unsupported)
+                raise Exception('indexed source maps with `url` property are unsupported')
 
         return IndexedSourceMapIndex(offsets, maps)
     else:

--- a/src/sentry/lang/javascript/sourcemaps.py
+++ b/src/sentry/lang/javascript/sourcemaps.py
@@ -182,6 +182,24 @@ def sourcemap_to_index(sourcemap):
         return _sourcemap_to_index(smap)
 
 
+def get_inline_content_sources(sourcemap_index, sourcemap_url):
+    """
+    Returns a list of tuples of (filename, content) for each inline
+    content found in the given source map index. Note that `content`
+    itself is a list of code lines.
+    """
+    out = []
+    if isinstance(sourcemap_index, IndexedSourceMapIndex):
+        for map in sourcemap_index.maps:
+            out = out + get_inline_content_sources(map, sourcemap_url)
+    else:
+        for source in sourcemap_index.sources:
+            next_filename = urljoin(sourcemap_url, source)
+            if source in sourcemap_index.content:
+                out.append((next_filename, sourcemap_index.content[source]))
+    return out
+
+
 def find_source(sourcemap_index, lineno, colno):
     """
     Given a SourceMapIndex and a transformed lineno/colno position,

--- a/src/sentry/lang/javascript/sourcemaps.py
+++ b/src/sentry/lang/javascript/sourcemaps.py
@@ -191,7 +191,7 @@ def get_inline_content_sources(sourcemap_index, sourcemap_url):
     out = []
     if isinstance(sourcemap_index, IndexedSourceMapIndex):
         for map in sourcemap_index.maps:
-            out = out + get_inline_content_sources(map, sourcemap_url)
+            out += get_inline_content_sources(map, sourcemap_url)
     else:
         for source in sourcemap_index.sources:
             next_filename = urljoin(sourcemap_url, source)

--- a/src/sentry/lang/javascript/sourcemaps.py
+++ b/src/sentry/lang/javascript/sourcemaps.py
@@ -173,13 +173,8 @@ def sourcemap_to_index(sourcemap):
         for section in smap.get('sections'):
             offset = section.get('offset')
 
-            # Variant 1: map property (supported)
-            if section.get('map'):
-                offsets.append((offset.get('line'), offset.get('column')))
-                maps.append(_sourcemap_to_index(section.get('map')))
-            else:
-                # Variant 2: url property (unsupported)
-                raise Exception('indexed source maps with `url` property are unsupported')
+            offsets.append((offset.get('line'), offset.get('column')))
+            maps.append(_sourcemap_to_index(section.get('map')))
 
         return IndexedSourceMapIndex(offsets, maps)
     else:

--- a/src/sentry/lang/javascript/sourcemaps.py
+++ b/src/sentry/lang/javascript/sourcemaps.py
@@ -4,6 +4,14 @@ sentry.utils.sourcemaps
 
 Originally based on https://github.com/martine/python-sourcemap
 
+Sentry implements the Source Map Revision 3 protocol. Specification:
+https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit
+
+Sentry supports both "standard" source maps, and has partial support for "indexed" source
+maps. Specifically, it supports indexed source maps with the "map" section property as
+output by the React Native bundler. It does NOT support indexed source maps with the "url"
+section property.
+
 :copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """

--- a/tests/sentry/lang/javascript/fixtures/indexed.min.js
+++ b/tests/sentry/lang/javascript/fixtures/indexed.min.js
@@ -1,0 +1,3 @@
+function add(a,b){"use strict";return a+b}
+function multiply(a,b){"use strict";return a*b}function divide(a,b){"use strict";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureException(e)}}
+//# sourceMappingURL=indexed.sourcemap.js

--- a/tests/sentry/lang/javascript/fixtures/indexed.sourcemap.js
+++ b/tests/sentry/lang/javascript/fixtures/indexed.sourcemap.js
@@ -1,0 +1,32 @@
+{
+    "version": 3,
+    "file": "min.js",
+    "sections": [
+        {
+            "offset": {
+                "line": 0,
+                "column": 0
+            },
+            "map": {
+                "version":3,
+                "sources":["file1.js"],
+                "names":["add","a","b"],
+                "mappings":"AAAA,QAASA,KAAIC,EAAGC,GACf,YACA,OAAOD,GAAIC",
+                "file":"file1.min.js"
+            }
+        },
+        {
+            "offset": {
+                "line": 1,
+                "column": 0
+            },
+            "map": {
+                "version":3,
+                "sources":["file2.js"],
+                "names":["multiply","a","b","divide","add","c","e","Raven","captureException"],
+                "mappings":"AAAA,QAASA,UAASC,EAAGC,GACpB,YACA,OAAOD,GAAIC,EAEZ,QAASC,QAAOF,EAAGC,GAClB,YACA,KACC,MAAOF,UAASI,IAAIH,EAAGC,GAAID,EAAGC,GAAKG,EAClC,MAAOC,GACRC,MAAMC,iBAAiBF",
+                "file":"file2.min.js"
+            }
+        }
+    ]
+}

--- a/tests/sentry/lang/javascript/fixtures/unsupported.min.js
+++ b/tests/sentry/lang/javascript/fixtures/unsupported.min.js
@@ -1,0 +1,2 @@
+function add(a,b){"use strict";return a+b}function multiply(a,b){"use strict";return a*b}function divide(a,b){"use strict";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureException(e)}}
+//@ sourceMappingURL=unsupported.sourcemap.js

--- a/tests/sentry/lang/javascript/fixtures/unsupported.sourcemap.js
+++ b/tests/sentry/lang/javascript/fixtures/unsupported.sourcemap.js
@@ -1,0 +1,20 @@
+{
+    "version": 3,
+    "file": "min.js",
+    "sections": [
+        {
+            "offset": {
+                "line": 0,
+                "column": 0
+            },
+            "url": "https://example.org/static/1.map"
+        },
+        {
+            "offset": {
+                "line": 1,
+                "column": 0
+            },
+            "url": "https://example.org/static/2.map"
+        }
+    ]
+}

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -198,6 +198,75 @@ class JavascriptIntegrationTest(TestCase):
         assert raw_frame_list[1] == frame_list[1]
 
     @responses.activate
+    def test_indexed_sourcemap_source_expansion(self):
+        responses.add(responses.GET, 'http://example.com/indexed.min.js',
+                      body=load_fixture('indexed.min.js'))
+        responses.add(responses.GET, 'http://example.com/file1.js',
+                      body=load_fixture('file1.js'))
+        responses.add(responses.GET, 'http://example.com/file2.js',
+                      body=load_fixture('file2.js'))
+        responses.add(responses.GET, 'http://example.com/indexed.sourcemap.js',
+                      body=load_fixture('indexed.sourcemap.js'))
+
+        data = {
+            'message': 'hello',
+            'platform': 'javascript',
+            'sentry.interfaces.Exception': {
+                'values': [{
+                    'type': 'Error',
+                    'stacktrace': {
+                        'frames': [
+                            {
+                                'abs_path': 'http://example.com/indexed.min.js',
+                                'filename': 'indexed.min.js',
+                                'lineno': 1,
+                                'colno': 39,
+                            },
+
+                            # NOTE: Intentionally source is not retrieved from this HTML file
+                            {
+                                'function': 'function: "HTMLDocument.<anonymous>"',
+                                'abs_path': "http//example.com/index.html",
+                                'filename': 'index.html',
+                                'lineno': 283,
+                                'colno': 17,
+                                'in_app': False,
+                            }
+                        ],
+                    },
+                }],
+            }
+        }
+
+        resp = self._postWithHeader(data)
+        assert resp.status_code, 200
+
+        event = Event.objects.get()
+        assert event.data['errors'] == [{'type': 'js_no_source', 'url': 'http//example.com/index.html'}]
+
+        exception = event.interfaces['sentry.interfaces.Exception']
+        frame_list = exception.values[0].stacktrace.frames
+
+        frame = frame_list[0]
+        assert frame.pre_context == [
+            'function add(a, b) {',
+            '\t"use strict";',
+        ]
+        assert frame.context_line == '\treturn a + b;'
+        assert frame.post_context == ['}']
+
+        raw_frame_list = exception.values[0].raw_stacktrace.frames
+        raw_frame = raw_frame_list[0]
+        assert raw_frame.pre_context == []
+        assert raw_frame.context_line == 'function add(a,b){"use strict";return a+b}function multiply(a,b){"use strict";return a*b}function divide(a,b){"use strict";try{return multip {snip}'
+        assert raw_frame.post_context == ['//@ sourceMappingURL=file.sourcemap.js']
+        assert raw_frame.lineno == 1
+
+        # Since we couldn't expand source for the 2nd frame, both
+        # its raw and original form should be identical
+        assert raw_frame_list[1] == frame_list[1]
+
+    @responses.activate
     def test_expansion_via_release_artifacts(self):
         project = self.project
         release = Release.objects.create(

--- a/tests/sentry/lang/javascript/test_sourcemaps.py
+++ b/tests/sentry/lang/javascript/test_sourcemaps.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import
 
-import pytest
-
 from sentry.lang.javascript.sourcemaps import (
     SourceMap, parse_vlq, parse_sourcemap, sourcemap_to_index, find_source, get_inline_content_sources
 )
@@ -71,27 +69,6 @@ indexed_sourcemap_example = json.dumps({
                 'file': "min.js",
                 'sourceRoot': "/the/root"
             }
-        }
-    ]
-})
-
-indexed_sourcemap_example_with_url = json.dumps({
-    'version': 3,
-    'file': 'min.js',
-    'sections': [
-        {
-            'offset': {
-                'line': 0,
-                'column': 0
-            },
-            'url': 'https://example.org/static/1.map'
-        },
-        {
-            'offset': {
-                'line': 1,
-                'column': 0
-            },
-            'url': 'https://example.org/static/2.map'
         }
     ]
 })
@@ -226,6 +203,3 @@ class ParseIndexedSourcemapTest(TestCase):
             SourceMap(dst_line=0, dst_col=28, src='/the/root/one.js', src_line=1, src_col=10, name='baz')
         assert find_source(indexed_sourcemap, 2, 12) == \
             SourceMap(dst_line=1, dst_col=9, src='/the/root/two.js', src_line=0, src_col=11, name=None)
-
-    def test_fails_on_unsupported_format(self):
-        pytest.raises(Exception, sourcemap_to_index, *(indexed_sourcemap_example_with_url))

--- a/tests/sentry/lang/javascript/test_sourcemaps.py
+++ b/tests/sentry/lang/javascript/test_sourcemaps.py
@@ -13,12 +13,65 @@ from sentry.utils import json
 sourcemap = """{
     "version":3,
     "file":"file.min.js",
-    "sources":["file1.js","file2.js"],
+    "sources":["file1.js","file2.js"],f
     "names":["add","a","b","multiply","divide","c","e","Raven","captureException"],
     "mappings":"AAAA,QAASA,KAAIC,EAAGC,GACf,YACA,OAAOD,GAAIC,ECFZ,QAASC,UAASF,EAAGC,GACpB,YACA,OAAOD,GAAIC,EAEZ,QAASE,QAAOH,EAAGC,GAClB,YACA,KACC,MAAOC,UAASH,IAAIC,EAAGC,GAAID,EAAGC,GAAKG,EAClC,MAAOC,GACRC,MAAMC,iBAAiBF",
     "sourceRoot": "foo"
 }"""
 
+indexed_sourcemap_example = json.dumps({
+  'version': 3,
+  'file': 'min.js',
+  'sections': [
+    {
+      'offset': {
+        'line': 0,
+        'column': 0
+      },
+      'map': {
+        'version': 3,
+        'sources': [
+          "one.js"
+        ],
+        'sourcesContent': [
+          ' ONE.foo = function (bar) {\n' +
+          '   return baz(bar);\n' +
+          ' };',
+        ],
+        'names': [
+          "bar",
+          "baz"
+        ],
+        'mappings': "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID",
+        'file': "min.js",
+        'sourceRoot': "/the/root"
+      }
+    },
+    {
+      'offset': {
+        'line': 1,
+        'column': 0
+      },
+      'map': {
+        'version': 3,
+        'sources': [
+          "two.js"
+        ],
+        'sourcesContent': [
+          ' TWO.inc = function (n) {\n' +
+          '   return n + 1;\n' +
+          ' };'
+        ],
+        'names': [
+          "n"
+        ],
+        'mappings': "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOA",
+        'file': "min.js",
+        'sourceRoot': "/the/root"
+      }
+    }
+  ]
+})
 
 class ParseVlqTest(TestCase):
     def test_simple(self):
@@ -95,3 +148,12 @@ class ParseSourcemapTest(TestCase):
             SourceMap(dst_line=0, dst_col=174, src='foo/file2.js', src_line=9, src_col=8, name='captureException'),
             SourceMap(dst_line=0, dst_col=191, src='foo/file2.js', src_line=9, src_col=25, name='e'),
         ]
+
+class ParseIndexedSourcemapTest(TestCase):
+    def test_basic(self):
+        indexed_sourcemap = sourcemap_to_index(indexed_sourcemap_example)
+
+        assert find_source(indexed_sourcemap, 1, 1) == \
+               SourceMap(dst_line=0, dst_col=32, src='/the/root/one.js', src_line=1, src_col=1, name='bar')
+        # assert find_source(indexed_sourcemap, 1, 20) == \
+        #        SourceMap(dst_line=0, dst_col=18, src='/the/root/one.js', src_line=0, src_col=21, name='bar')

--- a/tests/sentry/lang/javascript/test_sourcemaps.py
+++ b/tests/sentry/lang/javascript/test_sourcemaps.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+import pytest
+
 from sentry.lang.javascript.sourcemaps import (
     SourceMap, parse_vlq, parse_sourcemap, sourcemap_to_index, find_source, get_inline_content_sources
 )
@@ -69,6 +71,27 @@ indexed_sourcemap_example = json.dumps({
                 'file': "min.js",
                 'sourceRoot': "/the/root"
             }
+        }
+    ]
+})
+
+indexed_sourcemap_example_with_url = json.dumps({
+    'version': 3,
+    'file': 'min.js',
+    'sections': [
+        {
+            'offset': {
+                'line': 0,
+                'column': 0
+            },
+            'url': 'https://example.org/static/1.map'
+        },
+        {
+            'offset': {
+                'line': 1,
+                'column': 0
+            },
+            'url': 'https://example.org/static/2.map'
         }
     ]
 })
@@ -203,3 +226,6 @@ class ParseIndexedSourcemapTest(TestCase):
             SourceMap(dst_line=0, dst_col=28, src='/the/root/one.js', src_line=1, src_col=10, name='baz')
         assert find_source(indexed_sourcemap, 2, 12) == \
             SourceMap(dst_line=1, dst_col=9, src='/the/root/two.js', src_line=0, src_col=11, name=None)
+
+    def test_fails_on_unsupported_format(self):
+        pytest.raises(Exception, sourcemap_to_index, *(indexed_sourcemap_example_with_url))


### PR DESCRIPTION
Fixes #3224 

**Note**: This only supports indexed source maps with the `map` property, [as implemented by React Native](https://github.com/facebook/react-native/blob/235b16d93287061a09c4624e612b5dc4f960ce47/packager/react-packager/src/Bundler/Bundle.js#L165). It does not support indexed source maps with the `url` property.
## 

This is all working and tested, but I'd appreciate some feedback before calling this "done":
- `SourceMapIndex` existed before I started here ... but it's confusing when now you have `IndexedSourceMapIndex`. What else should we call this? `SourceMapLookupTable`?
- Is it okay for me to overload these source map functions the way I've done?

cc @getsentry/infrastructure 
