### PR TITLE
fix formData after submit

### DIFF
--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -116,4 +116,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
                     value=value,
                 )
 
-        return Response({'message': OK_UPDATED})
+        context = serialize(
+            plugin, request.user, PluginWithConfigSerializer(project))
+
+        return Response(context)

--- a/src/sentry/static/sentry/app/plugins/components/settings.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/settings.jsx
@@ -114,9 +114,13 @@ class PluginSettings extends React.Component {
         data: this.state.formData,
         method: 'PUT',
         success: (data) => {
+          let formData = {};
+          data.config.forEach((field) => {
+            formData[field.name] = field.value || field.defaultValue;
+          });
           this.setState({
-            formData: data,
-            initialData: Object.assign({}, data),
+            formData: formData,
+            initialData: Object.assign({}, formData),
             state: FormState.READY,
             errors: {},
           });


### PR DESCRIPTION
this was setting the `this.state.formData` to `{"message": "Successfully updated configuration."}`, which has the potential to wipe out config fields if the user clicks save again

@getsentry/plugins @dcramer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4134)

<!-- Reviewable:end -->
