### PR TITLE
Correct scope of API key settings

### DIFF
--- a/src/sentry/web/frontend/organization_api_key_settings.py
+++ b/src/sentry/web/frontend/organization_api_key_settings.py
@@ -21,7 +21,7 @@ class ApiKeyForm(forms.ModelForm):
 
 
 class OrganizationApiKeySettingsView(OrganizationView):
-    required_scope = 'org:write'
+    required_scope = 'org:delete'
 
     def handle(self, request, organization, key_id):
         key = get_object_or_404(ApiKey, organization=organization, id=key_id)

--- a/tests/sentry/web/frontend/test_organization_api_key_settings.py
+++ b/tests/sentry/web/frontend/test_organization_api_key_settings.py
@@ -20,6 +20,9 @@ class OrganizationApiKeySettingsPermissionTest(PermissionTestCase):
     def test_member_cannot_load(self):
         self.assert_member_cannot_access(self.path)
 
+    def test_manager_cannot_load(self):
+        self.assert_manager_cannot_access(self.path)
+
     def test_owner_can_load(self):
         self.assert_owner_can_access(self.path)
 


### PR DESCRIPTION
Only roles with org:delete should be able to affect API keys.

/cc @getsentry/security

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3877)

<!-- Reviewable:end -->
