### PR TITLE
Add "week" and "day" resolution to `Duration`.

### DIFF
--- a/src/sentry/static/sentry/app/components/duration.jsx
+++ b/src/sentry/static/sentry/app/components/duration.jsx
@@ -9,15 +9,21 @@ const Duration = React.createClass({
     let value = Math.abs(this.props.seconds * 1000);
     let result = '';
 
-    if (value >= 7200000) {
+    if (value >= 604800000) {  // one week
+      result = Math.round(value / 604800000);
+      result = (result !== 1 ? result + ' weeks' : result + ' week');
+    } else if (value >= 172800000) {  // two days
+      result = Math.round(value / 86400000);
+      result = (result !== 1 ? result + ' days' : result + ' day');
+    }  else if (value >= 7200000) {
       result = Math.round(value / 3600000);
-      result = (result !== 1 ? result + ' hours' : result + 'hour');
+      result = (result !== 1 ? result + ' hours' : result + ' hour');
     } else if (value >= 120000) {
       result = Math.round(value / 60000);
-      result = (result !== 1 ? result + ' minutes' : result + 'minute');
+      result = (result !== 1 ? result + ' minutes' : result + ' minute');
     } else if (value >= 1000) {
       result = Math.round(value / 1000);
-      result = (result !== 1 ? result + ' seconds' : result + 'second');
+      result = (result !== 1 ? result + ' seconds' : result + ' second');
     } else {
       result = Math.round(value) + ' ms';
     }


### PR DESCRIPTION
This prevents the activity feed from showing "$user snoozed an issue
for 168 hours" when an issue is snoozed for a week.

This also fixes a formatting error in the singular form of the suffix
(which was never reached because it's actually impossible to reach that
branch of the conditional.)

@getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3762)

<!-- Reviewable:end -->
