### PR TITLE
Don't filter legacy browsers by default

### DIFF
--- a/src/sentry/filters/legacy_browsers.py
+++ b/src/sentry/filters/legacy_browsers.py
@@ -18,7 +18,7 @@ class LegacyBrowsersFilter(Filter):
     id = 'legacy-browsers'
     name = 'Filter out known errors from legacy browsers'
     description = 'Older browsers often give less accurate information, and while they may report valid issues, the context to understand them is incorrect or missing.'
-    default = True
+    default = False
 
     def get_user_agent(self, data):
         try:


### PR DESCRIPTION
Per discussion w/ @dcramer, this filter needs to be activated manually.

/cc @getsentry/team

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4133)

<!-- Reviewable:end -->
