### PR TITLE
After adding user, redirect to org members page

### DIFF
--- a/src/sentry/web/frontend/create_organization_member.py
+++ b/src/sentry/web/frontend/create_organization_member.py
@@ -47,15 +47,16 @@ class CreateOrganizationMemberView(OrganizationView):
         if form.is_valid():
             om, created = form.save(request.user, organization, request.META['REMOTE_ADDR'])
 
+            user_email = form.cleaned_data['email']
             if created:
                 messages.add_message(request, messages.SUCCESS,
-                    _('The organization member was added.'))
+                    _('The organization member %s was added.') % user_email)
 
                 member_invited.send(member=om, user=request.user, sender=self)
 
             else:
                 messages.add_message(request, messages.INFO,
-                    _('The organization member already exists.'))
+                    _('The organization member %s already exists.') % user_email)
 
             redirect = reverse('sentry-organization-members', args=[organization.slug])
 

--- a/src/sentry/web/frontend/create_organization_member.py
+++ b/src/sentry/web/frontend/create_organization_member.py
@@ -57,8 +57,7 @@ class CreateOrganizationMemberView(OrganizationView):
                 messages.add_message(request, messages.INFO,
                     _('The organization member already exists.'))
 
-            redirect = reverse('sentry-organization-member-settings',
-                               args=[organization.slug, om.id])
+            redirect = reverse('sentry-organization-members', args=[organization.slug])
 
             return HttpResponseRedirect(redirect)
 

--- a/src/sentry/web/frontend/create_organization_member.py
+++ b/src/sentry/web/frontend/create_organization_member.py
@@ -47,16 +47,19 @@ class CreateOrganizationMemberView(OrganizationView):
         if form.is_valid():
             om, created = form.save(request.user, organization, request.META['REMOTE_ADDR'])
 
-            user_email = form.cleaned_data['email']
+            user_display = form.cleaned_data.get('email', None)
+            if not user_display:
+                user_display = form.cleaned_data['user']
+
             if created:
                 messages.add_message(request, messages.SUCCESS,
-                    _('The organization member %s was added.') % user_email)
+                    _('The organization member %s was added.') % user_display)
 
                 member_invited.send(member=om, user=request.user, sender=self)
 
             else:
                 messages.add_message(request, messages.INFO,
-                    _('The organization member %s already exists.') % user_email)
+                    _('The organization member %s already exists.') % user_display)
 
             redirect = reverse('sentry-organization-members', args=[organization.slug])
 

--- a/tests/sentry/web/frontend/test_create_organization_member.py
+++ b/tests/sentry/web/frontend/test_create_organization_member.py
@@ -63,7 +63,7 @@ class CreateOrganizationMemberTest(TestCase):
         assert len(om_teams) == 1
         assert om_teams[0].team_id == team.id
 
-        redirect_uri = reverse('sentry-organization-member-settings', args=[organization.slug, member.id])
+        redirect_uri = reverse('sentry-organization-members', args=[organization.slug])
         assert resp['Location'] == 'http://testserver' + redirect_uri
 
         assert len(mail.outbox) == 1
@@ -96,7 +96,7 @@ class CreateOrganizationMemberTest(TestCase):
         assert member.email is None
         assert member.role == 'member'
 
-        redirect_uri = reverse('sentry-organization-member-settings', args=[organization.slug, member.id])
+        redirect_uri = reverse('sentry-organization-members', args=[organization.slug])
         assert resp['Location'] == 'http://testserver' + redirect_uri
 
     def test_valid_for_direct_add(self):
@@ -120,7 +120,7 @@ class CreateOrganizationMemberTest(TestCase):
 
         assert member.email is None
 
-        redirect_uri = reverse('sentry-organization-member-settings', args=[organization.slug, member.id])
+        redirect_uri = reverse('sentry-organization-members', args=[organization.slug])
         assert resp['Location'] == 'http://testserver' + redirect_uri
 
     def test_invalid_user_for_direct_add(self):


### PR DESCRIPTION
Now that we let users set role + permission before invitation, there's no need to send them directly to the member details page.

Instead they are redirected back to the org members page, where they can add another member, or go somewhere else via the sidebar. The alert message has also been modified to clearly indicate who they just invited (or attempted to invite).

After inviting a user:

![image](https://cloud.githubusercontent.com/assets/2153/18370984/dd1dc948-75e5-11e6-94ee-c1de2356cd37.png)

/cc @getsentry/ui 💚 @mattrobenolt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4104)

<!-- Reviewable:end -->
