### PR TITLE
When inviting team member, preselect team if just 1

### DIFF
--- a/src/sentry/web/frontend/create_organization_member.py
+++ b/src/sentry/web/frontend/create_organization_member.py
@@ -18,9 +18,15 @@ class CreateOrganizationMemberView(OrganizationView):
     required_scope = 'org:write'
 
     def get_form(self, request, organization, all_teams, allowed_roles):
+
+        # If there is only one possible team to join, select it by default
+        initial_teams = []
+        if len(all_teams) == 1:
+            initial_teams = all_teams
+
         initial = {
             'role': organization.default_role,
-            'teams': [],
+            'teams': initial_teams
         }
 
         if settings.SENTRY_ENABLE_INVITES:


### PR DESCRIPTION
Most new organizations will only have one team. If they're inviting team members at that point, it's probably a safe assumption that those members are intended to join this (only) team.

/cc @getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4118)

<!-- Reviewable:end -->
