### PR TITLE
Make the merge event string static.

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -167,7 +167,8 @@ def merge_objects(models, group, new_group, limit=1000,
     has_more = False
     for model in models:
         if logger is not None:
-            logger.info('%s.merge', model.__name__.lower(), extra={
+            logger.info('model.merge', extra={
+                'model': model.__name__,
                 'group_id': group.id,
                 'new_group_id': new_group.id
             })


### PR DESCRIPTION
Making the model the noun in the event string makes the event way too sparse to do anything useful with it.

cc @getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3979)

<!-- Reviewable:end -->
