### PR TITLE
Stop redirecting back to "home" when logging out.

### DIFF
--- a/src/sentry/middleware/social_auth.py
+++ b/src/sentry/middleware/social_auth.py
@@ -8,12 +8,12 @@ sentry.middleware.social_auth
 
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
 from social_auth.middleware import SocialAuthExceptionMiddleware
 
 from sentry.utils.http import absolute_uri
+from sentry.web.helpers import get_login_url
 
 
 class SentrySocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
     def get_redirect_uri(self, request, exception):
-        return absolute_uri(reverse('sentry-login'))
+        return absolute_uri(get_login_url())

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -17,6 +17,7 @@ from django.contrib.auth.backends import ModelBackend
 from django.core.urlresolvers import reverse
 
 from sentry.models import User, Authenticator
+from sentry.web.helpers import get_login_url
 
 logger = logging.getLogger('sentry.auth')
 
@@ -67,7 +68,7 @@ def has_pending_2fa(request):
 
 def get_login_redirect(request, default=None):
     if default is None:
-        default = reverse('sentry')
+        default = get_login_url()
 
     # If there is a pending 2fa authentication bound to the session then
     # we need to go to the 2fa dialog.
@@ -83,7 +84,7 @@ def get_login_redirect(request, default=None):
     login_url = request.session.pop('_next', None) or default
     if login_url.startswith(('http://', 'https://')):
         login_url = default
-    elif login_url.startswith(reverse('sentry-login')):
+    elif login_url.startswith(get_login_url()):
         login_url = default
     return login_url
 

--- a/src/sentry/web/decorators.py
+++ b/src/sentry/web/decorators.py
@@ -32,7 +32,7 @@ def signed_auth_required(func):
         if not request.user_from_signed_request:
             messages.add_message(
                 request, messages.ERROR, ERR_BAD_SIGNATURE)
-            return HttpResponseRedirect(reverse('sentry'))
+            return HttpResponseRedirect(get_login_url())
         return func(request, *args, **kwargs)
     return wrapped
 

--- a/src/sentry/web/frontend/accept_organization_invite.py
+++ b/src/sentry/web/frontend/accept_organization_invite.py
@@ -27,7 +27,7 @@ class AcceptOrganizationInviteView(BaseView):
         return AcceptInviteForm()
 
     def handle(self, request, member_id, token):
-        assert request.method in ['POST', 'GET']
+        assert request.method in ('POST', 'GET')
 
         try:
             om = OrganizationMember.objects.get(pk=member_id)

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -28,7 +28,7 @@ from sentry.web.forms.accounts import (
     AccountSettingsForm, AppearanceSettingsForm,
     RecoverPasswordForm, ChangePasswordRecoverForm,
 )
-from sentry.web.helpers import render_to_response
+from sentry.web.helpers import render_to_response, get_login_url
 from sentry.utils.auth import get_auth_providers, get_login_redirect
 
 
@@ -287,7 +287,7 @@ def email_unsubscribe_project(request, project_id):
         if 'cancel' not in request.POST:
             UserOption.objects.set_value(
                 request.user, project, 'mail:alert', 0)
-        return HttpResponseRedirect(reverse('sentry'))
+        return HttpResponseRedirect(get_login_url())
 
     context = csrf(request)
     context['project'] = project

--- a/src/sentry/web/frontend/admin.py
+++ b/src/sentry/web/frontend/admin.py
@@ -33,13 +33,13 @@ from sentry.web.decorators import requires_admin
 from sentry.web.forms import (
     ChangeUserForm, NewUserForm, RemoveUserForm, TestEmailForm
 )
-from sentry.web.helpers import render_to_response, render_to_string
+from sentry.web.helpers import render_to_response, render_to_string, get_login_url
 
 
 def configure_plugin(request, slug):
     plugin = plugins.get(slug)
     if not plugin.has_site_conf():
-        return HttpResponseRedirect(reverse('sentry'))
+        return HttpResponseRedirect(get_login_url())
 
     view = plugin.configure(request=request)
     if isinstance(view, HttpResponse):
@@ -58,7 +58,7 @@ def configure_plugin(request, slug):
 @csrf_protect
 def create_new_user(request):
     if not request.is_superuser():
-        return HttpResponseRedirect(reverse('sentry'))
+        return HttpResponseRedirect(get_login_url())
 
     form = NewUserForm(request.POST or None, initial={
         'send_welcome_mail': True,
@@ -77,7 +77,7 @@ def create_new_user(request):
             context = {
                 'username': user.username,
                 'password': password,
-                'url': absolute_uri(reverse('sentry')),
+                'url': absolute_uri(get_login_url()),
             }
             body = render_to_string('sentry/emails/welcome_mail.txt', context, request)
 
@@ -105,7 +105,7 @@ def create_new_user(request):
 @csrf_protect
 def edit_user(request, user_id):
     if not request.is_superuser():
-        return HttpResponseRedirect(reverse('sentry'))
+        return HttpResponseRedirect(get_login_url())
 
     try:
         user = User.objects.get(pk=user_id)

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -143,6 +143,9 @@ class AuthLoginView(BaseView):
     @never_cache
     @transaction.atomic
     def handle(self, request):
+        if request.user.is_authenticated():
+            return self.redirect_to_org(request)
+
         # Single org mode -- send them to the org-specific handler
         if settings.SENTRY_SINGLE_ORGANIZATION:
             org = Organization.get_default()

--- a/src/sentry/web/frontend/home.py
+++ b/src/sentry/web/frontend/home.py
@@ -1,20 +1,8 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
-
-from sentry import features
 from sentry.web.frontend.base import BaseView
 
 
 class HomeView(BaseView):
     def get(self, request):
-        # TODO(dcramer): deal with case when the user cannot create orgs
-        organization = self.get_active_organization(request)
-        if organization:
-            url = reverse('sentry-organization-home', args=[organization.slug])
-        elif not features.has('organizations:create'):
-            return self.respond('sentry/no-organization-access.html', status=403)
-        else:
-            url = reverse('sentry-create-organization')
-        return HttpResponseRedirect(url)
+        return self.redirect_to_org(request)

--- a/src/sentry/web/frontend/organization_member_settings.py
+++ b/src/sentry/web/frontend/organization_member_settings.py
@@ -9,6 +9,7 @@ from sentry import roles
 from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 from sentry.web.frontend.base import OrganizationView
 from sentry.web.forms.edit_organization_member import EditOrganizationMemberForm
+from sentry.web.helpers import get_login_url
 
 
 class OrganizationMemberSettingsView(OrganizationView):
@@ -60,7 +61,7 @@ class OrganizationMemberSettingsView(OrganizationView):
                 id=member_id,
             )
         except OrganizationMember.DoesNotExist:
-            return self.redirect(reverse('sentry'))
+            return self.redirect(get_login_url())
 
         if request.POST.get('op') == 'reinvite' and member.is_pending:
             return self.resend_invite(request, organization, member)

--- a/src/sentry/web/frontend/twofactor.py
+++ b/src/sentry/web/frontend/twofactor.py
@@ -4,13 +4,12 @@ import six
 import time
 
 from django.http import HttpResponseRedirect, HttpResponse
-from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from sentry import options
 from sentry.web.frontend.base import BaseView
 from sentry.web.forms.accounts import TwoFactorForm
-from sentry.web.helpers import render_to_response
+from sentry.web.helpers import render_to_response, get_login_url
 from sentry.utils import auth, json
 from sentry.models import Authenticator
 
@@ -101,7 +100,7 @@ class TwoFactorAuthView(BaseView):
     def handle(self, request):
         user = auth.get_pending_2fa_user(request)
         if user is None or request.user.is_authenticated():
-            return HttpResponseRedirect(reverse('sentry'))
+            return HttpResponseRedirect(get_login_url())
 
         interfaces = Authenticator.objects.all_interfaces_for_user(user)
 

--- a/tests/sentry/utils/auth/tests.py
+++ b/tests/sentry/utils/auth/tests.py
@@ -42,12 +42,12 @@ class GetLoginRedirectTest(TestCase):
 
     def test_schema_uses_default(self):
         result = get_login_redirect(self.make_request('http://example.com'))
-        assert result == reverse('sentry')
+        assert result == reverse('sentry-login')
 
     def test_login_uses_default(self):
         result = get_login_redirect(self.make_request(reverse('sentry-login')))
-        assert result == reverse('sentry')
+        assert result == reverse('sentry-login')
 
     def test_no_value_uses_default(self):
         result = get_login_redirect(self.make_request())
-        assert result == reverse('sentry')
+        assert result == reverse('sentry-login')

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -76,3 +76,11 @@ class AuthLoginTest(TestCase):
         assert resp.status_code == 200
         assert resp.context['op'] == 'register'
         self.assertTemplateUsed('sentry/login.html')
+
+    def test_already_logged_in(self):
+        self.login_as(self.user)
+        with self.feature('organizations:create'):
+            resp = self.client.get(self.path)
+
+        assert resp.status_code == 302
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-create-organization')

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -60,7 +60,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'op': 'newuser'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             auth_provider=auth_provider,
@@ -104,7 +104,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'op': 'confirm'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             auth_provider=auth_provider,
@@ -145,7 +145,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'email': 'foo@example.com'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
     def test_flow_as_unauthenticated_existing_matched_user_no_merge(self):
         organization = self.create_organization(name='foo', owner=self.user)
@@ -174,7 +174,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'op': 'newuser'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             auth_provider=auth_provider,
@@ -228,7 +228,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'op': 'confirm'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             auth_provider=auth_provider,
@@ -281,7 +281,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'op': 'confirm'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             auth_provider=auth_provider,
@@ -340,7 +340,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'op': 'confirm'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             id=auth_identity.id,
@@ -399,7 +399,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         })
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             id=auth_identity.id,
@@ -464,7 +464,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # there should be no prompt as we auto merge the identity
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         auth_identity = AuthIdentity.objects.get(
             id=auth_identity.id,
@@ -576,7 +576,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {'email': 'adfadsf@example.com'})
 
         assert resp.status_code == 302
-        assert resp['Location'] == 'http://testserver/'
+        assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
 
         assert not AuthIdentity.objects.filter(
             id=identity1.id,


### PR DESCRIPTION
Sentry app doesn't have a "home" page, and this ultimately just
redirects back to Login page anyways.

This is is changing the default behaviors to redirect directly to login
page when unauthenticated, and also fixes the Login page to actually
check authentication and redirect to your dashboard correctly instead of
prompting for login... when already logged in.

This moves, I think, all flows where a logged out user would be kicked over to "home" and instead kicks them to login directly.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3941)

<!-- Reviewable:end -->
