### PR TITLE
Remove instance-local caching from event frequency conditions.

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -58,37 +58,27 @@ class BaseEventFrequencyCondition(EventCondition):
 
         return current_value > value
 
-    def clear_cache(self, event):
-        event._rate_cache = {}
-
     def query(self, event, start, end):
         """
         """
         raise NotImplementedError  # subclass must implement
 
     def get_rate(self, event, interval):
-        if not hasattr(event, '_rate_cache'):
-            event._rate_cache = {}
+        end = timezone.now()
+        if interval == Interval.ONE_MINUTE:
+            start = end - timedelta(minutes=1)
+        elif interval == Interval.ONE_HOUR:
+            start = end - timedelta(hours=1)
+        elif interval == Interval.ONE_DAY:
+            start = end - timedelta(hours=24)
+        else:
+            raise ValueError(interval)
 
-        result = event._rate_cache.get(interval)
-        if result is None:
-            end = timezone.now()
-            if interval == Interval.ONE_MINUTE:
-                start = end - timedelta(minutes=1)
-            elif interval == Interval.ONE_HOUR:
-                start = end - timedelta(hours=1)
-            elif interval == Interval.ONE_DAY:
-                start = end - timedelta(hours=24)
-            else:
-                raise ValueError(interval)
-
-            event._rate_cache[interval] = result = self.query(
-                event,
-                start,
-                end,
-            )
-
-        return result
+        return self.query(
+            event,
+            start,
+            end,
+        )
 
 
 class EventFrequencyCondition(BaseEventFrequencyCondition):

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -36,11 +36,9 @@ class FrequencyConditionMixin(object):
         )
         self.assertDoesNotPass(rule, event)
 
-        rule.clear_cache(event)
         self.increment(event, value)
         self.assertDoesNotPass(rule, event)
 
-        rule.clear_cache(event)
         self.increment(event, 1)
 
         self.assertPasses(rule, event)
@@ -63,11 +61,9 @@ class FrequencyConditionMixin(object):
         )
         self.assertDoesNotPass(rule, event)
 
-        rule.clear_cache(event)
         self.increment(event, value)
         self.assertDoesNotPass(rule, event)
 
-        rule.clear_cache(event)
         self.increment(event, 1)
 
         self.assertPasses(rule, event)
@@ -90,11 +86,9 @@ class FrequencyConditionMixin(object):
         )
         self.assertDoesNotPass(rule, event)
 
-        rule.clear_cache(event)
         self.increment(event, value)
         self.assertDoesNotPass(rule, event)
 
-        rule.clear_cache(event)
         self.increment(event, 1)
 
         self.assertPasses(rule, event)
@@ -111,7 +105,6 @@ class FrequencyConditionMixin(object):
 
         self.assertDoesNotPass(rule, event)
 
-        rule.clear_cache(event)
         self.increment(event, 1)
 
         self.assertPasses(rule, event)


### PR DESCRIPTION
The cache was being shared between both subclasses (oops) and was leaking
state between them. This removes it, since I couldn't find a reason why
it would be used anyway (maybe legacy?)
