### PR TITLE
Reload group tag values when route param changes

### DIFF
--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -31,7 +31,8 @@ const GroupTagValues = React.createClass({
   },
 
   componentDidUpdate(prevProps) {
-    if (prevProps.location.search !== this.props.location.search) {
+    if (prevProps.location.search !== this.props.location.search ||
+      prevProps.params.tagKey !== this.props.params.tagKey) {
       this.fetchData();
     }
   },


### PR DESCRIPTION
The page wouldn't update otherwise moving between `<some-tag>` and, say, users:

http://127.0.0.1:8000/sentry/ludic-science/issues/1/tags/browser/
http://127.0.0.1:8000/sentry/ludic-science/issues/1/tags/user/

cc @macqueen @kjlundsgaard 