### PR TITLE
Update release notification emails.

### DIFF
--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -12,7 +12,9 @@ from sentry.db.models import (
 
 
 class GroupSubscriptionReason(object):
-    implicit = -1  # not for use as a persisted field value
+    committed = -2  # not for use as a persisted field value
+    implicit = -1   # not for use as a persisted field value
+
     unknown = 0
     comment = 1
     assigned = 2
@@ -22,6 +24,7 @@ class GroupSubscriptionReason(object):
     descriptions = {
         implicit: u"have opted to receive updates for all issues within "
                   "projects that you are a member of",
+        committed: u"were involved in a commit that is part of this release",
         comment: u"have commented on this issue",
         assigned: u"have been assigned to this issue",
         bookmark: u"have bookmarked this issue",

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -8,7 +8,7 @@
         <option value="mail/assigned/">Assigned</option>
         <option value="mail/assigned/self/">Assigned (Self)</option>
         <option value="mail/note/">Note</option>
-        <option value="mail/release/">Release</option>
+        <option value="mail/new-release/">Release</option>
         <option value="mail/regression/">Regression</option>
         <option value="mail/regression/release/">Regression (w/ Release)</option>
         <option value="mail/resolved/">Resolved</option>

--- a/src/sentry/templates/sentry/emails/activity/generic.html
+++ b/src/sentry/templates/sentry/emails/activity/generic.html
@@ -20,7 +20,9 @@
 
   {% endblock %}
 
-  {% include "sentry/emails/group_header.html" %}
+  {% if group %}
+    {% include "sentry/emails/group_header.html" %}
+  {% endif %}
 
   {% if reason %}
     <p class="via">

--- a/src/sentry/templates/sentry/emails/activity/release.html
+++ b/src/sentry/templates/sentry/emails/activity/release.html
@@ -1,13 +1,12 @@
-{% extends "sentry/emails/base.html" %}
+{% extends "sentry/emails/activity/generic.html" %}
 
 {% load sentry_helpers %}
 
-{% block header %}
+{% block action %}
     <a href="{{ release_link }}" class="btn">View Release</a>
-    {{ block.super }}
 {% endblock %}
 
-{% block main %}
+{% block activity %}
     <h2>
         Version {{ release.short_version }}
     </h2>

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 from django.views.generic import View
 
 from sentry.models import (
-    Commit, CommitAuthor, Organization, Team, Project, Release
+    Commit, CommitAuthor, Organization, Team, Project, Release,
+    GroupSubscriptionReason,
 )
 from sentry.utils.http import absolute_uri
 
@@ -67,5 +68,8 @@ class DebugNewReleaseEmailView(View):
                 'release_link': release_link,
                 'project_link': project_link,
                 'commit_list': commit_list,
+                'reason': GroupSubscriptionReason.descriptions[
+                    GroupSubscriptionReason.committed
+                ],
             },
         ).render(request)

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 from django.views.generic import View
 
 from sentry.models import (
-    Commit, CommitAuthor, Organization, Team, Project, Release,
-    GroupSubscriptionReason,
+    Commit, CommitAuthor, GroupSubscriptionReason, Organization, Project,
+    Release, Team
 )
 from sentry.utils.http import absolute_uri
 

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from datetime import datetime
+
+import pytz
 from django.views.generic import View
 
 from sentry.models import (
@@ -34,6 +37,7 @@ class DebugNewReleaseEmailView(View):
         release = Release(
             project=project,
             version='6c998f755f304593a4713abd123eaf8833a2de5e',
+            date_added=datetime(2016, 10, 12, 15, 39, tzinfo=pytz.utc)
         )
 
         release_link = absolute_uri('/{}/{}/releases/{}/'.format(

--- a/tests/sentry/plugins/mail/activity/test_release.py
+++ b/tests/sentry/plugins/mail/activity/test_release.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import
 
 from django.core import mail
 from django.utils import timezone
+
 from sentry.models import (
-    Activity, Commit, CommitAuthor, GroupSubscriptionReason,
-    Release, ReleaseCommit, Repository,
-    UserEmail
+    Activity, Commit, CommitAuthor, GroupSubscriptionReason, Release,
+    ReleaseCommit, Repository, UserEmail
 )
 from sentry.plugins.sentry_mail.activity.release import ReleaseActivityEmail
 from sentry.testutils import TestCase

--- a/tests/sentry/plugins/mail/activity/test_release.py
+++ b/tests/sentry/plugins/mail/activity/test_release.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import
 from django.core import mail
 from django.utils import timezone
 from sentry.models import (
-    Activity, Commit, CommitAuthor, Release, ReleaseCommit, Repository,
+    Activity, Commit, CommitAuthor, GroupSubscriptionReason,
+    Release, ReleaseCommit, Repository,
     UserEmail
 )
 from sentry.plugins.sentry_mail.activity.release import ReleaseActivityEmail
@@ -89,7 +90,9 @@ class ReleaseTestCase(TestCase):
             )
         )
 
-        assert email.get_participants() == set([self.user])
+        assert email.get_participants() == {
+            self.user: GroupSubscriptionReason.committed,
+        }
 
         context = email.get_context()
         assert context['commit_list'] == [self.commit, self.commit2]


### PR DESCRIPTION
This updates GH-4332 to use the updated `get_participants` method signature from GH-4333.
