### PR TITLE
[admin] Add Team.transfer_to helper

### DIFF
--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 import warnings
 
 from django.conf import settings
-from django.db import models
+from django.db import connections, IntegrityError, models, router, transaction
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
@@ -155,6 +155,79 @@ class Team(Model):
             return True
 
         return auth_identity.is_valid(member)
+
+    def transfer_to(self, organization):
+        """
+        Transfers a team and all projects under it to the given organization.
+        """
+        from sentry.models import (
+            OrganizationAccessRequest, OrganizationMember,
+            OrganizationMemberTeam, Project
+        )
+
+        try:
+            with transaction.atomic():
+                self.update(organization=organization)
+        except IntegrityError:
+            # likely this means a team already exists, let's try to coerce to
+            # it instead of a blind transfer
+            new_team = Team.objects.get(
+                organization=organization,
+                slug=self.slug,
+            )
+        else:
+            new_team = self
+
+        Project.objects.filter(
+            team=self,
+        ).exclude(
+            organization=organization,
+        ).update(
+            team=new_team,
+            organization=organization,
+        )
+
+        # remove any pending access requests from the old organization
+        if self != new_team:
+            OrganizationAccessRequest.objects.filter(
+                team=self,
+            ).delete()
+
+        # identify shared members and ensure they retain team access
+        # under the new organization
+        old_memberships = OrganizationMember.objects.filter(
+            teams=self,
+        ).exclude(
+            organization=organization,
+        )
+        for member in old_memberships:
+            try:
+                new_member = OrganizationMember.objects.get(
+                    user=member.user,
+                    organization=organization,
+                )
+            except OrganizationMember.DoesNotExist:
+                continue
+
+            OrganizationMemberTeam.objects.create(
+                team=new_team,
+                organizationmember=new_member,
+            )
+
+        OrganizationMemberTeam.objects.filter(
+            team=self,
+        ).exclude(
+            organizationmember__organization=organization,
+        ).delete()
+
+        if new_team != self:
+            cursor = connections[router.db_for_write(Team)].cursor()
+            # we use a cursor here to avoid automatic cascading of relations
+            # in Django
+            try:
+                cursor.execute('DELETE FROM sentry_team WHERE id = %s', [self.id])
+            finally:
+                cursor.close()
 
     def get_audit_log_data(self):
         return {

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -2,7 +2,9 @@
 
 from __future__ import absolute_import
 
-from sentry.models import OrganizationMember, OrganizationMemberTeam
+from sentry.models import (
+    OrganizationMember, OrganizationMemberTeam, Project, Team
+)
 from sentry.testutils import TestCase
 
 
@@ -59,3 +61,73 @@ class TeamTest(TestCase):
         )
 
         assert member not in team.member_set.all()
+
+
+class TransferTest(TestCase):
+    def test_simple(self):
+        user = self.create_user()
+        org = self.create_organization(name='foo', owner=user)
+        org2 = self.create_organization(name='bar', owner=None)
+        team = self.create_team(organization=org)
+        project = self.create_project(team=team)
+        user2 = self.create_user('foo@example.com')
+        self.create_member(
+            user=user2,
+            organization=org,
+            role='admin',
+            teams=[team],
+        )
+        self.create_member(
+            user=user2,
+            organization=org2,
+            role='member',
+            teams=[],
+        )
+        team.transfer_to(org2)
+
+        assert team.organization == org2
+        team = Team.objects.get(id=team.id)
+        assert team.organization == org2
+
+        project = Project.objects.get(id=project.id)
+        assert project.organization == org2
+
+        # owner does not exist on new org, so should not be transferred
+        assert not OrganizationMember.objects.filter(
+            user=user,
+            organization=org2,
+        ).exists()
+
+        # existing member should now have access
+        member = OrganizationMember.objects.get(
+            user=user2,
+            organization=org2,
+        )
+        assert list(member.teams.all()) == [team]
+        # role should not automatically upgrade
+        assert member.role == 'member'
+
+        # old member row should still exist
+        assert OrganizationMember.objects.filter(
+            user=user2,
+            organization=org,
+        ).exists()
+
+        # no references to old org for this team should exist
+        assert not OrganizationMemberTeam.objects.filter(
+            organizationmember__organization=org,
+            team=team,
+        ).exists()
+
+    def test_existing_team(self):
+        org = self.create_organization(name='foo')
+        org2 = self.create_organization(name='bar')
+        team = self.create_team(name='foo', organization=org)
+        team2 = self.create_team(name='foo', organization=org2)
+        project = self.create_project(team=team)
+        team.transfer_to(org2)
+
+        project = Project.objects.get(id=project.id)
+        assert project.team == team2
+
+        assert not Team.objects.filter(id=team.id).exists()


### PR DESCRIPTION
This takes the change organization logic currently present in /admin/ and moves it into a utility function. It also adds handling of cases where a duplicate team already exists in the transfer org.
