### PR TITLE
Add reason for receiving a notification to workflow emails.

### DIFF
--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -12,11 +12,21 @@ from sentry.db.models import (
 
 
 class GroupSubscriptionReason(object):
+    implicit = -1  # not for use as a persisted field value
     unknown = 0
     comment = 1
     assigned = 2
     bookmark = 3
     status_change = 4
+
+    descriptions = {
+        implicit: u"have opted to receive updates for all issues within "
+                  "projects that you are a member of",
+        comment: u"have commented on this issue",
+        assigned: u"have been assigned to this issue",
+        bookmark: u"have bookmarked this issue",
+        status_change: u"have changed the resolution status of this issue",
+    }
 
 
 class GroupSubscriptionManager(BaseManager):
@@ -38,9 +48,6 @@ class GroupSubscriptionManager(BaseManager):
             pass
 
     def get_participants(self, group):
-        return self.get_participants_with_reason(group).keys()
-
-    def get_participants_with_reason(self, group):
         """
         Identify all users who are participating with a given issue.
         """
@@ -100,7 +107,7 @@ class GroupSubscriptionManager(BaseManager):
         results = {}
 
         for user in users:
-            results[user] = None
+            results[user] = GroupSubscriptionReason.implicit
 
         for user, reason in participants.items():
             results[user] = reason

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from sentry.db.models import (
-    BoundedPositiveIntegerField, FlexibleForeignKey, Model, BaseManager,
+    BaseManager, BoundedPositiveIntegerField, FlexibleForeignKey, Model,
     sane_repr
 )
 

--- a/src/sentry/plugins/sentry_mail/activity/base.py
+++ b/src/sentry/plugins/sentry_mail/activity/base.py
@@ -5,7 +5,8 @@ from django.utils.html import escape, mark_safe
 
 from sentry import options
 from sentry.models import (
-    GroupSubscription, GroupSubscriptionReason, ProjectOption, UserAvatar, UserOption
+    GroupSubscription, GroupSubscriptionReason, ProjectOption, UserAvatar,
+    UserOption
 )
 from sentry.utils.avatar import get_email_avatar
 from sentry.utils.email import MessageBuilder, group_id_to_email

--- a/src/sentry/plugins/sentry_mail/activity/base.py
+++ b/src/sentry/plugins/sentry_mail/activity/base.py
@@ -5,7 +5,7 @@ from django.utils.html import escape, mark_safe
 
 from sentry import options
 from sentry.models import (
-    GroupSubscription, ProjectOption, UserAvatar, UserOption
+    GroupSubscription, GroupSubscriptionReason, ProjectOption, UserAvatar, UserOption
 )
 from sentry.utils.avatar import get_email_avatar
 from sentry.utils.email import MessageBuilder, group_id_to_email
@@ -37,13 +37,9 @@ class ActivityEmail(object):
         if not self.group:
             return []
 
-        participants = set(
-            GroupSubscription.objects.get_participants(
-                group=self.group
-            )
-        )
+        participants = GroupSubscription.objects.get_participants(group=self.group)
 
-        if self.activity.user is not None:
+        if self.activity.user is not None and self.activity.user in participants:
             receive_own_activity = UserOption.objects.get_value(
                 user=self.activity.user,
                 project=None,
@@ -52,7 +48,7 @@ class ActivityEmail(object):
             ) == '1'
 
             if not receive_own_activity:
-                participants.discard(self.activity.user)
+                del participants[self.activity.user]
 
         return participants
 
@@ -224,8 +220,8 @@ class ActivityEmail(object):
         if not self.should_email():
             return
 
-        users = self.get_participants()
-        if not users:
+        participants = self.get_participants()
+        if not participants:
             return
 
         activity = self.activity
@@ -246,13 +242,19 @@ class ActivityEmail(object):
         email_type = self.get_email_type()
         headers = self.get_headers()
 
-        for user in users:
+        for user, reason in participants.items():
             if group:
-                context['unsubscribe_link'] = generate_signed_link(
-                    user.id,
-                    'sentry-account-email-unsubscribe-issue',
-                    kwargs={'issue_id': group.id},
-                )
+                context.update({
+                    'reason': GroupSubscriptionReason.descriptions.get(
+                        reason,
+                        "are subscribed to this issue",
+                    ),
+                    'unsubscribe_link': generate_signed_link(
+                        user.id,
+                        'sentry-account-email-unsubscribe-issue',
+                        kwargs={'issue_id': group.id},
+                    ),
+                })
 
             msg = MessageBuilder(
                 subject=subject,

--- a/src/sentry/templates/sentry/emails/activity/generic.html
+++ b/src/sentry/templates/sentry/emails/activity/generic.html
@@ -4,14 +4,28 @@
 {% load sentry_assets %}
 
 {% block header %}
-  <a href="{{ link }}" class="btn">View on Sentry</a>
+  {% block action %}
+    <a href="{{ link }}" class="btn">View on Sentry</a>
+  {% endblock %}
   {{ block.super }}
 {% endblock %}
 
 {% block main %}
-  <h2>{{ activity_name }}</h2>
 
-  <p>{{ html_description }}</p>
+  {% block activity %}
+
+    <h2>{{ activity_name }}</h2>
+
+    <p>{{ html_description }}</p>
+
+  {% endblock %}
 
   {% include "sentry/emails/group_header.html" %}
+
+  {% if reason %}
+    <p class="via">
+      You are receiving this email because you {{ reason }}.
+    </p>
+  {% endif %}
+
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/activity/note.html
+++ b/src/sentry/templates/sentry/emails/activity/note.html
@@ -1,14 +1,14 @@
-{% extends "sentry/emails/base.html" %}
+{% extends "sentry/emails/activity/generic.html" %}
 
 {% load sentry_helpers %}
 {% load sentry_assets %}
 
-{% block header %}
+{% block action %}
   <a href="{{ activity_link }}" class="btn">View on Sentry</a>
-  {{ block.super }}
 {% endblock %}
 
-{% block main %}
+{% block activity %}
+
   <h3>New comment by {{ author.get_display_name }}</h3>
 
   <table class="note">
@@ -31,5 +31,4 @@
     </tr>
   </table>
 
-  {% include "sentry/emails/group_header.html" %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/base.html
+++ b/src/sentry/templates/sentry/emails/base.html
@@ -32,17 +32,15 @@
           {% block main %}
           <p>This is the body of an email</p>
           {% endblock %}
-          {% if unsubscribe_link %}
-            <p>
-              <a href="{{ unsubscribe_link }}">Click to unsubscribe</a>
-            </p>
-          {% endif %}
         </div>
         <div class="footer">
           {% block footer %}
           <a href="{% absolute_uri %}" style="float:right">Home</a>
           {% url 'sentry-account-settings-notifications' as settings_link %}
           <a href="{% absolute_uri settings_link %}">Notification Settings</a>
+          {% if unsubscribe_link %}
+            &middot; <a href="{{ unsubscribe_link }}">Unsubscribe</a>
+          {% endif %}
           {% endblock %}
         </div>
       </div>

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -23,8 +23,8 @@ from sentry.digests.notifications import Notification, build_digest
 from sentry.digests.utilities import get_digest_metadata
 from sentry.http import get_server_hostname
 from sentry.models import (
-    Activity, Event, Group, GroupStatus, GroupSubscriptionReason, Organization, OrganizationMember,
-    Project, Release, Rule, Team
+    Activity, Event, Group, GroupStatus, GroupSubscriptionReason, Organization,
+    OrganizationMember, Project, Release, Rule, Team
 )
 from sentry.plugins.sentry_mail.activity import emails
 from sentry.utils.dates import to_datetime, to_timestamp

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -129,9 +129,12 @@ class ActivityMailPreview(object):
 
     def get_context(self):
         context = self.email.get_base_context()
-        context['reason'] = get_random(self.request).choice(
-            GroupSubscriptionReason.descriptions.values()
-        )
+        context.update({
+            'reason': get_random(self.request).choice(
+                GroupSubscriptionReason.descriptions.values()
+            ),
+            'unsubscribe_link': 'javascript:alert("This is a preview page, what did you expect to happen?");',
+        })
         context.update(self.email.get_context())
         return context
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.models import GroupSubscription, UserOption, UserOptionValue
+from sentry.models import GroupSubscription, GroupSubscriptionReason, UserOption, UserOptionValue
 from sentry.testutils import TestCase
 
 
@@ -34,7 +34,9 @@ class GetParticipantsTest(TestCase):
         # implicit membership
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == [user]
+        assert users == {
+            user: GroupSubscriptionReason.implicit,
+        }
 
         # unsubscribed
         GroupSubscription.objects.create(
@@ -46,7 +48,7 @@ class GetParticipantsTest(TestCase):
 
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == []
+        assert users == {}
 
         # not participating by default
         GroupSubscription.objects.filter(
@@ -63,7 +65,7 @@ class GetParticipantsTest(TestCase):
 
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == []
+        assert users == {}
 
         # explicitly participating
         GroupSubscription.objects.create(
@@ -71,11 +73,14 @@ class GetParticipantsTest(TestCase):
             group=group,
             project=project,
             is_active=True,
+            reason=GroupSubscriptionReason.comment,
         )
 
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == [user]
+        assert users == {
+            user: GroupSubscriptionReason.comment,
+        }
 
     def test_excludes_project_participating_only(self):
         org = self.create_organization()
@@ -94,4 +99,4 @@ class GetParticipantsTest(TestCase):
 
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == []
+        assert users == {}

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from sentry.models import GroupSubscription, GroupSubscriptionReason, UserOption, UserOptionValue
+from sentry.models import (
+    GroupSubscription, GroupSubscriptionReason, UserOption, UserOptionValue
+)
 from sentry.testutils import TestCase
 
 

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -373,7 +373,7 @@ class ActivityEmailTestCase(TransactionTestCase):
             )
         )
 
-        assert email.get_participants() == set([other])
+        assert set(email.get_participants()) == set([other])
 
         UserOption.objects.set_value(
             user=actor,
@@ -382,7 +382,7 @@ class ActivityEmailTestCase(TransactionTestCase):
             value='1'
         )
 
-        assert email.get_participants() == set([actor, other])
+        assert set(email.get_participants()) == set([actor, other])
 
     def test_get_participants_without_actor(self):
         group, (user,) = self.get_fixture_data(1)
@@ -394,4 +394,4 @@ class ActivityEmailTestCase(TransactionTestCase):
             )
         )
 
-        assert email.get_participants() == set([user])
+        assert set(email.get_participants()) == set([user])


### PR DESCRIPTION
This should clarify some confusion that users have around why they are receiving some emails.

This also fixes GH-4305.
