### PR TITLE
Capture Exception ID for Last Event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ example/db.sqlite
 /src/sentry/integration-docs
 /wheelhouse
 /test_cli/
+.idea

--- a/src/sentry/utils/raven.py
+++ b/src/sentry/utils/raven.py
@@ -43,7 +43,8 @@ class SentryInternalClient(DjangoClient):
             metrics.incr('internal.uncaptured.events')
             self.error_logger.error('Not capturing event due to unsafe stacktrace:\n%r', kwargs)
             return
-        return super(SentryInternalClient, self).capture(*args, **kwargs)
+        self.last_event_id = super(SentryInternalClient, self).capture(*args, **kwargs)
+        return self.last_event_id
 
     def send(self, **kwargs):
         # TODO(dcramer): this should respect rate limits/etc and use the normal


### PR DESCRIPTION
I'm looking to capture and store the last exception id for the event fired so I can associate it with some internal logging that we do.  In this PR I am attempting to do that.

FYI--the contributing page link is broken so I'm not sure how I'm supposed to do this.
