### PR TITLE
Record checksum as part of event data if used for grouping.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -478,6 +478,7 @@ class EventManager(object):
             hashes = map(md5_from_hash, get_hashes_from_fingerprint(event, fingerprint))
         elif checksum:
             hashes = [checksum]
+            data['checksum'] = checksum
         else:
             hashes = map(md5_from_hash, get_hashes_for_event(event))
 


### PR DESCRIPTION
This makes it possible to know after the fact if a checksum was used to influence grouping behavior.

@getsentry/infrastructure @mattrobenolt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3868)

<!-- Reviewable:end -->
