### PR TITLE
add editing/not editing state to PasswordField component

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Version 8.11 (Unreleased)
 - Ignore a ``null`` ``Origin`` header for authentication.
 - Added the ability to search for issues that you are subscribed to from the stream view.
 - Added the ability to search issues by their last seen timestamp.
+- Improved UI for password and API key fields used in integrations
 
 Version 8.10
 ------------

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -61,5 +61,8 @@ def serialize_field(project, plugin, field):
     }
     if field.get('type') != 'secret':
         data['value'] = plugin.get_option(field['name'], project)
+    else:
+        data['has_saved_value'] = field.get('has_saved_value', False)
+        data['prefix'] = field.get('prefix', '')
 
     return data

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -62,7 +62,7 @@ def serialize_field(project, plugin, field):
     if field.get('type') != 'secret':
         data['value'] = plugin.get_option(field['name'], project)
     else:
-        data['has_saved_value'] = field.get('has_saved_value', False)
+        data['has_saved_value'] = bool(field.get('has_saved_value', False))
         data['prefix'] = field.get('prefix', '')
 
     return data

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -57,8 +57,11 @@ class PluginConfigMixin(object):
                 # TODO(dcramer): probably should do something with default
                 # validations here, though many things will end up bring string
                 # based
-                if not value and config.get('required'):
-                    raise PluginError('Field is required')
+                if not value:
+                    if config.get('required'):
+                        raise PluginError('Field is required')
+                    if config.get('type') == 'secret':
+                        value = self.get_option(name, project)
 
             for validator in DEFAULT_VALIDATORS.get(config['type'], ()):
                 value = validator(project=project, value=value, actor=actor)

--- a/src/sentry/static/sentry/app/components/forms/passwordField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.jsx
@@ -39,18 +39,18 @@ class PasswordField extends InputField {
 
     if (this.state.editing) {
       return (
-        <div className="row">
-          <div className="col-md-10">
+        <div className="form-password editing">
+          <div style={{width: '85%', display: 'inline-block'}}>
             {super.getField()}
           </div>
-          <div className="col-md-2" style={{lineHeight: '37px'}}>
+          <div style={{lineHeight: '37px', marginLeft: '10px', display: 'inline-block'}}>
             <a href="#" onClick={this.cancelEdit}>Cancel</a>
           </div>
         </div>
       );
     } else {
       return (
-        <div>
+        <div className="form-password saved">
           <span>{this.props.prefix + '********************'}</span>
           {!this.props.disabled &&
             <a href="#" style={{marginLeft: '10px'}}

--- a/src/sentry/static/sentry/app/components/forms/passwordField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.jsx
@@ -40,10 +40,10 @@ class PasswordField extends InputField {
     if (this.state.editing) {
       return (
         <div className="form-password editing">
-          <div style={{width: '85%', display: 'inline-block'}}>
+          <div>
             {super.getField()}
           </div>
-          <div style={{lineHeight: '37px', marginLeft: '10px', display: 'inline-block'}}>
+          <div>
             <a href="#" onClick={this.cancelEdit}>Cancel</a>
           </div>
         </div>
@@ -53,8 +53,7 @@ class PasswordField extends InputField {
         <div className="form-password saved">
           <span>{this.props.prefix + '********************'}</span>
           {!this.props.disabled &&
-            <a href="#" style={{marginLeft: '10px'}}
-               onClick={this.startEdit}>Edit</a>}
+            <a href="#" onClick={this.startEdit}>Edit</a>}
         </div>
       );
     }

--- a/src/sentry/static/sentry/app/components/forms/passwordField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.jsx
@@ -51,7 +51,7 @@ class PasswordField extends InputField {
     } else {
       return (
         <div className="form-password saved">
-          <span>{this.props.prefix + '********************'}</span>
+          <span>{this.props.prefix + new Array(21 - this.props.prefix.length).join('*')}</span>
           {!this.props.disabled &&
             <a href="#" onClick={this.startEdit}>Edit</a>}
         </div>

--- a/src/sentry/static/sentry/app/components/forms/passwordField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.jsx
@@ -1,7 +1,69 @@
+import React from 'react';
 import InputField from './inputField';
 
-export default class PasswordField extends InputField {
+class PasswordField extends InputField {
+  constructor(props) {
+    super(props);
+
+    this.startEdit = this.startEdit.bind(this);
+    this.cancelEdit = this.cancelEdit.bind(this);
+
+    this.state.editing = false;
+  }
+
   getType() {
     return 'password';
   }
+
+  cancelEdit(ev) {
+    ev.preventDefault();
+    this.setState({
+      value: '',
+      editing: false
+    }, () => {
+      this.props.onChange('');
+    });
+  }
+
+  startEdit(ev) {
+    ev.preventDefault();
+    this.setState({
+      editing: true
+    });
+  }
+
+  getField() {
+    if (!this.props.has_saved_value) {
+      return super.getField();
+    }
+
+    if (this.state.editing) {
+      return (
+        <div className="row">
+          <div className="col-md-10">
+            {super.getField()}
+          </div>
+          <div className="col-md-2" style={{lineHeight: '37px'}}>
+            <a href="#" onClick={this.cancelEdit}>Cancel</a>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <span>{this.props.prefix + '********************'}</span>
+          {!this.props.disabled &&
+            <a href="#" style={{marginLeft: '10px'}}
+               onClick={this.startEdit}>Edit</a>}
+        </div>
+      );
+    }
+  }
 }
+
+PasswordField.defaultProps = Object.assign({}, InputField.defaultProps, {
+  'has_saved_value': false,
+  'prefix': ''
+});
+
+export default PasswordField;

--- a/src/sentry/static/sentry/less/forms.less
+++ b/src/sentry/static/sentry/less/forms.less
@@ -129,3 +129,23 @@ textarea.form-control[disabled] {
   margin-left: 5px;
   font-size: 80%;
 }
+
+.form-password {
+  &.editing {
+    div:first-child {
+      width: 85%;
+      display: inline-block;
+    }
+    div:last-child {
+      line-height: 37px;
+      margin-left: 10px;
+      display: inline-block;
+    }
+  }
+
+  &.saved {
+    a {
+      margin-left: 10px;
+    }
+  }
+}


### PR DESCRIPTION
needed for https://github.com/getsentry/sentry-plugins/issues/79 (sentry-plugins changes are also needed)

if no saved value exists or that prop wasn't provided:
![screenshot 2016-11-07 17 46 12](https://cloud.githubusercontent.com/assets/5026776/20083682/af4af53e-a512-11e6-85e2-bf78fc173c88.png)

if we have a saved value:
![screenshot 2016-11-07 17 46 34](https://cloud.githubusercontent.com/assets/5026776/20083712/db0ee748-a512-11e6-81e1-f0881b6c6008.png)

if a user clicks edit:
![screenshot 2016-11-07 18 08 34](https://cloud.githubusercontent.com/assets/5026776/20084112/3f5cb9d0-a515-11e6-9adc-21958c1b4902.png)

cc @getsentry/product 