### PR TITLE
utils: when missing origin, make sure we extract origin out of referer

### DIFF
--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -37,7 +37,7 @@ from sentry.utils.javascript import to_json
 from sentry.utils.strings import soft_break as _soft_break
 from sentry.utils.strings import soft_hyphenate, to_unicode, truncatechars
 from six.moves import range
-from six.moves.urllib.parse import quote, urlencode, urlparse
+from six.moves.urllib.parse import quote, urlencode
 
 SentryVersion = namedtuple('SentryVersion', [
     'current', 'latest', 'update_available', 'build',
@@ -72,9 +72,8 @@ def absolute_uri(path='', *args):
 
 @register.simple_tag
 def system_origin():
-    from sentry.utils.http import absolute_uri
-    url = urlparse(absolute_uri())
-    return '%s://%s' % (url.scheme, url.netloc)
+    from sentry.utils.http import absolute_uri, origin_from_url
+    return origin_from_url(absolute_uri())
 
 
 @register.filter

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -26,6 +26,13 @@ def absolute_uri(url=None):
     return urljoin(options.get('system.url-prefix').rstrip('/') + '/', url.lstrip('/'))
 
 
+def origin_from_url(url):
+    if not url:
+        return url
+    url = urlparse(url)
+    return '%s://%s' % (url.scheme, url.netloc)
+
+
 def safe_urlencode(params, doseq=0):
     """
     UTF-8-safe version of safe_urlencode
@@ -229,5 +236,5 @@ def origin_from_request(request):
     # Behavior is specified in RFC6454. In either case, we should
     # treat a "null" Origin as a nonexistent one and fallback to Referer.
     if rv in ('', 'null'):
-        rv = request.META.get('HTTP_REFERER')
+        rv = origin_from_url(request.META.get('HTTP_REFERER'))
     return rv

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -247,7 +247,7 @@ class OriginFromRequestTestCase(TestCase):
 
     def test_referer(self):
         request = HttpRequest()
-        request.META['HTTP_REFERER'] = 'http://example.com'
+        request.META['HTTP_REFERER'] = 'http://example.com/foo/bar'
         assert origin_from_request(request) == 'http://example.com'
 
     def test_null_origin(self):


### PR DESCRIPTION
Referer is not purely a valid substite for Origin in cases where Origin
is missing or null. Origin explicitly excludes paths.