### PR TITLE
Fix overflowing tags

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1518,6 +1518,7 @@ ul.faces {
     border-radius: 3px;
     box-shadow: 0 1px 2px rgba(0,0,0, .02);
     line-height: 1.2;
+    max-width: 100%;
 
     &.true .value {
       background: #FBFEFA;
@@ -1540,6 +1541,8 @@ ul.faces {
 
   .key, .value {
     padding: 4px 8px;
+    min-width: 0;
+    white-space: nowrap;
   }
 
   .value {
@@ -1547,6 +1550,21 @@ ul.faces {
     border-left: 1px solid @trim;
     border-radius: 0 3px 3px 0;
     font-family: Monaco, monospace;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    > a {
+      max-width: 100%;
+      .truncate;
+      display: inline-block;
+      line-height: 1;
+      vertical-align: text-bottom;
+    }
+
+    .external-icon {
+      display: inline;
+    }
   }
 }
 


### PR DESCRIPTION
Some work around making the new flexbox-based tags handle long values properly.

![screen shot 2016-07-07 at 2 03 34 pm](https://cloud.githubusercontent.com/assets/30713/16669689/b8e25baa-444b-11e6-9a6f-9947856206f4.png)

cc @getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3670)

<!-- Reviewable:end -->
