### PR TITLE
Handle missing stacktrace in crash header

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -28,7 +28,7 @@ const CrashHeader = React.createClass({
     return (
       (stacktrace && stacktrace.hasSystemFrames) ||
       (thread && thread.stacktrace && thread.stacktrace.hasSystemFrames) ||
-      (exception && exception.values.find(x => !!x.stacktrace.hasSystemFrames))
+      (exception && exception.values.find(x => !!(x.stacktrace && x.stacktrace.hasSystemFrames)))
     );
   },
 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3663)

<!-- Reviewable:end -->
