### PR TITLE
auth: password validators

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Version 8.11 (Unreleased)
 - Fixed bug where API responses would include incorrect `isSubscribed` values for issues.
 - Added support for switching to unsymbolicated tracebacks in cocoa.
 - Invalidate user sessions when changing password and 2fa settings.
+- Add configurable password validators to enforce password strength.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/Dangerfile
+++ b/Dangerfile
@@ -42,6 +42,10 @@
 # dont ever match against changes in these files
 @S_SECURITY_EXCLUDE_FILES ||= /test_.*\.py|south_migrations|CHANGES|tests/
 
+@S_BACKPORTED_FILES ||= [
+    "src/sentry/auth/password_validation.py",
+]
+
 # determine if any of the files were modified
 def checkFiles(files_array)
     files_array.select { |f| git.modified_files.include?(f) }
@@ -94,6 +98,9 @@ warn("Big PR -- consider splitting it up into multiple changesets") if git.lines
 
 # License is immutable
 fail("Do not modify the License") if @S_LICENSE_FILES && checkFiles(@S_LICENSE_FILES).any?
+
+# Notify about modifications to files that we've backported explicitly
+warn("This change includes modification to a file that was backported from newer Django.") if @S_BACKPORTED_FILES && checkFiles(@S_BACKPORTED_FILES).any?
 
 # Reasonable commits must update CHANGES
 if @S_CHANGE_LINES && git.lines_of_code > @S_CHANGE_LINES && !git.modified_files.include?("CHANGES") && checkFilesPattern(@S_CHANGES_REQUIRED_PATTERNS).any?

--- a/src/sentry/auth/password_validation.py
+++ b/src/sentry/auth/password_validation.py
@@ -1,0 +1,119 @@
+from __future__ import unicode_literals, absolute_import
+
+from django.conf import settings
+from django.core.exceptions import (
+    ImproperlyConfigured, ValidationError,
+)
+from django.utils.functional import lazy
+from django.utils.html import format_html
+from django.utils.six import text_type
+from django.utils.translation import ugettext as _, ungettext
+
+from sentry.utils.imports import import_string
+
+
+_default_password_validators = None
+
+
+def get_default_password_validators():
+    global _default_password_validators
+    if _default_password_validators is None:
+        _default_password_validators = get_password_validators(settings.AUTH_PASSWORD_VALIDATORS)
+    return _default_password_validators
+
+
+def get_password_validators(validator_config):
+    validators = []
+    for validator in validator_config:
+        try:
+            klass = import_string(validator['NAME'])
+        except ImportError:
+            msg = "The module in NAME could not be imported: %s. Check your AUTH_PASSWORD_VALIDATORS setting."
+            raise ImproperlyConfigured(msg % validator['NAME'])
+        validators.append(klass(**validator.get('OPTIONS', {})))
+
+    return validators
+
+
+def validate_password(password, password_validators=None):
+    """
+    Validate whether the password meets all validator requirements.
+
+    If the password is valid, return ``None``.
+    If the password is invalid, raise ValidationError with all error messages.
+    """
+    errors = []
+    if password_validators is None:
+        password_validators = get_default_password_validators()
+    for validator in password_validators:
+        try:
+            validator.validate(password)
+        except ValidationError as error:
+            errors.append(error)
+    if errors:
+        raise ValidationError(errors)
+
+
+def password_validators_help_texts(password_validators=None):
+    """
+    Return a list of all help texts of all configured validators.
+    """
+    help_texts = []
+    if password_validators is None:
+        password_validators = get_default_password_validators()
+    for validator in password_validators:
+        help_texts.append(validator.get_help_text())
+    return help_texts
+
+
+def _password_validators_help_text_html(password_validators=None):
+    """
+    Return an HTML string with all help texts of all configured validators
+    in an <ul>.
+    """
+    help_texts = password_validators_help_texts(password_validators)
+    help_items = [format_html('<li>{}</li>', help_text) for help_text in help_texts]
+    return '<ul>%s</ul>' % ''.join(help_items) if help_items else ''
+password_validators_help_text_html = lazy(_password_validators_help_text_html, text_type)
+
+
+class MinimumLengthValidator(object):
+    """
+    Validate whether the password is of a minimum length.
+    """
+    def __init__(self, min_length=8):
+        self.min_length = min_length
+
+    def validate(self, password):
+        if len(password) < self.min_length:
+            raise ValidationError(
+                ungettext(
+                    "This password is too short. It must contain at least %(min_length)d character.",
+                    "This password is too short. It must contain at least %(min_length)d characters.",
+                    self.min_length
+                ),
+                code='password_too_short',
+                params={'min_length': self.min_length},
+            )
+
+    def get_help_text(self):
+        return ungettext(
+            "Your password must contain at least %(min_length)d character.",
+            "Your password must contain at least %(min_length)d characters.",
+            self.min_length
+        ) % {'min_length': self.min_length}
+
+
+class NumericPasswordValidator(object):
+    """
+    Validate whether the password is alphanumeric.
+    """
+    def validate(self, password):
+        if password.isdigit():
+            raise ValidationError(
+                _("This password is entirely numeric."),
+                code='password_entirely_numeric',
+            )
+
+    def get_help_text(self):
+        return _("Your password can't be entirely numeric.")

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -303,6 +303,15 @@ AUTHENTICATION_BACKENDS = (
     'social_auth.backends.trello.TrelloBackend',
 )
 
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'sentry.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 6,
+        },
+    },
+]
+
 SOCIAL_AUTH_USER_MODEL = AUTH_USER_MODEL = 'sentry.User'
 
 SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -64,6 +64,8 @@ def pytest_configure(config):
         'django.contrib.auth.hashers.MD5PasswordHasher',
     ]
 
+    settings.AUTH_PASSWORD_VALIDATORS = []
+
     # Replace real sudo middleware with our mock sudo middleware
     # to assert that the user is always in sudo mode
     middleware = list(settings.MIDDLEWARE_CLASSES)


### PR DESCRIPTION
This is sort of a backport of Django 1.9's password validators.

The AUTH_PASSWORD_VALIDATORS allow is to enforce some minimum password
strength for setting user passwords. This allows us to be good citizens
and require stronger passwords on behalf of our users.

Right now, we're only enabling the MinimumLengthValidator, but we can
relatively figure out some slightly more complex algorithms or port some
of the other Django validator backends if we want to be fancier.

![image](https://cloud.githubusercontent.com/assets/375744/19920306/31af6c58-a095-11e6-9d9e-b5d26835823d.png)

@getsentry/security 