### PR TITLE
Fix scope check in OrganizationManager.get_for_user

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -63,7 +63,7 @@ class OrganizationManager(BaseManager):
         if scope is not None:
             return [
                 r.organization for r in results
-                if scope not in r.get_scopes()
+                if scope in r.get_scopes()
             ]
         return [r.organization for r in results]
 


### PR DESCRIPTION
@dcramer agrees that this filter was accidentally backwards. It wasn't previously used anywhere, so it didn't matter and nobody noticed, but I'm using it in something coming up, so I noticed and it will matter.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4232)

<!-- Reviewable:end -->
