### PR TITLE
Immediately delete GroupHash when deleting a group

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -13,9 +13,9 @@ from sentry.api.fields import UserField
 from sentry.api.serializers import serialize
 from sentry.constants import STATUS_CHOICES
 from sentry.models import (
-    Activity, Group, GroupAssignee, GroupSeen, GroupSubscription,
+    Activity, Group, GroupHash, GroupAssignee, GroupSeen, GroupSubscription,
     GroupSubscriptionReason, GroupStatus, GroupTagKey, GroupTagValue, Release,
-    User, UserReport
+    User, UserReport,
 )
 from sentry.plugins import IssueTrackingPlugin2, plugins
 from sentry.utils.safe import safe_execute
@@ -329,6 +329,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             ]
         ).update(status=GroupStatus.PENDING_DELETION)
         if updated:
+            GroupHash.objects.filter(group=group).delete()
             delete_group.apply_async(
                 kwargs={'object_id': group.id},
                 countdown=3600,

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -16,9 +16,9 @@ from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.db.models.query import create_or_update
 from sentry.models import (
-    Activity, EventMapping, Group, GroupBookmark, GroupResolution, GroupSeen,
+    Activity, EventMapping, Group, GroupHash, GroupBookmark, GroupResolution, GroupSeen,
     GroupSubscription, GroupSubscriptionReason, GroupSnooze, GroupStatus,
-    Release, TagKey
+    Release, TagKey,
 )
 from sentry.models.group import looks_like_short_id
 from sentry.search.utils import parse_query
@@ -663,6 +663,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                 GroupStatus.DELETION_IN_PROGRESS,
             ]
         ).update(status=GroupStatus.PENDING_DELETION)
+        GroupHash.objects.filter(group__id__in=group_ids).delete()
         for group in group_list:
             delete_group.apply_async(
                 kwargs={'object_id': group.id},

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.models import (
-    Activity, Group, GroupAssignee, GroupBookmark, GroupSeen, GroupSnooze,
+    Activity, Group, GroupHash, GroupAssignee, GroupBookmark, GroupSeen, GroupSnooze,
     GroupSubscription, GroupStatus, GroupTagValue, Release
 )
 from sentry.testutils import APITestCase
@@ -246,6 +246,24 @@ class GroupDeleteTest(APITestCase):
         self.login_as(user=self.user)
 
         group = self.create_group()
+        GroupHash.objects.create(
+            project=group.project,
+            hash='x' * 32,
+            group=group,
+        )
+
+        url = '/api/0/issues/{}/'.format(group.id)
+
+        response = self.client.delete(url, format='json')
+
+        assert response.status_code == 202, response.content
+
+        # Deletion was deferred, so it should still exist
+        assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
+        # BUT the hash should be gone
+        assert not GroupHash.objects.filter(group_id=group.id).exists()
+
+        Group.objects.filter(id=group.id).update(status=GroupStatus.UNRESOLVED)
 
         url = '/api/0/issues/{}/'.format(group.id)
 
@@ -254,5 +272,6 @@ class GroupDeleteTest(APITestCase):
 
         assert response.status_code == 202, response.content
 
-        group = Group.objects.filter(id=group.id).exists()
-        assert not group
+        # Now we killed everything with fire
+        assert not Group.objects.filter(id=group.id).exists()
+        assert not GroupHash.objects.filter(group_id=group.id).exists()


### PR DESCRIPTION
Since a group is deleted asynchrnously, new events will get grouped
together with the group that's hidden in it's pending deletion state.

Removing the GroupHash rows immediately means that new events can
regroup into a new group and resurface.

@getsentry/infrastructure 

The replaces GH-4036 as a better solution.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4056)

<!-- Reviewable:end -->
