### PR TITLE
Add libjpeg-dev required for Pillow install

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc \
         git \
         libffi-dev \
+        libjpeg-dev \
         libpq-dev \
         libxml2-dev \
         libxslt-dev \


### PR DESCRIPTION
Fixes Pillow installation in the docker container
