### PR TITLE
Enforce core attribute for backups

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -97,12 +97,6 @@ class BaseModel(models.Model):
         return self.__data.get(field_name)
 
 
-def __model_post_save(instance, **kwargs):
-    if not isinstance(instance, BaseModel):
-        return
-    instance._update_tracked_data()
-
-
 class Model(BaseModel):
     id = BoundedBigAutoField(primary_key=True)
 
@@ -112,4 +106,19 @@ class Model(BaseModel):
     __repr__ = sane_repr('id')
 
 
+def __model_post_save(instance, **kwargs):
+    if not isinstance(instance, BaseModel):
+        return
+    instance._update_tracked_data()
+
+
+def __model_class_prepared(sender, **kwargs):
+    if not issubclass(sender, BaseModel):
+        return
+
+    if not hasattr(sender, '__core__'):
+        raise ValueError('{!r} model has not defined __core__'.format(sender))
+
+
 signals.post_save.connect(__model_post_save)
+signals.class_prepared.connect(__model_class_prepared)

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -28,6 +28,8 @@ class ApiKeyStatus(object):
 
 
 class ApiKey(Model):
+    __core__ = True
+
     organization = FlexibleForeignKey('sentry.Organization', related_name='key_set')
     label = models.CharField(max_length=64, blank=True, default='Default')
     key = models.CharField(max_length=32, unique=True)

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -13,6 +13,8 @@ from sentry.db.models import (
 
 
 class ApiToken(Model):
+    __core__ = True
+
     # users can generate tokens without being key-bound
     key = FlexibleForeignKey('sentry.ApiKey', null=True)
     user = FlexibleForeignKey('sentry.User')

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -514,6 +514,8 @@ class U2fInterface(AuthenticatorInterface):
 
 
 class Authenticator(BaseModel):
+    __core__ = True
+
     id = BoundedAutoField(primary_key=True)
     user = FlexibleForeignKey('sentry.User', db_index=True)
     created_at = models.DateTimeField(_('created at'), default=timezone.now)

--- a/src/sentry/models/helppage.py
+++ b/src/sentry/models/helppage.py
@@ -16,6 +16,8 @@ from sentry.db.models.manager import BaseManager
 
 
 class HelpPage(Model):
+    __core__ = True
+
     # key is used internally for auto-generated/versioned pages
     key = models.CharField(max_length=64, null=True, unique=True)
     title = models.CharField(max_length=64)

--- a/src/sentry/models/option.py
+++ b/src/sentry/models/option.py
@@ -22,6 +22,8 @@ class Option(Model):
     Options which are specific to a plugin should namespace
     their key. e.g. key='myplugin:optname'
     """
+    __core__ = True
+
     key = models.CharField(max_length=64, unique=True)
     value = UnicodePickledObjectField()
     last_updated = models.DateTimeField(default=timezone.now)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -64,6 +64,8 @@ class Organization(Model):
     """
     An organization represents a group of individuals which maintain ownership of projects.
     """
+    __core__ = True
+
     name = models.CharField(max_length=64)
     slug = models.SlugField(unique=True)
     status = BoundedPositiveIntegerField(choices=(

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -16,6 +16,8 @@ from sentry.utils.http import absolute_uri
 
 
 class OrganizationAccessRequest(Model):
+    __core__ = True
+
     team = FlexibleForeignKey('sentry.Team')
     member = FlexibleForeignKey('sentry.OrganizationMember')
 

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -25,6 +25,8 @@ from sentry.utils.http import absolute_uri
 
 
 class OrganizationMemberTeam(BaseModel):
+    __core__ = True
+
     id = BoundedAutoField(primary_key=True)
     team = FlexibleForeignKey('sentry.Team')
     organizationmember = FlexibleForeignKey('sentry.OrganizationMember')
@@ -56,6 +58,8 @@ class OrganizationMember(Model):
     and could be thought of as team owners (though their access level may not)
     be set to ownership.
     """
+    __core__ = True
+
     organization = FlexibleForeignKey('sentry.Organization', related_name="member_set")
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True,

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -58,6 +58,8 @@ class OrganizationOnboardingTask(Model):
         ISSUE_ASSIGNMENT: { 'assigned_member': user.id }
         SECOND_PLATFORM: { 'platform': 'javascript' }
     """
+    __core__ = False
+
     TASK_CHOICES = (
         (OnboardingTask.FIRST_EVENT, 'First event'),  # Send an organization's first event to Sentry
         (OnboardingTask.INVITE_MEMBER, 'Invite member'),  # Add a second member to your Sentry org.

--- a/src/sentry/models/organizationoption.py
+++ b/src/sentry/models/organizationoption.py
@@ -115,6 +115,8 @@ class OrganizationOption(Model):
     key: onboarding:complete
     value: { updated: datetime }
     """
+    __core__ = True
+
     organization = FlexibleForeignKey('sentry.Organization')
     key = models.CharField(max_length=64)
     value = UnicodePickledObjectField()

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -74,6 +74,8 @@ class Project(Model):
     Projects are permission based namespaces which generally
     are the top level entry point for all data.
     """
+    __core__ = True
+
     slug = models.SlugField(null=True)
     name = models.CharField(max_length=200)
     forced_color = models.CharField(max_length=6, null=True, blank=True)

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -34,6 +34,8 @@ class ProjectKeyStatus(object):
 
 
 class ProjectKey(Model):
+    __core__ = True
+
     project = FlexibleForeignKey('sentry.Project', related_name='key_set')
     label = models.CharField(max_length=64, blank=True, null=True)
     public_key = models.CharField(max_length=32, unique=True, null=True)

--- a/src/sentry/models/projectoption.py
+++ b/src/sentry/models/projectoption.py
@@ -112,6 +112,8 @@ class ProjectOption(Model):
     Options which are specific to a plugin should namespace
     their key. e.g. key='myplugin:optname'
     """
+    __core__ = True
+
     project = FlexibleForeignKey('sentry.Project')
     key = models.CharField(max_length=64)
     value = UnicodePickledObjectField()

--- a/src/sentry/models/rule.py
+++ b/src/sentry/models/rule.py
@@ -17,6 +17,8 @@ from sentry.db.models.manager import BaseManager
 
 
 class Rule(Model):
+    __core__ = True
+
     project = FlexibleForeignKey('sentry.Project')
     label = models.CharField(max_length=64)
     data = GzippedDictField()

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -86,6 +86,8 @@ class Team(Model):
     """
     A team represents a group of individuals which maintain ownership of projects.
     """
+    __core__ = True
+
     organization = FlexibleForeignKey('sentry.Organization')
     slug = models.SlugField()
     name = models.CharField(max_length=64)

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -24,6 +24,8 @@ class UserManager(BaseManager, UserManager):
 
 
 class User(BaseModel, AbstractBaseUser):
+    __core__ = True
+
     id = BoundedAutoField(primary_key=True)
     username = models.CharField(_('username'), max_length=128, unique=True)
     # this column is called first_name for legacy reasons, but it is the entire

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -14,6 +14,7 @@ CHARACTERS = u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
 
 class UserEmail(Model):
+    __core__ = True
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL,
                               related_name='emails')

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -110,6 +110,8 @@ class UserOption(Model):
     key: "feature:assignment"
     value: { updated: datetime, state: bool }
     """
+    __core__ = True
+
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)
     project = FlexibleForeignKey('sentry.Project', null=True)
     key = models.CharField(max_length=64)

--- a/tests/sentry/utils/models/tests.py
+++ b/tests/sentry/utils/models/tests.py
@@ -10,6 +10,8 @@ from sentry.testutils import TestCase
 # There's a good chance this model wont get created in the db, so avoid
 # assuming it exists in these tests.
 class DummyModel(Model):
+    __core__ = False  # needs defined for Sentry to not yell at you
+
     foo = models.CharField(max_length=32)
     normint = BoundedIntegerField(null=True)
     bigint = BoundedBigIntegerField(null=True)


### PR DESCRIPTION
This enforces that all models which are part of the core Sentry infrastructure explicitly specify the `__core__` attribute.

@getsentry/infrastructure
