### PR TITLE
fix edge select element bug

### DIFF
--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -32,7 +32,7 @@ const SelectInput = React.createClass({
     /*below is a hack for a bug in edge related to form submitting.
     see: https://github.com/facebook/react/issues/7655
     (@maxbittker)*/
-    if(this.refs.select){
+    if(this.refs.select)  {
       let selectedIndex = this.refs.select.selectedIndex;
       if (selectedIndex >= 0) {
        let options = this.refs.select.options;

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -32,13 +32,15 @@ const SelectInput = React.createClass({
     /*below is a hack for a bug in edge related to form submitting.
     see: https://github.com/facebook/react/issues/7655
     (@maxbittker)*/
-    let selectedIndex = this.refs.select.selectedIndex;
-    if (this.refs.select && selectedIndex >= 0) {
-     let options = this.refs.select.options;
-     let tempIndex = (selectedIndex + 1) % options.length;
+    if(this.refs.select){
+      let selectedIndex = this.refs.select.selectedIndex;
+      if (selectedIndex >= 0) {
+       let options = this.refs.select.options;
+       let tempIndex = (selectedIndex + 1) % options.length;
 
-     options[tempIndex].selected = true;
-     options[selectedIndex].selected = true;
+       options[tempIndex].selected = true;
+       options[selectedIndex].selected = true;
+      }
     }
   },
 

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -29,6 +29,17 @@ const SelectInput = React.createClass({
 
   componentDidMount() {
     this.create();
+    /*below is a hack for a bug in edge related to form submitting.
+    see: https://github.com/facebook/react/issues/7655
+    (@maxbittker)*/
+    const selectedIndex = this.refs.select.selectedIndex;
+    if (this.refs.select && selectedIndex >= 0) {
+     const options = this.refs.select.options;
+     const tempIndex = (selectedIndex + 1) % options.length;
+
+     options[tempIndex].selected = true;
+     options[selectedIndex].selected = true;
+    }
   },
 
   componentWillUpdate() {

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -32,7 +32,7 @@ const SelectInput = React.createClass({
     /*below is a hack for a bug in edge related to form submitting.
     see: https://github.com/facebook/react/issues/7655
     (@maxbittker)*/
-    if  (this.refs.select)  {
+    if (this.refs.select) {
       let selectedIndex = this.refs.select.selectedIndex;
       if (selectedIndex >= 0) {
        let options = this.refs.select.options;

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -32,10 +32,10 @@ const SelectInput = React.createClass({
     /*below is a hack for a bug in edge related to form submitting.
     see: https://github.com/facebook/react/issues/7655
     (@maxbittker)*/
-    const selectedIndex = this.refs.select.selectedIndex;
+    let selectedIndex = this.refs.select.selectedIndex;
     if (this.refs.select && selectedIndex >= 0) {
-     const options = this.refs.select.options;
-     const tempIndex = (selectedIndex + 1) % options.length;
+     let options = this.refs.select.options;
+     let tempIndex = (selectedIndex + 1) % options.length;
 
      options[tempIndex].selected = true;
      options[selectedIndex].selected = true;

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -32,7 +32,7 @@ const SelectInput = React.createClass({
     /*below is a hack for a bug in edge related to form submitting.
     see: https://github.com/facebook/react/issues/7655
     (@maxbittker)*/
-    if(this.refs.select)  {
+    if  (this.refs.select)  {
       let selectedIndex = this.refs.select.selectedIndex;
       if (selectedIndex >= 0) {
        let options = this.refs.select.options;


### PR DESCRIPTION
Edge browser doesn't read the state of select tags correctly for form submission,
this workaround makes it work.
https://github.com/facebook/react/issues/7655

fixes #3999

cc @getsentry/team

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4195)

<!-- Reviewable:end -->
