### PR TITLE
Handle already being enrolled to 2fa nicer

### DIFF
--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -243,7 +243,7 @@ class AuthenticatorInterface(object):
             )
         else:
             if not self.allow_multi_enrollment:
-                raise RuntimeError('Already enrolled')
+                raise Authenticator.AlreadyEnrolled()
             self.authenticator.config = self.config
             self.authenticator.save()
 
@@ -553,6 +553,9 @@ class Authenticator(BaseModel):
     config = UnicodePickledObjectField()
 
     objects = AuthenticatorManager()
+
+    class AlreadyEnrolled(Exception):
+        pass
 
     class Meta:
         app_label = 'sentry'


### PR DESCRIPTION
This fixes at least the double submit problem that might happen but
also users getting stuck on the enrollment screen for some reason.
I have not been able to reproduce it but there is no harm in
supporting this.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3765)

<!-- Reviewable:end -->
