### PR TITLE
Remember used 2FA OTP tokens

### DIFF
--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -349,6 +349,11 @@ class OtpMixin(object):
             )
 
     def check_otp_counter(self, counter):
+        # OTP uses an internal counter that increments every 30 seconds.
+        # A hash function generates a six digit code based on the counter
+        # and a secret key.  If the generated PIN was used it is marked in
+        # redis as used by remembering which counter it was generated
+        # from.  This is what we check for here.
         cache_key = self._get_otp_counter_cache_key(counter)
         return cache_key is None or cache.get(cache_key) != '1'
 

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -344,7 +344,7 @@ class OtpMixin(object):
     def _get_otp_counter_cache_key(self, counter):
         if self.authenticator is not None:
             return 'used-otp-counters:%s:%s' % (
-                self.authenticator.user.id,
+                self.authenticator.user_id,
                 counter,
             )
 


### PR DESCRIPTION
This prevents replay attacks by marking used OTP tokens in the cache for a few minutes. This should not _really_ matter but you can never be too secure.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3572)

<!-- Reviewable:end -->
