### PR TITLE
runner: Make sure apps get loaded into Django

### DIFF
--- a/src/sentry/runner/importer.py
+++ b/src/sentry/runner/importer.py
@@ -75,6 +75,8 @@ class Importer(object):
         # install the custom settings for this app
         load_settings(self.config_path, settings=settings_mod, silent=True)
 
+        install_plugin_apps('sentry.apps', settings_mod)
+
         return settings_mod
 
 
@@ -96,6 +98,19 @@ def load_settings(mod_or_filename, settings, silent=False):
         conf = mod_or_filename
 
     add_settings(conf, settings=settings)
+
+
+def install_plugin_apps(entry_point, settings):
+    # entry_points={
+    #    'sentry.apps': [
+    #         'phabricator = sentry_phabricator'
+    #     ],
+    # },
+    from pkg_resources import iter_entry_points
+    installed_apps = list(settings.INSTALLED_APPS)
+    for ep in iter_entry_points(entry_point):
+        installed_apps.append(ep.module_name)
+    settings.INSTALLED_APPS = tuple(installed_apps)
 
 
 def add_settings(mod, settings):

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -15,19 +15,6 @@ from sentry.utils import warnings
 from sentry.utils.warnings import DeprecatedSettingWarning
 
 
-def install_plugin_apps(settings):
-    # entry_points={
-    #    'sentry.apps': [
-    #         'phabricator = sentry_phabricator'
-    #     ],
-    # },
-    from pkg_resources import iter_entry_points
-    installed_apps = list(settings.INSTALLED_APPS)
-    for ep in iter_entry_points('sentry.apps'):
-        installed_apps.append(ep.module_name)
-    settings.INSTALLED_APPS = tuple(installed_apps)
-
-
 def register_plugins(settings):
     from pkg_resources import iter_entry_points
     from sentry.plugins import register
@@ -223,8 +210,6 @@ def initialize_app(config, skip_backend_validation=False):
     apply_legacy_settings(settings)
 
     bind_cache_to_option_store()
-
-    install_plugin_apps(settings)
 
     # Commonly setups don't correctly configure themselves for production envs
     # so lets try to provide a bit more guidance


### PR DESCRIPTION
Not 100% sure why, but the way that we're adding apps into
INSTALLED_APPS is suspect of a race condition between the time that
Django's AppCache gets initialized and populated and the time we append
to INSTALLED_APPS.