### PR TITLE
Show error stacktrace from render failures

### DIFF
--- a/src/sentry/static/sentry/app/utils/errorHandler.jsx
+++ b/src/sentry/static/sentry/app/utils/errorHandler.jsx
@@ -8,7 +8,7 @@ export default function errorHandler(Component) {
       return originalRender.apply(this, arguments);
     } catch (err) {
       /*eslint no-console:0*/
-      console.log('Failed on render with', err);
+      console.error(err);
       return <RouteError error={err} component={this} />;
     }
   };


### PR DESCRIPTION
Before this change, you'd only get the output of `toString` on the error object (aka just the error type + message, no stacktrace).

/cc @getsentry/team

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4123)

<!-- Reviewable:end -->
