### PR TITLE
Add issue type distribution chart to report emails.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -7,7 +7,6 @@ import operator
 import zlib
 from collections import namedtuple
 from datetime import timedelta
-from six.moves import reduce
 
 from django.utils import dateformat, timezone
 
@@ -15,14 +14,14 @@ from sentry import features
 from sentry.app import tsdb
 from sentry.models import (
     Activity, Group, GroupStatus, Organization, OrganizationStatus, Project,
-    Release, TagValue, Team, User, UserOption,
+    Release, TagValue, Team, User, UserOption
 )
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, redis
 from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
 from sentry.utils.email import MessageBuilder
 from sentry.utils.math import mean
-
+from six.moves import reduce
 
 date_format = functools.partial(
     dateformat.format,

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -669,9 +669,9 @@ def to_context(report, fetch_groups=None):
             'types': list(
                 zip(
                     (
-                        DistributionType('New Issues', '#ccc'),
-                        DistributionType('Reopened Issues', '#aaa'),
-                        DistributionType('Existing Issues', '#888'),
+                        DistributionType('New', '#c9c2e1'),
+                        DistributionType('Reopened', '#9990ab'),
+                        DistributionType('Existing', '#675f76'),
                     ),
                     map(
                         lambda value: IssueListSummary(*value),

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -11,7 +11,8 @@
     padding: 0;
     margin: 0;
     background-color: #fff;
-    color: #3D4649;
+    color: #342c3e;
+    -webkit-font-smoothing: antialiased;
   }
   .main {
     max-width: 700px;
@@ -26,7 +27,7 @@
     font-weight: 300;
   }
   a {
-    color: #15A7F6;
+    color: #5688bf;
     font-weight: 500;
     text-decoration: none;
   }
@@ -147,8 +148,8 @@
   }
 
   .info-box {
-    background-color: #FDFDFE;
-    border: 1px solid #D6DBE4;
+    background-color: #f7f5fa;
+    border: 1px solid #dbd3e9;
     border-radius: 3px;
     padding: 15px;
     text-align: center;
@@ -668,15 +669,12 @@
 
   .weekly-report .legend .all,
   .weekly-report .issue-graph-bar .all {
-    background-color: #D6DBE4;
+    background-color: #e9e6ec;
   }
 
   .weekly-report .legend .resolved,
   .weekly-report .issue-graph-bar .resolved {
-    background-color: #A290D1;
-  }
-  .weekly-report .issues-resolved {
-    margin-bottom: 30px;
+    background-color: #675f76;
   }
 
   .weekly-report .issues-resolved .issues-resolved-column {
@@ -718,6 +716,15 @@
     font-size: 0;
   }
 
+  .weekly-report .issue-breakdown {
+    border-bottom: 1px solid #D6DBE4;
+    margin-bottom: 30px;
+  }
+
+  .weekly-report .issue-breakdown table {
+    margin-bottom: 40px;
+  }
+
   .weekly-report .user-impact {}
 
   .weekly-report .user-impact-stat {
@@ -726,7 +733,7 @@
     vertical-align: middle;
     text-align: center;
     font-size: 32px;
-    color: #836CC2;
+    color: #675f76;
     background-size: 90px 90px;
     background-image: url("{% absolute_asset_url 'sentry' 'images/email/circle-bg.png' %}");
   }

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -87,31 +87,34 @@
     </tr>
   </table>
 
-  <table>
-    {% with report.distribution.totals as totals %}
+  <table class="issue-breakdown">
     <tr>
-      {% for type, value in report.distribution.types %}
-        <td width="{% widthratio value.events totals.events 100 %}%" title="{{ type.label }}: {{ value.events }}" style="background-color: {{ type.color }}">
-          &nbsp;
-        </td>
-      {% endfor %}
+      <td>
+        <h4>Issue Breakdown</h4>
+      </td>
+      <td class="legend">
+        {% with report.distribution.totals as totals %}
+          {% for type, value in report.distribution.types %}
+            <span class="box" style="background-color: {{ type.color }};"></span>{{ type.label }}: {% percent value.events totals.events "0.1f" %}%
+          {% endfor %}
+        {% endwith %}
+      </td>
     </tr>
-    {% endwith %}
-  </table>
-
-  <table>
-    {% with report.distribution.totals as totals %}
     <tr>
-      {% for type, value in report.distribution.types %}
-        <td>
-          <strong style="color: {{ type.color }}">{{ type.label }}</strong>
-          {% percent value.events totals.events "0.1f" %}%
-          <br/>
-          {{ value.events }} events in {{ value.groups }} issues
-        </td>
-      {% endfor %}
+      <td colspan="2">
+        <table>
+          {% with report.distribution.totals as totals %}
+          <tr>
+            {% for type, value in report.distribution.types %}
+              <td width="{% widthratio value.events totals.events 100 %}%" title="{{ type.label }}: {{ value.events }} events in {{ value.groups }} issues" style="background-color: {{ type.color }}">
+                &nbsp;
+              </td>
+            {% endfor %}
+          </tr>
+          {% endwith %}
+        </table>
+      </td>
     </tr>
-    {% endwith %}
   </table>
 
   <table class="issue-table">

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -87,6 +87,33 @@
     </tr>
   </table>
 
+  <table>
+    {% with report.distribution.totals as totals %}
+    <tr>
+      {% for type, value in report.distribution.types %}
+        <td width="{% widthratio value.events totals.events 100 %}%" title="{{ type.label }}: {{ value.events }}" style="background-color: {{ type.color }}">
+          &nbsp;
+        </td>
+      {% endfor %}
+    </tr>
+    {% endwith %}
+  </table>
+
+  <table>
+    {% with report.distribution.totals as totals %}
+    <tr>
+      {% for type, value in report.distribution.types %}
+        <td>
+          <strong style="color: {{ type.color }}">{{ type.label }}</strong>
+          {% percent value.events totals.events "0.1f" %}%
+          <br/>
+          {{ value.events }} events in {{ value.groups }} issues
+        </td>
+      {% endfor %}
+    </tr>
+    {% endwith %}
+  </table>
+
   <table class="issue-table">
     <thead>
       <tr>

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -87,35 +87,33 @@
     </tr>
   </table>
 
+  {% with report.distribution.total as total %}
   <table class="issue-breakdown">
     <tr>
       <td>
         <h4>Issue Breakdown</h4>
       </td>
       <td class="legend">
-        {% with report.distribution.totals as totals %}
-          {% for type, value in report.distribution.types %}
-            <span class="box" style="background-color: {{ type.color }};"></span>{{ type.label }}: {% percent value.events totals.events "0.1f" %}%
-          {% endfor %}
-        {% endwith %}
+        {% for type, count in report.distribution.types %}
+          <span class="box" style="background-color: {{ type.color }};"></span>{{ type.label }}: {% percent count total "0.1f" %}%
+        {% endfor %}
       </td>
     </tr>
     <tr>
       <td colspan="2">
         <table>
-          {% with report.distribution.totals as totals %}
           <tr>
-            {% for type, value in report.distribution.types %}
-              <td width="{% widthratio value.events totals.events 100 %}%" title="{{ type.label }}: {{ value.events }} events in {{ value.groups }} issues" style="background-color: {{ type.color }}">
+            {% for type, count in report.distribution.types %}
+              <td width="{% widthratio count total 100 %}%" title="{{ type.label }}: {{ count }} events" style="background-color: {{ type.color }}">
                 &nbsp;
               </td>
             {% endfor %}
           </tr>
-          {% endwith %}
         </table>
       </td>
     </tr>
   </table>
+  {% endwith %}
 
   <table class="issue-table">
     <thead>

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -321,10 +321,16 @@ def with_metadata(group_list, request):
 
 
 @register.simple_tag
-def percent(value, total):
+def percent(value, total, format=None):
     if not (value and total):
-        return 0
-    return int(int(value) / float(total) * 100)
+        result = 0
+    else:
+        result = int(value) / float(total) * 100
+
+    if format is None:
+        return int(result)
+    else:
+        return ('%%%s' % format) % result
 
 
 @register.filter

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -9,15 +9,11 @@ from __future__ import absolute_import
 
 import functools
 import os.path
-import pytz
-import six
-
 from collections import namedtuple
 from datetime import timedelta
-from pkg_resources import parse_version as Version
-from six.moves import range
-from six.moves.urllib.parse import quote, urlencode
 
+import pytz
+import six
 from django import template
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -26,25 +22,22 @@ from django.utils import timezone
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
+from pkg_resources import parse_version as Version
+from templatetag_sugar.parser import Constant, Name, Optional, Variable
+from templatetag_sugar.register import tag
 
 from sentry import options
 from sentry.api.serializers import serialize as serialize_func
-from sentry.models import UserAvatar, Organization
+from sentry.models import Organization, UserAvatar
 from sentry.utils import json
-from sentry.utils.strings import to_unicode
 from sentry.utils.avatar import (
-    get_gravatar_url,
-    get_email_avatar,
-    get_letter_avatar
+    get_email_avatar, get_gravatar_url, get_letter_avatar
 )
 from sentry.utils.javascript import to_json
-from sentry.utils.strings import (
-    soft_break as _soft_break,
-    soft_hyphenate,
-    truncatechars,
-)
-from templatetag_sugar.register import tag
-from templatetag_sugar.parser import Name, Variable, Constant, Optional
+from sentry.utils.strings import soft_break as _soft_break
+from sentry.utils.strings import soft_hyphenate, to_unicode, truncatechars
+from six.moves import range
+from six.moves.urllib.parse import quote, urlencode
 
 SentryVersion = namedtuple('SentryVersion', [
     'current', 'latest', 'update_available', 'build',

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -457,8 +457,17 @@ def report(request):
     release_id_generator = make_release_id_generator()
 
     def build_issue_list():
-        count = random.randint(0, int(random.paretovariate(0.4)))
-        return count, [(
+        summaries = []
+        for i in range(3):
+            issues = int(random.weibullvariate(10, 1))
+            summaries.append((
+                issues,
+                int(issues * random.paretovariate(0.5)),
+            ))
+
+        count = sum(s[1] for s in summaries)
+
+        return summaries, [(
             next(group_id_sequence),
             (
                 int(random.paretovariate(0.3)),

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -459,13 +459,9 @@ def report(request):
     def build_issue_list():
         summaries = []
         for i in range(3):
-            issues = int(random.weibullvariate(10, 1))
-            summaries.append((
-                issues,
-                int(issues * random.paretovariate(0.5)),
-            ))
-
-        count = sum(s[1] for s in summaries)
+            summaries.append(
+                int(random.weibullvariate(10, 1) * random.paretovariate(0.5))
+            )
 
         return summaries, [(
             next(group_id_sequence),
@@ -473,7 +469,7 @@ def report(request):
                 int(random.paretovariate(0.3)),
                 int(random.paretovariate(0.3)),
             ),
-        ) for _ in xrange(0, min(count, 5))]
+        ) for _ in xrange(0, random.randint(1, 5))]
 
     def build_release_list():
         return reports.trim_release_list([

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -2,47 +2,33 @@ from __future__ import absolute_import, print_function
 
 import itertools
 import logging
-import six
 import time
 import traceback
 import uuid
+from datetime import datetime, timedelta
+from random import Random
 
-from datetime import (
-    datetime,
-    timedelta,
-)
+import six
 from django.contrib.webdesign.lorem_ipsum import WORDS
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.generic import View
-from random import Random
 
 from sentry.constants import LOG_LEVELS
 from sentry.digests import Record
-from sentry.digests.notifications import (
-    Notification,
-    build_digest,
-)
+from sentry.digests.notifications import Notification, build_digest
 from sentry.digests.utilities import get_digest_metadata
 from sentry.http import get_server_hostname
 from sentry.models import (
-    Activity,
-    Event,
-    Group,
-    GroupStatus,
-    Organization,
-    OrganizationMember,
-    Project,
-    Release,
-    Rule,
-    Team,
+    Activity, Event, Group, GroupStatus, Organization, OrganizationMember,
+    Project, Release, Rule, Team
 )
 from sentry.plugins.sentry_mail.activity import emails
 from sentry.utils.dates import to_datetime, to_timestamp
-from sentry.utils.samples import load_data
 from sentry.utils.email import inline_css
 from sentry.utils.http import absolute_uri
+from sentry.utils.samples import load_data
 from sentry.web.decorators import login_required
 from sentry.web.helpers import render_to_response, render_to_string
 


### PR DESCRIPTION
![screenshot 2016-08-29 14 32 30](https://cloud.githubusercontent.com/assets/65315/18068141/c8c4c8b4-6df4-11e6-9841-30b419cce8f7.png)

This adds a chart that shows the distribution of new, reopened, and existing issues over the reporting interval.

This also include's some other assorted style changes from @ckj in addition to the chart styles (see screenshot.)

@getsentry/infrastructure 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4027)

<!-- Reviewable:end -->
