### PR TITLE
upgrade react-router to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-document-title": "1.0.4",
     "react-dom": "15.3.2",
     "react-lazy-load": "3.0.10",
-    "react-router": "2.0.0",
+    "react-router": "2.8.1",
     "react-sparklines": "1.6.0",
     "react-sticky": "5.0.4",
     "reflux": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-document-title": "1.0.4",
     "react-dom": "15.3.2",
     "react-lazy-load": "3.0.10",
-    "react-router": "1.0.0",
+    "react-router": "2.0.0",
     "react-sparklines": "1.6.0",
     "react-sticky": "5.0.4",
     "reflux": "0.4.1",

--- a/src/sentry/static/sentry/app/components/actionOverlay.jsx
+++ b/src/sentry/static/sentry/app/components/actionOverlay.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {History} from 'react-router';
 import OrganizationState from '../mixins/organizationState';
 import {t} from '../locale';
 import requiredAdminActions from '../components/requiredAdminActions';
@@ -10,7 +9,12 @@ const ActionOverlay = React.createClass({
     actionId: React.PropTypes.string.isRequired,
     isLoading: React.PropTypes.bool
   },
-  mixins: [OrganizationState, History],
+
+  contextTypes: {
+    router: React.PropTypes.object.isRequired
+  },
+
+  mixins: [OrganizationState],
 
   componentWillMount() {
     let action = this.getAction();
@@ -25,7 +29,7 @@ const ActionOverlay = React.createClass({
 
   dismiss() {
     // is this the right thing?
-    this.context.history.goBack();
+    this.context.router.goBack();
   },
 
   onDoThisLater(event) {

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -37,8 +37,10 @@ const EventTags = React.createClass({
             return (
               <Pill key={tag.key} name={tag.key}>
                 <Link
-                  to={`/${orgId}/${projectId}/`}
-                  query={{query: `${tag.key}:"${tag.value}"`}}>
+                  to={{
+                    pathname: `/${orgId}/${projectId}/`,
+                    query: {query: `${tag.key}:"${tag.value}"`}
+                  }}>
                     {deviceNameMapper(tag.value)}
                 </Link>
                 {isUrl(tag.value) &&

--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 
 import ApiMixin from '../../mixins/apiMixin';
 import DropdownLink from '../dropdownLink';
@@ -33,8 +33,7 @@ const GroupReleaseStats = React.createClass({
 
   mixins: [
     ApiMixin,
-    GroupState,
-    History,
+    GroupState
   ],
 
   getDefaultProps() {
@@ -136,7 +135,7 @@ const GroupReleaseStats = React.createClass({
     let queryParams = Object.assign({}, this.props.location.query);
     queryParams.environment = env;
 
-    this.history.pushState(null, this.props.location.pathname, queryParams);
+    browserHistory.pushState(null, this.props.location.pathname, queryParams);
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/listLink.jsx
+++ b/src/sentry/static/sentry/app/components/listLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'underscore';
-import {Link, History} from 'react-router';
+import {Link} from 'react-router';
 import classNames from 'classnames';
 
 const ListLink = React.createClass({
@@ -19,7 +19,9 @@ const ListLink = React.createClass({
     isActive: React.PropTypes.func
   },
 
-  mixins: [History],
+  contextTypes: {
+    router: React.PropTypes.object.isRequired
+  },
 
   getDefaultProps() {
     return {
@@ -29,8 +31,8 @@ const ListLink = React.createClass({
   },
 
   isActive() {
-    return (this.props.isActive || this.history.isActive)(
-      this.props.to, this.props.query, this.props.index
+    return (this.props.isActive || this.context.router.isActive)(
+      {pathname: this.props.to, query: this.props.query}, this.props.index
     );
   },
 

--- a/src/sentry/static/sentry/app/components/menuItem.jsx
+++ b/src/sentry/static/sentry/app/components/menuItem.jsx
@@ -31,8 +31,7 @@ const MenuItem = React.createClass({
     if (this.props.to) {
       return (
         <Link
-            to={this.props.to}
-            query={this.props.query}
+            to={{pathname: this.props.to, query: this.props.query}}
             title={this.props.title}
             onClick={this.handleClick}
             className={this.props.linkClassName}

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -48,8 +48,7 @@ const OrganizationIssueList = React.createClass({
                   className={'btn btn-sm btn-default' + (status === 'unresolved' ? ' active' : '')}>
               {t('Unresolved')}
             </Link>
-            <Link to={path}
-                  query={{status: ''}}
+            <Link to={{pathname: path, query: {status: ''}}}
                   className={'btn btn-sm btn-default' + (status === '' ? ' active' : '')}>
               {t('All Issues')}
             </Link>

--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -35,14 +35,18 @@ const Pagination = React.createClass({
       <div className="stream-pagination">
         <div className="btn-group pull-right">
           <Link
-            to={this.props.to || location.pathname}
-            query={{...location.query, cursor: links.previous.cursor}}
+            to={{
+              pathname: this.props.to || location.pathname,
+              query: {...location.query, cursor: links.previous.cursor}
+            }}
             className={previousPageClassName}
             disabled={links.previous.results === false}>
             <span title={t('Previous')} className="icon-arrow-left"></span>
           </Link>
-          <Link to={this.props.to || location.pathname}
-            query={{...location.query, cursor: links.next.cursor}}
+          <Link to={{
+              pathname: this.props.to || location.pathname,
+              query: {...location.query, cursor: links.next.cursor}
+            }}
             className={nextPageClassName}
             disabled={links.next.results === false}>
             <span title={t('Next')} className="icon-arrow-right"></span>

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 import jQuery from 'jquery';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -25,10 +25,7 @@ const ProjectSelector = React.createClass({
     location: React.PropTypes.object
   },
 
-  mixins: [
-    ApiMixin,
-    History,
-  ],
+  mixins: [ApiMixin],
 
   getDefaultProps() {
     return {
@@ -221,7 +218,7 @@ const ProjectSelector = React.createClass({
       if (this.state.currentIndex > -1) {
         let url = this.getProjectUrlProps(projects[this.state.currentIndex][1]);
         if (url.to) {
-          this.history.pushState(null, url.to);
+          browserHistory.pushState(null, url.to);
         } else if (url.href) {
           window.location = url.href;
         }

--- a/src/sentry/static/sentry/app/components/resultGrid.jsx
+++ b/src/sentry/static/sentry/app/components/resultGrid.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import $ from 'jquery';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 
 import ApiMixin from '../mixins/apiMixin';
 import DropdownLink from './dropdownLink';
@@ -142,7 +142,7 @@ const ResultGrid = React.createClass({
     sortOptions: React.PropTypes.array,
   },
 
-  mixins: [ApiMixin, History],
+  mixins: [ApiMixin],
 
   getDefaultProps() {
     return {
@@ -239,7 +239,7 @@ const ResultGrid = React.createClass({
 
     e.preventDefault();
 
-    this.history.pushState(null, this.props.path, targetQueryParams);
+    browserHistory.pushState(null, this.props.path, targetQueryParams);
   },
 
   onQueryChange(evt) {

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -185,7 +185,7 @@ const StreamGroup = React.createClass({
               }
               {data.logger &&
                 <li className="event-annotation">
-                  <Link to={`/${orgId}/${projectId}/`} query={{query: 'logger:' + data.logger}}>
+                  <Link to={{pathname: `/${orgId}/${projectId}/`, query: {query: 'logger:' + data.logger}}}>
                     {data.logger}
                   </Link>
                 </li>

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -56,7 +56,6 @@ export default {
       DefaultIssuePlugin: plugins.DefaultIssuePlugin
     },
 
-    createHistory: require('history/lib/createBrowserHistory'),
     Alerts: require('./components/alerts'),
     AlertActions: require('./actions/alertActions'),
     AvatarSettings: require('./components/avatarSettings'),

--- a/src/sentry/static/sentry/app/views/apiNewToken.jsx
+++ b/src/sentry/static/sentry/app/views/apiNewToken.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import DocumentTitle from 'react-document-title';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 
 import ApiMixin from '../mixins/apiMixin';
 import IndicatorStore from '../stores/indicatorStore';
@@ -126,7 +126,7 @@ const TokenForm = React.createClass({
 });
 
 const ApiNewToken = React.createClass({
-  mixins: [ApiMixin, History],
+  mixins: [ApiMixin],
 
   getInitialState() {
     return {
@@ -140,11 +140,11 @@ const ApiNewToken = React.createClass({
   },
 
   onCancel() {
-    this.history.pushState(null, '/api/');
+    browserHistory.pushState(null, '/api/');
   },
 
   onSave() {
-    this.history.pushState(null, '/api/');
+    browserHistory.pushState(null, '/api/');
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -24,6 +24,10 @@ function getAlertTypeForProblem(problem) {
 }
 
 const App = React.createClass({
+  childContextTypes: {
+    location: React.PropTypes.object
+  },
+
   mixins: [
     ApiMixin
   ],
@@ -33,6 +37,12 @@ const App = React.createClass({
       loading: false,
       error: false,
       needsUpgrade: ConfigStore.get('needsUpgrade'),
+    };
+  },
+
+  getChildContext() {
+    return {
+      location: this.props.location
     };
   },
 

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
+import {browerHistory} from 'react-router';
 import ApiMixin from '../mixins/apiMixin';
 import DocumentTitle from 'react-document-title';
 import GroupHeader from './groupDetails/header';
@@ -8,7 +9,6 @@ import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import PropTypes from '../proptypes';
 import {t} from '../locale';
-import {History} from 'react-router';
 
 let ERROR_TYPES = {
   GROUP_NOT_FOUND: 'GROUP_NOT_FOUND'
@@ -22,11 +22,11 @@ const GroupDetails = React.createClass({
 
   childContextTypes: {
     group: PropTypes.Group,
+    location: React.PropTypes.object
   },
 
   mixins: [
     ApiMixin,
-    History,
     Reflux.listenTo(GroupStore, 'onGroupChange')
   ],
 
@@ -42,6 +42,7 @@ const GroupDetails = React.createClass({
   getChildContext() {
     return {
       group: this.state.group,
+      location: this.props.location
     };
   },
 
@@ -77,7 +78,7 @@ const GroupDetails = React.createClass({
         // https://github.com/reactjs/react-router/blob/v2.0.1/modules/index.js#L25
         if (this.props.params.groupId != data.id) {
           let location = this.props.location;
-          return void this.history.pushState(
+          return void browerHistory.pushState(
             null,
             location.pathname.replace(
               `/issues/${this.props.params.groupId}/`,

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
 import DropdownLink from '../../components/dropdownLink';
 import CustomSnoozeModal from '../../components/customSnoozeModal';
@@ -24,7 +24,6 @@ const GroupActions = React.createClass({
   mixins: [
     ApiMixin,
     GroupState,
-    History,
     TooltipMixin({
       selector: '.tip',
       container: 'body',
@@ -45,7 +44,7 @@ const GroupActions = React.createClass({
       complete: () => {
         IndicatorStore.remove(loadingIndicator);
 
-        this.history.pushState(null, `/${org.slug}/${project.slug}/`);
+        browserHistory.pushState(null, `/${org.slug}/${project.slug}/`);
       }
     });
   },

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// import Router from "react-router";
-import {Link, History} from 'react-router';
+import {Link, browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
 import AssigneeSelector from '../../components/assigneeSelector';
 import Count from '../../components/count';
@@ -25,8 +24,7 @@ const GroupHeader = React.createClass({
 
   mixins: [
     ApiMixin,
-    ProjectState,
-    History
+    ProjectState
   ],
 
   onToggleMute() {
@@ -51,7 +49,7 @@ const GroupHeader = React.createClass({
 
   onShare() {
     let {shareId} = this.props.group;
-    return this.history.pushState(null, `/share/issue/${shareId}/`);
+    return browserHistory.pushState(null, `/share/issue/${shareId}/`);
   },
 
   onTogglePublic() {
@@ -127,7 +125,10 @@ const GroupHeader = React.createClass({
               }
               {group.logger &&
                 <span className="event-annotation">
-                  <Link to={`/${orgId}/${projectId}/`} query={{query: 'logger:' + group.logger}}>
+                  <Link to={{
+                      pathname:`/${orgId}/${projectId}/`,
+                      query: {query: 'logger:' + group.logger}
+                    }}>
                     {group.logger}
                   </Link>
                 </span>
@@ -183,13 +184,13 @@ const GroupHeader = React.createClass({
           </div>
         }
         <ul className="nav nav-tabs">
-          <ListLink to={`/${orgId}/${projectId}/issues/${groupId}/`} isActive={function (to) {
+          <ListLink to={`/${orgId}/${projectId}/issues/${groupId}/`} isActive={() => {
             let rootGroupPath = `/${orgId}/${projectId}/issues/${groupId}/`;
             let pathname = this.context.location.pathname;
 
             // Because react-router 1.0 removes router.isActive(route)
             return pathname === rootGroupPath || /events\/\w+\/$/.test(pathname);
-          }.bind(this)}>
+          }}>
             {t('Details')}
           </ListLink>
           <ListLink to={`/${orgId}/${projectId}/issues/${groupId}/activity/`}>

--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {History, Link} from 'react-router';
+import {browserHistory, Link} from 'react-router';
 
 import ApiMixin from '../mixins/apiMixin';
 import DateTime from '../components/dateTime';
@@ -14,8 +14,7 @@ import {t} from '../locale';
 const GroupEvents = React.createClass({
   mixins: [
     ApiMixin,
-    GroupState,
-    History
+    GroupState
   ],
 
   getInitialState() {
@@ -49,7 +48,7 @@ const GroupEvents = React.createClass({
       targetQueryParams.query = query;
 
     let {groupId, orgId, projectId} = this.props.params;
-    this.history.pushState(null, `/${orgId}/${projectId}/issues/${groupId}/events/`, targetQueryParams);
+    browserHistory.pushState(null, `/${orgId}/${projectId}/issues/${groupId}/events/`, targetQueryParams);
   },
 
   getEndpoint() {

--- a/src/sentry/static/sentry/app/views/groupHashes.jsx
+++ b/src/sentry/static/sentry/app/views/groupHashes.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {History} from 'react-router';
 
 import ApiMixin from '../mixins/apiMixin';
 import GroupState from '../mixins/groupState';
@@ -11,8 +10,7 @@ import {t} from '../locale';
 const GroupHashes = React.createClass({
   mixins: [
     ApiMixin,
-    GroupState,
-    History
+    GroupState
   ],
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link, History} from 'react-router';
+import {Link} from 'react-router';
 import jQuery from 'jquery';
 import ApiMixin from '../mixins/apiMixin';
 import Count from '../components/count';
@@ -14,7 +14,6 @@ import {t, tn} from '../locale';
 const GroupTagValues = React.createClass({
   mixins: [
     ApiMixin,
-    History,
     GroupState
   ],
 
@@ -100,8 +99,10 @@ const GroupTagValues = React.createClass({
           </td>
           <td>
             <Link
-                to={`/${orgId}/${projectId}/`}
-                query={{query: tagKey.key + ':' + '"' + tagValue.value + '"'}}>
+                to={{
+                  pathname: `/${orgId}/${projectId}/`,
+                  query: {query: tagKey.key + ':' + '"' + tagValue.value + '"'}
+                }}>
               {deviceNameMapper(tagValue.name)}
             </Link>
             {isUrl(tagValue.value) &&

--- a/src/sentry/static/sentry/app/views/groupTags.jsx
+++ b/src/sentry/static/sentry/app/views/groupTags.jsx
@@ -82,8 +82,10 @@ const GroupTags = React.createClass({
             <li key={tagValueIdx}>
               <Link
                   className="tag-bar"
-                  to={`/${orgId}/${projectId}/`}
-                  query={{query: tag.key + ':' + '"' + tagValue.value + '"'}}>
+                  to={{
+                    pathname: `/${orgId}/${projectId}/`,
+                    query: {query: tag.key + ':' + '"' + tagValue.value + '"'}
+                  }}>
                 <span className="tag-bar-background" style={{width: pct + '%'}}></span>
                 <span className="tag-bar-label">{deviceNameMapper(tagValue.name)}</span>
                 <span className="tag-bar-count"><Count value={tagValue.count} /></span>

--- a/src/sentry/static/sentry/app/views/groupUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/groupUserReports.jsx
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import React from 'react';
-import {Link, History} from 'react-router';
+import {Link} from 'react-router';
 import ApiMixin from '../mixins/apiMixin';
 import Avatar from '../components/avatar';
 import GroupState from '../mixins/groupState';
@@ -13,8 +13,7 @@ import {t} from '../locale';
 const GroupUserReports = React.createClass({
   mixins: [
     ApiMixin,
-    GroupState,
-    History
+    GroupState
   ],
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/organizationAuditLog.jsx
+++ b/src/sentry/static/sentry/app/views/organizationAuditLog.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import DocumentTitle from 'react-document-title';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 
 import ApiMixin from '../mixins/apiMixin';
 import DateTime from '../components/dateTime';
@@ -52,7 +52,6 @@ const EVENT_TYPES = [
 const OrganizationAuditLog = React.createClass({
   mixins: [
     ApiMixin,
-    History,
     OrganizationState,
   ],
 
@@ -120,7 +119,7 @@ const OrganizationAuditLog = React.createClass({
     let queryParams = {
       event: value,
     };
-    this.history.pushState(null, this.props.location.pathname, queryParams);
+    browserHistory.pushState(null, this.props.location.pathname, queryParams);
   },
 
   renderResults() {

--- a/src/sentry/static/sentry/app/views/projectChooser.jsx
+++ b/src/sentry/static/sentry/app/views/projectChooser.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {History} from 'react-router';
 import $ from 'jquery';
 import {t} from '../locale';
 
@@ -7,10 +6,7 @@ import OrganizationState from '../mixins/organizationState';
 import TodoList from '../components/todos';
 
 const ProjectChooser = React.createClass({
-  mixins: [
-    OrganizationState,
-    History
-  ],
+  mixins: [OrganizationState],
 
   componentWillMount() {
     $(document.body).addClass('narrow');

--- a/src/sentry/static/sentry/app/views/projectDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard.jsx
@@ -117,8 +117,10 @@ const ProjectDashboard = React.createClass({
           <div className="pull-right">
             <div className="btn-group">
               <Link
-                to={url}
-                query={{...routeQuery, statsPeriod: PERIOD_HOUR}}
+                to={{
+                  pathname: url,
+                  query: {...routeQuery, statsPeriod: PERIOD_HOUR}
+                }}
                 active={statsPeriod === PERIOD_HOUR}
                 className={
                   'btn btn-sm btn-default' + (
@@ -126,8 +128,10 @@ const ProjectDashboard = React.createClass({
                 {t('1 hour')}
               </Link>
               <Link
-                to={url}
-                query={{...routeQuery, statsPeriod: PERIOD_DAY}}
+                to={{
+                  pathname: url,
+                  query: {...routeQuery, statsPeriod: PERIOD_DAY}
+                }}
                 active={statsPeriod === PERIOD_DAY}
                 className={
                   'btn btn-sm btn-default' + (
@@ -135,8 +139,10 @@ const ProjectDashboard = React.createClass({
                 {t('1 day')}
               </Link>
               <Link
-                to={url}
-                query={{...routeQuery, statsPeriod: PERIOD_WEEK}}
+                to={{
+                  pathname: url,
+                  query: {...routeQuery, statsPeriod: PERIOD_WEEK}
+                }}
                 className={
                   'btn btn-sm btn-default' + (
                     statsPeriod === PERIOD_WEEK ? ' active' : '')}>

--- a/src/sentry/static/sentry/app/views/projectEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/index.jsx
@@ -1,6 +1,6 @@
 import jQuery from 'jquery';
 import React from 'react';
-import {Link, History} from 'react-router';
+import {Link, browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
 import DateTime from '../../components/dateTime';
 import Avatar from '../../components/avatar';
@@ -16,10 +16,7 @@ const ProjectEvents = React.createClass({
     setProjectNavSection: React.PropTypes.func
   },
 
-  mixins: [
-    ApiMixin,
-    History
-  ],
+  mixins: [ApiMixin],
 
   getDefaultProps() {
     return {
@@ -59,7 +56,7 @@ const ProjectEvents = React.createClass({
       targetQueryParams.query = query;
 
     let {orgId, projectId} = this.props.params;
-    this.history.pushState(null, `/${orgId}/${projectId}/events/`, targetQueryParams);
+    browserHistory.pushState(null, `/${orgId}/${projectId}/events/`, targetQueryParams);
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -1,6 +1,6 @@
 import jQuery from 'jquery';
 import React from 'react';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 
 import ApiMixin from '../../mixins/apiMixin';
 import LoadingError from '../../components/loadingError';
@@ -17,10 +17,7 @@ const ProjectReleases = React.createClass({
     setProjectNavSection: React.PropTypes.func
   },
 
-  mixins: [
-    ApiMixin,
-    History
-  ],
+  mixins: [ApiMixin],
 
   getDefaultProps() {
     return {
@@ -60,7 +57,7 @@ const ProjectReleases = React.createClass({
       targetQueryParams.query = query;
 
     let {orgId, projectId} = this.props.params;
-    this.history.pushState(null, `/${orgId}/${projectId}/releases/`, targetQueryParams);
+    browserHistory.pushState(null, `/${orgId}/${projectId}/releases/`, targetQueryParams);
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -86,7 +86,7 @@ const ProjectSettings = React.createClass({
           <ul className="nav nav-stacked">
             <li><a href={`${settingsUrlRoot}/`}>{t('General')}</a></li>
             <ListLink to={`/${orgId}/${projectId}/settings/alerts/`}
-                      isActive={to => path.indexOf(to) === 0}>{t('Alerts')}</ListLink>
+                      isActive={loc => path.indexOf(loc.pathname) === 0}>{t('Alerts')}</ListLink>
             {features.has('quotas') &&
               <li><a href={`${settingsUrlRoot}/quotas/`}>{t('Rate Limits')}</a></li>
             }
@@ -98,7 +98,7 @@ const ProjectSettings = React.createClass({
           </ul>
           <h6 className="nav-header">{t('Data')}</h6>
           <ul className="nav nav-stacked">
-            <ListLink to={rootInstallPath} isActive={(to) => {
+            <ListLink to={rootInstallPath} isActive={(loc) => {
               // Because react-router 1.0 removes router.isActive(route)
               return path === rootInstallPath || /install\/[\w\-]+\/$/.test(path);
             }}>{t('Error Tracking')}</ListLink>

--- a/src/sentry/static/sentry/app/views/projectUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/projectUserReports.jsx
@@ -1,6 +1,6 @@
 import jQuery from 'jquery';
 import React from 'react';
-import {History, Link} from 'react-router';
+import {browserHistory, Link} from 'react-router';
 import ApiMixin from '../mixins/apiMixin';
 import Avatar from '../components/avatar';
 import GroupStore from '../stores/groupStore';
@@ -19,10 +19,7 @@ const ProjectUserReports = React.createClass({
     setProjectNavSection: React.PropTypes.func
   },
 
-  mixins: [
-    ApiMixin,
-    History,
-  ],
+  mixins: [ApiMixin],
 
   getDefaultProps() {
     return {
@@ -76,7 +73,7 @@ const ProjectUserReports = React.createClass({
       targetQueryParams.status = this.state.status;
 
     let {orgId, projectId} = this.props.params;
-    this.history.pushState(null, `/${orgId}/${projectId}/user-feedback/`, targetQueryParams);
+    browserHistory.pushState(null, `/${orgId}/${projectId}/user-feedback/`, targetQueryParams);
   },
 
   fetchData() {
@@ -218,8 +215,7 @@ const ProjectUserReports = React.createClass({
                     className={'btn btn-sm btn-default' + (status === 'unresolved' ? ' active' : '')}>
                 {t('Unresolved')}
               </Link>
-              <Link to={path}
-                    query={{status: ''}}
+              <Link to={{pathname: path, query: {status: ''}}}
                     className={'btn btn-sm btn-default' + (status === '' ? ' active' : '')}>
                 {t('All Issues')}
               </Link>

--- a/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
@@ -13,9 +13,10 @@ const ReleaseAllEvents = React.createClass({
     return (
       <div>
         <div className="alert alert-block">
-          <Link to={`/${orgId}/${projectId}/`} query={{
-            query: 'release:' + this.context.release.version
-          }}>
+          <Link to={{
+                  pathname: `/${orgId}/${projectId}/`,
+                  query: {query: 'release:' + this.context.release.version}
+                }}>
             <span className="icon icon-open"></span>
             {t('View all events seen in this release in the stream')}
           </Link>

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {History} from 'react-router';
 
 import ApiMixin from '../mixins/apiMixin';
 import FileSize from '../components/fileSize';
@@ -16,10 +15,7 @@ const ReleaseArtifacts = React.createClass({
     release: React.PropTypes.object
   },
 
-  mixins: [
-    ApiMixin,
-    History
-  ],
+  mixins: [ApiMixin],
 
   getInitialState() {
     return {

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -132,10 +132,10 @@ const ReleaseDetails = React.createClass({
               </div>
             </div>
             <ul className="nav nav-tabs">
-              <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/`} isActive={(to)=> {
+              <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/`} isActive={(loc) => {
                 // react-router isActive will return true for any route that is part of the active route
                 // e.g. parent routes. To avoid matching on sub-routes, insist on strict path equality.
-                return to === this.context.location.pathname;
+                return loc.pathname === this.props.location.pathname;
               }}>{t('New Issues')}</ListLink>
               <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/all-events/`}>{t('All Issues')}</ListLink>
               <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/artifacts/`}>{t('Artifacts')}</ListLink>

--- a/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
@@ -13,9 +13,10 @@ const ReleaseNewEvents = React.createClass({
     return (
       <div>
         <div className="alert alert-block">
-          <Link to={`/${orgId}/${projectId}/`} query={{
-            query: 'first-release:' + this.context.release.version
-          }}>
+          <Link to={{
+                  pathname: `/${orgId}/${projectId}/`,
+                  query: {query: 'first-release:' + this.context.release.version}
+                }}>
             <span className="icon icon-open"></span>
             {t('View new events seen in this release in the stream')}
           </Link>

--- a/src/sentry/static/sentry/app/views/requiredAdminActions/setCallsigns.jsx
+++ b/src/sentry/static/sentry/app/views/requiredAdminActions/setCallsigns.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 import ActionOverlay from '../../components/actionOverlay';
 import OrganizationState from '../../mixins/organizationState';
 import ApiMixin from '../../mixins/apiMixin';
@@ -53,7 +53,7 @@ function getProjectInfoForReview(org) {
 
 
 const SetCallsignsAction = React.createClass({
-  mixins: [ApiMixin, History, OrganizationState],
+  mixins: [ApiMixin, OrganizationState],
 
   getInitialState() {
     return {
@@ -77,7 +77,7 @@ const SetCallsignsAction = React.createClass({
       method: 'PUT',
       data: {slugs: this.state.slugs},
       success: (data) => {
-        this.context.history.pushState('refresh', `/${orgId}/`);
+        browserHistory.pushState('refresh', `/${orgId}/`);
       },
       error: (error) => {
         /*eslint no-console:0*/

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 import {Link} from 'react-router';
 import Cookies from 'js-cookie';
 import {StickyContainer, Sticky} from 'react-sticky';
@@ -36,7 +36,6 @@ const Stream = React.createClass({
   mixins: [
     Reflux.listenTo(GroupStore, 'onGroupChange'),
     Reflux.listenTo(StreamTagStore, 'onStreamTagChange'),
-    History,
     ApiMixin,
     ProjectState
   ],
@@ -220,7 +219,7 @@ const Stream = React.createClass({
     this.setState({
       savedSearchList: savedSearchList,
     });
-    this.history.pushState(null, `/${orgId}/${projectId}/searches/${data.id}/`);
+    browserHistory.pushState(null, `/${orgId}/${projectId}/searches/${data.id}/`);
   },
 
   getQueryState(props) {
@@ -331,7 +330,7 @@ const Stream = React.createClass({
         // the current props one as the shortIdLookup can return results for
         // different projects.
         if (jqXHR.getResponseHeader('X-Sentry-Direct-Hit') === '1') {
-          return void this.history.pushState(null,
+          return void browserHistory.pushState(null,
             `/${this.props.params.orgId}/${data[0].project.slug}/issues/${data[0].id}/`);
         }
 
@@ -481,7 +480,7 @@ const Stream = React.createClass({
       `/${params.orgId}/${params.projectId}/searches/${this.state.searchId}/` :
       `/${params.orgId}/${params.projectId}/`);
 
-    this.history.pushState(null, path, queryParams);
+    browserHistory.pushState(null, path, queryParams);
   },
 
   renderGroupNodes(ids, statsPeriod) {

--- a/src/sentry/static/sentry/app/views/teamDetails.jsx
+++ b/src/sentry/static/sentry/app/views/teamDetails.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {History} from 'react-router';
+import {browserHistory} from 'react-router';
 
 import ApiMixin from '../mixins/apiMixin';
 import DropdownLink from '../components/dropdownLink';
@@ -14,7 +14,6 @@ import {t} from '../locale';
 const TeamDetails = React.createClass({
   mixins: [
     ApiMixin,
-    History,
     OrganizationState
   ],
 
@@ -65,7 +64,7 @@ const TeamDetails = React.createClass({
     let team = this.state.team;
     if (data.slug !== team.slug) {
       let orgId = this.props.params.orgId;
-      this.history.pushState(null, `/organizations/${orgId}/teams/${data.slug}/settings/`);
+      browserHistory.pushState(null, `/organizations/${orgId}/teams/${data.slug}/settings/`);
     } else {
       Object.assign({}, team, data);
       this.setState({team: team});

--- a/src/sentry/templates/sentry/bases/react.html
+++ b/src/sentry/templates/sentry/bases/react.html
@@ -16,7 +16,7 @@
   <script>
   $(function(){
     ReactDOM.render(
-      React.createElement(Router.Router, {history:Sentry.createHistory()}, Sentry.routes()),
+      React.createElement(Router.Router, {history: Router.browserHistory}, Sentry.routes()),
       document.getElementById('blk_router')
     );
   });

--- a/tests/js/spec/views/projectReleases.spec.jsx
+++ b/tests/js/spec/views/projectReleases.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 
+import {browserHistory} from 'react-router';
 import stubReactComponents from '../../helpers/stubReactComponent';
 
 import {Client} from 'app/api';
@@ -14,6 +15,7 @@ describe('ProjectReleases', function () {
 
     this.sandbox.stub(Client.prototype, 'request');
     stubReactComponents(this.sandbox, [SearchBar, Pagination]);
+    this.sandbox.stub(browserHistory, 'pushState');
 
     this.props = {
       setProjectNavSection: function () {},
@@ -45,15 +47,10 @@ describe('ProjectReleases', function () {
     it('should change query string with new search parameter', function () {
       let projectReleases = this.projectReleases;
 
-      let pushState = this.sandbox.stub();
-      projectReleases.history = {
-        pushState: pushState
-      };
-
       projectReleases.onSearch('searchquery');
 
-      expect(pushState.calledOnce).to.be.ok;
-      expect(pushState.args[0]).to.eql([
+      expect(browserHistory.pushState.calledOnce).to.be.ok;
+      expect(browserHistory.pushState.args[0]).to.eql([
         null,
         '/123/456/releases/',
         {query: 'searchquery'}


### PR DESCRIPTION
change log here: https://github.com/ReactTraining/react-router/blob/master/CHANGES.md

main things that affected us are:
- deprecated all mixins -- the `History` one was the only one we were using
- replaced `context.history` with `context.router`
- deprecated `context.location` (you can get around this by defining `getChildContext` in our parent `App` component
- changed prop types/arguments for `<Link/>` and `isActive` to accept either a string or a [location descriptor](https://github.com/ReactTraining/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) instead of having separate `query` and `state` props/arguments

other notes:
- upgrading this also made all of the proptype warnings coming from react-router go away
- i also need to make similar updates in getsentry

@getsentry/product 