### PR TITLE
Allow coercing `chunked` iterator to a list.

### DIFF
--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -7,5 +7,5 @@ def chunked(iterator, size):
         chunk.append(item)
         if len(chunk) == size:
             yield chunk
-            del chunk[:]
+            chunk = []
     yield chunk

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -8,4 +8,6 @@ def chunked(iterator, size):
         if len(chunk) == size:
             yield chunk
             chunk = []
-    yield chunk
+
+    if chunk:
+        yield chunk

--- a/tests/sentry/utils/test_iterators.py
+++ b/tests/sentry/utils/test_iterators.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+
+from sentry.utils.iterators import chunked
+
+
+def test_chunked():
+    assert list(chunked(range(10), 4)) == [
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9],
+    ]

--- a/tests/sentry/utils/test_iterators.py
+++ b/tests/sentry/utils/test_iterators.py
@@ -4,6 +4,10 @@ from sentry.utils.iterators import chunked
 
 
 def test_chunked():
+    assert list(chunked(range(5), 5)) == [
+        [0, 1, 2, 3, 4],
+    ]
+
     assert list(chunked(range(10), 4)) == [
         [0, 1, 2, 3],
         [4, 5, 6, 7],


### PR DESCRIPTION
This container was being reused before, so if you coerced it to a list you'd just get the final state of the `chunk` variable as many times as there were chunks in the input iterator.
