### PR TITLE
Handle IntegrityError for duplicate team slugs

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -84,3 +84,20 @@ class OrganizationTeamsCreateTest(APITestCase):
         assert resp.status_code == 201, resp.content
         team = Team.objects.get(id=resp.data['id'])
         assert team.slug == 'hello-world'
+
+    def test_duplicate(self):
+        self.login_as(user=self.user)
+
+        resp = self.client.post(self.path, data={
+            'name': 'hello world',
+            'slug': 'foobar',
+        })
+
+        assert resp.status_code == 201, resp.content
+
+        resp = self.client.post(self.path, data={
+            'name': 'hello world',
+            'slug': 'foobar',
+        })
+
+        assert resp.status_code == 409, resp.content


### PR DESCRIPTION
This used to raise a 500, now just returns a more helpful 409.

@getsentry/api

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3647)

<!-- Reviewable:end -->
