### PR TITLE
Remove `since` bounds parameter from `GroupEnvironmentDetailsEndpoint`.

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -21,6 +21,7 @@ from rest_framework.views import APIView
 from sentry.app import raven, tsdb
 from sentry.models import ApiKey, AuditLogEntry
 from sentry.utils.cursors import Cursor
+from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin
 
 from .authentication import ApiKeyAuthentication, TokenAuthentication
@@ -220,13 +221,13 @@ class StatsMixin(object):
 
         end = request.GET.get('until')
         if end:
-            end = datetime.fromtimestamp(float(end)).replace(tzinfo=utc)
+            end = to_datetime(float(end))
         else:
             end = datetime.utcnow().replace(tzinfo=utc)
 
         start = request.GET.get('since')
         if start:
-            start = datetime.fromtimestamp(float(start)).replace(tzinfo=utc)
+            start = to_datetime(float(start))
             assert start <= end, 'start must be before or equal to end'
         else:
             start = end - timedelta(days=1, seconds=-1)

--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -105,13 +105,11 @@ const GroupReleaseStats = React.createClass({
     let env = this.state.environment || 'none';
     let stats = this.props.group.stats['24h'];
 
-    let since = stats[0][0];
     // due to the current stats logic in Sentry we need to extend the bounds
     let until = stats[stats.length - 1][0] + 1;
 
     this.api.request(`/issues/${group.id}/environments/${env}/`, {
       query: {
-        since: since,
         until: until,
       },
       success: (data) => {


### PR DESCRIPTION
This causes `GroupEnvironmentWithStatsSerializer` and
`GroupReleaseWithStatsSerializer` to use the default `since` (and for
this scenario, intended) behavior which is to show the full available
duration for each statistics period.

This maintains the existing `until` parameter, so that all statistics
can be fixed to a common endpoint.

This fixes GH-4076.

@getsentry/api

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4087)

<!-- Reviewable:end -->
