### PR TITLE
Bump to CRIT because of noisey exit>0s.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -565,7 +565,7 @@ LOGGING = {
         },
         'multiprocessing': {
             'handlers': ['console'],
-            'level': 'CRIT',
+            'level': 'CRITICAL',
             'propagate': False,
         },
         'celery': {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -565,6 +565,8 @@ LOGGING = {
         },
         'multiprocessing': {
             'handlers': ['console'],
+            'level': 'CRIT',
+            'propagate': False,
         },
         'celery': {
             'level': 'WARN',


### PR DESCRIPTION
@mattrobenolt 
