### PR TITLE
Unify AuditLogEntry creation so that logging them will be easier.

### DIFF
--- a/src/sentry/web/frontend/accept_organization_invite.py
+++ b/src/sentry/web/frontend/accept_organization_invite.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, OrganizationMember, Project
+    AuditLogEntryEvent, OrganizationMember, Project
 )
 from sentry.signals import member_joined
 from sentry.web.frontend.base import BaseView
@@ -92,10 +92,9 @@ class AcceptOrganizationInviteView(BaseView):
                 om.email = None
                 om.save()
 
-                AuditLogEntry.objects.create(
+                self.create_audit_entry(
+                    request,
                     organization=organization,
-                    actor=request.user,
-                    ip_address=request.META['REMOTE_ADDR'],
                     target_object=om.id,
                     target_user=request.user,
                     event=AuditLogEntryEvent.MEMBER_ACCEPT,

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -239,6 +239,7 @@ class BaseView(View, OrganizationMixin):
     def create_audit_entry(self, request, **kwargs):
         entry = AuditLogEntry.objects.create(
             actor=request.user if request.user.is_authenticated() else None,
+            # TODO(jtcunning): assert that REMOTE_ADDR is a real IP.
             ip_address=request.META['REMOTE_ADDR'],
             **kwargs
         )

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -237,23 +237,17 @@ class BaseView(View, OrganizationMixin):
         )
 
     def create_audit_entry(self, request, **kwargs):
-        if request.user.is_authenticated():
-            entry = AuditLogEntry.objects.create(
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
-                **kwargs
-            )
-            logger.info(
-                name='sentry.audit.entry',
-                event=entry.get_event_display(),
-                actor_id=request.user.id,
-                actor_label=entry.actor_label,
-            )
-
-        else:
-            logger.warn('Attempted to audit event for an AnonymousUser at %s' %
-                request.META['REMOTE_ADDR']
-            )
+        entry = AuditLogEntry.objects.create(
+            actor=request.user if request.user.is_authenticated() else None,
+            ip_address=request.META['REMOTE_ADDR'],
+            **kwargs
+        )
+        logger.info(
+            name='sentry.audit.entry',
+            event=entry.get_event_display(),
+            actor_id=entry.actor_id,
+            actor_label=entry.actor_label,
+        )
 
 
 class OrganizationView(BaseView):

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -236,11 +236,16 @@ class BaseView(View, OrganizationMixin):
         )
 
     def create_audit_entry(self, request, **kwargs):
-        entry = AuditLogEntry.objects.create(
-            actor=request.user,
-            ip_address=request.META['REMOTE_ADDR'],
-            **kwargs
-        )
+        if request.user.is_authenticated():
+            entry = AuditLogEntry.objects.create(
+                actor=request.user,
+                ip_address=request.META['REMOTE_ADDR'],
+                **kwargs
+            )
+        else:
+            logger.warn('Attempted to audit event for an AnonymousUser at %s' %
+                request.META['REMOTE_ADDR']
+            )
 
         logger.info('%s: %s' % (entry.actor_label, entry.get_event_display()))
 

--- a/src/sentry/web/frontend/create_organization.py
+++ b/src/sentry/web/frontend/create_organization.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from sentry import features, roles
 from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, Organization, OrganizationMember,
+    AuditLogEntryEvent, Organization, OrganizationMember,
     OrganizationMemberTeam
 )
 from sentry.web.frontend.base import BaseView
@@ -50,10 +50,9 @@ class CreateOrganizationView(BaseView):
                 is_active=True
             )
 
-            AuditLogEntry.objects.create(
+            self.create_audit_entry(
+                request,
                 organization=org,
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
                 target_object=org.id,
                 event=AuditLogEntryEvent.ORG_ADD,
                 data=org.get_audit_log_data(),

--- a/src/sentry/web/frontend/create_project_key.py
+++ b/src/sentry/web/frontend/create_project_key.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
-from sentry.models import AuditLogEntry, AuditLogEntryEvent, ProjectKey
+from sentry.models import AuditLogEntryEvent, ProjectKey
 from sentry.web.frontend.base import ProjectView
 
 
@@ -15,10 +15,9 @@ class CreateProjectKeyView(ProjectView):
             project=project,
         )
 
-        AuditLogEntry.objects.create(
+        self.create_audit_entry(
+            request,
             organization=organization,
-            actor=request.user,
-            ip_address=request.META['REMOTE_ADDR'],
             target_object=key.id,
             event=AuditLogEntryEvent.PROJECTKEY_ADD,
             data=key.get_audit_log_data(),

--- a/src/sentry/web/frontend/disable_project_key.py
+++ b/src/sentry/web/frontend/disable_project_key.py
@@ -4,9 +4,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, ProjectKey, ProjectKeyStatus
-)
+from sentry.models import AuditLogEntryEvent, ProjectKey, ProjectKeyStatus
 from sentry.web.frontend.base import ProjectView
 
 
@@ -21,10 +19,9 @@ class DisableProjectKeyView(ProjectView):
 
         key.update(status=ProjectKeyStatus.INACTIVE)
 
-        AuditLogEntry.objects.create(
+        self.create_audit_entry(
+            request,
             organization=organization,
-            actor=request.user,
-            ip_address=request.META['REMOTE_ADDR'],
             target_object=key.id,
             event=AuditLogEntryEvent.PROJECTKEY_DISABLE,
             data=key.get_audit_log_data(),

--- a/src/sentry/web/frontend/edit_project_key.py
+++ b/src/sentry/web/frontend/edit_project_key.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import AuditLogEntry, AuditLogEntryEvent, ProjectKey
+from sentry.models import AuditLogEntryEvent, ProjectKey
 from sentry.web.forms.projectkeys import EditProjectKeyForm
 from sentry.web.frontend.base import ProjectView
 
@@ -25,10 +25,9 @@ class EditProjectKeyView(ProjectView):
         if form.is_valid():
             key = form.save()
 
-            AuditLogEntry.objects.create(
+            self.create_audit_entry(
+                request,
                 organization=organization,
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
                 target_object=key.id,
                 event=AuditLogEntryEvent.PROJECTKEY_EDIT,
                 data=key.get_audit_log_data(),

--- a/src/sentry/web/frontend/enable_project_key.py
+++ b/src/sentry/web/frontend/enable_project_key.py
@@ -4,9 +4,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, ProjectKey, ProjectKeyStatus
-)
+from sentry.models import AuditLogEntryEvent, ProjectKey, ProjectKeyStatus
 from sentry.web.frontend.base import ProjectView
 
 
@@ -21,10 +19,9 @@ class EnableProjectKeyView(ProjectView):
 
         key.update(status=ProjectKeyStatus.ACTIVE)
 
-        AuditLogEntry.objects.create(
+        self.create_audit_entry(
+            request,
             organization=organization,
-            actor=request.user,
-            ip_address=request.META['REMOTE_ADDR'],
             target_object=key.id,
             event=AuditLogEntryEvent.PROJECTKEY_ENABLE,
             data=key.get_audit_log_data(),

--- a/src/sentry/web/frontend/organization_api_key_settings.py
+++ b/src/sentry/web/frontend/organization_api_key_settings.py
@@ -5,9 +5,7 @@ from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import (
-    ApiKey, AuditLogEntry, AuditLogEntryEvent
-)
+from sentry.models import ApiKey, AuditLogEntryEvent
 from sentry.web.forms.fields import OriginsField
 from sentry.web.frontend.base import OrganizationView
 
@@ -37,10 +35,9 @@ class OrganizationApiKeySettingsView(OrganizationView):
             key.allowed_origins = '\n'.join(form.cleaned_data['allowed_origins'])
             key.save()
 
-            AuditLogEntry.objects.create(
+            self.create_audit_entry(
+                request,
                 organization=organization,
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
                 target_object=key.id,
                 event=AuditLogEntryEvent.APIKEY_EDIT,
                 data=key.get_audit_log_data(),

--- a/src/sentry/web/frontend/organization_api_keys.py
+++ b/src/sentry/web/frontend/organization_api_keys.py
@@ -4,7 +4,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from operator import or_
 
-from sentry.models import ApiKey, AuditLogEntry, AuditLogEntryEvent
+from sentry.models import ApiKey, AuditLogEntryEvent
 from sentry.web.frontend.base import OrganizationView
 
 DEFAULT_SCOPES = [
@@ -26,10 +26,9 @@ class OrganizationApiKeysView(OrganizationView):
                 scopes=reduce(or_, [getattr(ApiKey.scopes, s) for s in DEFAULT_SCOPES])
             )
 
-            AuditLogEntry.objects.create(
+            self.create_audit_entry(
+                request,
                 organization=organization,
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
                 target_object=key.id,
                 event=AuditLogEntryEvent.APIKEY_ADD,
                 data=key.get_audit_log_data(),
@@ -50,10 +49,9 @@ class OrganizationApiKeysView(OrganizationView):
 
             key.delete()
 
-            AuditLogEntry.objects.create(
+            self.create_audit_entry(
+                request,
                 organization=organization,
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
                 target_object=key.id,
                 event=AuditLogEntryEvent.APIKEY_REMOVE,
                 data=audit_data,

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -11,9 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry import features, roles
 from sentry.auth import manager
 from sentry.auth.helper import AuthHelper
-from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, AuthProvider, OrganizationMember
-)
+from sentry.models import AuditLogEntryEvent, AuthProvider, OrganizationMember
 from sentry.plugins import Response
 from sentry.tasks.auth import email_missing_links
 from sentry.utils import db
@@ -44,10 +42,9 @@ class OrganizationAuthSettingsView(OrganizationView):
     required_scope = 'org:write'
 
     def _disable_provider(self, request, organization, auth_provider):
-        AuditLogEntry.objects.create(
+        self.create_audit_entry(
+            request,
             organization=organization,
-            actor=request.user,
-            ip_address=request.META['REMOTE_ADDR'],
             target_object=auth_provider.id,
             event=AuditLogEntryEvent.SSO_DISABLE,
             data=auth_provider.get_audit_log_data(),

--- a/src/sentry/web/frontend/organization_settings.py
+++ b/src/sentry/web/frontend/organization_settings.py
@@ -8,9 +8,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import roles
-from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, Organization
-)
+from sentry.models import AuditLogEntryEvent, Organization
 from sentry.web.frontend.base import OrganizationView
 
 
@@ -125,10 +123,9 @@ class OrganizationSettingsView(OrganizationView):
                 else:
                     organization.update_option('sentry:%s' % (opt,), value)
 
-            AuditLogEntry.objects.create(
+            self.create_audit_entry(
+                request,
                 organization=organization,
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
                 target_object=organization.id,
                 event=AuditLogEntryEvent.ORG_EDIT,
                 data=organization.get_audit_log_data(),

--- a/src/sentry/web/frontend/project_settings.py
+++ b/src/sentry/web/frontend/project_settings.py
@@ -8,9 +8,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from uuid import uuid1
 
-from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, Project, Team
-)
+from sentry.models import AuditLogEntryEvent, Project, Team
 from sentry.web.forms.fields import (
     CustomTypedChoiceField, RangeField, OriginsField, IPNetworksField,
 )
@@ -220,10 +218,9 @@ class ProjectSettingsView(ProjectView):
 
             project.update_option('sentry:reviewed-callsign', True)
 
-            AuditLogEntry.objects.create(
+            self.create_audit_entry(
+                request,
                 organization=organization,
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
                 target_object=project.id,
                 event=AuditLogEntryEvent.PROJECT_EDIT,
                 data=project.get_audit_log_data(),

--- a/src/sentry/web/frontend/remove_project_key.py
+++ b/src/sentry/web/frontend/remove_project_key.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import AuditLogEntry, AuditLogEntryEvent, ProjectKey
+from sentry.models import AuditLogEntryEvent, ProjectKey
 from sentry.web.frontend.base import ProjectView
 
 
@@ -24,10 +24,9 @@ class RemoveProjectKeyView(ProjectView):
 
         key.delete()
 
-        AuditLogEntry.objects.create(
+        self.create_audit_entry(
+            request,
             organization=organization,
-            actor=request.user,
-            ip_address=request.META['REMOTE_ADDR'],
             target_object=key.id,
             event=AuditLogEntryEvent.PROJECTKEY_REMOVE,
             data=data,


### PR DESCRIPTION
These are the changes required for frontend actions to be recorded in structlog (#3403).

Also takes out an import which is always nice.

cc @getsentry/infrastructure 
