### PR TITLE
eventerror: don't explode on missing keys while formatting

### DIFF
--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -1,6 +1,20 @@
 from __future__ import absolute_import
 
 import six
+from string import Formatter
+
+
+class dontexplodedict(object):
+    """
+    A dictionary that won't throw a KeyError and will
+    return back a sensible default value to be used in
+    string formatting.
+    """
+    def __init__(self, d=None):
+        self.data = d or {}
+
+    def __getitem__(self, key):
+        return self.data.get(key, '')
 
 
 class EventError(object):
@@ -51,7 +65,11 @@ class EventError(object):
 
     @classmethod
     def get_message(cls, data):
-        return cls._messages[data['type']].format(**data)
+        return Formatter().vformat(
+            cls._messages[data['type']],
+            [],
+            dontexplodedict(data),
+        )
 
     def to_dict(self):
         return {k: v for k, v in six.iteritems(self) if k != 'type'}

--- a/tests/sentry/models/test_eventerror.py
+++ b/tests/sentry/models/test_eventerror.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+import pytest
+
+from sentry.models import EventError
+
+
+@pytest.mark.parametrize('data,message', (
+    ({'type': 'unknown_error'}, u'Unknown error'),
+    ({'type': 'unknown_error', 'foo': 'bar'}, u'Unknown error'),
+    ({'type': 'invalid_data', 'name': 'foo'}, u"Discarded invalid value for parameter 'foo'"),
+    ({'type': 'invalid_data'}, u"Discarded invalid value for parameter ''"),
+))
+def test_get_message(data, message):
+    assert EventError.get_message(data) == message


### PR DESCRIPTION
This helps as messages evolve over time. Previous events will be stored
without keys that are needed if the message in turn, now expects it.
This allows things to gracefully roll forward.

@getsentry/platform 
