### PR TITLE
Add missing `DISTINCT` clause to personal report resolution count.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -413,7 +413,7 @@ def fetch_personal_statistics((start, stop), organization, user):
         datetime__gte=start,
         datetime__lt=stop,
         group__status=GroupStatus.RESOLVED,  # only count if the issue is still resolved
-    ).values_list('group_id', flat=True)
+    ).distinct().values_list('group_id', flat=True)
     return {
         'resolved': len(resolved_issue_ids),
         'users': tsdb.get_distinct_counts_union(


### PR DESCRIPTION
Without this, if you closed an issue twice in a week (for example, if it
was closed, regressed, and was closed again) this would show as two
resolutions -- now it only shows as one.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3955)

<!-- Reviewable:end -->
