### PR TITLE
This fixes a crash on bad version data

### DIFF
--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -93,8 +93,12 @@ def get_sdk_from_os(data):
     dsym_type = KNOWN_DSYM_TYPES.get(data['name'])
     if dsym_type is None:
         return
-    system_version = tuple(int(x) for x in (
-        data['version'] + '.0' * 3).split('.')[:3])
+    try:
+        system_version = tuple(int(x) for x in (
+            data['version'] + '.0' * 3).split('.')[:3])
+    except ValueError:
+        return
+
     return {
         'dsym_type': 'macho',
         'sdk_name': data['name'],
@@ -111,7 +115,7 @@ def get_sdk_from_apple_system_info(info):
         sdk_name = APPLE_SDK_MAPPING[info['system_name']]
         system_version = tuple(int(x) for x in (
             info['system_version'] + '.0' * 3).split('.')[:3])
-    except LookupError:
+    except (ValueError, LookupError):
         return None
 
     return {


### PR DESCRIPTION
Not entirely sure why this happens but there is at least one buggy SDK
version out there which generates it.

@getsentry/api

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3817)

<!-- Reviewable:end -->
