### PR TITLE
Move padding of addresses into api context functionality

### DIFF
--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -154,7 +154,6 @@ def convert_stacktrace(frames, system=None, notable_addresses=None):
             app_uuid = app_uuid.lower()
 
     converted_frames = []
-    longest_addr = 0
     for frame in reversed(frames):
         fn = frame.get('filename')
 
@@ -183,13 +182,6 @@ def convert_stacktrace(frames, system=None, notable_addresses=None):
         }
         cframe['in_app'] = is_in_app(cframe, app_uuid)
         converted_frames.append(cframe)
-        longest_addr = max(longest_addr, len(cframe['symbol_addr']),
-                           len(cframe['instruction_addr']))
-
-    # Pad out addresses to be of the same length and add prefix
-    for frame in converted_frames:
-        for key in 'symbol_addr', 'instruction_addr':
-            frame[key] = '0x' + frame[key][2:].rjust(longest_addr, '0')
 
     if converted_frames and notable_addresses:
         converted_frames[-1]['vars'] = notable_addresses
@@ -382,7 +374,6 @@ def resolve_frame_symbols(data):
             )
         })
 
-    longest_addr = 0
     processed_frames = []
     with sym:
         for stacktrace in stacktraces:
@@ -419,8 +410,6 @@ def resolve_frame_symbols(data):
                     frame['instruction_addr'] = '0x%x' % parse_addr(
                         sfrm['instruction_addr'])
                     frame['in_app'] = is_in_app(frame)
-                    longest_addr = max(longest_addr, len(frame['symbol_addr']),
-                                       len(frame['instruction_addr']))
                     processed_frames.append(frame)
                 except Exception:
                     logger.exception('Failed to symbolicate')
@@ -428,11 +417,6 @@ def resolve_frame_symbols(data):
                         'type': EventError.NATIVE_INTERNAL_FAILURE,
                         'error': 'The symbolicator encountered an internal failure',
                     })
-
-    # Pad out addresses to be of the same length
-    for frame in processed_frames:
-        for key in 'symbol_addr', 'instruction_addr':
-            frame[key] = '0x' + frame[key][2:].rjust(longest_addr - 2, '0')
 
     if errors:
         data.setdefault('errors', []).extend(errors)

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -37,19 +37,3 @@ def cassandra_is_available():
 requires_cassandra = pytest.mark.skipif(
     not cassandra_is_available(),
     reason="requires cassandra server running")
-
-
-def has_llvm_symbolizer():
-    try:
-        from symsynd.driver import find_llvm_symbolizer
-    except ImportError:
-        return False
-
-    try:
-        return find_llvm_symbolizer() is not None
-    except EnvironmentError:
-        return False
-
-requires_llvm_symbolizer = pytest.mark.skipif(
-    not has_llvm_symbolizer(),
-    reason="requires llvm symbolizer")

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -341,7 +341,7 @@ class BasicResolvingIntegrationTest(TestCase):
         frames = bt.frames
 
         assert frames[0].function == '<redacted>'
-        assert frames[0].instruction_addr == '0x002ac28b8'
+        assert frames[0].instruction_addr == '0x2ac28b8'
         assert not frames[0].in_app
 
         assert frames[1].function == 'real_main'
@@ -358,7 +358,7 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[2].lineno == 82
         assert frames[2].colno == 23
         assert frames[2].package == object_name
-        assert frames[2].instruction_addr == '0x000000001'
+        assert frames[2].instruction_addr == '0x1'
         assert frames[2].instruction_offset is None
         assert frames[2].in_app
 
@@ -370,3 +370,9 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[3].filename == '../../sentry/scripts/views.js'
         assert frames[3].instruction_offset is None
         assert frames[3].in_app
+
+        x = bt.get_api_context()
+        long_frames = x['frames']
+        assert long_frames[0]['instructionAddr'] == '0x002ac28b8'
+        assert long_frames[1]['instructionAddr'] == '0x100026330'
+        assert long_frames[2]['instructionAddr'] == '0x000000001'

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import
 from mock import patch
 
 from sentry.models import Event
-from sentry.testutils import requires_llvm_symbolizer, TestCase
+from sentry.testutils import TestCase
 from sentry.lang.native.symbolizer import Symbolizer
 
 
-@requires_llvm_symbolizer
 class BasicResolvingIntegrationTest(TestCase):
 
     @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_app_frame')
@@ -168,7 +167,7 @@ class BasicResolvingIntegrationTest(TestCase):
         frames = bt.frames
 
         assert frames[0].function == '<redacted>'
-        assert frames[0].instruction_addr == '0x002ac28b8'
+        assert frames[0].instruction_addr == '0x2ac28b8'
         assert not frames[0].in_app
 
         assert frames[1].function == 'real_main'

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -159,7 +159,7 @@ class BasicResolvingFileTest(TestCase):
         frames = bt['frames']
 
         assert frames[0]['function'] == '<redacted>'
-        assert frames[0]['instruction_addr'] == '0x2ac28b8'
+        assert frames[0]['instruction_addr'] == '0x002ac28b8'
 
         assert frames[1]['function'] == 'real_main'
         assert frames[1]['lineno'] == 42

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -160,7 +160,7 @@ class BasicResolvingFileTest(TestCase):
         frames = bt['frames']
 
         assert frames[0]['function'] == '<redacted>'
-        assert frames[0]['instruction_addr'] == '0x002ac28b8'
+        assert frames[0]['instruction_addr'] == '0x2ac28b8'
 
         assert frames[1]['function'] == 'real_main'
         assert frames[1]['lineno'] == 42

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from mock import patch
 
-from sentry.testutils import requires_llvm_symbolizer, TestCase
+from sentry.testutils import TestCase
 from sentry.lang.native.plugin import resolve_frame_symbols
 
 
@@ -44,7 +44,6 @@ def patched_symbolize_system_frame(self, frame, sdk_info):
         }
 
 
-@requires_llvm_symbolizer
 class BasicResolvingFileTest(TestCase):
 
     @patch('sentry.lang.native.symbolizer.Symbolizer.symbolize_app_frame',


### PR DESCRIPTION
This solves the problem that currently clients that pad out addresses themselves
(like old cocoa clients) mess up the stacktrace.  We used to do this on stacktrace
generation but now we just do it whenever we generate the api context and we store
the minimal version of it.

@getsentry/platform

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4214)

<!-- Reviewable:end -->
