### PR TITLE
Disable uwsgi logging when machine readable format is requested

### DIFF
--- a/tests/sentry/services/test_http.py
+++ b/tests/sentry/services/test_http.py
@@ -68,3 +68,11 @@ class HTTPServiceTest(TestCase):
             assert 'proc_name' not in server.options
             assert 'secure_scheme_headers' not in server.options
             assert 'loglevel' not in server.options
+
+    def test_format_logs(self):
+        with self.options({'system.logging-format': 'human'}):
+            server = SentryHTTPServer()
+            assert server.options['disable-logging'] is False
+        with self.options({'system.logging-format': 'machine'}):
+            server = SentryHTTPServer()
+            assert server.options['disable-logging'] is True


### PR DESCRIPTION
Ideally, we'd use a JSON format like:

```
{"event":"http.request","addr":"%(addr)","user":"%(user)","method":"%(method)","uri":"%(uri)","status":%(status),"referer":"%(referer)","uagent":"%(uagent)"}
```

But this can generate bad JSON because of a uwsgi bug. See:
https://github.com/unbit/uwsgi/issues/1293

@JTCunning 
