### PR TITLE
Add symbol support to frames

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Schema Changes
 ~~~~~~~~~~~~~~
 
 - Added ``User.session_nonce`` column.
+- Added support for recording symbols separately in frames independent of the function.
 
 Version 8.10
 ------------

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'symsynd>=1.1.0,<2.0.0',
+    'symsynd>=1.3.0,<2.0.0',
     'toronado>=0.0.11,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -393,7 +393,7 @@ def resolve_frame_symbols(data):
                     # XXX: log here if symbol could not be found?
                     symbol = sfrm.get('symbol_name') or \
                         new_frame.get('function') or '<unknown>'
-                    function = demangle_symbol(symbol)
+                    function = demangle_symbol(symbol, simplified=True)
 
                     new_frame['function'] = function
 

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -5,7 +5,6 @@ import six
 from symsynd.driver import Driver, SymbolicationError
 from symsynd.report import ReportSymbolizer
 from symsynd.macho.arch import get_cpu_name
-from symsynd.demangle import demangle_symbol
 
 from sentry.lang.native.dsymcache import dsymcache
 from sentry.utils.safe import trim
@@ -85,7 +84,7 @@ class Symbolizer(object):
     def symbolize_app_frame(self, frame):
         img = self.images.get(frame['object_addr'])
         new_frame = self.symsynd_symbolizer.symbolize_frame(
-            frame, silent=False)
+            frame, silent=False, demangle=False)
         if new_frame is not None:
             return self._process_frame(new_frame, img)
 
@@ -99,7 +98,6 @@ class Symbolizer(object):
         if symbol is None:
             return
 
-        symbol = demangle_symbol(symbol) or symbol
         rv = dict(frame, symbol_name=symbol, filename=None,
                   line=0, column=0, uuid=img['uuid'],
                   object_name=img['name'])

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -103,6 +103,27 @@ ValueError: hello world
         context = inst.get_api_context()
         assert context['hasSystemFrames']
 
+    def test_context_with_symbols(self):
+        inst = Exception.to_python(dict(values=[{
+            'type': 'ValueError',
+            'value': 'hello world',
+            'module': 'foo.bar',
+            'stacktrace': {'frames': [{
+                'filename': 'foo/baz.py',
+                'function': 'myfunc',
+                'symbol': 'Class.myfunc',
+                'lineno': 1,
+                'in_app': True,
+            }]},
+        }]))
+
+        self.create_event(data={
+            'sentry.interfaces.Exception': inst.to_json(),
+        })
+        context = inst.get_api_context()
+        assert context['values'][0]['stacktrace']['frames'][
+            0]['symbol'] == 'Class.myfunc'
+
     def test_context_with_only_system_frames(self):
         inst = Exception.to_python(dict(values=[{
             'type': 'ValueError',

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -400,6 +400,30 @@ class StacktraceTest(TestCase):
         result = interface.get_hash()
         assert result == []
 
+    def test_get_hash_uses_symbol_instead_of_function(self):
+        interface = Frame.to_python({
+            'module': 'libfoo',
+            'function': 'int main()',
+            'symbol': '_main',
+        })
+        result = interface.get_hash()
+        self.assertEquals(result, [
+            'libfoo',
+            '_main',
+        ])
+
+    def test_get_hash_skips_symbol_if_unknown(self):
+        interface = Frame.to_python({
+            'module': 'libfoo',
+            'function': 'main',
+            'symbol': '?',
+        })
+        result = interface.get_hash()
+        self.assertEquals(result, [
+            'libfoo',
+            'main',
+        ])
+
     @mock.patch('sentry.interfaces.stacktrace.Stacktrace.get_stacktrace')
     def test_to_string_returns_stacktrace(self, get_stacktrace):
         event = mock.Mock(spec=Event())


### PR DESCRIPTION
This adds support for recording a "symbol" in addition to a function name
in the frame.  If a symbol is provided then we group by that.  The idea
behind this is that we can change the way to demangle symbols without
changing the grouping behavior.  This is in particular necessary for
Swift which has many different ways in which we can demangle a symbol.

cc @dcramer