### PR TITLE
Add `get_most_frequent_series` method to TSDB.

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -260,6 +260,20 @@ class BaseTSDB(object):
         """
         raise NotImplementedError
 
+    def get_most_frequent_series(self, model, keys, start, end=None, rollup=None, limit=None):
+        """
+        Retrieve the most frequently seen items in a frequency table for each
+        interval in a series. (This is in contrast with ``get_most_frequent``,
+        which returns the most frequent item seen over the entire requested
+        range.)
+
+        Result are returned as a mapping, where the key is the key requested
+        and the value is a list of ``(timestamp, {item: score, ...})``) pairs
+        over the series. The maximum number of items returned for each interval
+        is the index capacity if no ``limit`` is provided.
+        """
+        raise NotImplementedError
+
     def get_frequency_series(self, model, items, start, end=None, rollup=None):
         """
         Retrieve the frequency of known items in a table over time.

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -264,11 +264,11 @@ class BaseTSDB(object):
         """
         Retrieve the most frequently seen items in a frequency table for each
         interval in a series. (This is in contrast with ``get_most_frequent``,
-        which returns the most frequent item seen over the entire requested
+        which returns the most frequent items seen over the entire requested
         range.)
 
-        Result are returned as a mapping, where the key is the key requested
-        and the value is a list of ``(timestamp, {item: score, ...})``) pairs
+        Results are returned as a mapping, where the key is the key requested
+        and the value is a list of ``(timestamp, {item: score, ...})`` pairs
         over the series. The maximum number of items returned for each interval
         is the index capacity if no ``limit`` is provided.
         """

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -38,6 +38,10 @@ class DummyTSDB(BaseTSDB):
     def get_most_frequent(self, model, keys, start, end=None, rollup=None, limit=None):
         return {key: [] for key in keys}
 
+    def get_most_frequent_series(self, model, keys, start, end=None, rollup=None, limit=None):
+        rollup, series = self.get_optimal_rollup_series(start, end, rollup)
+        return {key: [(timestamp, {}) for timestamp in series] for key in keys}
+
     def get_frequency_series(self, model, items, start, end=None, rollup=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 


### PR DESCRIPTION
This allows querying for the ranked items for each interval, rather than solely in aggregate.

@getsentry/infrastructure @dcramer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3686)

<!-- Reviewable:end -->
