### PR TITLE
[WIP] api: handle public share urls pointed to merged groups

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -287,7 +287,10 @@ class Group(Model):
             raise cls.DoesNotExist
         if not (project_id.isdigit() and group_id.isdigit()):
             raise cls.DoesNotExist
-        return cls.objects.get(project=project_id, id=group_id)
+        return get_group_with_redirect(
+            group_id,
+            queryset=cls.objects.filter(project=project_id),
+        )[0]
 
     def get_score(self):
         return int(math.log(self.times_seen) * 600 + float(time.mktime(self.last_seen.timetuple())))


### PR DESCRIPTION
Fixes GH-4578

## Concerns

This isn't ideal. Ideally, I'd want to return a redirect here from old -> new url. But this view is entirely done in React with this ultimately failing on the API response. In theory, I could do a redirect instead on the API response, but that won't really be useful. Ideally, I'd want to redirect from `/share/issue/abc/` -> `/share/issue/xyz/`, but I have no idea how we'd make that happen through React since it doesn't know what's going on. I guess we'd need to make that API response return back something to indicate that the frontend should redirect? cc @benvinegar 