### PR TITLE
Config issue button

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -230,7 +230,7 @@ const GroupActions = React.createClass({
         {!group.pluginIssues.length &&
           <a href={`/${this.getOrganization().slug}/${this.getProject().slug}/settings/issue-tracking/`}
              className={'btn btn-default btn-sm btn-config-issue-tracking'}>
-            Configure Issue Tracking
+            Link Issue Tracker
           </a>
         }
       </div>

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -100,6 +100,7 @@ const GroupActions = React.createClass({
 
     let hasRelease = defined(group.lastRelease);
     let releaseTrackingUrl = '/' + this.getOrganization().slug + '/' + this.getProject().slug + '/settings/release-tracking/';
+    let linkTrackerText = t('Link Issue Tracker');
 
     return (
       <div className="group-actions">
@@ -230,7 +231,7 @@ const GroupActions = React.createClass({
         {!group.pluginIssues.length &&
           <a href={`/${this.getOrganization().slug}/${this.getProject().slug}/settings/issue-tracking/`}
              className={'btn btn-default btn-sm btn-config-issue-tracking'}>
-            Link Issue Tracker
+            {linkTrackerText}
           </a>
         }
       </div>

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -227,6 +227,12 @@ const GroupActions = React.createClass({
         {group.pluginIssues && group.pluginIssues.map((plugin) => {
           return <IssuePluginActions key={plugin.slug} plugin={plugin}/>;
         })}
+        {!group.pluginIssues.length &&
+          <a href={`/${this.getOrganization().slug}/${this.getProject().slug}/settings/issue-tracking/`}
+             className={'btn btn-default btn-sm btn-config-issue-tracking'}>
+            Configure Issue Tracking
+          </a>
+        }
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -100,7 +100,6 @@ const GroupActions = React.createClass({
 
     let hasRelease = defined(group.lastRelease);
     let releaseTrackingUrl = '/' + this.getOrganization().slug + '/' + this.getProject().slug + '/settings/release-tracking/';
-    let linkTrackerText = t('Link Issue Tracker');
 
     return (
       <div className="group-actions">
@@ -231,7 +230,7 @@ const GroupActions = React.createClass({
         {!group.pluginIssues.length &&
           <a href={`/${this.getOrganization().slug}/${this.getProject().slug}/settings/issue-tracking/`}
              className={'btn btn-default btn-sm btn-config-issue-tracking'}>
-            {linkTrackerText}
+            {t('Link Issue Tracker')}
           </a>
         }
       </div>


### PR DESCRIPTION
Provides a link to the Issue Tracking configuration page when users do not already have an Issue Tracker linked
@getsentry/product 

![screen shot 2016-10-10 at 3 35 42 pm](https://cloud.githubusercontent.com/assets/9269824/19253353/6d759fde-8eff-11e6-9f34-d7ff9a0e9dbe.png)
