### PR TITLE
[WIP] Handle "resolve in this release" behavior

### DIFF
--- a/src/sentry/static/sentry/app/views/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupEventDetails.jsx
@@ -98,6 +98,13 @@ const GroupEventDetails = React.createClass({
                   occurrences.`)}</span>
               </div>
             }
+            {group.status === 'resolved' && group.statusDetails.inThisRelease &&
+              <div className="alert alert-info alert-block">
+                <span>{t(`This issue has been marked as being resolved in the most
+                  recent release. You will not get notified about new occurrences
+                  until a new release.`)}</span>
+              </div>
+            }
             {group.status === 'resolved' && group.statusDetails.autoResolved &&
               <div className="alert alert-info alert-block">
                 <span>{t(`This issue was automatically marked as resolved due to


### PR DESCRIPTION
When resolving an issue that has Release data attached to it, tie the
GroupResolution status to the most recent Release seen for that Group.

This fixes the following behavior:
- User forgets to do "Resolve in Next Release" prior to deploy.
- After deploy, mark issue as "Resolved".
- Issue pops up again from previous release, to trigger a regression.
- Continues on forever and user cries.

@getsentry/infrastructure 

![image](https://cloud.githubusercontent.com/assets/375744/15846889/ea35e240-2c35-11e6-8872-f9d675d18ec7.png)
