### PR TITLE
Revert "Raise 404 on unauthorized organization requests in the project scope."

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -4,7 +4,7 @@ from sentry.auth import access
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import ScopedPermission
-from sentry.models import Organization, Project, ProjectStatus
+from sentry.models import Project, ProjectStatus
 from sentry.models.apikey import ROOT_KEY
 
 
@@ -60,20 +60,8 @@ class ProjectEndpoint(Endpoint):
 
     def convert_args(self, request, organization_slug, project_slug, *args, **kwargs):
         try:
-            org = Organization.objects.get_from_cache(slug=organization_slug)
-            if request.user:
-                can_access_org = any(access.from_request(request, org).memberships)
-            if request.auth:
-                can_access_org = request.auth.organization_id == org.id
-            if not can_access_org:
-                raise ResourceDoesNotExist
-
-        except Organization.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        try:
             project = Project.objects.get_from_cache(
-                organization=org,
+                organization__slug=organization_slug,
                 slug=project_slug,
             )
         except Project.DoesNotExist:

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -20,18 +20,6 @@ class ProjectDetailsTest(APITestCase):
         assert response.status_code == 200
         assert response.data['id'] == str(project.id)
 
-    def test_other_projects(self):
-        # Should return a 404 and not a 403. See https://github.com/getsentry/sentry/issues/3807
-        other_org = self.create_organization()
-        other_project = self.create_project(organization=other_org)
-        self.login_as(user=self.user)
-        url = reverse('sentry-api-0-project-details', kwargs={
-            'organization_slug': other_org.slug,
-            'project_slug': other_project.slug,
-        })
-        response = self.client.get(url)
-        assert response.status_code == 404
-
     def test_numeric_org_slug(self):
         # Regression test for https://github.com/getsentry/sentry/issues/2236
         self.login_as(user=self.user)


### PR DESCRIPTION
Reverts getsentry/sentry#3810. Going to bench this in favor of #3821.
cc @tkaemming / @mattrobenolt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3823)

<!-- Reviewable:end -->
