### PR TITLE
Add an is_debug_build flag to debug_meta

### DIFF
--- a/src/sentry/interfaces/debug_meta.py
+++ b/src/sentry/interfaces/debug_meta.py
@@ -55,9 +55,14 @@ class DebugMeta(Interface):
     def to_python(cls, data):
         if 'images' not in data:
             raise InterfaceValidationError('Missing key "images"')
+        is_debug_build = data.get('is_debug_build')
+        if is_debug_build is not None and not isinstance(is_debug_build, bool):
+            raise InterfaceValidationError('Invalid value for "is_debug_build"')
+
         return cls(
             images=[cls.normalize_image(x) for x in data['images']],
             sdk_info=cls.normalize_sdk_info(data.get('sdk_info')),
+            is_debug_build=is_debug_build,
         )
 
     @staticmethod


### PR DESCRIPTION
This flag will help us make educated guesses about some potentially missing
dsym files if we do reprocessing later.  In particular we can start to ignore
some symbol files because they are most likely not going to result in a
significant improvement on processing for debug builds.