### PR TITLE
Make integrationdocs not utilize six

### DIFF
--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -3,19 +3,31 @@
 from __future__ import absolute_import
 
 import os
+import sys
 import json
 import logging
-import six
 
 import sentry
-
-from six.moves.urllib.request import urlopen
 
 BASE_URL = 'https://docs.sentry.io/hosted/_platforms/{}'
 
 # Also see INTEGRATION_DOC_FOLDER in setup.py
 DOC_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__),
                                           'integration-docs'))
+
+# We cannot leverage six here, so we need to vendor
+# bits that we need.
+if sys.version_info[0] == 3:
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    from urllib.request import urlopen
+
+else:
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)  # NOQA
+
+    from urllib2 import urlopen
 
 
 """
@@ -67,7 +79,7 @@ def sync_docs():
     body = urlopen(BASE_URL.format('_index.json')).read().decode('utf-8')
     data = json.loads(body)
     platform_list = []
-    for platform_id, integrations in six.iteritems(data['platforms']):
+    for platform_id, integrations in iteritems(data['platforms']):
         platform_list.append({
             'id': platform_id,
             'name': integrations['_self']['name'],
@@ -78,7 +90,7 @@ def sync_docs():
                     'type': i_data['type'],
                     'link': i_data['doc_link'],
                 } for i_id, i_data in sorted(
-                    six.iteritems(integrations),
+                    iteritems(integrations),
                     key=lambda x: x[1]['name']
                 )
             ],
@@ -88,8 +100,8 @@ def sync_docs():
 
     dump_doc('_platforms', {'platforms': platform_list})
 
-    for platform_id, platform_data in six.iteritems(data['platforms']):
-        for integration_id, integration in six.iteritems(platform_data):
+    for platform_id, platform_data in iteritems(data['platforms']):
+        for integration_id, integration in iteritems(platform_data):
             sync_integration_docs(platform_id, integration_id,
                                   integration['details'])
 


### PR DESCRIPTION
We can't import non-stdlib in this file. It needs to be imported during
setup.py

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4062)

<!-- Reviewable:end -->
