### PR TITLE
Don't hardcode app.getsentry.com as SSO url

### DIFF
--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -64,7 +64,7 @@
         <div class="control-group">
           <div class="controls">
             <label style="display: block">SSO URL</label>
-            <span style="padding: 7px 0; font-size: 15px">app.getsentry.com/</span> <input style="width: 240px; margin: 0 0 4px; padding: 5px 8px; display: inline" type="text" class="form-control" name="organization" placeholder="acme">
+            <span style="padding: 7px 0; font-size: 15px">{{ server_hostname }}/</span> <input style="width: 240px; margin: 0 0 4px; padding: 5px 8px; display: inline" type="text" class="form-control" name="organization" placeholder="acme">
             <p class="help-block">Enter your organization's ID and we'll get things started.</p>
           </div>
         </div>

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -10,6 +10,7 @@ from django.views.decorators.cache import never_cache
 
 from sentry import features
 from sentry.constants import WARN_SESSION_EXPIRED
+from sentry.http import get_server_hostname
 from sentry.models import AuthProvider, Organization, OrganizationStatus
 from sentry.web.forms.accounts import AuthenticationForm, RegistrationForm
 from sentry.web.frontend.base import BaseView
@@ -117,6 +118,7 @@ class AuthLoginView(BaseView):
 
         context = {
             'op': op or 'login',
+            'server_hostname': get_server_hostname(),
             'login_form': login_form,
             'register_form': register_form,
             'CAN_REGISTER': can_register,


### PR DESCRIPTION
Fixes GH-3856

See the original ticket for some context, I don't think this is complete without a bit of design tweak to accommodate urls other than `app.getsentry.com`. The sizing around this is pretty precise.

![image](https://cloud.githubusercontent.com/assets/375744/17336600/b98d41bc-5893-11e6-85a1-44e09f4239d5.png)

But fortunately for us, it isn't a regression for `app.getsentry.com` since `get_server_hostname` will yield the same as it was. :)

@getsentry/infrastructure @getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3857)

<!-- Reviewable:end -->
