### PR TITLE
Add `subscriptionDetails` to group API response.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,6 @@ Version 8.11 (Unreleased)
 - Add configurable password validators to enforce password strength.
 - Send email to specific email when adding a new email rather than sending to all unverified email addresses.
 - Allow user to resend email verification to primary email address.
-
 - Added additional detail to subscription help text when viewing a group.
 
 Schema Changes

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Version 8.11 (Unreleased)
 - Send email to specific email when adding a new email rather than sending to all unverified email addresses.
 - Allow user to resend email verification to primary email address.
 
+- Added additional detail to subscription help text when viewing a group.
+
 Schema Changes
 ~~~~~~~~~~~~~~
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -1,33 +1,34 @@
 from __future__ import absolute_import, division, print_function
 
-import six
-
 from datetime import timedelta
+from uuid import uuid4
+
+import six
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
-from uuid import uuid4
 
-from sentry.app import search
 from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.group import StreamGroupSerializer, serialize_subscription_details
+from sentry.api.serializers.models.group import (
+    StreamGroupSerializer, serialize_subscription_details
+)
+from sentry.app import search
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.db.models.query import create_or_update
 from sentry.models import (
-    Activity, EventMapping, Group, GroupHash, GroupBookmark, GroupResolution, GroupSeen,
-    GroupSubscription, GroupSubscriptionReason, GroupSnooze, GroupStatus,
-    Release, TagKey,
+    Activity, EventMapping, Group, GroupBookmark, GroupHash, GroupResolution,
+    GroupSeen, GroupSnooze, GroupStatus, GroupSubscription,
+    GroupSubscriptionReason, Release, TagKey
 )
 from sentry.models.group import looks_like_short_id
-from sentry.search.utils import parse_query
-from sentry.search.utils import InvalidQuery
+from sentry.search.utils import InvalidQuery, parse_query
 from sentry.tasks.deletion import delete_group
 from sentry.tasks.merge import merge_group
+from sentry.utils.apidocs import attach_scenarios, scenario
 from sentry.utils.cursors import Cursor
-from sentry.utils.apidocs import scenario, attach_scenarios
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -12,9 +12,8 @@ from rest_framework.response import Response
 from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.group import (
-    StreamGroupSerializer, serialize_subscription_details
-)
+from sentry.api.serializers.models.group import SUBSCRIPTION_REASON_MAP
+from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.app import search
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.db.models.query import create_or_update
@@ -580,12 +579,12 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                     },
                 )
 
-            # XXX: This is a bit of a hack, maybe this method shouldn't take
-            # the GroupSubscription instance at all...?
-            result['subscriptionDetails'] = serialize_subscription_details(
-                result['isSubscribed'],
-                GroupSubscription(reason=GroupSubscriptionReason.unknown),
-            )
+            result['subscriptionDetails'] = {
+                'reason': SUBSCRIPTION_REASON_MAP.get(
+                    GroupSubscriptionReason.unknown,
+                    'unknown',
+                ),
+            }
 
         if result.get('isPublic'):
             queryset.update(is_public=True)

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -12,8 +12,9 @@ from rest_framework.response import Response
 from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.group import SUBSCRIPTION_REASON_MAP
-from sentry.api.serializers.models.group import StreamGroupSerializer
+from sentry.api.serializers.models.group import (
+    SUBSCRIPTION_REASON_MAP, StreamGroupSerializer
+)
 from sentry.app import search
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.db.models.query import create_or_update

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -21,7 +21,6 @@ from sentry.utils.db import attach_foreignkey
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
-
 SUBSCRIPTION_REASON_MAP = {
     GroupSubscriptionReason.comment: 'commented',
     GroupSubscriptionReason.assigned: 'assigned',

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -32,6 +32,11 @@ SUBSCRIPTION_REASON_MAP = {
 @register(Group)
 class GroupSerializer(Serializer):
     def _get_subscriptions(self, item_list, user):
+        """
+        Returns a mapping of group IDs to a two-tuple of (subscribed: bool,
+        subscription: GroupSubscription or None) for the provided user and
+        groups.
+        """
         results = {group.id: None for group in item_list}
 
         # First, the easy part -- if there is a subscription record associated
@@ -81,12 +86,9 @@ class GroupSerializer(Serializer):
                     project.id,
                     default,
                 ) == UserOptionValue.all_conversations
-
                 for group_id in group_ids:
                     results[group_id] = (is_subscribed, None)
 
-        # These are the IDs of all of the groups that the user is subscribed to
-        # that were part of the original candidate list.
         return results
 
     def get_attrs(self, item_list, user):

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -21,14 +21,25 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
 
+REASON_MAP = {
+    GroupSubscriptionReason.comment: 'commented',
+    GroupSubscriptionReason.assigned: 'assigned',
+    GroupSubscriptionReason.bookmark: 'bookmarked',
+    GroupSubscriptionReason.status_change: 'changed_status',
+}
+
+
+def serialize_subscription_details(is_subscribed, subscription):
+    if is_subscribed and subscription is not None:
+        return {
+            'reason': REASON_MAP.get(subscription.reason, 'unknown'),
+        }
+    else:
+        return None
+
+
 @register(Group)
 class GroupSerializer(Serializer):
-    REASON_MAP = {
-        GroupSubscriptionReason.comment: 'commented',
-        GroupSubscriptionReason.assigned: 'assigned',
-        GroupSubscriptionReason.bookmark: 'bookmarked',
-        GroupSubscriptionReason.status_change: 'changed_status',
-    }
 
     def _get_subscriptions(self, item_list, user):
         results = {group.id: None for group in item_list}
@@ -189,12 +200,6 @@ class GroupSerializer(Serializer):
             obj.organization.slug, obj.project.slug, obj.id]))
 
         is_subscribed, subscription = attrs['subscription']
-        if is_subscribed and subscription is not None:
-            subscription_details = {
-                'reason': self.REASON_MAP.get(subscription.reason, 'unknown'),
-            }
-        else:
-            subscription_details = None
 
         return {
             'id': six.text_type(obj.id),
@@ -222,7 +227,10 @@ class GroupSerializer(Serializer):
             'assignedTo': attrs['assigned_to'],
             'isBookmarked': attrs['is_bookmarked'],
             'isSubscribed': is_subscribed,
-            'subscriptionDetails': subscription_details,
+            'subscriptionDetails': serialize_subscription_details(
+                is_subscribed,
+                subscription,
+            ),
             'hasSeen': attrs['has_seen'],
             'annotations': attrs['annotations'],
         }

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -21,7 +21,8 @@ from sentry.utils.db import attach_foreignkey
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
-REASON_MAP = {
+
+SUBSCRIPTION_REASON_MAP = {
     GroupSubscriptionReason.comment: 'commented',
     GroupSubscriptionReason.assigned: 'assigned',
     GroupSubscriptionReason.bookmark: 'bookmarked',
@@ -29,18 +30,8 @@ REASON_MAP = {
 }
 
 
-def serialize_subscription_details(is_subscribed, subscription):
-    if is_subscribed and subscription is not None:
-        return {
-            'reason': REASON_MAP.get(subscription.reason, 'unknown'),
-        }
-    else:
-        return None
-
-
 @register(Group)
 class GroupSerializer(Serializer):
-
     def _get_subscriptions(self, item_list, user):
         results = {group.id: None for group in item_list}
 
@@ -227,10 +218,12 @@ class GroupSerializer(Serializer):
             'assignedTo': attrs['assigned_to'],
             'isBookmarked': attrs['is_bookmarked'],
             'isSubscribed': is_subscribed,
-            'subscriptionDetails': serialize_subscription_details(
-                is_subscribed,
-                subscription,
-            ),
+            'subscriptionDetails': {
+                'reason': SUBSCRIPTION_REASON_MAP.get(
+                    subscription.reason,
+                    'unknown',
+                ),
+            } if is_subscribed and subscription is not None else None,
             'hasSeen': attrs['has_seen'],
             'annotations': attrs['annotations'],
         }

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, print_function
 
-import six
-
 from collections import defaultdict, namedtuple
 from datetime import timedelta
+
+import six
 from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.utils import timezone
@@ -13,13 +13,13 @@ from sentry.app import tsdb
 from sentry.constants import LOG_LEVELS
 from sentry.models import (
     Group, GroupAssignee, GroupBookmark, GroupMeta, GroupResolution,
-    GroupResolutionStatus, GroupSeen, GroupSnooze, GroupSubscription,
-    GroupStatus, GroupTagKey, UserOption, UserOptionValue, GroupSubscriptionReason,
+    GroupResolutionStatus, GroupSeen, GroupSnooze, GroupStatus,
+    GroupSubscription, GroupSubscriptionReason, GroupTagKey, UserOption,
+    UserOptionValue
 )
 from sentry.utils.db import attach_foreignkey
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
-
 
 REASON_MAP = {
     GroupSubscriptionReason.comment: 'commented',

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -69,6 +69,28 @@ const GroupSidebar = React.createClass({
     }
   },
 
+  getNotificationText() {
+    let group = this.getGroup();
+    let reasons = new Map([
+      ['commented', t('You\'re subscribed to this issue since you have commented on this issue.')],
+      ['assigned', t('You\'re subscribed to this issue since you were assigned to this issue.')],
+      ['bookmarked', t('You\'re subscribed to this issue since you have bookmarked this issue.')],
+      ['changed_status', t('You\'re subscribed to this issue since you have changed the status of this issue.')],
+    ]);
+
+    if (group.isSubscribed) {
+      let reason = t('You\'re subscribed to this issue.');
+      if (group.subscriptionDetails) {
+        reason = reasons.get(group.subscriptionDetails.reason) || reason;
+      } else {
+        reason = t('You\'re subscribed to workflow notifications for this project.');
+      }
+      return reason + ' ' + t('You\'ll be notified when updates happen.');
+    } else {
+      return t('You\'re not subscribed to this issue.');
+    }
+  },
+
   render() {
     let project = this.getProject();
     let projectId = project.slug;
@@ -103,11 +125,7 @@ const GroupSidebar = React.createClass({
         }
 
         <h6><span>{t('Notifications')}</span></h6>
-        {group.isSubscribed ?
-          <p className="help-block">{t('You\'re subscribed to this issue and will get notified when updates happen.')}</p>
-        :
-          <p className="help-block">{t('You\'re not subscribed in this issue.')}</p>
-        }
+        <p className="help-block">{this.getNotificationText()}</p>
         <a className={`btn btn-default btn-subscribe ${group.isSubscribed && 'subscribed'}`}
            onClick={this.toggleSubscription}>
           <span className="icon-signal" /> {group.isSubscribed ? t('Unsubscribe') : t('Subscribe')}

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -22,6 +22,13 @@ const GroupSidebar = React.createClass({
     GroupState
   ],
 
+  subscriptionReasons: {
+    commented: t('You\'re subscribed to this issue since you have commented on this issue.'),
+    assigned: t('You\'re subscribed to this issue since you were assigned to this issue.'),
+    bookmarked: t('You\'re subscribed to this issue since you have bookmarked this issue.'),
+    changed_status: t('You\'re subscribed to this issue since you have changed the status of this issue.'),
+  },
+
   toggleSubscription() {
     let group = this.props.group;
     let project = this.getProject();
@@ -71,21 +78,18 @@ const GroupSidebar = React.createClass({
 
   getNotificationText() {
     let group = this.getGroup();
-    let reasons = new Map([
-      ['commented', t('You\'re subscribed to this issue since you have commented on this issue.')],
-      ['assigned', t('You\'re subscribed to this issue since you were assigned to this issue.')],
-      ['bookmarked', t('You\'re subscribed to this issue since you have bookmarked this issue.')],
-      ['changed_status', t('You\'re subscribed to this issue since you have changed the status of this issue.')],
-    ]);
 
     if (group.isSubscribed) {
-      let reason = t('You\'re subscribed to this issue.');
+      let result = t('You\'re subscribed to this issue.');
       if (group.subscriptionDetails) {
-        reason = reasons.get(group.subscriptionDetails.reason) || reason;
+        let reason = group.subscriptionDetails.reason;
+        if (this.subscriptionReasons.hasOwnProperty(reason)) {
+          result = this.subscriptionReasons[reason];
+        }
       } else {
-        reason = t('You\'re subscribed to workflow notifications for this project.');
+        result = t('You\'re subscribed to workflow notifications for this project.');
       }
-      return reason + ' ' + t('You\'ll be notified when updates happen.');
+      return result + ' ' + t('You\'ll be notified when updates happen.');
     } else {
       return t('You\'re not subscribed to this issue.');
     }

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -23,10 +23,10 @@ const GroupSidebar = React.createClass({
   ],
 
   subscriptionReasons: {
-    commented: t('You\'re subscribed to this issue since you have commented on this issue.'),
-    assigned: t('You\'re subscribed to this issue since you were assigned to this issue.'),
-    bookmarked: t('You\'re subscribed to this issue since you have bookmarked this issue.'),
-    changed_status: t('You\'re subscribed to this issue since you have changed the status of this issue.'),
+    commented: t('You\'re receiving updates because you have commented on this issue.'),
+    assigned: t('You\'re receiving updates because you were assigned to this issue.'),
+    bookmarked: t('You\'re receiving updates because you have bookmarked this issue.'),
+    changed_status: t('You\'re receiving updates because you have changed the status of this issue.'),
   },
 
   toggleSubscription() {
@@ -80,16 +80,16 @@ const GroupSidebar = React.createClass({
     let group = this.getGroup();
 
     if (group.isSubscribed) {
-      let result = t('You\'re subscribed to this issue.');
+      let result = t('You\'re receiving updates because you are subscribed to this issue.');
       if (group.subscriptionDetails) {
         let reason = group.subscriptionDetails.reason;
         if (this.subscriptionReasons.hasOwnProperty(reason)) {
           result = this.subscriptionReasons[reason];
         }
       } else {
-        result = t('You\'re subscribed to workflow notifications for this project.');
+        result = t('You\'re receiving updates because you are subscribed to workflow notifications for this project.');
       }
-      return result + ' ' + t('You\'ll be notified when updates happen.');
+      return result;
     } else {
       return t('You\'re not subscribed to this issue.');
     }

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -540,6 +540,9 @@ class GroupUpdateTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {
             'isSubscribed': True,
+            'subscriptionDetails': {
+                'reason': 'unknown',
+            },
         }
 
         assert GroupSubscription.objects.filter(

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import
 
-import six
-
 from datetime import timedelta
+from uuid import uuid4
+
+import six
 from django.utils import timezone
 from exam import fixture
 from mock import patch
-from uuid import uuid4
 
 from sentry.models import (
-    Activity, EventMapping, Group, GroupHash, GroupBookmark, GroupResolution, GroupSeen,
-    GroupSnooze, GroupSubscription, GroupStatus, Release
+    Activity, EventMapping, Group, GroupBookmark, GroupHash, GroupResolution,
+    GroupSeen, GroupSnooze, GroupStatus, GroupSubscription, Release
 )
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import parse_link_header


### PR DESCRIPTION
If a user is subscribed to an issue via an explicit subscription, this includes the reason why the subscription was established. This also adds the reason to the text description shown on the group detail view.

This also changes the behavior to ensure that a subscription that was created explicitly (and not as a side-effect of another action, such as being assigned or commenting) updates the reason to "unknown."