### PR TITLE
only make it look like select2 fields are required

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/genericField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/genericField.jsx
@@ -52,6 +52,10 @@ class GenericField extends React.Component {
         return <TextareaField {...props} />;
       case 'choice':
       case 'select':
+        // the chrome required tip winds up in weird places
+        // for select2 elements, so just make it look like
+        // it's required (with *) and rely on server validation
+        delete props.required;
         if (props.has_autocomplete) {
           return <Select2FieldAutocomplete {...props} />;
         }


### PR DESCRIPTION
this is because of where select2 puts underlying hidden input elements

makes this:
![screenshot 2016-11-17 18 12 40](https://cloud.githubusercontent.com/assets/5026776/20416084/73c9da2a-acf1-11e6-95ea-4d51de1a1a98.png)

look like this:
![screenshot 2016-11-17 18 09 19](https://cloud.githubusercontent.com/assets/5026776/20416059/45a483e8-acf1-11e6-8be9-b90fadf0eddd.png)



@getsentry/product 