### PR TITLE
api: raise proper InterfaceValidationError from template interface

### DIFF
--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 
 __all__ = ('Template',)
 
-from sentry.interfaces.base import Interface
+from sentry.interfaces.base import Interface, InterfaceValidationError
 from sentry.interfaces.stacktrace import get_context
 from sentry.utils.safe import trim
 
@@ -42,9 +42,12 @@ class Template(Interface):
 
     @classmethod
     def to_python(cls, data):
-        assert data.get('filename')
-        assert data.get('context_line')
-        assert data.get('lineno')
+        if not data.get('filename'):
+            raise InterfaceValidationError("Missing 'filename'")
+        if not data.get('context_line'):
+            raise InterfaceValidationError("Missing 'context_line'")
+        if not data.get('lineno'):
+            raise InterfaceValidationError("Missing 'lineno'")
 
         kwargs = {
             'abs_path': trim(data.get('abs_path', None), 256),


### PR DESCRIPTION
Fixes SENTRY-3Y

Mostly just making this hush up and raise something expected rather than getting logged noisily.