### PR TITLE
api: guard against junky public keys

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -214,6 +214,12 @@ class ClientApiHelper(object):
         if not auth.public_key:
             raise APIUnauthorized('Invalid api key')
 
+        # Make sure the key even looks valid first, since it's
+        # possible to get some garbage input here causing further
+        # issues trying to query it from cache or the database.
+        if not ProjectKey.looks_like_api_key(auth.public_key):
+            raise APIUnauthorized('Invalid api key')
+
         try:
             pk = ProjectKey.objects.get_from_cache(public_key=auth.public_key)
         except ProjectKey.DoesNotExist:

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function
 
 import petname
 import six
+import re
 
 from bitfield import BitField
 from uuid import uuid4
@@ -25,6 +26,8 @@ from sentry.db.models import (
     Model, BaseManager, BoundedPositiveIntegerField, FlexibleForeignKey,
     sane_repr
 )
+
+_uuid4_re = re.compile(r'^[a-f0-9]{32}$')
 
 
 # TODO(dcramer): pull in enum library
@@ -81,6 +84,10 @@ class ProjectKey(Model):
     @classmethod
     def generate_api_key(cls):
         return uuid4().hex
+
+    @classmethod
+    def looks_like_api_key(cls, key):
+        return bool(_uuid4_re.match(key))
 
     @classmethod
     def from_dsn(cls, dsn):

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -96,6 +96,10 @@ class ProjectFromAuthTest(BaseAPITest):
         auth = Auth({'sentry_key': self.pk.public_key, 'sentry_secret': 'z'})
         self.assertRaises(APIUnauthorized, self.helper.project_from_auth, auth)
 
+    def test_nonascii_key(self):
+        auth = Auth({'sentry_key': '\xc3\xbc'})
+        self.assertRaises(APIUnauthorized, self.helper.project_from_auth, auth)
+
 
 class ProcessFingerprintTest(BaseAPITest):
     def test_invalid_as_string(self):


### PR DESCRIPTION
If non-ascii characters are sent along,
ProjectKey.objects.get_from_cache will be sad.

@getsentry/platform 

Without this, we just spit back a nice 500 error.
