### PR TITLE
Properly pass along auth through API client

### DIFF
--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -183,7 +183,6 @@ def cli(output_path):
 
         vars = {
             'org': org,
-            'api_key': api_key,
             'me': user,
             'api_key': api_key,
             'teams': [{

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -129,6 +129,17 @@ class Endpoint(APIView):
 
         return entry
 
+    def initialize_request(self, request, *args, **kwargs):
+        rv = super(Endpoint, self).initialize_request(request, *args, **kwargs)
+        # If our request is being made via our internal API client, we need to
+        # stitch back on auth and user information
+        if getattr(request, '__from_api_client__', False):
+            if rv.auth is None:
+                rv.auth = getattr(request, 'auth', None)
+            if rv.user is None:
+                rv.user = getattr(request, 'user', None)
+        return rv
+
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
         """

--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -44,6 +44,8 @@ class ApiClient(object):
 
         rf = APIRequestFactory()
         mock_request = getattr(rf, method.lower())(full_path, data or {})
+        # Flag to our API class that we should trust this auth passed through
+        mock_request.__from_api_client__ = True
 
         if request:
             mock_request.auth = getattr(request, 'auth', None)


### PR DESCRIPTION
We construct this fake WSGIRequest object and we were attempting to be
clever by patching on request.{auth,user} to preserve these from the
original request.

In Django Rest Framework, when we get into our Endpoint.dispatch(), the
first thing done is goes through `APIView.initialize_request()`. This
step is transforming the normal Django request object and wrapping it as
a Rest Framework Request object. When this happens, we lose our patched
on `request.{auth,user}` objects, and they are replaced with DRF's
getters for `request.{user,auth}` specifically. Otherwise, properties
are proxied back through into the original request. The behavior of the
getters is to actually go through the authentication flow. So it goes
through our DEFAULT_AUTHENTICATION again. And becasue we have this mock
object, it's not even close to being real, and we don't end up with real
auth information coming out out.

So this patch is just setting out explicit `request.{auth,user}`
information that we intend on overriding on the correct object.

@getsentry/api @getsentry/platform 

You can see this IRL here: https://docs.sentry.io/hosted/api/events/put-group-details/#example because we ourselves are erroring when trying to making this API call.

In production, we see:
- https://sentry.io/sentry/sentry/issues/138093760/
- https://sentry.io/sentry/freight/issues/138328381/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry/4237)

<!-- Reviewable:end -->
