### PR TITLE
api: add setting to disable usage of X-Forwarded-For header

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1029,6 +1029,10 @@ STATUS_PAGE_API_HOST = 'statuspage.io'
 
 SENTRY_ONPREMISE = True
 
+# Whether we should look at X-Forwarded-For header or not
+# when checking REMOTE_ADDR ip addresses
+SENTRY_USE_X_FORWARDED_FOR = True
+
 
 def get_raven_config():
     return {

--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -2,8 +2,15 @@ from __future__ import absolute_import
 
 import six
 
+from django.conf import settings
+
 
 class SetRemoteAddrFromForwardedFor(object):
+    def __init__(self):
+        if not getattr(settings, 'SENTRY_USE_X_FORWARDED_FOR', True):
+            from django.core.exceptions import MiddlewareNotUsed
+            raise MiddlewareNotUsed
+
     def process_request(self, request):
         try:
             real_ip = request.META['HTTP_X_FORWARDED_FOR']


### PR DESCRIPTION
In some cases, this value is wrong, other cases it's possibly insecure
to trust. In some cases, it's more preferable and expected to just trust
the REMOTE_ADDR given to wsgi. This is the case when paried with
something like nginx that will resolve and correct this for you and set
REMOTE_ADDR correctly to the IP address expected.