### PR TITLE
[sdk] add 'repos' interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,11 @@ Version 8.11
 - Added 'transaction' tag which automatically populates from explicit culprits.
 - Added beginnings of repository management to UI (behind `organizations:repos` feature).
 
+SDKs
+~~~~
+
+- The `repos` interface has been added.
+
 Schema Changes
 ~~~~~~~~~~~~~~
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Version 8.12 (Unreleased)
 -------------------------
 
+SDKs
+~~~~
+
+- The `repos` interface has been added.
+
+
 Version 8.11
 ------------
 
@@ -24,11 +30,6 @@ Version 8.11
 - Improved display of user tags.
 - Added 'transaction' tag which automatically populates from explicit culprits.
 - Added beginnings of repository management to UI (behind `organizations:repos` feature).
-
-SDKs
-~~~~
-
-- The `repos` interface has been added.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -754,6 +754,7 @@ SENTRY_INTERFACES = {
     'exception': 'sentry.interfaces.exception.Exception',
     'logentry': 'sentry.interfaces.message.Message',
     'query': 'sentry.interfaces.query.Query',
+    'repos': 'sentry.interfaces.repos.Repos',
     'request': 'sentry.interfaces.http.Http',
     'sdk': 'sentry.interfaces.sdk.Sdk',
     'stacktrace': 'sentry.interfaces.stacktrace.Stacktrace',

--- a/src/sentry/interfaces/repos.py
+++ b/src/sentry/interfaces/repos.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+__all__ = ('Repos',)
+
+import six
+
+from sentry.interfaces.base import Interface, InterfaceValidationError
+
+
+class Repos(Interface):
+    """
+    Details about repositories connected to an event.
+
+    This is primarily used to aid with mapping the application code's filepath
+    to the equivilent path inside of a repository.
+
+    >>> {
+    >>>     "/abs/path/to/sentry": {
+    >>>         "name": "getsentry/sentry",
+    >>>         "prefix": "src",
+    >>>         "revision": "..." // optional
+    >>>     }
+    >>> }
+    """
+    @classmethod
+    def to_python(cls, data):
+        result = {}
+        for path, config in six.iteritems(data):
+            if len(path) > 200:
+                raise InterfaceValidationError("Invalid repository `path` (> 200 characters)")
+
+            name = config.get('name')
+            if not name:
+                raise InterfaceValidationError("A repository must provide a value `name`")
+            # 200 chars is enforced by db, and while we dont validate if the
+            # repo actually exists, we know it could *never* exist if its beyond
+            # the schema constraints.
+            if len(name) > 200:
+                raise InterfaceValidationError("Invalid repository `name`")
+
+            prefix = config.get('prefix')
+            if prefix and len(prefix) > 200:
+                raise InterfaceValidationError("Invalid repository `prefix` (> 200 characters)")
+
+            revision = config.get('revision')
+            if revision and len(revision) > 40:
+                raise InterfaceValidationError("Invalid repository `revision` (> 40 characters)")
+
+            result[path] = {
+                'name': name,
+            }
+            if prefix:
+                result[path]['prefix'] = prefix
+            if revision:
+                result[path]['revision'] = revision
+        return cls(**result)
+
+    def get_path(self):
+        return 'repos'

--- a/tests/sentry/interfaces/test_repos.py
+++ b/tests/sentry/interfaces/test_repos.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import pytest
+
+from sentry.interfaces.base import InterfaceValidationError
+from sentry.interfaces.repos import Repos
+from sentry.testutils import TestCase
+
+
+class ReposTest(TestCase):
+    def test_minimal_valid(self):
+        assert Repos.to_python({
+            '/path/to/sentry': {
+                'name': 'sentry-unity',
+            },
+        }).to_json() == {
+            '/path/to/sentry': {
+                'name': 'sentry-unity',
+            },
+        }
+
+    def test_full_valid(self):
+        assert Repos.to_python({
+            '/path/to/sentry': {
+                'name': 'sentry-unity',
+                'prefix': 'src',
+                'revision': 'a' * 40,
+            },
+        }).to_json() == {
+            '/path/to/sentry': {
+                'name': 'sentry-unity',
+                'prefix': 'src',
+                'revision': 'a' * 40,
+            },
+        }
+
+    def test_missing_name(self):
+        with pytest.raises(InterfaceValidationError):
+            assert Repos.to_python({
+                '/path/to/sentry': {},
+            })
+
+    def test_long_name(self):
+        with pytest.raises(InterfaceValidationError):
+            assert Repos.to_python({
+                '/path/to/sentry': {
+                    'name': 'a' * 300,
+                },
+            })
+
+    def test_long_prefix(self):
+        with pytest.raises(InterfaceValidationError):
+            assert Repos.to_python({
+                '/path/to/sentry': {
+                    'name': 'a',
+                    'prefix': 'a' * 300,
+                },
+            })
+
+    def test_long_revision(self):
+        with pytest.raises(InterfaceValidationError):
+            assert Repos.to_python({
+                '/path/to/sentry': {
+                    'name': 'a',
+                    'revision': 'a' * 300,
+                },
+            })
+
+    def test_long_path(self):
+        with pytest.raises(InterfaceValidationError):
+            assert Repos.to_python({
+                '/' * 300: {
+                    'name': 'a',
+                },
+            })
+
+    def test_path(self):
+        assert Repos().get_path() == 'repos'


### PR DESCRIPTION
This adds local repository configuration available to SDKs describing how to map up an application's source frames to their appropriate path in a repository.

Refs GH-4484