### PR TITLE
Muted -> Ignored

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -324,15 +324,15 @@ const StreamActions = React.createClass({
                     }
                     confirmLabel={
                       this.state.allInQuerySelected
-                        ? t('Mute all issues')
+                        ? t('Ignore all issues')
                         : (count) =>
-                            tn('Mute %d selected issue',
-                               'Mute %d selected issues',
+                            tn('Ignore %d selected issue',
+                               'Ignore %d selected issues',
                                count)
                     }
                     onlyIfBulk={true}
                     selectAllActive={this.state.pageSelected}>
-                   {t('Set status to: Muted')}
+                   {t('Set status to: Ignored')}
                   </ActionLink>
                 </MenuItem>
                 <MenuItem divider={true} />


### PR DESCRIPTION
Fixes a couple muted strings we missed including:

![screen shot 2016-11-03 at 5 29 13 pm](https://cloud.githubusercontent.com/assets/30713/19990655/7739b168-a1ec-11e6-99bb-eacacdd31038.png)

@getsentry/product 