### PR TITLE
Add ability to set SMTP timeout through config

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -12,7 +12,7 @@ from sentry.options import (
     FLAG_IMMUTABLE, FLAG_NOSTORE, FLAG_PRIORITIZE_DISK, FLAG_REQUIRED, FLAG_ALLOW_EMPTY,
     register,
 )
-from sentry.utils.types import Dict, String, Sequence
+from sentry.utils.types import Dict, String, Sequence, Int
 
 # Cache
 # register('cache.backend', flags=FLAG_NOSTORE)
@@ -64,6 +64,7 @@ register('mail.list-namespace', type=String, default='localhost', flags=FLAG_NOS
 register('mail.enable-replies', default=False, flags=FLAG_PRIORITIZE_DISK)
 register('mail.reply-hostname', default='', flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register('mail.mailgun-api-key', default='', flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register('mail.timeout', default=None, type=Int, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 
 # SMS
 register('sms.twilio-account', default='', flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -417,6 +417,7 @@ def get_connection(fail_silently=False):
         username=options.get('mail.username'),
         password=options.get('mail.password'),
         use_tls=options.get('mail.use-tls'),
+        timeout=options.get('mail.timeout'),
         fail_silently=fail_silently,
     )
 


### PR DESCRIPTION
Running a small instance of Sentry where our email is handled externally by Office365, somewhere in `smtplib` a timeout is being hit, either during connection or whilst sending email. On the application level, I've solved this by upping the timeouts to 30 seconds. Thought it would be useful to other Sentry users if this was something we could set in the config file.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3561)

<!-- Reviewable:end -->
