### PR TITLE
Expand event types and message usage

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -99,6 +99,11 @@ class EventSerializer(Serializer):
             except TypeError:
                 received = None
 
+        event_type = obj.data.get('type', 'default')
+        metadata = obj.data.get('metadata') or {
+            'title': obj.message_short,
+        }
+
         # TODO(dcramer): move release serialization here
         d = {
             'id': str(obj.id),
@@ -107,14 +112,14 @@ class EventSerializer(Serializer):
             'size': obj.size,
             'entries': attrs['entries'],
             # See GH-3248
-            'message': obj.data.get('sentry.interfaces.Message', {
-                'message': obj.message,
-            })['message'],
+            'message': obj.get_legacy_message(),
             'user': attrs['user'],
             'sdk': attrs['sdk'],
             'device': attrs['device'],
             'context': obj.data.get('extra', {}),
             'packages': obj.data.get('modules', {}),
+            'type': event_type,
+            'metadata': metadata,
             'tags': tags,
             'platform': obj.platform,
             'dateCreated': obj.datetime,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -468,6 +468,9 @@ class EventManager(object):
         # TODO(dcramer): temp workaround for complexity
         del data['message']
 
+        data['type'] = event_type.key
+        data['metadata'] = event_metadata
+
         # index components into ``Event.message``
         # See GH-3248
         if event_type.key != 'default':

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -36,3 +36,6 @@ class DefaultEvent(BaseEvent):
         return {
             'title': title,
         }
+
+    def to_string(self, data):
+        return data['title']

--- a/src/sentry/eventtypes/csp.py
+++ b/src/sentry/eventtypes/csp.py
@@ -21,3 +21,6 @@ class CspEvent(BaseEvent):
             'uri': csp._normalized_blocked_uri,
             'message': csp.get_message(),
         }
+
+    def to_string(self, data):
+        return u'{}: {}'.format(data['directive'], data['uri'])

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -19,3 +19,6 @@ class ErrorEvent(BaseEvent):
             'type': trim(exception.get('type', 'Error'), 128),
             'value': trim(exception.get('value', ''), 1024),
         }
+
+    def to_string(self, data):
+        return u'{}: {}'.format(data['type'], data['value'])

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -80,3 +80,6 @@ class Message(Interface):
 
     def get_hash(self):
         return [self.message]
+
+    def to_string(self, event, is_public=False, **kwargs):
+        return self.formatted or self.message

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -83,8 +83,14 @@ class Event(Model):
 
     project = property(_get_project, _set_project)
 
+    def get_legacy_message(self):
+        msg_interface = self.data.get('sentry.interfaces.Message', {
+            'message': self.message,
+        })
+        return msg_interface.get('formatted', msg_interface['message'])
+
     def error(self):
-        message = strip(self.message)
+        message = strip(self.get_legacy_message())
         if not message:
             message = '<unlabeled message>'
         else:
@@ -93,12 +99,12 @@ class Event(Model):
     error.short_description = _('error')
 
     def has_two_part_message(self):
-        message = strip(self.message)
+        message = strip(self.get_legacy_message())
         return '\n' in message or len(message) > 100
 
     @property
     def message_short(self):
-        message = strip(self.message)
+        message = strip(self.get_legacy_message())
         if not message:
             message = '<unlabeled message>'
         else:
@@ -181,7 +187,7 @@ class Event(Model):
         data['release'] = self.get_tag('sentry:release')
         data['platform'] = self.platform
         data['culprit'] = self.group.culprit
-        data['message'] = self.message
+        data['message'] = self.get_legacy_message()
         data['datetime'] = self.datetime
         data['time_spent'] = self.time_spent
         data['tags'] = self.get_tags()
@@ -191,7 +197,7 @@ class Event(Model):
 
     @property
     def size(self):
-        data_len = len(self.message)
+        data_len = len(self.get_legacy_message())
         for value in self.data.itervalues():
             data_len += len(repr(value))
         return data_len

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -85,7 +85,10 @@ class NotificationPlugin(Plugin):
                 deliver_digest.delay(digest_key)
 
         else:
-            notification = Notification(event=event, rules=rules)
+            notification = Notification(
+                event=event,
+                rules=rules,
+            )
             self.notify(notification)
 
     def notify_users(self, group, event, fail_silently=False):

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -56,7 +56,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             'logger': event.get_tag('logger'),
             'level': event.get_tag('level'),
             'culprit': group.culprit,
-            'message': event.message,
+            'message': event.get_legacy_message(),
             'url': group.get_absolute_url(),
         }
         data['event'] = dict(event.data or {})

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -13,11 +13,31 @@ from sentry.utils.safe import safe_execute
 RuleFuture = namedtuple('RuleFuture', ['rule', 'kwargs'])
 
 
+# TODO(dcramer): come up with a clean way to kill this either by renaming
+# the Event.message attribute or updating all plugins (former is better)
+class EventCompatibilityProxy(object):
+    """
+    A proxy which manages the 'message' attribute on an event to safely
+    upgrade legacy notifications.
+    """
+    __class__ = property(lambda x: x._event.__class__)
+
+    def __init__(self, event):
+        self._event = event
+
+    def __getattr__(self, attr):
+        return getattr(self._event, attr)
+
+    @property
+    def message(self):
+        return self._event.get_legacy_message()
+
+
 class RuleProcessor(object):
     logger = logging.getLogger('sentry.rules')
 
     def __init__(self, event, is_new, is_regression, is_sample):
-        self.event = event
+        self.event = EventCompatibilityProxy(event)
         self.group = event.group
         self.project = event.project
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
@@ -24,7 +24,7 @@ const MessageInterface = React.createClass({
         <pre className="plain" dangerouslySetInnerHTML={{
           __html: utils.nl2br(utils.urlize(utils.escape(data.formatted || data.message)))
         }} />
-        {data.params &&
+        {data.params && !data.formatted &&
           <div>
             <h5>{t('Params')}</h5>
             <pre className="plain">{JSON.stringify(data.params, null, 2)}</pre>

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -92,7 +92,16 @@ const GroupEvents = React.createClass({
   },
 
   getEventTitle(event) {
-    return event.message.split('\n')[0].substr(0, 100);
+    switch (event.type) {
+      case 'error':
+        return `${event.metadata.type}: ${event.metadata.value}`;
+      case 'csp':
+        return `${event.metadata.directive}: ${event.metadata.uri}`;
+      case 'default':
+        return event.metadata.title;
+      default:
+        return event.message.split('\n')[0].substr(0, 100);
+    }
   },
 
   renderNoQueryResults() {

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -31,7 +31,6 @@
         controls are enabled. For more details about this issue, <a href="{{ link }}">view this issue on Sentry</a>.</div>
     {% else %}
       <div class="event">
-        <pre class="message">{{ event.message }}</pre>
         <div class="event-id">ID: {{ event.event_id }}</div>
         <div class="event-date">{{ event.datetime }} UTC</div>
       </div>

--- a/src/sentry/templates/sentry/emails/error.txt
+++ b/src/sentry/templates/sentry/emails/error.txt
@@ -9,10 +9,6 @@ Details
 
 {{ link }}
 {% else %}
-A new issue has been recorded in Sentry:
-
-    {{ event.message }}
-
 Details
 -------
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -7,6 +7,7 @@ sentry.testutils.fixtures
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
+import copy
 import json
 import six
 import warnings
@@ -19,12 +20,70 @@ from sentry.models import (
     Activity, Event, EventError, EventMapping, Group, Organization,
     OrganizationMember, OrganizationMemberTeam, Project, Team, User
 )
-from sentry.utils.compat import pickle
-from sentry.utils.strings import decompress
 
-
-# an example data blog from Sentry 5.4.1 (db level)
-LEGACY_DATA = pickle.loads(decompress("""eJy9WW1v20YS/q5fwfqLpECluMvXFSzjgKK9BrikByR3XwyDXpFLmjVFsnxxbAT57zczS0rUS+LGrU8IYu3s2+yzM8/MrGZxxSYfpo0q2vrJzIpW1YmMVGO+U00jUzWdVHwyiysbBm13IgdaH++yxoB/0mhV0xp9p5GqQtWyVbHRNVmRGre3tXxQBQ26vYW57qT5MK1kLbcNtLzJLK/8SQOyVqYoCVAicJB6bGsJEmahBoz0fGpMWacPKOU4kKFiy/80qm6WcQSLqnppPmR128lcFQ/NUp9sucmKJSmCM52JhO1AIWy42Lhr26pZLZdqE9luYtuKucyxWCJiJSPXEcIPNrFkbJXYjmUnAVOMKyfijnB47FpuYgXehkcy/oesKjNVbQ9oVG6XDHfxJhJOlJcylg8pCnzSPpj8YpnC9yzf4SzwQRdoB4FtW5YfMN63bVsEjo29sEYHZ8UFBBy8PzFekkUYbsu4yxXCyBmCxjmMGs7NESvbZCazseXQjNOb/xWwwH6XFvBgTlSW95le1SdhgNfT1TlKUA+ED9F7lNsqV3hq6LEtHHWnZAyXg23SyOZ0tQVeoW2TxEHJH52qn8KmrcFosMuFZafYEcsWjcD2aKyPoq1q78oYhQGM+ufPH/Gr+MpxPrQyugdDishwyZQcNKUEoUO9HDIkh3Rx0LKTrojarETIHFRj02V5HG4b1MvxUAG5acJKtnco8P+cAebZZlk9gd4FN/1lk7XqxwoUA5dptGEuN7JRZvWEaxK+Va3CqISDPKKdOgK1dC2CBSzWGH0QIrOr4I+afUYXYzDiwjj6fBublfH5AmbyczNpdo/XCjy8hXuCiWFWJOVMyxc42T5WbPzJs6YNt/IxBFjS9m7dqDwxj4QLVN4hM3+QZDQuWaGLVlh1mzyLwnuFELn+5D3aEQDXhu1ThZfrBoOxmyQfk5hLjBJ1eVVnCKdn7cY2UZ1VMLjuioJ8yWOTPR15fLRRhkbnoRu5Ikg2TNierXzHVVGwUZ7nKm8jg2DDNhzHkV3ffwK+ooXoJJ53QKQeWM/FC6kUEPfIUHJQDl3RQ1fkFnzzNRvcT5+hdh9Ommp69fkkZWjL1weEtDAO+IiaAx3d4Ao2riDwFAMZgV7+wC15gmPQiS412GTkP+UZKGWUm99V1BqyNaxHZjm28BNmXeEEcrI226qwqWAkivR9o4ljC28av+MYc/gy4xazFwZfGMyBP9bC8BaGDRLHF47P5jiRzOBOFnFOVx1Ye9UObeZIOztRG19rF5B51KrpctQsoPgY2JMUuPbi8+5yV8YL73VhDOFxZVzffAE4Aw0nUCbu5E7Sv2g2gXcQgwO6drzNIKCNdtQYoEVd9guW9YAJkFfdU4AeOkIpsVxCSVgj8hZE/QKDUV6mKUEvbDyDhp5iMSgm4KApBB7EEcMLYHgmtABAfQSAfmR/xEi4OPW1bkAAYilyxsV50sAhOoshWPB4weStxUZBGWViRzroB5TaEExJBvwHQJKEDYNGEYFZFDarEuhyHxMAcMoiLIxax3z7ZUEj3GNO/jInuYfy6Zjts+SZEGFkBYWa1QUu4B8vDPOJ07MiyrtYUYBsVrRZQJSeFSFkRyQQAA6dvD9MmGcFnZ5ZZ44yfHR2cBJETsR0QkZuiusWJbX55C1Hq5SUTIK/UnCPZNV2td4bre814jljaJw6gjPmHYdwAK4o2x68JgRL2OQqns0JO3aCc61AYcpjIX2UR2vh/RhrvdYub5ntw+SCRtD/8H1PsWQswOOySXXIZZBRpt+KqIzvgwfjL4sejJ8NH4xy0/S74wYmzOCmGLFTChip15/F+8ucySD1hfV2IZZhEgzbBLiN5jcGuXB6jtYYpsIv5DVms9ckNob5+DPMxiBPh6PuGC09w2OYxKdf4S7bpT7NVfaJ+WsfVkU8e/MGjZO81/ZP+EnbvTHDMdf7hOxGm/T1NLpT0X3Tbac3c1J6cA7cu+eb9Dy/UKG5MIi6wSkg8VvjfwvjzRudvmmVBC0ANOJAjqppBOqJAxoZuYfDXotNHL5nE8cenefi4oL6nTG8P9UKDAIspTAIMyOpyy0YRm8yt7cmzXFP8L66ujIi8jjz8HSz6bunfq3fOzC+O2B1sLv4hykB73jj7Qed/BG1QH1D7vjiNwTm4F18Pz+4aAM9J0CRhOyFfjWU5eAUf56+wJeoFAdnHKiLHMrlmoM+TN+XOqa5SHJAEXorSn9g0ogiFucCL5XhUJV9F2GcXendjjb+fgqB5lBU7c50xCAaFeQHgeHkY91pVNxDPoUarznPLa7/dW6BCLXnFleMuSVWidEb7s+PkaqwpJ8h2SzA4SMqXtd4RSM3p4gLZHhqvx573qewNWxETuXxr1HQMakRB/bKzs5H3MVwQ+v+70hvRNizB3pyvSHLgRJU09NWZpQxeO7fSkr9TS/1TfdX4nl7eiIvH85KdeoaPQDsynz7/pffKOvwgoNogCS8RiPRnWLcSdRcom0RP9M72sFtEZOvP1PHySPI4K/Vpxif6KpPXRbPyga/K/w6n19bN/iQwaAY3rOVjxQLNt+/u/mYbF+CEiQyf6Pr/jd1Q4IM6heRGnGPxS3NPT49fNZlSZm7j2HwcsDiX8QKJ8QVSE/0k+ndq6/nIzCa/hmE+fQC0D8xMF+jHlA432UfASHxym+ctBGnPD9uyNYCe/J/eFgN6JVFxylqf3dQwGp4yOCgFD6fwWFl/NIMLhCvmsEJ6/kMTuhKFF2H3o5Rm8v/yrzb1+5oq9HGwiBBVfvK0OSoH8J068sVLWYfJYEnL2hMHKeDZ5lCjBND4Y2oQhevYlf7zCkDE4f1DtRNfX4CXtcqM87iMJFZ3ldOQowJAEIUWMFU1XVZ/4CYgF9+i5iJMPaJgaaJvj2bL2gBNjAuPgkh4XIo0zXhXuqi/4qe5u3vIN3xDxXccnZUyi1cNttWZQ2l4hM9xusinmJPdZ+GtWrKroaIb/TDUN2Qlg2rMiP/4NY+sQb8whCfHcLQWK+NaRhimAjD6YpOt6Nl/NFFPWbtjOaPakRO2XQYYqHZAvfBVPzhATOd/vzGvhc6jRl9/zEr5mhInNGjRhji80c/9wU/53Dm6GX64NSv5NKDYY8UFt17nVB4oouvF6nVH10GSPar7Arg9Xr/ywmjV8Rz6HJ6Txx+QDi5gN07mXK4p4h+OGd6Y30RJOGEan8ZKLD1kLiMeoEDh+td8GCgu3O7A4S4t3c0zoeYPKeu4FtecHyA2REYmP6VRVPC/fUejiK973yGeQnnu7IJvsimMf8Hr5plBQ=="""))
+DEFAULT_EVENT_DATA = {
+    'extra': {
+        'loadavg': [0.97607421875, 0.88330078125, 0.833984375],
+        'sys.argv': [
+            '/Users/dcramer/.virtualenvs/sentry/bin/raven',
+            'test',
+            'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@app.getsentry.com/1'
+        ],
+        'user': 'dcramer'
+    },
+    'modules': {'raven': '3.1.13'},
+    'sentry.interfaces.Http': {
+        'cookies': {},
+        'data': {},
+        'env': {},
+        'headers': {},
+        'method': 'GET',
+        'query_string': '',
+        'url': 'http://example.com',
+    },
+    'sentry.interfaces.Stacktrace': {
+        'frames': [
+            {
+                'abs_path': '/Users/dcramer/.virtualenvs/sentry/lib/python2.7/site-packages/raven/base.py',
+                'context_line': '                        string_max_length=self.string_max_length)',
+                'filename': 'raven/base.py',
+                'function': 'build_msg',
+                'in_app': False,
+                'lineno': 290,
+                'module': 'raven.base',
+                'post_context': [
+                    '                },',
+                    '            })',
+                    '',
+                    "        if 'sentry.interfaces.Stacktrace' in data:",
+                    '            if self.include_paths:'
+                ],
+                'pre_context': [
+                    '',
+                    '            data.update({',
+                    "                'sentry.interfaces.Stacktrace': {",
+                    "                    'frames': get_stack_info(frames,",
+                    '                        list_max_length=self.list_max_length,'],
+                'vars': {
+                    'culprit': 'raven.scripts.runner',
+                    'date': 'datetime.datetime(2013, 2, 14, 20, 6, 33, 479471)',
+                    'event_id': '598fb19363e745ec8be665e6ba88b1b2',
+                    'event_type': 'raven.events.Message',
+                    'frames': '<generator object iter_stack_frames at 0x103fef050>',
+                    'handler': '<raven.events.Message object at 0x103feb710>',
+                    'k': 'sentry.interfaces.Message',
+                    'public_key': None,
+                    'result': {'sentry.interfaces.Message': "{'message': 'This is a test message generated using ``raven test``', 'params': []}"},
+                    'self': '<raven.base.Client object at 0x104397f10>',
+                    'stack': True,
+                    'tags': None,
+                    'time_spent': None,
+                },
+            },
+        ],
+    },
+    'tags': [],
+}
 
 
 class Fixtures(object):
@@ -161,8 +220,7 @@ class Fixtures(object):
         if 'group' not in kwargs:
             kwargs['group'] = self.group
         kwargs.setdefault('project', kwargs['group'].project)
-        kwargs.setdefault('message', kwargs['group'].message)
-        kwargs.setdefault('data', LEGACY_DATA.copy())
+        kwargs.setdefault('data', copy.deepcopy(DEFAULT_EVENT_DATA))
         if kwargs.get('tags'):
             tags = kwargs.pop('tags')
             if isinstance(tags, dict):

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -41,7 +41,7 @@ class StacktraceTest(TestCase):
         # objects
         event = self.event
         interface = Stacktrace.to_python(event.data['sentry.interfaces.Stacktrace'])
-        assert len(interface.frames) == 5
+        assert len(interface.frames) == 1
         assert interface == event.interfaces['sentry.interfaces.Stacktrace']
 
     def test_requires_filename(self):

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -19,9 +19,41 @@ class EventTest(TestCase):
         assert event.culprit == event.group.culprit
 
     def test_email_subject(self):
-        event1 = self.create_event(event_id='a' * 32, group=self.group, tags={'level': 'info'})
-        event2 = self.create_event(event_id='b' * 32, group=self.group, tags={'level': 'error'})
+        event1 = self.create_event(
+            event_id='a' * 32, group=self.group, tags={'level': 'info'},
+            message='Foo bar')
+        event2 = self.create_event(
+            event_id='b' * 32, group=self.group, tags={'level': 'error'},
+            message='Foo bar')
         self.group.level = 30
 
         assert event1.get_email_subject() == '[foo Bar] INFO: Foo bar'
         assert event2.get_email_subject() == '[foo Bar] ERROR: Foo bar'
+
+
+class EventGetLegacyMessageTest(TestCase):
+    def test_message(self):
+        event = self.create_event(message='foo bar')
+        assert event.get_legacy_message() == 'foo bar'
+
+    def test_message_interface(self):
+        event = self.create_event(
+            message='biz baz',
+            data={
+                'sentry.interfaces.Message': {'message': 'foo bar'}
+            },
+        )
+        assert event.get_legacy_message() == 'foo bar'
+
+    def test_message_interface_with_formatting(self):
+        event = self.create_event(
+            message='biz baz',
+            data={
+                'sentry.interfaces.Message': {
+                    'message': 'foo %s',
+                    'formatted': 'foo bar',
+                    'params': ['bar'],
+                }
+            },
+        )
+        assert event.get_legacy_message() == 'foo bar'

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -238,6 +238,7 @@ class MailPluginTest(TestCase):
         with self.options({'system.url-prefix': 'http://example.com'}), self.tasks():
             self.plugin.notify(notification)
 
+        assert len(mail.outbox) == 1
         msg = mail.outbox[0]
         assert msg.subject == u'[Sentry] [foo Bar] ERROR: רונית מגן'
 

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from sentry.models import Rule
 from sentry.plugins import plugins
 from sentry.testutils import TestCase
-from sentry.rules.processor import RuleProcessor
+from sentry.rules.processor import EventCompatibilityProxy, RuleProcessor
 
 
 class RuleProcessorTest(TestCase):
@@ -37,3 +37,20 @@ class RuleProcessorTest(TestCase):
         assert len(futures) == 1
         assert futures[0].rule == rule
         assert futures[0].kwargs == {}
+
+
+class EventCompatibilityProxyTest(TestCase):
+    def test_simple(self):
+        event = self.create_event(
+            message='biz baz',
+            data={
+                'sentry.interfaces.Message': {
+                    'message': 'foo %s',
+                    'formatted': 'foo bar',
+                    'params': ['bar'],
+                }
+            },
+        )
+
+        event_proxy = EventCompatibilityProxy(event)
+        assert event_proxy.message == 'foo bar'


### PR DESCRIPTION
- Serialize event type data with Event
- Add basic render to Related Events
- Add rendering to email for message interface
- Remove message attribute from email
- Swap out message for `get_legacy_message` in notification plugins
- Trim up example event data used in fixtures to exclude default message
- Add to_string on EventType (currently unused)

@getsentry/infrastructure
