### PR TITLE
Give AUTH_PROVIDERS to security page template

### DIFF
--- a/src/sentry/web/frontend/account_security.py
+++ b/src/sentry/web/frontend/account_security.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.models import Authenticator
+from sentry.utils.auth import get_auth_providers
 from sentry.web.frontend.base import BaseView
 
 
@@ -9,4 +10,5 @@ class AccountSecurityView(BaseView):
         return self.respond('sentry/account/security.html', {
             'page': 'security',
             'has_2fa': Authenticator.objects.user_has_2fa(request.user),
+            'AUTH_PROVIDERS': get_auth_providers(),
         })


### PR DESCRIPTION
Without this, the "Identities" tab fails to render.

@getsentry/infrastructure 

This logic happens in the base template: https://github.com/getsentry/sentry/blob/master/src/sentry/templates/sentry/bases/account.html#L26

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4107)

<!-- Reviewable:end -->
