### PR TITLE
Improve accuracy of regression query for reports.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -225,7 +225,7 @@ def prepare_project_issue_list(interval, project):
             ),
             datetime__gte=start,
             datetime__lt=stop,
-        ).order_by('group').distinct('group').values_list('group_id', flat=True)
+        ).order_by('group').distinct().values_list('group_id', flat=True)
     )
 
     rollup = 60 * 60 * 24

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -225,7 +225,7 @@ def prepare_project_issue_list(interval, project):
             ),
             datetime__gte=start,
             datetime__lt=stop,
-        ).order_by('group').distinct().values_list('group_id', flat=True)
+        ).distinct().values_list('group_id', flat=True)
     )
 
     rollup = 60 * 60 * 24

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -225,7 +225,7 @@ def prepare_project_issue_list(interval, project):
             ),
             datetime__gte=start,
             datetime__lt=stop,
-        ).order_by('group_id').distinct('group_id').values_list('group_id', flat=True)
+        ).order_by('group').distinct('group').values_list('group_id', flat=True)
     )
 
     rollup = 60 * 60 * 24


### PR DESCRIPTION
Previously, we were only fetching groups that had regressed within the
reporting interval and were _still_ marked as regressed when the report
was generated. This changes the behavior to select groups that regressed
during the reporting interval and were in _any_ state when the report
was generated.

References GH-3945.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3948)

<!-- Reviewable:end -->
