### PR TITLE
Assert that statistic range passed to API endpoints are valid.

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -220,6 +220,7 @@ class StatsMixin(object):
         start = request.GET.get('since')
         if start:
             start = datetime.fromtimestamp(float(start)).replace(tzinfo=utc)
+            assert start <= end, 'start must be before or equal to end'
         else:
             start = end - timedelta(days=1, seconds=-1)
 


### PR DESCRIPTION
"Fixes" SENTRY-E and SENTRY-1R by moving it to an error that hopefully
is at least understandable.
