### PR TITLE
Show filename in a tooltip if otherwise not shown

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -126,8 +126,9 @@ const Frame = React.createClass({
 
     if (defined(data.filename || data.module)) {
       // prioritize module name for Java as filename is often only basename
+      let shouldPrioritizeModuleName = this.shouldPrioritizeModuleName();
       let pathName = (
-        this.shouldPrioritizeModuleName() ?
+        this.shouldPrioritizeModuleName ?
         (data.module || data.filename) :
         (data.filename || data.module));
 
@@ -136,6 +137,17 @@ const Frame = React.createClass({
           <Truncate value={pathName} maxLength={100} leftTrim={true} />
         </code>
       ));
+
+      // in case we prioritized the module name but we also have a filename info
+      // we want to show a litle (?) icon that on hover shows the actual filename
+      if (shouldPrioritizeModuleName && data.filename) {
+        title.push(
+          <a key="real-filename" className="in-at tip real-filename" data-title={_.escape(data.filename)}>
+            <span className="icon-question" />
+          </a>
+        );
+      }
+
       if (isUrl(data.absPath)) {
         title.push(<a href={data.absPath} className="icon-open" key="share" target="_blank" onClick={this.preventCollapse}/>);
       }

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -128,7 +128,7 @@ const Frame = React.createClass({
       // prioritize module name for Java as filename is often only basename
       let shouldPrioritizeModuleName = this.shouldPrioritizeModuleName();
       let pathName = (
-        this.shouldPrioritizeModuleName ?
+        shouldPrioritizeModuleName ?
         (data.module || data.filename) :
         (data.filename || data.module));
 


### PR DESCRIPTION
This is useful for Java and C# where there is currently no information
about the filename at all.  It came up because people have quite a few
situations in which the filename reported is more useful than the
generated module name.

Fixes #3987

@getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/3998)

<!-- Reviewable:end -->
