### PR TITLE
Workaround for a concurrency bug with date parsing

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -11,7 +11,13 @@ import os
 import click
 import sys
 import sentry
+import datetime
 from sentry.utils.imports import import_string
+
+
+# We need to run this here because of a concurrency bug in Python's locale
+# with the lazy initialization.
+datetime.datetime.strptime('', '')
 
 # Parse out a pretty version for use with --version
 if sentry.__build__ is None:

--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -10,6 +10,12 @@ from __future__ import absolute_import
 import os
 import os.path
 import sys
+import datetime
+
+
+# We need to run this here because of a concurrency bug in Python's locale
+# with the lazy initialization.
+datetime.datetime.strptime('', '')
 
 # Add the project to the python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))

--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -10,12 +10,7 @@ from __future__ import absolute_import
 import os
 import os.path
 import sys
-import datetime
 
-
-# We need to run this here because of a concurrency bug in Python's locale
-# with the lazy initialization.
-datetime.datetime.strptime('', '')
 
 # Add the project to the python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))


### PR DESCRIPTION
This is needed because otherwise sometimes we fail parsing timestamps
that would otherwise be valid.  Mostly happens after interpreter
startup if there are multiple threads doing stuff.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3788)

<!-- Reviewable:end -->
