### PR TITLE
Look at the right POST params for mailgun

### DIFF
--- a/src/sentry/web/frontend/mailgun_inbound_webhook.py
+++ b/src/sentry/web/frontend/mailgun_inbound_webhook.py
@@ -10,7 +10,6 @@ from django.views.generic import View
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from email_reply_parser import EmailReplyParser
-from email.utils import parseaddr
 
 from sentry import options
 from sentry.tasks.email import process_inbound_email
@@ -49,8 +48,8 @@ class MailgunInboundWebhookView(View):
             })
             return HttpResponse(status=200)
 
-        to_email = parseaddr(request.POST['To'])[1]
-        from_email = parseaddr(request.POST['From'])[1]
+        to_email = request.POST['recipient']
+        from_email = request.POST['sender']
 
         try:
             group_id = email_to_group_id(to_email)

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -20,8 +20,8 @@ class TestMailgunInboundWebhookView(TestCase):
     def test_invalid_signature(self, process_inbound_email):
         with self.options({'mail.mailgun-api-key': 'a' * 32}):
             resp = self.client.post(reverse('sentry-mailgun-inbound-hook'), {
-                'To': 'Sentry <%s>' % (self.mailto,),
-                'From': 'David <%s>' % (self.user.email,),
+                'recipient': self.mailto,
+                'sender': self.user.email,
                 'body-plain': body_plain,
                 'signature': '',
                 'token': '',
@@ -32,8 +32,8 @@ class TestMailgunInboundWebhookView(TestCase):
     @mock.patch('sentry.web.frontend.mailgun_inbound_webhook.process_inbound_email')
     def test_missing_api_key(self, process_inbound_email):
         resp = self.client.post(reverse('sentry-mailgun-inbound-hook'), {
-            'To': 'Sentry <%s>' % (self.mailto,),
-            'From': 'David <%s>' % (self.user.email,),
+            'recipient': self.mailto,
+            'sender': self.user.email,
             'body-plain': body_plain,
             'signature': '',
             'token': '',
@@ -49,8 +49,8 @@ class TestMailgunInboundWebhookView(TestCase):
 
         with self.options({'mail.mailgun-api-key': 'a' * 32}):
             resp = self.client.post(reverse('sentry-mailgun-inbound-hook'), {
-                'To': 'Sentry <%s>' % (self.mailto,),
-                'From': 'David <%s>' % (self.user.email,),
+                'recipient': self.mailto,
+                'sender': self.user.email,
                 'body-plain': body_plain,
                 'signature': signature,
                 'token': token,


### PR DESCRIPTION
If the To header is wrong, we reject the payload entirely,
when we might actually be in the recipient list.

So we are switching to use the correct POST params, which also happen to
not be formatted and don't need to be run through parseaddr anymore
either.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3962)

<!-- Reviewable:end -->
