### PR TITLE
add status and assignee for github plugin

### DIFF
--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -376,6 +376,23 @@ class IPlugin(local, PluggableViewMixin):
         """
         return action_list
 
+    def extras(self, request, group, extras_list, **kwargs):
+        """
+        Modifies the extras list for a grouped message.
+
+        An extra is a dict containing additional details
+        about issues linked via plugins.
+
+        {'status': 'open'}
+
+        This must return ``extras_list``.
+
+        >>> def extras(self, request, group, extras_list, **kwargs):
+        >>>     extras_list.append({'status': 'open'})
+        >>>     return extras_list
+        """
+        return extras_list
+
     def panels(self, request, group, panel_list, **kwargs):
         """
         Modifies the panel list for a grouped message.

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -303,6 +303,20 @@ class IPlugin2(local):
         """
         return []
 
+    def get_extras(self, request, group, **kwargs):
+        """
+        Return a list of available extras to append this aggregate.
+
+        An extra is a dict containing additional details
+        about issues linked via plugins.
+
+        {'status': 'open'}
+
+        >>> def get_extras(self, request, group, **kwargs):
+        >>>     return [{'status': 'open'}]
+        """
+        return []
+
     def get_annotations(self, group, **kwargs):
         """
         Return a list of annotations to append to this aggregate.

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -140,6 +140,12 @@ class IssueTrackingPlugin(Plugin):
         """
         raise NotImplementedError
 
+    def get_issue_extras(self, request, group, issue_id):
+        """
+        Given an issue_id return useful details about an issue
+        """
+        return None
+
     def get_issue_label(self, group, issue_id, **kwargs):
         """
         Given an issue_id (string) return a string representing the issue.
@@ -315,6 +321,17 @@ class IssueTrackingPlugin(Plugin):
         ))
 
         return tag_list
+
+    def extras(self, request, group, extras_list, **kwargs):
+        if not self.is_configured(request=request, project=group.project):
+            return extras_list
+
+        prefix = self.get_conf_key()
+        issue_id = GroupMeta.objects.get_value(group, '%s:tid' % prefix)
+        if not issue_id:
+            return extras_list
+
+        extras_list.append(self.get_issue_extras(request, group, issue_id))
 
     def get_issue_doc_html(self, **kwargs):
         return ""

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -10,6 +10,7 @@ import IndicatorStore from '../../stores/indicatorStore';
 import ListLink from '../../components/listLink';
 import ShortId from '../../components/shortId';
 import ProjectState from '../../mixins/projectState';
+import PluginExtras from './pluginExtras';
 import {t} from '../../locale';
 
 const GroupHeader = React.createClass({
@@ -188,6 +189,9 @@ const GroupHeader = React.createClass({
             </div>
           </div>
         </div>
+        {group.pluginExtras && group.pluginExtras.map(function(p, i) {
+          return <PluginExtras key={i} pluginExtras={p}/>;
+        })}
         <GroupSeenBy />
         <GroupActions />
         {orgFeatures.has('shared-issues') &&

--- a/src/sentry/static/sentry/app/views/groupDetails/pluginExtras.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/pluginExtras.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const PluginExtras = React.createClass({
+  propTypes: {
+    pluginExtras: React.PropTypes.object.isRequired
+  },
+
+  render() {
+    let pluginExtras = this.props.pluginExtras;
+    return (
+      <div className="plugin-extras">
+        <ul className="mini-tag-list">
+          <li>{pluginExtras.label + ' Assignee: ' + (pluginExtras.assignee || 'unassigned')}</li>
+          <li>{pluginExtras.label + ' Status: ' + pluginExtras.status}</li>
+        </ul>
+      </div>
+    );
+  }
+});
+
+export default PluginExtras;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -79,6 +79,15 @@
     }
   }
 
+  .plugin-extras {
+    width: 50%;
+    color: #929dae;
+    font-size: 13px;
+    .mini-tag-list {
+      margin-bottom: 0px;
+    }
+  }
+
   .count span {
     font-size: 24px;
     display: block;


### PR DESCRIPTION
not totally sure about this approach since it requires a request to the github api for every request to the group details api if there is a linked github issue. however, this api doesn't **seem** to be used on pages where there are tons of groups listed (for example the stream) so maybe it's ok?

also see accompanying pr: https://github.com/getsentry/sentry-github/pull/32
@dcramer @mattrobenolt 

cc @getsentry/ui 

![screenshot 2016-06-23 17 59 10](https://cloud.githubusercontent.com/assets/5026776/16324755/3ba85d18-396c-11e6-8ae6-676b3dd05c9a.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3588)

<!-- Reviewable:end -->
