### PR TITLE
Secondary emails

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -95,8 +95,14 @@ class User(BaseModel, AbstractBaseUser):
         warnings.warn('User.has_module_perms is deprecated', DeprecationWarning)
         return self.is_superuser
 
+    def get_unverified_emails(self):
+        return self.emails.filter(is_verified=False)
+
+    def get_verified_emails(self):
+        return self.emails.filter(is_verified=True)
+
     def has_unverified_emails(self):
-        return self.emails.filter(is_verified=False).exists()
+        return self.get_unverified_emails().exists()
 
     def get_label(self):
         return self.email or self.username or self.id
@@ -120,7 +126,8 @@ class User(BaseModel, AbstractBaseUser):
         from sentry import options
         from sentry.utils.email import MessageBuilder
 
-        for email in self.emails.filter(is_verified=False):
+        email_list = self.get_unverified_emails()
+        for email in email_list:
             if not email.hash_is_valid():
                 email.set_hash()
                 email.save()

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext_lazy as _
 
+
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 
 CHARACTERS = u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'

--- a/src/sentry/static/sentry/less/auth.less
+++ b/src/sentry/static/sentry/less/auth.less
@@ -115,14 +115,22 @@ section.org-login {
 
 .primary-email {
   position: relative;
-  padding-right: 140px;
+
+  &.not-verified {
+    padding-right: 168px;
+  }
+
+  .verification-label {
+    position: absolute;
+    top: -3px;
+    left: 110px;
+  }
 
   .verified-status {
     position: absolute;
     top: 0;
     right: 0;
     padding-top: 28px;
-    padding-right: 30px;
   }
 
 }

--- a/src/sentry/static/sentry/less/auth.less
+++ b/src/sentry/static/sentry/less/auth.less
@@ -113,6 +113,20 @@ section.org-login {
   }
 }
 
+.primary-email {
+  position: relative;
+  padding-right: 140px;
+
+  .verified-status {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding-top: 28px;
+    padding-right: 30px;
+  }
+
+}
+
 .account-settings-overview {
   position: relative;
   padding-right: 140px;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2597,6 +2597,34 @@ ul.faces {
 }
 
 /**
+* Label
+* ============================================================================
+*/
+
+.label.verification {
+
+  &.label-warning {
+    background-color: @yellow-orange;
+  }
+
+  &.label-success {
+    background-color: @green-light;
+  }
+
+  display: inline;
+  padding: .2em .6em .3em;
+  font-size: 75%;
+  font-weight: bold;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+  margin-left: 4px;
+}
+
+/**
 * Circle indicators
 * ============================================================================
 */

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -14,44 +14,51 @@
       </div>
     {% endif %}
 
-    <legend style="margin-top: 0;">Emails</legend>
+    <legend class="m-t-0">Emails</legend>
 
     <form action="" method="post" class="">
         {% csrf_token %}
         <button type="submit" class="hidden"></button>
         {{ email_form|as_crispy_errors }}
-        <div class='primary-email'>
+
+        <div class='primary-email {% if not primary_email.is_verified %}not-verified{% endif %}'>
 	        <div class='email-input'>
+            {% if not primary_email.is_verified %}
+            <div class="verification-label">
+              <span class="label verification label-warning">Unverified</span>
+            </div>
+            {% else %}
+            <div class="verification-label">
+              <span class="label verification label-success">Verified</span>
+            </div>
+            {% endif %}
 		        {{ email_form.primary_email|as_crispy_field }}
-	        </div>
-	        <div class='verified-status'>
-		        {% if primary_email.is_verified %}
-		        <span class='btn btn-success'>Verified</span>{% else %}<a href="{% url 'sentry-account-confirm-email-send' %}" class='btn btn-warning'>Unverified</a>
-		        {% endif %}
 	        </div>
 	      </div>
         <br>
         <label for='id_alternative_emails' class='control-label'>Alternative Emails</label>
         {% if alt_emails %}
-        <table class="table table-bordered" style="margin-bottom: 20px">
+        <table class="table table-bordered m-b-0">
 	        <tbody>
         	{% for email in alt_emails %}
         	<tr>
-        		<td style="text-align:center">{{ email.email }}</td>
-        		<td style="text-align:center">
-	        	{% if email.is_verified %}
-		    		<span class='btn btn-success'>Verified</span>{% else %}<a href="{% url 'sentry-account-confirm-email-send' %}" class='btn btn-warning'>Unverified</a>
-		    	{% endif %}
-		    	</td>
-		    	<td style="text-align:center">
-			    	<input type='hidden' name='email' value={{ email.email }}>
-				    <button type='submit' name='remove' class='btn btn-danger remove'>Remove</button>
-			    </td>
-		    </tr>
+        		<td>
+              {{ email.email }}
+              {% if not email.is_verified %}
+              <span class="label verification label-warning">Unverified</span>
+              {% else %}
+              <span class="label verification label-success">Verified</span>
+              {% endif %}
+            </td>
+  		    	<td style="text-align:center">
+  			    	<input type='hidden' name='email' value={{ email.email }}>
+  				    <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
+  			    </td>
+  		    </tr>
 		    </tbody>
 	    {% endfor %}
 	    </table>
-	    <p class='help-block'>To use an email for notifications it must be verified</p>
+	    <p class='help-block'>To use an email for <a href="{% url "sentry-account-settings-notifications" %}">notifications</a> it must be verified</p>
 	    {% endif %}
 
 	    {% if not alt_emails %}

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -1,0 +1,67 @@
+{% extends "sentry/bases/account.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% load sentry_helpers %}
+
+{% block title %}{% trans "Notification Settings" %} | {{ block.super }}{% endblock %}
+
+{% block main %}
+    {% if request.user.has_unverified_emails %}
+      <div class="alert alert-warning alert-block">
+        {% trans "You have unverified emails. " %}
+        <a href="{% url 'sentry-account-confirm-email-send' %}">{% trans "Resend Verification Emails" %}</a>.
+      </div>
+    {% endif %}
+
+    <legend style="margin-top: 0;">Emails</legend>
+
+    <form action="" method="post" class="">
+        {% csrf_token %}
+        <button type="submit" class="hidden"></button>
+        {{ email_form|as_crispy_errors }}
+        <div class='primary-email'>
+	        <div class='email-input'>
+		        {{ email_form.primary_email|as_crispy_field }}
+	        </div>
+	        <div class='verified-status'>
+		        {% if primary_email.is_verified %}
+		        <span class='btn btn-success'>Verified</span>{% else %}<a href="{% url 'sentry-account-confirm-email-send' %}" class='btn btn-warning'>Unverified</a>
+		        {% endif %}
+	        </div>
+	      </div>
+        <br>
+        <label for='id_alternative_emails' class='control-label'>Alternative Emails</label>
+        {% if alt_emails %}
+        <table class="table table-bordered" style="margin-bottom: 20px">
+	        <tbody>
+        	{% for email in alt_emails %}
+        	<tr>
+        		<td style="text-align:center">{{ email.email }}</td>
+        		<td style="text-align:center">
+	        	{% if email.is_verified %}
+		    		<span class='btn btn-success'>Verified</span>{% else %}<a href="{% url 'sentry-account-confirm-email-send' %}" class='btn btn-warning'>Unverified</a>
+		    	{% endif %}
+		    	</td>
+		    	<td style="text-align:center">
+			    	<input type='hidden' name='email' value={{ email.email }}>
+				    <button type='submit' name='remove' class='btn btn-danger remove'>Remove</button>
+			    </td>
+		    </tr>
+		    </tbody>
+	    {% endfor %}
+	    </table>
+	    <p class='help-block'>To use an email for notifications it must be verified</p>
+	    {% endif %}
+
+	    {% if not alt_emails %}
+	    	<div>No alternative emails in your account</div>
+	    {% endif %}
+	    <br>
+    	{{ email_form.alt_email|as_crispy_field }}
+
+    	<fieldset class="form-actions">
+            <button type="submit" class="btn btn-primary">{% trans "Save Changes" %}</button>
+        </fieldset>
+    </form>
+{% endblock %}

--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -27,8 +27,6 @@
 
         <h4>{% trans "General" %}</h4>
 
-        {{ settings_form.alert_email|as_crispy_field }}
-
         <hr />
 
         <h4>{% trans "Alerts" %}</h4>
@@ -59,7 +57,7 @@
 
         <h4>{% trans "Fine Tuning" %}</h4>
 
-        <p>Use the settings below to fine tune notification settings per-project.</p>
+        <p>Use the settings below to fine tune notification settings per-project.<br>Add or verify emails in the <a href="{% url "sentry-account-settings-emails" %}">Emails</a> Tab.</p>
 
         {% for project, form in project_forms %}
             {{ form|as_crispy_errors }}
@@ -83,7 +81,7 @@
                             <th style="width:50px;text-align:center">
                               <a data-toggle="workflow">Workflow</a>
                             </th>
-                            <th style="width:150px;overflow:hidden;text-align:right">
+                            <th style="width:300px;overflow:hidden;text-align:center">
                               {% trans "Email Address" %}
                             </th>
                         </tr>
@@ -96,11 +94,10 @@
               </td>
               <td style="text-align:center">{{ form.alert }}</td>
               <td style="text-align:center">{{ form.workflow }}</td>
-              <td style="text-align:right">
-                <a href="javascript:void(0)" data-target="{{ form.email.auto_id }}" data-toggle="change-target-value">
-                  {% if form.email.value %}{{ form.email.value }}{% else %}<em>Default</em>{% endif %}
-                </a>
-                {{ form.email }}
+              <td style="text-align:center">
+              {% with form.email as field %}
+                {{ field|as_crispy_field }}
+              {% endwith %}
               </td>
             </tr>
         {% endfor %}
@@ -125,17 +122,6 @@
     </form>
     <script>
     $(function(){
-      $('form a[data-toggle="change-target-value"]').click(function(){
-        var $this = $(this);
-        var $target = $('#' + $this.data('target'));
-        var result = window.prompt('Enter an email address', $target.val());
-        $target.val(result || '');
-        if (result) {
-          $this.text(result);
-        } else {
-          $this.html('<em>Default</em>');
-        }
-      });
 
       function findCheckboxes(parent, match) {
         return $(parent).parents('table')

--- a/src/sentry/templates/sentry/bases/account.html
+++ b/src/sentry/templates/sentry/bases/account.html
@@ -23,6 +23,7 @@
           <li{% if page == 'avatar' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-avatar' %}">{% trans "Avatar" %}</a></li>
           <li{% if page == 'appearance' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-appearance' %}">{% trans "Appearance" %}</a></li>
           <li{% if page == 'notifications' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-notifications' %}">{% trans "Notifications" %}</a></li>
+          <li{% if page == 'emails' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-emails' %}">{% trans "Emails" %}</a></li>
           {% if AUTH_PROVIDERS %}
             <li{% if page == 'identities' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-identities' %}">{% trans "Identities" %}</a></li>
           {% endif %}

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -207,6 +207,37 @@ class ChangePasswordRecoverForm(forms.Form):
     password = forms.CharField(widget=forms.PasswordInput())
 
 
+class EmailForm(forms.Form):
+    primary_email = forms.EmailField(label=_('Primary Email'))
+
+    alt_email = forms.EmailField(
+        label=_('New Email'),
+        required=False,
+        help_text='Designate an alternative email for this account',
+    )
+
+    def __init__(self, user, *args, **kwargs):
+        self.user = user
+        super(EmailForm, self).__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+
+        if self.cleaned_data['primary_email'] != self.user.email:
+            new_username = self.user.email == self.user.username
+        else:
+            new_username = False
+
+        self.user.email = self.cleaned_data['primary_email']
+
+        if new_username and not User.objects.filter(username__iexact=self.user.email).exists():
+            self.user.username = self.user.email
+
+        if commit:
+            self.user.save()
+
+        return self.user
+
+
 class AccountSettingsForm(forms.Form):
     name = forms.CharField(required=True, label=_('Name'), max_length=30)
     username = forms.CharField(label=_('Username'), max_length=128)
@@ -413,6 +444,7 @@ class NotificationSettingsForm(forms.Form):
         help_text=_('Designate an alternative email address to send email notifications to.'),
         required=False
     )
+
     subscribe_by_default = forms.BooleanField(
         label=_('Subscribe to alerts for projects by default'),
         required=False,
@@ -487,7 +519,8 @@ class NotificationSettingsForm(forms.Form):
 class ProjectEmailOptionsForm(forms.Form):
     alert = forms.BooleanField(required=False)
     workflow = forms.BooleanField(required=False)
-    email = forms.EmailField(required=False, widget=forms.HiddenInput())
+    email = forms.ChoiceField(label="", choices=(), required=False,
+        widget=forms.Select())
 
     def __init__(self, project, user, *args, **kwargs):
         self.project = project
@@ -498,10 +531,20 @@ class ProjectEmailOptionsForm(forms.Form):
         has_alerts = project.is_user_subscribed_to_mail_alerts(user)
         has_workflow = project.is_user_subscribed_to_workflow(user)
 
+        # This allows users who have entered an alert_email value or have specified an email
+        # for notifications to keep their settings
+        emails = [e.email for e in user.get_verified_emails()]
+        alert_email = UserOption.objects.get_value(user=self.user, project=None, key='alert_email', default=None)
+        specified_email = UserOption.objects.get_value(user, project, 'mail:email', None)
+        emails.extend([user.email, alert_email, specified_email])
+
+        choices = [(email, email) for email in set(emails) if email is not None]
+        self.fields['email'].choices = choices
+
         self.fields['alert'].initial = has_alerts
         self.fields['workflow'].initial = has_workflow
         self.fields['email'].initial = UserOption.objects.get_value(
-            user, project, 'mail:email', None)
+            user, project, 'mail:email', None) or alert_email
 
     def save(self):
         UserOption.objects.set_value(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -264,6 +264,8 @@ urlpatterns += patterns(
         name='sentry-account-settings-notifications'),
     url(r'^account/settings/security/$', AccountSecurityView.as_view(),
         name='sentry-account-security'),
+    url(r'^account/settings/emails/$', accounts.show_emails,
+        name='sentry-account-settings-emails'),
 
     # compatibility
     url(r'^account/settings/notifications/unsubscribe/(?P<project_id>\d+)/$',

--- a/tests/sentry/web/frontend/accounts/tests.py
+++ b/tests/sentry/web/frontend/accounts/tests.py
@@ -273,7 +273,7 @@ class ConfirmEmailSendTest(TestCase):
     def test_valid(self, send_confirm_email):
         self.login_as(self.user)
         resp = self.client.get(reverse('sentry-account-confirm-email-send'))
-        self.assertRedirects(resp, reverse('sentry-account-settings'), status_code=302)
+        self.assertRedirects(resp, reverse('sentry-account-settings-emails'), status_code=302)
         send_confirm_email.assert_called_once_with()
 
 
@@ -294,6 +294,6 @@ class ConfirmEmailTest(TestCase):
         email = self.user.emails.first()
         resp = self.client.get(reverse('sentry-account-confirm-email',
                                        args=[self.user.id, email.validation_hash]))
-        self.assertRedirects(resp, reverse('sentry-account-settings'), status_code=302)
+        self.assertRedirects(resp, reverse('sentry-account-settings-emails'), status_code=302)
         email = self.user.emails.first()
         assert email.is_verified

--- a/tests/sentry/web/frontend/test_emails.py
+++ b/tests/sentry/web/frontend/test_emails.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from exam import fixture
+
+from sentry.testutils import TestCase
+from sentry.models import User, UserEmail
+
+
+class EmailsTest(TestCase):
+    @fixture
+    def path(self):
+        return reverse('sentry-account-settings-emails')
+
+    def test_render_emails(self):
+        user = self.create_user('foo@example.com')
+        self.login_as(user)
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/settings/emails.html')
+        assert 'alt_emails' in resp.context
+        assert 'primary_email' in resp.context
+        self.assertIn('foo@example.com', resp.content)
+
+    def test_show_alt_emails(self):
+        user = self.create_user('foo@example.com')
+        self.login_as(user)
+        email = UserEmail(user=user, email='bar@example.com')
+        email.save()
+        resp = self.client.get(self.path)
+        self.assertIn('bar@example.com', resp.content)
+        assert 'bar@example.com' in ([thing.email for thing in user.emails.all()])
+
+    def test_create_alt_email(self):
+        user = self.create_user('foo@example.com')
+        self.login_as(user)
+        resp = self.client.post(self.path, data={
+            'primary_email': user.email,
+            'alt_email': 'hello@gmail.com'},
+            follow=True
+        )
+        assert resp.status_code == 200
+        self.assertIn('hello@gmail.com', resp.content)
+        self.assertNotIn('bar@gmail.com', resp.content)
+        emails = UserEmail.objects.filter(user=user)
+        assert 'hello@gmail.com' in ([email.email for email in emails])
+
+    def test_remove_alt_email(self):
+        user = self.create_user('foo@example.com')
+        self.login_as(user)
+        email = UserEmail(user=user, email='bar@example.com')
+        email.save()
+        resp = self.client.get(self.path)
+        self.assertIn('bar@example.com', resp.content)
+        resp = self.client.post(self.path, data={'remove': '', 'email': 'bar@example.com'}, follow=True)
+        self.assertNotIn('bar@example.com', resp.content)
+        assert 'bar@example.com' not in (email.email for email in user.emails.all())
+
+    def test_change_primary_email(self):
+        user = self.create_user('foo@example.com')
+        self.login_as(user)
+        resp = self.client.get(self.path)
+        self.assertIn('foo@example.com', resp.content)
+        resp = self.client.post(self.path, {'primary_email': 'bar@example.com'}, follow=True)
+        self.assertIn('bar@example.com', resp.content)
+        user = User.objects.get(id=user.id)
+        assert user.email != 'foo@example.com'
+        assert user.email == 'bar@example.com'


### PR DESCRIPTION
Fixes #4029 
@getsentry/infrastructure 
cc @macqueen 
Creates an emails tab where users can add secondary email addresses. 
Users can add verified secondary emails in notifications, but this maintains access to alternative emails they may have already added to the notifications page.
![screen shot 2016-09-13 at 11 13 22 am](https://cloud.githubusercontent.com/assets/9269824/18486251/48bc62aa-79a5-11e6-9fdc-f8ec7f98c269.png)
![screen shot 2016-09-13 at 11 13 48 am](https://cloud.githubusercontent.com/assets/9269824/18486252/4a6f716e-79a5-11e6-895b-11e86ed180ca.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4130)

<!-- Reviewable:end -->
