### PR TITLE
account: don't validate new password unless it's being changed

### DIFF
--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -326,8 +326,9 @@ class AccountSettingsForm(forms.Form):
         return value
 
     def clean_new_password(self):
-        new_password = self.cleaned_data['new_password']
-        password_validation.validate_password(new_password)
+        new_password = self.cleaned_data.get('new_password')
+        if new_password:
+            password_validation.validate_password(new_password)
         return new_password
 
     def save(self, commit=True):


### PR DESCRIPTION
This was introduced with GH-4467