### PR TITLE
Preprocess node events

### DIFF
--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -119,6 +119,6 @@ class JavascriptPlugin(Plugin2):
         return False
 
     def get_event_preprocessors(self, data, **kwargs):
-        if data.get('platform') == 'javascript':
+        if data.get('platform') in ['javascript', 'node']:
             return [preprocess_event]
         return []


### PR DESCRIPTION
This allows node events to work with sourcemaps. 

There's a [similar line](https://github.com/getsentry/sentry/blob/master/src/sentry/interfaces/stacktrace.py#L506) here, but I'm not changing it since I'm not certain changing will help.