### PR TITLE
Make sure we json encode our error response for release webhook

### DIFF
--- a/src/sentry/web/frontend/release_webhook.py
+++ b/src/sentry/web/frontend/release_webhook.py
@@ -64,7 +64,7 @@ class ReleaseWebhookView(View):
         except client.ApiError as exc:
             return HttpResponse(
                 status=exc.status_code,
-                content=exc.body,
+                content=json.dumps(exc.body),
                 content_type='application/json',
             )
         return HttpResponse(


### PR DESCRIPTION
Fixes GH-4008

@getsentry/infrastructure @getsentry/api

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4011)

<!-- Reviewable:end -->
