### PR TITLE
[sso] require sso permissions on API session auth

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ API Changes
 - Add ``/organizations/{org}/repositories/`` endpoint.
 - Add ``/organizations/{org}/repositories/{repo}/commits/`` endpoint.
 - Add ``/projects/{org}/{project}/releases/{version}/commits/`` endpoint.
+- SSO restrictions are now applied across session-based API authentication.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import ScopedPermission
 from sentry.app import raven
-from sentry.auth import access
 from sentry.models import Project, ProjectStatus
-from sentry.models.apikey import ROOT_KEY
+
+from .team import TeamPermission
 
 
-class ProjectPermission(ScopedPermission):
+class ProjectPermission(TeamPermission):
     scope_map = {
         'GET': ['project:read', 'project:write', 'project:delete'],
         'POST': ['project:write', 'project:delete'],
@@ -18,24 +17,8 @@ class ProjectPermission(ScopedPermission):
     }
 
     def has_object_permission(self, request, view, project):
-        if request.user and request.user.is_authenticated() and request.auth:
-            request.access = access.from_request(
-                request, project.organization, scopes=request.auth.get_scopes(),
-            )
-
-        elif request.auth:
-            if request.auth is ROOT_KEY:
-                return True
-            return request.auth.organization_id == project.organization_id
-
-        else:
-            request.access = access.from_request(request, project.organization)
-
-        allowed_scopes = set(self.scope_map.get(request.method, []))
-        return any(
-            request.access.has_team_scope(project.team, s)
-            for s in allowed_scopes
-        )
+        return super(ProjectPermission, self).has_object_permission(
+            request, view, project.team)
 
 
 class ProjectReleasePermission(ProjectPermission):
@@ -71,15 +54,17 @@ class ProjectEndpoint(Endpoint):
 
     def convert_args(self, request, organization_slug, project_slug, *args, **kwargs):
         try:
-            project = Project.objects.get_from_cache(
+            project = Project.objects.filter(
                 organization__slug=organization_slug,
                 slug=project_slug,
-            )
+            ).select_related('organization', 'team').get()
         except Project.DoesNotExist:
             raise ResourceDoesNotExist
 
         if project.status != ProjectStatus.VISIBLE:
             raise ResourceDoesNotExist
+
+        project.team.organization = project.organization
 
         self.check_object_permissions(request, project)
 

--- a/src/sentry/api/bases/team.py
+++ b/src/sentry/api/bases/team.py
@@ -4,6 +4,7 @@ from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.app import raven
 from sentry.models import Team, TeamStatus
+from sentry.models.apikey import ROOT_KEY
 
 from .organization import OrganizationPermission
 
@@ -21,6 +22,11 @@ class TeamPermission(OrganizationPermission):
             request, view, team.organization)
         if not result:
             return result
+
+        if not (request.user and request.user.is_authenticated() and request.auth):
+            if request.auth is ROOT_KEY:
+                return True
+            return request.auth.organization_id == team.organization.id
 
         allowed_scopes = set(self.scope_map.get(request.method, []))
         return any(

--- a/src/sentry/api/bases/team.py
+++ b/src/sentry/api/bases/team.py
@@ -23,7 +23,7 @@ class TeamPermission(OrganizationPermission):
         if not result:
             return result
 
-        if not (request.user and request.user.is_authenticated() and request.auth):
+        if not (request.user and request.user.is_authenticated()) and request.auth:
             if request.auth is ROOT_KEY:
                 return True
             return request.auth.organization_id == team.organization.id

--- a/src/sentry/api/bases/team.py
+++ b/src/sentry/api/bases/team.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import ScopedPermission
 from sentry.app import raven
-from sentry.auth import access
 from sentry.models import Team, TeamStatus
-from sentry.models.apikey import ROOT_KEY
+
+from .organization import OrganizationPermission
 
 
-class TeamPermission(ScopedPermission):
+class TeamPermission(OrganizationPermission):
     scope_map = {
         'GET': ['team:read', 'team:write', 'team:delete'],
         'POST': ['team:write', 'team:delete'],
@@ -18,18 +17,10 @@ class TeamPermission(ScopedPermission):
     }
 
     def has_object_permission(self, request, view, team):
-        if request.user and request.user.is_authenticated() and request.auth:
-            request.access = access.from_request(
-                request, team.organization, scopes=request.auth.get_scopes(),
-            )
-
-        elif request.auth:
-            if request.auth is ROOT_KEY:
-                return True
-            return request.auth.organization_id == team.organization_id
-
-        else:
-            request.access = access.from_request(request, team.organization)
+        result = super(TeamPermission, self).has_object_permission(
+            request, view, team.organization)
+        if not result:
+            return result
 
         allowed_scopes = set(self.scope_map.get(request.method, []))
         return any(
@@ -43,10 +34,10 @@ class TeamEndpoint(Endpoint):
 
     def convert_args(self, request, organization_slug, team_slug, *args, **kwargs):
         try:
-            team = Team.objects.get(
+            team = Team.objects.filter(
                 organization__slug=organization_slug,
                 slug=team_slug,
-            )
+            ).select_related('organization').get()
         except Team.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -12,7 +12,8 @@ class AuthenticationTest(AuthProviderTestCase):
         user = self.create_user('foo@example.com', is_superuser=False)
         organization = self.create_organization(name='foo')
         team = self.create_team(name='bar', organization=organization)
-        project = self.create_project(name='baz', organization=organization)
+        project = self.create_project(name='baz', organization=organization,
+                                      team=team)
         member = self.create_member(user=user, organization=organization,
                                     teams=[team])
         setattr(member.flags, 'sso:linked', True)

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -41,7 +41,11 @@ class UpdateOrganizationMemberTest(APITestCase):
             user=member,
             role='member',
         )
-        AuthProvider.objects.create(organization=organization, provider='dummy')
+        AuthProvider.objects.create(
+            organization=organization,
+            provider='dummy',
+            flags=1,
+        )
 
         path = reverse('sentry-api-0-organization-member-details', args=[organization.slug, member_om.id])
 


### PR DESCRIPTION
This enforces the SSO permissions that were previously implemented in the server-rendered views (GH-4432).

@getsentry/security 