### PR TITLE
Use `generated` statistic for organization dashboard rather than `received`.

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -243,7 +243,7 @@ const OrganizationDashboard = React.createClass({
       orgId: this.props.params.orgId,
       query: {
         since: new Date().getTime() / 1000 - 3600 * 24,
-        stat: 'received',
+        stat: 'generated',
         group: 'project'
       }
     });


### PR DESCRIPTION
Fixes GH-3726, references GH-2782 — see those tickets for description.

@getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3727)

<!-- Reviewable:end -->
