### PR TITLE
[vcs] expand commits apis

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ API Changes
 
 - Add ``/organizations/{org}/repositories/`` endpoint.
 - Add ``/organizations/{org}/repositories/{repo}/commits/`` endpoint.
+- Add ``/projects/{org}/{project}/releases/{versoin}/commits/`` endpoint.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import string
 
 from django.db import IntegrityError, transaction
-from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
 
@@ -11,7 +10,9 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.fields.user import UserField
 from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework import CommitSerializer, ListField
 from sentry.models import Activity, Release
+from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -24,6 +25,9 @@ def create_new_release_scenario(runner):
         data={
             'version': '2.0rc2',
             'ref': '6ba09a7c53235ee8a8fa5ee4c1ca8ca886e7fdbb',
+            # TODO(dcramer): once we improve fixtures we should show the
+            # commits attribute being used, as well as 'dateReleased'
+            # 'commits': [{'id': 'a' * 40}, {'id': 'b' * 40}],
         }
     )
 
@@ -44,6 +48,7 @@ class ReleaseSerializer(serializers.Serializer):
     owner = UserField(required=False)
     dateStarted = serializers.DateTimeField(required=False)
     dateReleased = serializers.DateTimeField(required=False)
+    commits = ListField(child=CommitSerializer(), required=False)
 
     def validate_version(self, attrs, source):
         value = attrs[source]
@@ -131,29 +136,45 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
         if serializer.is_valid():
             result = serializer.object
 
-            with transaction.atomic():
-                try:
-                    release = Release.objects.create(
+            try:
+                with transaction.atomic():
+                    # release creation is idempotent to simplify user
+                    # experiences
+                    release, created = Release.objects.create(
                         project=project,
                         version=result['version'],
                         ref=result.get('ref'),
                         url=result.get('url'),
                         owner=result.get('owner'),
                         date_started=result.get('dateStarted'),
-                        date_released=result.get('dateReleased') or timezone.now(),
-                    )
-                except IntegrityError:
-                    return Response({
-                        'detail': 'Release with version already exists'
-                    }, status=400)
-                else:
-                    Activity.objects.create(
-                        type=Activity.RELEASE,
-                        project=project,
-                        ident=result['version'],
-                        data={'version': result['version']},
-                        datetime=release.date_released,
-                    )
+                        date_released=result.get('dateReleased'),
+                    ), True
+            except IntegrityError:
+                release, created = Release.objects.get(
+                    project=project,
+                    version=result['version'],
+                ), False
 
-            return Response(serialize(release, request.user), status=201)
+            commit_list = result.get('commits')
+            if commit_list:
+                hook = ReleaseHook(project)
+                # TODO(dcramer): handle errors with release payloads
+                hook.set_commits(release.version, commit_list)
+
+            if not created:
+                # This is the closest status code that makes sense, and we want
+                # a unique 2xx response code so people can understand when
+                # behavior differs.
+                #   208 Already Reported (WebDAV; RFC 5842)
+                status = 208
+            else:
+                Activity.objects.create(
+                    type=Activity.RELEASE,
+                    project=project,
+                    ident=result['version'],
+                    data={'version': result['version']},
+                    datetime=release.date_released or release.date_added,
+                )
+                status = 201
+            return Response(serialize(release, request.user), status=status)
         return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/release_commits.py
+++ b/src/sentry/api/endpoints/release_commits.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import
+
+from sentry.api.base import DocSection
+from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.models import Release, ReleaseCommit
+
+
+class ReleaseCommitsEndpoint(ProjectEndpoint):
+    doc_section = DocSection.RELEASES
+    permission_classes = (ProjectReleasePermission,)
+
+    def get(self, request, project, version):
+        """
+        List a Release's Commits
+        ````````````````````````
+
+        Retrieve a list of commits for a given release.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to list the
+                                     release files of.
+        :pparam string version: the version identifier of the release.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                project=project,
+                version=version,
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        queryset = ReleaseCommit.objects.filter(
+            release=release,
+        ).select_related('commit', 'commit__author')
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by='order',
+            on_results=lambda x: serialize([rc.commit for rc in x], request.user),
+        )

--- a/src/sentry/api/serializers/rest_framework/commit.py
+++ b/src/sentry/api/serializers/rest_framework/commit.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+
+
+class CommitSerializer(serializers.Serializer):
+    id = serializers.CharField(max_length=64)
+    repository = serializers.CharField(max_length=64, required=False)
+    message = serializers.CharField(required=False)
+    author_name = serializers.CharField(max_length=128, required=False)
+    author_email = serializers.EmailField(max_length=75, required=False)
+    timestamp = serializers.DateTimeField(required=False)

--- a/src/sentry/api/serializers/rest_framework/list.py
+++ b/src/sentry/api/serializers/rest_framework/list.py
@@ -4,20 +4,23 @@ from rest_framework.serializers import WritableField, ValidationError
 
 
 class ListField(WritableField):
-    def __init__(self, child):
+    def __init__(self, child=None, **kwargs):
         self.child = child
-        super(ListField, self).__init__()
+        super(ListField, self).__init__(**kwargs)
 
     def initialize(self, **kwargs):
         super(ListField, self).initialize(**kwargs)
-        self.child.initialize(**kwargs)
+        if self.child is not None:
+            self.child.initialize(**kwargs)
 
     def to_native(self, obj):
         return obj
 
     def from_native(self, data):
         if not isinstance(data, list):
-            msg = 'Incorrect type. Expected a mapping, but got %s'
+            msg = 'Incorrect type. Expected a list, but got %s'
             raise ValidationError(msg % type(data).__name__)
 
+        if self.child is None:
+            return data
         return [self.child.from_native(x) for x in data]

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -71,6 +71,7 @@ from .endpoints.project_tagkey_details import ProjectTagKeyDetailsEndpoint
 from .endpoints.project_tagkey_values import ProjectTagKeyValuesEndpoint
 from .endpoints.project_users import ProjectUsersEndpoint
 from .endpoints.project_user_reports import ProjectUserReportsEndpoint
+from .endpoints.release_commits import ReleaseCommitsEndpoint
 from .endpoints.release_details import ReleaseDetailsEndpoint
 from .endpoints.release_files import ReleaseFilesEndpoint
 from .endpoints.release_file_details import ReleaseFileDetailsEndpoint
@@ -270,6 +271,9 @@ urlpatterns = patterns(
     url(r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/$',
         ReleaseDetailsEndpoint.as_view(),
         name='sentry-api-0-release-details'),
+    url(r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/commits/$',
+        ReleaseCommitsEndpoint.as_view(),
+        name='sentry-api-0-release-commits'),
     url(r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/files/$',
         ReleaseFilesEndpoint.as_view(),
         name='sentry-api-0-release-files'),

--- a/tests/sentry/api/endpoints/test_release_commits.py
+++ b/tests/sentry/api/endpoints/test_release_commits.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import Commit, Release, ReleaseCommit, Repository
+from sentry.testutils import APITestCase
+
+
+class ReleaseCommitsListTest(APITestCase):
+    def test_simple(self):
+        project = self.create_project(
+            name='foo',
+        )
+        release = Release.objects.create(
+            project=project,
+            version='1',
+        )
+        repo = Repository.objects.create(
+            organization_id=project.organization_id,
+            name=project.name,
+        )
+        commit = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repo.id,
+            key='a' * 40,
+        )
+        commit2 = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repo.id,
+            key='b' * 40,
+        )
+        ReleaseCommit.objects.create(
+            project_id=project.id,
+            release=release,
+            commit=commit,
+            order=1,
+        )
+        ReleaseCommit.objects.create(
+            project_id=project.id,
+            release=release,
+            commit=commit2,
+            order=0,
+        )
+        url = reverse('sentry-api-0-release-commits', kwargs={
+            'organization_slug': project.organization.slug,
+            'project_slug': project.slug,
+            'version': release.version,
+        })
+
+        self.login_as(user=self.user)
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert response.data[0]['id'] == commit2.key
+        assert response.data[1]['id'] == commit.key

--- a/tests/sentry/api/endpoints/test_release_details.py
+++ b/tests/sentry/api/endpoints/test_release_details.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
-from sentry.models import File, Release, ReleaseFile
+from sentry.models import File, Release, ReleaseCommit, ReleaseFile
 from sentry.testutils import APITestCase
 
 
@@ -49,6 +49,35 @@ class UpdateReleaseDetailsTest(APITestCase):
 
         release = Release.objects.get(id=release.id)
         assert release.ref == 'master'
+
+    def test_commits(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project(name='foo')
+
+        release = Release.objects.create(
+            project=project,
+            version='1',
+        )
+
+        url = reverse('sentry-api-0-release-details', kwargs={
+            'organization_slug': project.organization.slug,
+            'project_slug': project.slug,
+            'version': release.version,
+        })
+        response = self.client.put(url, data={
+            'commits': [
+                {'id': 'a' * 40},
+                {'id': 'b' * 40},
+            ]
+        })
+
+        assert response.status_code == 200, (response.status_code, response.content)
+
+        rc_list = list(ReleaseCommit.objects.filter(
+            release=release,
+        ).select_related('commit', 'commit__author').order_by('order'))
+        assert len(rc_list) == 2
 
 
 class ReleaseDeleteTest(APITestCase):


### PR DESCRIPTION
- add release commits list endpoint
- support creating commits via attribute to webhook (and thus release details)
- make reposting of release details acceptable
