### PR TITLE
javascript/processor: only read response body if we have a 200 OK

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -362,7 +362,7 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
             response = None
             try:
                 try:
-                    now = time.time()
+                    start = time.time()
                     response = http_session.get(
                         url,
                         allow_redirects=True,
@@ -378,15 +378,21 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
                         cl = 0
                     if cl > settings.SENTRY_SOURCE_FETCH_MAX_SIZE:
                         raise OverflowError()
+
                     contents = []
                     cl = 0
-                    for chunk in response.iter_content(16 * 1024):
-                        if time.time() - now > settings.SENTRY_SOURCE_FETCH_TIMEOUT:
-                            raise Timeout()
-                        contents.append(chunk)
-                        cl += len(chunk)
-                        if cl > settings.SENTRY_SOURCE_FETCH_MAX_SIZE:
-                            raise OverflowError()
+
+                    # Only need to even attempt to read the response body if we
+                    # got a 200 OK
+                    if response.status_code == 200:
+                        for chunk in response.iter_content(16 * 1024):
+                            if time.time() - start > settings.SENTRY_SOURCE_FETCH_TIMEOUT:
+                                raise Timeout()
+                            contents.append(chunk)
+                            cl += len(chunk)
+                            if cl > settings.SENTRY_SOURCE_FETCH_MAX_SIZE:
+                                raise OverflowError()
+
                 except Exception as exc:
                     logger.debug('Unable to fetch %r', url, exc_info=True)
                     if isinstance(exc, RestrictedIPAddress):


### PR DESCRIPTION
If we get a non-200, we shouldn't actually do anything with the body.

@getsentry/platform 
