### PR TITLE
Improve signal support for weakrefs

### DIFF
--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from functools import wraps
-
 from django.dispatch import Signal
 
 
@@ -20,7 +18,14 @@ class BetterSignal(Signal):
 
         if receiver is None:
             return wrapped
-        return wraps(receiver)(wrapped(receiver))
+
+        if hasattr(receiver, '__name__'):
+            wrapped.__name__ = receiver.__name__
+        if hasattr(receiver, '__module__'):
+            wrapped.__module__ = receiver.__module__
+        if hasattr(receiver, '__doc__'):
+            wrapped.__doc__ = receiver.__doc__
+        return wrapped(receiver)
 
 
 regression_signal = BetterSignal(providing_args=["instance"])

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -11,3 +11,16 @@ from __future__ import absolute_import
 def assert_date_resembles(one, two):
     # this is mostly intended to handle discrepancies between mysql/postgres
     assert one.replace(microsecond=0) == two.replace(microsecond=0)
+
+
+def assert_mock_called_once_with_partial(mock, *args, **kwargs):
+    """
+    Similar to ``mock.assert_called_once_with()``, but we dont require all
+    args and kwargs to be specified.
+    """
+    assert len(mock.mock_calls) == 1
+    m_args, m_kwargs = mock.call_args
+    for i, arg in enumerate(args):
+        assert m_args[i] == arg
+    for kwarg in kwargs:
+        assert m_kwargs[kwarg] == kwargs[kwarg]

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -14,8 +14,8 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from django.utils import timezone
-from gzip import GzipFile
 from exam import fixture
+from gzip import GzipFile
 from raven import Client
 from six import StringIO
 


### PR DESCRIPTION
This allows us to use functions which are not strongly ref'd (e.g. no `__module__`) as connectors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4191)

<!-- Reviewable:end -->
