### PR TITLE
Fix invalid whitespace char in release version

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import string
 
 from django.db import IntegrityError, transaction
 from django.utils import timezone
@@ -42,6 +43,12 @@ class ReleaseSerializer(serializers.Serializer):
     owner = UserField(required=False)
     dateStarted = serializers.DateTimeField(required=False)
     dateReleased = serializers.DateTimeField(required=False)
+
+    def validate_version(self, attrs, source):
+        value = attrs[source]
+        if not set(value).isdisjoint(set(string.whitespace)):
+            raise serializers.ValidationError('Enter a valid value')
+        return attrs
 
 
 class ProjectReleasesEndpoint(ProjectEndpoint):


### PR DESCRIPTION
I had an issue with my Sentry server.  It does not deal with `\n` in `version` string.

The `serializers.RegexField` in `ReleaseSerializer` for `version` only accepts `[a-zA-Z0-9\-_\.]` (or at least it meant to), but there are edge cases as it will allow strings such as `abc\n`, `abc\n\n\n`, `\nabc`, `a\nbc` etc to pass.

The release detail endpoint needs the `version` as the identifier, while it's URL escaped and the `\n` is replaced by `%0A`.  The `\n` char(s) in version will cause such endpoint useless as it's always `404` (of cause).

Example:

```
[
  {
    "shortVersion": "2016.06.21-5-g85652e8\n",
    "version": "2016.06.21-5-g85652e8\n",
    "lastEvent": "2016-06-23T18:55:27Z",
    "owner": null,
    "dateCreated": "2016-06-23T18:55:27Z",
    "url": null,
    "newGroups": 1,
    "data": {
    },
    "dateStarted": null,
    "dateReleased": null,
    "firstEvent": "2016-06-23T18:55:28.342Z",
    "ref": null
  }
]
```

And the URL is like:

```
/releases/2016.06.21-5-g85652e8%0A/
```

In this case, there is NO WAY to use the API to GET/PUT/DELETE the resource.  I had to use Django shell to fix the version string first.

This fix will invalidate any white space char.
