### PR TITLE
Add french translation for error-page-embed title

### DIFF
--- a/src/sentry/locale/fr/LC_MESSAGES/django.po
+++ b/src/sentry/locale/fr/LC_MESSAGES/django.po
@@ -911,7 +911,7 @@ msgstr "Les équipes permettent de regrouper l'accès des membres à un domaine 
 
 #: templates/sentry/error-page-embed.html:258
 msgid "It looks like we're having <span>some internal</span> issues."
-msgstr ""
+msgstr "Il semblerait qu'un <span>problème</span> soit survenu."
 
 #: templates/sentry/error-page-embed.html:259
 msgid "Our team has been notified."


### PR DESCRIPTION
Hi,

Just a quick fix to the french translation to add a missing translation for the User FeedBack PopUp.

Kenny
