### PR TITLE
Remove sidebar from shared group

### DIFF
--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
@@ -5,7 +5,6 @@ import DocumentTitle from 'react-document-title';
 import ApiMixin from '../../mixins/apiMixin';
 import EventEntries from '../../components/events/eventEntries';
 import Footer from '../../components/footer';
-import Sidebar from '../../components/sidebar';
 import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 import PropTypes from '../../proptypes';
@@ -90,23 +89,32 @@ const SharedGroupDetails = React.createClass({
     return (
       <DocumentTitle title={this.getTitle()}>
         <div className="app">
-          <Sidebar />
+          <div className="pattern-bg" />
           <div className="container">
-            <div className="content">
-              <SharedGroupHeader group={group} />
-              <div className="group-overview event-details-container">
-                <div className="primary">
-                  <EventEntries
-                    group={group}
-                    event={evt}
-                    orgId={group.project.organization.slug}
-                    project={group.project}
-                    isShare={true} />
+            <div className="box box-modal">
+              <div className="box-header">
+                <a href="/">
+                  <span className="icon-sentry-logo-full" />
+                </a>
+              </div>
+              <div className="box-content">
+                <div className="content">
+                  <SharedGroupHeader group={group} />
+                  <div className="group-overview event-details-container">
+                    <div className="primary">
+                      <EventEntries
+                        group={group}
+                        event={evt}
+                        orgId={group.project.organization.slug}
+                        project={group.project}
+                        isShare={true} />
+                    </div>
+                  </div>
+                  <Footer />
                 </div>
               </div>
             </div>
           </div>
-          <Footer />
         </div>
       </DocumentTitle>
     );

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1978,13 +1978,57 @@ pre.val, span.val {
 */
 
 .shared-group {
+  padding: 40px 0;
+  background: none;
+
+  .app > .container {
+    max-width: 960px;
+
+    > .box {
+      > .box-header {
+        padding: 15px 30px 10px;
+
+        a {
+          font-size: 20px;
+
+          &:hover {
+            color: @gray-dark;
+          }
+        }
+
+        .back-to, .pull-right a {
+          font-size: 16px;
+        }
+
+        .back-to {
+          border-left: 1px solid @trim;
+          padding: 2px 10px;
+          display: inline-block;
+          margin-left: 7px;
+          position: relative;
+          top: -3px;
+        }
+      }
+    }
+  }
+
+  .box-content {
+
+  }
+
   .container {
     padding-left: 0;
     padding-right: 0;
   }
 
   .group-detail {
-    box-shadow: 0 1px 3px rgba(0,0,0, .08);
+    padding: 0 30px;
+    border-bottom: 1px solid darken(@trim, 5);
+    box-shadow: 0 2px 0 rgba(0,0,0, .03);
+
+    &:before {
+      display: none;
+    }
 
     .details {
       max-width: 960px;
@@ -1998,8 +2042,10 @@ pre.val, span.val {
     margin: 0;
 
     .primary {
+      max-width: 100%;
+
       .box {
-        padding: 0;
+        padding: 0 30px;
         &:first-child {
           border-top: 0;
         }


### PR DESCRIPTION
Modal-ifies shared group page. Fixes layout issue introduced in b8824940ca49131c27eb3667c5d34c427936de3e.

Looks like:

![screen shot 2016-10-13 at 5 44 38 pm](https://cloud.githubusercontent.com/assets/30713/19371994/c168d556-916c-11e6-999b-7d313ae39d51.png)

@getsentry/product 
