### PR TITLE
Prevent several classes of projects from inclusion in organization reports.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -571,17 +571,6 @@ class Skipped(object):
     NoReports = object()
 
 
-def has_received_first_event(interval, (project, report)):
-    # If the project has never seen an event, it shouldn't be included.
-    if project.first_event is None:
-        return False
-
-    # The project must have recieved at least one event prior to the end of the
-    # reporting period to be included.
-    _, stop = interval
-    return stop > project.first_event
-
-
 def has_valid_aggregates(interval, (project, report)):
     _, aggregates, _, _ = report
     return any(bool(value) for value in aggregates)
@@ -618,7 +607,6 @@ def deliver_organization_user_report(timestamp, duration, organization_id, user_
     projects = list(projects)
 
     inclusion_predicates = [
-        has_received_first_event,
         has_valid_aggregates,
     ]
 

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -12,8 +12,7 @@ from sentry.app import tsdb
 from sentry.models import Project, UserOption
 from sentry.tasks.reports import (
     DISABLED_ORGANIZATIONS_USER_OPTION_KEY, Skipped, change,
-    clean_series, deliver_organization_user_report,
-    has_received_first_event, has_valid_aggregates,
+    clean_series, deliver_organization_user_report, has_valid_aggregates,
     merge_mappings, merge_sequences, merge_series, prepare_reports, safe_add,
     user_subscribed_to_organization_reports
 )
@@ -166,26 +165,6 @@ def test_clean_series_rejects_offset_timestamp():
         )
 
 
-def test_has_received_first_event(interval):
-    _, stop = interval
-    report = None  # parameter is unused
-
-    assert has_received_first_event(
-        interval,
-        (Project(first_event=None), report),
-    ) is False
-
-    assert has_received_first_event(
-        interval,
-        (Project(first_event=stop), None),
-    ) is False
-
-    assert has_received_first_event(
-        interval,
-        (Project(first_event=stop - timedelta(seconds=1)), report),
-    ) is True
-
-
 def test_has_valid_aggregates(interval):
     project = None  # parameter is unused
 
@@ -223,7 +202,6 @@ class ReportTestCase(TestCase):
         project = self.create_project(
             organization=self.organization,
             team=self.team,
-            first_event=now - timedelta(days=1),
         )
 
         tsdb.incr(


### PR DESCRIPTION
This ensures that a project has received at least one event prior to the end of the reporting period for it to be considered for inclusion in an organization report. This change prevents users in a new organization from receiving an empty report if they have created a project but not yet sent any events.

A few things to note:
- The event is not required to have been received _during_ the reporting period -- it may have been received during the prior reporting period and there may have been no events received during the current reporting period. This allows for the comparisons to historical aggregates to be displayed, even if there was no a activity this week. In the future, we might want to also exclude projects that have no activity recent enough to show in the historical aggregates.
- That this does not guarantee that the event still exists, since the issue it belongs to may have been deleted later.

In the future, we might want to change this to provide some integration help if a user has created a project but not actually sent any data.

References GH-3945.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4122)

<!-- Reviewable:end -->
