### PR TITLE
fix dropdownLink memory leak

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -49,6 +49,10 @@ const DropdownLink = React.createClass({
       });
   },
 
+  componentWillUnmount(){
+    jQuery(this.refs.dropdownToggle.parentNode).off();
+  },
+
   close() {
     this.setState({isOpen: false});
   },

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
-import DropdownLink from 'app/components/DropdownLink';
+import DropdownLink from 'app/components/dropdownLink';
 
 describe('DropdownLink', function() {
   const INPUT_1 = {

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import DropdownLink from 'app/components/DropdownLink';
+
+describe('DropdownLink', function() {
+  const INPUT_1 = {
+    title: 'test',
+    onOpen: ()=>{},
+    onClose: ()=>{},
+    topLevelClasses: 'React.PropTypes.string',
+    menuClasses: ''
+  };
+
+
+  describe('componentWillUnmount()', function() {
+    it('should remove event handlers before unmounting', function() {
+      let dropdownlink = TestUtils.renderIntoDocument(<DropdownLink {...INPUT_1}/>);
+
+      let handlers = jQuery._data(dropdownlink.refs.dropdownToggle.parentNode, 'events');
+      expect(handlers).to.be.an('object');
+
+      dropdownlink.componentWillUnmount(dropdownlink);
+
+      handlers = jQuery._data(dropdownlink.refs.dropdownToggle.parentNode, 'events');
+      expect(handlers).to.be.an('undefined');
+    });
+  });
+
+});


### PR DESCRIPTION
dropdownLink now uses
`jQuery(this.refs.dropdownToggle.parentNode).off();`
to remove event handlers in componentWillUnmount, and has a new test
case to ensure this works. testcase calls componentWillUnmount manually
fixes #4275
/cc @getsentry/product
