### PR TITLE
Fix bad module generation for javascript if abs path is missing

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -586,7 +586,8 @@ class SourceProcessor(object):
         # TODO(dcramer): this doesn't really fit well with generic URLs so we
         # whitelist it to http/https
         for frame in frames:
-            if not frame.module and frame.abs_path.startswith(('http:', 'https:', 'webpack:')):
+            if not frame.module and frame.abs_path \
+               and frame.abs_path.startswith(('http:', 'https:', 'webpack:')):
                 frame.module = generate_module(frame.abs_path)
 
     def expand_frames(self, frames, release):

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -286,3 +286,36 @@ class SourceProcessorTest(TestCase):
         processor = SourceProcessor(project=self.project)
         result = processor.process(data)
         assert result['culprit'] == 'bar in oops'
+
+    def test_ensure_module_names(self):
+        data = {
+            'message': 'hello',
+            'platform': 'javascript',
+            'sentry.interfaces.Exception': {
+                'values': [{
+                    'type': 'Error',
+                    'stacktrace': {
+                        'frames': [
+                            {
+                                'filename': 'foo.js',
+                                'lineno': 4,
+                                'colno': 0,
+                                'function': 'thing',
+                            },
+                            {
+                                'abs_path': 'http://example.com/foo/bar.js',
+                                'filename': 'bar.js',
+                                'lineno': 1,
+                                'colno': 0,
+                                'function': 'oops',
+                            },
+                        ],
+                    },
+                }],
+            }
+        }
+
+        processor = SourceProcessor(project=self.project)
+        result = processor.process(data)
+        exc = result['sentry.interfaces.Exception']['values'][0]
+        assert exc['stacktrace']['frames'][1]['module'] == 'foo/bar'


### PR DESCRIPTION
This fixes SENTRY-1FY

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3657)

<!-- Reviewable:end -->
