### PR TITLE
Make it so verification is sent to specific emails upon adding them

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,8 @@ Version 8.9
 - Added weekly report emails behind feature flag.
 - Rebrand Rules as Alerts / Alert Rules.
 - Add frequency to Alerts.
+- Send email to specific email when adding a new email rather than sending to all unverified email addresses
+- Allow user to resend email verification to primary email address
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/CHANGES
+++ b/CHANGES
@@ -9,13 +9,14 @@ Version 8.11 (Unreleased)
 - Added support for switching to unsymbolicated tracebacks in cocoa.
 - Invalidate user sessions when changing password and 2fa settings.
 - Add configurable password validators to enforce password strength.
+- Send email to specific email when adding a new email rather than sending to all unverified email addresses.
+- Allow user to resend email verification to primary email address.
+
 
 Schema Changes
 ~~~~~~~~~~~~~~
 
 - Added ``User.session_nonce`` column.
-- Send email to specific email when adding a new email rather than sending to all unverified email addresses.
-- Allow user to resend email verification to primary email address.
 
 Version 8.10
 ------------

--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@ Schema Changes
 ~~~~~~~~~~~~~~
 
 - Added ``User.session_nonce`` column.
+- Send email to specific email when adding a new email rather than sending to all unverified email addresses.
+- Allow user to resend email verification to primary email address.
 
 Version 8.10
 ------------
@@ -62,8 +64,6 @@ Version 8.9
 - Added weekly report emails behind feature flag.
 - Rebrand Rules as Alerts / Alert Rules.
 - Add frequency to Alerts.
-- Send email to specific email when adding a new email rather than sending to all unverified email addresses
-- Allow user to resend email verification to primary email address
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2254,6 +2254,22 @@ ul.faces {
   background: @white-dark;
 }
 
+.email-alert-button {
+    display: inline;
+    margin: 0;
+
+    button {
+      font-weight: 600;
+      color: inherit;
+      padding: 0;
+      border:0;
+
+      &:hover {
+        color: inherit;
+      }
+    }
+  }
+
 /**
 * Dropdowns
 * ============================================================================

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -10,7 +10,10 @@
     {% if request.user.has_unverified_emails %}
       <div class="alert alert-warning alert-block">
         {% trans "You have unverified emails. " %}
-        <a href="{% url 'sentry-account-confirm-email-send' %}">{% trans "Resend Verification Emails" %}</a>.
+        <form action="{% url 'sentry-account-confirm-email-send' %}" method="post" class="email-alert-button">
+          {% csrf_token %}
+          <button type="submit" class="btn-link">{% trans "Resend Verification Emails." %}</button>
+        </form>
       </div>
     {% endif %}
 

--- a/src/sentry/templates/sentry/account/settings.html
+++ b/src/sentry/templates/sentry/account/settings.html
@@ -9,16 +9,20 @@
 {% block title %}{% trans "Account Settings" %} | {{ block.super }}{% endblock %}
 
 {% block main %}
+    {% if not email.is_verified %}
+      <div class="alert alert-warning alert-block">
+        {% trans "Your email address has not been verified. " %}
+        <form action="{% url 'sentry-account-confirm-email-send' %}" method="post" class="email-alert-button">
+          {% csrf_token %}
+          <input type="hidden" name="email" value="{{ email.email }}">
+          <button type="submit" name="primary-email" class="btn-link">{% trans "Resend Verification Email." %}</button>
+        </form>
+      </div>
+    {% endif %}
+
     <form action="" method="post">
         {% csrf_token %}
         {{ form|as_crispy_errors }}
-
-        {% if request.user.has_unverified_emails %}
-          <div class="alert alert-warning alert-block">
-            {% trans "Your email address has not been verified. " %}
-            <a href="{% url 'sentry-account-confirm-email-send' %}">{% trans "Resend Verification Email" %}</a>.
-          </div>
-        {% endif %}
 
         <legend style="margin-top: 0;">Your details</legend>
 

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -213,7 +213,7 @@ def account_settings(request):
                 user_email.set_hash()
                 user_email.save()
             user.send_confirm_email_singular(user_email)
-            msg = _('A confirmation email has been sent to %s.' % user_email.email)
+            msg = _('A confirmation email has been sent to %s.') % user_email.email
             messages.add_message(
                 request,
                 messages.SUCCESS,
@@ -426,7 +426,7 @@ def show_emails(request):
                 user_email.set_hash()
                 user_email.save()
             user.send_confirm_email_singular(user_email)
-            msg = _('A confirmation email has been sent to %s.' % user_email.email)
+            msg = _('A confirmation email has been sent to %s.') % user_email.email
             messages.add_message(
                 request,
                 messages.SUCCESS,
@@ -448,7 +448,7 @@ def show_emails(request):
                 new_email.save()
             # send confirmation emails to any non verified emails
             user.send_confirm_email_singular(new_email)
-            msg = _('A confirmation email has been sent to %s.' % new_email.email)
+            msg = _('A confirmation email has been sent to %s.') % new_email.email
             messages.add_message(
                 request,
                 messages.SUCCESS,

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -143,6 +143,7 @@ def start_confirm_email(request):
             email_to_send = UserEmail.objects.get(user=request.user, email=email)
         except UserEmail.DoesNotExist:
             msg = _('There was an error confirming your email.')
+            level = messages.ERROR
         else:
             request.user.send_confirm_email_singular(email_to_send)
             msg = _('A verification email has been sent to %s.') % (email)

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -139,10 +139,15 @@ def start_confirm_email(request):
 
     if 'primary-email' in request.POST:
         email = request.POST.get('email')
-        email_to_send = UserEmail.objects.get(user=request.user, email=email)
-        request.user.send_confirm_email_singular(email_to_send)
-        msg = _('A verification email has been sent to %s.') % (email)
-        messages.add_message(request, messages.SUCCESS, msg)
+        try:
+            email_to_send = UserEmail.objects.get(user=request.user, email=email)
+        except UserEmail.DoesNotExist:
+            msg = _('There was an error confirming your email.')
+        else:
+            request.user.send_confirm_email_singular(email_to_send)
+            msg = _('A verification email has been sent to %s.') % (email)
+            level = messages.SUCCESS
+        messages.add_message(request, level, msg)
         return HttpResponseRedirect(reverse('sentry-account-settings'))
     elif request.user.has_unverified_emails():
         request.user.send_confirm_emails()

--- a/tests/sentry/web/frontend/accounts/tests.py
+++ b/tests/sentry/web/frontend/accounts/tests.py
@@ -278,9 +278,25 @@ class ConfirmEmailSendTest(TestCase):
     @mock.patch('sentry.models.User.send_confirm_emails')
     def test_valid(self, send_confirm_email):
         self.login_as(self.user)
-        resp = self.client.get(reverse('sentry-account-confirm-email-send'))
+        resp = self.client.post(reverse('sentry-account-confirm-email-send'))
         self.assertRedirects(resp, reverse('sentry-account-settings-emails'), status_code=302)
         send_confirm_email.assert_called_once_with()
+
+    def test_get_request_not_valid(self):
+        self.login_as(self.user)
+        resp = self.client.get(reverse('sentry-account-confirm-email-send'))
+        assert resp.status_code == 405
+
+    @mock.patch('sentry.models.User.send_confirm_email_singular')
+    def test_send_single_email(self, send_confirm_email):
+        user = self.create_user('foo@example.com')
+        email = UserEmail.objects.create(user=user, email='bar@example.com')
+        email.save()
+        self.login_as(user)
+        self.client.post(reverse('sentry-account-confirm-email-send'),
+                        data={'primary-email': '', 'email': 'foo@example.com'},
+                        follow=True)
+        send_confirm_email.assert_called_once_with(UserEmail.get_primary_email(user))
 
 
 class ConfirmEmailTest(TestCase):
@@ -296,7 +312,7 @@ class ConfirmEmailTest(TestCase):
     def test_valid(self):
         self.user.save()
         self.login_as(self.user)
-        self.client.get(reverse('sentry-account-confirm-email-send'))
+        self.client.post(reverse('sentry-account-confirm-email-send'))
         email = self.user.emails.first()
         resp = self.client.get(reverse('sentry-account-confirm-email',
                                        args=[self.user.id, email.validation_hash]))


### PR DESCRIPTION
This makes it so that whenever a new email is added, the verification email should only be sent to that email. It also allows you to only send a verification email to your primary email from account settings, but clicking resend verification emails in the emails tab still sends to all unverified emails.

@getsentry/platform 
