### PR TITLE
Strip ports from IPv4-only IPs.

### DIFF
--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -11,7 +11,7 @@ class SetRemoteAddrFromForwardedFor(object):
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
             # Take just the first one.
             real_ip = real_ip.split(",")[0]
-            if '.' in real_ip and ':' in real_ip:
+            if ':' in real_ip and '.' in real_ip:
                 # Strip the port number off of an IPv4 FORWARDED_FOR entry.
                 real_ip = real_ip.split(':', 1)[0]
             request.META['REMOTE_ADDR'] = real_ip

--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -11,7 +11,8 @@ class SetRemoteAddrFromForwardedFor(object):
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
             # Take just the first one.
             real_ip = real_ip.split(",")[0]
-            if ':' in real_ip:
+            if '.' in real_ip and ':' in real_ip:
+                # Strip the port number off of an IPv4 FORWARDED_FOR entry.
                 real_ip = real_ip.split(':', 1)[0]
             request.META['REMOTE_ADDR'] = real_ip
 

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 
 from exam import fixture
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
 
 from sentry.testutils import TestCase
-from sentry.middleware.proxy import ContentLengthHeaderMiddleware
+from sentry.middleware.proxy import (
+    ContentLengthHeaderMiddleware, SetRemoteAddrFromForwardedFor)
 
 
 class ContentLengthHeaderMiddlewareTest(TestCase):
@@ -19,3 +20,19 @@ class ContentLengthHeaderMiddlewareTest(TestCase):
         response = self.middleware.process_response(None, StreamingHttpResponse())
         assert 'Transfer-Encoding' not in response
         assert 'Content-Length' not in response
+
+
+class SetRemoteAddrFromForwardedForTestCase(TestCase):
+    middleware = fixture(SetRemoteAddrFromForwardedFor)
+
+    def test_ipv4(self):
+        request = HttpRequest()
+        request.META['HTTP_X_FORWARDED_FOR'] = '8.8.8.8:80,8.8.4.4'
+        self.middleware.process_request(request)
+        assert request.META['REMOTE_ADDR'] == '8.8.8.8'
+
+    def test_ipv6(self):
+        request = HttpRequest()
+        request.META['HTTP_X_FORWARDED_FOR'] = '2001:4860:4860::8888,2001:4860:4860::8844'
+        self.middleware.process_request(request)
+        assert request.META['REMOTE_ADDR'] == '2001:4860:4860::8888'


### PR DESCRIPTION
Fixes #3416.
cc @rdoursenaud / @getsentry/infrastructure 
