### PR TITLE
Our internal logger can't handle logging `env.request`

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -24,7 +24,6 @@ from six import BytesIO
 from time import time
 
 from sentry import filters
-from sentry.app import env
 from sentry.cache import default_cache
 from sentry.constants import (
     CLIENT_RESERVED_ATTRS, DEFAULT_LOG_LEVEL, LOG_LEVELS_MAP,
@@ -165,7 +164,6 @@ class ClientLogHelper(object):
         tags.update(context.get_tags_context())
         tags['project'] = project_label
 
-        extra['request'] = env.request
         extra['tags'] = tags
         extra['agent'] = context.agent
         extra['protocol'] = context.version


### PR DESCRIPTION
Anywhere inside of coreapi, with the use of `logger.level(..,
exc_info=True)`, our internal Raven instance fails to log the event to
itself because this object can't be json encoded. This utimately stems
from the `helper.insert_data_to_database()` call.

The alternatively was to take the data dict and run through a
`json.dumps` using the raven-python version, then `json.dumps` back into
a better object, but this is expensive and just leaves useless data.

So concluded that even logging this was useless since the data doesn't
surface anywhere useful. It gets logged into Sentry as `<WSGIRequest
object>` if we try to massage it. Alternatively, if we just leverage
`repr(env.request)` we get back a value that gets trimmed in the UI,
making the value useless as well.

If we want to log this, we could/should pick some params from the
request to expliucitly log rather than logging the entire object.

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4138)

<!-- Reviewable:end -->
