### PR TITLE
Remove phantomjs-prebuilt devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "karma-sourcemap-loader": "0.3.6",
     "karma-webpack": "1.7.0",
     "mocha": "2.3.4",
-    "phantomjs-prebuilt": "^2.1.7",
     "platformicons": "0.0.14",
     "po-catalog-loader": "^1.2.0",
     "sinon": "1.17.2",


### PR DESCRIPTION
Until we figure out why this breaks our builds

@benvinegar 
