### PR TITLE
Fix development setup with Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxslt-dev \
         libyaml-dev \
         llvm-3.5 \
+        bzip2 \
 
         # Extra dev tooling
         make \
@@ -83,7 +84,7 @@ ENV LANG en_US.utf8
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 ENV PG_MAJOR 9.5
-ENV PG_VERSION 9.5.4-1.pgdg80+1
+ENV PG_VERSION 9.5.*
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list \


### PR DESCRIPTION
- Fix Dockerfile.dev to use wildcard hotfix version of postgres
- Add bzip2 package for phantom-prebuilt npm install

The dev setup with docker wasn't working ... these fixes make to setup with docker work again.
