### PR TITLE
Log if plugin has digests too and add two more items.

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -68,6 +68,7 @@ class NotificationPlugin(Plugin):
             'event_id': event.id,
             'plugin': self.slug,
         }
+        dispatched = False
         for future in futures:
             rules.append(future.rule)
             extra['rule_id'] = future.rule.id
@@ -92,6 +93,7 @@ class NotificationPlugin(Plugin):
             )
             if immediate_delivery:
                 deliver_digest.delay(digest_key)
+                dispatched = True
 
         else:
             notification = Notification(
@@ -99,8 +101,10 @@ class NotificationPlugin(Plugin):
                 rules=rules,
             )
             self.notify(notification)
+            dispatched = True
 
-        self.logger.info('notification.dispatched', extra=extra)
+        if dispatched:
+            self.logger.info('notification.dispatched', extra=extra)
 
     def notify_users(self, group, event, fail_silently=False):
         raise NotImplementedError

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -66,6 +66,7 @@ class NotificationPlugin(Plugin):
         rules = []
         extra = {
             'event_id': event.id,
+            'group_id': event.group_id,
             'plugin': self.slug,
         }
         log_event = 'dispatched'

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -68,7 +68,7 @@ class NotificationPlugin(Plugin):
             'event_id': event.id,
             'plugin': self.slug,
         }
-        dispatched = False
+        log_event = 'dispatched'
         for future in futures:
             rules.append(future.rule)
             extra['rule_id'] = future.rule.id
@@ -93,7 +93,8 @@ class NotificationPlugin(Plugin):
             )
             if immediate_delivery:
                 deliver_digest.delay(digest_key)
-                dispatched = True
+            else:
+                log_event = 'digested'
 
         else:
             notification = Notification(
@@ -101,10 +102,8 @@ class NotificationPlugin(Plugin):
                 rules=rules,
             )
             self.notify(notification)
-            dispatched = True
 
-        if dispatched:
-            self.logger.info('notification.dispatched', extra=extra)
+        self.logger.info('notification.%s' % log_event, extra=extra)
 
     def notify_users(self, group, event, fail_silently=False):
         raise NotImplementedError


### PR DESCRIPTION
@mattrobenolt @tkaemming @getsentry/infrastructure 

Fixes #4054 

```
17:56:58 worker  | 17:56:58 [INFO] sentry.plugins.notificationplugin: notification.dispatched (plugin='mail' event_id=299L project_id=1L rule_id=3L digest_key='mail:p:1')
17:56:58 worker  | 17:56:58 [INFO] sentry.mail: mail.queued (message_to=(u'****',) message_id='<20160912175658.62301.95757@localhost>' message_type='notify.error')
17:56:58 worker  | 17:56:58 [INFO] sentry.mail: mail.sent (message_id='<20160912175658.62301.95757@localhost>')
17:57:06 worker  | 17:57:06 [INFO] sentry.plugins.notificationplugin: notification.digested (plugin='mail' event_id=300L project_id=1L rule_id=3L digest_key='mail:p:1')
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4117)

<!-- Reviewable:end -->
