### PR TITLE
Improve consistency of acceptance tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -10,7 +10,8 @@ from __future__ import absolute_import
 
 __all__ = (
     'TestCase', 'TransactionTestCase', 'APITestCase', 'AuthProviderTestCase',
-    'RuleTestCase', 'PermissionTestCase', 'PluginTestCase', 'CliTestCase', 'LiveServerTestCase', 'AcceptanceTestCase',
+    'RuleTestCase', 'PermissionTestCase', 'PluginTestCase', 'CliTestCase',
+    'AcceptanceTestCase',
 )
 
 import base64
@@ -26,7 +27,7 @@ from django.contrib.auth import login
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.http import HttpRequest
-from django.test import TestCase, TransactionTestCase, LiveServerTestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils.importlib import import_module
 from django.utils.text import slugify
 from exam import before, fixture, Exam
@@ -250,10 +251,6 @@ class TransactionTestCase(BaseTestCase, TransactionTestCase):
     pass
 
 
-class LiveServerTestCase(BaseTestCase, LiveServerTestCase):
-    pass
-
-
 class APITestCase(BaseTestCase, BaseAPITestCase):
     pass
 
@@ -446,14 +443,17 @@ class CliTestCase(TestCase):
         return self.runner.invoke(self.command, args, obj={})
 
 
-@pytest.mark.usefixtures('browser_class', 'percy_class', 'screenshots_path_class')
-class AcceptanceTestCase(LiveServerTestCase):
+@pytest.mark.usefixtures(
+    'browser_class', 'live_server_class', 'percy_class',
+    'screenshots_path_class'
+)
+class AcceptanceTestCase(TransactionTestCase):
     # Use class setup/teardown to hold Selenium and Percy state across all acceptance tests.
     # For Selenium, this is done for performance to re-use the same browser across tests.
     # For Percy, this is done to call initialize and then finalize at the very end after all tests.
     def save_session(self):
         # XXX(dcramer): "hit a url before trying to set cookies"
-        if not hasattr(self.browser, '_has_initialized_cookie_store'):
+        if not getattr(self.browser, '_has_initialized_cookie_store', False):
             self.browser.get(self.route('/'))
             self.browser._has_initialized_cookie_store = True
 

--- a/src/sentry/utils/pytest.py
+++ b/src/sentry/utils/pytest.py
@@ -178,7 +178,7 @@ def percy(request, browser):
 
 
 @pytest.fixture(scope='session')
-def browser(request):
+def browser(request, live_server):
     # Initialize Selenium.
     # NOTE: this relies on the phantomjs binary packaged from npm to be in the right
     # location in node_modules.
@@ -199,6 +199,12 @@ def browser(request):
 
     request.addfinalizer(fin)
     return browser
+
+
+@pytest.fixture(scope='class')
+def live_server_class(request, live_server):
+    request.cls.live_server = live_server
+    request.cls.live_server_url = live_server.url
 
 
 @pytest.fixture(scope='class')
@@ -227,6 +233,8 @@ def percy_class(request, percy):
 def reset_browser_session(request):
     if not hasattr(request, 'browser'):
         return
+
+    browser = request.browser
 
     browser.delete_all_cookies()
     browser.get('about:blank')

--- a/tests/acceptance/test_auth.py
+++ b/tests/acceptance/test_auth.py
@@ -12,6 +12,9 @@ class AuthTest(AcceptanceTestCase):
             self.browser.find_element_by_id('id_username').send_keys(username)
             self.browser.find_element_by_id('id_password').send_keys(password)
             self.browser.find_element_by_xpath("//button[contains(text(), 'Login')]").click()
+            # give it one second to make sure the request goes through and we
+            # dont immediately re-set the captcha value
+            self.browser.implicitly_wait(1)
 
     def test_auth_page(self):
         self.browser.get(self.live_server_url)

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from datetime import datetime
+from django.utils import timezone
+
 from sentry.testutils import AcceptanceTestCase
 from sentry.utils.samples import create_sample_event
 
@@ -23,8 +26,23 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
         self.login_as(self.user)
 
+    def create_sample_event(self, platform):
+        event = create_sample_event(
+            project=self.project,
+            platform=platform,
+            event_id='d964fdbd649a4cf8bfc35d18082b6b0e',
+            timestamp=1452683305,
+        )
+        event.group.update(
+            first_seen=datetime(2015, 8, 13, 3, 8, 25, tzinfo=timezone.utc),
+            last_seen=datetime(2016, 1, 13, 3, 8, 25, tzinfo=timezone.utc),
+        )
+        return event
+
     def test_python_event(self):
-        event = create_sample_event(self.project, platform='python')
+        event = self.create_sample_event(
+            platform='python',
+        )
 
         self.browser.get(self.route(
             '/{}/{}/issues/{}/', self.org.slug, self.project.slug, event.group.id
@@ -33,7 +51,9 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.snapshot('issue details python')
 
     def test_cocoa_event(self):
-        event = create_sample_event(self.project, platform='cocoa')
+        event = self.create_sample_event(
+            platform='cocoa',
+        )
 
         self.browser.get(self.route(
             '/{}/{}/issues/{}/', self.org.slug, self.project.slug, event.group.id


### PR DESCRIPTION
- Fixed event IDs and dates
- Add delay on login (to avoid setting being wiped)
- Move live_server to pytest fixture
