### PR TITLE
Extend retention period for 1 day TSDB storage.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -838,7 +838,7 @@ SENTRY_TSDB_ROLLUPS = (
     # (time in seconds, samples to keep)
     (10, 360),  # 60 minutes at 10 seconds
     (3600, 24 * 7),  # 7 days at 1 hour
-    (3600 * 24, 60),  # 60 days at 1 day
+    (3600 * 24, 90),  # 90 days at 1 day
 )
 
 

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -374,10 +374,6 @@ def get_calendar_query_range(interval, months):
 def clean_calendar_data(project, series, start, stop, rollup, timestamp=None):
     earliest = tsdb.get_earliest_timestamp(rollup, timestamp=timestamp)
 
-    # XXX: This is temporary for sentry.io until 30 days after deployment and
-    # any preexisting records have their TTLs updated.
-    earliest = earliest + (30 * rollup)
-
     def remove_invalid_values(item):
         timestamp, value = item
         if timestamp < earliest:

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -374,6 +374,10 @@ def get_calendar_query_range(interval, months):
 def clean_calendar_data(project, series, start, stop, rollup, timestamp=None):
     earliest = tsdb.get_earliest_timestamp(rollup, timestamp=timestamp)
 
+    # XXX: This is temporary for sentry.io until 30 days after deployment and
+    # any preexisting records have their TTLs updated.
+    earliest = earliest + (30 * rollup)
+
     def remove_invalid_values(item):
         timestamp, value = item
         if timestamp < earliest:


### PR DESCRIPTION
This would allow us to fill out the 3 month history in the weekly reports.

If we do this, this should probably have a couple of follow up changes for hosted:
- Rewrite the TTL on existing entries so that they don't have the existing 60 day TTL. These keys are in a known format, so it shouldn't be too annoying to do.
- Update [this method](https://github.com/getsentry/sentry/blob/extend-rollup/src/sentry/tasks/reports.py#L377-L383) so the 60-90 day period doesn't report as 0 and throw off statistics in weekly reports until the data is actually available.

Both of these would affect on-premise, unless we wrote a data migration to specifically handle it. Open to thoughts on that. The failure mode isn't really that bad, but it can cause skewed stats until the point where all new data is written with the correct TTL.
