### PR TITLE
Remove release list from report builder.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -16,8 +16,8 @@ from django.utils import dateformat, timezone
 
 from sentry.app import tsdb
 from sentry.models import (
-    Activity, GroupStatus, Organization, OrganizationStatus, Project,
-    Team, User, UserOption
+    Activity, GroupStatus, Organization, OrganizationStatus, Project, Team,
+    User, UserOption
 )
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, redis

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -16,8 +16,8 @@ from django.utils import dateformat, timezone
 
 from sentry.app import tsdb
 from sentry.models import (
-    Activity, GroupStatus, Organization, OrganizationStatus, Project, Release,
-    TagValue, Team, User, UserOption
+    Activity, GroupStatus, Organization, OrganizationStatus, Project,
+    Team, User, UserOption
 )
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, redis
@@ -289,36 +289,6 @@ def prepare_project_issue_summaries(interval, project):
     ]
 
 
-def trim_release_list(value):
-    return sorted(
-        value,
-        key=lambda (id, count): count,
-        reverse=True,
-    )[:5]
-
-
-def prepare_project_release_list((start, stop), project):
-    return trim_release_list(
-        filter(
-            lambda item: item[1] > 0,
-            tsdb.get_sums(
-                tsdb.models.release,
-                Release.objects.filter(
-                    project=project,
-                    version__in=TagValue.objects.filter(
-                        project=project,
-                        key='sentry:release',
-                        last_seen__gte=start,  # lack of upper bound is intentional
-                    ).values_list('value', flat=True),
-                ).values_list('id', flat=True),
-                start,
-                stop,
-                rollup=60 * 60 * 24,
-            ).items(),
-        )
-    )
-
-
 def prepare_project_usage_summary((start, stop), project):
     return (
         tsdb.get_sums(
@@ -450,11 +420,6 @@ Report, prepare_project_report, merge_reports = build(
             'issue_summaries',
             prepare_project_issue_summaries,
             merge_sequences,
-        ),
-        (
-            'release_list',
-            prepare_project_release_list,
-            lambda target, other: trim_release_list(target + other),
         ),
         (
             'usage_summary',

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -445,17 +445,6 @@ def report(request):
                 date_started=dt,
             )
 
-    release_instances = {}
-
-    def make_release_id_generator():
-        release_generator = make_release_generator()
-        while True:
-            release = next(release_generator)
-            release_instances[release.id] = release
-            yield release.id
-
-    release_id_generator = make_release_id_generator()
-
     def build_issue_summaries():
         summaries = []
         for i in range(3):
@@ -463,14 +452,6 @@ def report(request):
                 int(random.weibullvariate(10, 1) * random.paretovariate(0.5))
             )
         return summaries
-
-    def build_release_list():
-        return reports.trim_release_list([
-            (
-                next(release_id_generator),
-                max(1, int(random.weibullvariate(20, 0.15))),
-            ) for _ in range(random.randint(0, 10))
-        ])
 
     def build_usage_summary():
         return (
@@ -517,7 +498,6 @@ def report(request):
             series,
             aggregates,
             build_issue_summaries(),
-            build_release_list(),
             build_usage_summary(),
             build_calendar_data(project),
         )

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -169,7 +169,7 @@ def test_has_valid_aggregates(interval):
     project = None  # parameter is unused
 
     def make_report(aggregates):
-        return Report(None, aggregates, None, None, None, None)
+        return Report(None, aggregates, None, None, None)
 
     assert has_valid_aggregates(
         interval,


### PR DESCRIPTION
This data isn't used right now (it'll probably get brought back for project reports) so there's no reason to generate it and store it.
