### PR TITLE
Pre-fill registration form email w/ invite email

### DIFF
--- a/src/sentry/web/frontend/accept_organization_invite.py
+++ b/src/sentry/web/frontend/accept_organization_invite.py
@@ -74,6 +74,7 @@ class AcceptOrganizationInviteView(BaseView):
             # Show login or register form
             request.session['_next'] = request.get_full_path()
             request.session['can_register'] = True
+            request.session['invite_email'] = om.email
 
             return self.respond('sentry/accept-organization-invite.html', context)
 

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -47,11 +47,11 @@ class AuthLoginView(BaseView):
             captcha=bool(request.session.get('needs_captcha')),
         )
 
-    def get_register_form(self, request):
+    def get_register_form(self, request, initial=None):
         op = request.POST.get('op')
         return RegistrationForm(
             request.POST if op == 'register' else None,
-            captcha=bool(request.session.get('needs_captcha')),
+            captcha=bool(request.session.get('needs_captcha')), initial=initial,
         )
 
     def handle_basic_auth(self, request):
@@ -66,7 +66,9 @@ class AuthLoginView(BaseView):
 
         login_form = self.get_login_form(request)
         if can_register:
-            register_form = self.get_register_form(request)
+            register_form = self.get_register_form(request, initial={
+                'username': request.session.get('invite_email', '')
+            })
         else:
             register_form = None
 
@@ -81,7 +83,7 @@ class AuthLoginView(BaseView):
 
             # can_register should only allow a single registration
             request.session.pop('can_register', None)
-
+            request.session.pop('invite_email', None)
             request.session.pop('needs_captcha', None)
 
             return self.redirect(auth.get_login_redirect(request))

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -84,3 +84,16 @@ class AuthLoginTest(TestCase):
 
         assert resp.status_code == 302
         assert resp['Location'] == 'http://testserver' + reverse('sentry-create-organization')
+
+    def test_register_prefills_invite_email(self):
+        self.session['invite_email'] = 'foo@example.com'
+        self.session['can_register'] = True
+        self.save_session()
+
+        register_path = reverse('sentry-register')
+        resp = self.client.get(register_path)
+
+        assert resp.status_code == 200
+        assert resp.context['op'] == 'register'
+        assert resp.context['register_form'].initial['username'] == 'foo@example.com'
+        self.assertTemplateUsed('sentry/login.html')


### PR DESCRIPTION
Small quality-of-life improvement for the user invitation flow – prefills the registration form with the email used in the invitation.

/cc @getsentry/team

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4032)

<!-- Reviewable:end -->
