### PR TITLE
Remove early adopter message from OrganizationIssueList

### DIFF
--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -56,7 +56,6 @@ const OrganizationIssueList = React.createClass({
           </div>
         </div>
         <h3>{this.props.title}</h3>
-        <div className="alert alert-block alert-info">{'Psst! This feature is still a work-in-progress. Thanks for being an early adopter!'}</div>
         <IssueList endpoint={this.props.endpoint} query={{
           status: this.state.status,
           statsPeriod: '24h',


### PR DESCRIPTION
This affects:
- Assigned To Me
- Bookmarks
- History

@getsentry/ui 

These pages haven't changed in many versions, so I don't think it's valuable to keep showing this message.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3707)

<!-- Reviewable:end -->
