### PR TITLE
Various sidebar follow up 01

### DIFF
--- a/src/sentry/static/sentry/app/components/narrowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.jsx
@@ -2,7 +2,6 @@ import jQuery from 'jquery';
 import React from 'react';
 
 import Footer from '../components/footer';
-import Sidebar from '../components/sidebar';
 
 const NarryLayout = React.createClass({
   componentWillMount() {
@@ -16,9 +15,14 @@ const NarryLayout = React.createClass({
   render() {
     return (
       <div className="app">
-        <Sidebar />
+        <div className="pattern-bg"/>
         <div className="container">
-          <div className="box">
+          <div className="box box-modal">
+            <div className="box-header">
+              <a href="/">
+                <span className="icon-sentry-logo" />
+              </a>
+            </div>
             <div className="box-content with-padding">
               {this.props.children}
             </div>

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -181,6 +181,13 @@ const Sidebar = React.createClass({
           </a>
         </li>
       </ul>
+      <ul className="navbar-nav">
+        <Broadcasts
+          showPanel={this.state.showPanel}
+          currentPanel={this.state.currentPanel}
+          onShowPanel={()=>this.togglePanel('broadcasts')}
+          hidePanel={()=>this.hidePanel()} />
+      </ul>
 
       {/* Panel bodies */}
       {this.state.showPanel && this.state.currentPanel == 'assigned' &&
@@ -277,11 +284,6 @@ const Sidebar = React.createClass({
                 onShowPanel={()=>this.togglePanel('todos')}
                 hidePanel={()=>this.hidePanel()} />
             }
-            <Broadcasts
-              showPanel={this.state.showPanel}
-              currentPanel={this.state.currentPanel}
-              onShowPanel={()=>this.togglePanel('broadcasts')}
-              hidePanel={()=>this.hidePanel()} />
 
             <Incidents
               showPanel={this.state.showPanel}

--- a/src/sentry/static/sentry/app/views/organizationAuditLog.jsx
+++ b/src/sentry/static/sentry/app/views/organizationAuditLog.jsx
@@ -174,7 +174,7 @@ const OrganizationAuditLog = React.createClass({
 
           <p>{t('Sentry keeps track of important events within your organization.')}</p>
 
-          <div className="panel panel-default horizontal-scroll">
+          <div className="panel panel-default horizontal-scroll c-b">
             <table className="table">
               <thead>
                 <tr>

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -395,6 +395,9 @@ footer {
 
     // Hide fake sidebar on mobile
     background: none;
+
+    // Account for there being no footer on mobile
+    padding-bottom: 20px;
   }
 
   .app {
@@ -457,5 +460,9 @@ footer {
         padding: 20px 20px 10px;
       }
     }
+  }
+
+  .app > footer {
+    display: none;
   }
 }

--- a/src/sentry/static/sentry/less/sidebar.less
+++ b/src/sentry/static/sentry/less/sidebar.less
@@ -479,7 +479,6 @@
   .sidebar-panel-item {
     padding: 15px 20px;
     line-height: 1.2;
-    cursor: pointer;
     border-bottom: 1px solid @trim;
     background: #fff;
     box-shadow: 0 1px 2px rgba(0,0,0, .06);

--- a/src/sentry/static/sentry/less/sidebar.less
+++ b/src/sentry/static/sentry/less/sidebar.less
@@ -647,6 +647,18 @@
       .org-selector {
         padding: 0;
         padding-right: 14px;
+
+        &.active:before {
+          top: auto;
+          right: auto;
+          bottom: -10px;
+          left: 50%;
+          margin-left: -12px;
+          border-bottom: 7px solid #F7F8F9;
+          border-right: 7px solid transparent;
+          border-left: 7px solid transparent;
+          border-top: 7px solid transparent;
+        }
       }
     }
 

--- a/src/sentry/static/sentry/less/sidebar.less
+++ b/src/sentry/static/sentry/less/sidebar.less
@@ -494,6 +494,10 @@
 
     p {
       margin-bottom: 5px;
+
+      &:last-child {
+        margin: 0;
+      }
     }
 
     a {

--- a/src/sentry/static/sentry/less/spacing.less
+++ b/src/sentry/static/sentry/less/spacing.less
@@ -92,3 +92,9 @@
 .b-r-1 { border-right: 1px solid @trim !important; }
 .b-b-1 { border-bottom: 1px solid @trim !important; }
 .b-l-1 { border-left: 1px solid @trim !important; }
+
+// Clear
+
+.c-b { clear: both; }
+.c-l { clear: left; }
+.c-r { clear: right; }


### PR DESCRIPTION
Fixes items related to #4281
- Remove sidebar from modals
- Only 'read more' links look clickable in broadcast items
- Make audit log full width
- Hide footer on mobile
- Move broadcast item to top nav
- Fix broadcast padding issue
- Fix active org notch on mobile

@getsentry/product 
