### PR TITLE
simplify formatBytes func

### DIFF
--- a/src/sentry/static/sentry/app/components/fileSize.jsx
+++ b/src/sentry/static/sentry/app/components/fileSize.jsx
@@ -5,19 +5,14 @@ const FileSize = React.createClass({
     bytes: React.PropTypes.number.isRequired
   },
 
-  units: ['KB','MB','GB','TB','PB','EB','ZB','YB'],
+  units: ['B', 'KB','MB','GB','TB','PB','EB','ZB','YB'],
 
   formatBytes: function(bytes) {
-      let thresh = 1024;
-      if (bytes < thresh) {
-        return bytes + ' B';
-      }
-
-      let u = -1;
-      do {
+      let thresh = 1024, u = 0;
+      while (bytes >= thresh) {
         bytes /= thresh;
-        ++u;
-      } while (bytes >= thresh);
+        ++ u;
+      }
       return bytes.toFixed(1) + ' ' + this.units[u];
   },
 


### PR DESCRIPTION
set `units` complete array, use `while` replace of `do ... while`. [Here](https://github.com/hustcc/filesize.js/blob/master/src/filesize.js#L49-L52).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4206)

<!-- Reviewable:end -->
