### PR TITLE
Sort notification settings by org name

### DIFF
--- a/src/sentry/web/frontend/account_notification.py
+++ b/src/sentry/web/frontend/account_notification.py
@@ -55,7 +55,7 @@ class AccountNotificationView(BaseView):
                 prefix='project-%s' % (project.id,)
             ))
             for project in sorted(project_list, key=lambda x: (
-                x.team.name if x.team else None, x.name))
+                x.organization.name, x.name))
         ]
 
         ext_forms = []


### PR DESCRIPTION
Since we were sorting previously on team name, the UI became a bit
confusing since you'd see groups of the same org a few times.

@getsentry/ui @getsentry/platform 

This is what could happen before:

![image](https://cloud.githubusercontent.com/assets/375744/18896304/7641a24a-84d5-11e6-958a-58242819db74.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4226)

<!-- Reviewable:end -->
