### PR TITLE
Use random group generator for email previews.

### DIFF
--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -33,10 +33,20 @@
                   </td>
                   <td class="event-detail">
                       {% url 'sentry-group' group.organization.slug group.project.slug group.id as group_link %}
-                      <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
+                      {% if group.data.type == "error" %}
+                        <div class="event-type error">
+                          <a href="{% absolute_uri group_link %}">{{ group.data.metadata.type }}</a>
+                          <small>{{ group.title|soft_break:50 }}</small>
+                          <p>{{ group.data.metadata.value }}</p>
+                        </div>
+                      {% else %}
+                        <div class="event-type default">
+                          <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
+                          <p>{{ group.title|soft_break:50 }}</p>
+                        </div>
+                      {% endif %}
                       <p>
-                        {{ group.title|soft_break:50 }}
-                        <small>&mdash; {{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
+                        <small>{{ records.0.datetime|date:"N j, Y, P e" }}</small>
                       </p>
                   </td>
               </tr>

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -33,20 +33,10 @@
                   </td>
                   <td class="event-detail">
                       {% url 'sentry-group' group.organization.slug group.project.slug group.id as group_link %}
-                      {% if group.data.type == "error" %}
-                        <div class="event-type error">
-                          <a href="{% absolute_uri group_link %}">{{ group.data.metadata.type }}</a>
-                          <small>{{ group.title|soft_break:50 }}</small>
-                          <p>{{ group.data.metadata.value }}</p>
-                        </div>
-                      {% else %}
-                        <div class="event-type default">
-                          <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
-                          <p>{{ group.title|soft_break:50 }}</p>
-                        </div>
-                      {% endif %}
+                      <a href="{% absolute_uri group_link %}">{{ group.message_short|soft_break:40 }}</a>
                       <p>
-                        <small>{{ records.0.datetime|date:"N j, Y, P e" }}</small>
+                        {{ group.title|soft_break:50 }}
+                        <small>&mdash; {{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
                       </p>
                   </td>
               </tr>

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -37,7 +37,7 @@ from sentry.models import (
     Team,
 )
 from sentry.plugins.sentry_mail.activity import emails
-from sentry.utils.dates import to_timestamp
+from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.samples import load_data
 from sentry.utils.email import inline_css
 from sentry.utils.http import absolute_uri
@@ -83,13 +83,19 @@ def make_group_metadata(random, group):
 
 
 def make_group_generator(random, project):
+    epoch = to_timestamp(datetime(2016, 6, 1, 0, 0, 0, tzinfo=timezone.utc))
     for id in itertools.count(1):
+        first_seen = epoch + random.randint(0, 60 * 60 * 24 * 30)
+        last_seen = random.randint(first_seen, first_seen + (60 * 60 * 24 * 30))
+
         group = Group(
             id=id,
             project=project,
             culprit=make_culprit(random),
             level=random.choice(LOG_LEVELS.keys()),
             message=make_message(random),
+            first_seen=to_datetime(first_seen),
+            last_seen=to_datetime(last_seen),
         )
 
         if random.random() < 0.8:

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -208,6 +208,12 @@ def new_event(request):
     ).render()
 
 
+def make_message(random, length=None):
+    if length is None:
+        length = int(random.weibullvariate(8, 3))
+    return ' '.join(random.choice(WORDS) for _ in xrange(length))
+
+
 def make_culprit(random):
     def make_module_path_components(min, max):
         for _ in xrange(random.randint(min, max)):
@@ -219,15 +225,32 @@ def make_culprit(random):
     )
 
 
+def make_group_metadata(random, group):
+    return {
+        'type': 'error',
+        'metadata': {
+            'type': '{}Error'.format(
+                ''.join(word.title() for word in random.sample(WORDS, random.randint(1, 3))),
+            ),
+            'value': make_message(random),
+        }
+    }
+
+
 def make_group_generator(random, project):
     for id in itertools.count(1):
-        yield Group(
+        group = Group(
             id=id,
             project=project,
-            message=' '.join(random.choice(WORDS) for _ in xrange(int(random.weibullvariate(8, 4)))),
             culprit=make_culprit(random),
             level=random.choice(LOG_LEVELS.keys()),
+            message=make_message(random),
         )
+
+        if random.random() < 0.8:
+            group.data = make_group_metadata(random, group)
+
+        yield group
 
 
 @login_required

--- a/tests/acceptance/test_activity_emails.py
+++ b/tests/acceptance/test_activity_emails.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from urllib import urlencode
+
 from sentry.testutils import AcceptanceTestCase
 
 
@@ -9,92 +11,101 @@ class ActivityEmailsTest(AcceptanceTestCase):
         self.user = self.create_user('foo@example.com')
         self.login_as(self.user)
 
+    def build_url(self, path, format='html'):
+        return u'{}?{}'.format(
+            path,
+            urlencode({
+                'format': format,
+                'seed': '123',
+            }),
+        )
+
     def test_assigned_html(self):
-        self.browser.get('/debug/mail/assigned/?format=html')
+        self.browser.get(self.build_url('/debug/mail/assigned/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('assigned email html')
 
     def test_assigned_txt(self):
-        self.browser.get('/debug/mail/assigned/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/assigned/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('assigned email txt')
 
     def test_assigned_self_html(self):
-        self.browser.get('/debug/mail/assigned/self/?format=html')
+        self.browser.get(self.build_url('/debug/mail/assigned/self/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('assigned_self email html')
 
     def test_assigned_self_txt(self):
-        self.browser.get('/debug/mail/assigned/self/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/assigned/self/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('assigned_self email txt')
 
     def test_note_html(self):
-        self.browser.get('/debug/mail/note/?format=html')
+        self.browser.get(self.build_url('/debug/mail/note/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('note email html')
 
     def test_note_txt(self):
-        self.browser.get('/debug/mail/note/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/note/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('note email txt')
 
     def test_regression_html(self):
-        self.browser.get('/debug/mail/regression/?format=html')
+        self.browser.get(self.build_url('/debug/mail/regression/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('regression email html')
 
     def test_regression_txt(self):
-        self.browser.get('/debug/mail/regression/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/regression/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('regression email txt')
 
     def test_regression_with_version_html(self):
-        self.browser.get('/debug/mail/regression/release/?format=html')
+        self.browser.get(self.build_url('/debug/mail/regression/release/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('regression_with_version email html')
 
     def test_regression_with_version_txt(self):
-        self.browser.get('/debug/mail/regression/release/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/regression/release/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('regression_with_version email txt')
 
     def test_resolved_html(self):
-        self.browser.get('/debug/mail/resolved/?format=html')
+        self.browser.get(self.build_url('/debug/mail/resolved/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('resolved email html')
 
     def test_resolved_txt(self):
-        self.browser.get('/debug/mail/resolved/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/resolved/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('resolved email txt')
 
     def test_resolved_in_release_html(self):
-        self.browser.get('/debug/mail/resolved-in-release/?format=html')
+        self.browser.get(self.build_url('/debug/mail/resolved-in-release/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('resolved_in_release email html')
 
     def test_resolved_in_release_txt(self):
-        self.browser.get('/debug/mail/resolved-in-release/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/resolved-in-release/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('resolved_in_release email txt')
 
     def test_resolved_in_release_upcoming_html(self):
-        self.browser.get('/debug/mail/resolved-in-release/upcoming/?format=html')
+        self.browser.get(self.build_url('/debug/mail/resolved-in-release/upcoming/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('resolved_in_release_upcoming email html')
 
     def test_resolved_in_release_upcoming_txt(self):
-        self.browser.get('/debug/mail/resolved-in-release/upcoming/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/resolved-in-release/upcoming/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('resolved_in_release_upcoming email txt')
 
     def test_unassigned_html(self):
-        self.browser.get('/debug/mail/unassigned/?format=html')
+        self.browser.get(self.build_url('/debug/mail/unassigned/'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('unassigned email html')
 
     def test_unassigned_txt(self):
-        self.browser.get('/debug/mail/unassigned/?format=txt')
+        self.browser.get(self.build_url('/debug/mail/unassigned/', 'txt'))
         self.browser.wait_until('#preview')
         self.browser.snapshot('unassigned email txt')


### PR DESCRIPTION
This uses the random group generator for generating content for email previews so that there is more  variation when developing. Specifically, this will generate different event types at random.

This is extracted from GH-3621, since I mainly just wanted to get a baseline for the visual tests, which use a seeded random number generator to ensure deterministic rendering.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3699)

<!-- Reviewable:end -->
