### PR TITLE
Utilize environment tag for attribute

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -301,6 +301,11 @@ class EventManager(object):
 
             data['tags'].append((key, value))
 
+            # XXX(dcramer): many legacy apps are using the environment tag
+            # rather than the key itself
+            if key == 'environment' and not data.get('environment'):
+                data['environment'] = value
+
         if not isinstance(data['extra'], dict):
             # throw it away
             data['extra'] = {}


### PR DESCRIPTION
When the environment tag is present and the environment attribute is missing, use it as the value.

/cc @getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3769)

<!-- Reviewable:end -->
