### PR TITLE
Prevent scheduling report delivery to organization members without associated user accounts.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -388,7 +388,10 @@ def prepare_organization_report(timestamp, duration, organization_id):
 
     # If an OrganizationMember row doesn't have an associated user, this is
     # actually a pending invitation, so no report should be delivered.
-    member_set = organization.member_set.exclude(user_id=None)
+    member_set = organization.member_set.filter(
+        user_id__isnull=False,
+        user__is_active=True,
+    )
 
     for user_id in member_set.values_list('user_id', flat=True):
         deliver_organization_user_report.delay(

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -386,7 +386,11 @@ def prepare_organization_report(timestamp, duration, organization_id):
 
     backend.prepare(timestamp, duration, organization)
 
-    for user_id in organization.member_set.values_list('user_id', flat=True):
+    # If an OrganizationMember row doesn't have an associated user, this is
+    # actually a pending invitation, so no report should be delivered.
+    member_set = organization.member_set.exclude(user_id=None)
+
+    for user_id in member_set.values_list('user_id', flat=True):
         deliver_organization_user_report.delay(
             timestamp,
             duration,


### PR DESCRIPTION
@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3940)

<!-- Reviewable:end -->
