### PR TITLE
Added support for minified react exceptions

### DIFF
--- a/src/sentry/lang/javascript/errormapping.py
+++ b/src/sentry/lang/javascript/errormapping.py
@@ -3,6 +3,7 @@ import cgi
 import json
 import time
 import logging
+import random
 
 from django.conf import settings
 from django.core.cache import cache
@@ -13,8 +14,9 @@ from sentry import http
 logger = logging.getLogger(__name__)
 
 
-SOFT_TIMEOUT = 300
-HARD_TIMEOUT = 3600
+SOFT_TIMEOUT = 600
+SOFT_TIMEOUT_FUZZINESS = 10
+HARD_TIMEOUT = 7200
 
 
 REACT_MAPPING_URL = ('https://raw.githubusercontent.com/facebook/'
@@ -25,7 +27,8 @@ error_processors = {}
 
 
 def is_expired(ts):
-    return ts > time.time() - SOFT_TIMEOUT
+    return ts > (time.time() - SOFT_TIMEOUT -
+                 random.random() * SOFT_TIMEOUT_FUZZINESS)
 
 
 class Processor(object):

--- a/src/sentry/lang/javascript/errormapping.py
+++ b/src/sentry/lang/javascript/errormapping.py
@@ -12,6 +12,10 @@ from sentry import http
 logger = logging.getLogger(__name__)
 
 
+REACT_MAPPING_URL = ('https://raw.githubusercontent.com/facebook/'
+                     'react/master/scripts/error-codes/codes.json')
+
+
 error_processors = {}
 
 
@@ -55,8 +59,7 @@ def minified_error(vendor, mapping_url, regex):
 
 @minified_error(
     vendor='react',
-    mapping_url=('https://raw.githubusercontent.com/facebook/'
-                 'react/master/scripts/error-codes/codes.json'),
+    mapping_url=REACT_MAPPING_URL,
     regex=r'Minified React error #(\d+); visit https?://[^?]+\?(\S+)'
 )
 def process_react_exception(exc, match, mapping):

--- a/src/sentry/lang/javascript/errormapping.py
+++ b/src/sentry/lang/javascript/errormapping.py
@@ -1,0 +1,95 @@
+import re
+import cgi
+import json
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+from sentry import http
+
+
+logger = logging.getLogger(__name__)
+
+
+error_processors = {}
+
+
+class Processor(object):
+
+    def __init__(self, vendor, mapping_url, regex, func):
+        self.vendor = vendor
+        self.mapping_url = mapping_url
+        self.regex = re.compile(regex)
+        self.func = func
+
+    def load_mapping(self):
+        key = 'javascript.errormapping:%s' % self.vendor
+        mapping = cache.get(key)
+        if mapping is not None:
+            return json.loads(mapping)
+
+        http_session = http.build_session()
+        response = http_session.get(self.mapping_url,
+            allow_redirects=True,
+            verify=False,
+            timeout=settings.SENTRY_SOURCE_FETCH_TIMEOUT,
+        )
+        data = response.json()
+        cache.set(key, json.dumps(data), 300)
+        return data
+
+    def try_process(self, exc):
+        match = self.regex.search(exc['value'])
+        if match is None:
+            return False
+        mapping = self.load_mapping()
+        return self.func(exc, match, mapping)
+
+
+def minified_error(vendor, mapping_url, regex):
+    def decorator(f):
+        error_processors[vendor] = Processor(vendor, mapping_url, regex, f)
+    return decorator
+
+
+@minified_error(
+    vendor='react',
+    mapping_url=('https://raw.githubusercontent.com/facebook/'
+                 'react/master/scripts/error-codes/codes.json'),
+    regex=r'Minified React error #(\d+); visit https?://[^?]+\?(\S+)'
+)
+def process_react_exception(exc, match, mapping):
+    error_id, qs = match.groups()
+    msg_format = mapping.get(error_id)
+    if msg_format is None:
+        return False
+    args = []
+    for k, v in cgi.parse_qsl(qs):
+        if k == 'args[]':
+            args.append(v)
+    exc['value'] = msg_format % tuple(args)
+    return True
+
+
+def rewrite_exception(data):
+    """Rewrite an exception in an event if needed.  Updates the exception
+    in place and returns `True` if a modification was performed or `False`
+    otherwise.
+    """
+    exc_data = data.get('sentry.interfaces.Exception')
+    if not exc_data:
+        return False
+
+    rv = False
+    for exc in exc_data['values']:
+        for processor in error_processors.itervalues():
+            try:
+                if processor.try_process(exc):
+                    rv = True
+                    break
+            except Exception as e:
+                logger.error('Failed to run processor "%s": %s',
+                             processor.vendor, e, exc_info=True)
+
+    return rv

--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -7,6 +7,7 @@ from sentry.models import Project
 from sentry.plugins import Plugin2
 
 from .processor import SourceProcessor
+from .errormapping import rewrite_exception
 
 
 def preprocess_event(data):
@@ -25,6 +26,8 @@ def preprocess_event(data):
             allow_scraping=allow_scraping,
         )
         processor.process(data)
+
+    rewrite_exception(data)
 
     inject_device_data(data)
 

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -335,42 +335,43 @@ class ErrorMappingTest(TestCase):
         }
         ''', content_type='application/json')
 
-        data = {
-            'platform': 'javascript',
-            'sentry.interfaces.Exception': {
-                'values': [{
-                    'type': 'InvariantViolation',
-                    'value': (
-                        'Minified React error #109; visit http://facebook'
-                        '.github.io/react/docs/error-decoder.html?invariant='
-                        '109&args[]=Component for the full message or use '
-                        'the non-minified dev environment for full errors '
-                        'and additional helpful warnings.'
-                    ),
-                    'stacktrace': {
-                        'frames': [
-                            {
-                                'abs_path': 'http://example.com/foo.js',
-                                'filename': 'foo.js',
-                                'lineno': 4,
-                                'colno': 0,
-                            },
-                            {
-                                'abs_path': 'http://example.com/foo.js',
-                                'filename': 'foo.js',
-                                'lineno': 1,
-                                'colno': 0,
-                            },
-                        ],
-                    },
-                }],
+        for x in xrange(3):
+            data = {
+                'platform': 'javascript',
+                'sentry.interfaces.Exception': {
+                    'values': [{
+                        'type': 'InvariantViolation',
+                        'value': (
+                            'Minified React error #109; visit http://facebook'
+                            '.github.io/react/docs/error-decoder.html?invariant='
+                            '109&args[]=Component for the full message or use '
+                            'the non-minified dev environment for full errors '
+                            'and additional helpful warnings.'
+                        ),
+                        'stacktrace': {
+                            'frames': [
+                                {
+                                    'abs_path': 'http://example.com/foo.js',
+                                    'filename': 'foo.js',
+                                    'lineno': 4,
+                                    'colno': 0,
+                                },
+                                {
+                                    'abs_path': 'http://example.com/foo.js',
+                                    'filename': 'foo.js',
+                                    'lineno': 1,
+                                    'colno': 0,
+                                },
+                            ],
+                        },
+                    }],
+                }
             }
-        }
 
-        assert rewrite_exception(data)
+            assert rewrite_exception(data)
 
-        assert data['sentry.interfaces.Exception']['values'][0]['value'] == (
-            'Component.render(): A valid React element (or null) must be '
-            'returned. You may have returned undefined, an array or '
-            'some other invalid object.'
-        )
+            assert data['sentry.interfaces.Exception']['values'][0]['value'] == (
+                'Component.render(): A valid React element (or null) must be '
+                'returned. You may have returned undefined, an array or '
+                'some other invalid object.'
+            )

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -14,7 +14,9 @@ from sentry.lang.javascript.processor import (
     SourceProcessor, trim_line, UrlResult
 )
 from sentry.lang.javascript.sourcemaps import SourceMap, SourceMapIndex
-from sentry.lang.javascript.errormapping import rewrite_exception
+from sentry.lang.javascript.errormapping import (
+    rewrite_exception, REACT_MAPPING_URL
+)
 from sentry.models import Release
 from sentry.testutils import TestCase
 
@@ -323,7 +325,16 @@ class SourceProcessorTest(TestCase):
 
 class ErrorMappingTest(TestCase):
 
+    @responses.activate
     def test_react_error_mapping_resolving(self):
+        responses.add(responses.GET, REACT_MAPPING_URL, body=r'''
+        {
+          "108": "%s.getChildContext(): key \"%s\" is not defined in childContextTypes.",
+          "109": "%s.render(): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.",
+          "110": "Stateless function components cannot have refs."
+        }
+        ''', content_type='application/json')
+
         data = {
             'platform': 'javascript',
             'sentry.interfaces.Exception': {


### PR DESCRIPTION
This looks up the minified react error codes and expands the message.  It
fetches the error map from github and keeps it cached for two minutes.  We
could expand that if we want.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3632)

<!-- Reviewable:end -->
