### PR TITLE
Only show personal statistics in reports if each field has a value.

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -156,7 +156,7 @@
     </tbody>
   </table>
 
-  {% if personal.resolved or personal.users %}
+  {% if personal.resolved and personal.users %}
     <h4>Your impact</h4>
     <table class="user-impact">
       <tr>


### PR DESCRIPTION
This prevents displaying that "0 users are rejoicing" since that is
demoralizing.

References GH-3945.

@ckj

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4137)

<!-- Reviewable:end -->
