### PR TITLE
Switch react_page to use RequestContext

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 from django.middleware.csrf import get_token as get_csrf_token
 from django.http import HttpResponse
-from django.template import loader, Context
+from django.template import RequestContext
+from django.template.loader import render_to_string
 
 from sentry.models import Project
 from sentry.signals import first_event_pending
@@ -11,20 +12,19 @@ from sentry.web.frontend.base import BaseView, OrganizationView
 
 class ReactMixin(object):
     def handle_react(self, request):
-        context = Context({'request': request})
-
         # Force a new CSRF token to be generated and set in user's
         # Cookie. Alternatively, we could use context_processor +
         # template tag, but in this case, we don't need a form on the
         # page. So there's no point in rendering a random `<input>` field.
         get_csrf_token(request)
 
-        template = loader.render_to_string('sentry/bases/react.html', context)
-
-        response = HttpResponse(template)
-        response['Content-Type'] = 'text/html'
-
-        return response
+        return HttpResponse(
+            render_to_string(
+                'sentry/bases/react.html',
+                RequestContext(request),
+            ),
+            content_type='text/html; charset=utf-8',
+        )
 
 
 # TODO(dcramer): once we implement basic auth hooks in React we can make this


### PR DESCRIPTION
This gives react pages access to template context processors

@getsentry/infrastructure @ehfeng 

/cc @dcramer specifically because I'm not sure if there was a reason that we were avoiding this to begin with.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3767)

<!-- Reviewable:end -->
