### PR TITLE
Update email templates to support event type display.

### DIFF
--- a/src/sentry/templates/sentry/emails/_group.html
+++ b/src/sentry/templates/sentry/emails/_group.html
@@ -1,0 +1,20 @@
+{% load sentry_helpers %}
+
+{% url 'sentry-group' group.organization.slug group.project.slug group.id as group_link %}
+
+{% if group.data.type == "error" %}
+  <div class="event-type error">
+    <h3>
+      <a href="{% absolute_uri group_link %}">{{ group.data.metadata.type }}</a>
+      <small>{{ group.title|soft_break:50 }}</small>
+    </h3>
+    <p>{{ group.data.metadata.value }}</p>
+  </div>
+{% else %}
+  <div class="event-type default">
+    <h3>
+      <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
+    </h3>
+    <p>{{ group.title|soft_break:50 }}</p>
+  </div>
+{% endif %}

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -32,23 +32,7 @@
                       <span class="level level-{{ group.get_level_display }}">{{ group.get_level_display }}</span>
                   </td>
                   <td class="event-detail">
-                      {% url 'sentry-group' group.organization.slug group.project.slug group.id as group_link %}
-                      {% if group.data.type == "error" %}
-                        <div class="event-type error">
-                          <h3>
-                            <a href="{% absolute_uri group_link %}">{{ group.data.metadata.type }}</a>
-                            <small>{{ group.title|soft_break:50 }}</small>
-                          </h3>
-                          <p>{{ group.data.metadata.value }}</p>
-                        </div>
-                      {% else %}
-                        <div class="event-type default">
-                          <h3>
-                            <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
-                          </h3>
-                          <p>{{ group.title|soft_break:50 }}</p>
-                        </div>
-                      {% endif %}
+                      {% include "sentry/emails/_group.html" %}
                       <p>
                         {{ group.title|soft_break:50 }}
                         <small>&mdash; {{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -34,8 +34,7 @@
                   <td class="event-detail">
                       {% include "sentry/emails/_group.html" %}
                       <p>
-                        {{ group.title|soft_break:50 }}
-                        <small>&mdash; {{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
+                        <small>{{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
                       </p>
                   </td>
               </tr>

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -33,7 +33,22 @@
                   </td>
                   <td class="event-detail">
                       {% url 'sentry-group' group.organization.slug group.project.slug group.id as group_link %}
-                      <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
+                      {% if group.data.type == "error" %}
+                        <div class="event-type error">
+                          <h3>
+                            <a href="{% absolute_uri group_link %}">{{ group.data.metadata.type }}</a>
+                            <small>{{ group.title|soft_break:50 }}</small>
+                          </h3>
+                          <p>{{ group.data.metadata.value }}</p>
+                        </div>
+                      {% else %}
+                        <div class="event-type default">
+                          <h3>
+                            <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
+                          </h3>
+                          <p>{{ group.title|soft_break:50 }}</p>
+                        </div>
+                      {% endif %}
                       <p>
                         {{ group.title|soft_break:50 }}
                         <small>&mdash; {{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -457,9 +457,9 @@
 
   .digest td.error-level {
     padding: 0;
-    padding-top: 12px;
+    padding-top: 14px;
     padding-right: 18px;
-    width: 46px;
+    width: 38px;
     vertical-align: top;
   }
 
@@ -505,16 +505,26 @@
     text-align: left;
   }
 
-  table.event-list .event-detail a {
-    font-size: 17px;
+  table.event-list .event-detail h3 {
+    margin-bottom: 0;
+    line-height: 1.1;
+  }
+
+  table.event-list .event-detail h3 a {
+    font-size: 16px;
     color: #15A7F6;
     font-weight: 600;
   }
 
+  table.event-list .event-detail h3 small {
+    font-size: 16px;
+  }
+
   table.event-list .event-detail p {
-    margin: 0;
+    margin: 0 0 2px;
     font-size: 15px;
-    color: #687276;
+    color: #474f56;
+    line-height: 1.3;
   }
 
   table.event-list .more-events {

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -313,6 +313,7 @@
 
   .inner .group-header table td {
     padding: 0;
+    vertical-align: top;
   }
 
   .inner .group-header table th.align-right {
@@ -357,6 +358,20 @@
     text-align: center;
     line-height: inherit;
     display: block;
+  }
+
+  /* Event type */
+
+  .event-type h3 a {
+    font-size: 15px;
+  }
+
+  .event-type h3 small {
+    font-size: 15px;
+  }
+
+  .event-type p {
+    margin: 0;
   }
 
   /* Note */

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -273,14 +273,6 @@
     padding-top: 30px;
   }
 
-  .group-header h3 {
-    margin: 0 0 4px;
-    font-size: 18px;
-    word-wrap: break-word;
-    word-break: break-all;
-    line-height: 1.1;
-  }
-
   .group-header .group-message {
     padding: 0 15px 0 0;
     width: 400px;
@@ -362,16 +354,23 @@
 
   /* Event type */
 
+  .event-type h3 {
+      line-height: 24px;
+      margin: 0;
+  }
+
   .event-type h3 a {
-    font-size: 15px;
+    font-size: 16px;
+    font-weight: 600;
   }
 
   .event-type h3 small {
-    font-size: 15px;
+    font-size: 14px;
   }
 
   .event-type p {
     margin: 0;
+    font-size: 14px;
   }
 
   /* Note */
@@ -516,30 +515,14 @@
   }
 
   table.event-list .event-detail {
+    line-height: 24px;
     width: 400px;
     text-align: left;
   }
 
-  table.event-list .event-detail h3 {
-    margin-bottom: 0;
-    line-height: 1.1;
-  }
-
-  table.event-list .event-detail h3 a {
-    font-size: 16px;
-    color: #15A7F6;
-    font-weight: 600;
-  }
-
-  table.event-list .event-detail h3 small {
-    font-size: 16px;
-  }
-
   table.event-list .event-detail p {
-    margin: 0 0 2px;
-    font-size: 15px;
-    color: #474f56;
-    line-height: 1.3;
+    margin: 0;
+    color: #546076;
   }
 
   table.event-list .more-events {
@@ -547,6 +530,7 @@
     text-align: left;
     font-size: 14px;
   }
+
 
   @media only screen and (max-device-width: 480px) {
     /* mobile-specific CSS styles */

--- a/src/sentry/templates/sentry/emails/group_header.html
+++ b/src/sentry/templates/sentry/emails/group_header.html
@@ -16,7 +16,7 @@
     </thead>
     <tr>
       <td class="group-message">
-        <h3>{{ group.message_short }}</h3>
+        {% include "sentry/emails/_group.html" %}
         <p class="meta">
           <span class="count">Seen <strong>{{ group.times_seen }}</strong> time{{ group.times_seen|pluralize }}.</span>
           <span class="last-seen pretty-date"> Last seen: {{ group.last_seen }} UTC</span>

--- a/src/sentry/templates/sentry/emails/group_header.html
+++ b/src/sentry/templates/sentry/emails/group_header.html
@@ -18,12 +18,14 @@
       <td class="group-message">
         {% include "sentry/emails/_group.html" %}
         <p class="meta">
-          <span class="count">Seen <strong>{{ group.times_seen }}</strong> time{{ group.times_seen|pluralize }}.</span>
-          <span class="last-seen pretty-date"> Last seen: {{ group.last_seen }} UTC</span>
-          {% if group.avg_time_spent %}
-            <span class="time-spent">{{ group.avg_time_spent|duration }}</span>
-          {% endif %}
-          in <a href="{% absolute_uri project_link %}"><strong>{{ group.project.organization.slug }} / {{ group.project.slug }}</strong></a>
+          <small>
+            <span class="count">Seen <strong>{{ group.times_seen }}</strong> time{{ group.times_seen|pluralize }}.</span>
+            <span class="last-seen pretty-date"> Last seen: {{ group.last_seen }} UTC</span>
+            {% if group.avg_time_spent %}
+              <span class="time-spent">{{ group.avg_time_spent|duration }}</span>
+            {% endif %}
+            in <a href="{% absolute_uri project_link %}"><strong>{{ group.project.organization.slug }} / {{ group.project.slug }}</strong></a>
+          </small>
         </p>
       </td>
       <td class="group-level">


### PR DESCRIPTION
This causes the digest templates to render differently based on the `group.data.type` attribute.

This fixes GH-3600, where group titles were rendering with unformatted messages, as well as brings the row for each group closer to parity with the web UI (for better or for worse.)

This is somewhat derived from the implementation details in GH-3456, which I'm assuming are correct for groups as well.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3621)

<!-- Reviewable:end -->
