### PR TITLE
Add `last_seen` parameter to search query parameters.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Version 8.11 (Unreleased)
 
 - Ignore a ``null`` ``Origin`` header for authentication.
 - Added the ability to search for issues that you are subscribed to from the stream view.
+- Added the ability to search issues by their last seen timestamp.
 
 Version 8.10
 ------------

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -69,6 +69,8 @@ class DjangoSearchBackend(SearchBackend):
                         sort_by='date', unassigned=None, subscribed_by=None,
                         age_from=None, age_from_inclusive=True,
                         age_to=None, age_to_inclusive=True,
+                        last_seen_from=None, last_seen_from_inclusive=True,
+                        last_seen_to=None, last_seen_to_inclusive=True,
                         date_from=None, date_from_inclusive=True,
                         date_to=None, date_to_inclusive=True,
                         cursor=None, limit=None):
@@ -151,6 +153,20 @@ class DjangoSearchBackend(SearchBackend):
                     params['first_seen__lte'] = age_to
                 else:
                     params['first_seen__lt'] = age_to
+            queryset = queryset.filter(**params)
+
+        if last_seen_from or last_seen_to:
+            params = {}
+            if last_seen_from:
+                if last_seen_from_inclusive:
+                    params['last_seen__gte'] = last_seen_from
+                else:
+                    params['last_seen__gt'] = last_seen_from
+            if last_seen_to:
+                if last_seen_to_inclusive:
+                    params['last_seen__lte'] = last_seen_to
+                else:
+                    params['last_seen__lt'] = last_seen_to
             queryset = queryset.filter(**params)
 
         if date_from or date_to:

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -173,6 +173,7 @@ reserved_tag_names = frozenset([
     'user.ip',
     'has',
     'age',
+    'last_seen',
     'environment',
     'browser',
     'device',
@@ -292,6 +293,8 @@ def parse_query(project, query, user):
                 results['tags'][value] = ANY
             elif key == 'age':
                 results.update(get_date_params(value, 'age_from', 'age_to'))
+            elif key == 'last_seen':
+                results.update(get_date_params(value, 'last_seen_from', 'last_seen_to'))
             elif key.startswith('user.'):
                 results['tags']['sentry:user'] = get_user_tag(
                     project, key.split('.', 1)[1], value)

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -211,6 +211,29 @@ class DjangoSearchBackendTest(TestCase):
         assert len(results) == 1
         assert results[0] == self.group1
 
+    def test_last_seen_filter(self):
+        results = self.backend.query(
+            self.project1,
+            last_seen_from=self.group1.last_seen,
+        )
+        assert len(results) == 1
+        assert results[0] == self.group1
+
+        results = self.backend.query(
+            self.project1,
+            last_seen_to=self.group2.last_seen + timedelta(minutes=1),
+        )
+        assert len(results) == 1
+        assert results[0] == self.group2
+
+        results = self.backend.query(
+            self.project1,
+            last_seen_from=self.group1.last_seen,
+            last_seen_to=self.group1.last_seen + timedelta(minutes=1),
+        )
+        assert len(results) == 1
+        assert results[0] == self.group1
+
     def test_date_filter(self):
         results = self.backend.query(
             self.project1,


### PR DESCRIPTION
Fixes GH-3756.