### PR TITLE
In single org mode, let the one organization consume the entire rate limit

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -96,7 +96,12 @@ class Quota(object):
         return quota
 
     def get_organization_quota(self, organization):
+        system_rate_limit = options.get('system.rate-limit')
+        # If there is only a single org, this one org should
+        # be allowed to consume the entire quota.
+        if settings.SENTRY_SINGLE_ORGANIZATION:
+            return system_rate_limit
         return self.translate_quota(
             settings.SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE,
-            options.get('system.rate-limit'),
+            system_rate_limit,
         )


### PR DESCRIPTION
It doesn't make much sense for a single organization to not be able to
fully soak up the system's rate limit.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3824)

<!-- Reviewable:end -->
