### PR TITLE
metrics: remove fake sampling for datadog

### DIFF
--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -10,13 +10,6 @@ from sentry.utils.cache import memoize
 from .base import MetricsBackend
 
 
-# XXX(dcramer): copied from sentry.utils.metrics
-def _sampled_value(value, sample_rate):
-    if sample_rate < 1:
-        value = int(value * (1.0 / sample_rate))
-    return value
-
-
 class DatadogMetricsBackend(MetricsBackend):
     def __init__(self, prefix=None, **kwargs):
         # TODO(dcramer): it'd be nice if the initialize call wasn't a global
@@ -50,9 +43,8 @@ class DatadogMetricsBackend(MetricsBackend):
             tags['instance'] = instance
         if tags:
             tags = ['{}:{}'.format(*i) for i in tags.items()]
-        # datadog does not implement sampling here
-        amount = _sampled_value(amount, sample_rate)
         self.stats.increment(self._get_key(key), amount,
+                             sample_rate=sample_rate,
                              tags=tags,
                              host=self.host)
 

--- a/tests/sentry/metrics/test_datadog.py
+++ b/tests/sentry/metrics/test_datadog.py
@@ -17,6 +17,7 @@ class DatadogMetricsBackendTest(TestCase):
         self.backend.incr('foo', instance='bar')
         mock_incr.assert_called_once_with(
             'sentrytest.foo', 1,
+            sample_rate=1,
             tags=['instance:bar'],
             host=get_hostname(),
         )


### PR DESCRIPTION
This is erronously 10x'ing all metrics before calls aren't actually
being sampled, but we treat values as if they are.

Fixing this once and for all.