### PR TITLE
api: Move '?' filename handling before validation

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -250,6 +250,14 @@ class Frame(Interface):
         module = data.get('module')
         package = data.get('package')
 
+        # For legacy reasons
+        if function == '?':
+            function = None
+
+        # For consistency reasons
+        if symbol == '?':
+            symbol = None
+
         for name in ('abs_path', 'filename', 'symbol', 'function', 'module',
                      'package'):
             v = data.get(name)
@@ -275,14 +283,6 @@ class Frame(Interface):
         if not (filename or function or module or package):
             raise InterfaceValidationError("No 'filename' or 'function' or "
                                            "'module' or 'package'")
-
-        # For legacy reasons
-        if function == '?':
-            function = None
-
-        # For consistency reasons
-        if symbol == '?':
-            symbol = None
 
         platform = data.get('platform')
         if platform not in VALID_PLATFORMS:

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -531,6 +531,11 @@ class StacktraceTest(TestCase):
                 'module': 1,
             })
 
+        with self.assertRaises(InterfaceValidationError):
+            Frame.to_python({
+                'function': '?',
+            })
+
     def test_context_with_nan(self):
         self.assertEquals(
             Frame.to_python({


### PR DESCRIPTION
Previously, a frame that had a function name of simply '?' with nothing
else was considered a valid `Frame`:

```
>>> Frame.to_python({'function': '?'}).to_json()
{}
```

But this resulting `Frame` was not able to be re-converted back into a
`Frame` interface later, causing it to be invalid because there is now a
missing `function` that was stripped.

The side effect of this is that during event ingestion, the event with a
frame shaped like this passed through the intial `validate_data` pass
and gets it's data mutated and massaged into a cleaned up version. Then
later, during EventManager.normalize(), we now raise an
InterfaceValidationError causing the entire exception interface to be
discarded and ignored silently.

This fix changes it so the initial `validate_data` call will detect the
bad frame and attach an appropriate error onto the event.

/cc @benvinegar 