### PR TITLE
Store original symbol on symbolication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'symsynd>=1.1.0,<2.0.0',
+    'symsynd>=1.3.0,<2.0.0',
     'toronado>=0.0.11,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -393,7 +393,7 @@ def resolve_frame_symbols(data):
                     # XXX: log here if symbol could not be found?
                     symbol = sfrm.get('symbol_name') or \
                         new_frame.get('function') or '<unknown>'
-                    function = demangle_symbol(symbol)
+                    function = demangle_symbol(symbol, simplified=True)
 
                     new_frame['function'] = function
 

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -5,7 +5,6 @@ import six
 from symsynd.driver import Driver, SymbolicationError
 from symsynd.report import ReportSymbolizer
 from symsynd.macho.arch import get_cpu_name
-from symsynd.demangle import demangle_symbol
 
 from sentry.lang.native.dsymcache import dsymcache
 from sentry.utils.safe import trim
@@ -85,7 +84,7 @@ class Symbolizer(object):
     def symbolize_app_frame(self, frame):
         img = self.images.get(frame['object_addr'])
         new_frame = self.symsynd_symbolizer.symbolize_frame(
-            frame, silent=False)
+            frame, silent=False, demangle=False)
         if new_frame is not None:
             return self._process_frame(new_frame, img)
 
@@ -99,7 +98,6 @@ class Symbolizer(object):
         if symbol is None:
             return
 
-        symbol = demangle_symbol(symbol) or symbol
         rv = dict(frame, symbol_name=symbol, filename=None,
                   line=0, column=0, uuid=img['uuid'],
                   object_name=img['name'])


### PR DESCRIPTION
This stores the original value before demangling. This way we can tweak the demangling for swift and others without breaking the grouping.

Related to #4514 