### PR TITLE
move field-rendering to base component

### DIFF
--- a/src/sentry/static/sentry/app/components/bases/settingsBase.jsx
+++ b/src/sentry/static/sentry/app/components/bases/settingsBase.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'underscore';
 
 import {Client} from '../../api';
-import {FormState} from '../../components/forms';
+import {FormState, GenericField} from '../../components/forms';
 import IndicatorStore from '../../stores/indicatorStore';
 import {t} from '../../locale';
 
@@ -26,7 +26,8 @@ class SettingsBase extends React.Component {
      'onSave',
      'onSaveSuccess',
      'onSaveError',
-     'onSaveComplete'].map(method => this[method] = this[method].bind(this));
+     'onSaveComplete',
+     'renderField'].map(method => this[method] = this[method].bind(this));
 
     if (this.fetchData) {
       this.fetchData = this.onLoad.bind(this, this.fetchData.bind(this));
@@ -107,6 +108,10 @@ class SettingsBase extends React.Component {
     IndicatorStore.remove(this._loadingIndicator);
     callback = callbackWithArgs(callback, ...args);
     callback && callback();
+  }
+
+  renderField(props) {
+    return <GenericField {...props}/>;
   }
 }
 

--- a/src/sentry/static/sentry/app/plugins/components/settings.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/settings.jsx
@@ -3,8 +3,7 @@ import underscore from 'underscore';
 
 import {
   Form,
-  FormState,
-  GenericField
+  FormState
 } from '../../components/forms';
 import SettingsBase from '../../components/bases/settingsBase';
 import LoadingIndicator from '../../components/loadingIndicator';
@@ -105,13 +104,12 @@ class PluginSettings extends SettingsBase {
           </div>
         }
         {this.state.fieldList.map(f => {
-          return (
-            <GenericField
-              config={f}
-              formData={this.state.formData}
-              formErrors={this.state.errors}
-              onChange={this.changeField.bind(this, f.name)} />
-          );
+          return this.renderField({
+            config: f,
+            formData: this.state.formData,
+            formErrors: this.state.errors,
+            onChange: this.changeField.bind(this, f.name)
+          });
         })}
       </Form>
     );


### PR DESCRIPTION
just doing this so we don't have to import `GenericField` separately when overriding `render` in plugins

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4179)

<!-- Reviewable:end -->
