### PR TITLE
Allow users to snooze issues until a specific date/time

### DIFF
--- a/src/sentry/static/sentry/app/components/customSnoozeModal.jsx
+++ b/src/sentry/static/sentry/app/components/customSnoozeModal.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import Modal from 'react-bootstrap/lib/Modal';
+import {t} from '../locale';
+import {sprintf} from 'sprintf-js';
+
+const CustomSnoozeModal = React.createClass({
+  propTypes: {
+    onSelected: React.PropTypes.func,
+    onCanceled: React.PropTypes.func,
+    show: React.PropTypes.bool,
+  },
+
+  getInitialState() {
+    return {
+      dateWarning: false
+    };
+  },
+
+  selectedSnoozeMinutes() {
+    const dateStr = this.refs.snoozeDateInput.value; // YYYY-MM-DD
+    const timeStr = this.refs.snoozeTimeInput.value; // HH:MM
+    if (dateStr && timeStr) {
+      const selectedDate = new Date(dateStr + 'T' + timeStr); // poor man's ISO datetime
+      if (!isNaN(selectedDate)) {
+        const now = new Date();
+        const millis = selectedDate.getTime() - now.getTime();
+        const minutes = parseInt(Math.ceil(millis / 1000.0 / 60.0), 10);
+        return minutes;
+      }
+    }
+    return 0;
+  },
+
+  snoozeClicked() {
+    const minutes = this.selectedSnoozeMinutes();
+
+    this.setState({
+      dateWarning: minutes <= 0
+    });
+
+    if (minutes > 0) {
+      this.props.onSelected(minutes);
+    }
+  },
+
+  render() {
+    const inputStyle = {
+      marginLeft: '5px',
+      width: '150px',
+    };
+
+    // Give the user a sane starting point to select a date
+    // (prettier than the empty date/time inputs):
+    let defaultDate = new Date();
+    defaultDate.setDate(defaultDate.getDate() + 14);
+    defaultDate.setSeconds(0);
+    defaultDate.setMilliseconds(0);
+
+    const defaultDateVal = sprintf('%d-%02d-%02d',
+        defaultDate.getUTCFullYear(),
+        defaultDate.getUTCMonth() + 1,
+        defaultDate.getUTCDate());
+
+    const defaultTimeVal = sprintf('%02d:00',
+        defaultDate.getUTCHours());
+
+    return (
+      <Modal show={this.props.show} animation={false} bsSize="sm">
+        <div className="modal-body">
+          <h5>{t('Ignore until:')}</h5>
+          <form>
+            <div className="form-group">
+              <label htmlFor="snooze-until-date">{t('Date:')}</label>
+              <input id="snooze-until-date" type="date"
+                     defaultValue={defaultDateVal} ref="snoozeDateInput" style={inputStyle}/>
+            </div>
+            <div className="form-group">
+              <label htmlFor="snooze-until-time">{t('Time:')}</label>
+              <input id="snooze-until-time" type="time"
+                     defaultValue={defaultTimeVal} ref="snoozeTimeInput" style={inputStyle}/>
+              <span> {t('UTC')}</span>
+            </div>
+          </form>
+        </div>
+        {this.state.dateWarning &&
+          <div className="alert alert-error" style={{'margin-top': '5px'}}>
+            {t('Please enter a valid date in the future')}
+          </div>}
+        <div className="modal-footer">
+          <button type="button" className="btn btn-primary"
+                  onClick={this.snoozeClicked}>{t('Ignore')}</button>
+          <button type="button" className="btn btn-default"
+                  onClick={this.props.onCanceled}>{t('Cancel')}</button>
+        </div>
+      </Modal>
+    );
+  },
+
+});
+
+export default CustomSnoozeModal;

--- a/src/sentry/static/sentry/app/components/customSnoozeModal.jsx
+++ b/src/sentry/static/sentry/app/components/customSnoozeModal.jsx
@@ -44,11 +44,6 @@ const CustomSnoozeModal = React.createClass({
   },
 
   render() {
-    const inputStyle = {
-      marginLeft: '5px',
-      width: '150px',
-    };
-
     // Give the user a sane starting point to select a date
     // (prettier than the empty date/time inputs):
     let defaultDate = new Date();
@@ -68,17 +63,28 @@ const CustomSnoozeModal = React.createClass({
       <Modal show={this.props.show} animation={false} bsSize="sm">
         <div className="modal-body">
           <h5>{t('Ignore until:')}</h5>
-          <form>
+          <form className="form-horizontal">
             <div className="form-group">
-              <label htmlFor="snooze-until-date">{t('Date:')}</label>
-              <input id="snooze-until-date" type="date"
-                     defaultValue={defaultDateVal} ref="snoozeDateInput" style={inputStyle}/>
+              <label htmlFor="snooze-until-date"
+                     className="col-sm-4 control-label">{t('Date:')}</label>
+              <div className="col-sm-7">
+                <input className="form-control"
+                       type="date"
+                       id="snooze-until-date"
+                       defaultValue={defaultDateVal}
+                       ref="snoozeDateInput"/>
+              </div>
             </div>
             <div className="form-group">
-              <label htmlFor="snooze-until-time">{t('Time:')}</label>
-              <input id="snooze-until-time" type="time"
-                     defaultValue={defaultTimeVal} ref="snoozeTimeInput" style={inputStyle}/>
-              <span> {t('UTC')}</span>
+              <label htmlFor="snooze-until-time"
+                     className="col-sm-4 control-label">{t('Time (UTC):')}</label>
+              <div className="col-sm-7">
+                <input className="form-control"
+                       type="time"
+                       id="snooze-until-time"
+                       defaultValue={defaultTimeVal}
+                       ref="snoozeTimeInput"/>
+              </div>
             </div>
           </form>
         </div>

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {History} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
 import DropdownLink from '../../components/dropdownLink';
+import CustomSnoozeModal from '../../components/customSnoozeModal';
 import GroupState from '../../mixins/groupState';
 import IndicatorStore from '../../stores/indicatorStore';
 import IssuePluginActions from '../../components/group/issuePluginActions';
@@ -78,6 +79,23 @@ const GroupActions = React.createClass({
     });
   },
 
+  customSnoozeClicked() {
+    this.setState({
+      isCustomSnoozeModalOpen: true
+    });
+  },
+
+  customSnoozeSelected(duration) {
+    this.onSnooze(duration);
+    this.customSnoozeCanceled();
+  },
+
+  customSnoozeCanceled() {
+    this.setState({
+      isCustomSnoozeModalOpen: false
+    });
+  },
+
   render() {
     let group = this.getGroup();
 
@@ -103,6 +121,10 @@ const GroupActions = React.createClass({
 
     return (
       <div className="group-actions">
+        <CustomSnoozeModal
+            show={this.state && this.state.isCustomSnoozeModalOpen}
+            onSelected={this.customSnoozeSelected}
+            onCanceled={this.customSnoozeCanceled}/>
         <div className="btn-group">
           {group.status === 'resolved' ? (
             group.statusDetails.autoResolved ?
@@ -175,6 +197,9 @@ const GroupActions = React.createClass({
               </MenuItem>
               <MenuItem noAnchor={true}>
                 <a onClick={this.onSnooze.bind(this, Snooze.ONEWEEK)}>{t('for 1 week')}</a>
+              </MenuItem>
+              <MenuItem noAnchor={true}>
+                <a onClick={this.customSnoozeClicked.bind(this)}>{t('until custom date...')}</a>
               </MenuItem>
               <MenuItem noAnchor={true}>
                 <a onClick={this.onUpdate.bind(this, {status: 'ignored'})}>{t('forever')}</a>


### PR DESCRIPTION
Why this change? My team has bi-weekly releases. Now we can snooze issues until the next release date. When used in conjunction with "Resolve in next release", our Sentry feeds can be awesomely de-cluttered.

No API changes required for this feature.

Here's how the UI looks:

<img width="571" alt="screen shot 2016-10-12 at 9 56 31 am" src="https://cloud.githubusercontent.com/assets/921044/19317443/45de11ae-9062-11e6-940b-60f19deb2983.png">

<img width="638" alt="screen shot 2016-10-12 at 9 57 05 am" src="https://cloud.githubusercontent.com/assets/921044/19317447/47e2411e-9062-11e6-8a8c-21c8a9330379.png">

<img width="731" alt="screen shot 2016-10-12 at 9 57 10 am" src="https://cloud.githubusercontent.com/assets/921044/19317456/4bfab7fe-9062-11e6-8f15-37aa183c443d.png">

Note that this is using the HTML5 date/time inputs, since I see that the React datepicker was removed from the project recently.

I also saw some recently closed PRs indicating that the term "snooze" might be changing to "ignore" https://github.com/getsentry/sentry/pull/4318

/cc @getsentry/team
