### PR TITLE
Add entry.id to audit log entry events.

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -115,6 +115,7 @@ class Endpoint(APIView):
 
         logger.info(
             name='sentry.audit.entry',
+            entry_id=entry.id,
             event=entry.get_event_display(),
             actor_label=entry.actor_label,
         )

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -245,6 +245,7 @@ class BaseView(View, OrganizationMixin):
         )
         logger.info(
             name='sentry.audit.entry',
+            entry_id=entry.id,
             event=entry.get_event_display(),
             actor_id=entry.actor_id,
             actor_label=entry.actor_label,


### PR DESCRIPTION
These aren't really useful events without at least an id to tie them back to django.

@getsentry/infrastructure 
