### PR TITLE
fix typo in docs/config.rst

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -75,7 +75,7 @@ Redis
 
     Declared in ``config.yml``.
 
-    Describes the Redis clusters avaialble to the Sentry server. These clusters
+    Describes the Redis clusters available to the Sentry server. These clusters
     may then be referenced by name by other internal services such as the
     cache, digests, and TSDB backends, among others.
 


### PR DESCRIPTION
A pretty simple typo fix I noticed while reading the docs, avaialble -> available.

I skimmed the guidelines for contributing, but apologies in advance if there are stylistic guidelines or something I've missed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4121)

<!-- Reviewable:end -->
