### PR TITLE
Add gettext and trans tags to feedback form

### DIFF
--- a/src/sentry/templates/sentry/error-page-embed.html
+++ b/src/sentry/templates/sentry/error-page-embed.html
@@ -255,7 +255,7 @@
 <div class="sentry-error-embed clearfix">
   <header>
     <h2>{% trans "It looks like we're having <span class=\"hide-tiny\">some internal</span> issues." %}</h2>
-    <p><span class="hide-tiny">{% trans "Our team has been notified. %}</span> {% trans "If you'd like to help, tell us what happened below. %}</p>
+    <p><span class="hide-tiny">{% trans "Our team has been notified." %}</span> {% trans "If you'd like to help, tell us what happened below." %}</p>
   </header>
   <form>
     <div class="error-wrapper"></div>

--- a/src/sentry/templates/sentry/error-page-embed.html
+++ b/src/sentry/templates/sentry/error-page-embed.html
@@ -252,31 +252,31 @@
 
 <div class="sentry-error-embed clearfix">
   <header>
-    <h2>It looks like we're having <span class="hide-tiny">some internal</span> issues.</h2>
-    <p><span class="hide-tiny">Our team has been notified.</span> If you'd like to help, tell us what happened below.</p>
+    <h2>{% trans "It looks like we're having <span class=\"hide-tiny\">some internal</span> issues." %}</h2>
+    <p><span class="hide-tiny">{% trans "Our team has been notified. %}</span> {% trans "If you'd like to help, tell us what happened below. %}</p>
   </header>
   <form>
     <div class="error-wrapper"></div>
     <div class="form-content">
       <div class="form-field clearfix">
-        <label>Name</label>
+        <label>{% trans "Name" %}</label>
         {{ form.name }}
       </div>
       <div class="form-field clearfix">
-        <label>Email</label>
+        <label>{% trans "Email" %}</label>
         {{ form.email }}
       </div>
       <div class="form-field clearfix">
-        <label>What happened?</label>
+        <label>{% trans "What happened?" %}</label>
         {{ form.comments }}
       </div>
     </div>
     <div class="form-submit clearfix">
-      <button type="submit" class="btn">Submit Crash Report</button>
-      <a class="close">Close</a>
+      <button type="submit" class="btn">{% trans "Submit Crash Report" %}</button>
+      <a class="close">{% trans "Close" %}</a>
       {% if show_branding %}
       <p class="powered-by">
-        Crash reports powered by <a href="https://sentry.io">Sentry</a>
+        {% trans "Crash reports powered by <a href=\"https://sentry.io\">Sentry</a>" %}
       </p>
       {% endif %}
     </div>

--- a/src/sentry/templates/sentry/error-page-embed.html
+++ b/src/sentry/templates/sentry/error-page-embed.html
@@ -1,3 +1,5 @@
+{% load i18n %}
+
 <style>
 /** Wrapper class name is provided by JS **/
 .sentry-error-embed-wrapper {

--- a/src/sentry/templates/sentry/error-page-embed.js
+++ b/src/sentry/templates/sentry/error-page-embed.js
@@ -13,8 +13,8 @@
     };
    */
 
-  var GENERIC_ERROR = '<p class="message-error">An unknown error occurred while submitting your report. Please try again.</p>';
-  var FORM_ERROR = '<p class="message-error">Some fields were invalid. Please correct the errors and try again.</p>';
+  var GENERIC_ERROR = '<p class="message-error">' + gettext('An unknown error occurred while submitting your report. Please try again.') + '</p>';
+  var FORM_ERROR = '<p class="message-error">' + gettext('Some fields were invalid. Please correct the errors and try again.') + '</p>';
 
   // XMLHttpRequest.DONE does not exist in all browsers
   var XHR_DONE = 4;
@@ -128,7 +128,7 @@
 
   SentryErrorEmbed.prototype.onSuccess = function() {
     this._errorWrapper.innerHTML = '';
-    this._formContent.innerHTML = '<p class="message-success">Your feedback has been sent. Thank you!</p>';
+    this._formContent.innerHTML = '<p class="message-success">' + gettext('Your feedback has been sent. Thank you!') + '</p>';
     this._submitBtn.parentNode.removeChild(this._submitBtn);
   };
 

--- a/src/sentry/templates/sentry/error-page-embed.js
+++ b/src/sentry/templates/sentry/error-page-embed.js
@@ -13,8 +13,8 @@
     };
    */
 
-  var GENERIC_ERROR = '<p class="message-error">' + gettext('An unknown error occurred while submitting your report. Please try again.') + '</p>';
-  var FORM_ERROR = '<p class="message-error">' + gettext('Some fields were invalid. Please correct the errors and try again.') + '</p>';
+  var GENERIC_ERROR = '<p class="message-error">{{ errors.generic }}</p>';
+  var FORM_ERROR = '<p class="message-error">{{ errors.form }}</p>';
 
   // XMLHttpRequest.DONE does not exist in all browsers
   var XHR_DONE = 4;
@@ -128,7 +128,7 @@
 
   SentryErrorEmbed.prototype.onSuccess = function() {
     this._errorWrapper.innerHTML = '';
-    this._formContent.innerHTML = '<p class="message-success">' + gettext('Your feedback has been sent. Thank you!') + '</p>';
+    this._formContent.innerHTML = '<p class="message-success">{{ messages.sent }}</p>';
     this._submitBtn.parentNode.removeChild(this._submitBtn);
   };
 

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -7,6 +7,7 @@ from django.views.generic import View
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.models import (
@@ -17,17 +18,21 @@ from sentry.utils import json
 from sentry.utils.http import is_valid_origin
 from sentry.utils.validators import is_event_id
 
+GENERIC_ERROR = _('An unknown error occurred while submitting your report. Please try again.')
+FORM_ERROR = _('Some fields were invalid. Please correct the errors and try again.')
+SENT_MESSAGE = ('Your feedback has been sent. Thank you!')
+
 
 class UserReportForm(forms.ModelForm):
     name = forms.CharField(max_length=128, widget=forms.TextInput(attrs={
-        'placeholder': 'Jane Doe',
+        'placeholder': _('Jane Doe'),
     }))
     email = forms.EmailField(max_length=75, widget=forms.TextInput(attrs={
-        'placeholder': 'jane@example.com',
+        'placeholder': _('jane@example.com'),
         'type': 'email',
     }))
     comments = forms.CharField(widget=forms.Textarea(attrs={
-        'placeholder': "I clicked on 'X' and then hit 'Confirm'",
+        'placeholder': _("I clicked on 'X' and then hit 'Confirm'"),
     }))
 
     class Meta:
@@ -152,6 +157,13 @@ class ErrorPageEmbedView(View):
         context = {
             'endpoint': mark_safe('*/' + json.dumps(request.build_absolute_uri()) + ';/*'),
             'template': mark_safe('*/' + json.dumps(template) + ';/*'),
+            'errors': {
+                'generic': GENERIC_ERROR,
+                'form': FORM_ERROR
+            },
+            'messages': {
+                'sent': SENT_MESSAGE
+            }
         }
 
         return render_to_response('sentry/error-page-embed.js', context, request,


### PR DESCRIPTION
A premature PR but following from the discussion started here: https://forum.sentry.io/t/localising-the-feedback-form/81

This might well just work as is, but I seem to remember we need some extra steps to get django to  generate a catalog of translation strings that javascript can use. Using makemessages that means generating a separate one with `-d djangojs` as an argument. Not completely sure how to test this, any tips welcome.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4106)

<!-- Reviewable:end -->
