### PR TITLE
Use correct variable name for package path

### DIFF
--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -70,7 +70,7 @@ class BuildAssetsCommand(BaseBuildCommand):
                 pass
             else:
                 log.info('pulled version information from \'{}\''.format(
-                    self.package_path,
+                    self.pkg_path,
                 ))
                 version, build = data['version'], data['build']
 


### PR DESCRIPTION
s/package_path/pkg_path/ in `build_assets.py`

Was causing this error when installing Sentry 8.9.0:

```
  File "/www/sentry/build/sentry/src/sentry/utils/distutils/commands/build_assets.py", line 98, in _needs_built

    version_info = self._get_package_version()

  File "/www/sentry/build/sentry/src/sentry/utils/distutils/commands/build_assets.py", line 73, in _get_package_version

    self.package_path,

  File "/usr/lib/python2.7/distutils/cmd.py", line 105, in __getattr__

    raise AttributeError, attr

AttributeError: package_path
```
