### PR TITLE
Update invite email text ...

### DIFF
--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -9,7 +9,7 @@
 
     <p><a href="{{ url }}" class="btn">Join your team</a></p>
 
-    <p>Check out our <a href="https://sentry.io/">website</a> if you'd like to learn more before diving in.</p>
+    <p>Check out the <a href="https://sentry.io/">Sentry website</a> if you'd like to learn more before diving in.</p>
 {% endblock %}
 
 {% block footer %}

--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -4,12 +4,12 @@
 {% load sentry_helpers %}
 
 {% block main %}
-    <h3>Welcome to Sentry</h3>
-    <p>Your teammates over at <strong>{{ organization.name }}</strong> have already been using Sentry without you, but the good news is that you've been invited to join them.</p>
+    <h3>You've been invited to Sentry</h3>
+    <p>Your teammates at <strong>{{ organization.name }}</strong> are using Sentry to track and debug software errors.</p>
 
     <p><a href="{{ url }}" class="btn">Join your team</a></p>
 
-    <p>If you'd like to learn more about Sentry before diving in head-first, check out our website, <a href="https://sentry.io/">sentry.io</a></p>
+    <p>Check out our <a href="https://sentry.io/">website</a> if you'd like to learn more before diving in.</p>
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
- Title no longer says "Welcome" (you haven't joined yet)
- Explains briefly what sentry does (track and debug software errors)
- Removes "the good news is...", felt a little presumptious
- Moves website link (cta) earlier
- More concise

With help from @cameronmcefee 

After:

![image](https://cloud.githubusercontent.com/assets/2153/18151109/4452db26-6fa1-11e6-9493-443af83ec31e.png)

Before:

![image](https://cloud.githubusercontent.com/assets/2153/18151064/c222e9e8-6fa0-11e6-9eca-100513e56d32.png)

/cc @getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4059)

<!-- Reviewable:end -->
