### PR TITLE
Require `toronado>=0.0.10`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'toronado>=0.0.8,<0.1.0',
+    'toronado>=0.0.9,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',
     'uwsgi>2.0.0,<2.1.0',

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'toronado>=0.0.4,<0.1.0',
+    'toronado>=0.0.8,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',
     'uwsgi>2.0.0,<2.1.0',

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'toronado>=0.0.9,<0.1.0',
+    'toronado>=0.0.10,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',
     'uwsgi>2.0.0,<2.1.0',

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -196,6 +196,10 @@
     margin: 0 -5px;
   }
 
+  .inner .interface table table {
+    margin: 0;  /* Don't apply negative side margin to nested tables by default. */
+  }
+
   .interface table th {
     font-weight: 500;
   }


### PR DESCRIPTION
This prevents some headaches with shorthand properties in inlined CSS.

https://github.com/disqus/toronado/compare/0.0.7...0.0.10

This also fixes a bug that was caused by incorrect CSS rule order application.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3796)

<!-- Reviewable:end -->
