### PR TITLE
utils: Don't blow up trimming a value that isn't ascii or unicode

### DIFF
--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -12,6 +12,7 @@ import six
 
 from django.conf import settings
 from django.db import transaction
+from django.utils.encoding import force_text
 
 from sentry.utils.strings import truncatechars
 
@@ -64,7 +65,7 @@ def trim(value, max_size=settings.SENTRY_MAX_VARIABLE_SIZE, max_depth=3,
         for k, v in six.iteritems(value):
             trim_v = trim(v, _size=_size, **options)
             result[k] = trim_v
-            _size += len(six.text_type(trim_v)) + 1
+            _size += len(force_text(trim_v)) + 1
             if _size >= max_size:
                 break
 
@@ -74,7 +75,7 @@ def trim(value, max_size=settings.SENTRY_MAX_VARIABLE_SIZE, max_depth=3,
         for v in value:
             trim_v = trim(v, _size=_size, **options)
             result.append(trim_v)
-            _size += len(six.text_type(trim_v))
+            _size += len(force_text(trim_v))
             if _size >= max_size:
                 break
 

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -15,6 +15,10 @@ class TrimTest(TestCase):
             a_very_long_string[:507] + '...',
         ]
 
+    def test_nonascii(self):
+        assert trim({'x': '\xc3\xbc'}) == {'x': '\xc3\xbc'}
+        assert trim(['x', '\xc3\xbc']) == ['x', '\xc3\xbc']
+
 
 class TrimDictTest(TestCase):
     def test_large_dict(self):


### PR DESCRIPTION
Input into trim may either be bytes or text, and we already expect this
since we check for `six.string_types`. But if we get a binary type that
isn't ascii, trim would blow up.

@getsentry/platform 
