### PR TITLE
Truncate User.email value to 75 characters

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -70,6 +70,7 @@ MINUTE_NORMALIZATION = 15
 MAX_TAG_KEY_LENGTH = 32
 MAX_TAG_VALUE_LENGTH = 200
 MAX_CULPRIT_LENGTH = 200
+MAX_EMAIL_FIELD_LENGTH = 75
 
 # Team slugs which may not be used. Generally these are top level URL patterns
 # which we don't want to worry about conflicts on.

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -15,6 +15,7 @@ from sentry.interfaces.base import Interface, InterfaceValidationError
 from sentry.utils.safe import trim, trim_dict
 from sentry.web.helpers import render_to_string
 from sentry.utils.validators import validate_ip
+from sentry.constants import MAX_EMAIL_FIELD_LENGTH
 
 
 def validate_email(value, required=True):
@@ -59,7 +60,7 @@ class User(Interface):
         if ident:
             ident = six.text_type(ident)
         try:
-            email = trim(validate_email(data.pop('email', None), False), 128)
+            email = trim(validate_email(data.pop('email', None), False), MAX_EMAIL_FIELD_LENGTH)
         except ValueError:
             raise InterfaceValidationError("Invalid value for 'email'")
         username = trim(data.pop('username', None), 128)

--- a/src/sentry/models/eventuser.py
+++ b/src/sentry/models/eventuser.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 from sentry.utils.hashlib import md5_text
+from sentry.constants import MAX_EMAIL_FIELD_LENGTH
 
 KEYWORD_MAP = {
     'id': 'ident',
@@ -20,7 +21,7 @@ class EventUser(Model):
     project = FlexibleForeignKey('sentry.Project')
     hash = models.CharField(max_length=32)
     ident = models.CharField(max_length=128, null=True)
-    email = models.EmailField(null=True)
+    email = models.EmailField(null=True, max_length=MAX_EMAIL_FIELD_LENGTH)
     username = models.CharField(max_length=128, null=True)
     ip_address = models.GenericIPAddressField(null=True)
     date_added = models.DateTimeField(default=timezone.now, db_index=True)


### PR DESCRIPTION
The EventUser.email column is only 75 characters wide

Fixes SENTRY-1NC

@getsentry/infrastructure 

Alternatively, we can ALTER the column width and let it be 128 chars.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4002)

<!-- Reviewable:end -->
