### PR TITLE
Make TSDB bounds behavior consistent across all methods.

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -8,6 +8,7 @@ sentry.tsdb.base
 from __future__ import absolute_import
 
 import six
+from datetime import timedelta
 
 from django.conf import settings
 from django.utils import timezone
@@ -131,17 +132,16 @@ class BaseTSDB(object):
         if end is None:
             end = timezone.now()
 
-        # NOTE: "optimal" here means "able to most closely reflect the upper
-        # and lower bounds", not "able to construct the most efficient query"
         if rollup is None:
             rollup = self.get_optimal_rollup(start, end)
 
-        series = [self.normalize_to_epoch(start, rollup)]
-        end_ts = int(to_timestamp(end))
-        while series[-1] + rollup < end_ts:
-            series.append(series[-1] + rollup)
+        series = []
+        timestamp = end
+        while timestamp >= start:
+            series.append(self.normalize_to_epoch(timestamp, rollup))
+            timestamp = timestamp - timedelta(seconds=rollup)
 
-        return rollup, series
+        return rollup, sorted(series)
 
     def calculate_expiry(self, rollup, samples, timestamp):
         """

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -179,8 +179,6 @@ class RedisTSDB(BaseTSDB):
         """
         To get a range of data for group ID=[1, 2, 3]:
 
-        Start and end are both inclusive.
-
         >>> now = timezone.now()
         >>> get_keys(TimeSeriesModel.group, [1, 2, 3],
         >>>          start=now - timedelta(days=1),

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -16,7 +16,8 @@ import uuid
 
 from binascii import crc32
 from collections import defaultdict, namedtuple
-from datetime import timedelta
+
+import six
 from django.utils import timezone
 from hashlib import md5
 from pkg_resources import resource_string
@@ -24,7 +25,7 @@ from redis.client import Script
 from six.moves import reduce
 
 from sentry.tsdb.base import BaseTSDB
-from sentry.utils.dates import to_timestamp
+from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.redis import check_cluster_versions, get_cluster_from_options
 from sentry.utils.versioning import Version
 
@@ -186,27 +187,27 @@ class RedisTSDB(BaseTSDB):
         >>>          start=now - timedelta(days=1),
         >>>          end=now)
         """
-        normalize_to_epoch = self.normalize_to_epoch
-        normalize_to_rollup = self.normalize_to_rollup
-        make_key = self.make_counter_key
-
-        if rollup is None:
-            rollup = self.get_optimal_rollup(start, end)
+        rollup, series = self.get_optimal_rollup_series(start, end, rollup)
+        series = map(to_datetime, series)
 
         results = []
-        timestamp = end
         with self.cluster.map() as client:
-            while timestamp >= start:
-                real_epoch = normalize_to_epoch(timestamp, rollup)
-                norm_epoch = normalize_to_rollup(timestamp, rollup)
-
-                for key in keys:
-                    model_key = self.get_model_key(key)
-                    hash_key = make_key(model, norm_epoch, model_key)
-                    results.append((real_epoch, key,
-                                    client.hget(hash_key, model_key)))
-
-                timestamp = timestamp - timedelta(seconds=rollup)
+            for key in keys:
+                model_key = self.get_model_key(key)
+                for timestamp in series:
+                    hash_key = self.make_counter_key(
+                        model,
+                        self.normalize_to_rollup(
+                            timestamp,
+                            rollup
+                        ),
+                        model_key,
+                    )
+                    results.append((
+                        to_timestamp(timestamp),
+                        key,
+                        client.hget(hash_key, model_key)
+                    ))
 
         results_by_key = defaultdict(dict)
         for epoch, key, count in results:

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -17,7 +17,6 @@ import uuid
 from binascii import crc32
 from collections import defaultdict, namedtuple
 
-import six
 from django.utils import timezone
 from hashlib import md5
 from pkg_resources import resource_string


### PR DESCRIPTION
This behavior was noted in GH-3849, and we've talked about this in the past. 

This change causes all methods that return a series to use the legacy behavior (or use it internally to generate their queries.) I'm not sure if this is a good thing, but it at least makes the behavior consistent across all methods.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3860)

<!-- Reviewable:end -->
