### PR TITLE
Add DynamoDB backend

### DIFF
--- a/src/sentry/nodestore/dynamodb/__init__.py
+++ b/src/sentry/nodestore/dynamodb/__init__.py
@@ -1,0 +1,10 @@
+"""
+sentry.nodestore.dynamodb
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+from __future__ import absolute_import
+
+from .backend import *  # NOQA

--- a/src/sentry/nodestore/dynamodb/backend.py
+++ b/src/sentry/nodestore/dynamodb/backend.py
@@ -1,0 +1,267 @@
+"""
+sentry.nodestore.dynamodb.backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from time import mktime
+from datetime import datetime
+from simplejson import JSONEncoder, _default_decoder
+from base64 import b64encode, b64decode
+
+from sentry.nodestore.base import NodeStorage
+from sentry.utils.iterators import chunked
+from .client import DynamodbClient
+
+
+# Cache an instance of the encoder we want to use
+json_dumps = JSONEncoder(
+    separators=(',', ':'),
+    skipkeys=False,
+    ensure_ascii=True,
+    check_circular=True,
+    allow_nan=True,
+    indent=None,
+    encoding='utf-8',
+    default=None,
+).encode
+
+json_loads = _default_decoder.decode
+
+
+class DynamodbException(Exception):
+    def __init__(self, type, message):
+        self.type = type
+        self.message = message
+
+    def __str__(self):
+        return '(%s) %s' % (self.type, self.message)
+
+
+def serialize(data):
+    return b64encode(data.encode('zlib'))
+
+
+def deserialize(data):
+    return b64decode(data).decode('zlib')
+
+
+def datetime_to_unix(dt):
+    return mktime(dt.timetuple())
+
+
+def utcnow():
+    return datetime_to_unix(datetime.utcnow())
+
+
+class DynamodbNodeStorage(NodeStorage):
+    """
+    A DynamoDB-based backend for storing node data.
+
+    >>> DynamodbNodeStorage(
+    ...     table='SentryNodestore',
+    ...     access_key='AWS_ACCESS_KEY',
+    ...     secret_key='AWS_SECRET_KEY',
+    ...     region='us-east-1',
+    ... )
+    """
+    def __init__(self, table='SentryNodestore',
+                 access_key=None, secret_key=None,
+                 region='us-east-1', endpoint=None,
+                 **connection_options):
+        self.table = table
+        self.client = DynamodbClient(
+            access_key=access_key,
+            secret_key=secret_key,
+            region=region,
+            endpoint=endpoint,
+            **connection_options
+        )
+
+    def set(self, id, data):
+        rv = self.client.urlopen(
+            target='DynamoDB_20120810.PutItem',
+            body=json_dumps({
+                'TableName': self.table,
+                'Item': {
+                    'Id': {
+                        'S': id,
+                    },
+                    'Created': {
+                        'N': str(utcnow()),
+                    },
+                    'Data': {
+                        'B': serialize(data),
+                    },
+                },
+            }),
+        )
+        if rv.status == 200:
+            return
+        if rv.status == 400:
+            rv = json_loads(rv.data)
+            raise DynamodbException(rv['__type'], rv['message'])
+        raise DynamodbException('<unknown>', rv.data)
+
+    def delete(self, id):
+        rv = self.client.urlopen(
+            target='DynamoDB_20120810.DeleteItem',
+            body=json_dumps({
+                'TableName': self.table,
+                'Key': {
+                    'Id': {
+                        'S': id,
+                    },
+                },
+                'ReturnValues': 'NONE',
+            }),
+        )
+        if rv.status == 200:
+            return
+        if rv.status == 400:
+            rv = json_loads(rv.data)
+            raise DynamodbException(rv['__type'], rv['Message'])
+        raise DynamodbException('<unknown>', rv.data)
+
+    def get(self, id):
+        rv = self.client.urlopen(
+            target='DynamoDB_20120810.GetItem',
+            body=json_dumps({
+                'TableName': self.table,
+                'Key': {
+                    'Id': {
+                        'S': id,
+                    },
+                },
+            })
+        )
+        if rv.status == 400:
+            rv = json_loads(rv.data)
+            raise DynamodbException(rv['__type'], rv['message'])
+
+        if rv.status != 200:
+            raise DynamodbException('<unknown>', rv.data)
+
+        data = json_loads(rv.data)
+
+        try:
+            item = data['Item']
+        except KeyError:
+            # DynamoDB won't actually return a 404 or anything
+            # sensible on a miss, it'll just return an empty
+            # dictionary missing 'Item'
+            return None
+
+        return deserialize(item['Data']['B'])
+
+    def get_multi(self, id_list):
+        # In theory, this entire payload is not allowed to be
+        # larger than 16MB for a single response, and we don't
+        # handle this case well, but this should be very unlikely
+        # since a single key isn't allowed to be more than 400KB
+        if len(id_list) == 0:
+            return {}
+
+        if len(id_list) == 1:
+            id = id_list[0]
+            return {id: self.get(id)}
+
+        results = {id: None for id in id_list}
+
+        # Max request size is 100 items
+        for chunk in chunked(id_list, 100):
+            rv = self.client.urlopen(
+                target='DynamoDB_20120810.BatchGetItem',
+                body=json_dumps({
+                    'RequestItems': {
+                        self.table: {
+                            'Keys': [
+                                {'Id': {'S': id}}
+                                for id in chunk
+                            ],
+                        },
+                    },
+                })
+            )
+
+            if rv.status != 200:
+                continue
+
+            data = json_loads(rv.data)
+
+            try:
+                items = data['Responses'][self.table]
+            except KeyError:
+                return None
+
+            for item in items:
+                results[item['Id']['S']] = deserialize(item['Data']['B'])
+
+        return results
+
+    def cleanup(self, cutoff_timestamp):
+        while True:
+            rv = self.client.urlopen(
+                target='DynamoDB_20120810.Scan',
+                body=json_dumps({
+                    'TableName': self.table,
+                    'FilterExpression': 'Created < :val',
+                    'ExpressionAttributeValues': {
+                        ':val': {'N': str(datetime_to_unix(cutoff_timestamp))},
+                    }
+                })
+            )
+            if rv.status != 200:
+                return
+
+            data = json_loads(rv.data)
+            if data['Count'] == 0:
+                return
+
+            # TODO(mattrobenolt): parallelize!
+            # This is going to be super slow with a large dataset
+            for item in data['Items']:
+                self.delete(item['Id']['S'])
+
+    def bootstrap(self, write_capacity_units=5, read_capacity_units=5):
+        rv = self.client.urlopen(
+            target='DynamoDB_20120810.CreateTable',
+            body=json_dumps({
+                'TableName': self.table,
+                'AttributeDefinitions': [
+                    {'AttributeName': 'Id', 'AttributeType': 'S'},
+                    {'AttributeName': 'Created', 'AttributeType': 'N'},
+                ],
+                'KeySchema': [
+                    {'KeyType': 'HASH', 'AttributeName': 'Id'},
+                ],
+                'GlobalSecondaryIndexes': [{
+                    'IndexName': 'CreatedIndex',
+                    'KeySchema': [
+                        {'KeyType': 'HASH', 'AttributeName': 'Id'},
+                        {'KeyType': 'RANGE', 'AttributeName': 'Created'},
+                    ],
+                    'Projection': {
+                        'ProjectionType': 'KEYS_ONLY',
+                    },
+                    'ProvisionedThroughput': {
+                        'WriteCapacityUnits': write_capacity_units,
+                        'ReadCapacityUnits': read_capacity_units,
+                    },
+                }],
+                'ProvisionedThroughput': {
+                    'WriteCapacityUnits': write_capacity_units,
+                    'ReadCapacityUnits': read_capacity_units,
+                },
+            })
+        )
+        if rv.status == 200:
+            return
+        if rv.status == 400:
+            rv = json_loads(rv.data)
+            raise DynamodbException(rv['__type'], rv['Message'])
+        raise DynamodbException('<unknown>', rv.data)

--- a/src/sentry/nodestore/dynamodb/client.py
+++ b/src/sentry/nodestore/dynamodb/client.py
@@ -1,0 +1,121 @@
+"""
+sentry.nodestore.dynamodb.client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from hmac import new as hmac_new
+from hashlib import sha256
+from datetime import datetime
+from urlparse import urlparse
+
+
+# Key derivation functions. See:
+# http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html#signature-v4-examples-python
+def sign(key, msg):
+    return hmac_new(key, msg.encode('utf-8'), sha256).digest()
+
+
+def now():
+    t = datetime.utcnow()
+    amz_date = t.strftime('%Y%m%dT%H%M%SZ')
+    date_stamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
+    return date_stamp, amz_date
+
+
+def get_signature_key(key, date_stamp, region):
+    k_date = sign(('AWS4' + key).encode('utf-8'), date_stamp)
+    k_region = sign(k_date, region)
+    k_service = sign(k_region, 'dynamodb')
+    k_signing = sign(k_service, 'aws4_request')
+    return k_signing
+
+
+def sign_request(body, headers, region, access_key, secret_key):
+    """
+    Mutate a request's headers with a X-Amx-Date and Authorization headers
+    needed for AWS.
+    """
+    # Stamp out current time, and add to headers
+    date_stamp, amz_date = now()
+    headers['X-Amz-Date'] = amz_date
+
+    # Now we need to construct a canonical request to be signed
+    # http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+    # For DynamoDB, the url and querystring are always the same, so they are hardcoded to
+    # '/' and '' respectively
+
+    # Create the list of headers to be signed. Again, for Dynamodb, these never change
+    signed_headers = 'content-type;host;x-amz-date;x-amz-target'
+    # Extract the values from the headers
+    canonical_headers = 'content-type:%(Content-Type)s\nhost:%(Host)s\nx-amz-date:%(X-Amz-Date)s\nx-amz-target:%(X-Amz-Target)s\n' % headers
+    # Generate sha256 of request body
+    payload_hash = sha256(body).hexdigest()
+    # Combine pieces into canonical request
+    canonical_request = 'POST\n/\n\n' + canonical_headers + '\n' + signed_headers + '\n' + payload_hash
+
+    # Now we need to create the sha256 signature
+    credential_scope = date_stamp + '/' + region + '/dynamodb/aws4_request'
+    string_to_sign = 'AWS4-HMAC-SHA256\n' + amz_date + '\n' + credential_scope + '\n' + sha256(canonical_request).hexdigest()
+
+    # Calculate the signature
+    signing_key = get_signature_key(secret_key, date_stamp, region)
+    signature = hmac_new(signing_key, string_to_sign.encode('utf-8'), sha256).hexdigest()
+    authorization_header = 'AWS4-HMAC-SHA256 Credential=' + access_key + '/' + credential_scope + ', ' + 'SignedHeaders=' + signed_headers + ', ' + 'Signature=' + signature
+
+    # Inject this authorization into the headers
+    headers['Authorization'] = authorization_header
+
+
+def create_pool(url, **options):
+    scheme = url.scheme
+    if scheme == 'http':
+        from urllib3 import HTTPConnectionPool
+        cls = HTTPConnectionPool
+    elif scheme == 'https':
+        from urllib3 import HTTPSConnectionPool
+        cls = HTTPSConnectionPool
+        verify_ssl = options.pop('verify_ssl', True)
+        if verify_ssl:
+            options.setdefault('cert_reqs', 'CERT_REQUIRED')
+        if not options.get('ca_certs'):
+            # utilize the ca_certs path from requests since we already depend on it
+            # and they bundle a ca cert.
+            from requests.certs import where
+            options['ca_certs'] = where()
+    else:
+        raise KeyError('Invalid scheme: %s' % scheme)
+    return cls(url.hostname, url.port, **options)
+
+
+class DynamodbClient(object):
+    def __init__(self, access_key, secret_key,
+                 region='us-east-1', endpoint=None,
+                 **connection_kwargs):
+        if not (access_key or secret_key):
+            raise ValueError('Must specify both `access_key` and `secret_key`')
+        self.access_key = access_key
+        self.secret_key = secret_key
+        if endpoint is None:
+            endpoint = 'https://dynamodb.%(region)s.amazonaws.com'
+        self.endpoint = endpoint % {'region': region}
+        self.region = region
+        url = urlparse(self.endpoint)
+        self.host = url.netloc
+        self.pool = create_pool(url, **connection_kwargs)
+
+    def urlopen(self, target, body):
+        headers = {
+            'Host': self.host,
+            'X-Amz-Target': target,
+            'Content-Type': 'application/x-amz-json-1.0',
+        }
+        sign_request(body, headers, self.region, self.access_key, self.secret_key)
+        return self.pool.urlopen('POST', '/', headers=headers, body=body)
+
+    def close(self):
+        self.pool.close()

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -1,8 +1,14 @@
 def chunked(iterator, size):
-    chunk = []
-    for item in iterator:
-        chunk.append(item)
-        if len(chunk) == size:
-            yield chunk
-            del chunk[:]
-    yield chunk
+    chunk = [None] * size
+    idx, i = None, None
+    for idx, item in enumerate(iterator):
+        i = idx % size
+        chunk[i] = item
+        if i == size - 1:
+            yield tuple(chunk)
+    if idx is None:
+        yield tuple()
+    else:
+        i += 1
+        if i < size:
+            yield tuple(chunk[:i])


### PR DESCRIPTION
This was a bit more complicated than I had hoped, but I spent a bunch of time fighting with DynamoDB and figuring out how it worked.

This is split into two pieces, the backend and the client.

The client is responsible for handling the AWS http request and managing the request signing and http transport with AWS.

The backend just interfaces with the client.

I've tested this against a running DynamoDB instance, but not sure the best way to write tests, other than asserting that the shape of the data is correct for the API calls. I'm open to ideas here.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3692)

<!-- Reviewable:end -->
