### PR TITLE
Do not propagate the sentry parent logger to the root logger.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -553,6 +553,8 @@ LOGGING = {
         },
         'sentry': {
             'level': 'INFO',
+            'handlers': ['console', 'internal'],
+            'propagate': False,
         },
         'sentry.errors': {
             'handlers': ['console'],


### PR DESCRIPTION
@mattrobenolt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3773)

<!-- Reviewable:end -->
