### PR TITLE
Environment names may have unicodes, so don't blow up

### DIFF
--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -32,7 +32,7 @@ class GroupRelease(Model):
     def get_cache_key(cls, group_id, release_id, environment):
         return 'grouprelease:1:{}:{}'.format(
             group_id,
-            md5_text('{}:{}'.format(release_id, environment)).hexdigest(),
+            md5_text(u'{}:{}'.format(release_id, environment)).hexdigest(),
         )
 
     @classmethod


### PR DESCRIPTION
Fixes SENTRY-1X6

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4075)

<!-- Reviewable:end -->
