### PR TITLE
Let DRF actually handle an auth failure without erroring

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -137,14 +137,15 @@ class Endpoint(APIView):
             time.sleep(settings.SENTRY_API_RESPONSE_DELAY / 1000.0)
 
         origin = request.META.get('HTTP_ORIGIN')
-        if origin and request.auth:
-            allowed_origins = request.auth.get_allowed_origins()
-            if not is_valid_origin(origin, allowed=allowed_origins):
-                response = Response('Invalid origin: %s' % (origin,), status=400)
-                self.response = self.finalize_response(request, response, *args, **kwargs)
-                return self.response
 
         try:
+            if origin and request.auth:
+                allowed_origins = request.auth.get_allowed_origins()
+                if not is_valid_origin(origin, allowed=allowed_origins):
+                    response = Response('Invalid origin: %s' % (origin,), status=400)
+                    self.response = self.finalize_response(request, response, *args, **kwargs)
+                    return self.response
+
             self.initial(request, *args, **kwargs)
 
             # Get the appropriate handler method


### PR DESCRIPTION
Fixes SENTRY-HP
Fixes GH-3722

@getsentry/api 

The problem is the exception is being raised when accessing `request.auth`, but nothing was catching it and turning it into a normal HTTP response code. So moving this block into the `try` causes it to be handled correctly and returns properly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3985)

<!-- Reviewable:end -->
