### PR TITLE
Remove sidebars on all modals. Fix add/edit member modals.

### DIFF
--- a/src/sentry/templates/sentry/bases/modal.html
+++ b/src/sentry/templates/sentry/bases/modal.html
@@ -3,15 +3,31 @@
 {% load i18n %}
 
 {% block wrapperclass %}{{ block.super }} narrow{% endblock %}
+{% block global_sidebar %}{% endblock %}
+{% block sub-header %}{% endblock %}
 
 {% block content %}
 <div class="pattern-bg"></div>
 <section class="org-login">
   <div class="box box-modal">
     <div class="box-header">
-      <a href="/">
-        <span class="icon-sentry-logo-full"></span>
+      {% block modal_header%}
+      {% block modal_header_signout %}
+        {% if request.user.is_authenticated %}
+          <div class="pull-right">
+            <a href="{% url 'sentry-logout' %}">{% trans "Sign out" %}</a>
+          </div>
+        {% endif %}
+      {% endblock %}
+      <a href="{% block modal_header_link %}/{% endblock %}">
+        {% if request.user.is_authenticated %}
+          <span class="icon-sentry-logo"></span>
+        {% else %}
+          <span class="icon-sentry-logo-full"></span>
+        {% endif %}
+        {% block modal_header_extra %}{% endblock %}
       </a>
+      {% endblock %}
     </div>
     <div class="box-content with-padding">
       {% block main %}{% endblock %}

--- a/src/sentry/templates/sentry/bases/modal.html
+++ b/src/sentry/templates/sentry/bases/modal.html
@@ -12,21 +12,21 @@
   <div class="box box-modal">
     <div class="box-header">
       {% block modal_header%}
-      {% block modal_header_signout %}
-        {% if request.user.is_authenticated %}
-          <div class="pull-right">
-            <a href="{% url 'sentry-logout' %}">{% trans "Sign out" %}</a>
-          </div>
-        {% endif %}
-      {% endblock %}
-      <a href="{% block modal_header_link %}/{% endblock %}">
-        {% if request.user.is_authenticated %}
-          <span class="icon-sentry-logo"></span>
-        {% else %}
-          <span class="icon-sentry-logo-full"></span>
-        {% endif %}
-        {% block modal_header_extra %}{% endblock %}
-      </a>
+        {% block modal_header_signout %}
+          {% if request.user.is_authenticated %}
+            <div class="pull-right">
+              <a href="{% url 'sentry-logout' %}">{% trans "Sign out" %}</a>
+            </div>
+          {% endif %}
+        {% endblock %}
+        <a href="{% block modal_header_link %}/{% endblock %}">
+          {% if request.user.is_authenticated %}
+            <span class="icon-sentry-logo"></span>
+          {% else %}
+            <span class="icon-sentry-logo-full"></span>
+          {% endif %}
+          {% block modal_header_extra %}{% endblock %}
+        </a>
       {% endblock %}
     </div>
     <div class="box-content with-padding">

--- a/src/sentry/templates/sentry/create-organization-member.html
+++ b/src/sentry/templates/sentry/create-organization-member.html
@@ -6,11 +6,16 @@
 {% block title %}{% trans "Add Member to Organization" %} | {{ block.super }}{% endblock %}
 {% block sub-header %}{% endblock %}
 
+{% block modal_header_link %}
+  {% url 'sentry-organization-members' organization.slug %}
+{% endblock %}
+
+{% block modal_header_extra %}
+  <span class="back-to">Back to Member List</span>
+{% endblock %}
+
 {% block main %}
-  <div class="page-header">
-    <a class="back-arrow" style="top: -3px;" href="{% url 'sentry-organization-members' organization.slug %}"><span class="icon-arrow-left"></span></a>
-    <h2>{% trans "Add Member to Organization" %}</h2>
-  </div>
+  <h2 class="p-b-1 m-b-1 b-b-1">{% trans "Add Member to Organization" %}</h2>
 
   {% block new_member_form_template_hook %}{% endblock %}
 

--- a/src/sentry/templates/sentry/organization-member-details.html
+++ b/src/sentry/templates/sentry/organization-member-details.html
@@ -6,15 +6,19 @@
 
 {% block title %}{% trans "Member Details" %} | {{ block.super }}{% endblock %}
 
-{% block main %}
-  <div class="page-header">
-    <a class="back-arrow" style="top: 0px;" href="{% url 'sentry-organization-members' organization.slug %}"><span class="icon-arrow-left"></span></a>
-    <h2>
-      {{ member.get_display_name }}
-      <br><small>Member Settings</small>
-    </h2>
-  </div>
+{% block modal_header_link %}
+  {% url 'sentry-organization-members' organization.slug %}
+{% endblock %}
 
+{% block modal_header_extra %}
+  <span class="back-to">Back to Member List</span>
+{% endblock %}
+
+{% block main %}
+  <h2 class="p-b-1 m-b-1 b-b-1">
+    {{ member.get_display_name }}
+    <br><small>Member Settings</small>
+  </h2>
 
   <div class="box">
     <div class="box-header">


### PR DESCRIPTION
This addresses the following from #4281:
- Hides sidebars and sub-headers at the modal template level on server pages
- Makes the modal header configurable from child templates
- Add / edit member templates use this for a more descriptive "back to" link

@getsentry/product
