### PR TITLE
Fix incorrect query used when identifying group participants.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Version 8.12 (Unreleased)
 -------------------------
 
+- Fix bug where some users would incorrectly not receive workflow notifications for projects they were subscribed to.
+
 SDKs
 ~~~~
 

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -99,7 +99,7 @@ class GroupSubscriptionManager(BaseManager):
                     key='workflow:notifications',
                     project=group.project,
                     value=UserOptionValue.all_conversations,
-                )
+                ).values_list('user', flat=True)
             ).values_list('user', flat=True)
         )
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -103,6 +103,34 @@ class GetParticipantsTest(TestCase):
 
         assert users == {}
 
+    def test_project_overrides_defaults(self):
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        project = self.create_project(team=team, organization=org)
+        group = self.create_group(project=project)
+        user = self.create_user('foo@example.com')
+        self.create_member(user=user, organization=org, teams=[team])
+
+        UserOption.objects.create(
+            id=300,
+            user=user,
+            project=None,
+            key='workflow:notifications',
+            value=UserOptionValue.participating_only,
+        )
+
+        UserOption.objects.create(
+            id=301,
+            user=user,
+            project=project,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
+
+        assert GroupSubscription.objects.get_participants(group=group) == {
+            user: GroupSubscriptionReason.implicit,
+        }
+
     def test_does_not_include_nonmember(self):
         org = self.create_organization()
         team = self.create_team(organization=org)


### PR DESCRIPTION
This was causing some users to not receive workflow notifications when they should have.

Specifically, this could happen when the user had disabled automatic workflow subscriptions for new projects (option `workflow:notifications` with project as `None`) but enabled them for a specific project, overriding the default. This override wasn't being correctly considered since the subquery intended to filter out these users was filtering on the wrong column (`id` instead of `user_id`.)