### PR TITLE
Speed up is_active_superuser check

### DIFF
--- a/src/sentry/auth/utils.py
+++ b/src/sentry/auth/utils.py
@@ -20,10 +20,7 @@ def is_privileged_request(request):
 
 def is_active_superuser(request):
     user = getattr(request, 'user', None)
-    if not user:
+    if not user or not user.is_superuser:
         return False
 
-    if not is_privileged_request(request):
-        return False
-
-    return user.is_superuser
+    return is_privileged_request(request)

--- a/tests/sentry/auth/test_utils.py
+++ b/tests/sentry/auth/test_utils.py
@@ -1,0 +1,23 @@
+from django.http import HttpRequest
+from django.test.utils import override_settings
+
+from sentry.models import User
+from sentry.auth.utils import is_active_superuser
+
+
+def test_is_active_superuser():
+    request = HttpRequest()
+    request.META['REMOTE_ADDR'] = '10.0.0.1'
+
+    with override_settings(INTERNAL_IPS=()):
+        assert is_active_superuser(request) is False
+        request.user = User()
+        assert is_active_superuser(request) is False
+        request.user.is_superuser = True
+        assert is_active_superuser(request) is True
+
+    with override_settings(INTERNAL_IPS=('127.0.0.1',)):
+        assert is_active_superuser(request) is False
+
+    with override_settings(INTERNAL_IPS=('10.0.0.1',)):
+        assert is_active_superuser(request) is True


### PR DESCRIPTION
Also added tests since this had 0 coverage and it's something pretty
critical

@getsentry/infrastructure 

tl;dr just checks the `is_superuser` property before iterating over the list of IP addresses.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3772)

<!-- Reviewable:end -->
