### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -175,7 +175,7 @@ Version 8.1.1
 Version 8.1.0
 -------------
 
-- Default web server is now uWSGI (https://uwsgi-docs.readthedocs.org/en/latest/) to replace gunicorn.
+- Default web server is now uWSGI (https://uwsgi-docs.readthedocs.io/en/latest/) to replace gunicorn.
 - New "Saved Searches". See: http://blog.getsentry.com/2016/01/19/introducing-saved-searches.html
 
 Schema Changes

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -299,7 +299,7 @@ All schema changes and database upgrades are handled via the ``upgrade``
 command, and this is the first thing you'll want to run when upgrading to
 future versions of Sentry.
 
-.. note:: Internally this uses `South <http://south.readthedocs.io/en/latest/index.html>`_ to
+.. note:: Internally this uses `South <https://south.readthedocs.io/en/latest/index.html>`_ to
           manage database migrations.
 
 Starting the Web Service

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -66,7 +66,7 @@ or can be passed through the command line as::
 
 	$ sentry run web -w 16
 
-See `uWSGI's official documentation <https://uwsgi-docs.readthedocs.org/en/latest/Options.html>`_
+See `uWSGI's official documentation <https://uwsgi-docs.readthedocs.io/en/latest/Options.html>`_
 for more options that can be configured in ``SENTRY_WEB_OPTIONS``.
 
 
@@ -124,7 +124,7 @@ nodes are using a lot of memory, you'll want to ensure you have some
 mechanisms for monitoring and resolving this.
 
 If you're using supervisord, we recommend taking a look at `superlance
-<http://superlance.readthedocs.org>`_ which aids in this situation::
+<https://superlance.readthedocs.io>`_ which aids in this situation::
 
 	[eventlistener:memmon]
 	command=memmon -a 400MB -m ops@example.com

--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -116,7 +116,7 @@ SENTRY_DIGESTS = 'sentry.digests.backends.redis.RedisBackend'
 ################
 
 # Any Django storage backend is compatible with Sentry. For more solutions see
-# the django-storages package: https://django-storages.readthedocs.org/en/latest/
+# the django-storages package: https://django-storages.readthedocs.io/en/latest/
 
 SENTRY_FILESTORE = 'django.core.files.storage.FileSystemStorage'
 SENTRY_FILESTORE_OPTIONS = {

--- a/src/sentry/receivers/stats.py
+++ b/src/sentry/receivers/stats.py
@@ -42,7 +42,7 @@ def record_task_signal(signal, name, **options):
     )
 
 # TODO: https://github.com/getsentry/sentry/issues/2495
-# https://celery.readthedocs.org/en/latest/userguide/signals.html#task-revoked
+# https://celery.readthedocs.io/en/latest/userguide/signals.html#task-revoked
 # def task_revoked_handler(sender, expired=False, **kwargs):
 #     if expired:
 #         metrics.incr('jobs.expired', instance=sender)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
