### PR TITLE
Temporarily remove report unsubscribe link.

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -143,9 +143,11 @@
     </table>
   {% endif %}
 
+  {% comment %}
   <div class="unsubscribe-box">
     Not enjoying these? <a>Click to unsubscribe</a>.
   </div>
+  {% endcomment %}
 </div>
 <div class="footer">
   <div class="container">


### PR DESCRIPTION
This'll come back eventually but right now you'll be able to unsubscribe via user notification settings.

References GH-3928, GH-3915.

@ckj @dcramer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3929)

<!-- Reviewable:end -->
