### PR TITLE
Render "message" as final crumb when no exception

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
@@ -98,7 +98,10 @@ const BreadcrumbsInterface = React.createClass({
     }
 
     if (crumb) {
-      crumb.timestamp = evt.dateCreated;
+      Object.assign(crumb, {
+        timestamp: evt.dateCreated,
+        last: true
+      });
     }
 
     return crumb;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
@@ -96,7 +96,11 @@ const BreadcrumbsInterface = React.createClass({
         message: evt.message
       };
     }
-    crumb.timestamp = evt.dateCreated;
+
+    if (crumb) {
+      crumb.timestamp = evt.dateCreated;
+    }
+
     return crumb;
   },
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -18,20 +18,25 @@ const Breadcrumb = React.createClass({
 
   getClassName() {
     let {crumb} = this.props;
-    let rv = 'crumb crumb-default crumb-' + crumb.level;
+
+    // use Set to avoid duplicate crumb classes (was previously adding
+    // values like "crumb-default" as many as three times)
+    let classes = new Set(['crumb', 'crumb-default', 'crumb-' + crumb.level]);
+
     if (crumb.type !== 'default') {
-      rv += ' crumb-' + crumb.type.replace(/[\s_]+/g, '-').toLowerCase();
+      classes.add('crumb-' + crumb.type.replace(/[\s_]+/g, '-').toLowerCase());
     }
+
     // special case for 'ui.' category breadcrumbs
     // TODO: find a better way to customize UI around non-schema data
     if (crumb.category && crumb.category.slice(0, 3) === 'ui.') {
-      rv += ' crumb-user';
+      classes.add('crumb-user');
     }
 
     if (crumb.last) {
-      rv += ' crumb-last';
+      classes.add('crumb-last');
     }
-    return rv;
+    return [...classes].join(' ');
   },
 
   renderType() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -27,6 +27,10 @@ const Breadcrumb = React.createClass({
     if (crumb.category && crumb.category.slice(0, 3) === 'ui.') {
       rv += ' crumb-user';
     }
+
+    if (crumb.last) {
+      rv += ' crumb-last';
+    }
     return rv;
   },
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -2112,12 +2112,12 @@ ul.crumbs {
       &:before {
         background: #F1D8D5;
       }
+    }
 
-      &:last-child {
-        &:before {
-           bottom: auto;
-           height: 20px;
-        }
+    &.crumb-last {
+      &:before {
+         bottom: auto;
+         height: 20px;
       }
     }
   }


### PR DESCRIPTION
We were only rendering "exception" events as breadcrumbs. This adds "message" events (no exception attached).

![image](https://cloud.githubusercontent.com/assets/2153/16435185/f056835e-3d48-11e6-8fa4-a04c0addb36a.png)

/cc @getsentry/ui
