### PR TITLE
Change tooltip placement to prevent overlap with buttons

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -41,7 +41,8 @@ let GroupEventToolbar  = React.createClass({
   mixins: [
     TooltipMixin({
       html: true,
-      selector: '.tip'
+      selector: '.tip',
+      placement: 'bottom'
     }),
   ],
 


### PR DESCRIPTION
Currently, when hovering the event date, you get an tooltip below the button like this:

![image](https://cloud.githubusercontent.com/assets/1469823/16116878/8bc1afcc-33cf-11e6-8246-4eedb4720e0c.png)
- The button `z-index` is 2 and it doesn't occur if it's 1.
- The tooltip `z-index` is 1007 (as it should be)

I don't modify the `z-index` of the button since I don't know what part can be affected by such a change but it was introduced in ac29dcf627dbb4f6c166211336a844b2254dcf9b if you want to investigate

EDIT: To be clear, the alternative could be

``` diff
diff --git a/src/sentry/static/sentry/less/group-detail.less b/src/sentry/static/sentry/less/group-detail.less
index 9d49421..0c701a2 100644
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -109,6 +109,7 @@

   .group-actions {
     margin-top: 15px;
+    z-index: 1 !important;

     .btn-group {
       margin-right: 5px;
```

cc @dcramer @benvinegar 
