### PR TITLE
[breadcrumbs] handle non-strings in data

### DIFF
--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -13,6 +13,7 @@ __all__ = ('Breadcrumbs',)
 import six
 
 from sentry.interfaces.base import Interface, InterfaceValidationError
+from sentry.utils import json
 from sentry.utils.safe import trim
 from sentry.utils.dates import to_timestamp, to_datetime, parse_timestamp
 
@@ -85,6 +86,9 @@ class Breadcrumbs(Interface):
             rv['event_id'] = event_id
 
         if 'data' in crumb:
+            for key, value in six.iteritems(crumb['data']):
+                if not isinstance(value, six.string_types):
+                    crumb['data'][key] = json.dumps(value)
             rv['data'] = trim(crumb['data'], 4096)
 
         return rv

--- a/tests/sentry/interfaces/test_breadcrumbs.py
+++ b/tests/sentry/interfaces/test_breadcrumbs.py
@@ -24,3 +24,14 @@ class BreadcrumbsTest(TestCase):
         assert int(ts) == 1458857193
         assert abs(ts - 1458857193.973275) < 0.001
         assert result.values[0]['data'] == {'message': 'Whats up dawg?'}
+
+    def test_non_string_keys(self):
+        result = Breadcrumbs.to_python(dict(values=[{
+            'type': 'message',
+            'timestamp': 1458857193.973275,
+            'data': {
+                'extra': {'foo': 'bar'},
+            },
+        }]))
+        assert len(result.values) == 1
+        assert result.values[0]['data'] == {'extra': '{"foo":"bar"}'}


### PR DESCRIPTION
This ensures all attributes of data are strings, as it seems we didn't enforce this in all SDKs.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4233)

<!-- Reviewable:end -->
