### PR TITLE
When inviting new member, can set initial role + teams

### DIFF
--- a/src/sentry/templates/sentry/create-organization-member.html
+++ b/src/sentry/templates/sentry/create-organization-member.html
@@ -20,9 +20,12 @@
   <form class="form-stacked" action="" method="post">
     {% csrf_token %}
 
-    {% for field in form %}
-      {{ field|as_crispy_field }}
-    {% endfor %}
+    {{ form|as_crispy_errors }}
+
+    {{ form.email|as_crispy_field }}
+
+    {% include "sentry/partial/members/_roles.html" %}
+    {% include "sentry/partial/members/_teams.html" %}
 
     <div class="form-actions">
       <button type="submit" class="btn btn-primary">{% trans "Add Member" %}</button>

--- a/src/sentry/templates/sentry/create-organization-member.html
+++ b/src/sentry/templates/sentry/create-organization-member.html
@@ -22,7 +22,11 @@
 
     {{ form|as_crispy_errors }}
 
-    {{ form.email|as_crispy_field }}
+    {% if is_invite %}
+      {{ form.email|as_crispy_field }}
+    {% else %}
+      {{ form.user|as_crispy_field }}
+    {% endif %}
 
     {% include "sentry/partial/members/_roles.html" %}
     {% include "sentry/partial/members/_teams.html" %}

--- a/src/sentry/templates/sentry/organization-member-settings.html
+++ b/src/sentry/templates/sentry/organization-member-settings.html
@@ -78,48 +78,8 @@
       </div>
     </div>
 
-    <div class="box">
-      <div class="box-header">
-        <h3>{% trans "Role" %}</h3>
-      </div>
-      <div class="box-content with-padding">
-        <ul class="radio-inputs">
-          {% for role, allowed in role_list %}
-            <li class="radio">
-              <label>
-                <input type="radio" name="role" value="{{ role.id }}"
-                       {% if role.id == form.role.value %} checked{% endif %}
-                       {% if not allowed %} disabled="disabled"{% endif %}/>
-                {{ role.name }}
-                <div class="help-block">{{ role.desc|linebreaksbr }}</div>
-              </label>
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
-
-    <div class="box">
-      <div class="box-header">
-        <h3>{% trans "Teams" %}</h3>
-      </div>
-      <div class="box-content with-padding">
-        <fieldset class="team-choices row">
-          {% for team in all_teams %}
-            <div class="control-group col-md-4">
-              <div class="controls">
-                <label class="checkbox">
-                  <input type="checkbox" name="teams" value="{{ team.id }}"
-                         class="checkboxinput"{% if team.id in form.teams.value %} checked="checked"{% endif %}>
-                    {{ team.name }}
-                    <span class="team-slug">{{ team.slug }}</span>
-                  </label>
-              </div>
-            </div>
-          {% endfor %}
-        </fieldset>
-      </div>
-    </div>
+    {% include "sentry/partial/members/_roles.html" %}
+    {% include "sentry/partial/members/_teams.html" %}
 
     <div class="form-actions">
       <button type="submit" class="btn btn-primary">{% trans "Save Changes" %}</button>

--- a/src/sentry/templates/sentry/partial/members/_roles.html
+++ b/src/sentry/templates/sentry/partial/members/_roles.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+
+<div class="box">
+  <div class="box-header">
+    <h3>{% trans "Role" %}</h3>
+  </div>
+  <div class="box-content with-padding">
+    <ul class="radio-inputs">
+      {% for role, allowed in role_list %}
+        <li class="radio">
+          <label>
+            <input type="radio" name="role" value="{{ role.id }}"
+                   {% if role.id == form.role.value %} checked{% endif %}
+                   {% if not allowed %} disabled="disabled"{% endif %}/>
+            {{ role.name }}
+            <div class="help-block">{{ role.desc|linebreaksbr }}</div>
+          </label>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>

--- a/src/sentry/templates/sentry/partial/members/_teams.html
+++ b/src/sentry/templates/sentry/partial/members/_teams.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+
+<div class="box">
+  <div class="box-header">
+    <h3>{% trans "Teams" %}</h3>
+  </div>
+  <div class="box-content with-padding">
+    <fieldset class="team-choices row">
+      {% for team in all_teams %}
+        <div class="control-group col-md-4">
+          <div class="controls">
+            <label class="checkbox">
+              <input type="checkbox" name="teams" value="{{ team.id }}"
+                     class="checkboxinput"{% if team.id in form.teams.value %} checked="checked"{% endif %}>
+                {{ team.name }}
+                <span class="team-slug">{{ team.slug }}</span>
+              </label>
+          </div>
+        </div>
+      {% endfor %}
+    </fieldset>
+  </div>
+</div>

--- a/src/sentry/web/forms/add_organization_member.py
+++ b/src/sentry/web/forms/add_organization_member.py
@@ -1,44 +1,22 @@
 from __future__ import absolute_import
 
-from django import forms
 from django.db import transaction, IntegrityError
 
 from sentry.models import (
     AuditLogEntry,
     AuditLogEntryEvent,
     OrganizationMember,
-    OrganizationMemberTeam,
-    Team,
 )
 from sentry.web.forms.fields import UserField
+from sentry.web.forms.base_organization_member import BaseOrganizationMember
 
 
-class AddOrganizationMemberForm(forms.ModelForm):
+class AddOrganizationMemberForm(BaseOrganizationMember):
     user = UserField()
-
-    teams = forms.ModelMultipleChoiceField(
-        queryset=Team.objects.none(),
-        widget=forms.CheckboxSelectMultiple(),
-        required=False,
-    )
-    role = forms.ChoiceField()
 
     class Meta:
         fields = ('user',)
         model = OrganizationMember
-
-    def __init__(self, *args, **kwargs):
-        allowed_roles = kwargs.pop('allowed_roles')
-        all_teams = kwargs.pop('all_teams')
-
-        super(AddOrganizationMemberForm, self).__init__(*args, **kwargs)
-
-        self.fields['role'].choices = (
-            (r.id, r.name)
-            for r in allowed_roles
-        )
-
-        self.fields['teams'].queryset = all_teams
 
     def save(self, actor, organization, ip_address):
         om = super(AddOrganizationMemberForm, self).save(commit=False)
@@ -53,15 +31,7 @@ class AddOrganizationMemberForm(forms.ModelForm):
                     organization=organization,
                 ), False
 
-        for team in self.cleaned_data['teams']:
-            OrganizationMemberTeam.objects.create_or_update(
-                team=team,
-                organizationmember=om,
-            )
-
-        OrganizationMemberTeam.objects.filter(
-            organizationmember=om,
-        ).exclude(team__in=self.cleaned_data['teams']).delete()
+        self.save_team_assignments(om)
 
         AuditLogEntry.objects.create(
             organization=organization,

--- a/src/sentry/web/forms/add_organization_member.py
+++ b/src/sentry/web/forms/add_organization_member.py
@@ -8,10 +8,10 @@ from sentry.models import (
     OrganizationMember,
 )
 from sentry.web.forms.fields import UserField
-from sentry.web.forms.base_organization_member import BaseOrganizationMember
+from sentry.web.forms.base_organization_member import BaseOrganizationMemberForm
 
 
-class AddOrganizationMemberForm(BaseOrganizationMember):
+class AddOrganizationMemberForm(BaseOrganizationMemberForm):
     user = UserField()
 
     class Meta:

--- a/src/sentry/web/forms/base_organization_member.py
+++ b/src/sentry/web/forms/base_organization_member.py
@@ -9,7 +9,7 @@ from sentry.models import (
 )
 
 
-class BaseOrganizationMember(forms.ModelForm):
+class BaseOrganizationMemberForm(forms.ModelForm):
     """
     Base form used by AddOrganizationMemberForm, InviteOrganizationMemberForm,
     and EditOrganizationMemberForm
@@ -29,7 +29,7 @@ class BaseOrganizationMember(forms.ModelForm):
         allowed_roles = kwargs.pop('allowed_roles')
         all_teams = kwargs.pop('all_teams')
 
-        super(BaseOrganizationMember, self).__init__(*args, **kwargs)
+        super(BaseOrganizationMemberForm, self).__init__(*args, **kwargs)
 
         self.fields['role'].choices = (
             (r.id, r.name)

--- a/src/sentry/web/forms/base_organization_member.py
+++ b/src/sentry/web/forms/base_organization_member.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+
+from django import forms
+
+from sentry.models import (
+    OrganizationMember,
+    OrganizationMemberTeam,
+    Team,
+)
+
+
+class BaseOrganizationMember(forms.ModelForm):
+    """
+    Base form used by AddOrganizationMemberForm, InviteOrganizationMemberForm,
+    and EditOrganizationMemberForm
+    """
+    teams = forms.ModelMultipleChoiceField(
+        queryset=Team.objects.none(),
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+    )
+    role = forms.ChoiceField()
+
+    class Meta:
+        fields = ('role',)
+        model = OrganizationMember
+
+    def __init__(self, *args, **kwargs):
+        allowed_roles = kwargs.pop('allowed_roles')
+        all_teams = kwargs.pop('all_teams')
+
+        super(BaseOrganizationMember, self).__init__(*args, **kwargs)
+
+        self.fields['role'].choices = (
+            (r.id, r.name)
+            for r in allowed_roles
+        )
+
+        self.fields['teams'].queryset = all_teams
+
+    def save_team_assignments(self, organization_member):
+        for team in self.cleaned_data['teams']:
+            OrganizationMemberTeam.objects.create_or_update(
+                team=team,
+                organizationmember=organization_member,
+            )
+
+        OrganizationMemberTeam.objects.filter(
+            organizationmember=organization_member,
+        ).exclude(team__in=self.cleaned_data['teams']).delete()

--- a/src/sentry/web/forms/edit_organization_member.py
+++ b/src/sentry/web/forms/edit_organization_member.py
@@ -4,10 +4,10 @@ from sentry.models import (
     AuditLogEntry,
     AuditLogEntryEvent,
 )
-from sentry.web.forms.base_organization_member import BaseOrganizationMember
+from sentry.web.forms.base_organization_member import BaseOrganizationMemberForm
 
 
-class EditOrganizationMemberForm(BaseOrganizationMember):
+class EditOrganizationMemberForm(BaseOrganizationMemberForm):
     def save(self, actor, organization, ip_address=None):
         om = super(EditOrganizationMemberForm, self).save()
 

--- a/src/sentry/web/forms/edit_organization_member.py
+++ b/src/sentry/web/forms/edit_organization_member.py
@@ -1,50 +1,17 @@
 from __future__ import absolute_import
 
-from django import forms
-
 from sentry.models import (
-    AuditLogEntry, AuditLogEntryEvent, OrganizationMember,
-    OrganizationMemberTeam, Team
+    AuditLogEntry,
+    AuditLogEntryEvent,
 )
+from sentry.web.forms.base_organization_member import BaseOrganizationMember
 
 
-class EditOrganizationMemberForm(forms.ModelForm):
-    teams = forms.ModelMultipleChoiceField(
-        queryset=Team.objects.none(),
-        widget=forms.CheckboxSelectMultiple(),
-        required=False,
-    )
-    role = forms.ChoiceField()
-
-    class Meta:
-        fields = ('role',)
-        model = OrganizationMember
-
-    def __init__(self, *args, **kwargs):
-        allowed_roles = kwargs.pop('allowed_roles')
-        all_teams = kwargs.pop('all_teams')
-
-        super(EditOrganizationMemberForm, self).__init__(*args, **kwargs)
-
-        self.fields['role'].choices = (
-            (r.id, r.name)
-            for r in allowed_roles
-        )
-
-        self.fields['teams'].queryset = all_teams
-
+class EditOrganizationMemberForm(BaseOrganizationMember):
     def save(self, actor, organization, ip_address=None):
         om = super(EditOrganizationMemberForm, self).save()
 
-        for team in self.cleaned_data['teams']:
-            OrganizationMemberTeam.objects.create_or_update(
-                team=team,
-                organizationmember=om,
-            )
-
-        OrganizationMemberTeam.objects.filter(
-            organizationmember=om,
-        ).exclude(team__in=self.cleaned_data['teams']).delete()
+        self.save_team_assignments(om)
 
         AuditLogEntry.objects.create(
             organization=organization,

--- a/src/sentry/web/forms/invite_organization_member.py
+++ b/src/sentry/web/forms/invite_organization_member.py
@@ -9,10 +9,10 @@ from sentry.models import (
     OrganizationMember,
 )
 from sentry.signals import member_invited
-from sentry.web.forms.base_organization_member import BaseOrganizationMember
+from sentry.web.forms.base_organization_member import BaseOrganizationMemberForm
 
 
-class InviteOrganizationMemberForm(BaseOrganizationMember):
+class InviteOrganizationMemberForm(BaseOrganizationMemberForm):
     # override this to ensure the field is required
     email = forms.EmailField()
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -362,6 +362,7 @@ class OrganizationView(BaseView):
     def get_allowed_roles(self, request, organization, member=None):
         can_admin = request.access.has_scope('member:delete')
 
+        allowed_roles = []
         if can_admin and not request.is_superuser():
             acting_member = OrganizationMember.objects.get(
                 user=request.user,

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -13,6 +13,7 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.generic import View
 from sudo.views import redirect_to_sudo
 
+from sentry import roles
 from sentry.auth import access
 from sentry.models import (
     AuditLogEntry, Organization, OrganizationMember, OrganizationStatus, Project,
@@ -357,6 +358,26 @@ class OrganizationView(BaseView):
         kwargs['organization'] = active_organization
 
         return (args, kwargs)
+
+    def get_allowed_roles(self, request, organization, member=None):
+        can_admin = request.access.has_scope('member:delete')
+
+        if can_admin and not request.is_superuser():
+            acting_member = OrganizationMember.objects.get(
+                user=request.user,
+                organization=organization,
+            )
+            if member and roles.get(acting_member.role).priority < roles.get(member.role).priority:
+                can_admin = False
+            else:
+                allowed_roles = [
+                    r for r in roles.get_all()
+                    if r.priority <= roles.get(acting_member.role).priority
+                ]
+                can_admin = bool(allowed_roles)
+        elif request.is_superuser():
+            allowed_roles = roles.get_all()
+        return (can_admin, allowed_roles,)
 
 
 class TeamView(OrganizationView):

--- a/src/sentry/web/frontend/create_organization_member.py
+++ b/src/sentry/web/frontend/create_organization_member.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import roles
-from sentry.models import Team
+from sentry.models import Team, TeamStatus
 from sentry.signals import member_invited
 from sentry.web.frontend.base import OrganizationView
 from sentry.web.forms.invite_organization_member import InviteOrganizationMemberForm
@@ -40,9 +40,9 @@ class CreateOrganizationMemberView(OrganizationView):
 
         all_teams = Team.objects.filter(
             organization=organization,
+            status=TeamStatus.VISIBLE
         )
 
-        # TODO if not can admim
         form = self.get_form(request, organization, all_teams, allowed_roles)
         if form.is_valid():
             om, created = form.save(request.user, organization, request.META['REMOTE_ADDR'])

--- a/src/sentry/web/frontend/create_organization_member.py
+++ b/src/sentry/web/frontend/create_organization_member.py
@@ -43,7 +43,6 @@ class CreateOrganizationMemberView(OrganizationView):
         )
 
         # TODO if not can admim
-
         form = self.get_form(request, organization, all_teams, allowed_roles)
         if form.is_valid():
             om, created = form.save(request.user, organization, request.META['REMOTE_ADDR'])

--- a/src/sentry/web/frontend/organization_member_settings.py
+++ b/src/sentry/web/frontend/organization_member_settings.py
@@ -76,23 +76,7 @@ class OrganizationMemberSettingsView(OrganizationView):
         elif request.POST.get('op') == 'regenerate' and member.is_pending:
             return self.resend_invite(request, organization, member, regen=True)
 
-        can_admin = request.access.has_scope('member:delete')
-
-        if can_admin and not request.is_superuser():
-            acting_member = OrganizationMember.objects.get(
-                user=request.user,
-                organization=organization,
-            )
-            if roles.get(acting_member.role).priority < roles.get(member.role).priority:
-                can_admin = False
-            else:
-                allowed_roles = [
-                    r for r in roles.get_all()
-                    if r.priority <= roles.get(acting_member.role).priority
-                ]
-                can_admin = bool(allowed_roles)
-        elif request.is_superuser():
-            allowed_roles = roles.get_all()
+        can_admin, allowed_roles = self.get_allowed_roles(request, organization, member)
 
         if member.user == request.user or not can_admin:
             return self.view_member(request, organization, member)

--- a/src/sentry/web/frontend/organization_member_settings.py
+++ b/src/sentry/web/frontend/organization_member_settings.py
@@ -54,10 +54,7 @@ class OrganizationMemberSettingsView(OrganizationView):
         context = {
             'member': member,
             'enabled_teams': set(member.teams.all()),
-            'all_teams': Team.objects.filter(
-                organization=organization,
-                status=TeamStatus.VISIBLE
-            ),
+            'all_teams': all_teams,
             'role_list': roles.get_all(),
         }
 

--- a/tests/acceptance/test_create_organization_member.py
+++ b/tests/acceptance/test_create_organization_member.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+from sentry.testutils import AcceptanceTestCase
+
+
+class CreateOrganizationMemberTest(AcceptanceTestCase):
+    def setUp(self):
+        super(CreateOrganizationMemberTest, self).setUp()
+        self.user = self.create_user('foo@example.com')
+        self.org = self.create_organization(
+            name='Rowdy Tiger',
+            owner=None,
+        )
+        self.team = self.create_team(
+            organization=self.org,
+            name='Mariachi Band'
+        )
+        self.create_member(
+            user=self.user,
+            organization=self.org,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+
+    def test_invite(self):
+        """
+        Add by username (on-premises / by configuration only)
+        """
+        self.browser.get('/organizations/{}/members/new'.format(self.org.slug))
+        self.browser.snapshot(name='invite organization member')


### PR DESCRIPTION
Before you could only _adjust_ a user's role / team membership **after** they had already been invited – which often resulted in new members being added with no initial teams being assigned. 

This can lead to a confusing experience when first using Sentry, since no teams means no projects means no errors to browse.

/cc @getsentry/team @dcramer

Before:

![image](https://cloud.githubusercontent.com/assets/2153/18296431/7b084d1a-745e-11e6-915d-2ecab2e98697.png)

After:

![image](https://cloud.githubusercontent.com/assets/2153/18296417/685c75d8-745e-11e6-888b-c7c49e980dfd.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4089)

<!-- Reviewable:end -->
