### PR TITLE
api: reduce log noise from invalid exception interface

### DIFF
--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -203,6 +203,9 @@ class Exception(Interface):
         if not data['values']:
             raise InterfaceValidationError("No 'values' present")
 
+        if not isinstance(data['values'], list):
+            raise InterfaceValidationError("Invalid value for 'values'")
+
         has_system_frames = cls.data_has_system_frames(data)
 
         kwargs = {


### PR DESCRIPTION
This raises an uncaught exception if `values` is the wrong type.
We see many cases of this value being simply a string.

Handling this case and explicitly raising an `InterfaceValidationError`
instead will cause log level to be DEBUG instead of ERROR.