### PR TITLE
Utilize event type for title generation

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -106,11 +106,6 @@ class EventSerializer(Serializer):
             except TypeError:
                 received = None
 
-        event_type = obj.data.get('type', 'default')
-        metadata = obj.data.get('metadata') or {
-            'title': obj.message_short,
-        }
-
         # TODO(dcramer): move release serialization here
         d = {
             'id': six.text_type(obj.id),
@@ -126,8 +121,8 @@ class EventSerializer(Serializer):
             # TODO(dcramer): move into contexts['extra']
             'context': obj.data.get('extra', {}),
             'packages': obj.data.get('modules', {}),
-            'type': event_type,
-            'metadata': metadata,
+            'type': obj.get_event_type(),
+            'metadata': obj.get_event_metadata(),
             'tags': tags,
             'platform': obj.platform,
             'dateCreated': obj.datetime,

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -144,24 +144,13 @@ class GroupSerializer(Serializer):
         permalink = absolute_uri(reverse('sentry-group', args=[
             obj.organization.slug, obj.project.slug, obj.id]))
 
-        event_type = obj.data.get('type', 'default')
-        metadata = obj.data.get('metadata') or {
-            'title': obj.message_short,
-        }
-        # TODO(dcramer): remove in 8.6+
-        if event_type == 'error':
-            if 'value' in metadata:
-                metadata['value'] = six.text_type(metadata['value'])
-            if 'type' in metadata:
-                metadata['type'] = six.text_type(metadata['type'])
-
         return {
             'id': six.text_type(obj.id),
             'shareId': obj.get_share_id(),
             'shortId': obj.qualified_short_id,
             'count': six.text_type(obj.times_seen),
             'userCount': attrs['user_count'],
-            'title': obj.message_short,
+            'title': obj.title,
             'culprit': obj.culprit,
             'permalink': permalink,
             'firstSeen': obj.first_seen,
@@ -175,8 +164,8 @@ class GroupSerializer(Serializer):
                 'name': obj.project.name,
                 'slug': obj.project.slug,
             },
-            'type': event_type,
-            'metadata': metadata,
+            'type': obj.get_event_type(),
+            'metadata': obj.get_event_metadata(),
             'numComments': obj.num_comments,
             'assignedTo': attrs['assigned_to'],
             'isBookmarked': attrs['is_bookmarked'],

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -76,6 +76,9 @@ class NodeData(collections.MutableMapping):
             return
         return ref_func(instance)
 
+    def copy(self):
+        return self.data.copy()
+
     @memoize
     def data(self):
         from sentry.app import nodestore

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -15,6 +15,9 @@ class BaseEvent(object):
     def get_metadata(self):
         raise NotImplementedError
 
+    def to_string(self, metadata):
+        raise NotImplementedError
+
 
 class DefaultEvent(BaseEvent):
     key = 'default'
@@ -37,5 +40,5 @@ class DefaultEvent(BaseEvent):
             'title': title,
         }
 
-    def to_string(self, data):
-        return data['title']
+    def to_string(self, metadata):
+        return metadata['title']

--- a/src/sentry/eventtypes/csp.py
+++ b/src/sentry/eventtypes/csp.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from sentry.interfaces.csp import Csp
-
 from .base import BaseEvent
 
 
@@ -12,6 +10,9 @@ class CspEvent(BaseEvent):
         return 'sentry.interfaces.Csp' in self.data
 
     def get_metadata(self):
+        # TODO(dcramer): we need to avoid importing interfaces in this module
+        # due to recursion at top level
+        from sentry.interfaces.csp import Csp
         # TODO(dcramer): pull get message into here to avoid instantiation
         # or ensure that these get interfaces passed instead of raw data
         csp = Csp.to_python(self.data['sentry.interfaces.Csp'])
@@ -22,5 +23,5 @@ class CspEvent(BaseEvent):
             'message': csp.get_message(),
         }
 
-    def to_string(self, data):
-        return data['message']
+    def to_string(self, metadata):
+        return metadata['message']

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -20,5 +20,5 @@ class ErrorEvent(BaseEvent):
             'value': trim(exception.get('value', ''), 1024),
         }
 
-    def to_string(self, data):
-        return u'{}: {}'.format(data['type'], data['value'])
+    def to_string(self, metadata):
+        return u'{}: {}'.format(metadata['type'], metadata['value'])

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -103,9 +103,7 @@ class Event(Model):
 
         See ``sentry.eventtypes``.
         """
-        etype = self.data.get('type')
-        if etype is None:
-            etype = 'default'
+        etype = self.data.get('type', 'default')
         if 'metadata' not in self.data:
             # TODO(dcramer): remove after Dec 1 2016
             data = self.data.copy() if self.data else {}
@@ -131,7 +129,7 @@ class Event(Model):
         return self.title
 
     def has_two_part_message(self):
-        warnings.warn('Event.message_short is no longer used',
+        warnings.warn('Event.has_two_part_message is no longer used',
                       DeprecationWarning)
         return False
 

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -15,6 +15,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
+from sentry import eventtypes
 from sentry.db.models import (
     BaseManager, BoundedBigIntegerField, BoundedIntegerField,
     Model, NodeField, sane_repr
@@ -22,7 +23,6 @@ from sentry.db.models import (
 from sentry.interfaces.base import get_interface
 from sentry.utils.cache import memoize
 from sentry.utils.safe import safe_execute
-from sentry.utils.strings import truncatechars, strip
 
 
 class Event(Model):
@@ -89,27 +89,51 @@ class Event(Model):
         })
         return msg_interface.get('formatted', msg_interface['message'])
 
-    def error(self):
-        message = strip(self.get_legacy_message())
-        if not message:
-            message = '<unlabeled message>'
-        else:
-            message = truncatechars(message.splitlines()[0], 100)
-        return message
-    error.short_description = _('error')
+    def get_event_type(self):
+        """
+        Return the type of this event.
 
-    def has_two_part_message(self):
-        message = strip(self.get_legacy_message())
-        return '\n' in message or len(message) > 100
+        See ``sentry.eventtypes``.
+        """
+        return self.data.get('type', 'default')
+
+    def get_event_metadata(self):
+        """
+        Return the metadata of this event.
+
+        See ``sentry.eventtypes``.
+        """
+        etype = self.data.get('type')
+        if etype is None:
+            etype = 'default'
+        if 'metadata' not in self.data:
+            # TODO(dcramer): remove after Dec 1 2016
+            data = self.data.copy() if self.data else {}
+            data['message'] = self.message
+            return eventtypes.get(etype)(data).get_metadata()
+        return self.data['metadata']
+
+    @property
+    def title(self):
+        et = eventtypes.get(self.get_event_type())(self.data)
+        return et.to_string(self.get_event_metadata())
+
+    def error(self):
+        warnings.warn('Event.error is deprecated, use Event.title',
+                      DeprecationWarning)
+        return self.title
+    error.short_description = _('error')
 
     @property
     def message_short(self):
-        message = strip(self.get_legacy_message())
-        if not message:
-            message = '<unlabeled message>'
-        else:
-            message = truncatechars(message.splitlines()[0], 100)
-        return message
+        warnings.warn('Event.message_short is deprecated, use Event.title',
+                      DeprecationWarning)
+        return self.title
+
+    def has_two_part_message(self):
+        warnings.warn('Event.message_short is no longer used',
+                      DeprecationWarning)
+        return False
 
     @property
     def team(self):
@@ -245,5 +269,5 @@ class Event(Model):
         return '[%s] %s: %s' % (
             self.project.get_full_name().encode('utf-8'),
             six.text_type(self.get_tag('level')).upper().encode('utf-8'),
-            self.message_short.encode('utf-8')
+            self.title.encode('utf-8')
         )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -415,7 +415,7 @@ class Group(Model):
         return self.title
 
     def has_two_part_message(self):
-        warnings.warn('Group.message_short is no longer used',
+        warnings.warn('Group.has_two_part_message is no longer used',
                       DeprecationWarning)
         return False
 

--- a/src/sentry/plugins/sentry_mail/activity/base.py
+++ b/src/sentry/plugins/sentry_mail/activity/base.py
@@ -109,7 +109,7 @@ class ActivityEmail(object):
         return u'[%s] %s: %s' % (
             self.project.get_full_name(),
             group.get_level_display().upper(),
-            group.message_short
+            group.title
         )
 
     def get_context(self):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -241,6 +241,21 @@ class Fixtures(object):
             'name': 'foobar',
         }])
 
+        # maintain simple event fixtures by supporting the legacy message
+        # parameter just like our API would
+        if 'sentry.interfaces.Message' not in kwargs['data']:
+            kwargs['data']['sentry.interfaces.Message'] = {
+                'message': kwargs.get('message') or '<unlabeled event>',
+            }
+
+        if 'type' not in kwargs['data']:
+            kwargs['data'].update({
+                'type': 'default',
+                'metadata': {
+                    'title': kwargs['data']['sentry.interfaces.Message']['message'],
+                },
+            })
+
         event = Event(
             event_id=event_id,
             **kwargs
@@ -335,6 +350,14 @@ class Fixtures(object):
         if checksum:
             warnings.warn('Checksum passed to create_group', DeprecationWarning)
         kwargs.setdefault('message', 'Hello world')
+        kwargs.setdefault('data', {})
+        if 'type' not in kwargs['data']:
+            kwargs['data'].update({
+                'type': 'default',
+                'metadata': {
+                    'title': kwargs['message'],
+                },
+            })
         return Group.objects.create(
             project=project or self.project,
             **kwargs

--- a/src/sentry/utils/javascript.py
+++ b/src/sentry/utils/javascript.py
@@ -185,7 +185,7 @@ class GroupTransformer(Transformer):
             'id': six.text_type(obj.id),
             'count': six.text_type(obj.times_seen),
             'title': escape(obj.title),
-            'message': escape(obj.message_short),
+            'message': escape(obj.get_legacy_message()),
             'level': obj.level,
             'levelName': escape(obj.get_level_display()),
             'logger': escape(obj.logger),


### PR DESCRIPTION
- Add {Group,Event}.get_event_type()
- Add {Group,Event}.get_event_metadata()
- Deprecate {Group,Event}.message_short
- Deprecate {Group,Event}.error()
- Deprecate {Group,Event}.has_two_part_message()
- Unify default metadata generation for legacy events
- Update {Group,Event}.title to use EventType.to_string()
- Update email subjects to use title
