### PR TITLE
Revert "Add event.type tag"

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -498,7 +498,6 @@ class EventManager(object):
 
         data['type'] = event_type.key
         data['metadata'] = event_metadata
-        tags.append(('event.type', event_type.key))
 
         # index components into ``Event.message``
         # See GH-3248


### PR DESCRIPTION
Considering renaming this to 'type'.

Reverts getsentry/sentry#4158