### PR TITLE
sourcemaps: guard against bad base64 sourcemap data

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -496,7 +496,13 @@ def is_utf8(encoding):
 
 def fetch_sourcemap(url, project=None, release=None, allow_scraping=True):
     if is_data_uri(url):
-        body = base64.b64decode(url[BASE64_PREAMBLE_LENGTH:])
+        try:
+            body = base64.b64decode(url[BASE64_PREAMBLE_LENGTH:])
+        except TypeError as e:
+            raise UnparseableSourcemap({
+                'url': '<base64>',
+                'reason': e.message,
+            })
     else:
         result = fetch_file(url, project=project, release=release,
                             allow_scraping=allow_scraping)

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -248,6 +248,10 @@ class FetchSourcemapTest(TestCase):
         assert smap_view.get_source_contents(0) == 'console.log("hello, World!")'
         assert smap_view.get_source_name(0) == u'/test.js'
 
+    def test_broken_base64(self):
+        with pytest.raises(UnparseableSourcemap):
+            fetch_sourcemap('data:application/json;base64,xxx')
+
     @responses.activate
     def test_simple_non_utf8(self):
         responses.add(responses.GET, 'http://example.com', body='{}',


### PR DESCRIPTION
Fixes SENTRY-2CP