### PR TITLE
Optionally leverage ujson for decoding initial store payloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install-python:
 	pip install "setuptools>=0.9.8"
 	# order matters here, base package must install first
 	pip install -e .
+	pip install ujson
 	pip install "file://`pwd`#egg=sentry[dev,dsym]"
 
 install-npm:

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -42,6 +42,16 @@ from sentry.utils.http import is_valid_ip
 from sentry.utils.strings import decompress
 from sentry.utils.validators import is_float, is_event_id
 
+try:
+    # Attempt to load ujson if it's installed.
+    # It's advantageous to leverage here because this is
+    # our primary data ingestion endpoint, and it's a
+    # simple win. ujson differs from simplejson a bunch
+    # so it's not worth utilizing it anywhere else.
+    import ujson as json  # noqa
+except ImportError:
+    from sentry.utils import json
+
 
 class APIError(Exception):
     http_status = 400


### PR DESCRIPTION
We can test this out on getsentry and see if it's a simple win. If so, we can commit to it and just make it a requirement.

This is just being done optionally so it's easy for us to swap it in and performance test it.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4035)

<!-- Reviewable:end -->
