### PR TITLE
Better stack traces from render errorHandler

### DIFF
--- a/src/sentry/static/sentry/app/utils/errorHandler.jsx
+++ b/src/sentry/static/sentry/app/utils/errorHandler.jsx
@@ -8,7 +8,7 @@ export default function errorHandler(Component) {
       return originalRender.apply(this, arguments);
     } catch (err) {
       /*eslint no-console:0*/
-      console.error(err);
+      setTimeout(() => { throw err; });
       return <RouteError error={err} component={this} />;
     }
   };


### PR DESCRIPTION
Before (`App_render` frame missing, replaced with `console.log`):

![image](https://cloud.githubusercontent.com/assets/2153/19785219/7b930344-9c4d-11e6-82ef-f76e8d159d2a.png)

After (`App_render` frame present):

![image](https://cloud.githubusercontent.com/assets/2153/19785174/526ce52a-9c4d-11e6-912e-6c316ce62afa.png)

This should seriously help with debugging in cases where `render` fails in top-level views.

/cc @getsentry/product @macqueen
