### PR TITLE
don't require plugin to be enabled to reset configuration

### DIFF
--- a/src/sentry/web/frontend/project_plugin_reset.py
+++ b/src/sentry/web/frontend/project_plugin_reset.py
@@ -15,9 +15,6 @@ class ProjectPluginResetView(ProjectView):
         except KeyError:
             return self.redirect(reverse('sentry-configure-project-plugin', args=[project.organization.slug, project.slug, slug]))
 
-        if not plugin.is_enabled(project):
-            return self.redirect(reverse('sentry-configure-project-plugin', args=[project.organization.slug, project.slug, slug]))
-
         plugin.reset_options(project=project)
 
         return self.redirect(reverse('sentry-configure-project-plugin', args=[project.organization.slug, project.slug, slug]))


### PR DESCRIPTION
currently, you see the `Reset Configuration` button even if the plugin is disabled, but it does nothing, which is confusing.

@getsentry/plugins 
