### PR TITLE
Improvements to project creation endpoints

### DIFF
--- a/src/sentry/api/endpoints/team_project_index.py
+++ b/src/sentry/api/endpoints/team_project_index.py
@@ -5,10 +5,12 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
-from sentry.api.bases.team import TeamEndpoint
+from sentry.api.bases.team import TeamEndpoint, TeamPermission
 from sentry.api.serializers import serialize
 from sentry.models import Project, ProjectStatus, AuditLogEntryEvent
+from sentry.signals import project_created
 from sentry.utils.apidocs import scenario, attach_scenarios
+from sentry.utils.samples import create_sample_event
 
 
 @scenario('ListTeamProjects')
@@ -37,8 +39,24 @@ class ProjectSerializer(serializers.Serializer):
     slug = serializers.CharField(max_length=200, required=False)
 
 
+# While currently the UI suggests teams are a parent of a project, in reality
+# the project is the core component, and which team it is on is simply an
+# attribute. Because you can already change the team of a project via mutating
+# it, and because Sentry intends to remove teams as a hierarchy item, we
+# allow you to view a teams projects, as well as create a new project as long
+# as you are a member of that team and have project scoped permissions.
+class TeamProjectPermission(TeamPermission):
+    scope_map = {
+        'GET': ['project:read', 'project:write', 'project:delete'],
+        'POST': ['project:write', 'project:delete'],
+        'PUT': ['project:write', 'project:delete'],
+        'DELETE': ['project:delete'],
+    }
+
+
 class TeamProjectIndexEndpoint(TeamEndpoint):
     doc_section = DocSection.TEAMS
+    permission_classes = (TeamProjectPermission,)
 
     @attach_scenarios([list_team_projects_scenario])
     def get(self, request, team):
@@ -110,6 +128,10 @@ class TeamProjectIndexEndpoint(TeamEndpoint):
                 event=AuditLogEntryEvent.PROJECT_ADD,
                 data=project.get_audit_log_data(),
             )
+
+            project_created.send(project=project, user=request.user, sender=self)
+
+            create_sample_event(project, platform='javascript')
 
             return Response(serialize(project, request.user), status=201)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/web/frontend/create_project.py
+++ b/src/sentry/web/frontend/create_project.py
@@ -4,6 +4,7 @@ from django import forms
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 
+from sentry.api import client
 from sentry.models import Project, Team
 from sentry.web.forms.add_project import AddProjectForm
 from sentry.web.frontend.base import OrganizationView
@@ -50,10 +51,13 @@ class AddProjectWithTeamForm(AddProjectForm):
 
 
 class CreateProjectView(OrganizationView):
-    # TODO(dcramer): I'm 95% certain the access is incorrect here as it would
-    # be probably validating against global org access, and all we care about is
-    # team admin
-    required_scope = 'team:write'
+    # While currently the UI suggests teams are a parent of a project, in reality
+    # the project is the core component, and which team it is on is simply an
+    # attribute. Because you can already change the team of a project via mutating
+    # it, and because Sentry intends to remove teams as a hierarchy item, we
+    # allow you to view a teams projects, as well as create a new project as long
+    # as you are a member of that team and have project scoped permissions.
+    required_scope = 'project:write'
 
     def get_form(self, request, organization, team_list):
         data = {
@@ -76,11 +80,18 @@ class CreateProjectView(OrganizationView):
 
         form = self.get_form(request, organization, team_list)
         if form.is_valid():
-            project = form.save(request.user, request.META['REMOTE_ADDR'])
+            team = form.cleaned_data.get('team', team_list[0])
+
+            response = client.post('/teams/{}/{}/projects/'.format(
+                organization.slug,
+                team.slug,
+            ), data={
+                'name': form.cleaned_data['name'],
+            }, request=request)
 
             install_uri = absolute_uri('/{}/{}/settings/install/'.format(
                 organization.slug,
-                project.slug,
+                response.data['slug'],
             ))
 
             if 'signup' in request.GET:


### PR DESCRIPTION
- Relax permission to project:write
- Add signals/sample event to API endpoint
- Switch internal view to use API

/cc @getsentry/security @getsentry/infrastructure

Fixes GH-3901

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3904)

<!-- Reviewable:end -->
