### PR TITLE
api: support wildcard host and port combinations in origin checks

### DIFF
--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -215,6 +215,10 @@ class IsValidOriginTestCase(TestCase):
         result = self.isValidOrigin('http://example.com', ['.'])
         assert result is False
 
+    def test_wildcard_hostname_with_port(self):
+        result = self.isValidOrigin('http://example.com:1234', ['*:1234'])
+        assert result is True
+
 
 class IsValidIPTestCase(TestCase):
     def is_valid_ip(self, ip, inputs):


### PR DESCRIPTION
This is more commonly needed for CSP where a common path might be
something like: `<ip>:1234` with varying IP addresses.

This allows adding a block rule to address `*:1234` correctly.