### PR TITLE
Log mail.queued and mail.sent events with structlog. 

### DIFF
--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -60,6 +60,7 @@ class LostPasswordHash(Model):
         msg = MessageBuilder(
             subject='%sPassword Recovery' % (options.get('mail.subject-prefix'),),
             template='sentry/emails/recover_account.txt',
+            type='user.password_recovery',
             context=context,
         )
         msg.send_async([self.user.email])

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -48,6 +48,7 @@ class OrganizationAccessRequest(Model):
             subject='Sentry Access Request',
             template='sentry/emails/request-team-access.txt',
             html_template='sentry/emails/request-team-access.html',
+            type='team.access.request',
             context=context,
         )
 
@@ -87,6 +88,7 @@ class OrganizationAccessRequest(Model):
             subject='Sentry Access Request',
             template='sentry/emails/access-approved.txt',
             html_template='sentry/emails/access-approved.html',
+            type='team.access.approved',
             context=context,
         )
 

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -7,8 +7,6 @@ sentry.models.organizationmember
 """
 from __future__ import absolute_import, print_function
 
-import logging
-
 from bitfield import BitField
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -16,6 +14,7 @@ from django.db import models, transaction
 from django.db.models import F
 from django.utils import timezone
 from hashlib import md5
+from structlog import get_logger
 
 from sentry import roles
 from sentry.db.models import (
@@ -151,13 +150,14 @@ class OrganizationMember(Model):
             subject='Join %s in using Sentry' % self.organization.name,
             template='sentry/emails/member-invite.txt',
             html_template='sentry/emails/member-invite.html',
+            type='organization.invite',
             context=context,
         )
 
         try:
             msg.send_async([self.get_email()])
         except Exception as e:
-            logger = logging.getLogger('sentry.mail.errors')
+            logger = get_logger(name='sentry.mail')
             logger.exception(e)
 
     def send_sso_link_email(self):
@@ -175,6 +175,7 @@ class OrganizationMember(Model):
             subject='Action Required for %s' % (self.organization.name,),
             template='sentry/emails/auth-link-identity.txt',
             html_template='sentry/emails/auth-link-identity.html',
+            type='organization.auth_link',
             context=context,
         )
         msg.send_async([self.get_email()])

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -327,7 +327,7 @@ class MailPlugin(NotificationPlugin):
                 project=project,
                 send_to=[user_id],
                 subject=subject,
-                type='notify.activity.%s' % activity.get_type_display(),
+                type='notify.activity.{}'.format(template_name),
                 context=context,
                 template='sentry/emails/activity/{}.txt'.format(template_name),
                 html_template='sentry/emails/activity/{}.html'.format(template_name),

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -56,7 +56,7 @@ class MailPlugin(NotificationPlugin):
 
     def _build_message(self, project, subject, template=None, html_template=None,
                    body=None, reference=None, reply_reference=None, headers=None,
-                   context=None, send_to=None, type=None):
+                   context=None, send_to=None, type='generic'):
         if send_to is None:
             send_to = self.get_send_to(project)
         if not send_to:

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -56,7 +56,7 @@ class MailPlugin(NotificationPlugin):
 
     def _build_message(self, project, subject, template=None, html_template=None,
                    body=None, reference=None, reply_reference=None, headers=None,
-                   context=None, send_to=None, type='generic'):
+                   context=None, send_to=None, type=None):
         if send_to is None:
             send_to = self.get_send_to(project)
         if not send_to:

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -54,8 +54,9 @@ class MailPlugin(NotificationPlugin):
             return self.subject_prefix
         return options.get('mail.subject-prefix')
 
-    def _build_message(self, project, subject, template=None, html_template=None, body=None,
-                   reference=None, reply_reference=None, headers=None, context=None, send_to=None):
+    def _build_message(self, project, subject, template=None, html_template=None,
+                   body=None, reference=None, reply_reference=None, headers=None,
+                   context=None, send_to=None, type=None):
         if send_to is None:
             send_to = self.get_send_to(project)
         if not send_to:
@@ -72,6 +73,7 @@ class MailPlugin(NotificationPlugin):
             html_template=html_template,
             body=body,
             headers=headers,
+            type=type,
             context=context,
             reference=reference,
             reply_reference=reply_reference,
@@ -195,6 +197,7 @@ class MailPlugin(NotificationPlugin):
                 project=project,
                 reference=group,
                 headers=headers,
+                type='notify.error',
                 context=context,
                 send_to=[user_id],
             )
@@ -232,6 +235,7 @@ class MailPlugin(NotificationPlugin):
                 template='sentry/emails/digests/body.txt',
                 html_template='sentry/emails/digests/body.html',
                 project=project,
+                type='notify.digest',
                 context=context,
                 send_to=[user_id],
             )
@@ -323,6 +327,7 @@ class MailPlugin(NotificationPlugin):
                 project=project,
                 send_to=[user_id],
                 subject=subject,
+                type='notify.activity.%s' % activity.get_type_display(),
                 context=context,
                 template='sentry/emails/activity/{}.txt'.format(template_name),
                 html_template='sentry/emails/activity/{}.html'.format(template_name),

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -349,9 +349,11 @@ class MessageBuilder(object):
         return results
 
     def format_to(self, to):
-        if to and len(to) > MAX_RECIPIENTS:
+        if not to:
+            return ''
+        if len(to) > MAX_RECIPIENTS:
             to = to[:MAX_RECIPIENTS] + ['and {} more.'.format(len(to[MAX_RECIPIENTS:]))]
-        return ', '.join(to) if isinstance(to, list) else to
+        return ', '.join(to)
 
     def send(self, to=None, bcc=None, fail_silently=False):
         return send_messages(

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -253,7 +253,7 @@ class MessageBuilder(object):
         self.reply_reference = reply_reference  # The object this message is replying about
         self.from_email = from_email or options.get('mail.from')
         self._send_to = set()
-        self.type = type
+        self.type = type if type else 'generic'
 
         if reference is not None and 'List-Id' not in headers:
             try:

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -39,7 +39,7 @@ from sentry.web.helpers import render_to_string
 # The maximum amount of recipients to display in human format.
 MAX_RECIPIENTS = 5
 
-logger = get_logger()
+logger = get_logger(name=__name__)
 
 
 class _CaseInsensitiveSigner(Signer):

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -348,6 +348,8 @@ class MessageBuilder(object):
         return results
 
     def format_to(self, to):
+        if not to:
+            return to
         trunc = to[:MAX_RECIPIENTS + 1]
         if len(trunc) > MAX_RECIPIENTS:
             trunc[-1] = 'and {} more.'.format(len(to) - len(trunc) - 1)

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -28,6 +28,7 @@ from django.utils.encoding import force_bytes, force_str, force_text
 from toronado import from_string as inline_css
 
 from sentry import options
+from sentry.logging import LoggingFormat
 from sentry.models import (
     Activity, Event, Group, GroupEmailThread, Project, User, UserOption
 )
@@ -375,10 +376,9 @@ class MessageBuilder(object):
                 _with_transaction=False,
             )
             logger.bind(message_id=message.extra_headers['Message-Id'])
-            # TODO(jtcunning): GH-3443
-            if fmt == 'human':
+            if fmt == LoggingFormat.HUMAN:
                 log_mail_queued(to=self.format_to(to))
-            elif fmt == 'machine':
+            elif fmt == LoggingFormat.MACHINE:
                 for recipient in to:
                     log_mail_queued(to=recipient)
 


### PR DESCRIPTION
- Will log queued emails that get shipped off to Celery with the mail id, who it is going to, and the type of mail being sent.
- Will log when an actual mail has been confirmed as sent.
- Adds the optional but recommended attribute of `type` to `MessageBuilder`.
