### PR TITLE
Allow to set as "resolved until next release" in bulk

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -335,6 +335,32 @@ const StreamActions = React.createClass({
                    {t('Set status to: Muted')}
                   </ActionLink>
                 </MenuItem>
+                <MenuItem noAnchor={true}>
+                  <ActionLink
+                    disabled={!this.state.anySelected}
+                    onAction={this.onUpdate.bind(this, {status: 'resolvedInNextRelease'})}
+                    extraDescription={extraDescription}
+                    confirmationQuestion={
+                      this.state.allInQuerySelected
+                        ? t('Are you sure you want to snooze all issues matching this search query?')
+                        : (count) =>
+                             tn('Are you sure you want to snooze this %d issue?',
+                                'Are you sure you want to snooze these %d issues?',
+                                count)
+                    }
+                    confirmLabel={
+                      this.state.allInQuerySelected
+                        ? t('Snooze all issues')
+                        : (count) =>
+                            tn('Snooze %d selected issue',
+                               'Snooze %d selected issues',
+                               count)
+                    }
+                    onlyIfBulk={true}
+                    selectAllActive={this.state.pageSelected}>
+                   {t('Set status to: Resolved in next release')}
+                  </ActionLink>
+                </MenuItem>
                 <MenuItem divider={true} />
                 <MenuItem noAnchor={true}>
                   <ActionLink


### PR DESCRIPTION
I think I also have to check if the project `has releases` like in `groupDetails/actions.jsx`

PS: So many useless `className` in these menu items i think, so I went with no `className` and I'm very tempted to remove the others items class names
