### PR TITLE
Ensure UserEmail object gets created from user email

### DIFF
--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -39,3 +39,10 @@ class UserEmail(Model):
 
     def hash_is_valid(self):
         return self.validation_hash and self.date_hash_added > timezone.now() - timedelta(hours=48)
+
+    @classmethod
+    def get_primary_email(self, user):
+        return UserEmail.objects.get_or_create(
+            user=user,
+            email=user.email,
+        )[0]

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -11,6 +11,7 @@ from django.contrib import messages
 from django.contrib.auth import login as login_user, authenticate
 from django.core.context_processors import csrf
 from django.core.urlresolvers import reverse
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, transaction
 from django.http import HttpResponseRedirect, Http404
 from django.views.decorators.cache import never_cache
@@ -322,6 +323,10 @@ def show_emails(request):
             'primary_email': primary_email,
         },
     )
+    try:
+        email = user.emails.get(email=primary_email)
+    except ObjectDoesNotExist:
+        UserEmail.objects.create(user=user, email=primary_email)
 
     if 'remove' in request.POST:
         email = request.POST.get('email')


### PR DESCRIPTION
This creates a UserEmail object on account or email settings page if one does not exist, since it's possible for users to not have a UserEmail object for their email. This ensures a resend verifications alert will appear for unverified emails in account settings or email settings .
@getsentry/platform  @dcramer 
