### PR TITLE
Make symsynd mandatory and update to latest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-python:
 	# order matters here, base package must install first
 	pip install -e .
 	pip install ujson
-	pip install "file://`pwd`#egg=sentry[dev,dsym]"
+	pip install "file://`pwd`#egg=sentry[dev]"
 
 install-npm:
 	@echo "--> Installing Node dependencies"

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
+    'symsynd>=1.1.0,<2.0.0',
     'toronado>=0.0.10,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',
@@ -137,10 +138,6 @@ install_requires = [
     'rb>=1.5.0,<2.0.0',
     'qrcode>=5.2.2,<6.0.0',
     'python-u2flib-server>=4.0.1,<4.1.0',
-]
-
-dsym_requires = [
-    'symsynd>=0.8.3,<1.0.0',
 ]
 
 
@@ -194,7 +191,6 @@ setup(
         'tests': tests_require,
         'dev': dev_requires,
         'postgres': install_requires,
-        'dsym': dsym_requires,
     },
     cmdclass=cmdclass,
     license='BSD',

--- a/src/sentry/lang/native/dsymcache.py
+++ b/src/sentry/lang/native/dsymcache.py
@@ -31,10 +31,9 @@ class DSymCache(object):
         bases = set()
         loaded = set()
         for image_uuid in uuids:
-            rv = self.fetch_dsym(project, image_uuid)
-            if rv is not None:
-                base, dsym = rv
-                loaded.add(dsym)
+            base = self.fetch_dsym(project, image_uuid)
+            if base is not None:
+                loaded.add(image_uuid)
                 bases.add(base)
         return list(bases), loaded
 
@@ -50,12 +49,12 @@ class DSymCache(object):
             base = self.get_project_path(project)
             dsym = os.path.join(base, image_uuid)
             try:
-                stat = os.stat(dsym)
+                os.stat(dsym)
             except OSError as e:
                 if e.errno != errno.ENOENT:
                     raise
             else:
-                return base, self.try_bump_timestamp(dsym, stat)
+                return base
 
         dsf = find_dsym_file(project, image_uuid)
         if dsf is None:
@@ -89,7 +88,7 @@ class DSymCache(object):
                     except Exception:
                         pass
 
-        return base, dsym
+        return base
 
     def clear_old_entries(self):
         try:

--- a/src/sentry/lang/native/dsymcache.py
+++ b/src/sentry/lang/native/dsymcache.py
@@ -29,12 +29,12 @@ class DSymCache(object):
 
     def fetch_dsyms(self, project, uuids):
         bases = set()
-        loaded = []
+        loaded = set()
         for image_uuid in uuids:
             rv = self.fetch_dsym(project, image_uuid)
             if rv is not None:
                 base, dsym = rv
-                loaded.append(dsym)
+                loaded.add(dsym)
                 bases.add(base)
         return list(bases), loaded
 

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -9,7 +9,7 @@ import posixpath
 
 from sentry.models import Project, EventError
 from sentry.plugins import Plugin2
-from sentry.lang.native.symbolizer import Symbolizer, have_symsynd
+from sentry.lang.native.symbolizer import Symbolizer
 from sentry.lang.native.utils import find_all_stacktraces, \
     find_apple_crash_report_referenced_images, get_sdk_from_event, \
     find_stacktrace_referenced_images, get_sdk_from_apple_system_info, \
@@ -251,14 +251,6 @@ def inject_apple_device_data(data, system):
             device['family'] = match.group(1)
 
 
-def record_no_symsynd(data):
-    if data.get('sentry.interfaces.AppleCrashReport'):
-        append_error(data, {
-            'type': EventError.NATIVE_NO_SYMSYND,
-        })
-        return data
-
-
 def dump_crash_report(report):
     import json
     with open('/tmp/sentry-apple-crash-report-%s.json' % time.time(), 'w') as f:
@@ -452,6 +444,4 @@ class NativePlugin(Plugin2):
     can_disable = False
 
     def get_event_preprocessors(self, **kwargs):
-        if not have_symsynd:
-            return [record_no_symsynd]
         return [preprocess_apple_crash_event, resolve_frame_symbols]

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -2,16 +2,11 @@ from __future__ import absolute_import
 
 import six
 
-try:
-    from symsynd.driver import Driver, SymbolicationError
-    from symsynd.report import ReportSymbolizer
-    from symsynd.macho.arch import get_cpu_name
-    from symsynd.demangle import demangle_symbol
-    have_symsynd = True
-except ImportError:
-    have_symsynd = False
+from symsynd.driver import Driver, SymbolicationError
+from symsynd.report import ReportSymbolizer
+from symsynd.macho.arch import get_cpu_name
+from symsynd.demangle import demangle_symbol
 
-from sentry import options
 from sentry.lang.native.dsymcache import dsymcache
 from sentry.utils.safe import trim
 from sentry.models import DSymSymbol, EventError
@@ -44,10 +39,7 @@ def make_symbolizer(project, binary_images, referenced_images=None):
     list of referenced images is referenced (UUIDs) then only images
     needed by those frames are loaded.
     """
-    if not have_symsynd:
-        raise RuntimeError('symsynd is unavailable.  Install sentry with '
-                           'the dsym feature flag.')
-    driver = Driver(options.get('dsym.llvm-symbolizer-path') or None)
+    driver = Driver()
 
     to_load = referenced_images
     if to_load is None:

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -46,7 +46,16 @@ def make_symbolizer(project, binary_images, referenced_images=None):
         to_load = [x['uuid'] for x in binary_images]
 
     dsym_paths, loaded = dsymcache.fetch_dsyms(project, to_load)
-    return ReportSymbolizer(driver, dsym_paths, binary_images)
+
+    # We only want to pass the actually loaded symbols to the report
+    # symbolizer to avoid the expensive FS operations that will otherwise
+    # happen.
+    user_images = []
+    for img in binary_images:
+        if img['uuid'] in loaded:
+            user_images.append(img)
+
+    return ReportSymbolizer(driver, dsym_paths, user_images)
 
 
 class Symbolizer(object):

--- a/src/sentry/models/dsymfile.py
+++ b/src/sentry/models/dsymfile.py
@@ -17,11 +17,7 @@ import tempfile
 from itertools import chain
 from django.db import models, router, transaction, connection, IntegrityError
 
-try:
-    from symsynd.macho.arch import get_macho_uuids
-    have_symsynd = True
-except ImportError:
-    have_symsynd = False
+from symsynd.macho.arch import get_macho_uuids
 
 from sentry.db.models import FlexibleForeignKey, Model, BoundedBigIntegerField, \
     sane_repr, BaseManager
@@ -406,9 +402,6 @@ def create_files_from_macho_zip(fileobj, project=None):
     """Creates all missing dsym files from the given zip file.  This
     returns a list of all files created.
     """
-    if not have_symsynd:
-        raise RuntimeError('symsynd is unavailable.  Install sentry with '
-                           'the dsym feature flag.')
     scratchpad = tempfile.mkdtemp()
     try:
         safe_extract_zip(fileobj, scratchpad)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -49,7 +49,6 @@ register(
 register('redis.options', type=Dict, flags=FLAG_NOSTORE)
 
 # symbolizer specifics
-register('dsym.llvm-symbolizer-path', type=String)
 register('dsym.cache-path', type=String, default='/tmp/sentry-dsym-cache')
 
 # Mail


### PR DESCRIPTION
This updates to latest symsynd and makes it mandatory.

These changes:
- no longer require llvm-symbolizer on the machine
- significantly simplifies the system as symsynd is always available now (less dead code)
- cuts the symbolication time down from 15ms to <1ms for the common case (the loading from cache is still slow)
- moves symbolication into process
- solves the problem with llvm-symbolizer and inline frames.

I tested this quite extensively over the last few weeks and it works quite well. There is a tiny memory leak I think in some circumstances but since we already cycle the processes it should not matter too much. I ran a soak test for symsynd's native extension over night and that seems stable.

@getsentry/platform 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4210)

<!-- Reviewable:end -->
