### PR TITLE
Improve wording of notification setting default options.

### DIFF
--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -73,11 +73,26 @@
           <li>{% trans "Resolution" %}</li>
         </ul>
 
+        <p>
+          {% blocktrans %}
+            When workflow notifications are enabled for a project, you'll
+            receive an email when your teammates perform any of these actions.
+          {% endblocktrans %}
+        </p>
+
         {{ settings_form.workflow_notifications|as_crispy_field }}
 
         {{ settings_form.self_notifications|as_crispy_field }}
 
-        <p>{% blocktrans %}You may subscribe (or unsubscribe) from individual issues on their respective pages.{% endblocktrans %}</p>
+        <p>
+          {% blocktrans %}
+            You'll always receive notifications from issues that you're
+            subscribed to. You may subscribe (or unsubscribe) from individual
+            issues on their respective pages. You'll be automatically
+            subscribed when participating on an issue by taking one of the
+            actions listed above.
+          {% endblocktrans %}
+        </p>
 
         <hr />
 

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -446,12 +446,14 @@ class NotificationSettingsForm(forms.Form):
     )
 
     subscribe_by_default = forms.BooleanField(
-        label=_('Subscribe to alerts for projects by default'),
+        label=_('Automatically subscribe to alerts for new projects'),
+        help_text=_("When enabled, you'll automatically subscribe to alerts when you create or join a project."),
         required=False,
     )
+
     workflow_notifications = forms.BooleanField(
-        label=_('Receive updates for all issues by default'),
-        help_text=_('You\'ll always receive notifications if you\'re explicitly participating on an issue.'),
+        label=_('Automatically subscribe to workflow notifications for new projects'),
+        help_text=_("When enabled, you'll automatically subscribe to workflow notifications when you create or join a project."),
         required=False,
     )
     self_notifications = forms.BooleanField(


### PR DESCRIPTION
This also clarifies a little bit of ambiguity around workflow
notification subscriptions.

This is tangentially related to GH-4472.