### PR TITLE
Log the length of messages sent via `send_messages`.

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -396,7 +396,10 @@ def send_messages(messages, fail_silently=False):
     sent = connection.send_messages(messages)
     metrics.incr('email.sent', len(messages))
     for message in messages:
-        extra = {'message_id': message.extra_headers['Message-Id']}
+        extra = {
+            'message_id': message.extra_headers['Message-Id'],
+            'size': len(message.message().as_bytes()),
+        }
         logger.info('mail.sent', extra=extra)
     return sent
 


### PR DESCRIPTION
This allows us to know if we're going over the 102kb limit[1] imposed by
Gmail which causes email messages to be trimmed.

1: http://kb.mailchimp.com/delivery/deliverability-research/gmail-is-clipping-my-email
