### PR TITLE
Fix role downgrade permissions

### DIFF
--- a/src/sentry/web/frontend/organization_member_settings.py
+++ b/src/sentry/web/frontend/organization_member_settings.py
@@ -72,11 +72,14 @@ class OrganizationMemberSettingsView(OrganizationView):
                 user=request.user,
                 organization=organization,
             )
-            allowed_roles = [
-                r for r in roles.get_all()
-                if r.priority <= roles.get(acting_member.role).priority
-            ]
-            can_admin = bool(allowed_roles)
+            if roles.get(acting_member.role).priority < roles.get(member.role).priority:
+                can_admin = False
+            else:
+                allowed_roles = [
+                    r for r in roles.get_all()
+                    if r.priority <= roles.get(acting_member.role).priority
+                ]
+                can_admin = bool(allowed_roles)
         elif request.is_superuser():
             allowed_roles = roles.get_all()
 


### PR DESCRIPTION
A manager (or similar) role should not be able to downgrade a higher level role (e.g. owner).

@getsentry/security

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3874)

<!-- Reviewable:end -->
