### PR TITLE
Fix off by one in release + environment graphs.

### DIFF
--- a/src/sentry/api/serializers/models/environment.py
+++ b/src/sentry/api/serializers/models/environment.py
@@ -44,7 +44,7 @@ class GroupEnvironmentWithStatsSerializer(EnvironmentSerializer):
 
         for key, (segments, interval) in six.iteritems(self.STATS_PERIODS):
             until = self.until or timezone.now()
-            since = self.since or until - ((segments - 1) * interval)
+            since = self.since or until - (segments * interval)
 
             try:
                 stats = tsdb.get_frequency_series(

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -61,7 +61,7 @@ class GroupReleaseWithStatsSerializer(GroupReleaseSerializer):
 
         for key, (segments, interval) in six.iteritems(self.STATS_PERIODS):
             until = self.until or timezone.now()
-            since = self.since or until - ((segments - 1) * interval)
+            since = self.since or until - (segments * interval)
 
             try:
                 stats = tsdb.get_frequency_series(


### PR DESCRIPTION
This is related to original issue in GH-4076 and was made observable by
the "almost flawless" GH-4087.

The 30 day graph returned by the issue details endpoint returns 31 days,
and the 24 day graph returns 25 days. This makes the
`GroupEnvironmentWithStatsSerializer` and
`GroupReleaseWithStatsSerializer` respect that behavior as well, so the
two graphs can be zipped together properly.

@getsentry/infrastructure @mattrobenolt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4102)

<!-- Reviewable:end -->
