### PR TITLE
Replace django-social-auth's url sanitization with better

### DIFF
--- a/src/sentry/social_auth/urls.py
+++ b/src/sentry/social_auth/urls.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, print_function
+
+from django.conf.urls import patterns, url
+
+from social_auth.views import complete
+from sentry.social_auth.views import auth, disconnect
+
+
+urlpatterns = patterns('',
+    # authentication
+    url(r'^login/(?P<backend>[^/]+)/$', auth,
+        name='socialauth_begin'),
+    url(r'^complete/(?P<backend>[^/]+)/$', complete,
+        name='socialauth_complete'),
+
+    # XXX: Deprecated, this URLs are deprecated, instead use the login and
+    #      complete ones directly, they will differentiate the user intention
+    #      by checking it's authenticated status association.
+    url(r'^associate/(?P<backend>[^/]+)/$', auth,
+        name='socialauth_associate_begin'),
+    url(r'^associate/complete/(?P<backend>[^/]+)/$', complete,
+        name='socialauth_associate_complete'),
+
+    # disconnection
+    url(r'^disconnect/(?P<backend>[^/]+)/$', disconnect,
+        name='socialauth_disconnect'),
+    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>[^/]+)/$',
+        disconnect, name='socialauth_disconnect_individual'),
+)

--- a/src/sentry/social_auth/views.py
+++ b/src/sentry/social_auth/views.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import, print_function
+
+
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect, HttpResponse
+from django.utils.http import is_safe_url
+
+from social_auth.decorators import dsa_view, disconnect_view
+from social_auth.utils import setting, backend_setting, clean_partial_pipeline
+
+
+DEFAULT_REDIRECT = setting('SOCIAL_AUTH_LOGIN_REDIRECT_URL',
+                           setting('LOGIN_REDIRECT_URL'))
+
+
+@login_required
+@dsa_view()
+@disconnect_view
+def disconnect(request, backend, association_id=None):
+    """Disconnects given backend from current logged in user."""
+    backend.disconnect(request.user, association_id)
+    data = request.REQUEST
+    if REDIRECT_FIELD_NAME in data:
+        redirect = data[REDIRECT_FIELD_NAME]
+        # NOTE: Django's `is_safe_url` is much better at catching bad
+        # redirections to different domains than social_auth's
+        # `sanitize_redirect` call.
+        if not is_safe_url(redirect, host=request.get_host()):
+            redirect = DEFAULT_REDIRECT
+    else:
+        redirect = backend_setting(backend, 'SOCIAL_AUTH_DISCONNECT_REDIRECT_URL')
+        if not redirect:
+            redirect = DEFAULT_REDIRECT
+    return HttpResponseRedirect(redirect)
+
+
+@dsa_view(setting('SOCIAL_AUTH_COMPLETE_URL_NAME', 'socialauth_complete'))
+def auth(request, backend):
+    """Start authentication process"""
+    return auth_process(request, backend)
+
+
+def auth_process(request, backend):
+    """Authenticate using social backend"""
+    data = request.POST if request.method == 'POST' else request.GET
+
+    # Save extra data into session.
+    for field_name in setting('SOCIAL_AUTH_FIELDS_STORED_IN_SESSION', []):
+        if field_name in data:
+            request.session[field_name] = data[field_name]
+
+    # Save any defined next value into session
+    if REDIRECT_FIELD_NAME in data:
+        # Check and sanitize a user-defined GET/POST next field value
+        redirect = data[REDIRECT_FIELD_NAME]
+        # NOTE: Django's `is_safe_url` is much better at catching bad
+        # redirections to different domains than social_auth's
+        # `sanitize_redirect` call.
+        if not is_safe_url(redirect, host=request.get_host()):
+            redirect = DEFAULT_REDIRECT
+        request.session[REDIRECT_FIELD_NAME] = redirect or DEFAULT_REDIRECT
+
+    # Clean any partial pipeline info before starting the process
+    clean_partial_pipeline(request)
+
+    if backend.uses_redirect:
+        return HttpResponseRedirect(backend.auth_url())
+    else:
+        return HttpResponse(backend.auth_html(),
+                            content_type='text/html;charset=UTF-8')

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -226,7 +226,7 @@ urlpatterns += patterns(
         name='sentry-account-email-unsubscribe-project'),
     url(r'^account/remove/$', RemoveAccountView.as_view(),
         name='sentry-remove-account'),
-    url(r'^account/settings/social/', include('social_auth.urls')),
+    url(r'^account/settings/social/', include('sentry.social_auth.urls')),
 
     # Admin
     url(r'^manage/queue/$', AdminQueueView.as_view(),


### PR DESCRIPTION
Specifically, this is vendorizing the two views, `auth`, and
`disconnect` into our app, so that we can fix this behavior.

django-social-auth's `sanitize_redirect` doesn't catch all of the attack
vectors that django's `is_safe_url` checks for.

So this is mostly a vendor + the changes we need.

@getsentry/infrastructure @dcramer 
