### PR TITLE
Add unique user frequency condition.

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -128,6 +128,7 @@ SENTRY_RULES = (
     'sentry.rules.conditions.regression_event.RegressionEventCondition',
     'sentry.rules.conditions.tagged_event.TaggedEventCondition',
     'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
+    'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
     'sentry.rules.conditions.event_attribute.EventAttributeCondition',
     'sentry.rules.conditions.level.LevelCondition',
 )

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -34,16 +34,16 @@ class EventFrequencyForm(forms.Form):
     }))
 
 
-class EventFrequencyCondition(EventCondition):
+class BaseEventFrequencyCondition(EventCondition):
     form_cls = EventFrequencyForm
-    label = 'An event is seen more than {value} times in {interval}'
+    label = NotImplemented  # subclass must implement
 
     def __init__(self, *args, **kwargs):
         from sentry.app import tsdb
 
         self.tsdb = kwargs.pop('tsdb', tsdb)
 
-        super(EventFrequencyCondition, self).__init__(*args, **kwargs)
+        super(BaseEventFrequencyCondition, self).__init__(*args, **kwargs)
 
     def passes(self, event, state):
         # when a rule is not active (i.e. it hasnt gone from inactive -> active)
@@ -74,6 +74,11 @@ class EventFrequencyCondition(EventCondition):
     def clear_cache(self, event):
         event._rate_cache = {}
 
+    def query(self, event, start, end):
+        """
+        """
+        raise NotImplementedError  # subclass must implement
+
     def get_rate(self, event, interval):
         if not hasattr(event, '_rate_cache'):
             event._rate_cache = {}
@@ -90,12 +95,34 @@ class EventFrequencyCondition(EventCondition):
             else:
                 raise ValueError(interval)
 
-            result = self.tsdb.get_sums(
-                model=self.tsdb.models.group,
-                keys=[event.group_id],
-                start=start,
-                end=end,
-            )[event.group_id]
-            event._rate_cache[interval] = result
+            event._rate_cache[interval] = result = self.query(
+                event,
+                start,
+                end,
+            )
 
         return result
+
+
+class EventFrequencyCondition(BaseEventFrequencyCondition):
+    label = 'An event is seen more than {value} times in {interval}'
+
+    def query(self, event, start, end):
+        return self.tsdb.get_sums(
+            model=self.tsdb.models.group,
+            keys=[event.group_id],
+            start=start,
+            end=end,
+        )[event.group_id]
+
+
+class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
+    label = 'An event is seen by more than {value} unique users in {interval}'
+
+    def query(self, event, start, end):
+        return self.tsdb.get_distinct_counts_totals(
+            model=self.tsdb.models.users_affected_by_group,
+            keys=[event.group_id],
+            start=start,
+            end=end,
+        )[event.group_id]

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -116,7 +116,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
 
 
 class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
-    label = 'An event is seen by more than {value} unique users in {interval}'
+    label = 'An event is seen by more than {value} users in {interval}'
 
     def query(self, event, start, end):
         return self.tsdb.get_distinct_counts_totals(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -8,9 +8,8 @@ sentry.rules.conditions.event_frequency
 
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django import forms
-from pytz import utc
 
 from django.utils import timezone
 from sentry.rules.conditions.base import EventCondition
@@ -85,7 +84,7 @@ class BaseEventFrequencyCondition(EventCondition):
 
         result = event._rate_cache.get(interval)
         if result is None:
-            end = datetime.utcnow().replace(tzinfo=utc)
+            end = timezone.now()
             if interval == Interval.ONE_MINUTE:
                 start = end - timedelta(minutes=1)
             elif interval == Interval.ONE_HOUR:

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
 import itertools
-from datetime import timedelta
+import pytz
+from datetime import datetime, timedelta
 
+import mock
 import six
 from django.utils import timezone
 
@@ -17,7 +19,10 @@ class FrequencyConditionMixin(object):
     def increment(self, event, count, timestamp=None):
         raise NotImplementedError
 
-    def test_one_minute(self):
+    @mock.patch('django.utils.timezone.now')
+    def test_one_minute(self, now):
+        now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+
         event = self.get_event()
         value = 10
         rule = self.get_rule({
@@ -28,9 +33,8 @@ class FrequencyConditionMixin(object):
         self.increment(
             event,
             value + 1,
-            timestamp=timezone.now() - timedelta(minutes=5),
+            timestamp=now() - timedelta(minutes=5),
         )
-
         self.assertDoesNotPass(rule, event)
 
         rule.clear_cache(event)
@@ -39,9 +43,14 @@ class FrequencyConditionMixin(object):
 
         rule.clear_cache(event)
         self.increment(event, 1)
+
+        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
-    def test_one_hour(self):
+    @mock.patch('django.utils.timezone.now')
+    def test_one_hour(self, now):
+        now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+
         event = self.get_event()
         value = 10
         rule = self.get_rule({
@@ -52,7 +61,7 @@ class FrequencyConditionMixin(object):
         self.increment(
             event,
             value + 1,
-            timestamp=timezone.now() - timedelta(minutes=90),
+            timestamp=now() - timedelta(minutes=90),
         )
         self.assertDoesNotPass(rule, event)
 
@@ -62,9 +71,14 @@ class FrequencyConditionMixin(object):
 
         rule.clear_cache(event)
         self.increment(event, 1)
+
+        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
-    def test_one_day(self):
+    @mock.patch('django.utils.timezone.now')
+    def test_one_day(self, now):
+        now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+
         event = self.get_event()
         value = 10
         rule = self.get_rule({
@@ -75,7 +89,7 @@ class FrequencyConditionMixin(object):
         self.increment(
             event,
             value + 1,
-            timestamp=timezone.now() - timedelta(hours=36),
+            timestamp=now() - timedelta(hours=36),
         )
         self.assertDoesNotPass(rule, event)
 
@@ -85,9 +99,14 @@ class FrequencyConditionMixin(object):
 
         rule.clear_cache(event)
         self.increment(event, 1)
+
+        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
-    def test_doesnt_send_consecutive(self):
+    @mock.patch('django.utils.timezone.now')
+    def test_doesnt_send_consecutive(self, now):
+        now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+
         event = self.get_event()
         value = 10
         rule = self.get_rule({
@@ -99,11 +118,16 @@ class FrequencyConditionMixin(object):
 
         rule.clear_cache(event)
         self.increment(event, value + 1)
+
+        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
-        self.assertDoesNotPass(rule, event, rule_last_active=timezone.now())
+        self.assertDoesNotPass(rule, event, rule_last_active=now())
 
-    def test_more_than_zero(self):
+    @mock.patch('django.utils.timezone.now')
+    def test_more_than_zero(self, now):
+        now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+
         event = self.get_event()
         rule = self.get_rule({
             'interval': Interval.ONE_MINUTE,
@@ -114,6 +138,8 @@ class FrequencyConditionMixin(object):
 
         rule.clear_cache(event)
         self.increment(event, 1)
+
+        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
 

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 
 import mock
 import six
-from django.utils import timezone
 
 from sentry.app import tsdb
 from sentry.rules.conditions.event_frequency import (
@@ -44,7 +43,6 @@ class FrequencyConditionMixin(object):
         rule.clear_cache(event)
         self.increment(event, 1)
 
-        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
     @mock.patch('django.utils.timezone.now')
@@ -72,7 +70,6 @@ class FrequencyConditionMixin(object):
         rule.clear_cache(event)
         self.increment(event, 1)
 
-        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
     @mock.patch('django.utils.timezone.now')
@@ -100,7 +97,6 @@ class FrequencyConditionMixin(object):
         rule.clear_cache(event)
         self.increment(event, 1)
 
-        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
     @mock.patch('django.utils.timezone.now')
@@ -119,7 +115,6 @@ class FrequencyConditionMixin(object):
         rule.clear_cache(event)
         self.increment(event, value + 1)
 
-        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
         self.assertDoesNotPass(rule, event, rule_last_active=now())
@@ -139,7 +134,6 @@ class FrequencyConditionMixin(object):
         rule.clear_cache(event)
         self.increment(event, 1)
 
-        now.return_value = now() + timedelta(seconds=1)
         self.assertPasses(rule, event)
 
 


### PR DESCRIPTION
New and improved version of GH-3848. Fixes GH-3708. This was also brought up in GH-2673.

This adds the ability to set a unique user threshold as a rule condition.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3849)

<!-- Reviewable:end -->
