### PR TITLE
Don't output invalid src location errors if no source

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -696,7 +696,7 @@ class SourceProcessor(object):
             frame.pre_context, frame.context_line, frame.post_context = get_source_context(
                 source=source, lineno=frame.lineno, colno=frame.colno or 0)
 
-            if not frame.context_line:
+            if not frame.context_line and source:
                 all_errors.append({
                     'type': EventError.JS_INVALID_SOURCEMAP_LOCATION,
                     'column': frame.colno,


### PR DESCRIPTION
Fixes redundant "invalid location in sourcemap" errors if no original source was found.

Example:

![image](https://cloud.githubusercontent.com/assets/2153/16034067/7a7320dc-31c4-11e6-9b2b-67165119abed.png)

In this example, the line/columns are actually mapped correctly (visible in stack trace), but because index.ios.js cannot be found, context information cannot be found at call locations occurring in that file – so we get this redundant, unhelpful error.

After patch:

![image](https://cloud.githubusercontent.com/assets/2153/16034119/c88d4946-31c4-11e6-8c33-1143e150ef9a.png)

/cc @getsentry/infrastructure
