### PR TITLE
Implement Flexible Symbolication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ install_requires = [
 ]
 
 dsym_requires = [
-    'symsynd>=0.8.1,<1.0.0',
+    'symsynd>=0.8.2,<1.0.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ install_requires = [
 ]
 
 dsym_requires = [
-    'symsynd>=0.7.0,<1.0.0',
+    'symsynd>=0.8.0,<1.0.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ install_requires = [
 ]
 
 dsym_requires = [
-    'symsynd>=0.8.0,<1.0.0',
+    'symsynd>=0.8.1,<1.0.0',
 ]
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -720,6 +720,7 @@ SENTRY_INTERFACES = {
     'applecrashreport': 'sentry.interfaces.applecrash.AppleCrashReport',
     'breadcrumbs': 'sentry.interfaces.breadcrumbs.Breadcrumbs',
     'contexts': 'sentry.interfaces.contexts.Contexts',
+    'threads': 'sentry.interfaces.threads.Threads',
     'sentry.interfaces.Exception': 'sentry.interfaces.exception.Exception',
     'sentry.interfaces.Message': 'sentry.interfaces.message.Message',
     'sentry.interfaces.Stacktrace': 'sentry.interfaces.stacktrace.Stacktrace',
@@ -731,6 +732,7 @@ SENTRY_INTERFACES = {
     'sentry.interfaces.AppleCrashReport': 'sentry.interfaces.applecrash.AppleCrashReport',
     'sentry.interfaces.Breadcrumbs': 'sentry.interfaces.breadcrumbs.Breadcrumbs',
     'sentry.interfaces.Contexts': 'sentry.interfaces.contexts.Contexts',
+    'sentry.interfaces.Threads': 'sentry.interfaces.threads.Threads',
 }
 
 SENTRY_EMAIL_BACKEND_ALIASES = {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -721,7 +721,7 @@ SENTRY_INTERFACES = {
     'breadcrumbs': 'sentry.interfaces.breadcrumbs.Breadcrumbs',
     'contexts': 'sentry.interfaces.contexts.Contexts',
     'threads': 'sentry.interfaces.threads.Threads',
-    'debug_images': 'sentry.interfaces.debug_images.DebugImages',
+    'debug_meta': 'sentry.interfaces.debug_meta.DebugMeta',
     'sentry.interfaces.Exception': 'sentry.interfaces.exception.Exception',
     'sentry.interfaces.Message': 'sentry.interfaces.message.Message',
     'sentry.interfaces.Stacktrace': 'sentry.interfaces.stacktrace.Stacktrace',
@@ -734,7 +734,7 @@ SENTRY_INTERFACES = {
     'sentry.interfaces.Breadcrumbs': 'sentry.interfaces.breadcrumbs.Breadcrumbs',
     'sentry.interfaces.Contexts': 'sentry.interfaces.contexts.Contexts',
     'sentry.interfaces.Threads': 'sentry.interfaces.threads.Threads',
-    'sentry.interfaces.DebugImages': 'sentry.interfaces.debug_images.DebugImages',
+    'sentry.interfaces.DebugMeta': 'sentry.interfaces.debug_meta.DebugMeta',
 }
 
 SENTRY_EMAIL_BACKEND_ALIASES = {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -721,6 +721,7 @@ SENTRY_INTERFACES = {
     'breadcrumbs': 'sentry.interfaces.breadcrumbs.Breadcrumbs',
     'contexts': 'sentry.interfaces.contexts.Contexts',
     'threads': 'sentry.interfaces.threads.Threads',
+    'debug_images': 'sentry.interfaces.debug_images.DebugImages',
     'sentry.interfaces.Exception': 'sentry.interfaces.exception.Exception',
     'sentry.interfaces.Message': 'sentry.interfaces.message.Message',
     'sentry.interfaces.Stacktrace': 'sentry.interfaces.stacktrace.Stacktrace',
@@ -733,6 +734,7 @@ SENTRY_INTERFACES = {
     'sentry.interfaces.Breadcrumbs': 'sentry.interfaces.breadcrumbs.Breadcrumbs',
     'sentry.interfaces.Contexts': 'sentry.interfaces.contexts.Contexts',
     'sentry.interfaces.Threads': 'sentry.interfaces.threads.Threads',
+    'sentry.interfaces.DebugImages': 'sentry.interfaces.debug_images.DebugImages',
 }
 
 SENTRY_EMAIL_BACKEND_ALIASES = {

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -197,3 +197,11 @@ WARN_SESSION_EXPIRED = 'Your session has expired.'  # TODO: translate this
 EVENT_ORDERING_KEY = attrgetter('datetime', 'id')
 
 FILTER_MASK = '[Filtered]'
+
+# Maximum length of a symbol
+MAX_SYM = 256
+
+# Known dsym mimetypes
+KNOWN_DSYM_TYPES = {
+    'application/x-mach-binary': 'macho'
+}

--- a/src/sentry/data/samples/cocoa.json
+++ b/src/sentry/data/samples/cocoa.json
@@ -389,6 +389,403 @@
             }
         ]
     },
+    "threads": {
+      "list": [
+        {
+          "current": true,
+          "crashed": true,
+          "id": 0,
+          "name": null,
+          "stacktrace": null
+        },
+        {
+          "current": false,
+          "crashed": false,
+          "id": 1,
+          "name": null,
+          "stacktrace": {
+            "frames": [
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 52,
+                "package": "/usr/lib/system/libdispatch.dylib",
+                "filename": null,
+                "symbol_addr": "0x002a93614",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002a93648"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 232,
+                "package": "/usr/lib/system/libdispatch.dylib",
+                "filename": null,
+                "symbol_addr": "0x002aa46f0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002aa47d8"
+              },
+              {
+                "function": "kevent_qos",
+                "abs_path": null,
+                "instruction_offset": 8,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002be14d0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002be14d8"
+              }
+            ]
+          }
+        },
+        {
+          "current": false,
+          "crashed": false,
+          "id": 2,
+          "name": null,
+          "stacktrace": {
+            "frames": [
+              {
+                "function": "_pthread_start",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002cab9f0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002caba8c"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002caba8c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002cabb28"
+              },
+              {
+                "function": "ksmachexc_i_handleExceptions",
+                "abs_path": null,
+                "instruction_offset": 168,
+                "package": "/private/var/containers/Bundle/Application/CDB578A5-7B13-44A7-88BE-4D3867D11CF7/SentryTest.app/Frameworks/KSCrash.framework/KSCrash",
+                "filename": null,
+                "symbol_addr": "0x0000f327c",
+                "lineno": null,
+                "in_app": true,
+                "instruction_addr": "0x0000f3324"
+              },
+              {
+                "function": "thread_suspend",
+                "abs_path": null,
+                "instruction_offset": 80,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002bc9138",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002bc9188"
+              },
+              {
+                "function": "mach_msg",
+                "abs_path": null,
+                "instruction_offset": 72,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002bc4e0c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002bc4e54"
+              },
+              {
+                "function": "mach_msg_trap",
+                "abs_path": null,
+                "instruction_offset": 8,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002bc4fd0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002bc4fd8"
+              }
+            ]
+          }
+        },
+        {
+          "current": false,
+          "crashed": false,
+          "id": 3,
+          "name": null,
+          "stacktrace": {
+            "frames": [
+              {
+                "function": "_pthread_start",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002cab9f0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002caba8c"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002caba8c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002cabb28"
+              },
+              {
+                "function": "ksmachexc_i_handleExceptions",
+                "abs_path": null,
+                "instruction_offset": 220,
+                "package": "/private/var/containers/Bundle/Application/CDB578A5-7B13-44A7-88BE-4D3867D11CF7/SentryTest.app/Frameworks/KSCrash.framework/KSCrash",
+                "filename": null,
+                "symbol_addr": "0x0000f327c",
+                "lineno": null,
+                "in_app": true,
+                "instruction_addr": "0x0000f3358"
+              },
+              {
+                "function": "mach_msg",
+                "abs_path": null,
+                "instruction_offset": 72,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002bc4e0c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002bc4e54"
+              },
+              {
+                "function": "mach_msg_trap",
+                "abs_path": null,
+                "instruction_offset": 8,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002bc4fd0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002bc4fd8"
+              }
+            ]
+          }
+        },
+        {
+          "current": false,
+          "crashed": false,
+          "id": 4,
+          "name": null,
+          "stacktrace": {
+            "frames": [
+              {
+                "function": "_pthread_start",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002cab9f0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002caba8c"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002caba8c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002cabb28"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 1000,
+                "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+                "filename": null,
+                "symbol_addr": "0x003a1ba64",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x003a1be4c"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 412,
+                "package": "/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
+                "filename": null,
+                "symbol_addr": "0x0036a5acc",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x0036a5c68"
+              },
+              {
+                "function": "CFRunLoopRunSpecific",
+                "abs_path": null,
+                "instruction_offset": 384,
+                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "filename": null,
+                "symbol_addr": "0x002f24ad0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002f24c50"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 1032,
+                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "filename": null,
+                "symbol_addr": "0x002ffa55c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002ffa964"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 196,
+                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "filename": null,
+                "symbol_addr": "0x002ffcb9c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002ffcc60"
+              },
+              {
+                "function": "mach_msg",
+                "abs_path": null,
+                "instruction_offset": 72,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002bc4e0c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002bc4e54"
+              },
+              {
+                "function": "mach_msg_trap",
+                "abs_path": null,
+                "instruction_offset": 8,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002bc4fd0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002bc4fd8"
+              }
+            ]
+          }
+        },
+        {
+          "current": false,
+          "crashed": false,
+          "id": 5,
+          "name": null,
+          "stacktrace": {
+            "frames": [
+              {
+                "function": "_pthread_start",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002cab9f0",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002caba8c"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 156,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002caba8c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002cabb28"
+              },
+              {
+                "function": "<redacted>",
+                "abs_path": null,
+                "instruction_offset": 648,
+                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "filename": null,
+                "symbol_addr": "0x003002f40",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x0030031c8"
+              },
+              {
+                "function": "select$DARWIN_EXTSN",
+                "abs_path": null,
+                "instruction_offset": 8,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002be033c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002be0344"
+              }
+            ]
+          }
+        },
+        {
+          "current": false,
+          "crashed": false,
+          "id": 6,
+          "name": null,
+          "stacktrace": {
+            "frames": [
+              {
+                "function": "_pthread_wqthread",
+                "abs_path": null,
+                "instruction_offset": 1284,
+                "package": "/usr/lib/system/libsystem_pthread.dylib",
+                "filename": null,
+                "symbol_addr": "0x002ca902c",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002ca9530"
+              },
+              {
+                "function": "__workq_kernreturn",
+                "abs_path": null,
+                "instruction_offset": 8,
+                "package": "/usr/lib/system/libsystem_kernel.dylib",
+                "filename": null,
+                "symbol_addr": "0x002be0b40",
+                "lineno": null,
+                "in_app": false,
+                "instruction_addr": "0x002be0b48"
+              }
+            ]
+          }
+        },
+        {
+          "current": false,
+          "crashed": false,
+          "id": 7,
+          "name": null,
+          "stacktrace": null
+        }
+      ]
+    },
     "contexts": {
         "device": {
             "model_id": "N78AP",

--- a/src/sentry/data/samples/cocoa.json
+++ b/src/sentry/data/samples/cocoa.json
@@ -390,7 +390,7 @@
         ]
     },
     "threads": {
-      "list": [
+      "values": [
         {
           "current": true,
           "crashed": true,

--- a/src/sentry/data/samples/cocoa.json
+++ b/src/sentry/data/samples/cocoa.json
@@ -1,806 +1,830 @@
 {
-    "sentry.interfaces.User": {
-        "username": "Example",
-        "data": {
-            "is_admin": false
-        },
-        "id": "3",
-        "email": "example@example.com"
+  "sentry.interfaces.User": {
+    "username": "Example",
+    "data": {
+      "is_admin": false
     },
-    "tags": [
-        [
-            "environment",
-            "production"
-        ],
-        [
-            "level",
-            "fatal"
-        ],
-        [
-            "sentry:user",
-            "id:3"
-        ]
+    "id": "3",
+    "email": "example@example.com"
+  },
+  "tags": [
+    [
+      "environment",
+      "production"
     ],
-    "type": "default",
-    "extra": {
-        "foobar": {
-            "foo": "bar"
-        },
-        "some_things": [
-            "green",
-            "red"
-        ],
-        "a_thing": 3
+    [
+      "level",
+      "fatal"
+    ],
+    [
+      "sentry:user",
+      "id:3"
+    ]
+  ],
+  "type": "default",
+  "extra": {
+    "foobar": {
+      "foo": "bar"
     },
-    "sentry.interfaces.Breadcrumbs": {
-        "values": [
-            {
-                "timestamp": 1463071692.0,
-                "type": "ui_event",
-                "data": {
-                    "type": "button",
-                    "target": "onClickBreak"
-                }
-            }
-        ]
-    },
-    "sentry.interfaces.Stacktrace": {
-        "frames": [
-            {
-                "function": "start",
-                "abs_path": null,
-                "instruction_offset": 1,
-                "package": "libdyld.dylib",
-                "filename": null,
-                "symbol_addr": "0x00064f9e8",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00064f9e9"
-            },
-            {
-                "function": "main",
-                "abs_path": "/Users/josh/iOS/Sentry/RavenSwift/Examples/SwiftTVOSExample/SwiftTVOSExample/AppDelegate.swift",
-                "instruction_offset": null,
-                "package": "SwiftTVOSExample",
-                "filename": "AppDelegate.swift",
-                "symbol_addr": "0x00d93c230",
-                "lineno": 12,
-                "in_app": true,
-                "instruction_addr": "0x00d93c2a2"
-            },
-            {
-                "function": "UIApplicationMain",
-                "abs_path": null,
-                "instruction_offset": 171,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4ad7ea",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4ad895"
-            },
-            {
-                "function": "GSEventRunModal",
-                "abs_path": null,
-                "instruction_offset": 161,
-                "package": "GraphicsServices",
-                "filename": null,
-                "symbol_addr": "0x0022f0a31",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x0022f0ad2"
-            },
-            {
-                "function": "CFRunLoopRunSpecific",
-                "abs_path": null,
-                "instruction_offset": 488,
-                "package": "CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x00dba1030",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00dba1218"
-            },
-            {
-                "function": "__CFRunLoopRun",
-                "abs_path": null,
-                "instruction_offset": 867,
-                "package": "CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x00dba14a0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00dba1803"
-            },
-            {
-                "function": "__CFRunLoopDoSources0",
-                "abs_path": null,
-                "instruction_offset": 556,
-                "package": "CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x00dba2120",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00dba234c"
-            },
-            {
-                "function": "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__",
-                "abs_path": null,
-                "instruction_offset": 17,
-                "package": "CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x00dbac410",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00dbac421"
-            },
-            {
-                "function": "_UIApplicationHandleEventQueue",
-                "abs_path": null,
-                "instruction_offset": 5480,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4a647b",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4a79e3"
-            },
-            {
-                "function": "-[UIApplication handleKeyHIDEvent:]",
-                "abs_path": null,
-                "instruction_offset": 634,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4cea7d",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4cecf7"
-            },
-            {
-                "function": "-[UIApplication handleKeyUIEvent:]",
-                "abs_path": null,
-                "instruction_offset": 79,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4ced18",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4ced67"
-            },
-            {
-                "function": "-[UIResponder _handleKeyUIEvent:]",
-                "abs_path": null,
-                "instruction_offset": 79,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e6c3204",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e6c3253"
-            },
-            {
-                "function": "-[UIResponder _handleKeyUIEvent:]",
-                "abs_path": null,
-                "instruction_offset": 79,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e6c3204",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e6c3253"
-            },
-            {
-                "function": "-[UIResponder _handleKeyUIEvent:]",
-                "abs_path": null,
-                "instruction_offset": 79,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e6c3204",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e6c3253"
-            },
-            {
-                "function": "-[UIApplication _handleKeyUIEvent:]",
-                "abs_path": null,
-                "instruction_offset": 2420,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4cf032",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4cf9a6"
-            },
-            {
-                "function": "-[UIApplication _sendButtonEventWithPressInfo:]",
-                "abs_path": null,
-                "instruction_offset": 302,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4c3070",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4c319e"
-            },
-            {
-                "function": "-[UIApplication sendEvent:]",
-                "abs_path": null,
-                "instruction_offset": 263,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4ce4bf",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4ce5c6"
-            },
-            {
-                "function": "-[UIWindow sendEvent:]",
-                "abs_path": null,
-                "instruction_offset": 999,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e522a5b",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e522e42"
-            },
-            {
-                "function": "-[UIWindow _sendButtonGesturesForEvent:]",
-                "abs_path": null,
-                "instruction_offset": 1042,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e5221e3",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e5225f5"
-            },
-            {
-                "function": "_UIGestureRecognizerUpdate",
-                "abs_path": null,
-                "instruction_offset": 2634,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e99612f",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e996b79"
-            },
-            {
-                "function": "_UIGestureRecognizerRemoveObjectsFromArrayAndApplyBlocks",
-                "abs_path": null,
-                "instruction_offset": 342,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e9a90a1",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e9a91f7"
-            },
-            {
-                "function": "___UIGestureRecognizerUpdate_block_invoke898",
-                "abs_path": null,
-                "instruction_offset": 79,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e9a930a",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e9a9359"
-            },
-            {
-                "function": "-[UIGestureRecognizer _updateGestureWithEvent:buttonEvent:]",
-                "abs_path": null,
-                "instruction_offset": 843,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e9a0b50",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e9a0e9b"
-            },
-            {
-                "function": "_UIGestureRecognizerSendActions",
-                "abs_path": null,
-                "instruction_offset": 162,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e9a2dfc",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e9a2e9e"
-            },
-            {
-                "function": "_UIGestureRecognizerSendTargetActions",
-                "abs_path": null,
-                "instruction_offset": 153,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e9a6793",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e9a682c"
-            },
-            {
-                "function": "-[UIControl _sendActionsForEvents:withEvent:]",
-                "abs_path": null,
-                "instruction_offset": 327,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e622718",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e62285f"
-            },
-            {
-                "function": "-[UIControl sendAction:to:forEvent:]",
-                "abs_path": null,
-                "instruction_offset": 67,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e622540",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e622583"
-            },
-            {
-                "function": "-[UIApplication sendAction:to:from:forEvent:]",
-                "abs_path": null,
-                "instruction_offset": 92,
-                "package": "UIKit",
-                "filename": null,
-                "symbol_addr": "0x00e4af3bd",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00e4af419"
-            },
-            {
-                "function": "@objc SwiftTVOSExample.ViewController.onClickBreak (Swift.AnyObject) -> ()",
-                "abs_path": "/Users/josh/iOS/Sentry/RavenSwift/Examples/SwiftTVOSExample/SwiftTVOSExample/ViewController.swift",
-                "instruction_offset": 54,
-                "package": "SwiftTVOSExample",
-                "filename": "ViewController.swift",
-                "symbol_addr": "0x00d93ad50",
-                "lineno": 0,
-                "in_app": true,
-                "instruction_addr": "0x00d93ad86"
-            },
-            {
-                "function": "SwiftTVOSExample.ViewController.onClickBreak (Swift.AnyObject) -> ()",
-                "abs_path": "/Users/josh/iOS/Sentry/RavenSwift/Examples/SwiftTVOSExample/SwiftTVOSExample/ViewController.swift",
-                "instruction_offset": null,
-                "package": "SwiftTVOSExample",
-                "filename": "ViewController.swift",
-                "symbol_addr": "0x00d93a9d0",
-                "lineno": 65,
-                "in_app": true,
-                "instruction_addr": "0x00d93acc7"
-            },
-            {
-                "function": "function signature specialization <Arg[0] = Exploded, Arg[1] = Exploded, Arg[2] = Dead, Arg[3] = Dead> of Swift._fatalErrorMessage (Swift.StaticString, Swift.StaticString, Swift.StaticString, Swift.UInt) -> ()",
-                "abs_path": null,
-                "instruction_offset": 40,
-                "package": "libswiftCore.dylib",
-                "filename": null,
-                "symbol_addr": "0x00ffcd0d0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x00ffcd0f8"
-            }
-        ]
-    },
-    "threads": {
-      "values": [
-        {
-          "current": true,
-          "crashed": true,
-          "id": 0,
-          "name": null,
-          "stacktrace": null
-        },
-        {
-          "current": false,
-          "crashed": false,
-          "id": 1,
-          "name": null,
-          "stacktrace": {
-            "frames": [
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 52,
-                "package": "/usr/lib/system/libdispatch.dylib",
-                "filename": null,
-                "symbol_addr": "0x002a93614",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002a93648"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 232,
-                "package": "/usr/lib/system/libdispatch.dylib",
-                "filename": null,
-                "symbol_addr": "0x002aa46f0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002aa47d8"
-              },
-              {
-                "function": "kevent_qos",
-                "abs_path": null,
-                "instruction_offset": 8,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002be14d0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002be14d8"
-              }
-            ]
-          }
-        },
-        {
-          "current": false,
-          "crashed": false,
-          "id": 2,
-          "name": null,
-          "stacktrace": {
-            "frames": [
-              {
-                "function": "_pthread_start",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002cab9f0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002caba8c"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002caba8c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002cabb28"
-              },
-              {
-                "function": "ksmachexc_i_handleExceptions",
-                "abs_path": null,
-                "instruction_offset": 168,
-                "package": "/private/var/containers/Bundle/Application/CDB578A5-7B13-44A7-88BE-4D3867D11CF7/SentryTest.app/Frameworks/KSCrash.framework/KSCrash",
-                "filename": null,
-                "symbol_addr": "0x0000f327c",
-                "lineno": null,
-                "in_app": true,
-                "instruction_addr": "0x0000f3324"
-              },
-              {
-                "function": "thread_suspend",
-                "abs_path": null,
-                "instruction_offset": 80,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002bc9138",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002bc9188"
-              },
-              {
-                "function": "mach_msg",
-                "abs_path": null,
-                "instruction_offset": 72,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002bc4e0c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002bc4e54"
-              },
-              {
-                "function": "mach_msg_trap",
-                "abs_path": null,
-                "instruction_offset": 8,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002bc4fd0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002bc4fd8"
-              }
-            ]
-          }
-        },
-        {
-          "current": false,
-          "crashed": false,
-          "id": 3,
-          "name": null,
-          "stacktrace": {
-            "frames": [
-              {
-                "function": "_pthread_start",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002cab9f0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002caba8c"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002caba8c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002cabb28"
-              },
-              {
-                "function": "ksmachexc_i_handleExceptions",
-                "abs_path": null,
-                "instruction_offset": 220,
-                "package": "/private/var/containers/Bundle/Application/CDB578A5-7B13-44A7-88BE-4D3867D11CF7/SentryTest.app/Frameworks/KSCrash.framework/KSCrash",
-                "filename": null,
-                "symbol_addr": "0x0000f327c",
-                "lineno": null,
-                "in_app": true,
-                "instruction_addr": "0x0000f3358"
-              },
-              {
-                "function": "mach_msg",
-                "abs_path": null,
-                "instruction_offset": 72,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002bc4e0c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002bc4e54"
-              },
-              {
-                "function": "mach_msg_trap",
-                "abs_path": null,
-                "instruction_offset": 8,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002bc4fd0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002bc4fd8"
-              }
-            ]
-          }
-        },
-        {
-          "current": false,
-          "crashed": false,
-          "id": 4,
-          "name": null,
-          "stacktrace": {
-            "frames": [
-              {
-                "function": "_pthread_start",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002cab9f0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002caba8c"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002caba8c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002cabb28"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 1000,
-                "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
-                "filename": null,
-                "symbol_addr": "0x003a1ba64",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x003a1be4c"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 412,
-                "package": "/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
-                "filename": null,
-                "symbol_addr": "0x0036a5acc",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x0036a5c68"
-              },
-              {
-                "function": "CFRunLoopRunSpecific",
-                "abs_path": null,
-                "instruction_offset": 384,
-                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x002f24ad0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002f24c50"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 1032,
-                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x002ffa55c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002ffa964"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 196,
-                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x002ffcb9c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002ffcc60"
-              },
-              {
-                "function": "mach_msg",
-                "abs_path": null,
-                "instruction_offset": 72,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002bc4e0c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002bc4e54"
-              },
-              {
-                "function": "mach_msg_trap",
-                "abs_path": null,
-                "instruction_offset": 8,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002bc4fd0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002bc4fd8"
-              }
-            ]
-          }
-        },
-        {
-          "current": false,
-          "crashed": false,
-          "id": 5,
-          "name": null,
-          "stacktrace": {
-            "frames": [
-              {
-                "function": "_pthread_start",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002cab9f0",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002caba8c"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 156,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002caba8c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002cabb28"
-              },
-              {
-                "function": "<redacted>",
-                "abs_path": null,
-                "instruction_offset": 648,
-                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
-                "filename": null,
-                "symbol_addr": "0x003002f40",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x0030031c8"
-              },
-              {
-                "function": "select$DARWIN_EXTSN",
-                "abs_path": null,
-                "instruction_offset": 8,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002be033c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002be0344"
-              }
-            ]
-          }
-        },
-        {
-          "current": false,
-          "crashed": false,
-          "id": 6,
-          "name": null,
-          "stacktrace": {
-            "frames": [
-              {
-                "function": "_pthread_wqthread",
-                "abs_path": null,
-                "instruction_offset": 1284,
-                "package": "/usr/lib/system/libsystem_pthread.dylib",
-                "filename": null,
-                "symbol_addr": "0x002ca902c",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002ca9530"
-              },
-              {
-                "function": "__workq_kernreturn",
-                "abs_path": null,
-                "instruction_offset": 8,
-                "package": "/usr/lib/system/libsystem_kernel.dylib",
-                "filename": null,
-                "symbol_addr": "0x002be0b40",
-                "lineno": null,
-                "in_app": false,
-                "instruction_addr": "0x002be0b48"
-              }
-            ]
-          }
-        },
-        {
-          "current": false,
-          "crashed": false,
-          "id": 7,
-          "name": null,
-          "stacktrace": null
+    "some_things": [
+      "green",
+      "red"
+    ],
+    "a_thing": 3
+  },
+  "sentry.interfaces.Breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1463071692.0,
+        "type": "ui_event",
+        "data": {
+          "type": "button",
+          "target": "onClickBreak"
         }
-      ]
-    },
-    "contexts": {
-        "device": {
-            "model_id": "N78AP",
-            "model": "iPod5,1",
-            "arch": "armv7f"
+      }
+    ]
+  },
+  "sentry.interfaces.Exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start",
+              "abs_path": null,
+              "instruction_offset": 1,
+              "package": "libdyld.dylib",
+              "filename": null,
+              "symbol_addr": "0x00064f9e8",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00064f9e9"
+            },
+            {
+              "function": "main",
+              "abs_path": "/Users/josh/iOS/Sentry/RavenSwift/Examples/SwiftTVOSExample/SwiftTVOSExample/AppDelegate.swift",
+              "instruction_offset": null,
+              "package": "SwiftTVOSExample",
+              "filename": "AppDelegate.swift",
+              "symbol_addr": "0x00d93c230",
+              "lineno": 12,
+              "in_app": true,
+              "instruction_addr": "0x00d93c2a2"
+            },
+            {
+              "function": "UIApplicationMain",
+              "abs_path": null,
+              "instruction_offset": 171,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4ad7ea",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4ad895"
+            },
+            {
+              "function": "GSEventRunModal",
+              "abs_path": null,
+              "instruction_offset": 161,
+              "package": "GraphicsServices",
+              "filename": null,
+              "symbol_addr": "0x0022f0a31",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x0022f0ad2"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "abs_path": null,
+              "instruction_offset": 488,
+              "package": "CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x00dba1030",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00dba1218"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "abs_path": null,
+              "instruction_offset": 867,
+              "package": "CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x00dba14a0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00dba1803"
+            },
+            {
+              "function": "__CFRunLoopDoSources0",
+              "abs_path": null,
+              "instruction_offset": 556,
+              "package": "CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x00dba2120",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00dba234c"
+            },
+            {
+              "function": "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__",
+              "abs_path": null,
+              "instruction_offset": 17,
+              "package": "CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x00dbac410",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00dbac421"
+            },
+            {
+              "function": "_UIApplicationHandleEventQueue",
+              "abs_path": null,
+              "instruction_offset": 5480,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4a647b",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4a79e3"
+            },
+            {
+              "function": "-[UIApplication handleKeyHIDEvent:]",
+              "abs_path": null,
+              "instruction_offset": 634,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4cea7d",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4cecf7"
+            },
+            {
+              "function": "-[UIApplication handleKeyUIEvent:]",
+              "abs_path": null,
+              "instruction_offset": 79,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4ced18",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4ced67"
+            },
+            {
+              "function": "-[UIResponder _handleKeyUIEvent:]",
+              "abs_path": null,
+              "instruction_offset": 79,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e6c3204",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e6c3253"
+            },
+            {
+              "function": "-[UIResponder _handleKeyUIEvent:]",
+              "abs_path": null,
+              "instruction_offset": 79,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e6c3204",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e6c3253"
+            },
+            {
+              "function": "-[UIResponder _handleKeyUIEvent:]",
+              "abs_path": null,
+              "instruction_offset": 79,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e6c3204",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e6c3253"
+            },
+            {
+              "function": "-[UIApplication _handleKeyUIEvent:]",
+              "abs_path": null,
+              "instruction_offset": 2420,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4cf032",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4cf9a6"
+            },
+            {
+              "function": "-[UIApplication _sendButtonEventWithPressInfo:]",
+              "abs_path": null,
+              "instruction_offset": 302,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4c3070",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4c319e"
+            },
+            {
+              "function": "-[UIApplication sendEvent:]",
+              "abs_path": null,
+              "instruction_offset": 263,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4ce4bf",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4ce5c6"
+            },
+            {
+              "function": "-[UIWindow sendEvent:]",
+              "abs_path": null,
+              "instruction_offset": 999,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e522a5b",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e522e42"
+            },
+            {
+              "function": "-[UIWindow _sendButtonGesturesForEvent:]",
+              "abs_path": null,
+              "instruction_offset": 1042,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e5221e3",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e5225f5"
+            },
+            {
+              "function": "_UIGestureRecognizerUpdate",
+              "abs_path": null,
+              "instruction_offset": 2634,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e99612f",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e996b79"
+            },
+            {
+              "function": "_UIGestureRecognizerRemoveObjectsFromArrayAndApplyBlocks",
+              "abs_path": null,
+              "instruction_offset": 342,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e9a90a1",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e9a91f7"
+            },
+            {
+              "function": "___UIGestureRecognizerUpdate_block_invoke898",
+              "abs_path": null,
+              "instruction_offset": 79,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e9a930a",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e9a9359"
+            },
+            {
+              "function": "-[UIGestureRecognizer _updateGestureWithEvent:buttonEvent:]",
+              "abs_path": null,
+              "instruction_offset": 843,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e9a0b50",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e9a0e9b"
+            },
+            {
+              "function": "_UIGestureRecognizerSendActions",
+              "abs_path": null,
+              "instruction_offset": 162,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e9a2dfc",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e9a2e9e"
+            },
+            {
+              "function": "_UIGestureRecognizerSendTargetActions",
+              "abs_path": null,
+              "instruction_offset": 153,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e9a6793",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e9a682c"
+            },
+            {
+              "function": "-[UIControl _sendActionsForEvents:withEvent:]",
+              "abs_path": null,
+              "instruction_offset": 327,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e622718",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e62285f"
+            },
+            {
+              "function": "-[UIControl sendAction:to:forEvent:]",
+              "abs_path": null,
+              "instruction_offset": 67,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e622540",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e622583"
+            },
+            {
+              "function": "-[UIApplication sendAction:to:from:forEvent:]",
+              "abs_path": null,
+              "instruction_offset": 92,
+              "package": "UIKit",
+              "filename": null,
+              "symbol_addr": "0x00e4af3bd",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00e4af419"
+            },
+            {
+              "function": "@objc SwiftTVOSExample.ViewController.onClickBreak (Swift.AnyObject) -> ()",
+              "abs_path": "/Users/josh/iOS/Sentry/RavenSwift/Examples/SwiftTVOSExample/SwiftTVOSExample/ViewController.swift",
+              "instruction_offset": 54,
+              "package": "SwiftTVOSExample",
+              "filename": "ViewController.swift",
+              "symbol_addr": "0x00d93ad50",
+              "lineno": 0,
+              "in_app": true,
+              "instruction_addr": "0x00d93ad86"
+            },
+            {
+              "function": "SwiftTVOSExample.ViewController.onClickBreak (Swift.AnyObject) -> ()",
+              "abs_path": "/Users/josh/iOS/Sentry/RavenSwift/Examples/SwiftTVOSExample/SwiftTVOSExample/ViewController.swift",
+              "instruction_offset": null,
+              "package": "SwiftTVOSExample",
+              "filename": "ViewController.swift",
+              "symbol_addr": "0x00d93a9d0",
+              "lineno": 65,
+              "in_app": true,
+              "instruction_addr": "0x00d93acc7"
+            },
+            {
+              "function": "function signature specialization <Arg[0] = Exploded, Arg[1] = Exploded, Arg[2] = Dead, Arg[3] = Dead> of Swift._fatalErrorMessage (Swift.StaticString, Swift.StaticString, Swift.StaticString, Swift.UInt) -> ()",
+              "abs_path": null,
+              "instruction_offset": 40,
+              "package": "libswiftCore.dylib",
+              "filename": null,
+              "symbol_addr": "0x00ffcd0d0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x00ffcd0f8"
+            }
+          ]
         },
-        "os": {
-            "kernel_version": "Darwin Kernel Version 14.0.0: Sun Mar 29 19:46:45 PDT 2015; root:xnu-2784.20.34~2/RELEASE_ARM_S5L8942X",
-            "version": "8.3",
-            "name": "iOS",
-            "build": "12F69"
+        "thread_id": 0,
+        "type": "NSRangeException",
+        "mechanism": {
+          "posix_signal": {
+            "signal": 6,
+            "code": 0,
+            "name": "SIGABRT",
+            "code_name": null
+          },
+          "type": "cocoa",
+          "mach_exception": {
+            "subcode": 0,
+            "code": 0,
+            "exception": 10,
+            "exception_name": "EXC_CRASH"
+          }
+        },
+        "value": "*** -[__NSArray0 objectAtIndex:]: index 3 beyond bounds for empty NSArray"
+      }
+    ]
+  },
+  "threads": {
+    "values": [
+      {
+        "current": true,
+        "crashed": true,
+        "id": 0,
+        "name": null,
+        "stacktrace": null
+      },
+      {
+        "current": false,
+        "crashed": false,
+        "id": 1,
+        "name": null,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 52,
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "filename": null,
+              "symbol_addr": "0x002a93614",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002a93648"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 232,
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "filename": null,
+              "symbol_addr": "0x002aa46f0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002aa47d8"
+            },
+            {
+              "function": "kevent_qos",
+              "abs_path": null,
+              "instruction_offset": 8,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002be14d0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002be14d8"
+            }
+          ]
         }
+      },
+      {
+        "current": false,
+        "crashed": false,
+        "id": 2,
+        "name": null,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002cab9f0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002caba8c"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002caba8c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002cabb28"
+            },
+            {
+              "function": "ksmachexc_i_handleExceptions",
+              "abs_path": null,
+              "instruction_offset": 168,
+              "package": "/private/var/containers/Bundle/Application/CDB578A5-7B13-44A7-88BE-4D3867D11CF7/SentryTest.app/Frameworks/KSCrash.framework/KSCrash",
+              "filename": null,
+              "symbol_addr": "0x0000f327c",
+              "lineno": null,
+              "in_app": true,
+              "instruction_addr": "0x0000f3324"
+            },
+            {
+              "function": "thread_suspend",
+              "abs_path": null,
+              "instruction_offset": 80,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002bc9138",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002bc9188"
+            },
+            {
+              "function": "mach_msg",
+              "abs_path": null,
+              "instruction_offset": 72,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002bc4e0c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002bc4e54"
+            },
+            {
+              "function": "mach_msg_trap",
+              "abs_path": null,
+              "instruction_offset": 8,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002bc4fd0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002bc4fd8"
+            }
+          ]
+        }
+      },
+      {
+        "current": false,
+        "crashed": false,
+        "id": 3,
+        "name": null,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002cab9f0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002caba8c"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002caba8c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002cabb28"
+            },
+            {
+              "function": "ksmachexc_i_handleExceptions",
+              "abs_path": null,
+              "instruction_offset": 220,
+              "package": "/private/var/containers/Bundle/Application/CDB578A5-7B13-44A7-88BE-4D3867D11CF7/SentryTest.app/Frameworks/KSCrash.framework/KSCrash",
+              "filename": null,
+              "symbol_addr": "0x0000f327c",
+              "lineno": null,
+              "in_app": true,
+              "instruction_addr": "0x0000f3358"
+            },
+            {
+              "function": "mach_msg",
+              "abs_path": null,
+              "instruction_offset": 72,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002bc4e0c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002bc4e54"
+            },
+            {
+              "function": "mach_msg_trap",
+              "abs_path": null,
+              "instruction_offset": 8,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002bc4fd0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002bc4fd8"
+            }
+          ]
+        }
+      },
+      {
+        "current": false,
+        "crashed": false,
+        "id": 4,
+        "name": null,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002cab9f0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002caba8c"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002caba8c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002cabb28"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 1000,
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "filename": null,
+              "symbol_addr": "0x003a1ba64",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x003a1be4c"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 412,
+              "package": "/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
+              "filename": null,
+              "symbol_addr": "0x0036a5acc",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x0036a5c68"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "abs_path": null,
+              "instruction_offset": 384,
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x002f24ad0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002f24c50"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 1032,
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x002ffa55c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002ffa964"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 196,
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x002ffcb9c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002ffcc60"
+            },
+            {
+              "function": "mach_msg",
+              "abs_path": null,
+              "instruction_offset": 72,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002bc4e0c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002bc4e54"
+            },
+            {
+              "function": "mach_msg_trap",
+              "abs_path": null,
+              "instruction_offset": 8,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002bc4fd0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002bc4fd8"
+            }
+          ]
+        }
+      },
+      {
+        "current": false,
+        "crashed": false,
+        "id": 5,
+        "name": null,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002cab9f0",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002caba8c"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 156,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002caba8c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002cabb28"
+            },
+            {
+              "function": "<redacted>",
+              "abs_path": null,
+              "instruction_offset": 648,
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "filename": null,
+              "symbol_addr": "0x003002f40",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x0030031c8"
+            },
+            {
+              "function": "select$DARWIN_EXTSN",
+              "abs_path": null,
+              "instruction_offset": 8,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002be033c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002be0344"
+            }
+          ]
+        }
+      },
+      {
+        "current": false,
+        "crashed": false,
+        "id": 6,
+        "name": null,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "abs_path": null,
+              "instruction_offset": 1284,
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "filename": null,
+              "symbol_addr": "0x002ca902c",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002ca9530"
+            },
+            {
+              "function": "__workq_kernreturn",
+              "abs_path": null,
+              "instruction_offset": 8,
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "filename": null,
+              "symbol_addr": "0x002be0b40",
+              "lineno": null,
+              "in_app": false,
+              "instruction_addr": "0x002be0b48"
+            }
+          ]
+        }
+      },
+      {
+        "current": false,
+        "crashed": false,
+        "id": 7,
+        "name": null,
+        "stacktrace": null
+      }
+    ]
+  },
+  "contexts": {
+    "device": {
+      "model_id": "N78AP",
+      "model": "iPod5,1",
+      "arch": "armv7f"
     },
-    "sdk": {
-        "version": "1",
-        "name": "raven-swift"
+    "os": {
+      "kernel_version": "Darwin Kernel Version 14.0.0: Sun Mar 29 19:46:45 PDT 2015; root:xnu-2784.20.34~2/RELEASE_ARM_S5L8942X",
+      "version": "8.3",
+      "name": "iOS",
+      "build": "12F69"
     }
+  },
+  "sdk": {
+    "version": "1",
+    "name": "raven-swift"
+  }
 }

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -326,8 +326,6 @@ class EventManager(object):
             except Exception:
                 # XXX: we should consider logging this.
                 pass
-            else:
-                data['tags'].extend(inst.iter_tags())
 
         # TODO(dcramer): this logic is duplicated in ``validate_data`` from
         # coreapi

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -52,7 +52,7 @@ class ContextType(object):
         ctx_data = {}
         for key, value in trim(data).iteritems():
             if value not in EMPTY_VALUES:
-                ctx_data[force_text(key)] = force_text(value)
+                ctx_data[force_text(key)] = value
         self.data = ctx_data
 
     def to_json(self):

--- a/src/sentry/interfaces/debug_images.py
+++ b/src/sentry/interfaces/debug_images.py
@@ -61,7 +61,7 @@ class DebugImages(Interface):
             raise InterfaceValidationError('Unknown image type %r' % image)
         rv = func(image)
         assert 'uuid' in rv, 'debug image normalizer did not produce a UUID'
-        assert 'object_addr' in rv, 'debug image normalizer did not ' \
+        assert 'image_addr' in rv, 'debug image normalizer did not ' \
             'produce an object address'
         rv['type'] = ty
         return rv

--- a/src/sentry/interfaces/debug_images.py
+++ b/src/sentry/interfaces/debug_images.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+__all__ = ('DebugImages',)
+
+from sentry.interfaces.base import Interface, InterfaceValidationError
+
+
+image_types = {}
+
+
+def imagetype(name):
+    def decorator(f):
+        image_types[name] = f
+        return f
+    return decorator
+
+
+@imagetype('apple')
+def process_apple_image(image):
+    try:
+        return {
+            'cpu_type': image['cpu_type'],
+            'cpu_subtype': image['cpu_subtype'],
+            'image_addr': image['image_addr'],
+            'image_size': image['image_size'],
+            'image_vmaddr': image.get('image_vmaddr') or 0,
+            'name': image['name'],
+            'uuid': image['uuid'],
+        }
+    except KeyError as e:
+        raise InterfaceValidationError('Missing value for apple image: %s'
+                                       % e.args[0])
+
+
+class DebugImages(Interface):
+    """
+    Holds debug image information for processing stacktraces and similar
+    things.
+    """
+
+    ephemeral = True
+
+    @classmethod
+    def to_python(cls, data):
+        if 'images' not in data:
+            raise InterfaceValidationError('Missing key "images"')
+        if 'sdk_info' not in data:
+            raise InterfaceValidationError('Missing key "sdk_info"')
+        return cls(
+            images=[cls.normalize_image(x) for x in data['images']],
+            sdk_info=data['sdk_info'],
+        )
+
+    @staticmethod
+    def normalize_image(image):
+        ty = image.get('type')
+        if not ty:
+            raise InterfaceValidationError('Image type not provided')
+        func = image_types.get(ty)
+        if func is None:
+            raise InterfaceValidationError('Unknown image type %r' % image)
+        rv = func(image)
+        assert 'uuid' in rv, 'debug image normalizer did not produce a UUID'
+        assert 'object_addr' in rv, 'debug image normalizer did not ' \
+            'produce an object address'
+        rv['type'] = ty
+        return rv
+
+    def get_path(self):
+        return 'debug_images'

--- a/src/sentry/interfaces/debug_meta.py
+++ b/src/sentry/interfaces/debug_meta.py
@@ -25,7 +25,7 @@ def process_apple_image(image):
             'cpu_type': image['cpu_type'],
             'cpu_subtype': image['cpu_subtype'],
             'image_addr': _addr(image['image_addr']),
-            'image_size': _addr(image['image_size']),
+            'image_size': image['image_size'],
             'image_vmaddr': _addr(image.get('image_vmaddr') or 0),
             'name': image['name'],
             'uuid': image['uuid'],

--- a/src/sentry/interfaces/debug_meta.py
+++ b/src/sentry/interfaces/debug_meta.py
@@ -17,13 +17,20 @@ def imagetype(name):
 
 @imagetype('apple')
 def process_apple_image(image):
+    def _addr(x):
+        if isinstance(x, (int, long)):
+            return '0x%x' % x
+        if isinstance(x, basestring):
+            if x[:2] != '0x':
+                return '0x%x' % int(x)
+        return x
     try:
         return {
             'cpu_type': image['cpu_type'],
             'cpu_subtype': image['cpu_subtype'],
-            'image_addr': image['image_addr'],
-            'image_size': image['image_size'],
-            'image_vmaddr': image.get('image_vmaddr') or 0,
+            'image_addr': _addr(image['image_addr']),
+            'image_size': _addr(image['image_size']),
+            'image_vmaddr': _addr(image.get('image_vmaddr') or 0),
             'name': image['name'],
             'uuid': image['uuid'],
         }

--- a/src/sentry/interfaces/debug_meta.py
+++ b/src/sentry/interfaces/debug_meta.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 __all__ = ('DebugMeta',)
 
 from sentry.interfaces.base import Interface, InterfaceValidationError
+from sentry.utils.native import parse_addr
 
 
 image_types = {}
@@ -18,12 +19,7 @@ def imagetype(name):
 @imagetype('apple')
 def process_apple_image(image):
     def _addr(x):
-        if isinstance(x, (int, long)):
-            return '0x%x' % x
-        if isinstance(x, basestring):
-            if x[:2] != '0x':
-                return '0x%x' % int(x)
-        return x
+        return '0x%x' % parse_addr(x)
     try:
         return {
             'cpu_type': image['cpu_type'],

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -86,6 +86,7 @@ class SingleException(Interface):
             'module': trim(data.get('module'), 128),
             'mechanism': mechanism,
             'stacktrace': stacktrace,
+            'thread_id': trim(data.get('thread_id', 40)),
             'raw_stacktrace': raw_stacktrace,
         }
 
@@ -126,6 +127,7 @@ class SingleException(Interface):
             'type': self.type,
             'value': unicode(self.value) if self.value else None,
             'mechanism': self.mechanism or None,
+            'threadId': self.thread_id,
             'module': self.module,
             'stacktrace': stacktrace,
             'rawStacktrace': raw_stacktrace,

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -86,7 +86,7 @@ class SingleException(Interface):
             'module': trim(data.get('module'), 128),
             'mechanism': mechanism,
             'stacktrace': stacktrace,
-            'thread_id': trim(data.get('thread_id', 40)),
+            'thread_id': trim(data.get('thread_id'), 40),
             'raw_stacktrace': raw_stacktrace,
         }
 
@@ -109,6 +109,7 @@ class SingleException(Interface):
             'mechanism': self.mechanism or None,
             'module': self.module,
             'stacktrace': stacktrace,
+            'thread_id': self.thread_id,
             'raw_stacktrace': raw_stacktrace,
         }
 

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -288,6 +288,7 @@ class Frame(Interface):
             'module': trim(module, 256),
             'function': trim(function, 256),
             'package': trim(data.get('package'), 256),
+            'package_addr': trim(data.get('package_addr'), 16),
             'symbol_addr': trim(data.get('symbol_addr'), 16),
             'instruction_addr': trim(data.get('instruction_addr'), 16),
             'instruction_offset': instruction_offset,

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -241,7 +241,9 @@ class Frame(Interface):
         if function == '?':
             function = None
 
-        platform = VALID_PLATFORMS.get(data.get('platform'))
+        platform = data.get('platform')
+        if platform not in VALID_PLATFORMS:
+            platform = None
 
         context_locals = data.get('vars') or {}
         if isinstance(context_locals, (list, tuple)):

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -370,6 +370,7 @@ class Frame(Interface):
             'absPath': self.abs_path,
             'module': self.module,
             'package': self.package,
+            'platform': self.platform,
             'instructionAddr': self.instruction_addr,
             'instructionOffset': self.instruction_offset,
             'symbolAddr': self.symbol_addr,

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -288,7 +288,7 @@ class Frame(Interface):
             'module': trim(module, 256),
             'function': trim(function, 256),
             'package': trim(data.get('package'), 256),
-            'image_addr': trim(data.get('image_addr'), 16),
+            'object_addr': trim(data.get('object_addr'), 16),
             'symbol_addr': trim(data.get('symbol_addr'), 16),
             'instruction_addr': trim(data.get('instruction_addr'), 16),
             'instruction_offset': instruction_offset,

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -288,7 +288,7 @@ class Frame(Interface):
             'module': trim(module, 256),
             'function': trim(function, 256),
             'package': trim(data.get('package'), 256),
-            'package_addr': trim(data.get('package_addr'), 16),
+            'image_addr': trim(data.get('image_addr'), 16),
             'symbol_addr': trim(data.get('symbol_addr'), 16),
             'instruction_addr': trim(data.get('instruction_addr'), 16),
             'instruction_offset': instruction_offset,

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -288,7 +288,7 @@ class Frame(Interface):
             'module': trim(module, 256),
             'function': trim(function, 256),
             'package': trim(data.get('package'), 256),
-            'object_addr': trim(data.get('object_addr'), 16),
+            'image_addr': trim(data.get('image_addr'), 16),
             'symbol_addr': trim(data.get('symbol_addr'), 16),
             'instruction_addr': trim(data.get('instruction_addr'), 16),
             'instruction_offset': instruction_offset,

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -50,7 +50,20 @@ def trim_package(pkg):
     return pkg
 
 
-def get_context(lineno, context_line, pre_context=None, post_context=None, filename=None):
+def to_hex_addr(addr):
+    if addr is None:
+        return None
+    elif isinstance(addr, (int, long)):
+        return '0x%x' % addr
+    elif isinstance(addr, basestring):
+        if addr[:2] == '0x':
+            return addr
+        return '0x%x' % int(addr)
+    raise ValueError('Unsupported address format %r' % (addr,))
+
+
+def get_context(lineno, context_line, pre_context=None, post_context=None,
+                filename=None):
     if lineno is None:
         return []
 
@@ -288,9 +301,9 @@ class Frame(Interface):
             'module': trim(module, 256),
             'function': trim(function, 256),
             'package': trim(data.get('package'), 256),
-            'image_addr': trim(data.get('image_addr'), 16),
-            'symbol_addr': trim(data.get('symbol_addr'), 16),
-            'instruction_addr': trim(data.get('instruction_addr'), 16),
+            'image_addr': to_hex_addr(trim(data.get('image_addr'), 16)),
+            'symbol_addr': to_hex_addr(trim(data.get('symbol_addr'), 16)),
+            'instruction_addr': to_hex_addr(trim(data.get('instruction_addr'), 16)),
             'instruction_offset': instruction_offset,
             'in_app': in_app,
             'context_line': context_line,

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+from sentry.interfaces.base import Interface
+from sentry.interfaces.stacktrace import Stacktrace
+from sentry.utils.safe import trim
+
+__all__ = ('Threads',)
+
+
+class Threads(Interface):
+    score = 3000
+
+    @classmethod
+    def to_python(cls, data):
+        threads = []
+
+        for thread in data.get('threads') or ():
+            stacktrace = None
+            if 'stacktrace' in thread:
+                stacktrace = Stacktrace.to_python(
+                    thread['stacktrace'],
+                    slim_frames=True,
+                )
+
+            threads.append({
+                'stacktrace': stacktrace,
+                'index': trim(thread.get('trim'), 20),
+                'id': trim(thread.get('id'), 40),
+                'current': bool(thread.get('current')),
+                'name': trim(thread.get('name'), 200),
+            })
+
+        return cls(threads=threads)
+
+    def to_json(self):
+        def export_thread(data):
+            rv = {
+                'index': data['index'],
+                'id': data['id'],
+                'current': data['current'],
+                'name': data['name'],
+                'stacktrace': None,
+            }
+            if data['stacktrace']:
+                rv['stacktrace'] = data['stacktrace'].to_json()
+            return data
+
+        return {
+            'threads': [export_thread(x) for x in self.threads],
+        }
+
+    def get_path(self):
+        return 'threads'

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -8,63 +8,60 @@ __all__ = ('Threads',)
 
 
 class Threads(Interface):
-    score = 3000
+    score = 1000
 
     @classmethod
     def to_python(cls, data):
         threads = []
 
-        for thread in data.get('threads') or ():
-            stacktrace = None
-            if 'stacktrace' in thread:
-                stacktrace = Stacktrace.to_python(
-                    thread['stacktrace'],
-                    slim_frames=True,
-                )
-
+        for thread in data.get('list') or ():
+            stacktrace = thread.get('stacktrace')
+            if stacktrace is not None:
+                stacktrace = Stacktrace.to_python(stacktrace,
+                                                  slim_frames=True)
             threads.append({
                 'stacktrace': stacktrace,
-                'index': trim(thread.get('trim'), 20),
                 'id': trim(thread.get('id'), 40),
+                'crashed': bool(thread.get('crashed')),
                 'current': bool(thread.get('current')),
                 'name': trim(thread.get('name'), 200),
             })
 
-        return cls(threads=threads)
+        return cls(list=threads)
 
     def to_json(self):
         def export_thread(data):
             rv = {
-                'index': data['index'],
                 'id': data['id'],
                 'current': data['current'],
+                'crashed': data['crashed'],
                 'name': data['name'],
                 'stacktrace': None,
             }
             if data['stacktrace']:
                 rv['stacktrace'] = data['stacktrace'].to_json()
-            return data
+            return rv
 
         return {
-            'threads': [export_thread(x) for x in self.threads],
+            'list': [export_thread(x) for x in self.list],
         }
 
     def get_api_context(self, is_public=False):
         def export_thread(data):
             rv = {
-                'index': data['index'],
                 'id': data['id'],
                 'current': data['current'],
+                'crashed': data['crashed'],
                 'name': data['name'],
                 'stacktrace': None,
             }
             if data['stacktrace']:
                 rv['stacktrace'] = data['stacktrace'].get_api_context(
                     is_public=is_public)
-            return data
+            return rv
 
         return {
-            'threads': [export_thread(x) for x in self.threads],
+            'list': [export_thread(x) for x in self.list],
         }
 
     def get_path(self):

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -14,7 +14,7 @@ class Threads(Interface):
     def to_python(cls, data):
         threads = []
 
-        for thread in data.get('list') or ():
+        for thread in data.get('values') or ():
             stacktrace = thread.get('stacktrace')
             if stacktrace is not None:
                 stacktrace = Stacktrace.to_python(stacktrace,
@@ -27,7 +27,7 @@ class Threads(Interface):
                 'name': trim(thread.get('name'), 200),
             })
 
-        return cls(list=threads)
+        return cls(values=threads)
 
     def to_json(self):
         def export_thread(data):
@@ -43,7 +43,7 @@ class Threads(Interface):
             return rv
 
         return {
-            'list': [export_thread(x) for x in self.list],
+            'values': [export_thread(x) for x in self.values],
         }
 
     def get_api_context(self, is_public=False):
@@ -61,7 +61,7 @@ class Threads(Interface):
             return rv
 
         return {
-            'list': [export_thread(x) for x in self.list],
+            'values': [export_thread(x) for x in self.values],
         }
 
     def get_path(self):

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -8,7 +8,7 @@ __all__ = ('Threads',)
 
 
 class Threads(Interface):
-    score = 1000
+    score = 1900
 
     @classmethod
     def to_python(cls, data):

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -49,5 +49,23 @@ class Threads(Interface):
             'threads': [export_thread(x) for x in self.threads],
         }
 
+    def get_api_context(self, is_public=False):
+        def export_thread(data):
+            rv = {
+                'index': data['index'],
+                'id': data['id'],
+                'current': data['current'],
+                'name': data['name'],
+                'stacktrace': None,
+            }
+            if data['stacktrace']:
+                rv['stacktrace'] = data['stacktrace'].get_api_context(
+                    is_public=is_public)
+            return data
+
+        return {
+            'threads': [export_thread(x) for x in self.threads],
+        }
+
     def get_path(self):
         return 'threads'

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -377,15 +377,12 @@ def resolve_frame_symbols(data):
     with sym:
         for stacktrace in stacktraces:
             for idx, frame in enumerate(stacktrace['frames']):
-                if 'package_addr' not in frame:
+                if 'image_addr' not in frame or \
+                   'instruction_addr' not in frame:
                     continue
                 try:
-                    # We need to create a symsynd compatible frame here so
-                    # that we can perform symbolication.
-                    sfrm = sym.symbolize_frame({
-                        'object_addr': frame['package_addr'],
-                        'instruction_addr': frame['instruction_addr'],
-                    }, sdk_info, report_error=report_error)
+                    sfrm = sym.symbolize_frame(frame, sdk_info,
+                                               report_error=report_error)
                     if not sfrm:
                         continue
                     frame['function'] = sfrm['symbol_name'] or '<unknown>'

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -320,7 +320,7 @@ def preprocess_apple_crash_event(data):
 
     if threads:
         data['threads'] = {
-            'list': sorted(threads.values(), key=lambda x: x['id']),
+            'values': sorted(threads.values(), key=lambda x: x['id']),
         }
 
     if system:

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, print_function
 
+import os
 import re
+import time
 import logging
 import posixpath
 
@@ -250,11 +252,20 @@ def record_no_symsynd(data):
         return data
 
 
+def dump_crash_report(report):
+    import json
+    with open('/tmp/sentry-apple-crash-report-%s.json' % time.time(), 'w') as f:
+        json.dump(report, f, indent=2)
+
+
 def preprocess_apple_crash_event(data):
     """This processes the "legacy" AppleCrashReport."""
     crash_report = data.get('sentry.interfaces.AppleCrashReport')
     if crash_report is None:
         return
+
+    if os.environ.get('SENTRY_DUMP_APPLE_CRASH_REPORT') == '1':
+        dump_crash_report(crash_report)
 
     project = Project.objects.get_from_cache(
         id=data['project'],

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -387,13 +387,11 @@ def resolve_frame_symbols(data):
     processed_frames = []
     with sym:
         for stacktrace in stacktraces:
-            set_in_app = False
             for idx, frame in enumerate(stacktrace['frames']):
                 if 'object_addr' not in frame or \
                    'instruction_addr' not in frame or \
                    'symbol_addr' not in frame:
                     continue
-                set_in_app = frame.get('in_app') is None
                 try:
                     sfrm = sym.symbolize_frame(frame, sdk_info,
                                                report_error=report_error)
@@ -413,6 +411,7 @@ def resolve_frame_symbols(data):
                     frame['package'] = sfrm['object_name']
                     frame['symbol_addr'] = '%x' % sfrm['symbol_addr']
                     frame['instruction_addr'] = '%x' % sfrm['instruction_addr']
+                    frame['in_app'] = is_in_app(frame)
                     longest_addr = max(longest_addr, len(frame['symbol_addr']),
                                        len(frame['instruction_addr']))
                     processed_frames.append(frame)
@@ -422,11 +421,6 @@ def resolve_frame_symbols(data):
                         'type': EventError.NATIVE_INTERNAL_FAILURE,
                         'error': '%s: %s' % (e.__class__.__name__, str(e)),
                     })
-
-            if set_in_app:
-                for frame in stacktrace['frames']:
-                    if frame.get('in_app') is None:
-                        frame['in_app'] = is_in_app(frame)
 
     # Pad out addresses to be of the same length and add prefix
     for frame in processed_frames:

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -317,11 +317,11 @@ def preprocess_apple_crash_event(data):
                     # We recorded an exception, so in this case we can
                     # skip having the stacktrace.
                     threads[crashed_thread['index']]['stacktrace'] = None
-            except Exception as e:
+            except Exception:
                 logger.exception('Failed to symbolicate')
-                append_error(data, {
+                errors.append({
                     'type': EventError.NATIVE_INTERNAL_FAILURE,
-                    'error': '%s: %s' % (e.__class__.__name__, str(e)),
+                    'error': 'The symbolicator encountered an internal failure',
                 })
 
         for thread in threads.itervalues():
@@ -424,11 +424,11 @@ def resolve_frame_symbols(data):
                     longest_addr = max(longest_addr, len(frame['symbol_addr']),
                                        len(frame['instruction_addr']))
                     processed_frames.append(frame)
-                except Exception as e:
+                except Exception:
                     logger.exception('Failed to symbolicate')
                     errors.append({
                         'type': EventError.NATIVE_INTERNAL_FAILURE,
-                        'error': '%s: %s' % (e.__class__.__name__, str(e)),
+                        'error': 'The symbolicator encountered an internal failure',
                     })
 
     # Pad out addresses to be of the same length

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -348,12 +348,12 @@ def preprocess_apple_crash_event(data):
 
 
 def resolve_frame_symbols(data):
-    debug_image_data = data.get('debug_images')
-    if not debug_image_data:
+    debug_meta = data.get('debug_meta')
+    if not debug_meta:
         return
 
-    debug_images = debug_image_data['images']
-    sdk_info = debug_image_data['sdk_info']
+    debug_images = debug_meta['images']
+    sdk_info = debug_meta['sdk_info']
 
     stacktraces = find_all_stacktraces(data)
     if not stacktraces:

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -131,7 +131,7 @@ def is_in_app(frame, app_uuid=None):
         frame_uuid = frame.get('uuid')
         if frame_uuid == app_uuid:
             return True
-    fn = frame.get('package', '')
+    fn = frame.get('package') or ''
     if not fn.startswith(APP_BUNDLE_PATHS):
         return False
     if fn.endswith(NON_APP_FRAMEWORKS):

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -79,7 +79,11 @@ class Symbolizer(object):
     def _process_frame(self, frame, img):
         rv = trim_frame(frame)
         if img is not None:
-            rv['object_name'] = img['name']
+            # Only set the object name if we "upgrade" it from a filename to
+            # full path.
+            if 'object_name' not in rv or \
+               ('/' not in rv['object_name'] and '/' in img['name']):
+                rv['object_name'] = img['name']
             rv['uuid'] = img['uuid']
         return rv
 

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -77,8 +77,7 @@ class Symbolizer(object):
             rv['uuid'] = img['uuid']
         return rv
 
-    def symbolize_frame(self, frame, sdk_info=None,
-                        report_error=None):
+    def symbolize_frame(self, frame, sdk_info=None, report_error=None):
         error = None
         img = self.images.get(frame['object_addr'])
 

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -71,7 +71,7 @@ class Symbolizer(object):
         if img is not None:
             # Only set the object name if we "upgrade" it from a filename to
             # full path.
-            if 'object_name' not in rv or \
+            if rv.get('object_name') is None or \
                ('/' not in rv['object_name'] and '/' in img['name']):
                 rv['object_name'] = img['name']
             rv['uuid'] = img['uuid']

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -35,8 +35,8 @@ def find_stacktrace_referenced_images(debug_images, stacktraces):
     to_load = set()
     for stacktrace in stacktraces:
         for frame in stacktrace['frames']:
-            if 'object_addr' in frame:
-                img_uuid = image_map.get(frame['object_addr'])
+            if 'image_addr' in frame:
+                img_uuid = image_map.get(frame['image_addr'])
                 if img_uuid is not None:
                     to_load.add(img_uuid)
 

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -62,7 +62,7 @@ def find_all_stacktraces(data):
 
     threads = data.get('threads')
     if threads:
-        for thread in threads:
+        for thread in threads['values']:
             stacktrace = thread.get('stacktrace')
             if stacktrace:
                 rv.append(stacktrace)
@@ -87,3 +87,15 @@ def get_sdk_from_apple_system_info(info):
         'version_minor': system_version[1],
         'version_patchlevel': system_version[2],
     }
+
+
+def parse_addr(x):
+    if x is None:
+        return 0
+    if isinstance(x, (int, long)):
+        return x
+    if isinstance(x, basestring):
+        if x[:2] == '0x':
+            return int(x[2:], 16)
+        return int(x)
+    raise ValueError('Unsupported address format %r' % (x,))

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -1,0 +1,89 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+APPLE_SDK_MAPPING = {
+    'iPhone OS': 'iOS',
+    'tvOS': 'tvOS',
+    'Mac OS': 'macOS',
+}
+
+
+def find_apple_crash_report_referenced_images(binary_images, threads):
+    """Given some binary images from an apple crash report and a thread
+    list this returns a list of image UUIDs to load.
+    """
+    image_map = {}
+    for image in binary_images:
+        image_map[image['image_addr']] = image['uuid']
+    to_load = set()
+    for thread in threads:
+        for frame in thread['backtrace']['contents']:
+            img_uuid = image_map.get(frame['object_addr'])
+            if img_uuid is not None:
+                to_load.add(img_uuid)
+    return list(to_load)
+
+
+def find_stacktrace_referenced_images(debug_images, stacktraces):
+    image_map = {}
+    for image in debug_images:
+        image_map[image['image_addr']] = image['uuid']
+
+    to_load = set()
+    for stacktrace in stacktraces:
+        for frame in stacktrace['frames']:
+            if 'object_addr' in frame:
+                img_uuid = image_map.get(frame['object_addr'])
+                if img_uuid is not None:
+                    to_load.add(img_uuid)
+
+    return list(to_load)
+
+
+def find_all_stacktraces(data):
+    """Given a data dictionary from an event this returns all
+    relevant stacktraces in a list.
+    """
+    rv = []
+
+    exc_container = data.get('sentry.interfaces.Exception')
+    if exc_container:
+        for exc in exc_container['values']:
+            stacktrace = exc.get('stacktrace')
+            if stacktrace:
+                rv.append(stacktrace)
+
+    stacktrace = data.get('sentry.interfaces.Stacktrace')
+    if stacktrace:
+        rv.append(stacktrace)
+
+    threads = data.get('threads')
+    if threads:
+        for thread in threads:
+            stacktrace = thread.get('stacktrace')
+            if stacktrace:
+                rv.append(stacktrace)
+
+    return rv
+
+
+def get_sdk_from_apple_system_info(info):
+    if not info:
+        return None
+    try:
+        sdk_name = APPLE_SDK_MAPPING[info['system_name']]
+        system_version = tuple(int(x) for x in (
+            info['system_version'] + '.0' * 3).split('.')[:3])
+    except LookupError:
+        return None
+
+    return {
+        'dsym_type': 'macho',
+        'sdk_name': sdk_name,
+        'version_major': system_version[0],
+        'version_minor': system_version[1],
+        'version_patchlevel': system_version[2],
+    }

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -87,15 +87,3 @@ def get_sdk_from_apple_system_info(info):
         'version_minor': system_version[1],
         'version_patchlevel': system_version[2],
     }
-
-
-def parse_addr(x):
-    if x is None:
-        return 0
-    if isinstance(x, (int, long)):
-        return x
-    if isinstance(x, basestring):
-        if x[:2] == '0x':
-            return int(x[2:], 16)
-        return int(x)
-    raise ValueError('Unsupported address format %r' % (x,))

--- a/src/sentry/models/dsymfile.py
+++ b/src/sentry/models/dsymfile.py
@@ -170,6 +170,10 @@ class DSymSymbolManager(BaseManager):
                       cpu_name=None, object_path=None, sdk_info=None,
                       image_vmaddr=None):
         """Finds a system symbol."""
+        # If we use the "none" dsym type we never return a symbol here.
+        if sdk_info is not None and sdk_info['dsym_type'] == 'none':
+            return
+
         addr_abs = None
         if image_vmaddr is not None:
             addr_abs = image_vmaddr + instruction_addr - image_addr

--- a/src/sentry/models/dsymfile.py
+++ b/src/sentry/models/dsymfile.py
@@ -26,6 +26,7 @@ from sentry.db.models import FlexibleForeignKey, Model, BoundedBigIntegerField, 
 from sentry.models.file import File
 from sentry.utils.zip import safe_extract_zip
 from sentry.utils.db import is_sqlite
+from sentry.utils.native import parse_addr
 from sentry.constants import KNOWN_DSYM_TYPES
 
 
@@ -174,8 +175,12 @@ class DSymSymbolManager(BaseManager):
         if sdk_info is not None and sdk_info['dsym_type'] == 'none':
             return
 
+        instruction_addr = parse_addr(instruction_addr)
+        image_addr = parse_addr(image_addr)
+
         addr_abs = None
         if image_vmaddr is not None:
+            image_vmaddr = parse_addr(image_vmaddr)
             addr_abs = image_vmaddr + instruction_addr - image_addr
         addr_rel = instruction_addr - image_addr
 

--- a/src/sentry/runner/commands/dsym.py
+++ b/src/sentry/runner/commands/dsym.py
@@ -21,7 +21,7 @@ SHUTDOWN = object()
 
 def load_bundle(q, uuid, data, sdk_info, trim_symbols, demangle):
     from sentry.models import DSymBundle, DSymObject, DSymSDK
-    from sentry.models.dsymfile import MAX_SYM
+    from sentry.constants import MAX_SYM
     from symsynd.demangle import demangle_symbol
 
     def _process_symbol(sym):

--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -34,7 +34,13 @@ const ContextChunk = React.createClass({
         title = toTitleCase(alias);
       }
     }
-    return title;
+
+    return (
+      <span>
+        {title + ' '}
+        {alias !== type ? <small>({alias})</small> : null}
+      </span>
+    );
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import GroupEventDataSection from './eventDataSection';
-import {objectIsEmpty, toTitleCase} from '../../utils';
+import {objectIsEmpty, toTitleCase, defined} from '../../utils';
 
 const CONTEXT_TYPES = {
   'default': require('./contexts/default'),
@@ -20,11 +20,27 @@ const ContextChunk = React.createClass({
     value: React.PropTypes.object.isRequired,
   },
 
+  renderTitle() {
+    let {value, alias, type} = this.props;
+    let title = null;
+    if (defined(value.title)) {
+      title = value.title;
+    } else {
+      let Component = CONTEXT_TYPES[type] || CONTEXT_TYPES.default;
+      if (Component.getTitle) {
+        title = Component.getTitle(value);
+      }
+      if (!defined(title)) {
+        title = toTitleCase(alias);
+      }
+    }
+    return title;
+  },
+
   render() {
     let group = this.props.group;
     let evt = this.props.event;
     let {type, alias, value} = this.props;
-    let title = value.title || toTitleCase(alias);
     let Component = CONTEXT_TYPES[type] || CONTEXT_TYPES.default;
 
     return (
@@ -33,7 +49,7 @@ const ContextChunk = React.createClass({
           event={evt}
           key={`context-${alias}`}
           type={`context-${alias}`}
-          title={title}>
+          title={this.renderTitle()}>
         <Component alias={alias} data={value} />
       </GroupEventDataSection>
     );

--- a/src/sentry/static/sentry/app/components/events/contexts/contextBlock.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/contextBlock.jsx
@@ -7,7 +7,6 @@ import {defined} from '../../../utils';
 const ContextBlock = React.createClass({
   propTypes: {
     alias: React.PropTypes.string.isRequired,
-    title: React.PropTypes.string,
     data: React.PropTypes.object.isRequired,
     knownData: React.PropTypes.array,
   },
@@ -17,9 +16,18 @@ const ContextBlock = React.createClass({
     let className = `context-block context-block-${this.props.data.type}`;
 
     (this.props.knownData || []).forEach(([key, value]) => {
-      if (defined(value)) {
-        data.push([key, value]);
+      let allowSkip = false;
+      if (key[0] === '?') {
+        allowSkip = true;
+        key = key.substr(1);
       }
+      if (!defined(value)) {
+        if (allowSkip) {
+          return;
+        }
+        value = 'n/a';
+      }
+      data.push([key, value]);
     });
 
     let extraData = [];

--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -29,4 +29,8 @@ const DeviceContextType = React.createClass({
   }
 });
 
+DeviceContextType.getTitle = function(value) {
+  return 'Device';
+};
+
 export default DeviceContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -16,13 +16,13 @@ const DeviceContextType = React.createClass({
       <ContextBlock
         data={data}
         knownData={[
-          ['Name', name],
+          ['?Name', name],
           ['Family', family],
           ['Model', model + (model_id ? ` (${model_id})` : '')],
           ['Architecture', arch],
-          ['Battery Level', defined(battery_level)
+          ['?Battery Level', defined(battery_level)
             ? `${battery_level}%` : null],
-          ['Orientation', orientation],
+          ['?Orientation', orientation],
         ]}
         alias={this.props.alias} />
     );

--- a/src/sentry/static/sentry/app/components/events/contexts/os.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/os.jsx
@@ -25,4 +25,8 @@ const OsContextType = React.createClass({
   }
 });
 
+OsContextType.getTitle = function(value) {
+  return 'Operating System';
+};
+
 export default OsContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/os.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/os.jsx
@@ -15,10 +15,10 @@ const OsContextType = React.createClass({
       <ContextBlock
         data={data}
         knownData={[
-          ['Name', name],
+          ['?Name', name],
           ['Version', version + (build ? ` (${build})` : '')],
           ['Kernel Version', kernel_version],
-          ['Rooted', defined(rooted) ? (rooted ? 'yes' : 'no') : null],
+          ['?Rooted', defined(rooted) ? (rooted ? 'yes' : 'no') : null],
         ]}
         alias={this.props.alias} />
     );

--- a/src/sentry/static/sentry/app/components/events/contexts/runtime.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/runtime.jsx
@@ -22,4 +22,8 @@ const RuntimeContextType = React.createClass({
   }
 });
 
+RuntimeContextType.getTitle = function(value) {
+  return 'Runtime';
+};
+
 export default RuntimeContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -39,4 +39,8 @@ const UserContextType = React.createClass({
   }
 });
 
+UserContextType.getTitle = function(value) {
+  return 'User';
+};
+
 export default UserContextType;

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -45,6 +45,7 @@ const EventEntries = React.createClass({
     template: require('./interfaces/template'),
     csp: require('./interfaces/csp'),
     breadcrumbs: require('./interfaces/breadcrumbs'),
+    threads: require('./interfaces/threads'),
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -15,6 +15,26 @@ import PropTypes from '../../proptypes';
 import utils from '../../utils';
 import {t} from '../../locale';
 
+import ExceptionInterface from './interfaces/exception';
+import MessageInterface from './interfaces/message';
+import RequestInterface from './interfaces/request';
+import StacktraceInterface from './interfaces/stacktrace';
+import TemplateInterface from './interfaces/template';
+import CspInterface from './interfaces/csp';
+import BreadcrumbsInterface from './interfaces/breadcrumbs';
+import ThreadsInterface from './interfaces/threads';
+
+export const INTERFACES = {
+  exception: ExceptionInterface,
+  message: MessageInterface,
+  request: RequestInterface,
+  stacktrace: StacktraceInterface,
+  template: TemplateInterface,
+  csp: CspInterface,
+  breadcrumbs: BreadcrumbsInterface,
+  threads: ThreadsInterface,
+};
+
 const EventEntries = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
@@ -36,17 +56,7 @@ const EventEntries = React.createClass({
     return this.props.event.id !== nextProps.event.id;
   },
 
-  // TODO(dcramer): make this extensible
-  interfaces: {
-    exception: require('./interfaces/exception'),
-    message: require('./interfaces/message'),
-    request: require('./interfaces/request'),
-    stacktrace: require('./interfaces/stacktrace'),
-    template: require('./interfaces/template'),
-    csp: require('./interfaces/csp'),
-    breadcrumbs: require('./interfaces/breadcrumbs'),
-    threads: require('./interfaces/threads'),
-  },
+  interfaces: INTERFACES,
 
   render() {
     let group = this.props.group;

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -7,6 +7,8 @@ import PropTypes from '../../proptypes';
 import EventDataSection from './eventDataSection';
 import {isUrl} from '../../utils';
 import {t} from '../../locale';
+import Pills from '../pills';
+import Pill from '../pill';
 
 const EventTags = React.createClass({
   propTypes: {
@@ -27,12 +29,12 @@ const EventTags = React.createClass({
           group={this.props.group}
           event={this.props.event}
           title={t('Tags')}
-          type="tags">
-        <ul className="mini-tag-list">
+          ype="tags">
+        <Pills>
           {tags.map((tag) => {
             return (
-              <li key={tag.key}>
-                {tag.key} = <Link
+              <Pill key={tag.key} name={tag.key}>
+                <Link
                   to={`/${orgId}/${projectId}/`}
                   query={{query: `${tag.key}:"${tag.value}"`}}>
                   {tag.value}
@@ -42,10 +44,10 @@ const EventTags = React.createClass({
                     <em className="icon-open" />
                   </a>
                 }
-              </li>
+              </Pill>
             );
           })}
-        </ul>
+        </Pills>
       </EventDataSection>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashContent.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from '../../../proptypes';
+import rawStacktraceContent from './rawStacktraceContent';
+import StacktraceContent from './stacktraceContent';
+import ExceptionContent from './exceptionContent';
+import RawExceptionContent from './rawExceptionContent';
+
+
+const CrashContent = React.createClass({
+  propTypes: {
+    group: PropTypes.Group.isRequired,
+    event: PropTypes.Event.isRequired,
+    stackView: React.PropTypes.string.isRequired,
+    stackType: React.PropTypes.string,
+    newestFirst: React.PropTypes.bool.isRequired,
+    exception: React.PropTypes.object,
+    stacktrace: React.PropTypes.object,
+  },
+
+  renderException() {
+    const {event, stackView, stackType, newestFirst, exception} = this.props;
+    return (
+      stackView === 'raw' ?
+        <RawExceptionContent
+          type={stackType}
+          values={exception.values}
+          platform={event.platform} /> :
+        <ExceptionContent
+          type={stackType}
+          view={stackView}
+          values={exception.values}
+          platform={event.platform}
+          newestFirst={newestFirst} />
+    );
+  },
+
+  renderStacktrace() {
+    const {event, stackView, newestFirst, stacktrace} = this.props;
+    return (
+      stackView === 'raw' ?
+        <pre className="traceback plain">
+          {rawStacktraceContent(stacktrace, event.platform)}</pre> :
+        <StacktraceContent
+          data={stacktrace}
+          className="no-exception"
+          includeSystemFrames={stackView === 'full'}
+          platform={event.platform}
+          newestFirst={newestFirst} />
+    );
+  },
+
+  render() {
+    if (this.props.exception) {
+      return this.renderException();
+    }
+    if (this.props.stacktrace) {
+      return this.renderStacktrace();
+    }
+  }
+});
+
+export default CrashContent;

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from '../../../proptypes';
+import TooltipMixin from '../../../mixins/tooltip';
+import {t} from '../../../locale';
+
+const CrashHeader = React.createClass({
+  propTypes: {
+    title: React.PropTypes.string,
+    group: PropTypes.Group.isRequired,
+    thread: React.PropTypes.object,
+    exception: React.PropTypes.object,
+    stacktrace: React.PropTypes.object,
+    stackView: React.PropTypes.string.isRequired,
+    newestFirst: React.PropTypes.bool.isRequired,
+    stackType: React.PropTypes.string.isRequired,
+    onChange: React.PropTypes.func,
+  },
+
+  mixins: [TooltipMixin({
+    html: false,
+    selector: '.tip',
+    trigger: 'hover'
+  })],
+
+  hasSystemFrames() {
+    const {stacktrace, thread, exception} = this.props;
+    return (
+      (stacktrace && stacktrace.hasSystemFrames) ||
+      (thread && thread.stacktrace && thread.stacktrace.hasSystemFrames) ||
+      (exception && exception.values.find(x => !!x.stacktrace.hasSystemFrames))
+    );
+  },
+
+  hasMinified() {
+    if (!this.props.stackType) {
+      return false;
+    }
+    const {exception} = this.props;
+    return exception && !!exception.values.find(x => x.rawStacktrace);
+  },
+
+  toggleOrder() {
+    this.notify({
+      newestFirst: !this.props.newestFirst
+    });
+  },
+
+  setStackType(type) {
+    this.notify({
+      stackType: type
+    });
+  },
+
+  setStackView(view) {
+    this.notify({
+      stackView: view
+    });
+  },
+
+  notify(obj) {
+    if (this.props.onChange) {
+      this.props.onChange(obj);
+    }
+  },
+
+  render() {
+    let {stackView, stackType, newestFirst} = this.props;
+
+    return (
+      <div className="crash-title">
+        <h3 className="pull-left">
+          {this.props.title || t('Exception')}
+          <small style={{marginLeft: 5}}>
+            (<a onClick={this.toggleOrder} className="tip" title={t('Toggle stacktrace order')} style={{borderBottom: '1px dotted #aaa'}}>
+              {newestFirst ?
+                t('most recent call first')
+              :
+                t('most recent call last')
+              }
+            </a>)
+          </small>
+        </h3>
+        {this.props.children}
+        <div className="btn-group" style={{marginLeft:10}}>
+          {this.hasSystemFrames() &&
+            <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setStackView.bind(this, 'app')}>{t('App Only')}</a>
+          }
+          <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setStackView.bind(this, 'full')}>{t('Full')}</a>
+          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setStackView.bind(this, 'raw')}>{t('Raw')}</a>
+        </div>
+        <div className="btn-group">
+          {this.hasMinified() &&
+            [
+              <a key="original" className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={() => this.setStackType('original')}>{t('Original')}</a>,
+              <a key="minified" className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={() => this.setStackType('minified')}>{t('Minified')}</a>
+            ]
+          }
+        </div>
+      </div>
+    );
+  }
+});
+
+export default CrashHeader;

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -6,6 +6,7 @@ import {t} from '../../../locale';
 const CrashHeader = React.createClass({
   propTypes: {
     title: React.PropTypes.string,
+    beforeTitle: React.PropTypes.any,
     group: PropTypes.Group.isRequired,
     thread: React.PropTypes.object,
     exception: React.PropTypes.object,
@@ -68,8 +69,9 @@ const CrashHeader = React.createClass({
 
     return (
       <div className="crash-title">
+        {this.props.beforeTitle}
         <h3 className="pull-left">
-          {this.props.title || t('Exception')}
+          {this.props.title !== undefined ? this.props.title : t('Exception')}
           <small style={{marginLeft: 5}}>
             (<a onClick={this.toggleOrder} className="tip" title={t('Toggle stacktrace order')} style={{borderBottom: '1px dotted #aaa'}}>
               {newestFirst ?
@@ -80,7 +82,6 @@ const CrashHeader = React.createClass({
             </a>)
           </small>
         </h3>
-        {this.props.children}
         <div className="btn-group" style={{marginLeft:10}}>
           {this.hasSystemFrames() &&
             <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.setStackView.bind(this, 'app')}>{t('App Only')}</a>

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -25,7 +25,6 @@ const ExceptionInterface = React.createClass({
     let user = ConfigStore.get('user');
     // user may not be authenticated
     let options = user ? user.options : {};
-    let platform = this.props.event.platform;
     let newestFirst;
     switch (options.stacktraceOrder) {
       case 'newestFirst':
@@ -36,7 +35,7 @@ const ExceptionInterface = React.createClass({
         break;
       case 'default':
       default:
-        newestFirst = (platform !== 'python');
+        newestFirst = false;
     }
 
     return {

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import ConfigStore from '../../../stores/configStore';
 import GroupEventDataSection from '../eventDataSection';
 import PropTypes from '../../../proptypes';
 import ExceptionContent from './exceptionContent';
 import RawExceptionContent from './rawExceptionContent';
 import TooltipMixin from '../../../mixins/tooltip';
 import {t} from '../../../locale';
+import {getStacktraceDefaultState} from './stacktrace';
 
 const ExceptionInterface = React.createClass({
   propTypes: {
@@ -22,27 +22,9 @@ const ExceptionInterface = React.createClass({
   })],
 
   getInitialState() {
-    let user = ConfigStore.get('user');
-    // user may not be authenticated
-    let options = user ? user.options : {};
-    let newestFirst;
-    switch (options.stacktraceOrder) {
-      case 'newestFirst':
-        newestFirst = true;
-        break;
-      case 'newestLast':
-        newestFirst = false;
-        break;
-      case 'default':
-      default:
-        newestFirst = false;
-    }
-
-    return {
-      stackView: (this.props.data.hasSystemFrames ? 'app' : 'full'),
-      stackType: 'original',
-      newestFirst: newestFirst
-    };
+    let rv = getStacktraceDefaultState(null, this.props.data.hasSystemFrames);
+    rv.stackType = 'original';
+    return rv;
   },
 
   toggleStackView(value) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -5,7 +5,7 @@ import ExceptionContent from './exceptionContent';
 import RawExceptionContent from './rawExceptionContent';
 import TooltipMixin from '../../../mixins/tooltip';
 import {t} from '../../../locale';
-import {getStacktraceDefaultState} from './stacktrace';
+import {isStacktraceNewestFirst} from './stacktrace';
 
 const ExceptionInterface = React.createClass({
   propTypes: {
@@ -22,9 +22,11 @@ const ExceptionInterface = React.createClass({
   })],
 
   getInitialState() {
-    let rv = getStacktraceDefaultState(null, this.props.data.hasSystemFrames);
-    rv.stackType = 'original';
-    return rv;
+    return {
+      stackView: this.props.data.hasSystemFrames ? 'app' : 'full',
+      newestFirst: isStacktraceNewestFirst(),
+      stackType: 'original',
+    };
   },
 
   toggleStackView(value) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
 import PropTypes from '../../../proptypes';
-import ExceptionContent from './exceptionContent';
-import RawExceptionContent from './rawExceptionContent';
-import TooltipMixin from '../../../mixins/tooltip';
-import {t} from '../../../locale';
 import {isStacktraceNewestFirst} from './stacktrace';
+import CrashHeader from './crashHeader';
+import CrashContent from './crashContent';
 
 const ExceptionInterface = React.createClass({
   propTypes: {
@@ -15,12 +13,6 @@ const ExceptionInterface = React.createClass({
     data: React.PropTypes.object.isRequired,
   },
 
-  mixins: [TooltipMixin({
-    html: false,
-    selector: '.tip',
-    trigger: 'hover'
-  })],
-
   getInitialState() {
     return {
       stackView: this.props.data.hasSystemFrames ? 'app' : 'full',
@@ -29,79 +21,52 @@ const ExceptionInterface = React.createClass({
     };
   },
 
-  toggleStackView(value) {
-    this.setState({
-      stackView: value
-    });
-  },
-
-  toggleOrder() {
-    this.setState({newestFirst: !this.state.newestFirst});
+  eventHasThreads() {
+    return !!this.props.event.entries.find(x => x.type === 'threads');
   },
 
   render() {
     let group = this.props.group;
-    let evt = this.props.event;
+    let event = this.props.event;
     let data = this.props.data;
     let stackView = this.state.stackView;
     let stackType = this.state.stackType;
     let newestFirst = this.state.newestFirst;
 
-    // at least one stack trace contains raw/minified code
-    let hasMinified = data.values.find(x => !!x.rawStacktrace);
+    // in case there are threads in the event data, we don't render the
+    // exception block.  Instead the exception is contained within the
+    // thread interface.
+    if (this.eventHasThreads()) {
+      return null;
+    }
 
     let title = (
-      <div>
-        <div className="btn-group" style={{marginLeft:10}}>
-          {data.hasSystemFrames &&
-            <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'app')}>{t('App Only')}</a>
-          }
-          <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'full')}>{t('Full')}</a>
-          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStackView.bind(this, 'raw')}>{t('Raw')}</a>
-        </div>
-        <div className="btn-group">
-          {hasMinified &&
-            [
-              <a key="original" className={(stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={() => this.setState({stackType: 'original'})}>{t('Original')}</a>,
-              <a key="minified" className={(stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={() => this.setState({stackType: 'minified'})}>{t('Minified')}</a>
-            ]
-          }
-        </div>
-        <h3>
-          {t('Exception')}
-          <small style={{marginLeft: 5}}>
-            (<a onClick={this.toggleOrder} className="tip" title={t('Toggle stacktrace order')} style={{borderBottom: '1px dotted #aaa'}}>
-              {newestFirst ?
-                t('most recent call first')
-              :
-                t('most recent call last')
-              }
-            </a>)
-          </small>
-        </h3>
-      </div>
+      <CrashHeader
+        group={group}
+        exception={data}
+        stackView={stackView}
+        newestFirst={newestFirst}
+        stackType={stackType}
+        onChange={(newState) => {
+          this.setState(newState);
+        }}
+      />
     );
 
     return (
       <GroupEventDataSection
           group={group}
-          event={evt}
+          event={event}
           type={this.props.type}
           title={title}
           wrapTitle={false}>
-        {stackView === 'raw' ?
-          <RawExceptionContent
-            type={stackType}
-            values={data.values}
-            platform={evt.platform}/> :
-
-          <ExceptionContent
-            type={stackType}
-            view={stackView}
-            values={data.values}
-            platform={evt.platform}
-            newestFirst={newestFirst}/>
-        }
+        <CrashContent
+          group={group}
+          event={event}
+          stackType={stackType}
+          stackView={stackView}
+          newestFirst={newestFirst}
+          exception={data} />
       </GroupEventDataSection>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import KeyValueList from '../interfaces/keyValueList';
+import Pills from '../../pills';
+import Pill from '../../pill';
 
 const ExceptionMechanism = React.createClass({
   propTypes: {
@@ -8,29 +9,44 @@ const ExceptionMechanism = React.createClass({
   },
 
   render() {
-    let elements = [];
+    let pills = [];
 
     if (this.props.data.mach_exception) {
       const {mach_exception} = this.props.data;
       if (mach_exception.exception_name) {
-        elements.push(['Mach Exception', mach_exception.exception_name]);
+        pills.push(<Pill
+          key="mach-exception"
+          name="mach exception"
+          value={mach_exception.exception_name}
+        />);
       }
       if (mach_exception.code_name) {
-        elements.push(['Mach Code', mach_exception.code_name]);
+        pills.push(<Pill
+          key="mach-code"
+          name="mach code"
+          value={mach_exception.code_name}
+        />);
       }
     }
     if (this.props.data.posix_signal) {
       const {posix_signal} = this.props.data;
-      elements.push(['Signal', posix_signal.name + ' (' + posix_signal.signal + ')']);
+      pills.push(<Pill
+        key="signal"
+        name="signal"
+        >
+        {posix_signal.name}
+        {' '}
+        <em>({posix_signal.signal})</em>
+      </Pill>);
     }
 
-    if (elements.length === 0) {
+    if (pills.length === 0) {
       return null;
     }
 
     return (
       <div className="exception-mechanism">
-        <KeyValueList data={elements} />
+        <Pills>{pills}</Pills>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -97,8 +97,14 @@ const Frame = React.createClass({
     return out;
   },
 
+  getPlatform() {
+    // prioritize the frame platform but fall back to the platform
+    // of the stacktrace / exception
+    return this.props.data.platform || this.props.platform;
+  },
+
   shouldPrioritizeModuleName() {
-    switch (this.props.platform) {
+    switch (this.getPlatform()) {
       case 'java':
       case 'csharp':
         return true;
@@ -289,7 +295,7 @@ const Frame = React.createClass({
   },
 
   renderLine() {
-    switch (this.props.platform) {
+    switch (this.getPlatform()) {
       case 'objc':
       case 'cocoa':
         return this.renderCocoaLine();

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -158,7 +158,7 @@ const Frame = React.createClass({
 
     if (defined(data.package)) {
       title.push(<span className="within" key="within"> within </span>);
-      title.push(<code title={data.package} className="package">{trimPackage(data.package)}</code>);
+      title.push(<code title={data.package} className="package" key="package">{trimPackage(data.package)}</code>);
     }
 
     if (defined(data.origAbsPath)) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -12,7 +12,7 @@ import {defined, objectIsEmpty, isUrl} from '../../../utils';
 import ContextLine from './contextLine';
 import FrameVariables from './frameVariables';
 
-function trimPackage(pkg) {
+export function trimPackage(pkg) {
   let pieces = pkg.split(/\//g);
   let rv = pieces[pieces.length - 1] || pieces[pieces.length - 2] || pkg;
   let match = rv.match(/^(.*?)\.(dylib|so|a)$/);

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
@@ -1,4 +1,5 @@
 import {defined, trim} from '../../../utils';
+import {trimPackage} from './frame';
 
 function getJavaScriptFrame(frame) {
   let result = '';
@@ -101,7 +102,7 @@ function ljust(str, len) {
 export function getCocoaFrame(frame) {
   let result = '  ';
   if (defined(frame.package)) {
-    result += ljust(frame.package, 20);
+    result += ljust(trimPackage(frame.package), 20);
   }
   if (defined(frame.instructionAddr)) {
     result += ljust(frame.instructionAddr, 12);
@@ -138,6 +139,9 @@ function getPreamble(exception, platform) {
 }
 
 function getFrame(frame, frameIdx, platform) {
+  if (frame.platform) {
+    platform = frame.platform;
+  }
   switch (platform) {
     case 'javascript':
       return getJavaScriptFrame(frame, frameIdx);

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -20,7 +20,6 @@ const StacktraceInterface = React.createClass({
     let user = ConfigStore.get('user');
     // user may not be authenticated
     let options = user ? user.options : {};
-    let platform = this.props.event.platform;
     let newestFirst;
     switch (options.stacktraceOrder) {
       case 'newestFirst':
@@ -31,7 +30,7 @@ const StacktraceInterface = React.createClass({
         break;
       case 'default': // is "default" a valid value? or bad case statement
       default:
-        newestFirst = (platform === 'python');
+        newestFirst = false;
     }
 
     return {

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -81,7 +81,7 @@ const StacktraceInterface = React.createClass({
           wrapTitle={false}>
         {stackView === 'raw' ?
           <pre className="traceback plain">
-            {rawStacktraceContent(data, this.props.platform)}
+            {rawStacktraceContent(data, evt.platform)}
           </pre>
         :
           <StacktraceContent

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -7,6 +7,32 @@ import StacktraceContent from './stacktraceContent';
 import {t} from '../../../locale';
 
 
+export function getStacktraceDefaultState(user, hasSystemFrames) {
+  if (!user) {
+    user = ConfigStore.get('user');
+  }
+  // user may not be authenticated
+  let options = user ? user.options : {};
+  let newestFirst;
+  switch (options.stacktraceOrder) {
+    case 'newestFirst':
+      newestFirst = true;
+      break;
+    case 'newestLast':
+      newestFirst = false;
+      break;
+    case 'default': // is "default" a valid value? or bad case statement
+    default:
+      newestFirst = false;
+  }
+
+  return {
+    stackView: hasSystemFrames ? 'app' : 'full',
+    newestFirst: newestFirst
+  };
+}
+
+
 const StacktraceInterface = React.createClass({
   propTypes: {
     group: PropTypes.Group.isRequired,
@@ -17,26 +43,7 @@ const StacktraceInterface = React.createClass({
   },
 
   getInitialState() {
-    let user = ConfigStore.get('user');
-    // user may not be authenticated
-    let options = user ? user.options : {};
-    let newestFirst;
-    switch (options.stacktraceOrder) {
-      case 'newestFirst':
-        newestFirst = true;
-        break;
-      case 'newestLast':
-        newestFirst = false;
-        break;
-      case 'default': // is "default" a valid value? or bad case statement
-      default:
-        newestFirst = false;
-    }
-
-    return {
-      stackView: (this.props.data.hasSystemFrames ? 'app' : 'full'),
-      newestFirst: newestFirst
-    };
+    return getStacktraceDefaultState(null, this.props.data.hasSystemFrames);
   },
 
   toggleStack(value) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ConfigStore from '../../../stores/configStore';
 import GroupEventDataSection from '../eventDataSection';
 import PropTypes from '../../../proptypes';
-import rawStacktraceContent from './rawStacktraceContent';
-import StacktraceContent from './stacktraceContent';
 import {t} from '../../../locale';
+import CrashHeader from './crashHeader';
+import CrashContent from './crashContent';
 
 
 export function isStacktraceNewestFirst() {
@@ -53,23 +53,16 @@ const StacktraceInterface = React.createClass({
     let newestFirst = this.state.newestFirst;
 
     let title = (
-      <div>
-        <div className="btn-group">
-          {data.hasSystemFrames &&
-            <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'app')}>{t('App Only')}</a>
-          }
-          <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'full')}>{t('Full')}</a>
-          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'raw')}>{t('Raw')}</a>
-        </div>
-        <h3>
-          {'Stacktrace '}
-          {newestFirst ?
-            <small>({t('most recent call last')})</small>
-          :
-            <small>({t('most recent call first')})</small>
-          }
-        </h3>
-      </div>
+      <CrashHeader
+        title={t('Stacktrace')}
+        group={group}
+        stacktrace={data}
+        stackView={stackView}
+        newestFirst={newestFirst}
+        onChange={(newState) => {
+          this.setState(newState);
+        }}
+      />
     );
 
     return (
@@ -79,18 +72,12 @@ const StacktraceInterface = React.createClass({
           type={this.props.type}
           title={title}
           wrapTitle={false}>
-        {stackView === 'raw' ?
-          <pre className="traceback plain">
-            {rawStacktraceContent(data, evt.platform)}
-          </pre>
-        :
-          <StacktraceContent
-              data={data}
-              className="no-exception"
-              includeSystemFrames={stackView === 'full'}
-              platform={evt.platform}
-              newestFirst={newestFirst} />
-        }
+        <CrashContent
+          group={group}
+          event={event}
+          stackView={stackView}
+          newestFirst={newestFirst}
+          stacktrace={data} />
       </GroupEventDataSection>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -7,29 +7,19 @@ import StacktraceContent from './stacktraceContent';
 import {t} from '../../../locale';
 
 
-export function getStacktraceDefaultState(user, hasSystemFrames) {
-  if (!user) {
-    user = ConfigStore.get('user');
-  }
+export function isStacktraceNewestFirst() {
+  let user = ConfigStore.get('user');
   // user may not be authenticated
   let options = user ? user.options : {};
-  let newestFirst;
   switch (options.stacktraceOrder) {
     case 'newestFirst':
-      newestFirst = true;
-      break;
+      return true;
     case 'newestLast':
-      newestFirst = false;
-      break;
+      return false;
     case 'default': // is "default" a valid value? or bad case statement
     default:
-      newestFirst = false;
+      return false;
   }
-
-  return {
-    stackView: hasSystemFrames ? 'app' : 'full',
-    newestFirst: newestFirst
-  };
 }
 
 
@@ -43,7 +33,10 @@ const StacktraceInterface = React.createClass({
   },
 
   getInitialState() {
-    return getStacktraceDefaultState(null, this.props.data.hasSystemFrames);
+    return {
+      stackView: this.props.data.hasSystemFrames ? 'app' : 'full',
+      newestFirst: isStacktraceNewestFirst(),
+    };
   },
 
   toggleStack(value) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -85,7 +85,7 @@ const ThreadsInterface = React.createClass({
 
   getInitialState() {
     let hasSystemFrames = false;
-    for (let thread of this.props.data.list) {
+    for (let thread of this.props.data.values) {
       if (thread.stacktrace && thread.stacktrace.hasSystemFrames) {
         hasSystemFrames = true;
         break;
@@ -134,7 +134,7 @@ const ThreadsInterface = React.createClass({
           type={this.props.type}
           title={title}
           wrapTitle={false}>
-        {this.props.data.list.map((thread, idx) => {
+        {this.props.data.values.map((thread, idx) => {
           return (
             <Thread
               key={idx}

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -34,20 +34,17 @@ function findThreadStacktrace(thread, event) {
   if (thread.stacktrace) {
     return thread.stacktrace;
   }
-  let stack = null;
   for (let entry of event.entries) {
-    if (entry.type === 'stacktrace') {
-      stack = entry.data;
-    } else if (entry.type === 'exception') {
-      for (let exc of entry.data.values) {
-        if (exc.threadId === thread.id && exc.stacktrace) {
-          stack = exc.stacktrace;
-          break;
-        }
+    if (entry.type !== 'exception') {
+      continue;
+    }
+    for (let exc of entry.data.values) {
+      if (exc.threadId === thread.id && exc.stacktrace) {
+        return exc.stacktrace;
       }
     }
   }
-  return stack;
+  return null;
 }
 
 function getThreadTitle(thread, event) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -48,6 +48,10 @@ const Thread = React.createClass({
   },
 
   render() {
+    let includeSystemFrames = this.props.stackView === 'full' ||
+      (this.props.data.stacktrace &&
+       !this.props.data.stacktrace.hasSystemFrames);
+
     return (
       <div className="thread">
         {this.renderTitle()}
@@ -59,7 +63,7 @@ const Thread = React.createClass({
           :
             <StacktraceContent
                 data={this.props.data.stacktrace}
-                includeSystemFrames={this.props.stackView === 'full'}
+                includeSystemFrames={includeSystemFrames}
                 platform={this.props.event.platform}
                 newestFirst={this.props.newestFirst} />
         ) : (
@@ -81,8 +85,8 @@ const ThreadsInterface = React.createClass({
 
   getInitialState() {
     let hasSystemFrames = false;
-    for (let thread in this.props.data.list) {
-      if (thread.hasSystemFrames) {
+    for (let thread of this.props.data.list) {
+      if (thread.stacktrace && thread.stacktrace.hasSystemFrames) {
         hasSystemFrames = true;
         break;
       }

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import GroupEventDataSection from '../eventDataSection';
+import PropTypes from '../../../proptypes';
+import rawStacktraceContent from './rawStacktraceContent';
+import StacktraceContent from './stacktraceContent';
+import {getStacktraceDefaultState} from './stacktrace';
+import {t} from '../../../locale';
+
+
+const Thread = React.createClass({
+  propTypes: {
+    event: PropTypes.Event.isRequired,
+    data: React.PropTypes.object.isRequired,
+    platform: React.PropTypes.string,
+    stackView: React.PropTypes.string.isRequired,
+    newestFirst: React.PropTypes.bool.isRequired,
+  },
+
+  renderTitle() {
+    let bits = [];
+    if (this.data.index) {
+      bits.push('#' + this.data.index);
+    }
+    if (this.data.name) {
+      bits.push(`"${this.data.name}"`);
+    }
+    if (this.data.id) {
+      bits.push('id=' + this.data.id);
+    }
+    return <h3>bits.join(' ')</h3>;
+  },
+
+  render() {
+    return (
+      <div className="thread">
+        {this.renderTitle()}
+        {this.props.data.stacktrace && (
+          this.props.stackView === 'raw' ?
+            <pre className="traceback plain">
+              {rawStacktraceContent(this.props.data.stacktrace, this.props.platform)}
+            </pre>
+          :
+            <StacktraceContent
+                data={this.props.data.stacktrace}
+                className="no-exception"
+                includeSystemFrames={this.props.stackView === 'full'}
+                platform={this.props.event.platform}
+                newestFirst={this.props.newestFirst} />
+        )}
+      </div>
+    );
+  }
+});
+
+const ThreadsInterface = React.createClass({
+  propTypes: {
+    group: PropTypes.Group.isRequired,
+    event: PropTypes.Event.isRequired,
+    type: React.PropTypes.string.isRequired,
+    data: React.PropTypes.object.isRequired,
+    platform: React.PropTypes.string
+  },
+
+  getInitialState() {
+    let hasSystemFrames = false;
+    for (let thread in this.props.data.threads) {
+      if (thread.hasSystemFrames) {
+        hasSystemFrames = true;
+        break;
+      }
+    }
+    let rv = getStacktraceDefaultState(null, hasSystemFrames);
+    rv.hasSystemFrames = hasSystemFrames;
+    return rv;
+  },
+
+  toggleStack(value) {
+    this.setState({
+      stackView: value
+    });
+  },
+
+  render() {
+    let group = this.props.group;
+    let evt = this.props.event;
+    let {stackView, newestFirst, hasSystemFrames} = this.state;
+
+    let title = (
+      <div>
+        <div className="btn-group">
+          {hasSystemFrames &&
+            <a className={(stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'app')}>{t('App Only')}</a>
+          }
+          <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'full')}>{t('Full')}</a>
+          <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'raw')}>{t('Raw')}</a>
+        </div>
+        <h3>
+          {'Threads'}
+          {newestFirst ?
+            <small>({t('most recent call last')})</small>
+          :
+            <small>({t('most recent call first')})</small>
+          }
+        </h3>
+      </div>
+    );
+
+    return (
+      <GroupEventDataSection
+          group={group}
+          event={evt}
+          type={this.props.type}
+          title={title}
+          wrapTitle={false}>
+        {this.state.threads.map((thread, idx) => {
+          return (
+            <Thread
+              key={idx}
+              data={thread}
+              event={evt}
+              stackView={stackView}
+              newestFirst={newestFirst} />
+          );
+        })}
+      </GroupEventDataSection>
+    );
+  }
+});
+
+export default ThreadsInterface;

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -97,7 +97,6 @@ const Thread = React.createClass({
   propTypes: {
     event: PropTypes.Event.isRequired,
     data: React.PropTypes.object.isRequired,
-    platform: React.PropTypes.string,
     stackView: React.PropTypes.string,
     newestFirst: React.PropTypes.bool,
     stacktrace: React.PropTypes.object,
@@ -137,7 +136,7 @@ const Thread = React.createClass({
           this.props.stackView === 'raw' ?
             <pre className="traceback plain">
               {rawStacktraceContent(
-                this.props.stacktrace, this.props.platform)}
+                this.props.stacktrace, this.props.event.platform)}
             </pre>
           :
             <StacktraceContent

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
 import PropTypes from '../../../proptypes';
+import KeyValueList from './keyValueList';
 import rawStacktraceContent from './rawStacktraceContent';
 import StacktraceContent from './stacktraceContent';
 import {isStacktraceNewestFirst} from './stacktrace';
@@ -121,9 +122,17 @@ const Thread = React.createClass({
   },
 
   render() {
+    const {data} = this.props;
     return (
       <div className="thread">
-        <h4>{getThreadTitle(this.props.data, this.props.event)}</h4>
+        <KeyValueList
+          data={[
+            ['Thread ID', data.id],
+            ['Name', data.name || 'n/a'],
+            ['Was Active', data.current ? 'yes' : 'no'],
+            ['Crashed', data.crashed ? 'yes' : 'no'],
+          ]}
+          isSorted={false} />
         {this.props.stacktrace ? (
           this.props.stackView === 'raw' ?
             <pre className="traceback plain">
@@ -190,8 +199,16 @@ const ThreadsInterface = React.createClass({
     let stacktrace = this.getStacktrace();
 
     let title = (
-      <div>
-        <div className="pull-right btn-group">
+      <div className="thread-title">
+        <h3 className="pull-left">
+          {'Threads '}
+          {newestFirst ?
+            <small>({t('most recent call last')})</small>
+          :
+            <small>({t('most recent call first')})</small>
+          }
+        </h3>
+        <div className="pull-left btn-group">
           <DropdownLink 
             btnGroup={true}
             caret={true}
@@ -214,14 +231,6 @@ const ThreadsInterface = React.createClass({
           <a className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'full')}>{t('Full')}</a>
           <a className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'} onClick={this.toggleStack.bind(this, 'raw')}>{t('Raw')}</a>
         </div>
-        <h3>
-          {'Threads '}
-          {newestFirst ?
-            <small>({t('most recent call last')})</small>
-          :
-            <small>({t('most recent call first')})</small>
-          }
-        </h3>
       </div>
     );
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -153,7 +153,7 @@ const Thread = React.createClass({
     return (
       <div className="thread">
         <Pills>
-          <Pill name="thread ID" value={data.id} />
+          <Pill name="id" value={data.id} />
           <Pill name="name" value={data.name} />
           <Pill name="was active" value={data.current} />
           <Pill name="crashed" className={data.crashed ? 'false' : 'true'

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -156,7 +156,8 @@ const Thread = React.createClass({
           <Pill name="thread ID" value={data.id} />
           <Pill name="name" value={data.name} />
           <Pill name="was active" value={data.current} />
-          <Pill name="crashed" value={data.crashed} />
+          <Pill name="crashed" className={data.crashed ? 'false' : 'true'
+            }>{data.crashed ? 'yes' : 'no'}</Pill>
         </Pills>
         {this.hasMissingStacktrace() ?
           this.renderMissingStacktrace() :

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
 import PropTypes from '../../../proptypes';
-import KeyValueList from './keyValueList';
 import {isStacktraceNewestFirst} from './stacktrace';
 import {t} from '../../../locale';
 import {defined} from '../../../utils';
@@ -10,6 +9,8 @@ import MenuItem from '../../menuItem';
 import {trimPackage} from './frame';
 import CrashHeader from './crashHeader';
 import CrashContent from './crashContent';
+import Pills from '../../pills';
+import Pill from '../../pill';
 
 function trimFilename(fn) {
   let pieces = fn.split(/\//g);
@@ -151,14 +152,12 @@ const Thread = React.createClass({
       newestFirst, exception, stacktrace} = this.props;
     return (
       <div className="thread">
-        <KeyValueList
-          data={[
-            ['Thread ID', data.id],
-            ['Name', data.name || 'n/a'],
-            ['Was Active', data.current ? 'yes' : 'no'],
-            ['Crashed', data.crashed ? 'yes' : 'no'],
-          ]}
-          isSorted={false} />
+        <Pills>
+          <Pill name="thread ID" value={data.id} />
+          <Pill name="name" value={data.name} />
+          <Pill name="was active" value={data.current} />
+          <Pill name="crashed" value={data.crashed} />
+        </Pills>
         {this.hasMissingStacktrace() ?
           this.renderMissingStacktrace() :
           <CrashContent

--- a/src/sentry/static/sentry/app/components/pill.jsx
+++ b/src/sentry/static/sentry/app/components/pill.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+
+const Pill = React.createClass({
+  propTypes: {
+    className: React.PropTypes.string,
+    name: React.PropTypes.string,
+    value: React.PropTypes.any,
+  },
+
+  renderValue() {
+    const {value} = this.props;
+    if (value === undefined) {
+      return [null, null];
+    }
+    let extraClass = null;
+    let renderedValue;
+    if (value === true || value === false) {
+      extraClass = value ? 'true' : 'false';
+      renderedValue = value ? 'yes' : 'no';
+    } else if (value === null) {
+      extraClass = 'false';
+      renderedValue = 'n/a';
+    } else {
+      renderedValue = value.toString();
+    }
+    return [extraClass, renderedValue];
+  },
+
+  render() {
+    const {name, value, children, className, ...props} = this.props;
+    let [extraClass, renderedValue] = this.renderValue();
+
+    return (
+      <li className={
+        (className || '') + (extraClass ? ' ' + extraClass : '')} {...props}>
+        <span className="key">{name}</span>
+        <span className="value">{renderedValue}{children}</span>
+      </li>
+    );
+  }
+});
+
+export default Pill;

--- a/src/sentry/static/sentry/app/components/pills.jsx
+++ b/src/sentry/static/sentry/app/components/pills.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+
+const Pills = React.createClass({
+  render() {
+    return (
+      <div className="pills">
+        {this.props.children}
+      </div>
+    );
+  }
+});
+
+export default Pills;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1741,10 +1741,10 @@ pre.val, span.val {
 }
 
 /**
-* Threads
+* Exceptions and Threads
 * ============================================================================
 */
-.box .thread-title {
+.box .crash-title {
   h3 {
     padding-right: 10px;
   }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1744,8 +1744,10 @@ pre.val, span.val {
 * Threads
 * ============================================================================
 */
-.box-content .thread {
-  margin: 0 0 20px 0;
+.box .thread-title {
+  h3 {
+    padding-right: 10px;
+  }
 }
 
 /**

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1746,13 +1746,6 @@ pre.val, span.val {
 */
 .box-content .thread {
   margin: 0 0 20px 0;
-
-  h4 {
-    margin: 0 -20px 0 -20px;
-    padding: 7px 20px;
-    color: @gray-darker;
-    font-size: 14px;
-  }
 }
 
 /**

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1087,6 +1087,10 @@ div.traceback > ul {
         font-weight: bold;
       }
 
+      .informal {
+        font-style: italic;
+      }
+
       a.annotation {
         &.trigger-popover {
           cursor: pointer;
@@ -1100,6 +1104,10 @@ div.traceback > ul {
 
     &.system-frame .title {
       background: @white-dark;
+    }
+
+    &.missing-frame .title {
+      background: lighten(@red-light, 30);
     }
 
     .title.as-table {
@@ -1729,6 +1737,21 @@ pre.val, span.val {
 
   &.val-toggle-open > a.val-toggle-link:hover {
     background: @gray;
+  }
+}
+
+/**
+* Threads
+* ============================================================================
+*/
+.box-content .thread {
+  margin: 0 0 20px 0;
+
+  h4 {
+    margin: 0 -20px 0 -20px;
+    padding: 7px 20px;
+    color: @gray-darker;
+    font-size: 14px;
   }
 }
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1750,6 +1750,15 @@ pre.val, span.val {
   }
 }
 
+.box .thread {
+  .exception {
+    margin-top: 10px;
+  }
+  .traceback.no-exception {
+    margin-top: 0;
+  }
+}
+
 /**
 * Shared Group Detail
 * ============================================================================

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1744,12 +1744,6 @@ pre.val, span.val {
 * Exceptions and Threads
 * ============================================================================
 */
-.box .crash-title {
-  h3 {
-    padding-right: 10px;
-  }
-}
-
 .box .thread {
   .exception {
     margin-top: 10px;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1499,6 +1499,59 @@ ul.faces {
 }
 
 /**
+* Key value pill / lozenge
+* ============================================================================
+*/
+
+.pills {
+  .list-unstyled;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 13px;
+
+  li {
+    white-space: nowrap;
+    margin: 0 15px 15px 0;
+    border-radius: 1px;
+    display: flex;
+    border: 1px solid @trim;
+    border-radius: 3px;
+    box-shadow: 0 1px 2px rgba(0,0,0, .06);
+    line-height: 1.2;
+
+    &.true .value {
+      background: #FBFEFA;
+      border: 1px solid #C7DBBD;
+      margin: -1px;
+      color: #6A726C;
+    }
+
+    &.false .value {
+      background: #FFF9F9;
+      border: 1px solid #E5C4C4;
+      margin: -1px;
+      color: #766A6A;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
+  .key {
+    padding: 5px 10px;
+  }
+
+  .value {
+    background: @white-dark;
+    padding: 5px 10px;
+    border-left: 1px solid @trim;
+    border-radius: 0 3px 3px 0;
+    font-family: Monaco, monospace;
+  }
+}
+
+/**
 * Assignee Selector
 * ============================================================================
 */

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1514,9 +1514,9 @@ ul.faces {
     margin: 0 15px 15px 0;
     border-radius: 1px;
     display: flex;
-    border: 1px solid @trim;
+    border: 1px solid darken(@trim, 2);
     border-radius: 3px;
-    box-shadow: 0 1px 2px rgba(0,0,0, .06);
+    box-shadow: 0 1px 2px rgba(0,0,0, .02);
     line-height: 1.2;
 
     &.true .value {
@@ -1538,13 +1538,12 @@ ul.faces {
     }
   }
 
-  .key {
-    padding: 5px 10px;
+  .key, .value {
+    padding: 4px 8px;
   }
 
   .value {
     background: @white-dark;
-    padding: 5px 10px;
     border-left: 1px solid @trim;
     border-radius: 0 3px 3px 0;
     font-family: Monaco, monospace;

--- a/src/sentry/utils/native.py
+++ b/src/sentry/utils/native.py
@@ -1,0 +1,10 @@
+def parse_addr(x):
+    if x is None:
+        return 0
+    if isinstance(x, (int, long)):
+        return x
+    if isinstance(x, basestring):
+        if x[:2] == '0x':
+            return int(x[2:], 16)
+        return int(x)
+    raise ValueError('Unsupported address format %r' % (x,))

--- a/tests/sentry/interfaces/test_contexts.py
+++ b/tests/sentry/interfaces/test_contexts.py
@@ -14,17 +14,20 @@ class ContextsTest(TestCase):
             'os': {
                 'name': 'Windows',
                 'version': '95',
+                'rooted': True,
             },
         })
         assert sorted(ctx.iter_tags()) == [
             ('os', 'Windows 95'),
             ('os.name', 'Windows'),
+            ('os.rooted', 'yes'),
         ]
         assert ctx.to_json() == {
             'os': {
                 'type': 'os',
                 'name': 'Windows',
                 'version': '95',
+                'rooted': True,
             }
         }
 

--- a/tests/sentry/interfaces/test_debug_meta.py
+++ b/tests/sentry/interfaces/test_debug_meta.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from sentry.interfaces.debug_meta import DebugMeta
+from sentry.testutils import TestCase
+
+
+class DebugMetaTest(TestCase):
+
+    def test_basic_behavior(self):
+        image_name = (
+            '/var/containers/Bundle/Application/'
+            'B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest'
+        )
+        interface = DebugMeta.to_python({
+            "images": [
+                {
+                    "type": "apple",
+                    "cpu_subtype": 0,
+                    "uuid": "C05B4DDD-69A7-3840-A649-32180D341587",
+                    "image_vmaddr": 4294967296,
+                    "image_addr": '0x100020000',
+                    "cpu_type": 16777228,
+                    "image_size": 32768,
+                    "name": image_name,
+                }
+            ],
+            "sdk_info": {
+                "dsym_type": "macho",
+                "sdk_name": "iOS",
+                "version_major": 9,
+                "version_minor": 3,
+                "version_patchlevel": 0
+            }
+        })
+
+        assert len(interface.images) == 1
+        img = interface.images[0]
+        assert img['type'] == 'apple'
+        assert img['cpu_type'] == 16777228
+        assert img['cpu_subtype'] == 0
+        assert img['uuid'] == 'C05B4DDD-69A7-3840-A649-32180D341587'
+        assert img['image_vmaddr'] == '0x100000000'
+        assert img['image_addr'] == '0x100020000'
+        assert img['image_size'] == 32768
+        assert img['name'] == image_name
+
+        assert interface.sdk_info['dsym_type'] == 'macho'
+        assert interface.sdk_info['sdk_name'] == 'iOS'
+        assert interface.sdk_info['version_major'] == 9
+        assert interface.sdk_info['version_minor'] == 3
+        assert interface.sdk_info['version_patchlevel'] == 0

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -173,6 +173,7 @@ class SingleExceptionTest(TestCase):
             'type': self.interface.type,
             'value': self.interface.value,
             'module': self.interface.module,
+            'thread_id': None,
             'mechanism': None,
             'stacktrace': None,
             'raw_stacktrace': None,

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -449,6 +449,19 @@ class StacktraceTest(TestCase):
             {'x': '<nan>'},
         )
 
+    def test_address_normalization(self):
+        interface = Frame.to_python({
+            'lineno': 1,
+            'filename': 'blah.c',
+            'function': 'main',
+            'instruction_addr': 123456,
+            'symbol_addr': '123450',
+            'image_addr': '0x0',
+        })
+        assert interface.instruction_addr == '0x1e240'
+        assert interface.symbol_addr == '0x1e23a'
+        assert interface.image_addr == '0x0'
+
 
 class SlimFrameDataTest(TestCase):
     def test_under_max(self):

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -6,7 +6,7 @@ from sentry.testutils import TestCase
 
 class BasicResolvingIntegrationTest(TestCase):
 
-    @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_frame')
+    @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_app_frame')
     def test_frame_resolution(self, symbolize_frame):
         object_name = (
             "/var/containers/Bundle/Application/"

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -1,0 +1,145 @@
+from mock import patch
+
+from sentry.models import Event
+from sentry.testutils import TestCase
+
+
+class BasicResolvingIntegrationTest(TestCase):
+
+    @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_frame')
+    def test_frame_resolution(self, symbolize_frame):
+        object_name = (
+            "/var/containers/Bundle/Application/"
+            "B33C37A8-F933-4B6B-9FFA-152282BFDF13/"
+            "SentryTest.app/SentryTest"
+        )
+
+        symbolize_frame.return_value = {
+            'filename': 'Foo.swift',
+            'line': 42,
+            'column': 23,
+            'object_name': object_name,
+            'symbol_name': 'real_main',
+            'symbol_addr': '0x1000262a0',
+            "instruction_addr": '0x100026330',
+        }
+
+        event_data = {
+            "sentry.interfaces.User": {
+                "ip_address": "31.172.207.97"
+            },
+            "extra": {},
+            "project": self.project.id,
+            "platform": "cocoa",
+            "debug_meta": {
+                "images": [
+                    {
+                        "type": "apple",
+                        "cpu_subtype": 0,
+                        "uuid": "C05B4DDD-69A7-3840-A649-32180D341587",
+                        "image_vmaddr": 4294967296,
+                        "image_addr": 4295098368,
+                        "cpu_type": 16777228,
+                        "image_size": 32768,
+                        "name": object_name,
+                    }
+                ],
+                "sdk_info": {
+                    "dsym_type": "macho",
+                    "sdk_name": "iOS",
+                    "version_major": 9,
+                    "version_minor": 3,
+                    "version_patchlevel": 0
+                }
+            },
+            "sentry.interfaces.Exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "<redacted>",
+                                    "abs_path": None,
+                                    "instruction_offset": 4,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "in_app": False,
+                                    "instruction_addr": "0x002ac28b8"
+                                },
+                                {
+                                    "function": "main",
+                                    "instruction_addr": 4295123760,
+                                    "symbol_addr": 4295123616,
+                                    "image_addr": 4295098368
+                                },
+                                {
+                                    "platform": "javascript",
+                                    "function": "merge",
+                                    "abs_path": "/scripts/views.js",
+                                    "vars": {},
+                                    "module": None,
+                                    "filename": "../../sentry/scripts/views.js",
+                                    "colno": 16,
+                                    "in_app": True,
+                                    "lineno": 268
+                                }
+                            ]
+                        },
+                        "type": "NSRangeException",
+                        "mechanism": {
+                            "posix_signal": {
+                                "signal": 6,
+                                "code": 0,
+                                "name": "SIGABRT",
+                                "code_name": None
+                            },
+                            "type": "cocoa",
+                            "mach_exception": {
+                                "subcode": 0,
+                                "code": 0,
+                                "exception": 10,
+                                "exception_name": "EXC_CRASH"
+                            }
+                        },
+                        "value": (
+                            "*** -[__NSArray0 objectAtIndex:]: index 3 "
+                            "beyond bounds for empty NSArray"
+                        )
+                    }
+                ]
+            },
+            "contexts": {
+                "device": {
+                    "model_id": "N102AP",
+                    "model": "iPod7,1",
+                    "arch": "arm64",
+                    "family": "iPod"
+                },
+                "os": {
+                    "version": "9.3.2",
+                    "rooted": False,
+                    "build": "13F69",
+                    "name": "iOS"
+                }
+            }
+        }
+
+        resp = self._postWithHeader(event_data)
+        assert resp.status_code == 200
+
+        event = Event.objects.get()
+
+        bt = event.interfaces['sentry.interfaces.Exception'].values[0].stacktrace
+        frames = bt.frames
+
+        assert frames[0].function == '<redacted>'
+        assert frames[0].instruction_addr == '0x002ac28b8'
+
+        assert frames[1].function == 'real_main'
+        assert frames[1].lineno == 42
+        assert frames[1].colno == 23
+        assert frames[1].package == object_name
+        assert frames[1].instruction_addr == '0x100026330'
+        assert frames[1].instruction_offset is None

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -136,10 +136,22 @@ class BasicResolvingIntegrationTest(TestCase):
 
         assert frames[0].function == '<redacted>'
         assert frames[0].instruction_addr == '0x002ac28b8'
+        assert not frames[0].in_app
 
         assert frames[1].function == 'real_main'
+        assert frames[1].filename == 'Foo.swift'
         assert frames[1].lineno == 42
         assert frames[1].colno == 23
         assert frames[1].package == object_name
         assert frames[1].instruction_addr == '0x100026330'
         assert frames[1].instruction_offset is None
+        assert frames[1].in_app
+
+        assert frames[2].platform == 'javascript'
+        assert frames[2].abs_path == '/scripts/views.js'
+        assert frames[2].function == 'merge'
+        assert frames[2].lineno == 268
+        assert frames[2].colno == 16
+        assert frames[2].filename == '../../sentry/scripts/views.js'
+        assert frames[2].instruction_offset is None
+        assert frames[2].in_app

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -4,26 +4,51 @@ from sentry.testutils import TestCase
 from sentry.lang.native.plugin import resolve_frame_symbols
 
 
-class BasicResolvingFileTest(TestCase):
+OBJECT_NAME = (
+    "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/"
+    "SentryTest.app/SentryTest"
+)
 
-    @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_frame')
-    def test_frame_resolution(self, symbolize_frame):
-        object_name = (
-            "/var/containers/Bundle/Application/"
-            "B33C37A8-F933-4B6B-9FFA-152282BFDF13/"
-            "SentryTest.app/SentryTest"
-        )
+SDK_INFO = {
+    "dsym_type": "macho",
+    "sdk_name": "iOS",
+    "version_major": 9,
+    "version_minor": 3,
+    "version_patchlevel": 0
+}
 
-        symbolize_frame.return_value = {
+
+def patched_symbolize_app_frame(self, frame):
+    if frame['instruction_addr'] == 4295123760:
+        return {
             'filename': 'Foo.swift',
             'line': 42,
             'column': 23,
-            'object_name': object_name,
+            'object_name': OBJECT_NAME,
             'symbol_name': 'real_main',
             'symbol_addr': '0x1000262a0',
-            "instruction_addr": '0x100026330',
+            'instruction_addr': '0x100026330',
         }
 
+
+def patched_symbolize_system_frame(self, frame, sdk_info):
+    assert sdk_info == SDK_INFO
+    if frame['instruction_addr'] == 4295123360:
+        return {
+            'object_name': '/usr/lib/whatever.dylib',
+            'symbol_name': 'whatever_system',
+            'symbol_addr': '0x100026110',
+            'instruction_addr': '0x1000261a0',
+        }
+
+
+class BasicResolvingFileTest(TestCase):
+
+    @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_app_frame',
+           new=patched_symbolize_app_frame)
+    @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_system_frame',
+           new=patched_symbolize_system_frame)
+    def test_frame_resolution(self):
         event_data = {
             "sentry.interfaces.User": {
                 "ip_address": "31.172.207.97"
@@ -41,16 +66,10 @@ class BasicResolvingFileTest(TestCase):
                         "image_addr": 4295098368,
                         "cpu_type": 16777228,
                         "image_size": 32768,
-                        "name": object_name,
+                        "name": OBJECT_NAME,
                     }
                 ],
-                "sdk_info": {
-                    "dsym_type": "macho",
-                    "sdk_name": "iOS",
-                    "version_major": 9,
-                    "version_minor": 3,
-                    "version_patchlevel": 0
-                }
+                "sdk_info": SDK_INFO,
             },
             "sentry.interfaces.Exception": {
                 "values": [
@@ -73,6 +92,12 @@ class BasicResolvingFileTest(TestCase):
                                     "instruction_addr": 4295123760,
                                     "symbol_addr": 4295123616,
                                     "image_addr": 4295098368
+                                },
+                                {
+                                    "function": "whatever_system",
+                                    "instruction_addr": 4295123360,
+                                    "symbol_addr": 4295123216,
+                                    "image_addr": 4295092368
                                 },
                                 {
                                     "platform": "javascript",
@@ -137,6 +162,11 @@ class BasicResolvingFileTest(TestCase):
         assert frames[1]['function'] == 'real_main'
         assert frames[1]['lineno'] == 42
         assert frames[1]['colno'] == 23
-        assert frames[1]['package'] == object_name
+        assert frames[1]['package'] == OBJECT_NAME
         assert frames[1]['instruction_addr'] == '0x100026330'
         assert frames[1].get('instruction_offset') is None
+
+        assert frames[2]['function'] == 'whatever_system'
+        assert frames[2]['package'] == '/usr/lib/whatever.dylib'
+        assert frames[2]['instruction_addr'] == '0x1000261a0'
+        assert frames[2].get('instruction_offset') == 144

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -1,0 +1,142 @@
+from mock import patch
+
+from sentry.testutils import TestCase
+from sentry.lang.native.plugin import resolve_frame_symbols
+
+
+class BasicResolvingFileTest(TestCase):
+
+    @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_frame')
+    def test_frame_resolution(self, symbolize_frame):
+        object_name = (
+            "/var/containers/Bundle/Application/"
+            "B33C37A8-F933-4B6B-9FFA-152282BFDF13/"
+            "SentryTest.app/SentryTest"
+        )
+
+        symbolize_frame.return_value = {
+            'filename': 'Foo.swift',
+            'line': 42,
+            'column': 23,
+            'object_name': object_name,
+            'symbol_name': 'real_main',
+            'symbol_addr': '0x1000262a0',
+            "instruction_addr": '0x100026330',
+        }
+
+        event_data = {
+            "sentry.interfaces.User": {
+                "ip_address": "31.172.207.97"
+            },
+            "extra": {},
+            "project": self.project.id,
+            "platform": "cocoa",
+            "debug_meta": {
+                "images": [
+                    {
+                        "type": "apple",
+                        "cpu_subtype": 0,
+                        "uuid": "C05B4DDD-69A7-3840-A649-32180D341587",
+                        "image_vmaddr": 4294967296,
+                        "image_addr": 4295098368,
+                        "cpu_type": 16777228,
+                        "image_size": 32768,
+                        "name": object_name,
+                    }
+                ],
+                "sdk_info": {
+                    "dsym_type": "macho",
+                    "sdk_name": "iOS",
+                    "version_major": 9,
+                    "version_minor": 3,
+                    "version_patchlevel": 0
+                }
+            },
+            "sentry.interfaces.Exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "<redacted>",
+                                    "abs_path": None,
+                                    "instruction_offset": 4,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "in_app": False,
+                                    "instruction_addr": "0x002ac28b8"
+                                },
+                                {
+                                    "function": "main",
+                                    "instruction_addr": 4295123760,
+                                    "symbol_addr": 4295123616,
+                                    "image_addr": 4295098368
+                                },
+                                {
+                                    "platform": "javascript",
+                                    "function": "merge",
+                                    "abs_path": "/scripts/views.js",
+                                    "vars": {},
+                                    "module": None,
+                                    "filename": "../../sentry/scripts/views.js",
+                                    "colno": 16,
+                                    "in_app": True,
+                                    "lineno": 268
+                                }
+                            ]
+                        },
+                        "type": "NSRangeException",
+                        "mechanism": {
+                            "posix_signal": {
+                                "signal": 6,
+                                "code": 0,
+                                "name": "SIGABRT",
+                                "code_name": None
+                            },
+                            "type": "cocoa",
+                            "mach_exception": {
+                                "subcode": 0,
+                                "code": 0,
+                                "exception": 10,
+                                "exception_name": "EXC_CRASH"
+                            }
+                        },
+                        "value": (
+                            "*** -[__NSArray0 objectAtIndex:]: index 3 "
+                            "beyond bounds for empty NSArray"
+                        )
+                    }
+                ]
+            },
+            "contexts": {
+                "device": {
+                    "model_id": "N102AP",
+                    "model": "iPod7,1",
+                    "arch": "arm64",
+                    "family": "iPod"
+                },
+                "os": {
+                    "version": "9.3.2",
+                    "rooted": False,
+                    "build": "13F69",
+                    "name": "iOS"
+                }
+            }
+        }
+
+        resolve_frame_symbols(event_data)
+
+        bt = event_data['sentry.interfaces.Exception']['values'][0]['stacktrace']
+        frames = bt['frames']
+
+        assert frames[0]['function'] == '<redacted>'
+        assert frames[0]['instruction_addr'] == '0x002ac28b8'
+
+        assert frames[1]['function'] == 'real_main'
+        assert frames[1]['lineno'] == 42
+        assert frames[1]['colno'] == 23
+        assert frames[1]['package'] == object_name
+        assert frames[1]['instruction_addr'] == '0x100026330'
+        assert frames[1].get('instruction_offset') is None


### PR DESCRIPTION
This is the work in progress pull request for #3352.  It adds flexible symbolication
for frames which allows mixing of platforms and more.  Instead of using the apple
crash report format we send our own stuff along.
## Flexible Symbolication Overview

Essentially unlike the old crash report system this does symbolication on a frame by frame basis. It requires that the clients send the data in the format that sentry expects in general as there is no service side data munching going on.  The stacktraces are sent as normal however there is per-frame support for symbol resolution.

This is implemented by combining two interfaces:
- `debug_meta`. This is a new ephemeral interface which holds metadata for resolving symbols and other things. After processing this data is discarded. This is where debug images and SDK information is stored.
- The frame keys `instruction_addr`, `symbol_addr` and `image_addr` (the latter is basically what `object_addr` is in apple's crash format). We accept addresses as integers or hexadecimal strings (with `0x` prefix) to avoid issues with JSON limitations.
### Debug Mapping Example

The debug image mapping and sdk info in the debug meta looks like this:

``` json
{
  "debug_meta": {
    "images": [
      {
        "type": "apple",
        "cpu_subtype": 0, 
        "uuid": "C05B4DDD-69A7-3840-A649-32180D341587", 
        "image_vmaddr": 4294967296, 
        "image_addr": 4295098368, 
        "cpu_type": 16777228, 
        "image_size": 32768, 
        "name": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest"
      }
    ],
    "sdk_info": {
      "dsym_type": "macho",
      "sdk_name": "iOS",
      "version_major": 9,
      "version_minor": 3,
      "version_patchlevel": 0
    }
  }
}
```

As you can see it mostly follows what we do with the apple crash reports already but there are some subtle differences:
1. the type of the image needs to be defined. Currently only `apple` is supported. Depending on the image type the method could change. In particular this will become relevant as we add PDB support.
2. the uuid and image address is required
3. the SDK info is needed to look up system symbols but can be left out if unused.

I'm considering picking up the sdk info from the OS context information but this is undecided so far.
### Example normal frame

``` json
{
  "function": "<redacted>",
  "abs_path": null,
  "instruction_offset": 4,
  "package": "/usr/lib/system/libdyld.dylib",
  "filename": null,
  "symbol_addr": "0x002ac28b4",
  "lineno": null,
  "in_app": false,
  "instruction_addr": "0x002ac28b8"
}
```
### Example unsymbolicated frame

``` json
{
  "function": "main",
  "package": "FooBar",
  "instruction_addr": "0x100026330",
  "symbol_addr": "0x1000262a0",
  "image_addr": "0x100020000"
}
```

Notes for the above frame:
- The `function` and `package` keys are optional. They correspond to `symbol_name` and `object_name` in the apple crash report respectively and are only used in case the lookup fails.
- All addresses could also be sent as integers but it's discouraged due to some JSON libraries having problems with numbers > 53bit
- `image_addr` is what `object_addr` is in apple crash reports.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3634)

<!-- Reviewable:end -->
