### PR TITLE
tooltips: fix 24h time display

### DIFF
--- a/src/sentry/static/sentry/app/components/dateTime.jsx
+++ b/src/sentry/static/sentry/app/components/dateTime.jsx
@@ -23,9 +23,7 @@ const DateTime = React.createClass({
     let date = this.props.date;
     let user = ConfigStore.get('user');
     let options = user ? user.options : {};
-    let format = (
-      options.clock24Hours ? 'MMMM D YYYY HH:mm:ss z' : this.getDefaultFormat()
-    );
+    let format = options.clock24Hours ? 'MMMM D YYYY HH:mm:ss z' : this.getDefaultFormat();
 
     if (_.isString(date) || _.isNumber(date)) {
       date = new Date(date);

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -108,9 +108,7 @@ const StackedBarChart = React.createClass({
   timeLabelAsHour(point) {
     let timeMoment = moment(point.x * 1000);
     let nextMoment = timeMoment.clone().add(59, 'minute');
-    let format = (
-      this.use24Hours() ? 'HH:mm' : 'LT'
-    );
+    let format = this.use24Hours() ? 'HH:mm' : 'LT';
 
     return (
       '<span>' +
@@ -133,9 +131,7 @@ const StackedBarChart = React.createClass({
   timeLabelAsRange(interval, point) {
     let timeMoment = moment(point.x * 1000);
     let nextMoment = timeMoment.clone().add(interval - 1, 'second');
-    let format = (
-      this.use24Hours() ? 'MMM Do, HH:mm' : 'MMM Do, h:mm a'
-    );
+    let format = this.use24Hours() ? 'MMM Do, HH:mm' : 'MMM Do, h:mm a';
 
     return (
       '<span>' +

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 import React from 'react';
 import {intcomma, valueIsEqual} from '../utils';
 import TooltipMixin from '../mixins/tooltip';
+import ConfigStore from '../stores/configStore.jsx';
 
 const StackedBarChart = React.createClass({
   propTypes: {
@@ -93,6 +94,12 @@ const StackedBarChart = React.createClass({
     return !valueIsEqual(this.props, nextProps, true);
   },
 
+  use24Hours() {
+    let user = ConfigStore.get('user');
+    let options = user ? user.options : {};
+    return options.clock24Hours;
+  },
+
   floatFormat(number, places) {
     let multi = Math.pow(10, places);
     return parseInt(number * multi, 10) / multi;
@@ -101,11 +108,14 @@ const StackedBarChart = React.createClass({
   timeLabelAsHour(point) {
     let timeMoment = moment(point.x * 1000);
     let nextMoment = timeMoment.clone().add(59, 'minute');
+    let format = (
+      this.use24Hours() ? 'HH:mm' : 'LT'
+    );
 
     return (
       '<span>' +
         timeMoment.format('LL') + '<br />' +
-        timeMoment.format('LT') + '  &#8594; ' + nextMoment.format('LT') +
+        timeMoment.format(format) + '  &#8594; ' + nextMoment.format(format) +
       '</span>'
     );
   },
@@ -123,12 +133,15 @@ const StackedBarChart = React.createClass({
   timeLabelAsRange(interval, point) {
     let timeMoment = moment(point.x * 1000);
     let nextMoment = timeMoment.clone().add(interval - 1, 'second');
+    let format = (
+      this.use24Hours() ? 'MMM Do, HH:mm' : 'MMM Do, h:mm a'
+    );
 
     return (
       '<span>' +
         // e.g. Aug 23rd, 12:50 pm
-        timeMoment.format('MMM Do, h:mm a') +
-        ' &#8594 ' + nextMoment.format('MMM Do, h:mm a') +
+        timeMoment.format(format) +
+        ' &#8594 ' + nextMoment.format(format) +
       '</span>'
     );
   },

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -53,9 +53,7 @@ let GroupEventToolbar  = React.createClass({
     let evt = this.props.event;
     let user = ConfigStore.get('user');
     let options = user ? user.options : {};
-    let format = (
-      options.clock24Hours ? 'HH:mm:ss z' : 'LTS z'
-    );
+    let format = options.clock24Hours ? 'HH:mm:ss z' : 'LTS z';
     let dateCreated = moment(evt.dateCreated);
     let resp = (
       '<dl class="flat" style="text-align:left;margin:0;min-width:200px">' +


### PR DESCRIPTION
We never took into account 24h display preferences in the barchart tooltips.

Fixes https://github.com/getsentry/sentry/issues/4473