### PR TITLE
Guard against junk data being sent over the network

### DIFF
--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import six
 import mock
 
 from datetime import datetime
@@ -379,6 +380,17 @@ class SafelyLoadJSONStringTest(BaseAPITest):
     def test_unexpected_type(self):
         with self.assertRaises(APIError):
             self.helper.safely_load_json_string('1')
+
+
+class DecodeDataTest(BaseAPITest):
+    def test_valid_data(self):
+        data = self.helper.decode_data('foo')
+        assert data == u'foo'
+        assert type(data) == six.text_type
+
+    def test_invalid_data(self):
+        with self.assertRaises(APIError):
+            self.helper.decode_data('\x99')
 
 
 class GetInterfaceTest(TestCase):


### PR DESCRIPTION
After inspecting some of the errors we're getting, the data packets look
completely valid, except for junk bytes within the payload. We can only
assume that somewhere between the client and us, some bytes get messed
up. This just guards against it and sends back a potentially more useful
error instead of a 500.

@getsentry/infrastructure 

Fixes SENTRY-1VJ

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4051)

<!-- Reviewable:end -->
