### PR TITLE
Bump raven-js to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "platformicons": "0.0.14",
     "po-catalog-loader": "^1.2.0",
     "query-string": "2.4.2",
-    "raven-js": "3.0.5",
+    "raven-js": "3.1.0",
     "react": "0.14.7",
     "react-addons-css-transition-group": "0.14.7",
     "react-addons-pure-render-mixin": "0.14.7",


### PR DESCRIPTION
[3.1.0](https://github.com/getsentry/raven-js/releases/tag/3.1.0) adds TypeScript bindings and some deprecated cleanup

cc @mattrobenolt 
