### PR TITLE
javascript: ignore truncated urls when attemping to fetch

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -300,6 +300,13 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
 
     Attempts to fetch from the cache.
     """
+    # If our url has been truncated, it'd be impossible to fetch
+    # so we check for this early and bail
+    if url[-3:] == '...':
+        raise CannotFetchSource({
+            'type': EventError.JS_MISSING_SOURCE,
+            'url': expose_url(url),
+        })
     if release:
         with metrics.timer('sourcemaps.release_file'):
             result = fetch_release_file(url, release)

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -21,6 +21,7 @@ from sentry.lang.javascript.errormapping import (
 )
 from sentry.models import File, Release, ReleaseFile, EventError
 from sentry.testutils import TestCase
+from sentry.utils.strings import truncatechars
 
 base64_sourcemap = 'data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zb2xlLmxvZyhcImhlbGxvLCBXb3JsZCFcIikiXX0='
 
@@ -168,6 +169,15 @@ class FetchFileTest(TestCase):
         assert len(responses.calls) == 1
 
         assert result == result2
+
+    @responses.activate
+    def test_truncated(self):
+        url = truncatechars('http://example.com', 3)
+        with pytest.raises(CannotFetchSource) as exc:
+            fetch_file(url)
+
+        assert exc.value.data['type'] == EventError.JS_MISSING_SOURCE
+        assert exc.value.data['url'] == url
 
 
 class DiscoverSourcemapTest(TestCase):


### PR DESCRIPTION
Inside the stacktrace interface, we trim abs_path to 256 characters, and
when we do so, we will absolutely fail to fetch source, and also
potenitally trigger another subsequent on the backend it's attempting to
fetch from.

Fixes GH-4598