### PR TITLE
Enforce slug constraints in API

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -47,6 +47,8 @@ def update_organization_scenario(runner):
 
 class OrganizationSerializer(serializers.ModelSerializer):
     projectRateLimit = serializers.IntegerField(min_value=1, max_value=100)
+    slug = serializers.RegexField(r'^[a-z0-9_\-]+$', max_length=50,
+                                  required=False)
 
     class Meta:
         model = Organization

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -29,8 +29,9 @@ def list_your_organizations_scenario(runner):
 
 
 class OrganizationSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=200, required=True)
-    slug = serializers.CharField(max_length=200, required=False)
+    name = serializers.CharField(max_length=64, required=True)
+    slug = serializers.RegexField(r'^[a-z0-9_\-]+$', max_length=50,
+                                  required=False)
 
 
 class OrganizationIndexEndpoint(Endpoint):

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -36,7 +36,8 @@ def list_organization_teams_scenario(runner):
 
 class TeamSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=200, required=True)
-    slug = serializers.CharField(max_length=200, required=False)
+    slug = serializers.RegexField(r'^[a-z0-9_\-]+$', max_length=50,
+                                  required=False)
 
 
 class OrganizationTeamsEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -75,7 +75,7 @@ class ProjectAdminSerializer(serializers.Serializer):
     isBookmarked = serializers.BooleanField()
     isSubscribed = serializers.BooleanField()
     name = serializers.CharField(max_length=200)
-    slug = serializers.SlugField(max_length=200)
+    slug = serializers.RegexField(r'^[a-z0-9_\-]+$', max_length=50)
 
 
 class RelaxedProjectPermission(ProjectPermission):

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -37,6 +37,8 @@ def update_team_scenario(runner):
 
 
 class TeamSerializer(serializers.ModelSerializer):
+    slug = serializers.RegexField(r'^[a-z0-9_\-]+$', max_length=50)
+
     class Meta:
         model = Team
         fields = ('name', 'slug')

--- a/src/sentry/api/endpoints/team_project_index.py
+++ b/src/sentry/api/endpoints/team_project_index.py
@@ -35,8 +35,9 @@ def create_project_scenario(runner):
 
 
 class ProjectSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=200, required=True)
-    slug = serializers.CharField(max_length=200, required=False)
+    name = serializers.CharField(max_length=64, required=True)
+    slug = serializers.RegexField(r'^[a-z0-9_\-]+$', max_length=50,
+                                  required=False)
 
 
 # While currently the UI suggests teams are a parent of a project, in reality


### PR DESCRIPTION
Most slug serialization endpoints were using a simple CharField, which was allowing invalid slugs. This switches them to RegexField with the restrictive charset.

As a follow up it would be useful to abstract things into a SlugField.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3924)

<!-- Reviewable:end -->
