### PR TITLE
Instantiate the sentry logger so celery will log at the default level.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -546,10 +546,13 @@ LOGGING = {
     },
     # LOGGING.overridable is a list of loggers including root that will change
     # based on the overridden level defined above.
-    'overridable': ['celery'],
+    'overridable': ['celery', 'sentry'],
     'loggers': {
         'celery': {
             'level': 'WARN',
+        },
+        'sentry': {
+            'level': 'INFO',
         },
         'sentry.errors': {
             'handlers': ['console'],

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -50,7 +50,7 @@ class HumanRenderer(object):
             now().strftime('%H:%M:%S'),
             real_level,
             event_dict.pop('name', 'root'),
-            event_dict.pop('event'),
+            event_dict.pop('event', ''),
         )
         join = ' '.join(k + '=' + repr(v)
                for k, v in event_dict.iteritems())


### PR DESCRIPTION
@mattrobenolt: This fixes `INFO` displaying correctly in celery workers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3771)

<!-- Reviewable:end -->
