### PR TITLE
Protect ourselves against broken plugin urls

### DIFF
--- a/src/sentry/plugins/base/project_api_urls.py
+++ b/src/sentry/plugins/base/project_api_urls.py
@@ -1,17 +1,44 @@
 from __future__ import absolute_import
 
+import logging
 import re
 
+from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.conf.urls import patterns, include, url
 
 from sentry.plugins import plugins
 
+logger = logging.getLogger('sentry.plugins')
 
-urlpatterns = patterns('')
 
-for _plugin in plugins.all():
-    _plugin_project_urls = _plugin.get_project_urls()
-    if _plugin_project_urls:
-        urlpatterns.append(
-            url(r'^%s/' % re.escape(_plugin.slug), include(_plugin_project_urls))
-        )
+def load_plugin_urls(plugins):
+    urlpatterns = patterns('')
+
+    for _plugin in plugins:
+        try:
+            _plugin_project_urls = _plugin.get_project_urls()
+            # We're definitely allowed to not have any urls
+            if not _plugin_project_urls:
+                continue
+            # Once we have urls, we need to assert that the
+            # routes are the correct type. If not, once they
+            # are registered in Django, they will error very
+            # loudly later when trying to do url resolution.
+            for u in _plugin_project_urls:
+                if not isinstance(u, (RegexURLResolver, RegexURLPattern)):
+                    raise TypeError(
+                        'url must be RegexURLResolver or RegexURLPattern, not %r: %r' % (type(u).__name__, u)
+                    )
+        except Exception:
+            logger.exception('routes.failed', extra={
+                'plugin': type(_plugin).__name__,
+            })
+        else:
+            urlpatterns.append(
+                url(r'^%s/' % re.escape(_plugin.slug), include(_plugin_project_urls))
+            )
+
+    return urlpatterns
+
+
+urlpatterns = load_plugin_urls(plugins.all())

--- a/tests/sentry/plugins/base/test.py
+++ b/tests/sentry/plugins/base/test.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from django.conf.urls import url
+from sentry.plugins.base.project_api_urls import load_plugin_urls
 from sentry.plugins.base.response import JSONResponse
 
 
@@ -10,3 +12,39 @@ def test_json_response():
 def test_json_response_with_status_kwarg():
     resp = JSONResponse({}, status=400).respond(None)
     assert resp.status_code == 400
+
+
+def test_load_plugin_urls():
+    class BadPluginA(object):
+        def get_project_urls(self):
+            assert False
+
+    class BadPluginB(object):
+        def get_project_urls(self):
+            return 'lol'
+
+    class BadPluginC(object):
+        def get_project_urls(self):
+            return None
+
+    class BadPluginD(object):
+        def get_project_urls(self):
+            return [('foo', 'bar')]
+
+    class GoodPlugin(object):
+        slug = 'thing'
+
+        def get_project_urls(self):
+            return [
+                url('', None),
+            ]
+
+    patterns = load_plugin_urls((
+        BadPluginA(),
+        BadPluginB(),
+        BadPluginC(),
+        BadPluginD(),
+        GoodPlugin(),
+    ))
+
+    assert len(patterns) == 1


### PR DESCRIPTION
@getsentry/infrastructure @dcramer @macqueen 

This should prevent any mishap of a plugin returning garbage or raising an exception taking everything down.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4070)

<!-- Reviewable:end -->
