### PR TITLE
Create AuthCloseView to communicate with plugins that open sentry auth in new window

### DIFF
--- a/src/sentry/templates/sentry/auth_close.html
+++ b/src/sentry/templates/sentry/auth_close.html
@@ -15,8 +15,8 @@
   }
 
     (function checkAuthChange() {
-      var logged_in = '{{ logged_in }}';
-      if (window.opener && logged_in === 'True') {
+      var loggedIn = '{{ logged_in }}';
+      if (window.opener && loggedIn === 'True') {
         window.opener.postMessage('User is logged in', extractOrigin());
       }
       window.close();

--- a/src/sentry/templates/sentry/auth_close.html
+++ b/src/sentry/templates/sentry/auth_close.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title></title>
+</head>
+<body>
+  <script>
+  // sends message to window that opened this popup if user is authenticated and closes the window
+  function extractDomain(url) {
+    var matches = url.match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i);
+    var domain = matches && matches[1];
+    return domain;
+  }
+
+    (function checkAuthChange() {
+      var logged_in = '{{ logged_in }}';
+      if (window.opener && logged_in === 'True') {
+        window.opener.postMessage('User is logged in', "https://" + extractDomain(window.location.href));
+      }
+      window.close();
+    })();
+  </script>
+</body>
+</html>

--- a/src/sentry/templates/sentry/auth_close.html
+++ b/src/sentry/templates/sentry/auth_close.html
@@ -6,16 +6,18 @@
 <body>
   <script>
   // sends message to window that opened this popup if user is authenticated and closes the window
-  function extractDomain(url) {
-    var matches = url.match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i);
-    var domain = matches && matches[1];
-    return domain;
+  function extractOrigin() {
+    var pathArray = location.href.split( '/' );
+    var protocol = pathArray[0];
+    var host = pathArray[2];
+    var origin = protocol + '//' + host;
+    return origin;
   }
 
     (function checkAuthChange() {
       var logged_in = '{{ logged_in }}';
       if (window.opener && logged_in === 'True') {
-        window.opener.postMessage('User is logged in', "https://" + extractDomain(window.location.href));
+        window.opener.postMessage('User is logged in', extractOrigin());
       }
       window.close();
     })();

--- a/src/sentry/templates/sentry/auth_close.html
+++ b/src/sentry/templates/sentry/auth_close.html
@@ -14,13 +14,13 @@
     return origin;
   }
 
-    (function checkAuthChange() {
-      var loggedIn = '{{ logged_in }}';
-      if (window.opener && loggedIn === 'True') {
-        window.opener.postMessage('User is logged in', extractOrigin());
-      }
-      window.close();
-    })();
+  (function checkAuthChange() {
+    var loggedIn = '{{ logged_in }}';
+    if (window.opener && loggedIn === 'True') {
+      window.opener.postMessage('user_authenticated', extractOrigin());
+    }
+    window.close();
+  })();
   </script>
 </body>
 </html>

--- a/src/sentry/web/frontend/auth_close.py
+++ b/src/sentry/web/frontend/auth_close.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from django.shortcuts import render_to_response
+
+from sentry.web.frontend.base import BaseView
+
+
+class AuthCloseView(BaseView):
+    """This is a view to handle when sentry log in has been opened from
+    another window. This view loads an html page with a script that sends a message
+    back to the window opener and closes the window"""
+    def handle(self, request):
+        logged_in = request.user.is_authenticated()
+
+        return render_to_response('sentry/auth_close.html',
+            {'logged_in': logged_in})

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -25,6 +25,7 @@ from sentry.web.frontend.auth_logout import AuthLogoutView
 from sentry.web.frontend.auth_organization_login import \
     AuthOrganizationLoginView
 from sentry.web.frontend.auth_provider_login import AuthProviderLoginView
+from sentry.web.frontend.auth_close import AuthCloseView
 from sentry.web.frontend.create_organization import CreateOrganizationView
 from sentry.web.frontend.create_organization_member import \
     CreateOrganizationMemberView
@@ -225,6 +226,8 @@ urlpatterns += patterns(
         name='sentry-reactivate-account'),
     url(r'^auth/register/$', AuthLoginView.as_view(),
         name='sentry-register'),
+    url(r'^auth/close/$', AuthCloseView.as_view(),
+        name='sentry-auth-close'),
 
     # Account
     url(r'^login-redirect/$', accounts.login_redirect,

--- a/tests/sentry/web/frontend/test_auth_close.py
+++ b/tests/sentry/web/frontend/test_auth_close.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from django.utils.http import urlquote
+
+from exam import fixture
+
+from sentry.testutils import TestCase
+
+
+class AuthClose(TestCase):
+    @fixture
+    def path(self):
+        return reverse('sentry-auth-close')
+
+    def test_renders_auth_close_view(self):
+        self.login_as(self.user)
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/auth_close.html')
+
+    def test_renders_auth_close_view_again(self):
+        resp = self.client.get(reverse('sentry-login') + '?next=' + urlquote('/auth/close/'))
+        self.login_as(self.user)
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/auth_close.html')
+
+    def test_context_anonymous_user(self):
+        """page should redirect for unauthenticated user"""
+        resp = self.client.get(self.path)
+        assert resp.status_code == 302
+
+    def test_context_logged_in(self):
+        self.login_as(self.user)
+
+        resp = self.client.get(self.path)
+        assert resp.context['logged_in'] is True


### PR DESCRIPTION
If a plugin opens Sentry as a popup, this sends a message back to the plugin to confirm that the user was logged in and then closes the window.

@getsentry/platform @benvinegar 
