### PR TITLE
Point user to Rules area.

### DIFF
--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -56,7 +56,7 @@
 
         <h4>{% trans "Alerts" %}</h4>
 
-        <p>Alerts are generated based on a project's rules, defined in <strong>[Project] &raquo; Settings &raquo; Rules</strong>.</p>
+        <p>Alerts are generated based on a project's rules, defined in <strong>[Project] &raquo; Project Settings &raquo; Alerts &raquo; Rules</strong>.</p>
 
         {{ settings_form.subscribe_by_default|as_crispy_field }}
 


### PR DESCRIPTION
Text didn't really match the trail to find the rules area.