### PR TITLE
Add subject to MailPreview

### DIFF
--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -1,5 +1,6 @@
 <div style="padding: 20px; border-bottom: 1px solid #ddd; background: #fff; margin-bottom: 20px;">
   <div style="width: 500; margin: 0 auto">
+  {% if subject %}<h1>{{ preview.subject }}</h1>{% endif %}
     <label for="event" style="margin-right: 10px">Selection:</label>
     <select id="event" style="width: 200px; margin-right: 20px;">
       <option></option>

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -1,6 +1,6 @@
 <div style="padding: 20px; border-bottom: 1px solid #ddd; background: #fff; margin-bottom: 20px;">
   <div style="width: 500; margin: 0 auto">
-  {% if subject %}<h1>{{ preview.subject }}</h1>{% endif %}
+    {% if preview.subject %}<h1>{{ preview.subject }}</h1>{% endif %}
     <label for="event" style="margin-right: 10px">Selection:</label>
     <select id="event" style="width: 200px; margin-right: 20px;">
       <option></option>

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -98,17 +98,11 @@ def make_group_generator(random, project):
 
 # TODO(dcramer): use https://github.com/disqus/django-mailviews
 class MailPreview(object):
-    def __init__(self, html_template, text_template, context=None, subject_template=None):
+    def __init__(self, html_template, text_template, context=None, subject=None):
         self.html_template = html_template
         self.text_template = text_template
-        self.subject_template = subject_template
+        self.subject = subject
         self.context = context if context is not None else {}
-
-    def subject(self):
-        if self.subject_template:
-            return render_to_string(self.subject_template, self.context)
-        else:
-            return None
 
     def text_body(self):
         return render_to_string(self.text_template, self.context)

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -98,10 +98,17 @@ def make_group_generator(random, project):
 
 # TODO(dcramer): use https://github.com/disqus/django-mailviews
 class MailPreview(object):
-    def __init__(self, html_template, text_template, context=None):
+    def __init__(self, html_template, text_template, context=None, subject_template=None):
         self.html_template = html_template
         self.text_template = text_template
+        self.subject_template = subject_template
         self.context = context if context is not None else {}
+
+    def subject(self):
+        if self.subject_template:
+            return render_to_string(self.subject_template, self.context)
+        else:
+            return None
 
     def text_body(self):
         return render_to_string(self.text_template, self.context)


### PR DESCRIPTION
Adding optional `subject_template` to MailPreview object. Shouldn't affect previous templates.

/cc @getsentry/team

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4216)

<!-- Reviewable:end -->
