### PR TITLE
plugins: handle anon user for auth flows

### DIFF
--- a/src/sentry/plugins/providers/base.py
+++ b/src/sentry/plugins/providers/base.py
@@ -33,6 +33,9 @@ class ProviderMixin(object):
         if self.auth_provider is None:
             return None
 
+        if not user.is_authenticated():
+            return None
+
         return UserSocialAuth.objects.filter(
             user=user,
             provider=self.auth_provider,


### PR DESCRIPTION
Unclear why this method was added becasue it's a duplicate of `get_auth_for_user` except without this anon check, which was causing tests to fail in sentry-plugins.