### PR TITLE
Remove stacktrace grouping logic for inlined JS

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -683,14 +683,14 @@ class Stacktrace(Interface):
     def get_hash(self, system_frames=True):
         frames = self.frames
 
-        # TODO(dcramer): this should apply only to JS
-        # In a common case (I believe from window.onerror) we can end up with
-        # a stacktrace which includes a single frame and a reference that isnt
-        # valuable. It would generally point to the loading page, so it's possible
-        # we could improve this check using that information.
+        # TODO(dcramer): this should apply only to platform=javascript
+        # Browser JS will often throw errors (from inlined code in an HTML page)
+        # which contain only a single frame, no function name, and have the HTML
+        # document as the filename. In this case the hash is often not usable as
+        # the context cannot be trusted and the URL is dynamic (this also means
+        # the line number cannot be trusted).
         stack_invalid = (
-            len(frames) == 1 and frames[0].lineno == 1
-            and not frames[0].function and frames[0].is_url()
+            len(frames) == 1 and not frames[0].function and frames[0].is_url()
         )
 
         if stack_invalid:

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -344,6 +344,27 @@ class StacktraceTest(TestCase):
         result = interface.get_hash()
         assert result != []
 
+    def test_get_hash_excludes_single_frame_urls(self):
+        """
+        Browser JS will often throw errors (from inlined code in an HTML page)
+        which contain only a single frame, no function name, and have the HTML
+        document as the filename.
+
+        In this case the hash is often not usable as the context cannot be
+        trusted and the URL is dynamic.
+        """
+        interface = Stacktrace.to_python({
+            'frames': [{
+                'context_line': 'hello world',
+                'abs_path': 'http://foo.com/bar/',
+                'lineno': 107,
+                'filename': '/bar/',
+                'module': '<unknown module>',
+            }],
+        })
+        result = interface.get_hash()
+        assert result == []
+
     def test_cocoa_culprit(self):
         stacktrace = Stacktrace.to_python(dict(frames=[
             {


### PR DESCRIPTION
This is rule previously only functioned if the line number was 1, but the same issue exists throughout inlined sourcecode in documents. Because extensions and dynamic rendering change pages, its unreliable to rely on the stacktrace for grouping in these situations and creates noise for which should be an uncommon situation.

/cc @getsentry/javascript

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3937)

<!-- Reviewable:end -->
