### PR TITLE
First pass on getting the 'extra' kwarg into structlog.

### DIFF
--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -61,10 +61,11 @@ class StructLogHandler(logging.StreamHandler):
         # a record because the RootLogger will take the 'extra' dictionary
         # and just turn them into attributes.
         kwargs = {
-            (k if k not in throwaways else 'popme'): v
-            for k, v in record.__dict__.iteritems()
+            k: v
+            for k, v in vars(record).iteritems()
+            if k not in throwaways
+            and v is not None
         }
-        kwargs.pop('popme', None)
         kwargs.update({
             'level': record.levelno,
             'event': record.msg,

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -48,13 +48,23 @@ class HumanRenderer(object):
 
 class StructLogHandler(logging.StreamHandler):
     def emit(self, record, logger=get_logger()):
+        # This may seem a little gross, but when logging with the RootLogger,
+        # anything passed into 'extra' gets turned into a real kwarg
+        throwaways = [
+            'threadName', 'thread', 'created', 'process', 'processName', 'args',
+            'module', 'filename', 'levelno', 'exc_text', 'msg', 'pathname', 'lineno',
+            'funcName', 'relativeCreated', 'levelname', 'msecs',
+        ]
+
         kwargs = {
+            (k if k not in throwaways else 'popme'): v
+            for k, v in record.__dict__.iteritems()
+        }
+        kwargs.pop('popme')
+        kwargs.update({
             'level': record.levelno,
             'event': record.msg,
-            'name': record.name,
-        }
-        if record.exc_info:
-            kwargs['exc_info'] = record.exc_info
+        })
 
         if record.args:
             # record.args inside of LogRecord.__init__ gets unrolled

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -23,6 +23,14 @@ _default_encoder = JSONEncoder(
     default=_json_fallback_handler,
 ).encode
 
+# These are values that come default from logging.LogRecord.
+# They are defined here: https://github.com/python/cpython/blob/2.7/Lib/logging/__init__.py#L237-L310
+throwaways = frozenset((
+    'threadName', 'thread', 'created', 'process', 'processName', 'args',
+    'module', 'filename', 'levelno', 'exc_text', 'msg', 'pathname', 'lineno',
+    'funcName', 'relativeCreated', 'levelname', 'msecs',
+))
+
 
 class JSONRenderer(object):
     def __call__(self, logger, name, event_dict):
@@ -43,24 +51,20 @@ class HumanRenderer(object):
         )
         join = ' '.join(k + '=' + repr(v)
                for k, v in event_dict.iteritems())
-        return '%s %s' % (base, join)
+        return '%s (%s)' % (base, join)
 
 
 class StructLogHandler(logging.StreamHandler):
     def emit(self, record, logger=get_logger()):
-        # This may seem a little gross, but when logging with the RootLogger,
-        # anything passed into 'extra' gets turned into a real kwarg
-        throwaways = [
-            'threadName', 'thread', 'created', 'process', 'processName', 'args',
-            'module', 'filename', 'levelno', 'exc_text', 'msg', 'pathname', 'lineno',
-            'funcName', 'relativeCreated', 'levelname', 'msecs',
-        ]
-
+        # If anyone wants to use the 'extra' kwarg to provide context within
+        # structlog, we have to strip all of the default attributes from
+        # a record because the RootLogger will take the 'extra' dictionary
+        # and just turn them into attributes.
         kwargs = {
             (k if k not in throwaways else 'popme'): v
             for k, v in record.__dict__.iteritems()
         }
-        kwargs.pop('popme')
+        kwargs.pop('popme', None)
         kwargs.update({
             'level': record.levelno,
             'event': record.msg,


### PR DESCRIPTION
This is ugly, but it was pretty much the only way I saw getting the `extra` dict from `log.info('stuff', extra={'org_id':1})` into the structlog event dict. Loggers turn anything in `extra` into a regular attribute and I can't find a good way to decipher between stdlib attributes and appended attributes.

@mattrobenolt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3687)

<!-- Reviewable:end -->
