### PR TITLE
api: Properly handle internationalized domain names

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 8.10 (Unreleased)
 - ``SENTRY_FILESTORE`` deprecated and replaced with ``filestore.backend``
 - ``SENTRY_FILESTORE_OPTIONS`` deprecated and replaced with ``filestore.options``
 - Add watchOS support for cocoa interface.
+- Fix support for internationalized Origins and raven-js.
 
 API Changes
 ~~~~~~~~~~~

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -14,7 +14,7 @@ class ErrorPageEmbedTest(TestCase):
     def setUp(self):
         super(ErrorPageEmbedTest, self).setUp()
         self.project = self.create_project()
-        self.project.update_option('sentry:origins', 'example.com')
+        self.project.update_option('sentry:origins', ['example.com'])
         self.key = self.create_project_key(self.project)
         self.event_id = uuid4().hex
         self.path = '%s?eventId=%s&dsn=%s' % (


### PR DESCRIPTION
If a user specified `*.løcalhost` in their "Allowed Origins" setting,
then a request came from `Origin: http://løcalhost`, we errored comparing
since the hostname was bytes, and allowed origins was text.

This is coercing both sides to bytes. Hostname shouldn't ever actually
be text, but added a check to make sure since I'm not confident there
isn't a case where that'd be false.

Rather than just blindly coercing to bytes, we coerce both the Origin
and the Allowed Domains to punycode. This allows comparison between
punycode and utf-8 encoded results as well. Also allowing a user to
specify Allowed Domains as either unicode or punycode.

@getsentry/platform 

This is also some relevant information: https://docs.python.org/2/library/codecs.html#module-encodings.idna
