### PR TITLE
Add API link to Django base pages

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -88,6 +88,7 @@
             </a>
             <ul class="dropdown-menu dropdown-menu-right">
               <li><a href="{% url 'sentry-account-settings' %}">{% trans "Account" %}</a></li>
+              <li><a href="{% url 'sentry-api' %}">{% trans "API" %}</a></li>
               {% if request.user.is_superuser %}
                 <li><a href="{% url 'sentry-admin-overview' %}">{% trans "Admin" %}</a></li>
               {% endif %}


### PR DESCRIPTION
This only existed in the React views, not Django views.

@getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3739)

<!-- Reviewable:end -->
