### PR TITLE
sourcemaps: More libsourcemap compatibility

### DIFF
--- a/src/sentry/lang/javascript/sourcemaps/native.py
+++ b/src/sentry/lang/javascript/sourcemaps/native.py
@@ -155,7 +155,7 @@ def _sourcemap_to_index(smap):
             if value is None:
                 continue
 
-            content[src_id] = value.split('\n')
+            content[src_id] = value
 
     for token in parse_sourcemap(smap):
         token_list.append(token)

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -10,7 +10,9 @@ from mock import patch
 from sentry.models import Event, File, Release, ReleaseFile
 from sentry.testutils import TestCase
 
-BASE64_SOURCEMAP = 'data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zb2xlLmxvZyhcImhlbGxvLCBXb3JsZCFcIikiXX0='
+BASE64_SOURCEMAP = 'data:application/json;base64,' + (
+    '{"version":3,"file":"generated.js","sources":["/test.js"],"names":[],"mappings":"AAAA","sourcesContent":["console.log(\\"hello, World!\\")"]}'.encode('base64').replace('\n', '')
+)
 
 
 def get_fixture_path(name):

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -251,7 +251,7 @@ class FetchBase64SourcemapTest(TestCase):
         tokens = [Token(1, 0, '/test.js', 0, 0, 0, None)]
         sources = ['/test.js']
         keys = [(1, 0)]
-        content = {0: ['console.log("hello, World!")']}
+        content = {0: 'console.log("hello, World!")'}
 
         assert smap_view.index == IndexedSourceMapIndex([(0, 0)], [SourceMapIndex(tokens, keys, sources, content)])
 

--- a/tests/sentry/lang/javascript/test_sourcemaps.py
+++ b/tests/sentry/lang/javascript/test_sourcemaps.py
@@ -127,8 +127,14 @@ class GetSourceContentsTest(TestCase):
     def test_indexed_inline(self):
         smap_view = NativeView.from_json(indexed_sourcemap_example)
 
-        assert smap_view.get_source_contents((0, 0)) == [' ONE.foo = function (bar) {', '   return baz(bar);', ' };']
-        assert smap_view.get_source_contents((1, 0)) == [' TWO.inc = function (n) {', '   return n + 1;', ' };']
+        assert smap_view.get_source_contents((0, 0)) == (
+            ' ONE.foo = function (bar) {\n' +
+            '   return baz(bar);\n' +
+            ' };')
+        assert smap_view.get_source_contents((1, 0)) == (
+            ' TWO.inc = function (n) {\n' +
+            '   return n + 1;\n' +
+            ' };')
 
 
 class ParseSourcemapTest(TestCase):


### PR DESCRIPTION
This is splitting out from #4366 to limit number of moving pieces.
- `libsourcemap` returns sources as `bytes`, but `native` returns `unicode`. Opted to coerce the `bytes` to `unicode` purely for simplicity since this leads to extra complications. We'll follow up with a change to use `bytes` later.
- `libsourcemap` doesn't return content as a list of lines, whereas `native` did. So moves the `split` logic out of `native` into `processor` so that this logic can be shared. Again, another temporary thing.
- Fixed tests to go with these changes.

@getsentry/platform 
