### PR TITLE
[plugins] improve handling of disconnect in social auth

### DIFF
--- a/src/sentry/templates/sentry/account/identities.html
+++ b/src/sentry/templates/sentry/account/identities.html
@@ -27,7 +27,7 @@
                         <td>{{ identity.provider|auth_provider_label }}</td>
                         <td style="text-align: center;">
                             <form method="post"
-                                  action="{% url 'sentry-account-disconnect-identity' identity.provider identity.id %}">
+                                  action="{% url 'sentry-account-disconnect-identity' identity.id %}">
                                 {% csrf_token %}
                                 <button type="submit" class="btn btn-default btn-sm">Disconnect</button>
                             </form>

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -260,7 +260,7 @@ urlpatterns += patterns(
         name='sentry-account-settings-appearance'),
     url(r'^account/settings/identities/$', accounts.list_identities,
         name='sentry-account-settings-identities'),
-    url(r'^account/settings/identities/(?P<backend>[^\/]+)/(?P<identity_id>[^\/]+)/disconnect/$',
+    url(r'^account/settings/identities/(?P<identity_id>[^\/]+)/disconnect/$',
         accounts.disconnect_identity,
         name='sentry-account-disconnect-identity'),
     url(r'^account/settings/notifications/$', AccountNotificationView.as_view(),

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -719,8 +719,8 @@ def get_backends(force_load=False):
     """
     global BACKENDSCACHE
 
-    with _import_lock:
-        if not BACKENDSCACHE or force_load:
+    if not BACKENDSCACHE or force_load:
+        with _import_lock:
             for auth_backend in setting('AUTHENTICATION_BACKENDS'):
                 mod, cls_name = auth_backend.rsplit('.', 1)
                 module = __import__(mod, {}, {}, ['BACKENDS', cls_name])

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -102,7 +102,7 @@ class SocialAuthBackend(object):
         for idx, name in enumerate(pipeline):
             out['pipeline_index'] = base_index + idx
             mod_name, func_name = name.rsplit('.', 1)
-            mod = __import__(mod_name)
+            mod = __import__(mod_name, {}, {}, [func_name])
             func = getattr(mod, func_name, None)
 
             try:

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -12,9 +12,9 @@ enabled.
 from __future__ import absolute_import
 
 import six
+import threading
 
 from django.contrib.auth import authenticate
-from django.utils.importlib import import_module
 from django.utils.crypto import get_random_string, constant_time_compare
 from six.moves.urllib.error import HTTPError
 from six.moves.urllib.request import Request
@@ -102,7 +102,7 @@ class SocialAuthBackend(object):
         for idx, name in enumerate(pipeline):
             out['pipeline_index'] = base_index + idx
             mod_name, func_name = name.rsplit('.', 1)
-            mod = import_module(mod_name)
+            mod = __import__(mod_name)
             func = getattr(mod, func_name, None)
 
             try:
@@ -193,7 +193,7 @@ class OAuthBackend(SocialAuthBackend):
         names = (cls.EXTRA_DATA or []) + setting(name + '_EXTRA_DATA', [])
 
         for entry in names:
-            if type(entry) is str:
+            if isinstance(entry, six.string_types):
                 entry = (entry,)
 
             try:
@@ -367,8 +367,9 @@ class BaseOAuth(BaseAuth):
     @classmethod
     def enabled(cls):
         """Return backend enabled status by checking basic settings"""
-        return (setting(cls.SETTINGS_KEY_NAME) and
-                setting(cls.SETTINGS_SECRET_NAME))
+        return bool(
+            setting(cls.SETTINGS_KEY_NAME) and setting(cls.SETTINGS_SECRET_NAME)
+        )
 
     def get_scope(self):
         """Return list with needed access scope"""
@@ -691,16 +692,10 @@ class BaseOAuth2(BaseOAuth):
         return authenticate(*args, **kwargs)
 
 
-# Backend loading was previously performed via the
-# SOCIAL_AUTH_IMPORT_BACKENDS setting - as it's no longer used,
-# provide a deprecation warning.
-if setting('SOCIAL_AUTH_IMPORT_BACKENDS'):
-    from warnings import warn
-    warn("SOCIAL_AUTH_IMPORT_SOURCES is deprecated")
-
-
 # Cache for discovered backends.
 BACKENDSCACHE = {}
+
+_import_lock = threading.Lock()
 
 
 def get_backends(force_load=False):
@@ -722,35 +717,30 @@ def get_backends(force_load=False):
     A force_load boolean arg is also provided so that get_backend
     below can retry a requested backend that may not yet be discovered.
     """
-    if not BACKENDSCACHE or force_load:
-        for auth_backend in setting('AUTHENTICATION_BACKENDS'):
-            mod, cls_name = auth_backend.rsplit('.', 1)
-            module = import_module(mod)
-            backend = getattr(module, cls_name)
+    global BACKENDSCACHE
 
-            if issubclass(backend, SocialAuthBackend):
-                name = backend.name
-                backends = getattr(module, 'BACKENDS', {})
-                if name in backends and backends[name].enabled():
-                    BACKENDSCACHE[name] = backends[name]
+    with _import_lock:
+        if not BACKENDSCACHE or force_load:
+            for auth_backend in setting('AUTHENTICATION_BACKENDS'):
+                mod, cls_name = auth_backend.rsplit('.', 1)
+                module = __import__(mod, {}, {}, ['BACKENDS', cls_name])
+                backend = getattr(module, cls_name)
+
+                if issubclass(backend, SocialAuthBackend):
+                    name = backend.name
+                    backends = getattr(module, 'BACKENDS', {})
+                    if name in backends and backends[name].enabled():
+                        BACKENDSCACHE[name] = backends[name]
     return BACKENDSCACHE
 
 
 def get_backend(name, *args, **kwargs):
-    """Returns a backend by name. Backends are stored in the BACKENDSCACHE
-    cache dict. If not found, each of the modules referenced in
-    AUTHENTICATION_BACKENDS is imported and checked for a BACKENDS
-    definition. If the named backend is found in the module's BACKENDS
-    definition, it's then stored in the cache for future access.
-    """
+    get_backends()
+
     try:
         # Cached backend which has previously been discovered.
-        return BACKENDSCACHE[name](*args, **kwargs)
+        backend_cls = BACKENDSCACHE[name]
     except KeyError:
-        # Force a reload of BACKENDS to ensure a missing
-        # backend hasn't been missed.
-        get_backends(force_load=True)
-        try:
-            return BACKENDSCACHE[name](*args, **kwargs)
-        except KeyError:
-            return None
+        return None
+    else:
+        return backend_cls(*args, **kwargs)


### PR DESCRIPTION
- add lock around get_backends()
- improve handling of get_backends() (dont re-import for no reason)
- move disconnect view into sentry and remove magical failure scenario
