### PR TITLE
Fix tooltip width in event timestamp

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -950,6 +950,11 @@
       border-left: 1px solid @trim;
     }
   }
+  .tooltip {
+    .tooltip-inner {
+      max-width: 250px;
+    }
+  }
 }
 
 .sticky .event-toolbar {


### PR DESCRIPTION
Fixes #3884 
@getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3887)

<!-- Reviewable:end -->
