### PR TITLE
Fix awkward clip animation on frame variables/http interface/others

### DIFF
--- a/src/sentry/static/sentry/app/components/clippedBox.jsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.jsx
@@ -11,7 +11,7 @@ const ClippedBox = React.createClass({
 
   getDefaultProps() {
     return {
-      defaultClipped: false,
+      defaultClipped: true,
       clipHeight: 200
     };
   },

--- a/src/sentry/static/sentry/app/components/clippedBox.jsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.jsx
@@ -11,14 +11,16 @@ const ClippedBox = React.createClass({
 
   getDefaultProps() {
     return {
-      defaultClipped: true,
-      clipHeight: 200
+      defaultClipped: false,
+      clipHeight: 200,
+      renderedHeight: null
     };
   },
 
   getInitialState() {
     return {
-      clipped: this.props.defaultClipped
+      clipped: this.props.defaultClipped,
+      revealed: false, // True once user has clicked "Show More" button
     };
   },
 
@@ -39,7 +41,8 @@ const ClippedBox = React.createClass({
     e.stopPropagation();
 
     this.setState({
-      clipped: false
+      clipped: false,
+      revealed: true
     });
   },
 
@@ -48,6 +51,9 @@ const ClippedBox = React.createClass({
     if (this.state.clipped) {
       className += ' clipped';
     }
+    if (this.state.revealed) {
+      className += ' revealed';
+    }
 
     return (
       <div className={className}>
@@ -55,11 +61,14 @@ const ClippedBox = React.createClass({
           <h5>{this.props.title}</h5>
         }
         {this.props.children}
-        <div className="clip-fade">
-          <a onClick={this.reveal} className="show-more btn btn-primary btn-xs">
-            {t('Show more')}
-          </a>
-        </div>
+
+        {this.state.clipped &&
+          <div className="clip-fade">
+            <a onClick={this.reveal} className="show-more btn btn-primary btn-xs">
+              {t('Show more')}
+            </a>
+          </div>
+        }
       </div>
     );
   }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1719,7 +1719,11 @@ div.commands {
   padding: 16px 20px 1px;
   border-top: 1px solid #f1f2f3;
   .transition(all 5s ease-in-out);
-  max-height: 50000px;
+
+  &.revealed {
+    /* For "Show More" animation */
+    max-height: 50000px;
+  }
 
   &:first-of-type {
     margin-top: -20px;
@@ -1731,7 +1735,6 @@ div.commands {
   }
 
   .clip-fade {
-    display: none;
     position: absolute;
     left: 0;
     right: 0;
@@ -1743,10 +1746,6 @@ div.commands {
   }
 
   &.clipped {
-    .clip-fade {
-      display: block;
-    }
-
     max-height: 200px;
     overflow: hidden;
   }


### PR DESCRIPTION
The problem was that items began in an unclipped state, then when they were added to the DOM, they became "clipped" and the animation began going from max-height 50000px -> 200px.

This way they begin in a clipped state first.

/cc @getsentry/ui @ckj
