### PR TITLE
Improve handling of event type rendering

### DIFF
--- a/src/sentry/eventtypes/csp.py
+++ b/src/sentry/eventtypes/csp.py
@@ -23,4 +23,4 @@ class CspEvent(BaseEvent):
         }
 
     def to_string(self, data):
-        return u'{}: {}'.format(data['directive'], data['uri'])
+        return data['message']

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -131,9 +131,23 @@ const GroupDetails = React.createClass({
   },
 
   getTitle() {
-    if (this.state.group)
-      return this.state.group.title;
-    return 'Sentry';
+    let group = this.state.group;
+
+    if (!group)
+      return 'Sentry';
+
+    switch (group.type) {
+      case 'error':
+        if (group.metadata.type && group.metadata.value)
+          return `${group.metadata.type}: ${group.metadata.value}`;
+        return group.metadata.type || group.metadata.value;
+      case 'csp':
+        return group.metadata.message;
+      case 'default':
+        return group.metadata.title;
+      default:
+        return group.message.split('\n')[0];
+    }
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -94,9 +94,11 @@ const GroupEvents = React.createClass({
   getEventTitle(event) {
     switch (event.type) {
       case 'error':
-        return `${event.metadata.type}: ${event.metadata.value}`;
+        if (event.metadata.type && event.metadata.value)
+          return `${event.metadata.type}: ${event.metadata.value}`;
+        return event.metadata.type || event.metadata.value;
       case 'csp':
-        return `${event.metadata.directive}: ${event.metadata.uri}`;
+        return event.metadata.message;
       case 'default':
         return event.metadata.title;
       default:

--- a/src/sentry/templates/sentry/emails/_group.html
+++ b/src/sentry/templates/sentry/emails/_group.html
@@ -7,8 +7,20 @@
   {% if group.data.type == "error" %}
   <div class="event-type error">
       <h3>
-        <a href="{% absolute_uri group_link %}">{{ group.data.metadata.type }}</a>
-        <small>{{ group.data.metadata.value|truncatechars:100|soft_break:40 }}</small>
+        {% if group.data.metadata.type %}
+          <a href="{% absolute_uri group_link %}">{{ group.data.metadata.type|truncatechars:40 }}</a>
+          {% if group.data.metadata.value %}
+            <small>{{ group.data.metadata.value|truncatechars:100|soft_break:40 }}</small>
+          {% endif %}
+        {% else %}
+          <a href="{% absolute_uri group_link %}">{{ group.data.metadata.value|truncatechars:40 }}</a>
+        {% endif %}
+      </h3>
+    </div>
+  {% elif group.data.type == "csp" %}
+    <div class="event-type csp">
+      <h3>
+        <a href="{% absolute_uri group_link %}">{{ group.data.metadata.message|truncatechars:40 }}</a>
       </h3>
     </div>
   {% else %}


### PR DESCRIPTION
- Handle missing 'type' on errors in rollup emails and Related Events
- Remove legacy title usage for GroupDetails page title
- Utilize CSP message for string representation

/cc @getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3938)

<!-- Reviewable:end -->
