### PR TITLE
Fix Angular 2 doc instructions rendered w/ generic icon

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -3185,6 +3185,14 @@ ul.tag-list {
       color: #fff;
     }
 
+    &.javascript-angular2 .platformicon {
+      background: @blue;
+      color: #fff;
+      &:before {
+        content: "\e900";
+      }
+    }
+
     &.java .platformicon {
       background: @orange;
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2153/16249009/0101a7fa-37c8-11e6-8f0d-eb64a49b2da9.png)

I kind of liked giving these different colors, since the Angular webpage is red + blue ([link](https://angular.io)). We could also use the different colors to better differentiate our landing pages for each version.

/cc @getsentry/ui
