### PR TITLE
sourcemaps: automatically pad out base64 encoded sourcemaps

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -497,7 +497,9 @@ def is_utf8(encoding):
 def fetch_sourcemap(url, project=None, release=None, allow_scraping=True):
     if is_data_uri(url):
         try:
-            body = base64.b64decode(url[BASE64_PREAMBLE_LENGTH:])
+            body = base64.b64decode(
+                url[BASE64_PREAMBLE_LENGTH:] + (b'=' * (-(len(url) - BASE64_PREAMBLE_LENGTH) % 4))
+            )
         except TypeError as e:
             raise UnparseableSourcemap({
                 'url': '<base64>',

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -248,6 +248,14 @@ class FetchSourcemapTest(TestCase):
         assert smap_view.get_source_contents(0) == 'console.log("hello, World!")'
         assert smap_view.get_source_name(0) == u'/test.js'
 
+    def test_base64_without_padding(self):
+        smap_view = fetch_sourcemap(base64_sourcemap.rstrip('='))
+        tokens = [Token(1, 0, '/test.js', 0, 0, 0, None)]
+
+        assert list(smap_view) == tokens
+        assert smap_view.get_source_contents(0) == 'console.log("hello, World!")'
+        assert smap_view.get_source_name(0) == u'/test.js'
+
     def test_broken_base64(self):
         with pytest.raises(UnparseableSourcemap):
             fetch_sourcemap('data:application/json;base64,xxx')


### PR DESCRIPTION
Following up from https://github.com/getsentry/sentry/pull/4503