### PR TITLE
Correct invalid logic for release config

### DIFF
--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -10,7 +10,7 @@ import GroupState from '../../mixins/groupState';
 import GroupReleaseChart from './releaseChart';
 import MenuItem from '../menuItem';
 import SeenInfo from './seenInfo';
-import {toTitleCase} from '../../utils';
+import {defined, toTitleCase} from '../../utils';
 import {t} from '../../locale';
 
 const DEFAULT_ENV_NAME = '(Default Environment)';
@@ -154,8 +154,8 @@ const GroupReleaseStats = React.createClass({
     );
 
     let envList = this.state.envList;
+    let hasRelease = defined(group.lastRelease);
 
-    console.log(environment);
     return (
       <div className="env-stats">
         <h6><span>
@@ -212,6 +212,7 @@ const GroupReleaseStats = React.createClass({
                   orgId={orgId}
                   projectId={projectId}
                   date={firstSeen}
+                  hasRelease={hasRelease}
                   release={data.firstRelease ? data.firstRelease.release : null} />
 
               <h6 className="last-seen">
@@ -221,6 +222,7 @@ const GroupReleaseStats = React.createClass({
                   orgId={orgId}
                   projectId={projectId}
                   date={lastSeen}
+                  hasRelease={hasRelease}
                   release={data.lastRelease ? data.lastRelease.release : null} />
             </div>
           )}

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -12,7 +12,8 @@ const SeenInfo = React.createClass({
       version: React.PropTypes.string.isRequired
     }),
     orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    projectId: React.PropTypes.string.isRequired,
+    hasRelease: React.PropTypes.bool.isRequired,
   },
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -47,7 +48,7 @@ const SeenInfo = React.createClass({
         <dt key={4}>{t('Release')}:</dt>
         {utils.defined(release) ?
           <dd key={5}><Version orgId={orgId} projectId={projectId} version={release.version} /></dd>
-        : (date ?
+        : (!this.props.hasRelease ?
           <dd key={5}><small style={{marginLeft: 5, fontStyle: 'italic'}}><a href={this.getReleaseTrackingUrl()}>not configured</a></small></dd>
         :
           <dd key={5}>n/a</dd>


### PR DESCRIPTION
The 'not configured' bit of release stats was showing even when release data was available.

/cc @getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3768)

<!-- Reviewable:end -->
