### PR TITLE
Added new device interface

### DIFF
--- a/src/sentry/interfaces/device.py
+++ b/src/sentry/interfaces/device.py
@@ -11,45 +11,59 @@ class Device(Interface):
     An interface which describes the device.
 
     >>> {
-    >>>     "name": "Windows",
-    >>>     "version": "95",
-    >>>     "build": "95.0.134.1651",
-    >>>     "arbitrary": "data"
+    >>>     "model": "iPad7,1",
+    >>>     "model_id": "N102AP",
+    >>>     "os": "iOS",
+    >>>     "os_version": "9.3.2",
+    >>>     "os_build": "13F69",
+    >>>     "arch": "arm64"
+    >>> }
+
+    For computers:
+
+    >>> {
+    >>>     "model": "MacBookPro12,1",
+    >>>     "os": "macOS",
+    >>>     "os_version": "10.11.5",
+    >>>     "os_build": "15F34",
+    >>>     "arch": "x86_64"
     >>> }
     """
     @classmethod
     def to_python(cls, data):
-        data = data.copy()
-
-        extra_data = data.pop('data', data)
+        extra_data = data.get('data')
         if not isinstance(extra_data, dict):
             extra_data = {}
 
         try:
-            name = trim(data.pop('name'), 64)
+            model = trim(data['model'], 64)
         except KeyError:
-            raise InterfaceValidationError("Missing or invalid value for 'name'")
+            raise InterfaceValidationError("Missing or invalid value for 'model'")
 
         try:
-            version = trim(data.pop('version'), 64)
+            os = trim(data['os'], 64)
         except KeyError:
-            raise InterfaceValidationError("Missing or invalid value for 'version'")
-
-        build = trim(data.pop('build', None), 64)
+            raise InterfaceValidationError("Missing or invalid value for 'os'")
 
         kwargs = {
-            'name': name,
-            'version': version,
-            'build': build,
+            'model': model,
+            'model_id': trim(data.get('model_id'), 40),
+            'os': os,
+            'os_version': trim(data.get('os_version'), 40),
+            'os_build': trim(data.get('os_version'), 40),
+            'arch': trim(data.get('arch'), 40),
             'data': trim_dict(extra_data),
         }
         return cls(**kwargs)
 
     def get_api_context(self, is_public=False):
         return {
-            'name': self.name,
-            'version': self.version,
-            'build': self.build,
+            'model': self.model,
+            'model_id': self.model_id,
+            'os': self.os,
+            'os_version': self.os_version,
+            'os_build': self.os_build,
+            'arch': self.arch,
             'data': self.data,
         }
 

--- a/src/sentry/interfaces/device.py
+++ b/src/sentry/interfaces/device.py
@@ -35,15 +35,10 @@ class Device(Interface):
         if not isinstance(extra_data, dict):
             extra_data = {}
 
-        try:
-            model = trim(data['model'], 64)
-        except KeyError:
-            raise InterfaceValidationError("Missing or invalid value for 'model'")
-
-        try:
-            os = trim(data['os'], 64)
-        except KeyError:
-            raise InterfaceValidationError("Missing or invalid value for 'os'")
+        model = trim(data.get('model'), 64)
+        os = trim(data.get('os'), 64)
+        if not (model or os):
+            raise InterfaceValidationError("One of 'model' or 'os' is required.")
 
         kwargs = {
             'model': model,

--- a/src/sentry/static/sentry/app/components/events/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/device.jsx
@@ -37,20 +37,35 @@ const DeviceInterface = React.createClass({
         wrapTitle={true}>
         <table className="table key-value">
           <tbody>
-            {data.name &&
+            {data.model &&
               <tr>
-                <td className="key">Name</td>
-                <td className="value"><pre>{data.name}</pre></td>
+                <td className="key">Model</td>
+                <td className="value"><pre>{data.model}</pre></td>
               </tr>}
-            {data.version && 
+            {data.model_id && 
               <tr>
-                <td className="key">Version</td>
-                <td className="value"><pre>{data.version}</pre></td>
+                <td className="key">Model ID</td>
+                <td className="value"><pre>{data.model_id}</pre></td>
               </tr>}
-            {data.build &&
+            {data.os &&
               <tr>
-                <td className="key">Build</td>
-                <td className="value"><pre>{data.build}</pre></td>
+                <td className="key">OS</td>
+                <td className="value"><pre>{data.os}</pre></td>
+              </tr>}
+            {data.os_version &&
+              <tr>
+                <td className="key">OS Version</td>
+                <td className="value"><pre>{data.os_version}</pre></td>
+              </tr>}
+            {data.os_build &&
+              <tr>
+                <td className="key">OS Build</td>
+                <td className="value"><pre>{data.os_build}</pre></td>
+              </tr>}
+            {data.arch &&
+              <tr>
+                <td className="key">CPU Architecture</td>
+                <td className="value"><pre>{data.arch}</pre></td>
               </tr>}
             {extras}
           </tbody>


### PR DESCRIPTION
This makes the device interface more flexible but is not compatible with the old data.
- `name` -> `os`
- `version` -> `os_version`
- `build` -> `os_build`
- new: `model` (eg: iPad etc.)
- new: `model_id` (eg: 12345AB)
- new: `arch` (eg: arm64)
