### PR TITLE
Correct subscription checks in issue API response.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 8.11 (Unreleased)
 - Added the ability to search for issues that you are subscribed to from the stream view.
 - Added the ability to search issues by their last seen timestamp.
 - Improved UI for password and API key fields used in integrations
+- Fixed bug where API responses would include incorrect `isSubscribed` values for issues.
 
 Version 8.10
 ------------

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -43,6 +43,7 @@ class GroupSerializer(Serializer):
                 user=user,
                 project=None,
                 key='workflow:notifications',
+                default=UserOptionValue.all_conversations,
             )
 
             for project, group_ids in projects.items():

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -5,6 +5,7 @@ import six
 from collections import defaultdict, namedtuple
 from datetime import timedelta
 from django.core.urlresolvers import reverse
+from django.db.models import Q
 from django.utils import timezone
 
 from sentry.api.serializers import Serializer, register, serialize
@@ -53,8 +54,8 @@ class GroupSerializer(Serializer):
                 option.project_id: option.value
                 for option in
                 UserOption.objects.filter(
+                    Q(project__in=projects.keys()) | Q(project__isnull=True),
                     user=user,
-                    project__in=set(projects.keys()) | set([None]),
                     key='workflow:notifications',
                 )
             }

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -73,7 +73,7 @@ class GroupSerializer(Serializer):
 
         # These are the IDs of all of the groups that the user is subscribed to
         # that were part of the original candidate list.
-        return set(group_id for group_id, is_subscribed in results.items() if is_subscribed)
+        return {group_id for group_id, is_subscribed in results.items() if is_subscribed}
 
     def get_attrs(self, item_list, user):
         from sentry.plugins import plugins

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -9,7 +9,7 @@ from mock import patch
 from sentry.api.serializers import serialize
 from sentry.models import (
     GroupResolution, GroupResolutionStatus, GroupSnooze, GroupSubscription,
-    GroupStatus, Release
+    GroupStatus, Release, UserOption, UserOptionValue
 )
 from sentry.testutils import TestCase
 
@@ -129,8 +129,37 @@ class GroupSerializerTest(TestCase):
         user = self.create_user()
         group = self.create_group()
 
-        result = serialize(group, user)
-        assert result['isSubscribed']
+        combinations = (
+            ((None, None), True),
+            ((UserOptionValue.all_conversations, None), True),
+            ((UserOptionValue.all_conversations, UserOptionValue.all_conversations), True),
+            ((UserOptionValue.all_conversations, UserOptionValue.participating_only), False),
+            ((UserOptionValue.participating_only, None), False),
+            ((UserOptionValue.participating_only, UserOptionValue.all_conversations), True),
+            ((UserOptionValue.participating_only, UserOptionValue.participating_only), False),
+        )
+
+        def maybe_set_value(project, value):
+            if value is not None:
+                UserOption.objects.set_value(
+                    user=user,
+                    project=project,
+                    key='workflow:notifications',
+                    value=value,
+                )
+            else:
+                UserOption.objects.unset_value(
+                    user=user,
+                    project=project,
+                    key='workflow:notifications',
+                )
+
+        for options, expected_result in combinations:
+            UserOption.objects.clear_cache()
+            default_value, project_value = options
+            maybe_set_value(None, default_value)
+            maybe_set_value(group.project, project_value)
+            assert serialize(group, user)['isSubscribed'] is expected_result, 'expected {!r} for {!r}'.format(expected_result, options)
 
     def test_no_user_unsubscribed(self):
         group = self.create_group()


### PR DESCRIPTION
This previously wasn't checking the project's `workflow:notifications` option, and would return incorrect responses accordingly based on the user's default option value. This fixes that issue, and adds tests for it.