### PR TITLE
Expand on feedback from more verbose deletion logging.

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -111,6 +111,9 @@ class Endpoint(APIView):
         )
 
         extra = {
+            'ip_address': entry.ip_address,
+            'organization_id': entry.organization_id,
+            'object_id': entry.target_object,
             'entry_id': entry.id,
             'actor_label': entry.actor_label
         }

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -189,7 +189,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             delete_logger.info('object.delete.queued', extra={
                 'object_id': organization.id,
                 'transaction_id': transaction_id,
-                'model': type(organization).__name__,
+                'model': Organization.__name__,
             })
 
         return Response(status=204)

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -16,9 +16,7 @@ from django.db.models import F
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.deletion import delete_group
 
-# TODO(dcramer): probably should have a new logger for this, but it removes data
-# so lets bundle under deletions
-logger = logging.getLogger('sentry.deletions.merge')
+logger = logging.getLogger('sentry.group.merge')
 
 
 @instrumented_task(name='sentry.tasks.merge.merge_group', queue='merge',
@@ -39,13 +37,17 @@ def merge_group(from_object_id=None, to_object_id=None, **kwargs):
     try:
         group = Group.objects.get(id=from_object_id)
     except Group.DoesNotExist:
-        logger.warn('merge_group.malformed.invalid_id', extra={'object_id': from_object_id})
+        logger.warn('merge_group.malformed.invalid_id', extra={
+            'old_object_id': from_object_id,
+        })
         return
 
     try:
         new_group = Group.objects.get(id=to_object_id)
     except Group.DoesNotExist:
-        logger.warn('merge_group.malformed.invalid_id', extra={'object_id': from_object_id})
+        logger.warn('merge_group.malformed.invalid_id', extra={
+            'old_object_id': from_object_id,
+        })
         return
 
     model_list = (
@@ -167,9 +169,10 @@ def merge_objects(models, group, new_group, limit=1000,
     has_more = False
     for model in models:
         if logger is not None:
-            logger.info('%s.merge' % model.__name__.lower(), extra={
+            logger.info('group.merge', extra={
                 'new_group_id': new_group.id,
                 'old_group_id': group.id,
+                'model': model.__name__,
             })
         all_fields = model._meta.get_all_field_names()
         has_group = 'group' in all_fields

--- a/src/sentry/web/frontend/remove_account.py
+++ b/src/sentry/web/frontend/remove_account.py
@@ -12,6 +12,8 @@ from sentry.models import (
 )
 from sentry.web.frontend.base import BaseView
 
+delete_logger = logging.getLogger('sentry.deletions.ui')
+
 
 class RemoveAccountForm(forms.Form):
     pass
@@ -51,7 +53,7 @@ class RemoveAccountView(BaseView):
                 if result['single_owner']:
                     orgs_to_remove.add(result['organization'].slug)
 
-            logging.getLogger('sentry.deletions.ui').info('user.deactivate', extra={
+            delete_logger.info('user.deactivate', extra={
                 'actor_id': request.user.id,
                 'ip_address': request.META['REMOTE_ADDR'],
             })

--- a/src/sentry/web/frontend/remove_organization.py
+++ b/src/sentry/web/frontend/remove_organization.py
@@ -8,13 +8,15 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import OrganizationStatus, Organization
+from sentry.models import AuditLogEntryEvent, OrganizationStatus, Organization
 from sentry.tasks.deletion import delete_organization
 from sentry.web.frontend.base import OrganizationView
 
 ERR_DEFAULT_ORG = _('You cannot remove the default organization.')
 
 MSG_REMOVE_SUCCESS = _('The %s organization has been scheduled for removal.')
+
+delete_logger = logging.getLogger('sentry.deletions.ui')
 
 
 class RemoveOrganizationForm(forms.Form):
@@ -39,20 +41,13 @@ class RemoveOrganizationView(OrganizationView):
 
         form = self.get_form(request, organization)
         if form.is_valid():
-            transaction_id = uuid4().hex
-            logging.getLogger('sentry.deletions.ui').info('organization.remove.queued', extra={
-                'organization_id': organization.id,
-                'organization_slug': organization.slug,
-                'actor_id': request.user.id,
-                'transaction_id': transaction_id,
-                'ip_address': request.META['REMOTE_ADDR'],
-            })
-
             updated = Organization.objects.filter(
                 id=organization.id,
                 status=OrganizationStatus.VISIBLE,
             ).update(status=OrganizationStatus.PENDING_DELETION)
             if updated:
+                transaction_id = uuid4().hex
+
                 delete_organization.apply_async(
                     kwargs={
                         'object_id': organization.id,
@@ -60,6 +55,21 @@ class RemoveOrganizationView(OrganizationView):
                     },
                     countdown=86400,
                 )
+
+                self.create_audit_entry(
+                    request=request,
+                    organization=organization,
+                    target_object=organization.id,
+                    event=AuditLogEntryEvent.ORG_REMOVE,
+                    data=organization.get_audit_log_data(),
+                    transaction_id=transaction_id,
+                )
+
+                delete_logger.info('object.delete.queued', extra={
+                    'object_id': organization.id,
+                    'transaction_id': transaction_id,
+                    'model': Organization.__name__,
+                })
 
             messages.add_message(request, messages.SUCCESS,
                 MSG_REMOVE_SUCCESS % (organization.name,))


### PR DESCRIPTION
@mattrobenolt: TLDR, frontload the auditable information into the audit log entry, log queued deletes after they've actually been queued, and make the events generic so that we can actually use correct patterns.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4022)

<!-- Reviewable:end -->
