### PR TITLE
api: allow 2048 characters for abs_path on Stacktrace

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -325,7 +325,7 @@ class Frame(Interface):
             raise InterfaceValidationError("Invalid value for 'instruction_offset'")
 
         kwargs = {
-            'abs_path': trim(abs_path, 256),
+            'abs_path': trim(abs_path, 2048),
             'filename': trim(filename, 256),
             'platform': platform,
             'module': trim(module, 256),


### PR DESCRIPTION
This value is also leveraged by raven-js for the absolute url of a file.
URLs are allowed to be much larger than 256 characters, and when this
value is truncated, it breaks all post_processing for JS events.

2048 characters is the max URI length for IE, so I feel that this length
is still reasonable without being excessive.