### PR TITLE
Add locking to upgrade

### DIFF
--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -11,19 +11,11 @@ import click
 from sentry.runner.decorators import configuration
 
 
-@click.command()
-@click.option('--verbosity', '-v', default=1, help='Verbosity level.')
-@click.option('--traceback', default=True, is_flag=True, help='Raise on exception.')
-@click.option('--noinput', default=False, is_flag=True, help='Do not prompt the user for input of any kind.')
-@configuration
-@click.pass_context
-def upgrade(ctx, verbosity, traceback, noinput):
-    "Perform any pending database migrations and upgrades."
-
+def _upgrade(interactive, traceback, verbosity):
     from django.core.management import call_command as dj_call_command
     dj_call_command(
         'syncdb',
-        interactive=not noinput,
+        interactive=interactive,
         traceback=traceback,
         verbosity=verbosity,
     )
@@ -32,7 +24,7 @@ def upgrade(ctx, verbosity, traceback, noinput):
         'migrate',
         merge=True,
         ignore_ghost_migrations=True,
-        interactive=not noinput,
+        interactive=interactive,
         traceback=traceback,
         verbosity=verbosity,
     )
@@ -41,3 +33,26 @@ def upgrade(ctx, verbosity, traceback, noinput):
     call_command(
         'sentry.runner.commands.repair.repair',
     )
+
+
+@click.command()
+@click.option('--verbosity', '-v', default=1, help='Verbosity level.')
+@click.option('--traceback', default=True, is_flag=True, help='Raise on exception.')
+@click.option('--noinput', default=False, is_flag=True, help='Do not prompt the user for input of any kind.')
+@click.option('--lock', default=False, is_flag=True, help='Hold a global lock and limit upgrade to one concurrent.')
+@configuration
+@click.pass_context
+def upgrade(ctx, verbosity, traceback, noinput, lock):
+    "Perform any pending database migrations and upgrades."
+
+    if lock:
+        from sentry.app import locks
+        from sentry.utils.locking import UnableToAcquireLock
+        lock = locks.get('upgrade', duration=0)
+        try:
+            with lock.acquire():
+                _upgrade(not noinput, traceback, verbosity)
+        except UnableToAcquireLock:
+            raise click.ClickException('Unable to acquire `upgrade` lock.')
+    else:
+        _upgrade(not noinput, traceback, verbosity)


### PR DESCRIPTION
This adds:
- A `--lock` option to `sentry upgrade` which will bail out and error if
  there is already a claimed lock.
- A `--with-lock` option to `sentry run web --upgrade` which will skip
  running `upgrade` if the lock is already claimed.

This change is to better facilitate automated cluster deployments where
the recommended means of upgrading/deploying Sentry is just by running
`sentry run web --upgrade` without needing a manual step of running
`upgrade`. In distributed systems, it's not a great idea to be running
multiple concurrent `upgrades` since they'll likely conflict and error
out or do something potentially worse.

Fixes GH-3705

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3740)

<!-- Reviewable:end -->
