### PR TITLE
Collapse repeat frames

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -267,7 +267,7 @@ const Frame = React.createClass({
     } else if (nRepeats > 0) {
       return (
       <span className="repeated-frames">
-        ↻  {nRepeats} &nbsp;&nbsp;&nbsp;
+        ↻  {nRepeats} 
       </span>
       );
     } else return null;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -271,7 +271,8 @@ const Frame = React.createClass({
       return (
       <span className="repeated-frames"
         title={`Frame repeated ${this.props.timesRepeated} times`}>
-        ↻  {this.props.timesRepeated}
+          <span className="icon-refresh"/>
+          <span>{this.props.timesRepeated}</span>
       </span>
       );
     } else

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -266,18 +266,19 @@ const Frame = React.createClass({
       );
     } else return null;
   },
+
   renderRepeats() {
     if (this.props.timesRepeated > 0) {
       return (
-      <span className="repeated-frames"
-        title={`Frame repeated ${this.props.timesRepeated} times`}>
-          <span className="icon-refresh"/>
-          <span>{this.props.timesRepeated}</span>
-      </span>
+        <span className="repeated-frames"
+          title={`Frame repeated ${this.props.timesRepeated} times`}>
+            <span className="icon-refresh"/>
+            <span>{this.props.timesRepeated}</span>
+        </span>
       );
-    } else
-     return null;
+    } else return null;
   },
+
   renderDefaultLine() {
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : null}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -257,28 +257,33 @@ const Frame = React.createClass({
     return !this.props.data.inApp && this.props.nextFrameInApp;
   },
 
-  renderLeadHint(nRepeats) {
+  renderLeadHint() {
     if (this.leadsToApp() && !this.state.isExpanded) {
       return (
         <span className="leads-to-app-hint">
           {'Called from: '}
         </span>
       );
-    } else if (nRepeats > 0) {
-      return (
-      <span className="repeated-frames">
-        ↻  {nRepeats} 
-      </span>
-      );
     } else return null;
   },
-
-  renderDefaultLine(nRepeats) {
+  renderRepeats() {
+    if (this.props.timesRepeated > 0) {
+      return (
+      <span className="repeated-frames"
+        title={`Frame repeated ${this.props.timesRepeated} times`}>
+        ↻  {this.props.timesRepeated}
+      </span>
+      );
+    } else
+     return null;
+  },
+  renderDefaultLine() {
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : null}>
         <div className="title">
-          {this.renderLeadHint(nRepeats)}
+          {this.renderLeadHint()}
           {this.renderDefaultTitle()}
+          {this.renderRepeats()}
         </div>
       </StrictClick>
     );
@@ -316,13 +321,13 @@ const Frame = React.createClass({
     );
   },
 
-  renderLine(nRepeats) {
+  renderLine() {
     switch (this.getPlatform()) {
       case 'objc':
       case 'cocoa':
         return this.renderCocoaLine();
       default:
-        return this.renderDefaultLine(nRepeats);
+        return this.renderDefaultLine();
     }
   },
 
@@ -343,7 +348,7 @@ const Frame = React.createClass({
 
     return (
       <li {...props}>
-        {this.renderLine(this.props.timesRepeated)}
+        {this.renderLine()}
         {context}
       </li>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -28,6 +28,7 @@ const Frame = React.createClass({
     isExpanded: React.PropTypes.bool,
     emptySourceNotation: React.PropTypes.bool,
     isOnlyFrame: React.PropTypes.bool,
+    timesRepeated: React.PropTypes.number,
   },
 
   mixins: [
@@ -256,23 +257,27 @@ const Frame = React.createClass({
     return !this.props.data.inApp && this.props.nextFrameInApp;
   },
 
-  renderLeadHint() {
+  renderLeadHint(nRepeats) {
     if (this.leadsToApp() && !this.state.isExpanded) {
       return (
         <span className="leads-to-app-hint">
           {'Called from: '}
         </span>
       );
-    } else {
-      return null;
-    }
+    } else if (nRepeats > 0) {
+      return (
+      <span className="repeated-frames">
+        ↻  {nRepeats} &nbsp;&nbsp;&nbsp;
+      </span>
+      );
+    } else return null;
   },
 
-  renderDefaultLine() {
+  renderDefaultLine(nRepeats) {
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : null}>
         <div className="title">
-          {this.renderLeadHint()}
+          {this.renderLeadHint(nRepeats)}
           {this.renderDefaultTitle()}
         </div>
       </StrictClick>
@@ -311,13 +316,13 @@ const Frame = React.createClass({
     );
   },
 
-  renderLine() {
+  renderLine(nRepeats) {
     switch (this.getPlatform()) {
       case 'objc':
       case 'cocoa':
         return this.renderCocoaLine();
       default:
-        return this.renderDefaultLine();
+        return this.renderDefaultLine(nRepeats);
     }
   },
 
@@ -338,7 +343,7 @@ const Frame = React.createClass({
 
     return (
       <li {...props}>
-        {this.renderLine()}
+        {this.renderLine(this.props.timesRepeated)}
         {context}
       </li>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -66,9 +66,16 @@ const StacktraceContent = React.createClass({
 
     let expandFirstFrame = this.props.expandFirstFrame;
     let frames = [];
+    let nRepeats = 0;
     data.frames.forEach((frame, frameIdx) => {
       let nextFrame = data.frames[frameIdx + 1];
-      if (this.frameIsVisible(frame, nextFrame)) {
+      let repeatedFrame = nextFrame && frame.lineNo == nextFrame.lineNo && frame.function == nextFrame.function;
+      if(repeatedFrame){
+        nRepeats++;
+      }
+      debugger
+      if (this.frameIsVisible(frame, nextFrame)
+          && !repeatedFrame ){
         frames.push(
           <Frame
             key={frameIdx}
@@ -77,8 +84,12 @@ const StacktraceContent = React.createClass({
             emptySourceNotation={lastFrameIdx === frameIdx && frameIdx === 0}
             isOnlyFrame={this.props.data.frames.length === 1}
             nextFrameInApp={nextFrame && nextFrame.inApp}
-            platform={this.props.platform} />
+            platform={this.props.platform}
+            timesRepeated={nRepeats}/>
         );
+      }
+      if(!repeatedFrame){
+        nRepeats = 0;
       }
       if (frameIdx === firstFrameOmitted) {
         frames.push(this.renderOmittedFrames(

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -73,7 +73,6 @@ const StacktraceContent = React.createClass({
       if(repeatedFrame){
         nRepeats++;
       }
-      debugger
       if (this.frameIsVisible(frame, nextFrame)
           && !repeatedFrame ){
         frames.push(

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -69,12 +69,15 @@ const StacktraceContent = React.createClass({
     let nRepeats = 0;
     data.frames.forEach((frame, frameIdx) => {
       let nextFrame = data.frames[frameIdx + 1];
-      let repeatedFrame = nextFrame && frame.lineNo == nextFrame.lineNo && frame.function == nextFrame.function;
+      let repeatedFrame = nextFrame &&
+       frame.lineNo === nextFrame.lineNo &&
+       frame.function === nextFrame.function;
+
       if(repeatedFrame){
         nRepeats++;
       }
-      if (this.frameIsVisible(frame, nextFrame)
-          && !repeatedFrame ){
+
+      if (this.frameIsVisible(frame, nextFrame) && !repeatedFrame ){
         frames.push(
           <Frame
             key={frameIdx}
@@ -87,9 +90,11 @@ const StacktraceContent = React.createClass({
             timesRepeated={nRepeats}/>
         );
       }
+
       if(!repeatedFrame){
         nRepeats = 0;
       }
+
       if (frameIdx === firstFrameOmitted) {
         frames.push(this.renderOmittedFrames(
           firstFrameOmitted, lastFrameOmitted));

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -73,7 +73,7 @@ const StacktraceContent = React.createClass({
        frame.lineNo === nextFrame.lineNo &&
        frame.function === nextFrame.function;
 
-      if(repeatedFrame){
+      if (repeatedFrame) {
         nRepeats++;
       }
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1405,16 +1405,18 @@ div.traceback > ul {
   }
   .repeated-frames{
     border-radius: 50px;
-    padding: 1px 3px 0 3px;
-    margin-top: -2px;
-    margin-right: 30px;
+    padding: 1px 3px;
+    margin-left: 1em;
     border-width: thin;
     border-style: solid;
-    float: right;
     border-color: @yellow-orange-dark;
     color: @yellow-orange-dark;
     background-color: @white-dark;
+    span {
+      vertical-align: middle;
+    }
   }
+
   &.in-app-traceback .frame.leads-to-app {
     .leads-to-app-hint {
       display: none;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1403,7 +1403,18 @@ div.traceback > ul {
       }
     }
   }
-
+  .repeated-frames{
+    border-radius: 50px;
+    padding: 1px 3px 0 3px;
+    margin-top: -2px;
+    margin-right: 30px;
+    border-width: thin;
+    border-style: solid;
+    float: right;
+    border-color: @yellow-orange-dark;
+    color: @yellow-orange-dark;
+    background-color: @white-dark;
+  }
   &.in-app-traceback .frame.leads-to-app {
     .leads-to-app-hint {
       display: none;

--- a/src/sentry/static/sentry/less/palette.less
+++ b/src/sentry/static/sentry/less/palette.less
@@ -33,7 +33,7 @@
 
 @purple:              #836CC2;
 @purple-light:        #A290D1;
-@purple-lightest:     lighten(#A290D1, 6);
+@purple-lightest:     lighten(@purple-light, 6);
 @purple-dark:         #6958A2;
 
 @gray:                #6F7E94;


### PR DESCRIPTION
filter repeated stack frames in UI
this works by comparing if two stack frames share a lineNo and function name. displays a small card eg: (↻ 20248)
fixes #4078
/cc @getsentry/product

![screenshot 2016-09-27 15 00 20](https://cloud.githubusercontent.com/assets/5915546/18893601/7203f1c2-84c3-11e6-86a4-373ce45cd3c7.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4224)

<!-- Reviewable:end -->
