### PR TITLE
Add `subscribed` parameter to search query parameters.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 8.11 (Unreleased)
 -------------------------
 
 - Ignore a ``null`` ``Origin`` header for authentication.
+- Added the ability to search for issues that you are subscribed to from the stream view.
 
 Version 8.10
 ------------

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -115,13 +115,13 @@ class DjangoSearchBackend(SearchBackend):
                 assignee_set__isnull=unassigned,
             )
 
-        if subscribed_by:
+        if subscribed_by is not None:
             queryset = queryset.filter(
                 id__in=GroupSubscription.objects.filter(
                     project=project,
                     user=subscribed_by,
                     is_active=True,
-                ),
+                ).values_list('group'),
             )
 
         if first_release:

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -67,13 +67,13 @@ class DjangoSearchBackend(SearchBackend):
 
     def _build_queryset(self, project, query=None, status=None, tags=None,
                         bookmarked_by=None, assigned_to=None, first_release=None,
-                        sort_by='date', unassigned=None,
+                        sort_by='date', unassigned=None, subscribed_by=None,
                         age_from=None, age_from_inclusive=True,
                         age_to=None, age_to_inclusive=True,
                         date_from=None, date_from_inclusive=True,
                         date_to=None, date_to_inclusive=True,
                         cursor=None, limit=None):
-        from sentry.models import Event, Group, GroupStatus
+        from sentry.models import Event, Group, GroupSubscription, GroupStatus
 
         engine = get_db_engine('default')
 
@@ -113,6 +113,15 @@ class DjangoSearchBackend(SearchBackend):
         elif unassigned in (True, False):
             queryset = queryset.filter(
                 assignee_set__isnull=unassigned,
+            )
+
+        if subscribed_by:
+            queryset = queryset.filter(
+                id__in=GroupSubscription.objects.filter(
+                    project=project,
+                    user=subscribed_by,
+                    is_active=True,
+                ),
             )
 
         if first_release:

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -9,15 +9,14 @@ sentry.search.django.backend
 from __future__ import absolute_import
 
 import six
-
 from django.db import router
 from django.db.models import Q
 
 from sentry.api.paginator import DateTimePaginator, Paginator
 from sentry.search.base import ANY, EMPTY, SearchBackend
 from sentry.search.django.constants import (
-    SORT_CLAUSES, SQLITE_SORT_CLAUSES, MYSQL_SORT_CLAUSES, MSSQL_SORT_CLAUSES,
-    MSSQL_ENGINES, ORACLE_SORT_CLAUSES
+    MSSQL_ENGINES, MSSQL_SORT_CLAUSES, MYSQL_SORT_CLAUSES, ORACLE_SORT_CLAUSES,
+    SORT_CLAUSES, SQLITE_SORT_CLAUSES
 )
 from sentry.utils.db import get_db_engine
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-import six
-
 from collections import defaultdict
 from datetime import datetime, timedelta
+
+import six
+from django.db import DataError
 from django.utils import timezone
 
 from sentry.constants import STATUS_CHOICES
 from sentry.models import EventUser, Release, User
 from sentry.search.base import ANY, EMPTY
 from sentry.utils.auth import find_users
-from django.db import DataError
 
 
 class InvalidQuery(Exception):

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -132,6 +132,18 @@ def parse_datetime_expression(value):
     return parse_datetime_value(value)
 
 
+def parse_user_value(value, user):
+    if value == 'me':
+        return user
+
+    try:
+        return find_users(value)[0]
+    except IndexError:
+        # XXX(dcramer): hacky way to avoid showing any results when
+        # an invalid user is entered
+        return User(id=0)
+
+
 def get_date_params(value, from_field, to_field):
     date_from, date_to = parse_datetime_expression(value)
     result = {}
@@ -255,25 +267,11 @@ def parse_query(project, query, user):
                     except KeyError:
                         raise InvalidQuery(u"'is:' had unknown status code '{}'.".format(value))
             elif key == 'assigned':
-                if value == 'me':
-                    results['assigned_to'] = user
-                else:
-                    try:
-                        results['assigned_to'] = find_users(value)[0]
-                    except IndexError:
-                        # XXX(dcramer): hacky way to avoid showing any results when
-                        # an invalid user is entered
-                        results['assigned_to'] = User(id=0)
+                results['assigned_to'] = parse_user_value(value, user)
             elif key == 'bookmarks':
-                if value == 'me':
-                    results['bookmarked_by'] = user
-                else:
-                    try:
-                        results['bookmarked_by'] = find_users(value)[0]
-                    except IndexError:
-                        # XXX(dcramer): hacky way to avoid showing any results when
-                        # an invalid user is entered
-                        results['bookmarked_by'] = User(id=0)
+                results['bookmarked_by'] = parse_user_value(value, user)
+            elif key == 'subscribed':
+                results['subscribed_by'] = parse_user_value(value, user)
             elif key == 'first-release':
                 results['first_release'] = parse_release(project, value)
             elif key == 'release':

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -164,6 +164,7 @@ reserved_tag_names = frozenset([
     'is',
     'assigned',
     'bookmarks',
+    'subscribed',
     'first-release',
     'release',
     'level',

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from datetime import datetime, timedelta
 
-from sentry.models import GroupAssignee, GroupBookmark, GroupStatus, GroupTagValue
+from sentry.models import GroupAssignee, GroupBookmark, GroupStatus, GroupTagValue, GroupSubscription
 from sentry.search.base import ANY
 from sentry.search.django.backend import DjangoSearchBackend
 from sentry.testutils import TestCase
@@ -93,6 +93,20 @@ class DjangoSearchBackendTest(TestCase):
             user=self.user,
             group=self.group2,
             project=self.group2.project,
+        )
+
+        GroupSubscription.objects.create(
+            user=self.user,
+            group=self.group1,
+            project=self.group1.project,
+            is_active=True,
+        )
+
+        GroupSubscription.objects.create(
+            user=self.user,
+            group=self.group2,
+            project=self.group2.project,
+            is_active=False,
         )
 
     def test_query(self):
@@ -233,3 +247,11 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project1, assigned_to=self.user)
         assert len(results) == 1
         assert results[0] == self.group2
+
+    def test_subscribed_by(self):
+        results = self.backend.query(
+            self.group1.project,
+            subscribed_by=self.user,
+        )
+        assert len(results) == 1
+        assert results[0] == self.group1

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import
 
 from datetime import datetime, timedelta
 
-from sentry.models import GroupAssignee, GroupBookmark, GroupStatus, GroupTagValue, GroupSubscription
+from sentry.models import (
+    GroupAssignee, GroupBookmark, GroupStatus, GroupSubscription, GroupTagValue
+)
 from sentry.search.base import ANY
 from sentry.search.django.backend import DjangoSearchBackend
 from sentry.testutils import TestCase


### PR DESCRIPTION
This uses the same semantics as `assigned` and `bookmarked`:

- `me` is the special value for looking up yourself,
- you can use any other user as the value and see their results too