### PR TITLE
Fallback config options shouldn't be broken

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -53,9 +53,9 @@ sys.path.insert(0, os.path.normpath(os.path.join(PROJECT_ROOT, os.pardir)))
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'sentry.db',
-        'USER': '',
+        'ENGINE': 'sentry.db.postgres',
+        'NAME': 'sentry',
+        'USER': 'postgres',
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
@@ -360,7 +360,7 @@ SOCIAL_AUTH_FORCE_POST_DISCONNECT = True
 # Queue configuration
 from kombu import Exchange, Queue
 
-BROKER_URL = "django://"
+BROKER_URL = "redis://localhost:6379"
 BROKER_TRANSPORT_OPTIONS = {}
 
 # Ensure workers run async by default

--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -14,6 +14,8 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
+        'AUTOCOMMIT': True,
+        'ATOMIC_REQUESTS': False,
     }
 }
 


### PR DESCRIPTION
We've since passed sqlite and Django as a Celery broker, so we shouldn't
even fall back to them.

Refs GH-2589

@getsentry/infrastructure 
