### PR TITLE
onboarding: reduce needless transactions against database

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Version 8.11 (Unreleased)
 - Add Asana to supported auth backends in social auth (for plugins)
 - Cleaner install UI when creating a new project.
 - Added support for recording symbols separately in frames independent of the function.
+- Reduce noisy Postgres logs from inserting duplicate onboarding rows.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -24,16 +24,16 @@ from sentry.signals import (
 from sentry.utils.javascript import has_sourcemap
 
 
-def check_for_onboarding_complete(organization):
-    if OrganizationOption.objects.filter(organization=organization, key="onboarding:complete").exists():
+def check_for_onboarding_complete(organization_id):
+    if OrganizationOption.objects.filter(organization_id=organization_id, key="onboarding:complete").exists():
         return
 
-    completed = set(OrganizationOnboardingTask.objects.filter(Q(organization=organization) & (Q(status=OnboardingTaskStatus.COMPLETE) | Q(status=OnboardingTaskStatus.SKIPPED))).values_list('task', flat=True))
+    completed = set(OrganizationOnboardingTask.objects.filter(Q(organization_id=organization_id) & (Q(status=OnboardingTaskStatus.COMPLETE) | Q(status=OnboardingTaskStatus.SKIPPED))).values_list('task', flat=True))
     if completed >= OnboardingTask.REQUIRED_ONBOARDING_TASKS:
         try:
             with transaction.atomic():
                 OrganizationOption.objects.create(
-                    organization=organization,
+                    organization_id=organization_id,
                     key="onboarding:complete",
                     value={'updated': timezone.now()}
                 )
@@ -46,45 +46,32 @@ def record_new_project(project, user, **kwargs):
     if not user.is_authenticated():
         user = None
 
-    try:
-        with transaction.atomic():
-            OrganizationOnboardingTask.objects.create(
-                organization=project.organization,
-                task=OnboardingTask.FIRST_PROJECT,
-                user=user,
-                status=OnboardingTaskStatus.COMPLETE,
-                project_id=project.id,
-                date_completed=timezone.now(),
-            )
-    except IntegrityError:
-        try:
-            with transaction.atomic():
-                OrganizationOnboardingTask.objects.create(
-                    organization=project.organization,
-                    task=OnboardingTask.SECOND_PLATFORM,
-                    user=user,
-                    status=OnboardingTaskStatus.PENDING,
-                    project_id=project.id,
-                    date_completed=timezone.now(),
-                )
-        except IntegrityError:
-            pass
+    success = OrganizationOnboardingTask.objects.record(
+        organization_id=project.organization_id,
+        task=OnboardingTask.FIRST_PROJECT,
+        user=user,
+        status=OnboardingTaskStatus.COMPLETE,
+        project_id=project.id,
+    )
+    if not success:
+        OrganizationOnboardingTask.objects.record(
+            organization_id=project.organization_id,
+            task=OnboardingTask.SECOND_PLATFORM,
+            user=user,
+            status=OnboardingTaskStatus.PENDING,
+            project_id=project.id,
+        )
 
 
 @first_event_pending.connect(weak=False)
 def record_raven_installed(project, user, **kwargs):
-    try:
-        with transaction.atomic():
-            OrganizationOnboardingTask.objects.create(
-                organization=project.organization,
-                task=OnboardingTask.FIRST_EVENT,
-                status=OnboardingTaskStatus.PENDING,
-                user=user,
-                project_id=project.id,
-                date_completed=timezone.now()
-            )
-    except IntegrityError:
-        pass
+    OrganizationOnboardingTask.objects.record(
+        organization_id=project.organization_id,
+        task=OnboardingTask.FIRST_EVENT,
+        status=OnboardingTaskStatus.PENDING,
+        user=user,
+        project_id=project.id,
+    )
 
 
 @first_event_received.connect(weak=False)
@@ -98,7 +85,7 @@ def record_first_event(project, group, **kwargs):
     # If pending, update.
     # If does not exist, create.
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
-        organization=project.organization,
+        organization_id=project.organization_id,
         task=OnboardingTask.FIRST_EVENT,
         status=OnboardingTaskStatus.PENDING,
         values={
@@ -113,8 +100,8 @@ def record_first_event(project, group, **kwargs):
     if not rows_affected and not created:
         try:
             oot = OrganizationOnboardingTask.objects.filter(
-                organization=project.organization,
-                task=OnboardingTask.FIRST_EVENT
+                organization_id=project.organization_id,
+                task=OnboardingTask.FIRST_EVENT,
             )[0]
         except IndexError:
             return
@@ -122,7 +109,7 @@ def record_first_event(project, group, **kwargs):
         # Only counts if it's a new project and platform
         if oot.project_id != project.id and oot.data.get('platform', group.platform) != group.platform:
             OrganizationOnboardingTask.objects.create_or_update(
-                organization=project.organization,
+                organization_id=project.organization_id,
                 task=OnboardingTask.SECOND_PLATFORM,
                 status=OnboardingTaskStatus.PENDING,
                 values={
@@ -136,24 +123,19 @@ def record_first_event(project, group, **kwargs):
 
 @member_invited.connect(weak=False)
 def record_member_invited(member, user, **kwargs):
-    try:
-        with transaction.atomic():
-            OrganizationOnboardingTask.objects.create(
-                organization=member.organization,
-                task=OnboardingTask.INVITE_MEMBER,
-                user=user,
-                status=OnboardingTaskStatus.PENDING,
-                date_completed=timezone.now(),
-                data={'invited_member_id': member.id}
-            )
-    except IntegrityError:
-        pass
+    OrganizationOnboardingTask.objects.record(
+        organization_id=member.organization_id,
+        task=OnboardingTask.INVITE_MEMBER,
+        user=user,
+        status=OnboardingTaskStatus.PENDING,
+        data={'invited_member_id': member.id}
+    )
 
 
 @member_joined.connect(weak=False)
 def record_member_joined(member, **kwargs):
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
-        organization=member.organization,
+        organization_id=member.organization_id,
         task=OnboardingTask.INVITE_MEMBER,
         status=OnboardingTaskStatus.PENDING,
         values={
@@ -163,58 +145,52 @@ def record_member_joined(member, **kwargs):
         }
     )
     if created or rows_affected:
-        check_for_onboarding_complete(organization=member.organization)
+        check_for_onboarding_complete(member.organization_id)
 
 
 @event_processed.connect(weak=False)
 def record_release_received(project, group, event, **kwargs):
-    if event.get_tag('sentry:release'):
-        try:
-            with transaction.atomic():
-                OrganizationOnboardingTask.objects.create(
-                    organization=project.organization,
-                    task=OnboardingTask.RELEASE_TRACKING,
-                    status=OnboardingTaskStatus.COMPLETE,
-                    project_id=project.id,
-                    date_completed=timezone.now()
-                )
-                check_for_onboarding_complete(project.organization)
-        except IntegrityError:
-            pass
+    if not event.get_tag('sentry:release'):
+        return
+
+    success = OrganizationOnboardingTask.objects.record(
+        organization_id=project.organization_id,
+        task=OnboardingTask.RELEASE_TRACKING,
+        status=OnboardingTaskStatus.COMPLETE,
+        project_id=project.id,
+    )
+    if success:
+        check_for_onboarding_complete(project.organization_id)
 
 
 @event_processed.connect(weak=False)
 def record_user_context_received(project, group, event, **kwargs):
-    if event.data.get('sentry.interfaces.User'):
-        try:
-            with transaction.atomic():
-                OrganizationOnboardingTask.objects.create(
-                    organization=project.organization,
-                    task=OnboardingTask.USER_CONTEXT,
-                    status=OnboardingTaskStatus.COMPLETE,
-                    project_id=project.id,
-                    date_completed=timezone.now()
-                )
-                check_for_onboarding_complete(project.organization)
-        except IntegrityError:
-            pass
+    if not event.data.get('sentry.interfaces.User'):
+        return
+
+    success = OrganizationOnboardingTask.objects.record(
+        organization_id=project.organization_id,
+        task=OnboardingTask.USER_CONTEXT,
+        status=OnboardingTaskStatus.COMPLETE,
+        project_id=project.id,
+    )
+    if success:
+        check_for_onboarding_complete(project.organization_id)
 
 
 @event_processed.connect(weak=False)
 def record_sourcemaps_received(project, group, event, **kwargs):
-    if has_sourcemap(event):
-        try:
-            with transaction.atomic():
-                OrganizationOnboardingTask.objects.create(
-                    organization=project.organization,
-                    task=OnboardingTask.SOURCEMAPS,
-                    status=OnboardingTaskStatus.COMPLETE,
-                    project_id=project.id,
-                    date_completed=timezone.now()
-                )
-                check_for_onboarding_complete(project.organization)
-        except IntegrityError:
-            pass
+    if not has_sourcemap(event):
+        return
+
+    success = OrganizationOnboardingTask.objects.record(
+        organization_id=project.organization_id,
+        task=OnboardingTask.SOURCEMAPS,
+        status=OnboardingTaskStatus.COMPLETE,
+        project_id=project.id,
+    )
+    if success:
+        check_for_onboarding_complete(project.organization_id)
 
 
 @plugin_enabled.connect(weak=False)
@@ -226,26 +202,22 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
         task = OnboardingTask.NOTIFICATION_SERVICE
         status = OnboardingTaskStatus.COMPLETE
 
-    try:
-        with transaction.atomic():
-            OrganizationOnboardingTask.objects.create(
-                organization=project.organization,
-                task=task,
-                status=status,
-                user=user,
-                project_id=project.id,
-                date_completed=timezone.now(),
-                data={'plugin': plugin.slug}
-            )
-            check_for_onboarding_complete(project.organization)
-    except IntegrityError:
-        pass
+    success = OrganizationOnboardingTask.objects.record(
+        organization_id=project.organization_id,
+        task=task,
+        status=status,
+        user=user,
+        project_id=project.id,
+        data={'plugin': plugin.slug},
+    )
+    if success:
+        check_for_onboarding_complete(project.organization_id)
 
 
 @issue_tracker_used.connect(weak=False)
 def record_issue_tracker_used(plugin, project, user, **kwargs):
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
-        organization=project.organization,
+        organization_id=project.organization_id,
         task=OnboardingTask.ISSUE_TRACKER,
         status=OnboardingTaskStatus.PENDING,
         values={
@@ -257,4 +229,4 @@ def record_issue_tracker_used(plugin, project, user, **kwargs):
         }
     )
     if rows_affected or created:
-        check_for_onboarding_complete(project.organization)
+        check_for_onboarding_complete(project.organization_id)


### PR DESCRIPTION
We are attempting to blast out INSERTS into postgres constantly for
onboarding information and relying on the fact that the INSERT will fail
and we fall back gracefully.

This attempts to alleviate the pressure and noisy logs that others have
brought up from this behavior and reduce is drastically by just simply
caching the fact that we've done this once per hour.

This also switches queries to use `organization_id` explicitly to avoid implicitly resolving a query just to get the organization id.

/cc @ehfeng @JTCunning 