### PR TITLE
Bump raven-js to 3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "platformicons": "0.1.1",
     "po-catalog-loader": "^1.2.0",
     "query-string": "2.4.2",
-    "raven-js": "3.8.0",
+    "raven-js": "3.9.0",
     "react": "15.3.2",
     "react-addons-css-transition-group": "15.3.2",
     "react-addons-pure-render-mixin": "15.3.2",


### PR DESCRIPTION
Release notes: https://github.com/getsentry/raven-js/releases/tag/3.9.0