### PR TITLE
Tweak styling of `.via` block in emails.

### DIFF
--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -281,8 +281,11 @@
     font-weight: 200;
   }
 
-  .via {
-    border: 1px solid #CFD9DE;
+  .inner p.via {
+    border-radius: 4px;
+    margin-top: 15px;
+    font-size: 14px;
+    background-color: #f7f8f9;
     text-align: center;
     padding: 15px;
     border-radius: 3px;


### PR DESCRIPTION
This is intended to deprioritize this block visually.
