### PR TITLE
Fix an attribute error caused by sending a null stacktrace

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -162,8 +162,9 @@ def generate_culprit(data, platform=None):
             if e.get('stacktrace')
         ]
     except KeyError:
-        if 'sentry.interfaces.Stacktrace' in data:
-            stacktraces = [data['sentry.interfaces.Stacktrace']]
+        stacktrace = data.get('sentry.interfaces.Stacktrace')
+        if stacktrace:
+            stacktraces = [stacktrace]
         else:
             stacktraces = None
 

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -839,6 +839,15 @@ class GenerateCulpritTest(TestCase):
         }
         assert generate_culprit(data) == 'PLZNOTME.py in ?'
 
+    def test_with_empty_stacktrace(self):
+        data = {
+            'sentry.interfaces.Stacktrace': None,
+            'sentry.interfaces.Http': {
+                'url': 'http://example.com'
+            },
+        }
+        assert generate_culprit(data) == 'http://example.com'
+
     def test_with_only_http_interface(self):
         data = {
             'sentry.interfaces.Http': {


### PR DESCRIPTION
This fixes an attribute error that can be caused by sending a null
stack trace.  We believe this can be sent by earlier versions of the
objective-c or swift client.

@getsentry/platform 