### PR TITLE
Clear env.request properly

### DIFF
--- a/src/sentry/middleware/env.py
+++ b/src/sentry/middleware/env.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from django.core.signals import request_finished
+
 from sentry.app import env
 
 
@@ -7,3 +9,9 @@ class SentryEnvMiddleware(object):
     def process_request(self, request):
         # bind request to env
         env.request = request
+
+
+def clear_request(**kwargs):
+    env.request = None
+
+request_finished.connect(clear_request)


### PR DESCRIPTION
This ensures env.request is cleaned up based on the request_finished signal from Django.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3660)

<!-- Reviewable:end -->
