### PR TITLE
Per project rate limit fix

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
@@ -24,7 +24,7 @@ const RateLimitEditor = React.createClass({
     };
   },
 
-  onProjectLimitChange(e, value) {
+  onProjectLimitChange(value) {
     this.setState({
       currentProjectLimit: value,
     });


### PR DESCRIPTION
Fixes #4176 
#3986 broke this because the rangeField.jsx was split off and the onChange directly passes back the value, instead of (e, value).

/cc @dcramer

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4177)

<!-- Reviewable:end -->
