### PR TITLE
stacktrace: handle generated method names from Java

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -165,6 +165,8 @@ def remove_filename_outliers(filename):
 
 def remove_module_outliers(module):
     """Remove things that augment the module but really should not."""
+    if module[:35] == 'sun.reflect.GeneratedMethodAccessor':
+        return 'sun.reflect.GeneratedMethodAccessor'
     return _java_enhancer_re.sub(r'\1<auto>', module)
 
 

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -244,6 +244,17 @@ class StacktraceTest(TestCase):
             'jipJipManagementApplication',
         ])
 
+    def test_get_hash_ignores_sun_java_generated_methods(self):
+        interface = Frame.to_python({
+            'module': 'sun.reflect.GeneratedMethodAccessor12345',
+            'function': 'invoke',
+        })
+        result = interface.get_hash()
+        self.assertEquals(result, [
+            'sun.reflect.GeneratedMethodAccessor',
+            'invoke',
+        ])
+
     def test_get_hash_sanitizes_erb_templates(self):
         # This is Ruby specific
         interface = Frame.to_python({


### PR DESCRIPTION
Ignores generated modules such as:
- sun.reflect.GeneratedMethodAccessor123