### PR TITLE
Added more lenient stack handling to improve symbolication

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -226,8 +226,10 @@ class Frame(Interface):
         filename = data.get('filename')
         function = data.get('function')
         module = data.get('module')
+        package = data.get('package')
 
-        for name in ('abs_path', 'filename', 'function', 'module'):
+        for name in ('abs_path', 'filename', 'function', 'module',
+                     'package'):
             v = data.get(name)
             if v is not None and not isinstance(v, six.string_types):
                 raise InterfaceValidationError("Invalid value for '%s'" % name)
@@ -248,8 +250,8 @@ class Frame(Interface):
             else:
                 filename = abs_path
 
-        if not (filename or function or module):
-            raise InterfaceValidationError("No 'filename' or 'function' or 'module'")
+        if not (filename or function or module or package):
+            raise InterfaceValidationError("No 'filename' or 'function' or 'module' or 'package'")
 
         if function == '?':
             function = None
@@ -300,7 +302,7 @@ class Frame(Interface):
             'platform': platform,
             'module': trim(module, 256),
             'function': trim(function, 256),
-            'package': trim(data.get('package'), 256),
+            'package': package,
             'image_addr': to_hex_addr(trim(data.get('image_addr'), 16)),
             'symbol_addr': to_hex_addr(trim(data.get('symbol_addr'), 16)),
             'instruction_addr': to_hex_addr(trim(data.get('instruction_addr'), 16)),

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -127,6 +127,35 @@ class BasicResolvingIntegrationTest(TestCase):
                     "build": "13F69",
                     "name": "iOS"
                 }
+            },
+            "threads": {
+                "values": [
+                    {
+                        "id": 39,
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "in_app": False,
+                                    "platform": "apple",
+                                    "package": "\/usr\/lib\/system\/libsystem_pthread.dylib",
+                                    "symbol_addr": "0x00000001843a102c",
+                                    "image_addr": "0x00000001843a0000",
+                                    "instruction_addr": "0x00000001843a1530"
+                                },
+                                {
+                                    "in_app": False,
+                                    "platform": "apple",
+                                    "package": "\/usr\/lib\/system\/libsystem_kernel.dylib",
+                                    "symbol_addr": "0x00000001842d8b40",
+                                    "image_addr": "0x00000001842bc000",
+                                    "instruction_addr": "0x00000001842d8b48"
+                                }
+                            ]
+                        },
+                        "crashed": False,
+                        "current": False
+                    }
+                ]
             }
         }
 
@@ -159,6 +188,8 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[2].filename == '../../sentry/scripts/views.js'
         assert frames[2].instruction_offset is None
         assert frames[2].in_app
+
+        assert len(event.interfaces['threads'].values) == 1
 
     def sym_app_frame(self, frame):
         object_name = (


### PR DESCRIPTION
This is some future proofing to improve the wire protocol for
symbolicated setups in the future.  Right now it requires some
dummy data to be sent.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4010)

<!-- Reviewable:end -->
