### PR TITLE
Add TSDB counter for Release instances.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -588,10 +588,15 @@ class EventManager(object):
                 datetime=date,
             )
 
-        tsdb.incr_multi([
+        counters = [
             (tsdb.models.group, group.id),
             (tsdb.models.project, project.id),
-        ], timestamp=event.datetime)
+        ]
+
+        if release:
+            counters.append((tsdb.models.release, release.id))
+
+        tsdb.incr_multi(counters, timestamp=event.datetime)
 
         frequencies = [
             # (tsdb.models.frequent_projects_by_organization, {
@@ -610,6 +615,7 @@ class EventManager(object):
                 },
             })
         ]
+
         if release:
             frequencies.append(
                 (tsdb.models.frequent_releases_by_group, {

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -31,6 +31,7 @@ class TSDBModel(Enum):
     group = 4
     group_tag_key = 5
     group_tag_value = 6
+    release = 7
 
     # the number of events sent to the server
     project_total_received = 100


### PR DESCRIPTION
This is to support showing events by release in weekly reports.

I opted to avoid using sketches since we don't need an on-demand top list and the associated costs. Instead, we can use `TagValue.last_seen` to find the active releases over the past week, and compute the top list during report preparation from there.

References GH-3945.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3974)

<!-- Reviewable:end -->
