### PR TITLE
api: make sure environment isn't longer than 64 chars

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -676,6 +676,17 @@ class ClientApiHelper(object):
                     'value': data['release'],
                 })
                 del data['release']
+
+        if data.get('environment'):
+            data['environment'] = six.text_type(data['environment'])
+            if len(data['environment']) > 64:
+                data['errors'].append({
+                    'type': EventError.VALUE_TOO_LONG,
+                    'name': 'environment',
+                    'value': data['environment'],
+                })
+                del data['environment']
+
         return data
 
     def ensure_does_not_have_ip(self, data):

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -367,6 +367,22 @@ class ValidateDataTest(BaseAPITest):
         })
         assert data.get('platform') == 'other'
 
+    def test_environment_too_long(self):
+        data = self.helper.validate_data(self.project, {
+            'environment': 'a' * 65,
+        })
+        assert not data.get('environment')
+        assert len(data['errors']) == 1
+        assert data['errors'][0]['type'] == 'value_too_long'
+        assert data['errors'][0]['name'] == 'environment'
+        assert data['errors'][0]['value'] == 'a' * 65
+
+    def test_environment_as_non_string(self):
+        data = self.helper.validate_data(self.project, {
+            'environment': 42,
+        })
+        assert data.get('environment') == '42'
+
 
 class SafelyLoadJSONStringTest(BaseAPITest):
     def test_valid_payload(self):


### PR DESCRIPTION
fixes SENTRY-1XH

@getsentry/platform 
