### PR TITLE
Mark Group as PENDING_DELETION before queueing

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -637,7 +637,15 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         """
         group_ids = request.GET.getlist('id')
         if group_ids:
-            group_list = Group.objects.filter(project=project, id__in=group_ids)
+            group_list = list(Group.objects.filter(
+                project=project,
+                id__in=set(group_ids),
+            ).exclude(
+                status__in=[
+                    GroupStatus.PENDING_DELETION,
+                    GroupStatus.DELETION_IN_PROGRESS,
+                ]
+            ))
             # filter down group ids to only valid matches
             group_ids = [g.id for g in group_list]
         else:
@@ -647,7 +655,14 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         if not group_ids:
             return Response(status=204)
 
-        # TODO(dcramer): set status to pending deletion
+        Group.objects.filter(
+            id__in=group_ids,
+        ).exclude(
+            status__in=[
+                GroupStatus.PENDING_DELETION,
+                GroupStatus.DELETION_IN_PROGRESS,
+            ]
+        ).update(status=GroupStatus.PENDING_DELETION)
         for group in group_list:
             delete_group.apply_async(
                 kwargs={'object_id': group.id},


### PR DESCRIPTION
This is a side effect of GH-4009. By chanced, this was working because
we weren't actually deferring the tasks. And immediately in the task,
status gets set to PENDING_DELETION. But now that I fixed the glitch,
the status would take an hour to get set.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4019)

<!-- Reviewable:end -->
