### PR TITLE
Move str,unicode,basestring,long name checks into a visit_Name

### DIFF
--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -115,6 +115,6 @@ def organizations(metrics, since, until):
                 '{} {} {}\n'.format(
                     instance.id,
                     instance.slug,
-                    ' '.join(map(str, values)),
+                    ' '.join(map(six.binary_type, values)),
                 ),
             )

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -55,7 +55,7 @@ register.filter(to_json)
 @register.filter
 def multiply(x, y):
     def coerce(value):
-        if isinstance(value, (int, long, float)):
+        if isinstance(value, (six.integer_types, float)):
             return value
         try:
             return int(value)
@@ -102,7 +102,7 @@ def subtract(value, amount):
 
 @register.filter
 def absolute_value(value):
-    return abs(int(value) if isinstance(value, (int, long)) else float(value))
+    return abs(int(value) if isinstance(value, six.integer_types) else float(value))
 
 
 @register.filter

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -213,7 +213,7 @@ class ListResolver(object):
                 'Cannot generate mailing list identifier for {!r}'.format(instance)
             )
 
-        label = '.'.join(map(str, handler(instance)))
+        label = '.'.join(map(six.binary_type, handler(instance)))
         assert is_valid_dot_atom(label)
 
         return '{}.{}'.format(label, self.__namespace)

--- a/src/sentry/utils/numbers.py
+++ b/src/sentry/utils/numbers.py
@@ -60,5 +60,5 @@ def base36_encode(number):
     return _encode(number, BASE36_ALPHABET)
 
 
-def base36_decode(str):
-    return int(str, 36)
+def base36_decode(s):
+    return int(s, 36)

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
+import six
+
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
 
 
 class Version(tuple):
     def __str__(self):
-        return '.'.join(map(str, self))
+        return '.'.join(map(six.binary_type, self))
 
 
 def summarize(sequence, max=3):
@@ -21,7 +23,7 @@ def summarize(sequence, max=3):
 
 def make_upgrade_message(service, modality, version, hosts):
     return '{service} {modality} be upgraded to {version} on {hosts}.'.format(
-        hosts=','.join(map(str, summarize(hosts.keys(), 2))),
+        hosts=','.join(map(six.binary_type, summarize(hosts.keys(), 2))),
         modality=modality,
         service=service,
         version=version,

--- a/src/sentry/web/frontend/admin.py
+++ b/src/sentry/web/frontend/admin.py
@@ -221,7 +221,7 @@ def status_warnings(request):
         else:
             warnings.append(warning)
 
-    sort_by_message = functools.partial(sorted, key=str)
+    sort_by_message = functools.partial(sorted, key=six.binary_type)
 
     return render_to_response(
         'sentry/admin/status/warnings.html',


### PR DESCRIPTION
When they were in visit_Call, they only got visited when explicitly
doing `str()`, now it covers all of these uses:
- `str('thing')`
- `isinstance(a, str)`
- `a = str`

For all of str, unicode, basestring, and long

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4199)

<!-- Reviewable:end -->
