### PR TITLE
Guard against empty key sequence provided to `RedisTSDB.get_distinct_counts_union`.

### DIFF
--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -295,6 +295,9 @@ class RedisTSDB(BaseTSDB):
         return {key: value.value for key, value in responses.iteritems()}
 
     def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
+        if not keys:
+            return 0
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         temporary_id = uuid.uuid1().hex

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -150,6 +150,7 @@ class RedisTSDBTest(TestCase):
             2: 2,
         }
 
+        assert self.db.get_distinct_counts_union(model, [], dts[0], dts[-1], rollup=3600) == 0
         assert self.db.get_distinct_counts_union(model, [1, 2], dts[0], dts[-1], rollup=3600) == 3
 
     def test_frequency_tables(self):


### PR DESCRIPTION
If no keys were provided, the `random.choice` that is used to choose the host to do the final cardinality check would error. If there are no keys provided, we know that the cardinality is 0, so it's safe to just return that.

@getsentry/infrastructure @mattrobenolt 
