### PR TITLE
mail: prevent a newline from existing in mail subject

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -336,7 +336,7 @@ class MessageBuilder(object):
                 headers.setdefault('References', thread.msgid)
 
         msg = EmailMultiAlternatives(
-            subject=subject,
+            subject=subject.splitlines()[0],
             body=self.__render_text_body(),
             from_email=self.from_email,
             to=(to,),

--- a/tests/sentry/utils/email/tests.py
+++ b/tests/sentry/utils/email/tests.py
@@ -299,6 +299,17 @@ class MessageBuilderTest(TestCase):
 
         assert 'List-Id' not in message
 
+    def test_stripped_newline(self):
+        msg = MessageBuilder(
+            subject='Foo\r\nBar',
+            body='hello world',
+            html_body='<b>hello world</b',
+        )
+        msg.send(['foo@example.com'])
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == 'Foo'
+
 
 class MiscTestCase(TestCase):
     def test_get_from_email_domain(self):


### PR DESCRIPTION
Fixes SENTRY-223