### PR TITLE
Explicitly accept certain image types for avatar upload

### DIFF
--- a/src/sentry/static/sentry/app/components/avatarCropper.jsx
+++ b/src/sentry/static/sentry/app/components/avatarCropper.jsx
@@ -356,7 +356,7 @@ const AvatarCropper = React.createClass({
         {this.renderCanvas()}
         <div className="form-group">
           {src && <a onClick={this.uploadClick}>{t('Change Photo')}</a>}
-          <input ref="file" type="file" accept="image/*" onChange={this.onChange} style={style}/>
+          <input ref="file" type="file" accept="image/gif,image/jpeg,image/png" onChange={this.onChange} style={style}/>
         </div>
       </div>
     );


### PR DESCRIPTION
This prevents svgs from being uploaded, which potentially exposes a
security vector through blob: uris.

@getsentry/ui @macqueen

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3798)

<!-- Reviewable:end -->
