### PR TITLE
exclude link existing issue form completely when not supported

### DIFF
--- a/src/sentry/templates/sentry/plugins/bases/issue/create_issue.html
+++ b/src/sentry/templates/sentry/plugins/bases/issue/create_issue.html
@@ -48,22 +48,24 @@
             </form>
         </div>
 
-        <div class="tab-pane{% if op == "link" %} active{% endif %}" id="link">
-            <form class="form-stacked" action="" method="post">
-                {% csrf_token %}
-                {{ link_form|as_crispy_errors }}
-                <input type="hidden" name="next" value="{{ next }}" />
-                <input type="hidden" name="op" value="link" />
-                <fieldset>
-                    {% for field in link_form %}
-                        {{ field|as_crispy_field }}
-                    {% endfor %}
-                </fieldset>
-                <p class="actions">
-                    <button type="submit" class="btn btn-primary">{% trans "Link Issue" %}</button>
-                </p>
-            </form>
-        </div>
+        {% if can_link_existing_issues %}
+            <div class="tab-pane{% if op == "link" %} active{% endif %}" id="link">
+                <form class="form-stacked" action="" method="post">
+                    {% csrf_token %}
+                    {{ link_form|as_crispy_errors }}
+                    <input type="hidden" name="next" value="{{ next }}" />
+                    <input type="hidden" name="op" value="link" />
+                    <fieldset>
+                        {% for field in link_form %}
+                            {{ field|as_crispy_field }}
+                        {% endfor %}
+                    </fieldset>
+                    <p class="actions">
+                        <button type="submit" class="btn btn-primary">{% trans "Link Issue" %}</button>
+                    </p>
+                </form>
+            </div>
+        {% endif %}
 
     </div>
 {% endblock %}


### PR DESCRIPTION
this would have broken sentry-jira auto-submitting on issue type change, buuuut it was already broken (see https://github.com/getsentry/sentry-jira/pull/105)

@dcramer @mattrobenolt 
