### PR TITLE
Update issue search to use AND matching for tags

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -69,6 +69,8 @@ class GroupEventsEndpoint(GroupEndpoint):
                 event_id__in=matches,
                 group_id=group.id,
             ).values_list('event_id', flat=True)[:1000])
+            if not matches:
+                return []
         return matches
 
     @attach_scenarios([list_available_samples_scenario])
@@ -97,9 +99,13 @@ class GroupEventsEndpoint(GroupEndpoint):
                 )
 
             if query_kwargs['tags']:
-                events = events.filter(
-                    id__in=self._tags_to_filter(group, query_kwargs['tags']),
-                )
+                matches = self._tags_to_filter(group, query_kwargs['tags'])
+                if matches:
+                    events = events.filter(
+                        id__in=matches,
+                    )
+                else:
+                    events = events.none()
 
         return self.paginate(
             request=request,

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -21,6 +21,41 @@ from sentry.utils.db import get_db_engine
 
 
 class DjangoSearchBackend(SearchBackend):
+    def _tags_to_filter(self, project, tags):
+        # Django doesnt support union, so we limit results and try to find
+        # reasonable matches
+        from sentry.models import GroupTagValue
+
+        # ANY matches should come last since they're the least specific and
+        # will provide the largest range of matches
+        tag_lookups = sorted(tags.iteritems(), key=lambda x: x != ANY)
+
+        # get initial matches to start the filter
+        matches = None
+
+        # for each remaining tag, find matches contained in our
+        # existing set, pruning it down each iteration
+        for k, v in tag_lookups:
+            if v != ANY:
+                base_qs = GroupTagValue.objects.filter(
+                    key=k,
+                    value=v,
+                    project=project,
+                )
+            else:
+                base_qs = GroupTagValue.objects.filter(
+                    key=k,
+                    project=project,
+                ).distinct()
+
+            if matches:
+                base_qs = base_qs.filter(group_id__in=matches)
+
+            matches = list(base_qs.values_list('group_id', flat=True)[:1000])
+            if not matches:
+                return None
+        return matches
+
     def query(self, project, query=None, status=None, tags=None,
               bookmarked_by=None, assigned_to=None, first_release=None,
               sort_by='date', unassigned=None,
@@ -78,19 +113,13 @@ class DjangoSearchBackend(SearchBackend):
             )
 
         if tags:
-            for k, v in tags.iteritems():
-                if v == ANY:
-                    queryset = queryset.filter(
-                        grouptag__project=project,
-                        grouptag__key=k,
-                    )
-                else:
-                    queryset = queryset.filter(
-                        grouptag__project=project,
-                        grouptag__key=k,
-                        grouptag__value=v,
-                    )
-            queryset = queryset.distinct()
+            matches = self._tags_to_filter(project, tags)
+            if matches:
+                queryset = queryset.filter(
+                    id__in=matches,
+                )
+            else:
+                queryset = queryset.none()
 
         if age_from or age_to:
             params = {}

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -140,6 +140,17 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project1, tags={'env': ANY})
         assert len(results) == 2
 
+        results = self.backend.query(self.project1, tags={'env': 'staging', 'server': 'example.com'})
+        assert len(results) == 1
+        assert results[0] == self.group2
+
+        results = self.backend.query(self.project1, tags={'env': 'staging', 'server': ANY})
+        assert len(results) == 1
+        assert results[0] == self.group2
+
+        results = self.backend.query(self.project1, tags={'env': 'staging', 'server': 'bar.example.com'})
+        assert len(results) == 0
+
     def test_bookmarked_by(self):
         results = self.backend.query(self.project1, bookmarked_by=self.user)
         assert len(results) == 1


### PR DESCRIPTION
This updates the issue search and event search to better support tags.
- Issue search now uses union optimization (similar to event search) to limit results pulled back but ensure matches are AND'd together.
- Event search now handles the 'has:tag' query term
- Short circuit pattern for weak matches

@getsentry/api 
