### PR TITLE
Remove app-hash on low frame count

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -697,7 +697,13 @@ class Stacktrace(Interface):
             return []
 
         if not system_frames:
+            total_frames = len(frames)
             frames = [f for f in frames if f.in_app] or frames
+
+            # if app frames make up less than 10% of the stacktrace discard
+            # the hash as invalid
+            if len(frames) / float(total_frames) < 0.10:
+                return []
 
         output = []
         for frame in frames:

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -140,6 +140,20 @@ class StacktraceTest(TestCase):
         result = interface.compute_hashes('python')
         assert result == [['foo.py', 1, 'bar.py', 1], ['foo.py', 1]]
 
+    def test_get_hash_with_minimal_app_frames(self):
+        frames = [{
+            'lineno': 1,
+            'filename': 'foo.py',
+            'in_app': True,
+        }] + [{
+            'lineno': 1,
+            'filename': 'bar.py',
+            'in_app': False,
+        } for _ in xrange(11)]
+        interface = Stacktrace.to_python(dict(frames=frames))
+        result = interface.get_hash(system_frames=False)
+        assert not result
+
     def test_get_hash_with_only_required_vars(self):
         interface = Frame.to_python({
             'lineno': 1,


### PR DESCRIPTION
When application frames make up less than 10% of a stacktrace discard the app-only hash.

/cc @getsentry/infrastructure

Fixes GH-3757

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3758)

<!-- Reviewable:end -->
