### PR TITLE
fix event timestamp tooltip not updating on pagination

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -147,7 +147,8 @@ let GroupEventToolbar  = React.createClass({
         </div>
         <h4>{t('Event %s', evt.eventID)}</h4>
         <span>
-          <span className="tip" data-title={this.getDateTooltip()}>
+          {/* use a key here to force removal of tooltip parent - fixes #3341 */}
+          <span className="tip" data-title={this.getDateTooltip()} key={evt.id}>
             <DateTime date={evt.dateCreated} style={style} />
             {isOverLatencyThreshold && <span className="icon-alert" />}
           </span>


### PR DESCRIPTION
fixes #3341 

I think `.tooltip('destroy')` wasn't working because that apparently doesn't work on tooltips using delegation: http://getbootstrap.com/javascript/#tooltip-destroy

@getsentry/ui @tkaemming

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3839)

<!-- Reviewable:end -->
