### PR TITLE
Link to project notification settings from account notification settings

### DIFF
--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -92,7 +92,7 @@
             {% endifchanged %}
             <tr>
               <td>
-                {{ project.organization.slug}} / {{ project.slug }}
+                <a href="{% url 'sentry-project-notifications' project.organization.slug project.slug %}">{{ project.organization.slug}} / {{ project.slug }}</a>
               </td>
               <td style="text-align:center">{{ form.alert }}</td>
               <td style="text-align:center">{{ form.workflow }}</td>


### PR DESCRIPTION
Thought it might be nice to allow users to go directly to project notification settings from their account notification settings
@getsentry/ui

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4169)

<!-- Reviewable:end -->
