### PR TITLE
Pull message into formatted param

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -581,30 +581,42 @@ class ClientApiHelper(object):
                     'value': value,
                 })
 
+        # TODO(dcramer): ideally this logic would happen in normalize, but today
+        # we don't do "validation" there (create errors)
+
         # message is coerced to an interface, as its used for pure
         # index of searchable strings
         # See GH-3248
-        if 'sentry.interfaces.Message' not in data and data.get('message'):
-            k = 'sentry.interfaces.Message'
-            value = {
-                'message': data.pop('message'),
-            }
-            interface = get_interface(k)
-            try:
-                inst = interface.to_python(value)
-                data[inst.get_path()] = inst.to_json()
-            except Exception as e:
-                if isinstance(e, InterfaceValidationError):
-                    log = self.log.info
-                else:
-                    log = self.log.error
-                log('Discarded invalid value for interface: %s (%r)', k, value,
-                    exc_info=True)
-                data['errors'].append({
-                    'type': EventError.INVALID_DATA,
-                    'name': k,
-                    'value': value,
-                })
+        message = data.pop('message', None)
+        if message:
+            if 'sentry.interfaces.Message' not in data:
+                value = {
+                    'message': message,
+                }
+            elif not data['sentry.interfaces.Message'].get('formatted'):
+                value = data['sentry.interfaces.Message']
+                value['formatted'] = message
+            else:
+                value = None
+
+            if value is not None:
+                k = 'sentry.interfaces.Message'
+                interface = get_interface(k)
+                try:
+                    inst = interface.to_python(value)
+                    data[inst.get_path()] = inst.to_json()
+                except Exception as e:
+                    if isinstance(e, InterfaceValidationError):
+                        log = self.log.info
+                    else:
+                        log = self.log.error
+                    log('Discarded invalid value for interface: %s (%r)', k, value,
+                        exc_info=True)
+                    data['errors'].append({
+                        'type': EventError.INVALID_DATA,
+                        'name': k,
+                        'value': value,
+                    })
 
         level = data.get('level') or DEFAULT_LOG_LEVEL
         if isinstance(level, six.string_types) and not level.isdigit():

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -49,7 +49,7 @@ class Message(Interface):
 
         kwargs = {
             'message': trim(data['message'], settings.SENTRY_MAX_MESSAGE_LENGTH),
-            'formatted': None,
+            'formatted': data.get('formatted'),
         }
 
         if data.get('params'):
@@ -81,6 +81,10 @@ class Message(Interface):
                 )
             except Exception:
                 pass
+
+        # don't wastefully store formatted message twice
+        if kwargs['formatted'] == kwargs['message']:
+            kwargs['formatted'] = None
 
         return cls(**kwargs)
 

--- a/tests/sentry/interfaces/test_message.py
+++ b/tests/sentry/interfaces/test_message.py
@@ -13,7 +13,8 @@ class MessageTest(TestCase):
     def interface(self):
         return Message.to_python(dict(
             message='Hello there %s!',
-            params=('world',)
+            params=('world',),
+            formatted='Hello there world!',
         ))
 
     def test_serialize_behavior(self):
@@ -35,3 +36,20 @@ class MessageTest(TestCase):
             'message': {'foo': 'bar'},
         })
         assert result.message == '{"foo":"bar"}'
+
+    # we had a regression which was throwing this data away
+    def test_retains_formatted(self):
+        result = type(self.interface).to_python({
+            'message': 'foo bar',
+            'formatted': 'foo bar baz'
+        })
+        assert result.message == 'foo bar'
+        assert result.formatted == 'foo bar baz'
+
+    def test_discards_dupe_formatted(self):
+        result = type(self.interface).to_python({
+            'message': 'foo bar',
+            'formatted': 'foo bar'
+        })
+        assert result.message == 'foo bar'
+        assert result.formatted is None

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -619,14 +619,38 @@ class EventManagerTest(TransactionTestCase):
         # test that the message is handled gracefully
         manager = EventManager(self.make_event(**{
             'message': 1234,
+        }))
+        manager.normalize()
+        event = manager.save(self.project.id)
+
+        assert event.message == '1234'
+        assert event.data['sentry.interfaces.Message'] == {
+            'message': '1234',
+        }
+
+    def test_message_attribute_goes_to_interface(self):
+        manager = EventManager(self.make_event(**{
+            'message': 'hello world',
+        }))
+        manager.normalize()
+        event = manager.save(self.project.id)
+        assert event.data['sentry.interfaces.Message'] == {
+            'message': 'hello world',
+        }
+
+    def test_message_attribute_goes_to_formatted(self):
+        manager = EventManager(self.make_event(**{
+            'message': 'world hello',
             'sentry.interfaces.Message': {
                 'message': 'hello world',
             },
         }))
         manager.normalize()
         event = manager.save(self.project.id)
-
-        assert event.message == '1234 hello world'
+        assert event.data['sentry.interfaces.Message'] == {
+            'message': 'hello world',
+            'formatted': 'world hello',
+        }
 
 
 class GetHashesFromEventTest(TestCase):


### PR DESCRIPTION
When the Message interface is already present and we've sent a core message attribute, try to set it as the formatted param of the interface rather than purely discarding it.

Additionally this corrects some behavior in which the formatted param was not being stored when it was explicitly passed.

/cc @getsentry/infrastructure
