### PR TITLE
use saved value for passwords, etc when validating plugin settings

### DIFF
--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -48,6 +48,8 @@ class PluginConfigMixin(object):
             if value is None:
                 if config.get('required'):
                     raise PluginError('Field is required')
+                if config.get('type') == 'secret':
+                    value = self.get_option(name, project)
                 return value
 
             if isinstance(value, six.string_types):


### PR DESCRIPTION
i could also make this like the url validator and add it to `DEFAULT_VALIDATORS` if you want

@getsentry/plugins 
