### PR TITLE
Add project tag key details endpoint

### DIFF
--- a/src/sentry/api/serializers/models/tagkey.py
+++ b/src/sentry/api/serializers/models/tagkey.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import TagKey
+
+
+@register(TagKey)
+class TagKeySerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            'id': str(obj.id),
+            'key': TagKey.get_standardized_key(obj.key),
+            'name': obj.get_label(),
+            'uniqueValues': obj.values_seen,
+        }

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -8,6 +8,30 @@ from sentry.models import TagKey, TagKeyStatus
 from sentry.testutils import APITestCase
 
 
+class ProjectTagKeyDetailsTest(APITestCase):
+    def test_simple(self):
+        project = self.create_project()
+        tagkey = TagKey.objects.create(
+            project=project,
+            key='foo',
+            values_seen=16,
+        )
+
+        self.login_as(user=self.user)
+
+        url = reverse('sentry-api-0-project-tagkey-details', kwargs={
+            'organization_slug': project.organization.slug,
+            'project_slug': project.slug,
+            'key': tagkey.key,
+        })
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.data['id'] == str(tagkey.id)
+        assert response.data['uniqueValues'] == tagkey.values_seen
+
+
 class ProjectTagKeyDeleteTest(APITestCase):
     @mock.patch('sentry.api.endpoints.project_tagkey_details.delete_tag_key')
     def test_simple(self, mock_delete_tag_key):


### PR DESCRIPTION
This would allow a user, for example, to answer 'how many users have been affected by errors (all time)'.

@getsentry/api
