### PR TITLE
[workflow] fix non-member participants

### DIFF
--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -82,6 +82,7 @@ class GroupSubscriptionManager(BaseManager):
             GroupSubscription.objects.filter(
                 group=group,
                 is_active=True,
+                user__in=users,
             ).select_related('user')
         }
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -102,3 +102,74 @@ class GetParticipantsTest(TestCase):
         users = GroupSubscription.objects.get_participants(group=group)
 
         assert users == {}
+
+    def test_does_not_include_nonmember(self):
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        project = self.create_project(team=team, organization=org)
+        group = self.create_group(project=project)
+        user = self.create_user('foo@example.com')
+
+        # implicit participation, included by default
+        users = GroupSubscription.objects.get_participants(group=group)
+
+        assert users == {}
+
+        GroupSubscription.objects.create(
+            user=user,
+            group=group,
+            project=project,
+            is_active=True,
+            reason=GroupSubscriptionReason.comment,
+        )
+
+        # explicit participation, included by default
+        users = GroupSubscription.objects.get_participants(group=group)
+
+        assert users == {}
+
+        UserOption.objects.set_value(
+            user=user,
+            project=project,
+            key='workflow:notifications',
+            value=UserOptionValue.participating_only,
+        )
+
+        # explicit participation, participating only
+        users = GroupSubscription.objects.get_participants(group=group)
+
+        assert users == {}
+
+        GroupSubscription.objects.filter(
+            user=user,
+            group=group,
+        ).delete()
+
+        # implicit participation, participating only
+        users = GroupSubscription.objects.get_participants(group=group)
+
+        assert users == {}
+
+        UserOption.objects.set_value(
+            user=user,
+            project=project,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
+
+        # explicit participation, explicit participating only
+        users = GroupSubscription.objects.get_participants(group=group)
+
+        assert users == {}
+
+        GroupSubscription.objects.filter(
+            user=user,
+            group=group,
+        ).update(
+            reason=GroupSubscriptionReason.implicit,
+        )
+
+        # implicit participation, explicit participating only
+        users = GroupSubscription.objects.get_participants(group=group)
+
+        assert users == {}


### PR DESCRIPTION
add tests covering non-member (e.g. a removed member)

@getsentry/security 
