### PR TITLE
Add support link to forum for on premise users

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -13,6 +13,7 @@ import OrganizationSelector from './organizationSelector';
 import SidebarPanel from '../sidebarPanel';
 import TodoList from '../todos';
 import IssueList from '../issueList';
+import ConfigStore from '../../stores/configStore';
 
 import {t} from '../../locale';
 
@@ -145,6 +146,7 @@ const Sidebar = React.createClass({
 
   renderBody() {
     let org = this.getOrganization();
+    let config = ConfigStore.getConfig();
 
     if (!org) {
       // When no organization, just render Sentry logo at top
@@ -192,11 +194,19 @@ const Sidebar = React.createClass({
           currentPanel={this.state.currentPanel}
           onShowPanel={()=>this.togglePanel('statusupdate')}
           hidePanel={()=>this.hidePanel()} />
-        <li>
-          <a title="Support" href={`/organizations/${org.slug}/support/`}>
-            <span className="icon icon-support" />
-          </a>
-        </li>
+        {!config.isOnPremise ?
+          <li>
+            <a title="Support" href={`/organizations/${org.slug}/support/`}>
+              <span className="icon icon-support" />
+            </a>
+          </li>
+          :
+          <li>
+            <a title="Support" href="https://forum.sentry.io/" target="_blank">
+              <span className="icon icon-support" />
+            </a>
+          </li>
+        }
       </ul>
 
       {/* Panel bodies */}

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -194,19 +194,11 @@ const Sidebar = React.createClass({
           currentPanel={this.state.currentPanel}
           onShowPanel={()=>this.togglePanel('statusupdate')}
           hidePanel={()=>this.hidePanel()} />
-        {!config.isOnPremise ?
-          <li>
-            <a title="Support" href={`/organizations/${org.slug}/support/`}>
-              <span className="icon icon-support" />
-            </a>
-          </li>
-          :
-          <li>
-            <a title="Support" href="https://forum.sentry.io/" target="_blank">
-              <span className="icon icon-support" />
-            </a>
-          </li>
-        }
+        <li>
+          <a title="Support" href={!config.isOnPremise ? `/organizations/${org.slug}/support/` : 'https://forum.sentry.io/'}>
+            <span className="icon icon-support" />
+          </a>
+        </li>
       </ul>
 
       {/* Panel bodies */}


### PR DESCRIPTION
Fixes #4512 

Support button link led to a Page Not Found for those who installed Sentry on premise. I added a link to the forum for that case. Let me know if we should link elsewhere instead.

@benvinegar @getsentry/product 