### PR TITLE
Delete alt email fix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,7 @@ Version 8.11 (Unreleased)
 - Add configurable password validators to enforce password strength.
 - Send email to specific email when adding a new email rather than sending to all unverified email addresses.
 - Allow user to resend email verification to primary email address.
-
+- Fix bug with incorrect email address removal
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,6 @@ Version 8.11 (Unreleased)
 - Add configurable password validators to enforce password strength.
 - Send email to specific email when adding a new email rather than sending to all unverified email addresses.
 - Allow user to resend email verification to primary email address.
-- Fix bug with incorrect email address removal
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -20,50 +20,50 @@
     <legend class="m-t-0">Emails</legend>
 
     <form action="" method="post" class="">
-        {% csrf_token %}
-        <button type="submit" class="hidden"></button>
-        {{ email_form|as_crispy_errors }}
+      {% csrf_token %}
+      <button type="submit" class="hidden"></button>
+      {{ email_form|as_crispy_errors }}
 
-        <div class='primary-email {% if not primary_email.is_verified %}not-verified{% endif %}'>
-	        <div class='email-input'>
-            {% if not primary_email.is_verified %}
-            <div class="verification-label">
+      <div class='primary-email {% if not primary_email.is_verified %}not-verified{% endif %}'>
+        <div class='email-input'>
+          {% if not primary_email.is_verified %}
+          <div class="verification-label">
+            <span class="label verification label-warning">Unverified</span>
+          </div>
+          {% else %}
+          <div class="verification-label">
+            <span class="label verification label-success">Verified</span>
+          </div>
+          {% endif %}
+          {{ email_form.primary_email|as_crispy_field }}
+        </div>
+      </div>
+      <br>
+      <label for='id_alternative_emails' class='control-label'>Alternative Emails</label>
+      {% if alt_emails %}
+      <table class="table table-bordered m-b-0">
+        <tbody>
+        {% for email in alt_emails %}
+          <tr>
+            <td>
+              {{ email.email }}
+              {% if not email.is_verified %}
               <span class="label verification label-warning">Unverified</span>
-            </div>
-            {% else %}
-            <div class="verification-label">
+              {% else %}
               <span class="label verification label-success">Verified</span>
-            </div>
-            {% endif %}
-		        {{ email_form.primary_email|as_crispy_field }}
-	        </div>
-	      </div>
-        <br>
-        <label for='id_alternative_emails' class='control-label'>Alternative Emails</label>
-        {% if alt_emails %}
-        <table class="table table-bordered m-b-0">
-          <tbody>
-        	{% for email in alt_emails %}
-            <tr>
-              <td>
-                {{ email.email }}
-                {% if not email.is_verified %}
-                <span class="label verification label-warning">Unverified</span>
-                {% else %}
-                <span class="label verification label-success">Verified</span>
-                {% endif %}
-              </td>
-              <td style="text-align:center">
-                <form action="" method="post">
-                  {% csrf_token %}
-                  <input type='hidden' name='email' value='{{ email.email }}'>
-                  <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
-                </form>
-              </td>
-            </tr>
-          {% endfor %}
+              {% endif %}
+            </td>
+            <td style="text-align:center">
+              <form action="" method="post">
+                {% csrf_token %}
+                <input type='hidden' name='email' value='{{ email.email }}'>
+                <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
         </tbody>
-	    </table>
+      </table>
 	    <p class='help-block'>To use an email for <a href="{% url "sentry-account-settings-notifications" %}">notifications</a> it must be verified</p>
 	    {% endif %}
 

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -62,7 +62,7 @@
               </td>
             </tr>
           {% endfor %}
-		    </tbody>
+        </tbody>
 	    </table>
 	    <p class='help-block'>To use an email for <a href="{% url "sentry-account-settings-notifications" %}">notifications</a> it must be verified</p>
 	    {% endif %}

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -54,9 +54,12 @@
               {% endif %}
             </td>
   		    	<td style="text-align:center">
-  			    	<input type='hidden' name='email' value={{ email.email }}>
-  				    <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
-  			    </td>
+              <form action="" method="post">
+                {% csrf_token %}
+                <input type='hidden' name='email' value='{{ email.email }}'>
+                <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
+              </form>
+          </td>
   		    </tr>
 		    </tbody>
 	    {% endfor %}

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -42,27 +42,27 @@
         <label for='id_alternative_emails' class='control-label'>Alternative Emails</label>
         {% if alt_emails %}
         <table class="table table-bordered m-b-0">
-	        <tbody>
+          <tbody>
         	{% for email in alt_emails %}
-        	<tr>
-        		<td>
-              {{ email.email }}
-              {% if not email.is_verified %}
-              <span class="label verification label-warning">Unverified</span>
-              {% else %}
-              <span class="label verification label-success">Verified</span>
-              {% endif %}
-            </td>
-  		    	<td style="text-align:center">
-              <form action="" method="post">
-                {% csrf_token %}
-                <input type='hidden' name='email' value='{{ email.email }}'>
-                <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
-              </form>
-          </td>
-  		    </tr>
+            <tr>
+              <td>
+                {{ email.email }}
+                {% if not email.is_verified %}
+                <span class="label verification label-warning">Unverified</span>
+                {% else %}
+                <span class="label verification label-success">Verified</span>
+                {% endif %}
+              </td>
+              <td style="text-align:center">
+                <form action="" method="post">
+                  {% csrf_token %}
+                  <input type='hidden' name='email' value='{{ email.email }}'>
+                  <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
 		    </tbody>
-	    {% endfor %}
 	    </table>
 	    <p class='help-block'>To use an email for <a href="{% url "sentry-account-settings-notifications" %}">notifications</a> it must be verified</p>
 	    {% endif %}

--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -7,74 +7,74 @@
 {% block title %}{% trans "Notification Settings" %} | {{ block.super }}{% endblock %}
 
 {% block main %}
-    {% if request.user.has_unverified_emails %}
-      <div class="alert alert-warning alert-block">
-        {% trans "You have unverified emails. " %}
-        <form action="{% url 'sentry-account-confirm-email-send' %}" method="post" class="email-alert-button">
-          {% csrf_token %}
-          <button type="submit" class="btn-link">{% trans "Resend Verification Emails." %}</button>
-        </form>
+  {% if request.user.has_unverified_emails %}
+    <div class="alert alert-warning alert-block">
+      {% trans "You have unverified emails. " %}
+      <form action="{% url 'sentry-account-confirm-email-send' %}" method="post" class="email-alert-button">
+        {% csrf_token %}
+        <button type="submit" class="btn-link">{% trans "Resend Verification Emails." %}</button>
+      </form>
+    </div>
+  {% endif %}
+
+  <legend class="m-t-0">Emails</legend>
+
+  <form action="" method="post" class="">
+    {% csrf_token %}
+    <button type="submit" class="hidden"></button>
+    {{ email_form|as_crispy_errors }}
+
+    <div class='primary-email {% if not primary_email.is_verified %}not-verified{% endif %}'>
+      <div class='email-input'>
+        {% if not primary_email.is_verified %}
+        <div class="verification-label">
+          <span class="label verification label-warning">Unverified</span>
+        </div>
+        {% else %}
+        <div class="verification-label">
+          <span class="label verification label-success">Verified</span>
+        </div>
+        {% endif %}
+        {{ email_form.primary_email|as_crispy_field }}
       </div>
+    </div>
+    <br>
+    <label for='id_alternative_emails' class='control-label'>Alternative Emails</label>
+    {% if alt_emails %}
+    <table class="table table-bordered m-b-0">
+      <tbody>
+      {% for email in alt_emails %}
+        <tr>
+          <td>
+            {{ email.email }}
+            {% if not email.is_verified %}
+            <span class="label verification label-warning">Unverified</span>
+            {% else %}
+            <span class="label verification label-success">Verified</span>
+            {% endif %}
+          </td>
+          <td style="text-align:center">
+            <form action="" method="post">
+              {% csrf_token %}
+              <input type='hidden' name='email' value='{{ email.email }}'>
+              <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    <p class='help-block'>To use an email for <a href="{% url "sentry-account-settings-notifications" %}">notifications</a> it must be verified</p>
     {% endif %}
 
-    <legend class="m-t-0">Emails</legend>
+    {% if not alt_emails %}
+      <div>No alternative emails in your account</div>
+    {% endif %}
+    <br>
+    {{ email_form.alt_email|as_crispy_field }}
 
-    <form action="" method="post" class="">
-      {% csrf_token %}
-      <button type="submit" class="hidden"></button>
-      {{ email_form|as_crispy_errors }}
-
-      <div class='primary-email {% if not primary_email.is_verified %}not-verified{% endif %}'>
-        <div class='email-input'>
-          {% if not primary_email.is_verified %}
-          <div class="verification-label">
-            <span class="label verification label-warning">Unverified</span>
-          </div>
-          {% else %}
-          <div class="verification-label">
-            <span class="label verification label-success">Verified</span>
-          </div>
-          {% endif %}
-          {{ email_form.primary_email|as_crispy_field }}
-        </div>
-      </div>
-      <br>
-      <label for='id_alternative_emails' class='control-label'>Alternative Emails</label>
-      {% if alt_emails %}
-      <table class="table table-bordered m-b-0">
-        <tbody>
-        {% for email in alt_emails %}
-          <tr>
-            <td>
-              {{ email.email }}
-              {% if not email.is_verified %}
-              <span class="label verification label-warning">Unverified</span>
-              {% else %}
-              <span class="label verification label-success">Verified</span>
-              {% endif %}
-            </td>
-            <td style="text-align:center">
-              <form action="" method="post">
-                {% csrf_token %}
-                <input type='hidden' name='email' value='{{ email.email }}'>
-                <button type='submit' name='remove' class='btn btn-danger btn-sm remove'><span class="icon-trash"></span></button>
-              </form>
-            </td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-	    <p class='help-block'>To use an email for <a href="{% url "sentry-account-settings-notifications" %}">notifications</a> it must be verified</p>
-	    {% endif %}
-
-	    {% if not alt_emails %}
-	    	<div>No alternative emails in your account</div>
-	    {% endif %}
-	    <br>
-    	{{ email_form.alt_email|as_crispy_field }}
-
-    	<fieldset class="form-actions">
-            <button type="submit" class="btn btn-primary">{% trans "Save Changes" %}</button>
-        </fieldset>
-    </form>
+    <fieldset class="form-actions">
+      <button type="submit" class="btn btn-primary">{% trans "Save Changes" %}</button>
+    </fieldset>
+  </form>
 {% endblock %}


### PR DESCRIPTION
Mostly this wraps the trash (remove) button in a form (see line 57) which was causing the wrong alternate email address to be removed, but I also fixed the confusing indentation issues.

@mattrobenolt 