### PR TITLE
Restrict Auth settings to Owner

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -70,7 +70,7 @@ const HomeSidebar = React.createClass({
                   </a>
                 </li>
               }
-              {features.has('sso') && access.has('org:write') &&
+              {features.has('sso') && access.has('org:delete') &&
                 <li><a href={urlPrefix + '/auth/'}>{t('Auth')}</a></li>
               }
               {access.has('org:delete') && features.has('api-keys') &&

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -39,7 +39,9 @@ class AuthProviderSettingsForm(forms.Form):
 
 
 class OrganizationAuthSettingsView(OrganizationView):
-    required_scope = 'org:write'
+    # We restrict auth settings to org:delete as it allows a non-owner to
+    # escalate members to own by disabling the default role.
+    required_scope = 'org:delete'
 
     def _disable_provider(self, request, organization, auth_provider):
         self.create_audit_entry(


### PR DESCRIPTION
This changes Auth so that it can only be modified and configured by an Owner of the ornanization. This incidentally fixes a role escalation issue wherein a Manager could change the default_role to Owner, have a new user authentication, and then escalate themselves to Owner via that new user.

@getsentry/security

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3918)

<!-- Reviewable:end -->
