### PR TITLE
Skip over missing backtraces in old format

### DIFF
--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -20,6 +20,8 @@ def find_apple_crash_report_referenced_images(binary_images, threads):
         image_map[image['image_addr']] = image['uuid']
     to_load = set()
     for thread in threads:
+        if 'backtrace' not in thread:
+            continue
         for frame in thread['backtrace']['contents']:
             img_uuid = image_map.get(frame['object_addr'])
             if img_uuid is not None:


### PR DESCRIPTION
This fixes SENTRY-1GZ

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3658)

<!-- Reviewable:end -->
