### PR TITLE
Fix behavior of `GroupTagKey.values_seen` counter merging.

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -204,7 +204,12 @@ def merge_objects(models, group, new_group, limit=1000,
                             model.objects.filter(
                                 group=new_group,
                                 key=obj.key,
-                            ).update(values_seen=F('values_seen') + obj.values_seen)
+                            ).update(
+                                values_seen=GroupTagValue.objects.filter(
+                                    group=new_group,
+                                    key=obj.key,
+                                ).count()
+                            )
                     elif model == GroupTagValue:
                         with transaction.atomic(using=router.db_for_write(model)):
                             model.objects.filter(

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from collections import defaultdict
+
 from sentry.tasks.merge import merge_group, rehash_group_events
 from sentry.models import Event, Group, GroupMeta, GroupRedirect, GroupTagKey, GroupTagValue
 from sentry.testutils import TestCase
@@ -53,58 +55,82 @@ class MergeGroupTest(TestCase):
 
     def test_merge_updates_tag_values_seen(self):
         project = self.create_project()
-        groups = [self.create_group(project) for _ in range(0, 2)]
+        target, other = [self.create_group(project) for _ in range(0, 2)]
 
-        for group in groups:
-            GroupTagKey.objects.create(
+        data = {
+            'sentry:user': {
+                'id:1': {
+                    target: 2,
+                },
+                'id:2': {
+                    other: 3,
+                },
+                'id:3': {
+                    target: 1,
+                    other: 2,
+                },
+            },
+            'key': {
+                'foo': {
+                    other: 3,
+                },
+            },
+        }
+
+        input_group_tag_keys = defaultdict(int)    # [(group, key)] = values_seen
+        input_group_tag_values = defaultdict(int)  # [(group, key, value)] = times_seen
+        output_group_tag_keys = defaultdict(int)    # [key] = values_seen
+        output_group_tag_values = defaultdict(int)  # [(key, value)] = times_seen
+
+        for key, values in data.items():
+            output_group_tag_keys[key] = len(values)
+
+            for value, groups in values.items():
+                for group, count in groups.items():
+                    input_group_tag_keys[(group, key)] += 1
+                    input_group_tag_values[(group, key, value)] += count
+                    output_group_tag_values[(key, value)] += count
+
+        GroupTagKey.objects.bulk_create([
+            GroupTagKey(
                 project=project,
                 group=group,
-                key='sentry:user',
-                values_seen=1,
-            )
-            GroupTagKey.objects.create(
+                key=key,
+                values_seen=values_seen,
+            ) for ((group, key), values_seen) in input_group_tag_keys.items()
+        ])
+
+        GroupTagValue.objects.bulk_create([
+            GroupTagValue(
                 project=project,
                 group=group,
-                key='foo',
-                values_seen=5,
-            )
-            GroupTagValue.objects.create(
-                project=project,
-                group=group,
-                key='key1',
-                times_seen=1,
-            )
-            GroupTagValue.objects.create(
-                project=project,
-                group=group,
-                key='key2',
-                times_seen=5,
-            )
+                key=key,
+                value=value,
+                times_seen=times_seen,
+            ) for ((group, key, value), times_seen) in input_group_tag_values.items()
+        ])
 
         with self.tasks():
-            merge_group(groups[0].id, groups[1].id)
+            merge_group(other.id, target.id)
 
-        assert not Group.objects.filter(id=groups[0].id).exists()
-        assert not GroupTagKey.objects.filter(group_id=groups[0].id).exists()
-        assert not GroupTagValue.objects.filter(group_id=groups[0].id).exists()
+        assert not Group.objects.filter(id=other.id).exists()
+        assert not GroupTagKey.objects.filter(group_id=other.id).exists()
+        assert not GroupTagValue.objects.filter(group_id=other.id).exists()
 
-        assert GroupTagKey.objects.get(
-            group_id=groups[1].id,
-            key='sentry:user',
-        ).values_seen == 2
-        assert GroupTagKey.objects.get(
-            group_id=groups[1].id,
-            key='foo',
-        ).values_seen == 10
+        for key, values_seen in output_group_tag_keys.items():
+            assert GroupTagKey.objects.get(
+                project=project,
+                group=target,
+                key=key
+            ).values_seen == values_seen
 
-        assert GroupTagValue.objects.get(
-            group_id=groups[1].id,
-            key='key1',
-        ).times_seen == 2
-        assert GroupTagValue.objects.get(
-            group_id=groups[1].id,
-            key='key2',
-        ).times_seen == 10
+        for (key, value), times_seen in output_group_tag_values.items():
+            assert GroupTagValue.objects.get(
+                project=project,
+                group=target,
+                key=key,
+                value=value,
+            ).times_seen == times_seen
 
     def test_merge_with_group_meta(self):
         project1 = self.create_project()


### PR DESCRIPTION
This includes a rewritten test that ensures the value of `GroupTagKey.values_seen` is correctly derived from the source data.

Basically, this was adding together two set cardinalities, rather than unioning the sets and taking the cardinality of that union.

Fixes GH-3883.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4092)

<!-- Reviewable:end -->
