### PR TITLE
Add support link to sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -192,6 +192,11 @@ const Sidebar = React.createClass({
           currentPanel={this.state.currentPanel}
           onShowPanel={()=>this.togglePanel('statusupdate')}
           hidePanel={()=>this.hidePanel()} />
+        <li>
+          <a title="Support" href={`/organizations/${org.slug}/support/`}>
+            <span className="icon icon-support" />
+          </a>
+        </li>
       </ul>
 
       {/* Panel bodies */}


### PR DESCRIPTION
Uses the [support icon](https://github.com/getsentry/sentry/pull/4413) to link to the support page.

@getsentry/product 

![screen shot 2016-10-25 at 10 41 04 am](https://cloud.githubusercontent.com/assets/9269824/19697291/a139a2b0-9a9f-11e6-84fb-b0a597413f7b.png)
