### PR TITLE
Add a small utility to wrap structlog.logger.bind()

### DIFF
--- a/src/sentry/logging/__init__.py
+++ b/src/sentry/logging/__init__.py
@@ -7,7 +7,17 @@ sentry.logging
 
 from __future__ import absolute_import
 
+from structlog import get_logger
+
 
 class LoggingFormat(object):
     HUMAN = 'human'
     MACHINE = 'machine'
+
+
+def bind(name, **kwargs):
+    """
+    Syntactic sugar for binding arbitrary kv pairs to a given logger instantiated from
+    logging.getLogger instead of structlog.get_logger.
+    """
+    return get_logger(name=name).bind(**kwargs)


### PR DESCRIPTION
@mattrobenolt

Example:

```
In [1]: import logging

In [2]: logger = logging.getLogger('sentry.example')

In [3]: from sentry.logging import bind

In [4]: bind(logger.name, k1='v1')
Out[4]: <BoundLogger...>

In [5]: logger.info('something.happened', extra={'k2':'v2'})
[INFO] sentry.example: something.happened (k2='v2' k1='v1')
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3717)

<!-- Reviewable:end -->
