### PR TITLE
Minor changes to organization reports.

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -25,7 +25,8 @@
 
 <div class="container">
   <p class="info-box">
-    You're seeing a preview release of our Weekly Reports. Have feedback? Let us know by sending an email to <a href="mailto:support@getsentry.com">support@getsentry.com</a>.
+    You're seeing a preview release of our Weekly Reports.<br />
+    Have feedback? Let us know on our <a href="https://forum.sentry.io/t/weekly-reports-for-early-adopter-organizations/132">support forum</a>.
   </p>
 
   <table style="margin-bottom: 10px">

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -67,7 +67,7 @@
           </tr>
           <tr class="labels">
             {% for timestamp, metrics in report.series.points %}
-              <td title="{{ timestamp }}" style="width: {% widthratio 1 report.series.points|length 100 %}%">{{ timestamp|date:duration.date_format }}</td>
+              <td title="{{ timestamp }}" style="width: {% widthratio 1 report.series.points|length 100 %}%">{{ timestamp|date:duration.date_format|first }}</td>
             {% endfor %}
           </tr>
         </table>


### PR DESCRIPTION
- The feedback link is now for the forum thread, not the support email.
- Displays the first letter (instead of the full abbreviation) of the formatted date for the small series bar chart.

@dcramer @ckj

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4161)

<!-- Reviewable:end -->
