### PR TITLE
Fix cursorwrapper and base model

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -75,6 +75,9 @@ class BaseModel(models.Model):
         if self.id:
             data = {}
             for f in self._meta.fields:
+                # This is a deferred field, so we can't load it
+                if f.attname not in self.__dict__:
+                    continue
                 try:
                     data[f.column] = self.__get_field_value(f)
                 except AttributeError as e:

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -35,7 +35,7 @@ class CursorWrapper(object):
     @auto_reconnect_cursor
     @less_shitty_error_messages
     def execute(self, sql, params=None):
-        if params is not None:
+        if params:
             return self.cursor.execute(sql, params)
         return self.cursor.execute(sql)
 


### PR DESCRIPTION
- CursorWrapper passes along params even if it's an empty tuple. This
  causes a problem with psycopg2 when doing a query such as:
  `cursor.execute('select 1 % 1', ())` and raises an `IndexError`
  whereas `cursor.execute('select 1 % 1')` is fine.
- In the base model, if a field is deferred, it'd cause infinite
  recursion during model instantiation. Check that the data exists in
  `__dict__` before updating the local tracked data. This is how Django
  internally checks for deferred fields:
  https://github.com/django/django/blob/master/django/db/models/base.py#L647-L654

@getsentry/platform

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4174)

<!-- Reviewable:end -->
