### PR TITLE
Convert all delay calls with countdown to apply_async

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -329,6 +329,9 @@ class GroupDetailsEndpoint(GroupEndpoint):
             ]
         ).update(status=GroupStatus.PENDING_DELETION)
         if updated:
-            delete_group.delay(object_id=group.id, countdown=3600)
+            delete_group.apply_async(
+                kwargs={'object_id': group.id},
+                countdown=3600,
+            )
 
         return Response(status=202)

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -174,9 +174,11 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             status=OrganizationStatus.VISIBLE,
         ).update(status=OrganizationStatus.PENDING_DELETION)
         if updated:
-            delete_organization.delay(
-                object_id=organization.id,
-                transaction_id=transaction_id,
+            delete_organization.apply_async(
+                kwargs={
+                    'object_id': organization.id,
+                    'transaction_id': transaction_id,
+                },
                 countdown=86400,
             )
 

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -295,7 +295,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             status=ProjectStatus.VISIBLE,
         ).update(status=ProjectStatus.PENDING_DELETION)
         if updated:
-            delete_project.delay(object_id=project.id, countdown=3600)
+            delete_project.apply_async(
+                kwargs={'object_id': project.id},
+                countdown=3600,
+            )
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -649,6 +649,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
 
         # TODO(dcramer): set status to pending deletion
         for group in group_list:
-            delete_group.delay(object_id=group.id, countdown=3600)
+            delete_group.apply_async(
+                kwargs={'object_id': group.id},
+                countdown=3600,
+            )
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -129,7 +129,10 @@ class TeamDetailsEndpoint(TeamEndpoint):
             status=TeamStatus.VISIBLE,
         ).update(status=TeamStatus.PENDING_DELETION)
         if updated:
-            delete_team.delay(object_id=team.id, countdown=3600)
+            delete_team.apply_async(
+                kwargs={'object_id': team.id},
+                countdown=3600,
+            )
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -47,7 +47,10 @@ def delete_organization(object_id, transaction_id=None, continuous=True, **kwarg
         team.update(status=TeamStatus.DELETION_IN_PROGRESS)
         delete_team(team.id, transaction_id=transaction_id, continuous=False)
         if continuous:
-            delete_organization.delay(object_id=object_id, transaction_id=transaction_id, countdown=15)
+            delete_organization.apply_async(
+                kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                countdown=15,
+            )
         return
 
     model_list = (OrganizationMember,)
@@ -55,7 +58,10 @@ def delete_organization(object_id, transaction_id=None, continuous=True, **kwarg
     has_more = delete_objects(model_list, transaction_id=transaction_id, relation={'organization': o}, logger=logger)
     if has_more:
         if continuous:
-            delete_organization.delay(object_id=object_id, transaction_id=transaction_id, countdown=15)
+            delete_organization.apply_async(
+                kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                countdown=15,
+            )
         return
     o.delete()
 
@@ -88,7 +94,10 @@ def delete_team(object_id, transaction_id=None, continuous=True, **kwargs):
         project.update(status=ProjectStatus.DELETION_IN_PROGRESS)
         delete_project(project.id, transaction_id=transaction_id, continuous=False)
         if continuous:
-            delete_team.delay(object_id=object_id, transaction_id=transaction_id, countdown=15)
+            delete_team.apply_async(
+                kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                countdown=15,
+            )
         return
 
     t.delete()
@@ -133,7 +142,10 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
         has_more = bulk_delete_objects(model, project_id=p.id, transaction_id=transaction_id, logger=logger)
         if has_more:
             if continuous:
-                delete_project.delay(object_id=object_id, transaction_id=transaction_id, countdown=15)
+                delete_project.apply_async(
+                    kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                    countdown=15,
+                )
             return
 
     # TODO(dcramer): no project relation so we cant easily bulk
@@ -144,13 +156,19 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
                               logger=logger)
     if has_more:
         if continuous:
-            delete_project.delay(object_id=object_id, transaction_id=transaction_id, countdown=15)
+            delete_project.apply_async(
+                kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                countdown=15,
+            )
         return
 
     has_more = delete_events(relation={'project_id': p.id}, transaction_id=transaction_id, logger=logger)
     if has_more:
         if continuous:
-            delete_project.delay(object_id=object_id, transaction_id=transaction_id, countdown=15)
+            delete_project.apply_async(
+                kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                countdown=15,
+            )
         return
 
     # Release needs to handle deletes after Group is cleaned up as the foreign
@@ -160,7 +178,10 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
         has_more = bulk_delete_objects(model, project_id=p.id, transaction_id=transaction_id, logger=logger)
         if has_more:
             if continuous:
-                delete_project.delay(object_id=object_id, transaction_id=transaction_id, countdown=15)
+                delete_project.apply_async(
+                    kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                    countdown=15,
+                )
             return
 
     p.delete()
@@ -196,13 +217,19 @@ def delete_group(object_id, transaction_id=None, continuous=True, **kwargs):
         has_more = bulk_delete_objects(model, group_id=object_id, logger=logger)
         if has_more:
             if continuous:
-                delete_group.delay(object_id=object_id, countdown=15)
+                delete_group.apply_async(
+                    kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                    countdown=15,
+                )
             return
 
     has_more = delete_events(relation={'group_id': object_id}, logger=logger)
     if has_more:
         if continuous:
-            delete_group.delay(object_id=object_id, countdown=15)
+            delete_group.apply_async(
+                kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                countdown=15,
+            )
         return
     group.delete()
 
@@ -231,14 +258,20 @@ def delete_tag_key(object_id, transaction_id=None, continuous=True, **kwargs):
                                        key=tagkey.key, logger=logger)
         if has_more:
             if continuous:
-                delete_tag_key.delay(object_id=object_id, countdown=15)
+                delete_tag_key.apply_async(
+                    kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                    countdown=15,
+                )
             return
 
     has_more = bulk_delete_objects(EventTag, project_id=tagkey.project_id,
                                    key_id=tagkey.id, logger=logger)
     if has_more:
         if continuous:
-            delete_tag_key.delay(object_id=object_id, countdown=15)
+            delete_tag_key.apply_async(
+                kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+                countdown=15,
+            )
         return
 
     tagkey.delete()

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -97,9 +97,11 @@ class OrganizationDeleteTest(APITestCase):
 
         assert org.status == OrganizationStatus.PENDING_DELETION
 
-        mock_delete_organization.delay.assert_called_once_with(
-            object_id=org.id,
-            transaction_id='abc123',
+        mock_delete_organization.apply_async.assert_called_once_with(
+            kwargs={
+                'object_id': org.id,
+                'transaction_id': 'abc123',
+            },
             countdown=86400,
         )
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -198,8 +198,8 @@ class ProjectDeleteTest(APITestCase):
 
         assert response.status_code == 204
 
-        mock_delete_project.delay.assert_called_once_with(
-            object_id=project.id,
+        mock_delete_project.apply_async.assert_called_once_with(
+            kwargs={'object_id': project.id},
             countdown=3600,
         )
 

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -72,8 +72,8 @@ class TeamDeleteTest(APITestCase):
 
         assert team.status == TeamStatus.PENDING_DELETION
 
-        delete_team.delay.assert_called_once_with(
-            object_id=team.id,
+        delete_team.apply_async.assert_called_once_with(
+            kwargs={'object_id': team.id},
             countdown=3600,
         )
 


### PR DESCRIPTION
When calling .delay with countdown, countdown is just passed as a kwarg,
and doesn't actually delay the task. The task executes immediately.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4009)

<!-- Reviewable:end -->
