### PR TITLE
tasks: remove `events` queue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,8 +2,7 @@ Version 8.10 (Unreleased)
 -------------------------
 
 - Removed previously deprecated ``sentry celery`` command.
-- Split the ``events`` queue into ``events.{preprocess,save}_event``.
-- Add additional ``events.process_event`` queue.
+- Replaced the ``events`` queue with ``events.{preprocess,process,save}_event``.
 
 API Changes
 ~~~~~~~~~~~

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -404,7 +404,6 @@ CELERY_QUEUES = [
     Queue('digests.delivery', routing_key='digests.delivery'),
     Queue('digests.scheduling', routing_key='digests.scheduling'),
     Queue('email', routing_key='email'),
-    Queue('events', routing_key='events'),
     Queue('events.preprocess_event', routing_key='events.preprocess_event'),
     Queue('events.process_event', routing_key='events.process_event'),
     Queue('events.save_event', routing_key='events.save_event'),

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -46,11 +46,22 @@ class QueueSetType(click.ParamType):
         # without the need to explicitly add them.
         queues = set()
         for queue in value.split(','):
-            queues.add(queue)
             if queue == 'events':
                 queues.add('events.preprocess_event')
                 queues.add('events.process_event')
                 queues.add('events.save_event')
+
+                from sentry.runner.initializer import show_big_error
+                show_big_error([
+                    'DEPRECATED',
+                    '`events` queue no longer exists.',
+                    'Switch to using:',
+                    '- events.preprocess_event',
+                    '- events.process_event',
+                    '- events.save_event',
+                ])
+            else:
+                queues.add(queue)
         return frozenset(queues)
 
 


### PR DESCRIPTION
Superseded by events.\* queues now.

@getsentry/platform 

![image](https://cloud.githubusercontent.com/assets/375744/19251832/432d5130-8ef6-11e6-8031-dbe22891025e.png)
