### PR TITLE
Improve formatting of large percentage values in report email.

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -81,7 +81,9 @@
             {% else %}
                 <img src="{% absolute_asset_url 'sentry' 'images/email/arrow-decrease.png' %}" width="20px" height="10px">
             {% endif %}
-            {{ change|multiply:"100"|absolute_value|floatformat:"-1" }}%
+            {% with change|multiply:"100"|absolute_value as percentage %}
+                {% if percentage >= 1000 %}{{ percentage|floatformat:"0" }}{% else %}{{ percentage|floatformat:"-1" }}{% endif %}%
+            {% endwith %}
             </div>
             <small>{% if change >= 0 %}more{% else %}fewer{% endif %} events than {{ label }}</small>
           {% else %}
@@ -100,7 +102,7 @@
       </td>
       <td class="legend">
         {% for type, count in report.distribution.types %}
-          <span class="box" style="background-color: {{ type.color }};"></span>{{ type.label }}: {% percent count total "0.1f" %}%
+          <span class="box" style="background-color: {{ type.color }};"></span>{{ type.label }}: {% percent count total "0.0f" %}%
         {% endfor %}
       </td>
     </tr>


### PR DESCRIPTION
This makes the emails look better when displaying large percentage values.
## Before

![screenshot 2016-09-06 11 14 27](https://cloud.githubusercontent.com/assets/65315/18285256/66d0cbf6-7422-11e6-8237-ff232489d8d9.png)
## After

![screenshot 2016-09-06 11 13 27](https://cloud.githubusercontent.com/assets/65315/18285234/49583d52-7422-11e6-9f7d-3aa5902c81b0.png)

@ckj

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4082)

<!-- Reviewable:end -->
