### PR TITLE
Remove unused `organizations:new-tracebacks` flag.

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -12,7 +12,6 @@ default_manager.add('organizations:create')
 default_manager.add('organizations:sso', OrganizationFeature)  # NOQA
 default_manager.add('organizations:onboarding', OrganizationFeature)  # NOQA
 default_manager.add('organizations:callsigns', OrganizationFeature)  # NOQA
-default_manager.add('organizations:new-tracebacks', OrganizationFeature)  # NOQA
 default_manager.add('organizations:reports:prepare', OrganizationFeature)  # NOQA
 default_manager.add('organizations:reports:deliver', OrganizationFeature)  # NOQA
 default_manager.add('projects:global-events', ProjectFeature)  # NOQA


### PR DESCRIPTION
```
ted@estoque % git grep "new-tracebacks" | wc -l
       0
```

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4083)

<!-- Reviewable:end -->
