### PR TITLE
Fix report graph display when either point is 0.

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -45,7 +45,7 @@
           {% for timestamp, metrics in report.series.points %}
             <td valign="bottom" style="padding-right: 5px;">
               <table class="issue-graph-bar">
-                {% if metrics.resolved and metrics.unresolved %}
+                {% if metrics.resolved or metrics.unresolved %}
                   <tr>
                     <td class="all" height="{% widthratio metrics.unresolved max 56 %}px" title="{{ metrics.unresolved }}">&nbsp;</td>
                   </tr>


### PR DESCRIPTION
The intention of this if block was to ensure that a baseline was
displayed when a segment was empty (e.g. sum of both points is 0) to
avoid having a totally empty space where the filled bar would normally
be, but this accidentally was showing a space when _either_ point was 0.

@ckj @dcramer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3936)

<!-- Reviewable:end -->
