### PR TITLE
Add method to get the cardinality of a union of distinct counters.

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -230,6 +230,13 @@ class BaseTSDB(object):
         """
         raise NotImplementedError
 
+    def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
+        """
+        Count the total number of distinct items across multiple counters
+        during a time range.
+        """
+        raise NotImplementedError
+
     def record_frequency_multi(self, requests, timestamp=None):
         """
         Record items in a frequency table.

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -29,6 +29,9 @@ class DummyTSDB(BaseTSDB):
     def get_distinct_counts_totals(self, model, keys, start, end=None, rollup=None):
         return {k: 0 for k in keys}
 
+    def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
+        return 0
+
     def record_frequency_multi(self, requests, timestamp=None):
         pass
 

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -95,6 +95,18 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
+    def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
+        rollup, series = self.get_optimal_rollup_series(start, end, rollup)
+
+        values = set()
+        for key in keys:
+            source = self.sets[model][key]
+            for timestamp in series:
+                r = self.normalize_ts_to_rollup(timestamp, rollup)
+                values.update(source[r])
+
+        return len(values)
+
     def flush(self):
         # model => key => timestamp = count
         self.data = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -316,17 +316,15 @@ class RedisTSDB(BaseTSDB):
 
         def map_key_to_host(hosts, key):
             """
-            Identify the host where each key is located, adding it to the
-            ``host`` mapping.
+            Identify the host where a key is located and add it to the host map.
             """
             hosts[router.get_host_for_key(key)].add(key)
             return hosts
 
         def get_partition_aggregate((host, keys)):
             """
-            Fetch the HyperLogLog values (in their raw byte representations)
-            that results from the union of all HyperLogLog structures at the
-            provided keys.
+            Fetch the HyperLogLog value (in its raw byte representation) that
+            results from merging all HyperLogLogs at the provided keys.
             """
             destination = make_temporary_key('p:{}'.format(host))
             client = self.cluster.get_local_client(host)
@@ -344,8 +342,8 @@ class RedisTSDB(BaseTSDB):
             aggregates = {make_temporary_key('a:{}'.format(host)): value for host, value in values}
 
             # Choose a random host to execute the reduction on. (We use a host
-            # here that's we've already accessed as part of this process --
-            # this way, we constrain the choices to only hosts that we know are
+            # here that we've already accessed as part of this process -- this
+            # way, we constrain the choices to only hosts that we know are
             # running.)
             client = self.cluster.get_local_client(random.choice(values)[0])
             with client.pipeline(transaction=False) as pipeline:

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -303,7 +303,7 @@ class RedisTSDB(BaseTSDB):
 
         temporary_id = uuid.uuid1().hex
 
-        def make_key(key):
+        def make_temporary_key(key):
             return '{}{}:{}'.format(self.prefix, temporary_id, key)
 
         def expand_key(key):
@@ -328,7 +328,7 @@ class RedisTSDB(BaseTSDB):
             that results from the union of all HyperLogLog structures at the
             provided keys.
             """
-            destination = make_key('p:{}'.format(host))
+            destination = make_temporary_key('p:{}'.format(host))
             client = self.cluster.get_local_client(host)
             with client.pipeline(transaction=False) as pipeline:
                 pipeline.execute_command('PFMERGE', destination, *chain(map(expand_key, keys)))
@@ -340,8 +340,8 @@ class RedisTSDB(BaseTSDB):
             """
             Calculate the cardinality of the provided HyperLogLog values.
             """
-            destination = make_key('a')  # all values will be merged into this key
-            aggregates = {make_key('a:{}'.format(host)): value for host, value in values}
+            destination = make_temporary_key('a')  # all values will be merged into this key
+            aggregates = {make_temporary_key('a:{}'.format(host)): value for host, value in values}
 
             # Choose a random host to execute the reduction on. (We use a host
             # here that's we've already accessed as part of this process --

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -150,6 +150,8 @@ class RedisTSDBTest(TestCase):
             2: 2,
         }
 
+        assert self.db.get_distinct_counts_union(model, [1, 2], dts[0], dts[-1], rollup=3600) == 3
+
     def test_frequency_tables(self):
         now = datetime.utcnow().replace(tzinfo=pytz.UTC)
         model = TSDBModel.frequent_projects_by_organization


### PR DESCRIPTION
This is needed to support GH-647, which requires the ability to query how many total unique users were affected by an issue that the user resolved over the past week.

The HyperLogLog structures that track the number of unique users that have been affected by a group over time are not colocated by organization (shard placement is by group primary key), so this needs to be able to:
1. map over all shards that contain data to fulfill the request, returning a HyperLogLog that is the result of merging together all the HyperLogLog values from that shard,
2. merge those intermediate HyperLogLog values together to produce a single HyperLogLog that is the union of all of the requested keys,
3. return the cardinality of the unioned keys.

@getsentry/infrastructure 
