### PR TITLE
Add rule_id to notifications and move logging statement to universal method.

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -59,11 +59,6 @@ class NotificationPlugin(Plugin):
         return 'notification'
 
     def notify(self, notification):
-        self.logger.info('notification.dispatched', extra={
-            'event_id': notification.event.id,
-            'plugin': self.slug,
-            'rule_ids': [rule.id for rule in notification.rules],
-        })
         event = notification.event
         return self.notify_users(event.group, event)
 
@@ -97,6 +92,11 @@ class NotificationPlugin(Plugin):
                 rules=rules,
             )
             self.notify(notification)
+            self.logger.info('notification.dispatched', extra={
+                'event_id': event.id,
+                'plugin': self.slug,
+                'rule_id': rules[0] if any(rules) else None,
+            })
 
     def notify_users(self, group, event, fail_silently=False):
         raise NotImplementedError

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -95,7 +95,7 @@ class NotificationPlugin(Plugin):
             self.logger.info('notification.dispatched', extra={
                 'event_id': event.id,
                 'plugin': self.slug,
-                'rule_id': rules[0] if any(rules) else None,
+                'rule_id': rules[0] if rules else None,
             })
 
     def notify_users(self, group, event, fail_silently=False):

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -61,7 +61,8 @@ class NotificationPlugin(Plugin):
     def notify(self, notification):
         self.logger.info('notification.dispatched', extra={
             'event_id': notification.event.id,
-            'plugin': self.slug
+            'plugin': self.slug,
+            'rule_ids': [rule.id for rule in notification.rules],
         })
         event = notification.event
         return self.notify_users(event.group, event)


### PR DESCRIPTION
@mattrobenolt: Since this is still a little convoluted, let's have `rule_ids` come along with `notification.dispatched` until I get a good sample size of production data.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4112)

<!-- Reviewable:end -->
