### PR TITLE
Added new platforms to Sentry

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -183,6 +183,9 @@ VALID_PLATFORMS = set([
     'php',
     'python',
     'ruby',
+    'elixir',
+    'haskell',
+    'groovy',
 ])
 
 OK_PLUGIN_ENABLED = _("The {name} integration has been enabled.")


### PR DESCRIPTION
This adds three new platforms to Sentry:
- elixir
- haskell
- groovy

The reason is that our "other" category keeps growing and ranks above
go, perl and some others now and my guess is that this is most likely
elixir or groovy.  So we should be able to let clients better tell
what they are now so we can start tracking them.

Thoughts?

Clients:
- https://github.com/agorapulse/grails-raven
- https://github.com/vishnevskiy/raven-elixir
- https://bitbucket.org/dpwiz/raven-haskell

@getsentry/infrastructure 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3720)

<!-- Reviewable:end -->
