### PR TITLE
Remove references to sentry-stream

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -12,7 +12,6 @@ import six
 import warnings
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import F
 from django.utils import timezone
@@ -122,8 +121,7 @@ class Project(Model):
             super(Project, self).save(*args, **kwargs)
 
     def get_absolute_url(self):
-        return absolute_uri(reverse('sentry-stream', args=[
-            self.organization.slug, self.slug]))
+        return absolute_uri('/{}/{}/'.format(self.organization.slug, self.slug))
 
     def merge_to(self, project):
         from sentry.models import (

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -87,10 +87,7 @@ class MailPlugin(NotificationPlugin):
         return absolute_uri(reverse('sentry-account-settings-notifications'))
 
     def get_project_url(self, project):
-        return absolute_uri(reverse('sentry-stream', args=[
-            project.organization.slug,
-            project.slug,
-        ]))
+        return absolute_uri('/{}/{}/'.format(project.organization.slug, project.slug))
 
     def is_configured(self, project, **kwargs):
         # Nothing to configure here

--- a/src/sentry/templates/sentry/admin/users/edit.html
+++ b/src/sentry/templates/sentry/admin/users/edit.html
@@ -44,7 +44,7 @@
                     {% for project, avg_events in project_list|with_event_counts %}
                         <tr>
                             <td>
-                                {{ project.name }} <a href="{% url 'sentry-stream' project.organization.slug project.slug %}">[view]</a>
+                                {{ project.name }} <a href="{% absolute_uri '/{}/{}/' project.organization.slug project.slug %}">[view]</a>
                                 </a>
                             </td>
                             <td style="text-align:center; vertical-align:middle;">

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -18,11 +18,10 @@
 
 {% block main %}
     <h2 style="margin-bottom: 15px">
-        {% url 'sentry-stream' group.project.organization.slug group.project.slug as project_link %}
         {% if group.times_seen == 1 %}
-            New Issue on <a href="{% absolute_uri project_link %}">{{ project_label }}</a>
+            New Issue on <a href="{% absolute_uri '/{}/{}/' group.project.organization.slug group.project.slug %}">{{ project_label }}</a>
         {% else %}
-            Regression on <a href="{% absolute_uri project_link %}">{{ project_label }}</a>
+            Regression on <a href="{% absolute_uri '/{}/{}/' group.project.organization.slug group.project.slug %}">{{ project_label }}</a>
         {% endif %}
     </h2>
 

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
 from django.views.generic import View
 from hashlib import sha1
 from uuid import uuid4
@@ -42,10 +41,10 @@ class DebugNewReleaseEmailView(View):
             release.version,
         ))
 
-        project_link = absolute_uri(reverse('sentry-stream', kwargs={
-            'organization_slug': org.slug,
-            'project_id': project.slug,
-        }))
+        project_link = absolute_uri('/{}/{}/'.format(
+            org.slug,
+            project.slug,
+        ))
 
         return MailPreview(
             html_template='sentry/emails/activity/release.html',

--- a/src/sentry/web/frontend/group_plugin_action.py
+++ b/src/sentry/web/frontend/group_plugin_action.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division
 
-from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 
@@ -26,8 +25,8 @@ class GroupPluginActionView(ProjectView):
         if response:
             return response
 
-        redirect = request.META.get('HTTP_REFERER') or reverse('sentry-stream', kwargs={
-            'organization_slug': organization.slug,
-            'project_id': group.project.slug
-        })
+        redirect = request.META.get('HTTP_REFERER') or '/{}/{}/'.format(
+            organization.slug,
+            group.project.slug,
+        )
         return HttpResponseRedirect(redirect)

--- a/tests/sentry/web/frontend/test_create_project.py
+++ b/tests/sentry/web/frontend/test_create_project.py
@@ -54,8 +54,8 @@ class CreateProjectTest(TestCase):
 
         assert project.team == team
 
-        redirect_uri = reverse('sentry-stream', args=[organization.slug, project.slug])
-        assert resp['Location'] == absolute_uri('%ssettings/install/' % (redirect_uri,))
+        redirect_uri = '/{}/{}/settings/install/'.format(organization.slug, project.slug)
+        assert resp['Location'] == absolute_uri(redirect_uri)
 
     def test_multiple_teams(self):
         organization = self.create_organization()
@@ -73,5 +73,5 @@ class CreateProjectTest(TestCase):
 
         assert project.team == team
 
-        redirect_uri = reverse('sentry-stream', args=[organization.slug, project.slug])
-        assert resp['Location'] == absolute_uri('%ssettings/install/' % (redirect_uri,))
+        redirect_uri = '/{}/{}/settings/install/'.format(organization.slug, project.slug)
+        assert resp['Location'] == absolute_uri(redirect_uri)


### PR DESCRIPTION
As we move towards React, we move away from named URL patterns

/cc @getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3875)

<!-- Reviewable:end -->
