### PR TITLE
sourcemaps: fix content decoding regression

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -440,7 +440,13 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
                 body = b''.join(contents)
                 z_body = zlib.compress(body)
                 headers = {k.lower(): v for k, v in response.headers.items()}
-                text_body = body.decode(response.encoding or 'utf-8', 'replace')
+                encoding = response.encoding or 'utf-8'
+                try:
+                    text_body = body.decode(encoding, 'replace')
+                except LookupError:
+                    # A LookupError occurs when the encoding is unknown to python,
+                    # so we try to save and force decoding as utf-8
+                    text_body = body.decode('utf-8', 'replace')
 
                 cache.set(cache_key, (headers, z_body, response.status_code), 60)
                 result = (headers, text_body, response.status_code)


### PR DESCRIPTION
requests used to do this behavior for us automatically, and now that we
handle this ourselves, we regressed in this behavior. This restores it
back to mimic:
https://github.com/kennethreitz/requests/blob/master/requests/models.py#L788-L798

@getsentry/platform 
