### PR TITLE
api: avoid O(n) queries on event serializer

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -109,7 +109,7 @@ class EventSerializer(Serializer):
         # TODO(dcramer): move release serialization here
         d = {
             'id': six.text_type(obj.id),
-            'groupID': six.text_type(obj.group.id),
+            'groupID': six.text_type(obj.group_id),
             'eventID': six.text_type(obj.event_id),
             'size': obj.size,
             'entries': attrs['entries'],


### PR DESCRIPTION
I'm not sure this is really O(n) in many places, but it is defintiely on
`ProjectEventsEndpoint`, which strictly pulls 100 Events, in turn
causing 100 queries to traverse all the Group lookups just to get the
primary key, which we already have.

Coincidently, this will also fix SENTRY-210 since we're not actually
querying for the object anymore.