### PR TITLE
Don't notify everybody about every commit by default in commit template.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ reset-db:
 setup-git:
 	@echo "--> Installing git hooks"
 	git config branch.autosetuprebase always
-	git config commit.template config/commit-template
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
 	@echo ""
 

--- a/config/commit-template
+++ b/config/commit-template
@@ -1,3 +1,0 @@
-
-
-/cc @getsentry/team


### PR DESCRIPTION
This keeps me from having to do this myself each time I run `make`, so that I don't do stupid stuff like forgetting to remove — this as in 48e15fe4a1311c9a7e94c2b365d81a0bd630c50c, which notifies the team about an inconsequential commit. Nobody should be leaving this as-is anyway, and authors should be assigning other team members in their pull requests now.

Note that this doesn't actually delete the `config/commit-template` file, it just clears all of the contents. Because if you delete the file, this happens:

```
ted@reventon % git commit
fatal: could not read 'config/commit-template': No such file or directory
```