### PR TITLE
Correctly handle actorless activities when identifying notification recipients.

### DIFF
--- a/src/sentry/plugins/sentry_mail/activity/base.py
+++ b/src/sentry/plugins/sentry_mail/activity/base.py
@@ -43,15 +43,16 @@ class ActivityEmail(object):
             )
         )
 
-        receive_own_activity = UserOption.objects.get_value(
-            user=self.activity.user,
-            project=None,
-            key='self_notifications',
-            default='0'
-        ) == '1'
+        if self.activity.user is not None:
+            receive_own_activity = UserOption.objects.get_value(
+                user=self.activity.user,
+                project=None,
+                key='self_notifications',
+                default='0'
+            ) == '1'
 
-        if not receive_own_activity:
-            participants.discard(self.activity.user)
+            if not receive_own_activity:
+                participants.discard(self.activity.user)
 
         return participants
 


### PR DESCRIPTION
Introduced by GH-4178. Fixes SENTRY-1ZF.

@getsentry/platform @mattrobenolt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4192)

<!-- Reviewable:end -->
