### PR TITLE
Don't defer deletion of groups

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -331,7 +331,6 @@ class GroupDetailsEndpoint(GroupEndpoint):
         if updated:
             delete_group.apply_async(
                 kwargs={'object_id': group.id},
-                countdown=3600,
             )
 
         return Response(status=202)

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -666,7 +666,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         for group in group_list:
             delete_group.apply_async(
                 kwargs={'object_id': group.id},
-                countdown=3600,
             )
 
         return Response(status=204)


### PR DESCRIPTION
This leads to more confusion than it's worth, and nobody has ever needed
to revert this decision. Considering it never worked, let's just
explicitly not defer.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4036)

<!-- Reviewable:end -->
