### PR TITLE
Display issue timestamps in email with seconds resolution.

### DIFF
--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -36,7 +36,7 @@
                       <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
                       <p>
                         {{ group.title|soft_break:50 }}
-                        <small>&mdash; {{ records.0.datetime|date:"N j, Y, P e" }}</small>
+                        <small>&mdash; {{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
                       </p>
                   </td>
               </tr>

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -32,7 +32,7 @@
     {% else %}
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
-        <div class="event-date">{{ event.datetime }} UTC</div>
+        <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e" }}</div>
       </div>
 
       {% for label, html, _ in interfaces %}


### PR DESCRIPTION
This was mentioned in a support request. This changes the display format from `July 1, 2016, 1:03 a.m. UTC` to `July 1, 2016, 1:03:22 a.m. UTC`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3622)

<!-- Reviewable:end -->
