### PR TITLE
Don't kick to org create screen for super users if their activeorg isn't found

### DIFF
--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -66,7 +66,6 @@ class OrganizationMixin(object):
                 except Organization.DoesNotExist:
                     logger.info('Active organization [%s] not found',
                         organization_slug)
-                    return None
 
         if active_organization is None:
             organizations = Organization.objects.get_for_user(


### PR DESCRIPTION
Not even sure why this logic made sense, but it was an awkward
experience. Delete an organization while being a superuser, and you
don't get kicked back to another organization you're a part of. You were
left at the organization create page and had to url munge to get back to
somewhere sensible.

Note: this path is only hit for superusers. Normal users don't hit this awkward flow.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4012)

<!-- Reviewable:end -->
