### PR TITLE
Whitelist url protocols to render with markdown

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/note.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note.jsx
@@ -5,8 +5,10 @@ import TimeSince from '../../components/timeSince';
 import ConfigStore from '../../stores/configStore';
 import LinkWithConfirmation from '../../components/linkWithConfirmation';
 import {t} from '../../locale';
+import Renderer from '../../utils/marked';
 
 marked.setOptions({
+  renderer: new Renderer(),
   // Disable all HTML input and only accept Markdown
   sanitize: true
 });

--- a/src/sentry/static/sentry/app/utils/marked.jsx
+++ b/src/sentry/static/sentry/app/utils/marked.jsx
@@ -1,0 +1,53 @@
+import marked from 'marked';
+
+function isSafeHref(href, pattern) {
+  try {
+    return pattern.test(decodeURIComponent(unescape(href)));
+  } catch(e) {
+    return false;
+  }
+}
+
+
+// We need to implement our own marked Renderer to not render
+// potentially malicious uris.
+// This is copy/pasted from
+// https://github.com/chjj/marked/blob/master/lib/marked.js#L869-L888
+// and modified.
+function Renderer() {
+  return marked.Renderer.apply(this, arguments);
+}
+Object.assign(Renderer.prototype, marked.Renderer.prototype);
+
+// Anythign except javascript, vbscript, data protocols
+const safeLinkPattern = /^(?!javascript|vbscript|data:)/i;
+
+Renderer.prototype.link = function(href, title, text) {
+  // For a bad link, just return the plain text href
+  if (this.options.sanitize && !isSafeHref(href, safeLinkPattern)) return href;
+
+  let out = '<a href="' + href + '"';
+  if (title) {
+    out += ' title="' + title + '"';
+  }
+  out += '>' + text + '</a>';
+  return out;
+};
+
+
+// Only allow http(s) for image tags
+const safeImagePattern = /^https?:\/\/./i;
+
+Renderer.prototype.image = function(href, title, text) {
+  // For a bad image, return an empty string
+  if (this.options.sanitize && !isSafeHref(href, safeImagePattern)) return '';
+
+  let out = '<img src="' + href + '" alt="' + text + '"';
+  if (title) {
+    out += ' title="' + title + '"';
+  }
+  out += this.options.xhtml ? '/>' : '>';
+  return out;
+};
+
+export default Renderer;

--- a/tests/js/spec/utils/marked.spec.jsx
+++ b/tests/js/spec/utils/marked.spec.jsx
@@ -1,0 +1,56 @@
+/*eslint no-script-url:0*/
+
+import marked from 'marked';
+import Renderer from 'app/utils/marked';
+
+function expectMarkdown(test) {
+  expect(marked(test[0])).to.eql('<p>' + test[1] + '</p>\n');
+}
+
+describe('marked', function () {
+  beforeEach(function () {
+    marked.options = marked.defaults;
+    marked.setOptions({
+      sanitize: true,
+      renderer: new Renderer()
+    });
+  });
+
+  it('normal links get rendered as html', function () {
+    for (let test of [
+      ['[x](http://example.com)', '<a href="http://example.com">x</a>'],
+      ['[x](https://example.com)', '<a href="https://example.com">x</a>'],
+      ['[x](mailto:foo@example.com)', '<a href="mailto:foo@example.com">x</a>'],
+    ]) {
+      expectMarkdown(test);
+    }
+  });
+
+  it('rejected links should be rendered as plain text', function () {
+    for (let test of [
+      ['[x](javascript:foo)', 'javascript:foo'],
+      ['[x](data:foo)', 'data:foo'],
+      ['[x](vbscript:foo)', 'vbscript:foo'],
+    ]) {
+      expectMarkdown(test);
+    }
+  });
+
+  it('normal images get rendered as html', function () {
+    for (let test of [
+      ['![](http://example.com)', '<img src="http://example.com" alt="">'],
+      ['![x](http://example.com)', '<img src="http://example.com" alt="x">'],
+      ['![x](https://example.com)', '<img src="https://example.com" alt="x">'],
+    ]) {
+      expectMarkdown(test);
+    }
+  });
+
+  it('rejected images shouldn\'t be rendered at all', function() {
+    for (let test of [
+      ['![x](javascript:foo)', ''],
+    ]) {
+      expectMarkdown(test);
+    }
+  });
+});


### PR DESCRIPTION
This implements a custom marked Renderer class which replaces the `link`
and `image` methods. The changes are:
- Restrict javascript, vbscript, and data uris from links
- When linking to an invalid protocol, just return plaintext href
  instead of linking it up, that way if someone is trying to link to
  something and we block it, the content is at least visible without
  hiding it entirely.
- Only allow http(s) uris in image tags

@getsentry/javascript 
