### PR TITLE
Per-project workflow settings

### DIFF
--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.conf import settings
 from django.db import IntegrityError, models, transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -57,10 +58,19 @@ class GroupSubscriptionManager(BaseManager):
             ).values('user')
         )
 
+        # find users which by default do not subscribe
         participating_only = set(UserOption.objects.filter(
+            Q(project__isnull=True) | Q(project=group.project),
             user__in=users,
             key='workflow:notifications',
             value=UserOptionValue.participating_only,
+        ).exclude(
+            user__in=UserOption.objects.filter(
+                user__in=users,
+                key='workflow:notifications',
+                project=group.project,
+                value=UserOptionValue.all_conversations,
+            )
         ).values_list('user', flat=True))
 
         if participating_only:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -269,3 +269,14 @@ class Project(Model):
         else:
             is_enabled = bool(is_enabled)
         return is_enabled
+
+    def is_user_subscribed_to_workflow(self, user):
+        from sentry.models import UserOption, UserOptionValue
+
+        opt_value = UserOption.objects.get_value(
+            user, self, 'workflow:notifications', None)
+        if opt_value is None:
+            opt_value = UserOption.objects.get_value(
+                user, None, 'workflow:notifications',
+                UserOptionValue.all_conversations)
+        return opt_value == UserOptionValue.all_conversations

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -18,6 +18,8 @@ from sentry.db.models.manager import BaseManager
 
 
 class UserOptionValue(object):
+    # 'workflow:notifications'
+    all_conversations = '0'
     participating_only = '1'
 
 

--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -31,19 +31,27 @@
 
         <hr />
 
-        <h4>{% trans "Workflow" %}</h4>
+        <h4>{% trans "Alerts" %}</h4>
 
-        <p>{% blocktrans %}Workflow notifications are separate from alerts, and are generated for things like comments and issue updates. You may subscribe (or unsubscribe) form individual issues on their respective pages.{% endblocktrans %}</p>
+        <p>Alerts are generated based on a project's rules, defined in <strong>[Project] &raquo; Settings &raquo; Rules</strong>.</p>
 
-        {{ settings_form.workflow_notifications|as_crispy_field }}
+        {{ settings_form.subscribe_by_default|as_crispy_field }}
 
         <hr />
 
-        <h4>{% trans "Alerts" %}</h4>
+        <h4>{% trans "Workflow" %}</h4>
 
-        <p>Alerts are generated based on a project's rules, defined in <strong>[Project] &raquo; Settings</strong>.</p>
+        <p>{% blocktrans %}Workflow notifications are separate from alerts, and are generated for things like comments and issue updates. You may subscribe (or unsubscribe) from individual issues on their respective pages.{% endblocktrans %}</p>
 
-        {{ settings_form.subscribe_by_default|as_crispy_field }}
+        {{ settings_form.workflow_notifications|as_crispy_field }}
+
+        <p class="help-text help-block">Note: You'll always receive notifications if you're explicitly participating on an issue.</p>
+
+        <hr />
+
+        <h4>{% trans "Fine Tuning" %}</h4>
+
+        <p>Use the settings below to fine tune notification settings per-project.</p>
 
         {% for project, form in project_forms %}
             {{ form|as_crispy_errors }}
@@ -60,52 +68,50 @@
                 <table class="table table-bordered table-striped" style="margin-bottom: 20px">
                     <thead>
                         <tr>
-                          <th style="width:31px;"><input type="checkbox" data-toggle="alerts" /></th>
                             <th>{% trans "Project" %}</th>
+                            <th style="width:50px;text-align:center">
+                              <a data-toggle="alert">Alerts</a>
+                            </th>
+                            <th style="width:50px;text-align:center">
+                              <a data-toggle="workflow">Workflow</a>
+                            </th>
                             <th style="width:150px;overflow:hidden;text-align:right">
-                                {% trans "Email Address" %}
+                              {% trans "Email Address" %}
                             </th>
                         </tr>
                     </thead>
                     <tbody>
             {% endifchanged %}
             <tr>
-              <td>{{ form.alert }}</td>
-                <td>
-                    <label for="{{ form.alert.auto_id }}">{{ project.organization.slug}} / {{ project.slug }}</label>
-                </td>
-                <td style="text-align:right">
-                    <a href="javascript:void(0)" data-target="{{ form.email.auto_id }}" data-toggle="change-target-value">
-                        {% if form.email.value %}{{ form.email.value }}{% else %}<em>Default</em>{% endif %}
-                    </a>
-                    {{ form.email }}
-                </td>
+              <td>
+                {{ project.organization.slug}} / {{ project.slug }}
+              </td>
+              <td style="text-align:center">{{ form.alert }}</td>
+              <td style="text-align:center">{{ form.workflow }}</td>
+              <td style="text-align:right">
+                <a href="javascript:void(0)" data-target="{{ form.email.auto_id }}" data-toggle="change-target-value">
+                  {% if form.email.value %}{{ form.email.value }}{% else %}<em>Default</em>{% endif %}
+                </a>
+                {{ form.email }}
+              </td>
             </tr>
         {% endfor %}
         </tbody></table>
 
-        <p><small>{% blocktrans %}Note: You will never receive notifications if a project has them disabled (via the Project settings){% endblocktrans %}</small></p>
-
         {% for form in ext_forms %}
-            <fieldset>
-                <h4>{{ form.get_title }}</h4>
-                {% with form.get_description as description %}
-                    {% if description %}
-                        {{ description|linebreaks }}
-                    {% endif %}
-                {% endwith %}
-                {% include "sentry/partial/form_base.html" %}
-            </fieldset>
+            <h4>{{ form.get_title }}</h4>
+            {% with form.get_description as description %}
+                {% if description %}
+                    {{ description|linebreaks }}
+                {% endif %}
+            {% endwith %}
+            {% include "sentry/partial/form_base.html" %}
         {% endfor %}
 
         <fieldset class="form-actions">
             <button type="submit" class="btn btn-primary">{% trans "Save Changes" %}</button>
         </fieldset>
     </form>
-    <style>
-    #div_id_workflow_notifications label { display:none; }
-    #div_id_subscribe_by_default label { display:none; }
-    </style>
     <script>
     $(function(){
       $('form a[data-toggle="change-target-value"]').click(function(){
@@ -119,11 +125,32 @@
           $this.html('<em>Default</em>');
         }
       });
-      $('form input[data-toggle="alerts"]').click(function(e){
-        $(this).parents('table')
+
+      function findCheckboxes(parent, match) {
+        return $(parent).parents('table')
           .find('tbody input[type="checkbox"]')
-          .prop('checked', e.target.checked);
-      });
+          .filter(function() {
+            return this.name.indexOf(match) !== -1;
+          });
+      }
+
+      function setupChecker(pattern) {
+        $('form a[data-toggle="' + pattern + '"]').click(function(e){
+          var checked = $(this).data('checked');
+          findCheckboxes(this, pattern).prop('checked', !checked);
+          $(this).data('checked', !checked);
+        }).each(function() {
+          var boxes = findCheckboxes(this, pattern);
+          var checkedBoxes = boxes.filter(function(){
+            return $(this).is(':checked');
+          });
+          var defaultChecked = (boxes.length === checkedBoxes.length);
+          $(this).data('checked', defaultChecked);
+        });
+      }
+
+      setupChecker('alert');
+      setupChecker('workflow');
     });
     </script>
 {% endblock %}

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -19,7 +19,7 @@ from django.utils.translation import ugettext_lazy as _
 from six.moves import range
 
 from sentry.constants import LANGUAGES
-from sentry.models import UserOption, User
+from sentry.models import User, UserOption, UserOptionValue
 from sentry.utils.auth import find_users
 from sentry.web.forms.fields import ReadOnlyTextField
 
@@ -181,69 +181,6 @@ class ChangePasswordRecoverForm(forms.Form):
     password = forms.CharField(widget=forms.PasswordInput())
 
 
-class NotificationSettingsForm(forms.Form):
-    alert_email = forms.EmailField(label=_('Email'), help_text=_('Designate an alternative email address to send email notifications to.'), required=False)
-    subscribe_by_default = forms.ChoiceField(
-        label=_('Alerts'),
-        choices=(
-            ('1', _('Automatically subscribe to alerts for new projects')),
-            ('0', _('Do not subscribe to alerts for new projects')),
-        ), required=False,
-        widget=forms.Select(attrs={'class': 'input-xxlarge'}))
-    workflow_notifications = forms.ChoiceField(
-        label=_('Workflow Notifications'),
-        choices=(
-            ('0', _('Receive updates for all issues by default')),
-            ('1', _('Only notify me when I\'m participating or mentioned on an issue')),
-        ), required=False,
-        widget=forms.Select(attrs={'class': 'input-xxlarge'}))
-
-    def __init__(self, user, *args, **kwargs):
-        self.user = user
-        super(NotificationSettingsForm, self).__init__(*args, **kwargs)
-        self.fields['alert_email'].initial = UserOption.objects.get_value(
-            user=self.user,
-            project=None,
-            key='alert_email',
-            default=user.email,
-        )
-        self.fields['subscribe_by_default'].initial = UserOption.objects.get_value(
-            user=self.user,
-            project=None,
-            key='subscribe_by_default',
-            default='1',
-        )
-        self.fields['workflow_notifications'].initial = UserOption.objects.get_value(
-            user=self.user,
-            project=None,
-            key='workflow:notifications',
-            default='0',
-        )
-
-    def get_title(self):
-        return "General"
-
-    def save(self):
-        UserOption.objects.set_value(
-            user=self.user,
-            project=None,
-            key='alert_email',
-            value=self.cleaned_data['alert_email'],
-        )
-        UserOption.objects.set_value(
-            user=self.user,
-            project=None,
-            key='subscribe_by_default',
-            value=self.cleaned_data['subscribe_by_default'],
-        )
-        UserOption.objects.set_value(
-            user=self.user,
-            project=None,
-            key='workflow:notifications',
-            value=self.cleaned_data['workflow_notifications'],
-        )
-
-
 class AccountSettingsForm(forms.Form):
     name = forms.CharField(required=True, label=_('Name'), max_length=30)
     username = forms.CharField(label=_('Username'), max_length=128)
@@ -403,8 +340,81 @@ class AppearanceSettingsForm(forms.Form):
         return self.user
 
 
+class NotificationSettingsForm(forms.Form):
+    alert_email = forms.EmailField(label=_('Email'), help_text=_('Designate an alternative email address to send email notifications to.'), required=False)
+    subscribe_by_default = forms.BooleanField(
+        label=_('Subscribe to alerts for projects by default'),
+        required=False,
+    )
+    workflow_notifications = forms.BooleanField(
+        label=_('Receive updates for all issues by default'),
+        required=False,
+    )
+
+    def __init__(self, user, *args, **kwargs):
+        self.user = user
+        super(NotificationSettingsForm, self).__init__(*args, **kwargs)
+        self.fields['alert_email'].initial = UserOption.objects.get_value(
+            user=self.user,
+            project=None,
+            key='alert_email',
+            default=user.email,
+        )
+        self.fields['subscribe_by_default'].initial = (
+            UserOption.objects.get_value(
+                user=self.user,
+                project=None,
+                key='subscribe_by_default',
+                default='1',
+            ) == '1'
+        )
+
+        self.fields['workflow_notifications'].initial = (
+            UserOption.objects.get_value(
+                user=self.user,
+                project=None,
+                key='workflow:notifications',
+                default=UserOptionValue.all_conversations,
+            ) == UserOptionValue.all_conversations
+        )
+
+    def get_title(self):
+        return "General"
+
+    def save(self):
+        UserOption.objects.set_value(
+            user=self.user,
+            project=None,
+            key='alert_email',
+            value=self.cleaned_data['alert_email'],
+        )
+
+        UserOption.objects.set_value(
+            user=self.user,
+            project=None,
+            key='subscribe_by_default',
+            value='1' if self.cleaned_data['subscribe_by_default'] else '0',
+        )
+
+        if self.cleaned_data.get('workflow_notifications') is True:
+            UserOption.objects.set_value(
+                user=self.user,
+                project=None,
+                key='workflow:notifications',
+                value=UserOptionValue.all_conversations,
+            )
+        else:
+            UserOption.objects.set_value(
+                user=self.user,
+                project=None,
+                key='workflow:notifications',
+                value=UserOptionValue.participating_only,
+            )
+
+
 class ProjectEmailOptionsForm(forms.Form):
     alert = forms.BooleanField(required=False)
+    workflow = forms.BooleanField(required=False)
     email = forms.EmailField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, project, user, *args, **kwargs):
@@ -414,8 +424,10 @@ class ProjectEmailOptionsForm(forms.Form):
         super(ProjectEmailOptionsForm, self).__init__(*args, **kwargs)
 
         has_alerts = project.is_user_subscribed_to_mail_alerts(user)
+        has_workflow = project.is_user_subscribed_to_workflow(user)
 
         self.fields['alert'].initial = has_alerts
+        self.fields['workflow'].initial = has_workflow
         self.fields['email'].initial = UserOption.objects.get_value(
             user, project, 'mail:email', None)
 
@@ -423,6 +435,11 @@ class ProjectEmailOptionsForm(forms.Form):
         UserOption.objects.set_value(
             self.user, self.project, 'mail:alert',
             int(self.cleaned_data['alert']),
+        )
+
+        UserOption.objects.set_value(
+            self.user, self.project, 'workflow:notifications',
+            UserOptionValue.all_conversations if self.cleaned_data['workflow'] else UserOptionValue.participating_only,
         )
 
         if self.cleaned_data['email']:

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -76,3 +76,22 @@ class GetParticipantsTest(TestCase):
         users = GroupSubscription.objects.get_participants(group=group)
 
         assert users == [user]
+
+    def test_excludes_project_participating_only(self):
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        project = self.create_project(team=team, organization=org)
+        group = self.create_group(project=project)
+        user = self.create_user('foo@example.com')
+        self.create_member(user=user, organization=org, teams=[team])
+
+        UserOption.objects.set_value(
+            user=user,
+            project=project,
+            key='workflow:notifications',
+            value=UserOptionValue.participating_only,
+        )
+
+        users = GroupSubscription.objects.get_participants(group=group)
+
+        assert users == []

--- a/tests/sentry/web/frontend/accounts/tests.py
+++ b/tests/sentry/web/frontend/accounts/tests.py
@@ -8,7 +8,10 @@ from django.core.urlresolvers import reverse
 from exam import fixture
 from social_auth.models import UserSocialAuth
 
-from sentry.models import UserEmail, LostPasswordHash, ProjectStatus, User, UserOption
+from sentry.models import (
+    UserEmail, LostPasswordHash, ProjectStatus, User, UserOption,
+    UserOptionValue
+)
 from sentry.testutils import TestCase
 
 
@@ -216,7 +219,19 @@ class NotificationSettingsTest(TestCase):
             user=self.user, project=None
         )
 
-        assert options.get('workflow:notifications') == '1'
+        assert options.get('workflow:notifications') == '0'
+
+        resp = self.client.post(self.path, {
+            'workflow_notifications': '',
+        })
+        assert resp.status_code == 302
+
+        options = UserOption.objects.get_all_values(
+            user=self.user, project=None
+        )
+
+        assert options.get('workflow:notifications') == \
+            UserOptionValue.participating_only
 
     def test_can_change_subscribe_by_default(self):
         self.login_as(self.user)


### PR DESCRIPTION
This adds a per-project "Workflow" configuration much like the "Alert" configuration. Just like the normal workflow settings, you cannot disable the emails, only opt-out of implicit membership.

/cc @getsentry/infrastructure @getsentry/ui 

![screenshot 2016-07-06 10 44 51](https://cloud.githubusercontent.com/assets/23610/16628472/c04f3880-4366-11e6-8a6f-5fe85b759a53.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3648)

<!-- Reviewable:end -->
