### PR TITLE
[sso] require per-organization validation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 8.10 (Unreleased)
 - Replaced the ``events`` queue with ``events.{preprocess,process,save}_event``.
 - Added Danger (danger/danger) for monitoring various PR requirements.
 - Enabled organization weekly report emails for all organizations.
+- SSO is now enforced to access data within any org that has it set as a requirement.
 
 API Changes
 ~~~~~~~~~~~

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -430,7 +430,8 @@ class AuthHelper(object):
                 ).exists()
                 if has_membership:
                     if not auth.login(request, existing_user,
-                                      after_2fa=request.build_absolute_uri()):
+                                      after_2fa=request.build_absolute_uri(),
+                                      organization_id=self.organization.id):
                         return HttpResponseRedirect(auth.get_login_redirect(
                             self.request))
                     # assume they've confirmed they want to attach the identity

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -42,6 +42,7 @@ from sentry.models import GroupMeta, ProjectOption
 from sentry.plugins import plugins
 from sentry.rules import EventState
 from sentry.utils import json
+from sentry.utils.auth import mark_sso_complete
 
 from .fixtures import Fixtures
 from .helpers import AuthProvider, Feature, get_auth_header, TaskRunner, override_options
@@ -103,7 +104,7 @@ class BaseTestCase(Fixtures, Exam):
         self.client.cookies[session_cookie] = self.session.session_key
         self.client.cookies[session_cookie].update(cookie_data)
 
-    def login_as(self, user):
+    def login_as(self, user, organization_id=None):
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
 
         request = HttpRequest()
@@ -111,6 +112,8 @@ class BaseTestCase(Fixtures, Exam):
 
         login(request, user)
         request.user = user
+        if organization_id:
+            mark_sso_complete(organization_id)
 
         # Save the session values.
         self.save_session()

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -57,7 +57,7 @@ class AuthOrganizationLoginView(BaseView):
             # HACK: grab whatever the first backend is and assume it works
             user.backend = settings.AUTHENTICATION_BACKENDS[0]
 
-            auth.login(request, user)
+            auth.login(request, user, organization_id=organization.id)
 
             # can_register should only allow a single registration
             request.session.pop('can_register', None)

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -3,12 +3,10 @@ from __future__ import absolute_import
 import logging
 import six
 
-from django.contrib import messages
 from django.core.context_processors import csrf
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_protect
 from django.views.generic import View
 from sudo.views import redirect_to_sudo
@@ -21,8 +19,6 @@ from sentry.models import (
 )
 from sentry.utils import auth
 from sentry.web.helpers import render_to_response
-
-ERR_MISSING_SSO_LINK = _('You need to link your account with the SSO provider to continue.')
 
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger('sentry.audit.ui')
@@ -299,8 +295,11 @@ class OrganizationView(BaseView):
     def has_permission(self, request, organization, *args, **kwargs):
         if organization is None:
             return False
-        if self.valid_sso_required and not request.access.sso_is_valid:
-            return False
+        if self.valid_sso_required:
+            if not request.access.sso_is_valid:
+                return False
+            if self.needs_sso(request, organization):
+                return False
         if self.required_scope and not request.access.has_scope(self.required_scope):
             logger.info('User %s does not have %s permission to access organization %s',
                 request.user, self.required_scope, organization)
@@ -334,23 +333,36 @@ class OrganizationView(BaseView):
         return False
 
     def handle_permission_required(self, request, organization, *args, **kwargs):
-        needs_link = (
-            organization and request.user.is_authenticated()
-            and self.valid_sso_required and not request.access.sso_is_valid
-        )
-
-        auth.initiate_login(request, next_url=request.get_full_path())
-
-        if needs_link:
-            messages.add_message(
-                request, messages.ERROR,
-                ERR_MISSING_SSO_LINK,
-            )
+        if self.needs_sso(request, organization):
+            logger.info('access.must-sso', extra={
+                'organization_id': organization.id,
+                'user_id': request.user.id,
+            })
+            auth.initiate_login(request, next_url=request.get_full_path())
             redirect_uri = reverse('sentry-auth-organization',
                                    args=[organization.slug])
         else:
             redirect_uri = self.get_no_permission_url(request, *args, **kwargs)
         return self.redirect(redirect_uri)
+
+    def needs_sso(self, request, organization):
+        if not organization:
+            return False
+        # XXX(dcramer): this branch should really never hit
+        if not request.user.is_authenticated():
+            return False
+        if not self.valid_sso_required:
+            return False
+        if not request.access.has_sso:
+            return False
+
+        # sso_is_valid implies that "SSO is required to access this organization
+        # and the user's account has been validated"
+        if request.access.sso_is_valid:
+            return False
+        if not auth.has_completed_sso(request, organization.id):
+            return True
+        return False
 
     def convert_args(self, request, organization_slug=None, *args, **kwargs):
         active_organization = self.get_active_organization(

--- a/tests/integration/test_sso.py
+++ b/tests/integration/test_sso.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.models import AuthIdentity, AuthProvider
+from sentry.testutils import AuthProviderTestCase
+from sentry.utils.auth import SSO_SESSION_KEY
+
+
+# TODO(dcramer): this is an integration test
+class OrganizationAuthLoginTest(AuthProviderTestCase):
+    def test_sso_auth_required(self):
+        user = self.create_user('foo@example.com', is_superuser=False)
+        organization = self.create_organization(name='foo')
+        member = self.create_member(user=user, organization=organization)
+        setattr(member.flags, 'sso:linked', True)
+        member.save()
+
+        auth_provider = AuthProvider.objects.create(
+            organization=organization,
+            provider='dummy',
+        )
+
+        AuthIdentity.objects.create(
+            auth_provider=auth_provider,
+            user=user,
+        )
+
+        self.login_as(user)
+
+        path = '/{}/'.format(organization.slug)
+        redirect_uri = 'http://testserver/auth/login/{}/'.format(organization.slug)
+
+        # we should be redirecting the user to the authentication form as they
+        # haven't verified this specific organization
+        resp = self.client.get(path)
+        assert resp.status_code == 302
+        assert resp['Location'] == redirect_uri
+
+        # superuser should still require SSO as they're a member of the org
+        user.update(is_superuser=True)
+        resp = self.client.get(path)
+        assert resp.status_code == 302
+        assert resp['Location'] == redirect_uri
+
+        # XXX(dcramer): using internal API as exposing a request object is hard
+        self.session[SSO_SESSION_KEY] = six.text_type(organization.id)
+        self.save_session()
+
+        # now that SSO is marked as complete, we should be able to access dash
+        resp = self.client.get(path)
+        assert resp.status_code == 200


### PR DESCRIPTION
This expands on SSO security for accounts which span multiple organizations or existed before SSO. It changes the requirements so that to access an SSO-only organization, you now **must** authenticate against that organization.

For superusers this is still special cased, in that if you're part of an organization and it requires it, you must also do it. If you're not a member of the org you can bypass it.
