### PR TITLE
Filter out None's when cleaning up nodestore

### DIFF
--- a/src/sentry/nodestore/django/backend.py
+++ b/src/sentry/nodestore/django/backend.py
@@ -30,10 +30,13 @@ class DjangoNodeStorage(NodeStorage):
             return None
 
     def get_multi(self, id_list):
-        return dict(
-            (n.id, n.data)
+        return {
+            n.id: n.data
             for n in Node.objects.filter(id__in=id_list)
-        )
+        }
+
+    def delete_multi(self, id_list):
+        Node.objects.filter(id__in=id_list).delete()
 
     def set(self, id, data):
         create_or_update(

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -238,8 +238,9 @@ def delete_events(relation, limit=100, logger=None):
     has_more = bool(result_set)
     if has_more:
         # delete objects from nodestore first
-        node_ids = set(r.data.id for r in result_set)
-        nodestore.delete_multi(node_ids)
+        node_ids = set(r.data.id for r in result_set if r.data.id)
+        if node_ids:
+            nodestore.delete_multi(node_ids)
 
         event_ids = [r.id for r in result_set]
 


### PR DESCRIPTION
This was stupid hard to test, and ended up giving up since the test isn't super useful. The problem is that even if the `nodestore.delete_multi` doesn't succeed, it ends up falling back to the `NodeField.on_delete()` behavior, which cleans up its nodestore record.

So we are just making a sane attempt to only delete node ids with actual values since it's perfectly acceptable to be `None` and other backends aren't as forgiving as the `django` backend.

This `None` value breaks Cassandra for example:

```
InvalidRequest: Error from server: code=2200 [Invalid query] message="Invalid null value for partition key part key"
```

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3659)

<!-- Reviewable:end -->
