### PR TITLE
Don't route celery logger through root, it goes to sentry logger.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -569,6 +569,9 @@ LOGGING = {
             'propagate': False,
         },
         'celery': {
+            'level': 'WARN',
+        },
+        'celery.worker.job': {
             'handlers': ['console'],
             'level': 'ERROR',
             'propagate': False,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -569,7 +569,9 @@ LOGGING = {
             'propagate': False,
         },
         'celery': {
-            'level': 'WARN',
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
         },
         'static_compiler': {
             'level': 'INFO',


### PR DESCRIPTION
@mattrobenolt 

Fixes SENTRY-1F4.
