### PR TITLE
Make sure Rules labels are unicode

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -92,7 +92,7 @@ class EventAttributeCondition(EventCondition):
     # TODO(dcramer): add support for stacktrace.vars.[name]
 
     form_cls = EventAttributeForm
-    label = 'An events {attribute} value {match} {value}'
+    label = u'An events {attribute} value {match} {value}'
 
     def _get_attribute_values(self, event, attr):
         # TODO(dcramer): we should validate attributes (when we can) before

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -44,7 +44,7 @@ class TaggedEventForm(forms.Form):
 
 class TaggedEventCondition(EventCondition):
     form_cls = TaggedEventForm
-    label = 'An events tags match {key} {match} {value}'
+    label = u'An events tags match {key} {match} {value}'
 
     def passes(self, event, state, **kwargs):
         key = self.get_option('key')

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -52,6 +52,14 @@ class EventAttributeConditionTest(RuleTestCase):
         )
         return event
 
+    def test_render_label(self):
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'attribute': u'\xc3',
+            'value': u'\xc4',
+        })
+        assert rule.render_label() == u'An events \xc3 value equals \xc4'
+
     def test_equals(self):
         event = self.get_event()
         rule = self.get_rule({

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -17,6 +17,14 @@ class TaggedEventConditionTest(RuleTestCase):
         )
         return event
 
+    def test_render_label(self):
+        rule = self.get_rule({
+            'match': MatchType.EQUAL,
+            'key': u'\xc3',
+            'value': u'\xc4',
+        })
+        assert rule.render_label() == u'An events tags match \xc3 eq \xc4'
+
     def test_equals(self):
         event = self.get_event()
         rule = self.get_rule({


### PR DESCRIPTION
This causes formatting issues since the values we pass in are unicode,
so if they're outside ascii, it blows up.

Fixes SENTRY-188

@getsentry/infrastructure 
