### PR TITLE
Pass along 2fa status to security settings tab

### DIFF
--- a/src/sentry/web/frontend/account_security.py
+++ b/src/sentry/web/frontend/account_security.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.models import Authenticator
 from sentry.web.frontend.base import BaseView
 
 
@@ -7,4 +8,5 @@ class AccountSecurityView(BaseView):
     def handle(self, request):
         return self.respond('sentry/account/security.html', {
             'page': 'security',
+            'has_2fa': Authenticator.objects.user_has_2fa(request.user),
         })


### PR DESCRIPTION
This was missing, causing the page to always say 2fa was disabled

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3661)

<!-- Reviewable:end -->
