### PR TITLE
Add React compat layer for plugins

### DIFF
--- a/src/sentry/plugins/base/group_api_urls.py
+++ b/src/sentry/plugins/base/group_api_urls.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import
 
 from django.conf.urls import patterns, include, url
 
-from sentry.plugins import plugins, IssueTrackingPlugin2
+from sentry.plugins import plugins
 
 
 urlpatterns = patterns('')
 
 for _plugin in plugins.all():
-    if isinstance(_plugin, IssueTrackingPlugin2):
-        _plugin_group_urls = _plugin.get_group_urls()
-        if _plugin_group_urls:
-            urlpatterns += (url(r'^%s/' % _plugin.slug, include(_plugin_group_urls)),)
+    _plugin_group_urls = _plugin.get_group_urls()
+    if _plugin_group_urls:
+        urlpatterns.append(
+            url(r'^%s/' % _plugin.slug, include(_plugin_group_urls))
+        )

--- a/src/sentry/plugins/base/project_api_urls.py
+++ b/src/sentry/plugins/base/project_api_urls.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import
 
 from django.conf.urls import patterns, include, url
 
-from sentry.plugins import plugins, IssueTrackingPlugin2
+from sentry.plugins import plugins
 
 
 urlpatterns = patterns('')
 
 for _plugin in plugins.all():
-    if isinstance(_plugin, IssueTrackingPlugin2):
-        _plugin_project_urls = _plugin.get_project_urls()
-        if _plugin_project_urls:
-            urlpatterns += (url(r'^%s/' % _plugin.slug, include(_plugin_project_urls)),)
+    _plugin_project_urls = _plugin.get_project_urls()
+    if _plugin_project_urls:
+        urlpatterns.append(
+            url(r'^%s/' % _plugin.slug, include(_plugin_project_urls))
+        )

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -15,6 +15,7 @@ import six
 from django.http import HttpResponseRedirect
 from threading import local
 
+from sentry.plugins.config import PluginConfigMixin
 from sentry.plugins.base.response import Response
 from sentry.plugins.base.configuration import (
     default_plugin_config, default_plugin_options,
@@ -36,7 +37,7 @@ class PluginMount(type):
         return new_cls
 
 
-class IPlugin2(local):
+class IPlugin2(local, PluginConfigMixin):
     """
     Plugin interface. Should not be inherited from directly.
 

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -6,14 +6,13 @@ from rest_framework.response import Response
 from social_auth.models import UserSocialAuth
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.urlresolvers import reverse
 from django.utils.html import format_html
 
-from sentry.api.bases.group import GroupEndpoint
-from sentry.api.bases.project import ProjectEndpoint
 from sentry.models import Activity, Event, GroupMeta
 from sentry.plugins import Plugin
+from sentry.plugins.endpoints import PluginGroupEndpoint, PluginProjectEndpoint
 from sentry.plugins.base.configuration import default_issue_plugin_config
 from sentry.signals import issue_tracker_used
 from sentry.utils.auth import get_auth_providers
@@ -21,38 +20,20 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
 
-class PluginError(Exception):
-    pass
-
-
-class IssueGroupActionEndpoint(GroupEndpoint):
+# TODO(dcramer): remove this in favor of GroupEndpoint
+class IssueGroupActionEndpoint(PluginGroupEndpoint):
     view_method_name = None
     plugin = None
 
     def _handle(self, request, group, *args, **kwargs):
         GroupMeta.objects.populate_cache([group])
 
-        return getattr(self.plugin, self.view_method_name)(request, group, *args, **kwargs)
-
-    def get(self, request, group, *args, **kwargs):
-        return self._handle(request, group, *args, **kwargs)
-
-    def post(self, request, group, *args, **kwargs):
-        return self._handle(request, group, *args, **kwargs)
+        return getattr(self.plugin, self.view_method_name)(
+            request, group, *args, **kwargs)
 
 
-class IssuePluginProjectEndpoint(ProjectEndpoint):
-    view_method_name = None
-    plugin = None
-
-    def _handle(self, request, project, *args, **kwargs):
-        return getattr(self.plugin, self.view_method_name)(request, project, *args, **kwargs)
-
-    def get(self, request, project, *args, **kwargs):
-        return self._handle(request, project, *args, **kwargs)
-
-    def post(self, request, project, *args, **kwargs):
-        return self._handle(request, project, *args, **kwargs)
+class PluginError(Exception):
+    pass
 
 
 class IssueTrackingPlugin2(Plugin):
@@ -61,27 +42,6 @@ class IssueTrackingPlugin2(Plugin):
 
     def has_project_conf(self):
         return True
-
-    def get_group_urls(self):
-        _urls = []
-        for action in self.allowed_actions:
-            view_method_name = 'view_%s' % action
-            _urls.append(url(r'^%s/' % action,
-                             IssueGroupActionEndpoint.as_view(view_method_name=view_method_name,
-                                                              plugin=self)))
-
-        return patterns('', *_urls)
-
-    def get_project_urls(self):
-        _urls = []
-        # TODO: add enable here when moved to api
-        for action in ('configure', 'disable'):
-            view_method_name = 'view_%s' % action
-            _urls.append(url(r'^%s/' % action,
-                             IssuePluginProjectEndpoint.as_view(view_method_name=view_method_name,
-                                                                plugin=self)))
-
-        return patterns('', *_urls)
 
     def get_group_body(self, request, group, event, **kwargs):
         result = []
@@ -110,6 +70,34 @@ class IssueTrackingPlugin2(Plugin):
 
     def is_configured(self, request, project, **kwargs):
         raise NotImplementedError
+
+    def get_group_urls(self):
+        _urls = []
+        for action in self.allowed_actions:
+            view_method_name = 'view_%s' % action
+            _urls.append(
+                url(r'^%s/' % action,
+                    PluginGroupEndpoint.as_view(
+                        view=getattr(self, view_method_name),
+                    ),
+                )
+            )
+        return _urls
+
+    def get_project_urls(self):
+        _urls = []
+        # TODO: add enable here when moved to api
+        for action in ('configure', 'disable'):
+            view_method_name = 'view_%s' % action
+
+            _urls.append(
+                url(r'^%s/' % action,
+                    PluginProjectEndpoint.as_view(
+                        view=getattr(self, view_method_name),
+                    ),
+                )
+            )
+        return _urls
 
     def get_auth_for_user(self, user, **kwargs):
         """

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+__all__ = ['PluginConfigMixin']
+
+from django import forms
+
+
+class PluginConfigMixin(object):
+    def field_to_config(self, name, field):
+        config = {
+            'name': name,
+            'label': field.label,
+            'placeholder': field.widget.attrs.get('placeholder'),
+            'help': field.help_text,
+        }
+        if isinstance(field, forms.CharField):
+            if field.widget == forms.Textarea:
+                config['type'] = 'textarea'
+            else:
+                config['type'] = 'text'
+        elif isinstance(field, forms.ChoiceField):
+            config['type'] = 'select'
+            config['choices'] = field.choices
+        return config
+
+    def get_group_urls(self):
+        return []
+
+    def get_project_urls(self):
+        return []

--- a/src/sentry/plugins/endpoints.py
+++ b/src/sentry/plugins/endpoints.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+__all__ = ['PluginProjectEndpoint', 'PluginGroupEndpoint']
+
+from sentry.api.bases.group import GroupEndpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.models import GroupMeta
+
+
+class PluginProjectEndpoint(ProjectEndpoint):
+    view = None
+
+    def _handle(self, request, project, *args, **kwargs):
+        return self.view(request, project, *args, **kwargs)
+
+    def get(self, request, project, *args, **kwargs):
+        return self._handle(request, project, *args, **kwargs)
+
+    def post(self, request, project, *args, **kwargs):
+        return self._handle(request, project, *args, **kwargs)
+
+
+class PluginGroupEndpoint(GroupEndpoint):
+    view = None
+
+    def _handle(self, request, group, *args, **kwargs):
+        GroupMeta.objects.populate_cache([group])
+
+        return self.view(request, group, *args, **kwargs)
+
+    def get(self, request, group, *args, **kwargs):
+        return self._handle(request, group, *args, **kwargs)
+
+    def post(self, request, group, *args, **kwargs):
+        return self._handle(request, group, *args, **kwargs)

--- a/src/sentry/static/sentry/app/components/plugins/pluginConfigureForm.jsx
+++ b/src/sentry/static/sentry/app/components/plugins/pluginConfigureForm.jsx
@@ -6,7 +6,7 @@ import LoadingIndicator from '../loadingIndicator';
 import {t} from '../../locale';
 import {defined} from '../../utils';
 
-const IssuePluginConfigForm = React.createClass({
+const PluginConfigForm = React.createClass({
   propTypes: {
     organization: React.PropTypes.object.isRequired,
     project: React.PropTypes.object.isRequired,
@@ -29,8 +29,9 @@ const IssuePluginConfigForm = React.createClass({
   getPluginConfigureEndpoint() {
     let org = this.props.organization;
     let project = this.props.project;
-    return ('/projects/' + org.slug + '/' + project.slug +
-            '/plugin/' + this.props.plugin.slug + '/configure/');
+    return (
+      `/projects/${org.slug}/${project.slug}/plugin/${this.props.plugin.slug}/configure/`
+    );
   },
 
   fetchData() {
@@ -127,4 +128,4 @@ const IssuePluginConfigForm = React.createClass({
   }
 });
 
-export default IssuePluginConfigForm;
+export default PluginConfigForm;


### PR DESCRIPTION
The goal here is to put in a compatibility layer that will allow us to transition the majority of plugins to React without rewriting them.

Specifically, we're going to transition webhooks, hipchat, and slack as part of #3947, and this will be a good test bed to see if we can avoid defining options statically. The goal is that we can pus out the Alerts change, with it fully configurable in React, without touching the Slack or HipChat plugins.

@macqueen

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3949)

<!-- Reviewable:end -->
