### PR TITLE
Add configuration for weekly reports

### DIFF
--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -49,6 +49,14 @@
 
         <hr />
 
+        <h4>{% trans "Weekly Reports" %}</h4>
+
+        <p>{% blocktrans %}Reports contain a summary of what's happened within your organization over the last week.{% endblocktrans %}</p>
+
+        {{ reports_form.organizations|as_crispy_field }}
+
+        <hr />
+
         <h4>{% trans "Fine Tuning" %}</h4>
 
         <p>Use the settings below to fine tune notification settings per-project.</p>

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -21,7 +21,9 @@ from six.moves import range
 from sentry import options
 from sentry.app import ratelimiter
 from sentry.constants import LANGUAGES
-from sentry.models import User, UserOption, UserOptionValue
+from sentry.models import (
+    Organization, OrganizationStatus, User, UserOption, UserOptionValue
+)
 from sentry.utils.auth import find_users, logger
 from sentry.web.forms.fields import ReadOnlyTextField
 
@@ -386,6 +388,48 @@ class AppearanceSettingsForm(forms.Form):
         )
 
         return self.user
+
+
+class NotificationReportSettingsForm(forms.Form):
+    organizations = forms.ModelMultipleChoiceField(
+        queryset=Organization.objects.none(),
+        required=False,
+        widget=forms.CheckboxSelectMultiple(),
+    )
+
+    def __init__(self, user, *args, **kwargs):
+        self.user = user
+        super(NotificationReportSettingsForm, self).__init__(*args, **kwargs)
+
+        org_queryset = Organization.objects.filter(
+            status=OrganizationStatus.VISIBLE,
+            member_set__user=user,
+        )
+
+        disabled_orgs = set(UserOption.objects.get_value(
+            user=user,
+            project=None,
+            key='reports:disabled-organizations',
+            default=[],
+        ))
+
+        self.fields['organizations'].queryset = org_queryset
+        self.fields['organizations'].initial = [
+            o.id for o in org_queryset
+            if o.id not in disabled_orgs
+        ]
+
+    def save(self):
+        enabled_orgs = set((
+            o.id for o in self.cleaned_data.get('organizations')
+        ))
+        all_orgs = set(self.fields['organizations'].queryset.values_list('id', flat=True))
+        UserOption.objects.set_value(
+            user=self.user,
+            project=None,
+            key='reports:disabled-organizations',
+            value=list(all_orgs.difference(enabled_orgs)),
+        )
 
 
 class NotificationSettingsForm(forms.Form):

--- a/tests/sentry/web/frontend/accounts/tests.py
+++ b/tests/sentry/web/frontend/accounts/tests.py
@@ -10,8 +10,7 @@ from exam import fixture
 from social_auth.models import UserSocialAuth
 
 from sentry.models import (
-    UserEmail, LostPasswordHash, ProjectStatus, User, UserOption,
-    UserOptionValue
+    UserEmail, LostPasswordHash, User, UserOption
 )
 from sentry.testutils import TestCase
 
@@ -177,89 +176,6 @@ class SettingsTest(TestCase):
         assert resp.context['form'].errors
         user = User.objects.get(id=self.user.id)
         assert user.email == 'admin@localhost'
-
-
-class NotificationSettingsTest(TestCase):
-    @fixture
-    def path(self):
-        return reverse('sentry-account-settings-notifications')
-
-    def params(self, without=()):
-        params = {
-            'alert_email': 'foo@example.com',
-        }
-        return dict((k, v) for k, v in six.iteritems(params) if k not in without)
-
-    def test_requires_authentication(self):
-        self.assertRequiresAuthentication(self.path)
-
-    def test_renders_with_required_context(self):
-        user = self.create_user('foo@example.com')
-        organization = self.create_organization()
-        team = self.create_team(organization=organization)
-        project = self.create_project(organization=organization, team=team)
-        team2 = self.create_team(organization=organization)
-        self.create_project(organization=organization, team=team, status=ProjectStatus.PENDING_DELETION)
-        self.create_project(organization=organization, team=team2)
-        self.create_member(organization=organization, user=user, teams=[project.team])
-        self.login_as(user)
-        resp = self.client.get(self.path)
-        assert resp.status_code == 200
-        self.assertTemplateUsed('sentry/account/notifications.html')
-        assert 'form' in resp.context
-        assert len(resp.context['project_forms']) == 1
-
-    def test_valid_params(self):
-        self.login_as(self.user)
-
-        params = self.params()
-
-        resp = self.client.post(self.path, params)
-        assert resp.status_code == 302
-
-        options = UserOption.objects.get_all_values(user=self.user, project=None)
-
-        assert options.get('alert_email') == 'foo@example.com'
-
-    def test_can_change_workflow(self):
-        self.login_as(self.user)
-
-        resp = self.client.post(self.path, {
-            'workflow_notifications': '1',
-        })
-        assert resp.status_code == 302
-
-        options = UserOption.objects.get_all_values(
-            user=self.user, project=None
-        )
-
-        assert options.get('workflow:notifications') == '0'
-
-        resp = self.client.post(self.path, {
-            'workflow_notifications': '',
-        })
-        assert resp.status_code == 302
-
-        options = UserOption.objects.get_all_values(
-            user=self.user, project=None
-        )
-
-        assert options.get('workflow:notifications') == \
-            UserOptionValue.participating_only
-
-    def test_can_change_subscribe_by_default(self):
-        self.login_as(self.user)
-
-        resp = self.client.post(self.path, {
-            'subscribe_by_default': '1',
-        })
-        assert resp.status_code == 302
-
-        options = UserOption.objects.get_all_values(
-            user=self.user, project=None
-        )
-
-        assert options.get('subscribe_by_default') == '1'
 
 
 class ListIdentitiesTest(TestCase):

--- a/tests/sentry/web/frontend/test_account_notifications.py
+++ b/tests/sentry/web/frontend/test_account_notifications.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import six
+
+from django.core.urlresolvers import reverse
+from exam import fixture
+
+from sentry.models import ProjectStatus, UserOption, UserOptionValue
+from sentry.testutils import TestCase
+
+
+class NotificationSettingsTest(TestCase):
+    @fixture
+    def path(self):
+        return reverse('sentry-account-settings-notifications')
+
+    def params(self, without=()):
+        params = {
+            'alert_email': 'foo@example.com',
+        }
+        return dict((k, v) for k, v in six.iteritems(params) if k not in without)
+
+    def test_requires_authentication(self):
+        self.assertRequiresAuthentication(self.path)
+
+    def test_renders_with_required_context(self):
+        user = self.create_user('foo@example.com')
+        organization = self.create_organization()
+        team = self.create_team(organization=organization)
+        project = self.create_project(organization=organization, team=team)
+        team2 = self.create_team(organization=organization)
+        self.create_project(organization=organization, team=team, status=ProjectStatus.PENDING_DELETION)
+        self.create_project(organization=organization, team=team2)
+        self.create_member(organization=organization, user=user, teams=[project.team])
+        self.login_as(user)
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/notifications.html')
+        assert 'form' in resp.context
+        assert 'settings_form' in resp.context
+        assert 'reports_form' in resp.context
+        assert len(resp.context['project_forms']) == 1
+
+    def test_valid_params(self):
+        self.login_as(self.user)
+
+        params = self.params()
+
+        resp = self.client.post(self.path, params)
+        assert resp.status_code == 302
+
+        options = UserOption.objects.get_all_values(user=self.user, project=None)
+
+        assert options.get('alert_email') == 'foo@example.com'
+
+    def test_can_change_workflow(self):
+        self.login_as(self.user)
+
+        resp = self.client.post(self.path, {
+            'workflow_notifications': '1',
+        })
+        assert resp.status_code == 302
+
+        options = UserOption.objects.get_all_values(
+            user=self.user, project=None
+        )
+
+        assert options.get('workflow:notifications') == '0'
+
+        resp = self.client.post(self.path, {
+            'workflow_notifications': '',
+        })
+        assert resp.status_code == 302
+
+        options = UserOption.objects.get_all_values(
+            user=self.user, project=None
+        )
+
+        assert options.get('workflow:notifications') == \
+            UserOptionValue.participating_only
+
+    def test_can_change_subscribe_by_default(self):
+        self.login_as(self.user)
+
+        resp = self.client.post(self.path, {
+            'subscribe_by_default': '1',
+        })
+        assert resp.status_code == 302
+
+        options = UserOption.objects.get_all_values(
+            user=self.user, project=None
+        )
+
+        assert options.get('subscribe_by_default') == '1'
+
+    def test_can_disable_reports(self):
+        self.login_as(self.user)
+
+        org1 = self.create_organization(name='foo', owner=self.user)
+        org2 = self.create_organization(name='bar', owner=self.user)
+
+        resp = self.client.post(self.path, {
+            'reports-organizations': org1.id,
+        })
+        assert resp.status_code == 302
+
+        options = UserOption.objects.get_all_values(
+            user=self.user, project=None
+        )
+
+        disabled_orgs = set(options.get('reports:disabled-organizations', []))
+        assert org1.id not in disabled_orgs
+        assert org2.id in disabled_orgs


### PR DESCRIPTION
This adds UI in account -> notifications for disabled reports on a per-project basis. The
results are saved as ProjectOption['reports.disabled-organizations'].

@getsentry/ui @getsentry/infrastructure @tkaemming

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3915)

<!-- Reviewable:end -->
