### PR TITLE
Restrict default user feedback to unresolved

### DIFF
--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -10,7 +10,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize, ProjectUserReportSerializer
 from sentry.api.paginator import DateTimePaginator
-from sentry.models import EventMapping, Group, UserReport
+from sentry.models import EventMapping, Group, GroupStatus, UserReport
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -53,6 +53,14 @@ class ProjectUserReportsEndpoint(ProjectEndpoint):
             project=project,
             group__isnull=False,
         ).select_related('group')
+
+        status = request.GET.get('status', 'unresolved')
+        if status == 'unresolved':
+            queryset = queryset.filter(
+                group__status=GroupStatus.UNRESOLVED,
+            )
+        elif status:
+            return Response({'status': 'Invalid status choice'}, status=400)
 
         return self.paginate(
             request=request,

--- a/src/sentry/static/sentry/app/views/projectUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/projectUserReports.jsx
@@ -14,6 +14,7 @@ import {t} from '../locale';
 const ProjectUserReports = React.createClass({
   propTypes: {
     defaultQuery: React.PropTypes.string,
+    defaultStatus: React.PropTypes.string,
     setProjectNavSection: React.PropTypes.func
   },
 
@@ -25,18 +26,19 @@ const ProjectUserReports = React.createClass({
   getDefaultProps() {
     return {
       defaultQuery: '',
+      defaultStatus: 'unresolved',
     };
   },
 
   getInitialState() {
-    let queryParams = this.props.location.query;
-
     return {
       reportList: [],
       loading: true,
       error: false,
-      query: queryParams.query || this.props.defaultQuery,
       pageLinks: '',
+      query: this.props.defaultQuery,
+      status: this.props.defaultStatus,
+      ...this.getQueryStringState(this.props)
     };
   },
 
@@ -47,17 +49,30 @@ const ProjectUserReports = React.createClass({
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.location.search !== this.props.location.search) {
-      let queryParams = nextProps.location.query;
-      this.setState({
-        query: queryParams.query
-      }, this.fetchData);
+      this.setState(this.getQueryStringState(nextProps), this.fetchData);
     }
+  },
+
+  getQueryStringState(props) {
+    let location = props.location;
+    let status = (location.query.hasOwnProperty('status')
+      ? location.query.status
+      : this.props.defaultStatus);
+    let query = (location.query.hasOwnProperty('query')
+      ? location.query.query
+      : this.props.defaultQuery);
+    return {
+      query: query,
+      status: status,
+    };
   },
 
   onSearch(query) {
     let targetQueryParams = {};
     if (query !== '')
       targetQueryParams.query = query;
+    if (this.state.status !== this.props.defaultStatus)
+      targetQueryParams.status = this.state.status;
 
     let {orgId, projectId} = this.props.params;
     this.history.pushState(null, `/${orgId}/${projectId}/user-feedback/`, targetQueryParams);
@@ -92,7 +107,8 @@ const ProjectUserReports = React.createClass({
     let queryParams = {
       ...this.props.location.query,
       limit: 50,
-      query: this.state.query
+      query: this.state.query,
+      status: this.state.status,
     };
 
     return `/projects/${params.orgId}/${params.projectId}/user-reports/?${jQuery.param(queryParams)}`;
@@ -185,11 +201,26 @@ const ProjectUserReports = React.createClass({
   },
 
   render() {
+    let path = this.props.location.pathname;
+    let status = this.state.status;
     return (
       <div>
         <div className="row release-list-header">
-          <div className="col-sm-7">
+          <div className="col-sm-9">
             <h3>{t('User Feedback')}</h3>
+          </div>
+          <div className="col-sm-3" style={{textAlign: 'right'}}>
+            <div className="btn-group">
+              <Link to={path}
+                    className={'btn btn-sm btn-default' + (status === 'unresolved' ? ' active' : '')}>
+                {t('Unresolved')}
+              </Link>
+              <Link to={path}
+                    query={{status: ''}}
+                    className={'btn btn-sm btn-default' + (status === '' ? ' active' : '')}>
+                {t('All Issues')}
+              </Link>
+            </div>
           </div>
         </div>
         <div className="alert alert-block alert-info">Psst! This feature is still a work-in-progress. Thanks for being an early adopter!</div>


### PR DESCRIPTION
Similar to user-based issue lists, this restricts the user feedback view to show unresolved issues by default with a toggle to show all issues.

/cc @getsentry/api @getsentry/ui
