### PR TITLE
Buffer incr for GroupTagValue is overqualified hitting wrong index

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -134,7 +134,6 @@ class GroupManager(BaseManager):
                 'times_seen': 1,
             }, {
                 'group_id': group.id,
-                'project_id': project_id,
                 'key': key,
                 'value': value,
             }, {


### PR DESCRIPTION
GroupTagValue already has a UNIQUE index on (group_id, key, value)
so adding the additional project_id is overqualifying since there's only
1 row anyways. The addition of this extra project_id causes the
queryplanner to hit the wrong index.

We want to be hitting sentry_messagefiltervalue_uniq, but instead it
hits sentry_messagefiltervalue_project_id_20c4ea4f3c397e01.

In production, I'm seeing simple UPDATES with a query plan like:

```
 Update on sentry_messagefiltervalue  (cost=0.70..4.73 rows=1 width=77) (actual time=71689.483..71689.483 rows=0 loops=1)
   ->  Index Scan using sentry_messagefiltervalue_project_id_20c4ea4f3c397e01 on sentry_messagefiltervalue  (cost=0.70..4.73 rows=1 width=77) (actual time=17.775..71689.316 rows=1 loops=1)
         Index Cond: ((project_id = 61287) AND ((key)::text = 'environment'::text) AND ((value)::text = 'live'::text))
         Filter: (group_id = 115774750)
         Rows Removed by Filter: 279501
 Total runtime: 71689.568 ms
(6 rows)
```

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3912)

<!-- Reviewable:end -->
