### PR TITLE
Add report backend for intermediate caching.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -307,6 +307,12 @@ class RedisReportBackend(ReportBackend):
                 self.build(timestamp, duration, project),
             )
 
+        if not reports:
+            # XXX: HMSET requires at least one key/value pair, so we need to
+            # protect ourselves here against organizations that were created
+            # but haven't set up any projects yet.
+            return
+
         with self.cluster.map() as client:
             key = self.__make_key(timestamp, duration, organization)
             client.hmset(key, reports)

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import functools
 import itertools
-import json
 import logging
 import operator
 import zlib
@@ -20,7 +19,7 @@ from sentry.models import (
     Team, User
 )
 from sentry.tasks.base import instrumented_task
-from sentry.utils import redis
+from sentry.utils import json, redis
 from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
 from sentry.utils.email import MessageBuilder
 from sentry.utils.math import mean


### PR DESCRIPTION
This allows reports to be built once for each project in an organization, so that individual user reports can be primarily composed from cached data.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3931)

<!-- Reviewable:end -->
