### PR TITLE
Fix .statuspage width

### DIFF
--- a/src/sentry/static/sentry/less/components/statuspage.less
+++ b/src/sentry/static/sentry/less/components/statuspage.less
@@ -10,4 +10,8 @@
     text-align: right;
     font-weight: bold;
   }
+  
+  > ul {
+    min-width: 300px;
+  }
 }


### PR DESCRIPTION
Turns <img width="150" alt="screen shot 2016-09-27 at 12 41 18 pm" src="https://cloud.githubusercontent.com/assets/72919/18889009/b8f46e86-84af-11e6-989c-8a7964ceb3bf.png"> into <img width="250" alt="screen shot 2016-09-27 at 12 41 06 pm" src="https://cloud.githubusercontent.com/assets/72919/18889010/b8f52b96-84af-11e6-869b-ec7e0b61ef5f.png">

Please note, I know nothing of the range of this change. @getsentry/ui should verify that this won't have adverse side effects elsewhere.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4223)

<!-- Reviewable:end -->
