### PR TITLE
Sample data fixtures can now specify breadcrumbs

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -174,99 +174,6 @@ def create_sample_time_series(event, release=None):
         now = now - timedelta(hours=1)
 
 
-epoch = datetime.utcfromtimestamp(0)
-
-
-def milliseconds_ago(now, milliseconds):
-    ago = (now - timedelta(milliseconds=milliseconds))
-    return (ago - epoch).total_seconds()
-
-
-def get_sample_breadcrumbs(prior_event_id=None):
-    now = datetime.now()
-    sample_breadcrumbs = {
-        "values": [
-            {
-                "type": "navigation",
-                "timestamp": milliseconds_ago(now, 5200),
-                "category": "react-router",
-                "data": {
-                    "from": "/login/",
-                    "to": "/dashboard/",
-                }
-            },
-            {
-                "timestamp": milliseconds_ago(now, 4000),
-                "message": "This is an info log message",
-                "category": "django"
-            },
-            {
-                "timestamp": milliseconds_ago(now, 3300),
-                "message": "This is a warning log message",
-                "level": "warning",
-                "category": 'django'
-            },
-            {
-                "timestamp": milliseconds_ago(now, 2700),
-                "message": "This is an error log message",
-                "level": "error",
-                "category": 'django'
-            },
-            {
-                "timestamp": milliseconds_ago(now, 2700),
-                "message": "This is a critical log message",
-                "level": "critical",
-                "category": 'django'
-            },
-            {
-                "timestamp": milliseconds_ago(now, 2700),
-                "message": "This is a debug log message",
-                "level": "debug",
-                "category": 'django',
-                "data": {
-                    "foo": "bar",
-                    "baz": "blah"
-                }
-            },
-            {
-                "type": "http",
-                "category": "requests",
-                "timestamp": milliseconds_ago(now, 1300),
-                "data": {
-                    "reason": "OK",
-                    "status_code": 200,
-                    "url": "Http://example.com/",
-                    "method": "POST"
-                }
-            },
-            {
-                "type": "query",
-                "category": "django",
-                "timestamp": milliseconds_ago(now, 1200),
-                "message": u'SELECT "auth_user"."password", "auth_user"."last_login", "auth_user"."id", "auth_user"."username", "auth_user"."first_name", "auth_user"."email", "auth_user"."is_staff", "auth_user"."is_active", "auth_user"."is_superuser", "auth_user"."is_managed", "auth_user"."date_joined" FROM "auth_user" WHERE "auth_user"."id" = 1',
-                "duration": 0.002
-            },
-            {
-                "type": "ui",
-                "timestamp": milliseconds_ago(now, 1000),
-                "message": "div > form[name=\"post\"] > button.btn.btn-small[name=\"submit\"]",
-                "category": 'ui.click'
-            }
-        ]
-    }
-
-    if prior_event_id:
-        sample_breadcrumbs["values"].insert(2, {
-            "type": "error",
-            "timestamp": milliseconds_ago(now, 3000),
-            "message": "TypeError: something broke earlier",
-            "category": "error",
-            "event_id": prior_event_id
-        })
-
-    return sample_breadcrumbs
-
-
 def main(num_events=1):
     user = User.objects.filter(is_superuser=True)[0]
 
@@ -370,7 +277,6 @@ def main(num_events=1):
                     environment=ENVIRONMENTS.next(),
                     message='This is a mostly useless example %s exception' % platform,
                     checksum=md5(platform + str(_)).hexdigest(),
-                    breadcrumbs=get_sample_breadcrumbs(prior_event_id=last_event.id if last_event else None),
                 )
 
             for _ in range(num_events):
@@ -385,7 +291,6 @@ def main(num_events=1):
                     project=project,
                     platform='javascript',
                     release=release.version,
-                    breadcrumbs=get_sample_breadcrumbs(prior_event_id=event1.event_id),
                     environment=ENVIRONMENTS.next(),
                     sdk={
                         'name': 'raven-js',

--- a/src/sentry/data/samples/javascript.json
+++ b/src/sentry/data/samples/javascript.json
@@ -1,9 +1,4 @@
 {
-    "errors": [
-        {"type": "invalid_attribute", "name": "foobar"},
-        {"type": "invalid_attribute", "name": "foobar"},
-        {"type": "invalid_data", "name": "event_id", "value": "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8"}
-    ],
     "sentry.interfaces.Exception": {
         "values": [
             {
@@ -146,6 +141,69 @@
                 "type": "TypeError",
                 "value": "Object [object Object] has no method 'updateFrom'",
                 "module": null
+            }
+        ]
+    },
+    "sentry.interfaces.Breadcrumbs": {
+        "values": [
+            {
+                "type": "navigation",
+                "timestamp": 1463071692.0,
+                "category": "react-router",
+                "data": {
+                    "from": "/login/",
+                    "to": "/dashboard/"
+                }
+            },
+            {
+                "timestamp": 1463072692.0,
+                "message": "This is an info log message",
+                "category": "console"
+            },
+            {
+                "timestamp": 1463073692.0,
+                "message": "This is a warning log message",
+                "level": "warning",
+                "category": "console"
+            },
+            {
+                "timestamp": 1463074692.0,
+                "message": "This is an error log message",
+                "level": "error",
+                "category": "console"
+            },
+            {
+                "timestamp": 1463075692.0,
+                "message": "This is a critical log message",
+                "level": "critical",
+                "category": "console"
+            },
+            {
+                "timestamp": 1463076692.0,
+                "message": "This is a debug log message",
+                "level": "debug",
+                "category": "console",
+                "data": {
+                    "foo": "bar",
+                    "baz": "blah"
+                }
+            },
+            {
+                "type": "http",
+                "category": "ajax",
+                "timestamp": 1463077692.0,
+                "data": {
+                    "reason": "OK",
+                    "status_code": 200,
+                    "url": "Http://example.com/",
+                    "method": "POST"
+                }
+            },
+            {
+                "type": "ui",
+                "timestamp": 1463078692.0,
+                "message": "div > form[name=\"post\"] > button.btn.btn-small[name=\"submit\"]",
+                "category": "ui.click"
             }
         ]
     }


### PR DESCRIPTION
Does a few things:
1. Fixes the sample JavaScript event (added during new project creation) to have breadcrumbs.
2. Each sample event fixture file can now specify its own breadcrumbs (via `sentry.interfaces.Breadcrumbs`), with timestamps altered during creation to be "sensible" (1s apart).
3. Removes errors from the sample JavaScript event because they are confusing for new users / onboarding. _Perhaps these should be moved to `bin/load-mocks` so that they are still present during testing?_

/cc @getsentry/team @ehfeng

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3742)

<!-- Reviewable:end -->
