### PR TITLE
Improved permission error for member editing.

### DIFF
--- a/src/sentry/templates/sentry/organization-member-details.html
+++ b/src/sentry/templates/sentry/organization-member-details.html
@@ -101,7 +101,7 @@
       {% if member.user == user %}
         <p>You cannot make changes to your own membership.</p>
       {% else %}
-        <p>You cannot make changes to this member as they have more access than you.</p>
+        <p>You cannot make changes to this member as you do not have the right permissions.</p>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
This fixes the case where an admin is told upon editing a normal member
that a user has more rights than them.
