### PR TITLE
Handle long request paths better

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -83,7 +83,7 @@ const RequestInterface = React.createClass({
 
     children.push(
       <h3 key="title">
-        <a href={fullUrl}>
+        <a href={fullUrl} title={fullUrl}>
           <div className="path"><strong>{data.method || 'GET'}</strong> {parsedUrl.pathname}</div>
           <span className="external-icon">
             <em className="icon-open" />

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -84,12 +84,12 @@ const RequestInterface = React.createClass({
     children.push(
       <h3 key="title">
         <a href={fullUrl}>
-          <strong>{data.method || 'GET'} {parsedUrl.pathname}</strong>
+          <div className="path"><strong>{data.method || 'GET'}</strong> {parsedUrl.pathname}</div>
           <span className="external-icon">
             <em className="icon-open" />
           </span>
         </a>
-        <small style={{marginLeft: 20}}>{parsedUrl.hostname}</small>
+        <small style={{marginLeft: 10}} className="host">{parsedUrl.hostname}</small>
       </h3>
     );
 
@@ -103,7 +103,8 @@ const RequestInterface = React.createClass({
           event={evt}
           type={this.props.type}
           title={title}
-          wrapTitle={false}>
+          wrapTitle={false}
+          className="request">
         {view === 'curl' ?
           <pre>{getCurlCommand(data)}</pre>
         :

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -6,6 +6,7 @@ import {getCurlCommand} from './utils';
 import {t} from '../../../locale';
 
 import RequestActions from './requestActions';
+import Truncate from '../../../components/truncate';
 
 const RequestInterface = React.createClass({
   propTypes: {
@@ -84,7 +85,7 @@ const RequestInterface = React.createClass({
     children.push(
       <h3 key="title">
         <a href={fullUrl} title={fullUrl}>
-          <div className="path"><strong>{data.method || 'GET'}</strong> {parsedUrl.pathname}</div>
+          <div className="path"><strong>{data.method || 'GET'}</strong> <Truncate value={parsedUrl.pathname} maxLength={36} leftTrim={true} /></div>
           <span className="external-icon">
             <em className="icon-open" />
           </span>

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -85,7 +85,9 @@ const RequestInterface = React.createClass({
     children.push(
       <h3 key="title">
         <a href={fullUrl} title={fullUrl}>
-          <div className="path"><strong>{data.method || 'GET'}</strong> <Truncate value={parsedUrl.pathname} maxLength={36} leftTrim={true} /></div>
+          <span className="path"><strong>{data.method || 'GET'}</strong>
+            <Truncate value={parsedUrl.pathname} maxLength={36} leftTrim={true} />
+          </span>
           <span className="external-icon">
             <em className="icon-open" />
           </span>

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1659,11 +1659,8 @@ div.commands {
 .request {
   .path {
     font-weight: normal;
-    text-overflow: ellipsis;
-    max-width: 50%;
-    overflow: hidden;
-    white-space: nowrap;
     float: left;
+    
     strong {
       margin-right: 4px;
     }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1656,6 +1656,20 @@ div.commands {
 
 // Request
 
+.request {
+  .path {
+    font-weight: normal;
+    text-overflow: ellipsis;
+    max-width: 50%;
+    overflow: hidden;
+    white-space: nowrap;
+    float: left;
+    strong {
+      margin-right: 4px;
+    }
+  }
+}
+
 .box-clippable {
   position: relative;
   margin-left: -20px;


### PR DESCRIPTION
**Before:**

![screen shot 2016-06-16 at 1 09 46 pm](https://cloud.githubusercontent.com/assets/30713/16131574/b5dfe83e-33c3-11e6-903c-8c2b38b8b816.png)

**After:**

![screen shot 2016-06-16 at 1 06 32 pm](https://cloud.githubusercontent.com/assets/30713/16131518/60c87910-33c3-11e6-8cf4-eaa267e0ac29.png)

/cc @getsentry/ui 
