### PR TITLE
api: url-password data scrubber was too overly eager

### DIFF
--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -54,7 +54,7 @@ class SensitiveDataFilter(object):
         # social security numbers (US)
         r'^\b(?!(000|666|9))\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b',
     ]), re.DOTALL)
-    URL_PASSWORD_RE = re.compile(r'\b((?:[a-z0-9]+:)?//[^:]+:)([^@]+)@')
+    URL_PASSWORD_RE = re.compile(r'\b((?:[a-z0-9]+:)?//[a-zA-Z0-9%_.-]+:)([a-zA-Z0-9%_.-]+)@')
 
     def __init__(self, fields=None, include_defaults=True, exclude_fields=()):
         if fields:


### PR DESCRIPTION
The original pattern would cause whole blocks of text to be erronously
filtered out if they contained `@` and `//` anywhere in the content.

So a string such as `http://localhost something:something foo@localhost`
would cause `something foo` to get stripped out. This was more commonly
happening across JSON blobs where this pattern was more likely to match.

This refines the regular expression to url-safe characters only.