### PR TITLE
api: remove a needless query/cache lookup from common store path

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -32,7 +32,7 @@ from sentry.constants import (
 from sentry.interfaces.base import get_interface, InterfaceValidationError
 from sentry.interfaces.csp import Csp
 from sentry.event_manager import EventManager
-from sentry.models import EventError, Project, ProjectKey, TagKey, TagValue
+from sentry.models import EventError, ProjectKey, TagKey, TagValue
 from sentry.tasks.store import preprocess_event
 from sentry.utils import json
 from sentry.utils.auth import parse_auth_header
@@ -235,7 +235,7 @@ class ClientApiHelper(object):
         if not pk.roles.store:
             raise APIUnauthorized('Key does not allow event storage access')
 
-        return Project.objects.get_from_cache(id=pk.project_id)
+        return pk.project_id
 
     def decode_data(self, encoded_data):
         try:

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -210,7 +210,7 @@ class ClientApiHelper(object):
         """
         return origin_from_request(request)
 
-    def project_from_auth(self, auth):
+    def project_id_from_auth(self, auth):
         if not auth.public_key:
             raise APIUnauthorized('Invalid api key')
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -184,13 +184,13 @@ class APIView(BaseView):
         else:
             auth = self._parse_header(request, helper, project)
 
-            project_ = helper.project_from_auth(auth)
+            project_id = helper.project_id_from_auth(auth)
 
             # Legacy API was /api/store/ and the project ID was only available elsewhere
             if not project:
-                project = Project.objects.get_from_cache(id=project_)
+                project = Project.objects.get_from_cache(id=project_id)
                 helper.context.bind_project(project)
-            elif project_ != project.id:
+            elif project_id != project.id:
                 raise APIError('Two different projects were specified')
 
             helper.context.bind_auth(auth)
@@ -466,8 +466,8 @@ class CspReportView(StoreView):
         # `sentry_version` to be set in querystring
         auth = helper.auth_from_request(request)
 
-        project_ = helper.project_from_auth(auth)
-        if project_ != project.id:
+        project_id = helper.project_id_from_auth(auth)
+        if project_id != project.id:
             raise APIError('Two different projects were specified')
 
         helper.context.bind_auth(auth)

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -188,11 +188,9 @@ class APIView(BaseView):
 
             # Legacy API was /api/store/ and the project ID was only available elsewhere
             if not project:
-                if not project_:
-                    raise APIError('Unable to identify project')
-                project = project_
+                project = Project.objects.get_from_cache(id=project_)
                 helper.context.bind_project(project)
-            elif project_ != project:
+            elif project_ != project.id:
                 raise APIError('Two different projects were specified')
 
             helper.context.bind_auth(auth)
@@ -469,7 +467,7 @@ class CspReportView(StoreView):
         auth = helper.auth_from_request(request)
 
         project_ = helper.project_from_auth(auth)
-        if project_ != project:
+        if project_ != project.id:
             raise APIError('Two different projects were specified')
 
         helper.context.bind_auth(auth)

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -86,7 +86,7 @@ class ProjectFromAuthTest(BaseAPITest):
     def test_valid_with_key(self):
         auth = Auth({'sentry_key': self.pk.public_key})
         result = self.helper.project_from_auth(auth)
-        self.assertEquals(result, self.project)
+        self.assertEquals(result, self.project.id)
 
     def test_invalid_key(self):
         auth = Auth({'sentry_key': 'z'})

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -79,26 +79,26 @@ class AuthFromRequestTest(BaseAPITest):
             self.helper.auth_from_request(request)
 
 
-class ProjectFromAuthTest(BaseAPITest):
+class ProjectIdFromAuthTest(BaseAPITest):
     def test_invalid_if_missing_key(self):
-        self.assertRaises(APIUnauthorized, self.helper.project_from_auth, Auth({}))
+        self.assertRaises(APIUnauthorized, self.helper.project_id_from_auth, Auth({}))
 
     def test_valid_with_key(self):
         auth = Auth({'sentry_key': self.pk.public_key})
-        result = self.helper.project_from_auth(auth)
+        result = self.helper.project_id_from_auth(auth)
         self.assertEquals(result, self.project.id)
 
     def test_invalid_key(self):
         auth = Auth({'sentry_key': 'z'})
-        self.assertRaises(APIUnauthorized, self.helper.project_from_auth, auth)
+        self.assertRaises(APIUnauthorized, self.helper.project_id_from_auth, auth)
 
     def test_invalid_secret(self):
         auth = Auth({'sentry_key': self.pk.public_key, 'sentry_secret': 'z'})
-        self.assertRaises(APIUnauthorized, self.helper.project_from_auth, auth)
+        self.assertRaises(APIUnauthorized, self.helper.project_id_from_auth, auth)
 
     def test_nonascii_key(self):
         auth = Auth({'sentry_key': '\xc3\xbc'})
-        self.assertRaises(APIUnauthorized, self.helper.project_from_auth, auth)
+        self.assertRaises(APIUnauthorized, self.helper.project_id_from_auth, auth)
 
 
 class ProcessFingerprintTest(BaseAPITest):


### PR DESCRIPTION
We are needlessly fetching a duplicate Project id when we only need to
check if the ids mismatch. In the historical path, we then choose to
explicitly resolve the object. This isn't more work since we didn't have
a project id within the url to begin with. Now both paths do same amount
of I/O.