### PR TITLE
Separate team name from project name on invite page

### DIFF
--- a/src/sentry/templates/sentry/accept-organization-invite.html
+++ b/src/sentry/templates/sentry/accept-organization-invite.html
@@ -23,7 +23,7 @@
         <ul>
           {% for project in project_list|slice:"5" %}
             <li>
-              {{ project.get_full_name }}
+              {{ project.team.name }} &#47; {{ project.name }}
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
/cc @getsentry/ui

---

Before:

![image](https://cloud.githubusercontent.com/assets/2153/18150346/f638cdf2-6f9a-11e6-9eb4-d299ed1867e7.png)

---

After:

![image](https://cloud.githubusercontent.com/assets/2153/18150341/ebfa6756-6f9a-11e6-8acc-82b46bea3f77.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4057)

<!-- Reviewable:end -->
