### PR TITLE
Add rate limits to auth

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -74,3 +74,6 @@ register('sms.twilio-number', default='', flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITI
 register('u2f.app-id', default='', flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register('u2f.facets', default=(), type=Sequence,
          flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+
+register('auth.ip-rate-limit', default=0, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register('auth.user-rate-limit', default=0, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/ratelimits/base.py
+++ b/src/sentry/ratelimits/base.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 
 class RateLimiter(object):
+    window = 60
+
     def validate(self):
         """
         Validates the settings for this backend (i.e. such as proper connection
@@ -10,5 +12,5 @@ class RateLimiter(object):
         Raise ``InvalidConfiguration`` if there is a configuration error.
         """
 
-    def is_limited(self, project, key, limit):
+    def is_limited(self, key, limit, project=None, window=None):
         return False

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from hashlib import md5
 from time import time
 
 from sentry.exceptions import InvalidConfiguration
@@ -8,7 +9,7 @@ from sentry.utils.redis import get_cluster_from_options
 
 
 class RedisRateLimiter(RateLimiter):
-    ttl = 60
+    window = 60
 
     def __init__(self, **options):
         self.cluster, options = get_cluster_from_options('SENTRY_RATELIMITER_OPTIONS', options)
@@ -20,13 +21,20 @@ class RedisRateLimiter(RateLimiter):
         except Exception as e:
             raise InvalidConfiguration(unicode(e))
 
-    def is_limited(self, project, key, limit):
-        key = 'rl:%s:%s:%s' % (
-            key, project.id, int(time() / self.ttl)
-        )
+    def is_limited(self, key, limit, project=None, window=None):
+        if window is None:
+            window = self.window
+
+        key_hex = md5(key).hexdigest()
+        bucket = int(time() / window)
+
+        if project:
+            key = 'rl:%s:%s:%s' % (key_hex, project.id, bucket)
+        else:
+            key = 'rl:%s:%s' % (key_hex, bucket)
 
         with self.cluster.map() as client:
-            proj_result = client.incr(key)
-            client.expire(key, self.ttl)
+            result = client.incr(key)
+            client.expire(key, window)
 
-        return proj_result.value > limit
+        return result.value > limit

--- a/src/sentry/static/sentry/app/options.jsx
+++ b/src/sentry/static/sentry/app/options.jsx
@@ -40,6 +40,18 @@ const definitions = [
     help: t('The maximum number of events the system should accept per minute. A value of 0 will disable the default rate limit.'),
   },
   {
+    key: 'auth.ip-rate-limit',
+    label: t('IP Rate Limit'),
+    placeholder: 'e.g. 10',
+    help: t('The maximum number of times an authentication attempt may be made by a single IP address in a 60 second window.'),
+  },
+  {
+    key: 'auth.user-rate-limit',
+    label: t('User Rate Limit'),
+    placeholder: 'e.g. 10',
+    help: t('The maximum number of times an authentication attempt may be made against a single account in a 60 second window.'),
+  },
+  {
     key: 'mail.from',
     label: t('Email From'),
     component: EmailField,

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -13,6 +13,8 @@ const optionsAvailable = [
   'system.url-prefix',
   'system.admin-email',
   'system.rate-limit',
+  'auth.ip-rate-limit',
+  'auth.user-rate-limit',
 ];
 
 const SettingsList = React.createClass({
@@ -26,7 +28,7 @@ const SettingsList = React.createClass({
     let options = this.props.options;
     let formData = {};
     let required = [];
-    let fields = [];
+    let fields = {};
     for (let key of optionsAvailable) {
       // TODO(dcramer): we should not be mutating options
       let option = options[key] || {field: {}};
@@ -39,7 +41,7 @@ const SettingsList = React.createClass({
       if (option.field.required) {
         required.push(key);
       }
-      fields.push(getOptionField(key, this.onFieldChange.bind(this, key), formData[key], option.field));
+      fields[key] = getOptionField(key, this.onFieldChange.bind(this, key), formData[key], option.field);
     }
 
     return {
@@ -68,7 +70,14 @@ const SettingsList = React.createClass({
 
     return (
       <Form onSubmit={this.onSubmit} submitDisabled={submitDisabled}>
-        {fields}
+        <h4>General</h4>
+        {fields['system.url-prefix']}
+        {fields['system.admin-email']}
+        {fields['system.rate-limit']}
+
+        <h4>Authentication</h4>
+        {fields['auth.ip-rate-limit']}
+        {fields['auth.user-rate-limit']}
       </Form>
     );
   }

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -18,9 +18,11 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 from six.moves import range
 
+from sentry import options
+from sentry.app import ratelimiter
 from sentry.constants import LANGUAGES
 from sentry.models import User, UserOption, UserOptionValue
-from sentry.utils.auth import find_users
+from sentry.utils.auth import find_users, logger
 from sentry.web.forms.fields import ReadOnlyTextField
 
 
@@ -78,6 +80,8 @@ class AuthenticationForm(CaptchaForm):
     error_messages = {
         'invalid_login': _("Please enter a correct %(username)s and password. "
                            "Note that both fields may be case-sensitive."),
+        'rate_limited': _("You have made too many failed authentication "
+                          "attempts. Please try again later."),
         'no_cookies': _("Your Web browser doesn't appear to have cookies "
                         "enabled. Cookies are required for logging in."),
         'inactive': _("This account is inactive."),
@@ -106,8 +110,48 @@ class AuthenticationForm(CaptchaForm):
             return
         return value.lower()
 
+    def is_rate_limited(self):
+        if self._is_ip_rate_limited():
+            return True
+        if self._is_user_rate_limited():
+            return True
+        return False
+
+    def _is_ip_rate_limited(self):
+        limit = options.get('auth.ip-rate-limit')
+        if not limit:
+            return False
+
+        ip_address = self.request.META['REMOTE_ADDR']
+        return ratelimiter.is_limited(
+            'auth:ip:{}'.format(ip_address),
+            limit,
+        )
+
+    def _is_user_rate_limited(self):
+        limit = options.get('auth.user-rate-limit')
+        if not limit:
+            return False
+
+        username = self.cleaned_data.get('username')
+        if not username:
+            return False
+
+        return ratelimiter.is_limited(
+            'auth:username:{}'.format(username),
+            limit,
+        )
+
     def clean(self):
         username = self.cleaned_data.get('username')
+
+        if self.is_rate_limited():
+            logger.info('user.auth.rate-limited', extra={
+                'ip_address': self.request.META['REMOTE_ADDR'],
+                'username': username,
+            })
+            raise forms.ValidationError(self.error_messages['rate_limited'])
+
         password = self.cleaned_data.get('password')
 
         if username and password:

--- a/tests/sentry/ratelimits/test_redis.py
+++ b/tests/sentry/ratelimits/test_redis.py
@@ -10,6 +10,10 @@ class RedisRateLimiterTest(TestCase):
     def setUp(self):
         self.backend = RedisRateLimiter()
 
-    def test_integration(self):
-        assert not self.backend.is_limited(self.project, 'foo', 1)
-        assert self.backend.is_limited(self.project, 'foo', 1)
+    def test_project_key(self):
+        assert not self.backend.is_limited('foo', 1, self.project)
+        assert self.backend.is_limited('foo', 1, self.project)
+
+    def test_simple_key(self):
+        assert not self.backend.is_limited('foo', 1)
+        assert self.backend.is_limited('foo', 1)


### PR DESCRIPTION
This adds two configurable rate limits for authentication:
- per ip address
- per account (username based)

@getsentry/security

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3816)

<!-- Reviewable:end -->
