### PR TITLE
Fix ReferenceError for `event`

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -74,7 +74,7 @@ const StacktraceInterface = React.createClass({
           wrapTitle={false}>
         <CrashContent
           group={group}
-          event={event}
+          event={evt}
           stackView={stackView}
           newestFirst={newestFirst}
           stacktrace={data} />


### PR DESCRIPTION
Fixes JAVASCRIPT-11K

@getsentry/ui @mitsuhiko

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3664)

<!-- Reviewable:end -->
