### PR TITLE
Fix alert button alignment

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2182,6 +2182,9 @@ ul.faces {
 .alert-block {
   .btn {
     float: right;
+    position: relative;
+    top: -3px;
+    right: -6px;
   }
 }
 


### PR DESCRIPTION
Properly aligns btns inside of alerts

![screen shot 2016-10-26 at 1 53 46 pm](https://cloud.githubusercontent.com/assets/30713/19744754/b6912a54-9b83-11e6-95ee-8cb13ac650ad.png)

@dcramer 
