### PR TITLE
Wait for all previous objects to be deleted before continuing

### DIFF
--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -48,6 +48,14 @@ def delete_organization(object_id, transaction_id=None, continuous=True, **kwarg
             )
         return
 
+    # Wait until all Teams have actually been deleted before continuing
+    if Team.objects.filter(organization=o).exists():
+        delete_organization.apply_async(
+            kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+            countdown=30,
+        )
+        return
+
     model_list = (OrganizationMember,)
 
     has_more = delete_objects(model_list, transaction_id=transaction_id, relation={'organization': o}, logger=logger)
@@ -58,6 +66,7 @@ def delete_organization(object_id, transaction_id=None, continuous=True, **kwarg
                 countdown=15,
             )
         return
+
     o_id = o.id
     o.delete()
     logger.info('object.delete.executed', extra={
@@ -94,6 +103,14 @@ def delete_team(object_id, transaction_id=None, continuous=True, **kwargs):
                 kwargs={'object_id': object_id, 'transaction_id': transaction_id},
                 countdown=15,
             )
+        return
+
+    # Wait until all Projects have actually been deleted before continuing
+    if Project.objects.filter(team=t).exists():
+        delete_team.apply_async(
+            kwargs={'object_id': object_id, 'transaction_id': transaction_id},
+            countdown=30,
+        )
         return
 
     t_id = t.id


### PR DESCRIPTION
Related to 373562702009df1692da6eb80a933139f29e094b

As a side effect of this previous commit, it's possible that the current
task now continues along before all of it's expected objects have
actually been removed. This leads to issues when it tries to delete the
Team/Organization which has dependent objects still remaining to be
deleted.

This just adds a check and a try again later to the task until all of
the previous tasks are actually finished.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4037)

<!-- Reviewable:end -->
