### PR TITLE
Fix grammar in empty query results message

### DIFF
--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -122,7 +122,7 @@ const GroupList = React.createClass({
       return (
         <div className="box empty-stream">
           <span className="icon icon-exclamation"></span>
-          <p>{t('There don\'t seem to be any events fitting the query.')}</p>
+          <p>{t('There doesn\'t seem to be any events fitting the query.')}</p>
         </div>
       );
 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3879)

<!-- Reviewable:end -->
