### PR TITLE
Prevent leaking organization summary on login

### DIFF
--- a/src/sentry/templates/sentry/bases/auth.html
+++ b/src/sentry/templates/sentry/bases/auth.html
@@ -3,6 +3,8 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
+{% block sub-header %}{% endblock %}
+
 {% block wrapperclass %}narrow auth org-login hide-sidebar{% endblock %}
 
 {% block main %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -141,7 +141,7 @@
     </header>
     {% endblock %}
 
-    {% if organization and request.user.is_authenticated %}
+    {% if organization and ACCESS.org_read %}
     {% block sub-header %}
     <div class="sub-header">
       <div class="container">


### PR DESCRIPTION
While nothing sensitive is present here, let's ensure that the information is absolutely only available when you have appropriate access.

@getsentry/security

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4128)

<!-- Reviewable:end -->
