### PR TITLE
Store issue freqs for [release+env]

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -62,7 +62,9 @@ class TSDBModel(Enum):
     # number of issues seen for a project, by project
     frequent_issues_by_project = 404
     # number of events seen for a release, by issue
-    frequent_releases_by_groups = 406
+    # frequent_releases_by_groups = 406  # DEPRECATED
+    # number of events seen for a release, by issue
+    frequent_releases_by_groups = 407
 
 
 class BaseTSDB(object):

--- a/tests/sentry/models/test_grouprelease.py
+++ b/tests/sentry/models/test_grouprelease.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+from django.utils import timezone
+
+from sentry.models import GroupRelease, Release
+from sentry.testutils import TestCase
+
+
+class GetOrCreateTest(TestCase):
+    def test_simple(self):
+        project = self.create_project()
+        group = self.create_group(project=project)
+        release = Release.objects.create(version='abc', project=project)
+
+        datetime = timezone.now()
+
+        grouprelease = GroupRelease.get_or_create(
+            group=group,
+            release=release,
+            environment='prod',
+            datetime=datetime,
+        )
+
+        assert grouprelease.project_id == project.id
+        assert grouprelease.group_id == group.id
+        assert grouprelease.release_id == release.id
+        assert grouprelease.environment == 'prod'
+        assert grouprelease.first_seen == datetime
+        assert grouprelease.last_seen == datetime
+
+        datetime_new = timezone.now() + timedelta(days=1)
+
+        grouprelease = GroupRelease.get_or_create(
+            group=group,
+            release=release,
+            environment='prod',
+            datetime=datetime_new,
+        )
+
+        assert grouprelease.first_seen == datetime
+        assert grouprelease.last_seen == datetime_new
+
+    def test_empty_env(self):
+        project = self.create_project()
+        group = self.create_group(project=project)
+        release = Release.objects.create(version='abc', project=project)
+
+        datetime = timezone.now()
+
+        grouprelease = GroupRelease.get_or_create(
+            group=group,
+            release=release,
+            environment=None,
+            datetime=datetime,
+        )
+
+        assert grouprelease.environment == ''


### PR DESCRIPTION
This adjusts the tsdb storage for release frequencies to use the new GroupRelease which is bound to an environment.

/cc @getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3729)

<!-- Reviewable:end -->
