### PR TITLE
Show culprit as a subtitle even for events of type "default"

### DIFF
--- a/src/sentry/static/sentry/app/components/group/title.jsx
+++ b/src/sentry/static/sentry/app/components/group/title.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const GroupTitle = React.createClass({
+  propTypes: {
+    data: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    let data = this.props.data;
+    let metadata = data.metadata;
+    let title = data.title;
+    let subtitle = data.culprit;
+    if (data.type == 'error') {
+      title = metadata.type;
+      subtitle = data.culprit;
+    } else if (data.type == 'csp') {
+      title = metadata.directive;
+      subtitle = metadata.uri;
+    } else if (data.type == 'default') {
+      title = metadata.title;
+    }
+    if (subtitle) {
+      return (
+        <span>
+          <span style={{marginRight: 10}}>{title}</span>
+          <em style={{fontSize: '80%', color: '#6F7E94', fontWeight: 'normal'}}>{subtitle}</em><br/>
+        </span>
+      );
+    }
+    return <span>{title}</span>;
+  },
+});
+
+export default GroupTitle;

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -9,6 +9,7 @@ import GroupChart from './groupChart';
 import GroupCheckBox from './groupCheckBox';
 import ProjectState from '../../mixins/projectState';
 import TimeSince from '../timeSince';
+import GroupTitle from '../group/title';
 import GroupStore from '../../stores/groupStore';
 import SelectedGroupStore from '../../stores/selectedGroupStore';
 import ShortId from '../shortId';
@@ -20,31 +21,6 @@ const StreamGroupHeader = React.createClass({
     data: React.PropTypes.object.isRequired,
     orgId: React.PropTypes.string.isRequired,
     projectId: React.PropTypes.string.isRequired,
-  },
-
-  getTitle() {
-    let data = this.props.data;
-    let metadata = data.metadata;
-    switch (data.type) {
-      case 'error':
-        return (
-          <span>
-            <span style={{marginRight: 10}}>{metadata.type}</span>
-            <em style={{fontSize: '80%', color: '#6F7E94', fontWeight: 'normal'}}>{data.culprit}</em><br/>
-          </span>
-        );
-      case 'csp':
-        return (
-          <span>
-            <span style={{marginRight: 10}}>{metadata.directive}</span>
-            <em style={{fontSize: '80%', color: '#6F7E94', fontWeight: 'normal'}}>{metadata.uri}</em><br/>
-          </span>
-        );
-      case 'default':
-        return <span>{metadata.title}</span>;
-      default:
-        return <span>{data.title}</span>;
-    }
   },
 
   getMessage() {
@@ -69,7 +45,7 @@ const StreamGroupHeader = React.createClass({
             <span className="error-level truncate">{data.level}</span>
             <span className="icon icon-soundoff" />
             <span className="icon icon-star-solid" />
-            {this.getTitle()}
+            <GroupTitle data={data} />
           </Link>
         </h3>
         <div className="event-message truncate">

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -9,6 +9,7 @@ import GroupSeenBy from './seenBy';
 import IndicatorStore from '../../stores/indicatorStore';
 import ListLink from '../../components/listLink';
 import ShortId from '../../components/shortId';
+import GroupTitle from '../../components/group/title';
 import ProjectState from '../../mixins/projectState';
 import {t} from '../../locale';
 
@@ -73,31 +74,6 @@ const GroupHeader = React.createClass({
     });
   },
 
-  getTitle() {
-    let data = this.props.group;
-    let metadata = data.metadata;
-    switch (data.type) {
-      case 'error':
-        return (
-          <span>
-            <span style={{marginRight: 10}}>{metadata.type}</span>
-            <em style={{fontSize: '80%', color: '#6F7E94', fontWeight: 'normal'}}>{data.culprit}</em><br/>
-          </span>
-        );
-      case 'csp':
-        return (
-          <span>
-            <span style={{marginRight: 10}}>{metadata.directive}</span>
-            <em style={{fontSize: '80%', color: '#6F7E94', fontWeight: 'normal'}}>{metadata.uri}</em><br/>
-          </span>
-        );
-      case 'default':
-        return <span>{metadata.title}</span>;
-      default:
-        return <span>{data.title}</span>;
-    }
-  },
-
   getMessage() {
     let data = this.props.group;
     let metadata = data.metadata;
@@ -140,7 +116,7 @@ const GroupHeader = React.createClass({
         <div className="row">
           <div className="col-sm-8">
             <h3>
-              {this.getTitle()}
+              <GroupTitle data={group} />
             </h3>
             <div className="event-message">
               <span className="error-level">{group.level}</span>


### PR DESCRIPTION
When I was sending message via `.captureMessage(...` and adding a culprit in the data, it wouldn't show as a subtitle.

Also de-duplicate because the code for `getTitle` :+1: 

cc @benvinegar @mitsuhiko @dcramer 
