### PR TITLE
Allow passing sentry_release querystring to CSP reports

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -489,6 +489,12 @@ class CspReportView(StoreView):
             metrics.incr('events.blacklisted')
             raise APIForbidden('Rejected CSP report')
 
+        # Attach on collected meta data. This data obviously isn't a part
+        # of the spec, but we need to append to the report sentry specific things.
+        report['_meta'] = {
+            'release': request.GET.get('sentry_release'),
+        }
+
         response_or_event_id = self.process(
             request,
             project=project,

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -480,11 +480,16 @@ class CspApiHelperTest(BaseAPITest):
             "effective-directive": "img-src",
             "original-policy": "default-src  https://45.55.25.245:8123/; child-src  https://45.55.25.245:8123/; connect-src  https://45.55.25.245:8123/; font-src  https://45.55.25.245:8123/; img-src  https://45.55.25.245:8123/; media-src  https://45.55.25.245:8123/; object-src  https://45.55.25.245:8123/; script-src  https://45.55.25.245:8123/; style-src  https://45.55.25.245:8123/; form-action  https://45.55.25.245:8123/; frame-ancestors 'none'; plugin-types 'none'; report-uri http://45.55.25.245:8123/csp-report?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion",
             "blocked-uri": "http://google.com",
-            "status-code": 200
+            "status-code": 200,
+            "_meta": {
+                "release": "abc123",
+            }
         }
         result = self.helper.validate_data(self.project, report)
         assert result['logger'] == 'csp'
         assert result['project'] == self.project.id
+        assert result['release'] == 'abc123'
+        assert result['errors'] == []
         assert 'message' in result
         assert 'culprit' in result
         assert 'tags' in result


### PR DESCRIPTION
This allows passing along release information to CSP reports which will
help reduce noise by being able to leverage "resolved in next release"
functionality.

@getsentry/api

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3665)

<!-- Reviewable:end -->
