### PR TITLE
templates: add {% system_origin %} tag to spit out simply the origin

### DIFF
--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -37,7 +37,7 @@ from sentry.utils.javascript import to_json
 from sentry.utils.strings import soft_break as _soft_break
 from sentry.utils.strings import soft_hyphenate, to_unicode, truncatechars
 from six.moves import range
-from six.moves.urllib.parse import quote, urlencode
+from six.moves.urllib.parse import quote, urlencode, urlparse
 
 SentryVersion = namedtuple('SentryVersion', [
     'current', 'latest', 'update_available', 'build',
@@ -68,6 +68,13 @@ def multiply(x, y):
 def absolute_uri(path='', *args):
     from sentry.utils.http import absolute_uri
     return absolute_uri(path.format(*args))
+
+
+@register.simple_tag
+def system_origin():
+    from sentry.utils.http import absolute_uri
+    url = urlparse(absolute_uri())
+    return '%s://%s' % (url.scheme, url.netloc)
 
 
 @register.filter

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from django.template import Context, Template
+
+
+def test_system_origin():
+    result = Template("""
+        {% load sentry_helpers %}
+        {% system_origin %}
+    """).render(Context()).strip()
+
+    assert result == 'http://testserver'


### PR DESCRIPTION
This varies slightly from `{% absolute uri '' %}` in that it'd guarantee
there is no path.

@getsentry/platform @kjlundsgaard 

Refs https://github.com/getsentry/sentry-plugins/pull/61
