### PR TITLE
Return back a 404 on an attempt to access a insecure path

### DIFF
--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -27,7 +27,12 @@ def resolve(path):
     # Mostly yanked from Django core and changed to return the path:
     # See: https://github.com/django/django/blob/1.6.11/django/contrib/staticfiles/views.py
     normalized_path = posixpath.normpath(unquote(path)).lstrip('/')
-    absolute_path = finders.find(normalized_path)
+    try:
+        absolute_path = finders.find(normalized_path)
+    except Exception:
+        # trying to access bad paths like, `../../etc/passwd`, etc that
+        # Django rejects, but respond nicely instead of erroring.
+        absolute_path = None
     if not absolute_path:
         raise Http404("'%s' could not be found" % path)
     if path[-1] == '/' or os.path.isdir(absolute_path):

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -88,6 +88,11 @@ class StaticMediaTest(TestCase):
         response = self.client.get(url)
         assert response.status_code == 404, response
 
+    def test_bad_access(self):
+        url = '/_static/sentry/images/../../../../../etc/passwd'
+        response = self.client.get(url)
+        assert response.status_code == 404, response
+
     def test_directory(self):
         url = '/_static/sentry/images/'
         response = self.client.get(url)


### PR DESCRIPTION
To be clear, we were just raising a 500 in this case, but this is a bit
friendlier and less noisy to not log it into Sentry when someone is
trying to poke at us.

@getsentry/api

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3983)

<!-- Reviewable:end -->
