### PR TITLE
Add the ability to disable workflow notifications.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Version 8.12 (Unreleased)
 - Added ``firstRelease`` to search (uses ``first_release``).
 - Fixed usage (and propagation) of ``Group.first_release``.
 - The + and - datetime search helpers now work with ranges (e.g. ``<=``).
+- Added the ability for users to disable workflow notifications on a per-project basis.
 
 SDKs
 ~~~~

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -132,12 +132,11 @@ class GroupSubscriptionManager(BaseManager):
 
         results = {}
 
-        # The remaining users are at mininum implicit subscribers.
         for user in users:
-            results[user] = GroupSubscriptionReason.implicit
-
-        for user, reason in participants.items():
-            results[user] = reason
+            results[user] = participants.get(
+                user,
+                GroupSubscriptionReason.implicit,
+            )
 
         return results
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -266,14 +266,3 @@ class Project(Model):
         else:
             is_enabled = bool(is_enabled)
         return is_enabled
-
-    def is_user_subscribed_to_workflow(self, user):
-        from sentry.models import UserOption, UserOptionValue
-
-        opt_value = UserOption.objects.get_value(
-            user, self, 'workflow:notifications', None)
-        if opt_value is None:
-            opt_value = UserOption.objects.get_value(
-                user, None, 'workflow:notifications',
-                UserOptionValue.all_conversations)
-        return opt_value == UserOptionValue.all_conversations

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -8,9 +8,9 @@ sentry.models.project
 from __future__ import absolute_import, print_function
 
 import logging
-import six
 import warnings
 
+import six
 from django.conf import settings
 from django.db import models
 from django.db.models import F
@@ -27,7 +27,6 @@ from sentry.db.models.utils import slugify_instance
 from sentry.utils.colors import get_hashed_color
 from sentry.utils.http import absolute_uri
 from sentry.utils.retries import TimedRetryPolicy
-
 
 # TODO(dcramer): pull in enum library
 ProjectStatus = ObjectStatus

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -21,6 +21,7 @@ class UserOptionValue(object):
     # 'workflow:notifications'
     all_conversations = '0'
     participating_only = '1'
+    no_conversations = '2'
 
 
 class UserOptionManager(BaseManager):

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -8,8 +8,8 @@ sentry.models.useroption
 from __future__ import absolute_import, print_function
 
 from celery.signals import task_postrun
-from django.core.signals import request_finished
 from django.conf import settings
+from django.core.signals import request_finished
 from django.db import models
 
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -76,6 +76,10 @@ const GroupSidebar = React.createClass({
     }
   },
 
+  canChangeSubscriptionState() {
+    return !(this.getGroup().subscriptionDetails || {disabled: false}).disabled;
+  },
+
   getNotificationText() {
     let group = this.getGroup();
 
@@ -93,7 +97,13 @@ const GroupSidebar = React.createClass({
       }
       return result;
     } else {
-      return t('You\'re not subscribed to this issue.');
+      if (group.subscriptionDetails && group.subscriptionDetails.disabled) {
+        return tct('You have [link:disabled workflow notifications] for this project.', {
+          link: <a href="/account/settings/notifications/" />,
+        });
+      } else {
+        return t('You\'re not subscribed to this issue.');
+      }
     }
   },
 
@@ -132,10 +142,12 @@ const GroupSidebar = React.createClass({
 
         <h6><span>{t('Notifications')}</span></h6>
         <p className="help-block">{this.getNotificationText()}</p>
-        <a className={`btn btn-default btn-subscribe ${group.isSubscribed && 'subscribed'}`}
-           onClick={this.toggleSubscription}>
-          <span className="icon-signal" /> {group.isSubscribed ? t('Unsubscribe') : t('Subscribe')}
-        </a>
+        {this.canChangeSubscriptionState() &&
+          <a className={`btn btn-default btn-subscribe ${group.isSubscribed && 'subscribed'}`}
+            onClick={this.toggleSubscription}>
+            <span className="icon-signal" /> {group.isSubscribed ? t('Unsubscribe') : t('Subscribe')}
+          </a>
+        }
       </div>
     );
   }

--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -129,7 +129,7 @@
                               <a data-toggle="alert">Alerts</a>
                             </th>
                             <th style="width:50px;text-align:center">
-                              <a data-toggle="workflow">Workflow</a>
+                              {% trans "Workflow" %}
                             </th>
                         </tr>
                     </thead>
@@ -194,7 +194,6 @@
       }
 
       setupChecker('alert');
-      setupChecker('workflow');
     });
     </script>
 {% endblock %}

--- a/src/sentry/templates/sentry/account/notifications.html
+++ b/src/sentry/templates/sentry/account/notifications.html
@@ -64,35 +64,26 @@
 
         <h4>{% trans "Workflow" %}</h4>
 
-        <p>{% blocktrans %}Workflow notifications are separate from alerts and are generated for issue updates, such as:{% endblocktrans %}</p>
-
-        <ul>
-          <li>{% trans "Assignment" %}</li>
-          <li>{% trans "Comments" %}</li>
-          <li>{% trans "Regressions" %}</li>
-          <li>{% trans "Resolution" %}</li>
-        </ul>
-
+        <p>
+          {% blocktrans %}
+            Workflow notifications are separate from alerts and are generated
+            for issue updates, such as changes in issue assignment, changes to
+            resolution status (including regressions), and comments.
+          {% endblocktrans %}
+        </p>
         <p>
           {% blocktrans %}
             When workflow notifications are enabled for a project, you'll
             receive an email when your teammates perform any of these actions.
+            You'll be automatically be added as a participant on an issue by
+            taking one of the actions listed above. You may subscribe (or
+            unsubscribe) from individual issues on their respective pages.
           {% endblocktrans %}
         </p>
 
         {{ settings_form.workflow_notifications|as_crispy_field }}
 
         {{ settings_form.self_notifications|as_crispy_field }}
-
-        <p>
-          {% blocktrans %}
-            You'll always receive notifications from issues that you're
-            subscribed to. You may subscribe (or unsubscribe) from individual
-            issues on their respective pages. You'll be automatically
-            subscribed when participating on an issue by taking one of the
-            actions listed above.
-          {% endblocktrans %}
-        </p>
 
         <hr />
 

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -565,12 +565,20 @@ class NotificationSettingsForm(forms.Form):
             value='1' if self.cleaned_data['self_notifications'] else '0',
         )
 
-        UserOption.objects.set_value(
-            user=self.user,
-            project=None,
-            key='workflow:notifications',
-            value=self.cleaned_data['workflow_notifications'],
-        )
+        workflow_notifications_value = self.cleaned_data.get('workflow_notifications')
+        if not workflow_notifications_value:
+            UserOption.objects.unset_value(
+                user=self.user,
+                project=None,
+                key='workflow:notifications',
+            )
+        else:
+            UserOption.objects.set_value(
+                user=self.user,
+                project=None,
+                key='workflow:notifications',
+                value=workflow_notifications_value,
+            )
 
 
 class ProjectEmailOptionsForm(forms.Form):

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -495,7 +495,7 @@ class NotificationSettingsForm(forms.Form):
         label=_('Default workflow subscription level for new projects'),
         choices=[
             (UserOptionValue.all_conversations, "Receive workflow updates for all issues."),
-            (UserOptionValue.participating_only, "Recieve workflow updates for issues that I am participating in."),
+            (UserOptionValue.participating_only, "Receive workflow updates for issues that I am participating in."),
             (UserOptionValue.no_conversations, "Never receive workflow updates."),
         ],
         required=False,

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -492,18 +492,19 @@ class NotificationSettingsForm(forms.Form):
     )
 
     workflow_notifications = forms.ChoiceField(
-        label=_('Default workflow subscription level for new projects'),
+        label=_('Preferred workflow subscription level for new projects'),
         choices=[
             (UserOptionValue.all_conversations, "Receive workflow updates for all issues."),
-            (UserOptionValue.participating_only, "Receive workflow updates for issues that I am participating in."),
+            (UserOptionValue.participating_only, "Receive workflow updates only for issues that I am participating in or have subscribed to."),
             (UserOptionValue.no_conversations, "Never receive workflow updates."),
         ],
+        help_text=_("This will be automatically set as your subscription preference when you create or join a project. It has no effect on existing projects."),
         required=False,
     )
 
     self_notifications = forms.BooleanField(
         label=_('Receive notifications about my own activity'),
-        help_text=_('Enable this if you wish to receive emails for your own actions, as well as others.'),
+        help_text=_('Enable this if you wish to receive emails for your own actions, in addition to the actions of others.'),
         required=False,
     )
 
@@ -585,9 +586,9 @@ class ProjectEmailOptionsForm(forms.Form):
     alert = forms.BooleanField(required=False)
     workflow = forms.ChoiceField(
         choices=[
-            (UserOptionValue.no_conversations, 'No updates'),
+            (UserOptionValue.no_conversations, 'Nothing'),
             (UserOptionValue.participating_only, 'Participating'),
-            (UserOptionValue.all_conversations, 'All updates'),
+            (UserOptionValue.all_conversations, 'Everything'),
         ],
     )
     email = forms.ChoiceField(label="", choices=(), required=False,

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -17,8 +17,8 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import options
-from sentry.auth import password_validation
 from sentry.app import ratelimiter
+from sentry.auth import password_validation
 from sentry.constants import LANGUAGES
 from sentry.models import (
     Organization, OrganizationStatus, User, UserOption, UserOptionValue

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -3,13 +3,14 @@
 from __future__ import absolute_import
 
 from datetime import timedelta
+
 from django.utils import timezone
 from mock import patch
 
 from sentry.api.serializers import serialize
 from sentry.models import (
-    GroupResolution, GroupResolutionStatus, GroupSnooze, GroupSubscription,
-    GroupStatus, Release, UserOption, UserOptionValue
+    GroupResolution, GroupResolutionStatus, GroupSnooze, GroupStatus,
+    GroupSubscription, Release, UserOption, UserOptionValue
 )
 from sentry.testutils import TestCase
 

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -114,6 +114,9 @@ class GroupSerializerTest(TestCase):
 
         result = serialize(group, user)
         assert result['isSubscribed']
+        assert result['subscriptionDetails'] == {
+            'reason': 'unknown',
+        }
 
     def test_explicit_unsubscribed(self):
         user = self.create_user()
@@ -128,19 +131,27 @@ class GroupSerializerTest(TestCase):
 
         result = serialize(group, user)
         assert not result['isSubscribed']
+        assert not result['subscriptionDetails']
 
     def test_implicit_subscribed(self):
         user = self.create_user()
         group = self.create_group()
 
         combinations = (
-            ((None, None), True),
-            ((UserOptionValue.all_conversations, None), True),
-            ((UserOptionValue.all_conversations, UserOptionValue.all_conversations), True),
-            ((UserOptionValue.all_conversations, UserOptionValue.participating_only), False),
-            ((UserOptionValue.participating_only, None), False),
-            ((UserOptionValue.participating_only, UserOptionValue.all_conversations), True),
-            ((UserOptionValue.participating_only, UserOptionValue.participating_only), False),
+            # ((default, project), (subscribed, details))
+            ((None, None), (True, None)),
+            ((UserOptionValue.all_conversations, None), (True, None)),
+            ((UserOptionValue.all_conversations, UserOptionValue.all_conversations), (True, None)),
+            ((UserOptionValue.all_conversations, UserOptionValue.participating_only), (False, None)),
+            ((UserOptionValue.all_conversations, UserOptionValue.no_conversations), (False, {'disabled': True})),
+            ((UserOptionValue.participating_only, None), (False, None)),
+            ((UserOptionValue.participating_only, UserOptionValue.all_conversations), (True, None)),
+            ((UserOptionValue.participating_only, UserOptionValue.participating_only), (False, None)),
+            ((UserOptionValue.participating_only, UserOptionValue.no_conversations), (False, {'disabled': True})),
+            ((UserOptionValue.no_conversations, None), (False, {'disabled': True})),
+            ((UserOptionValue.no_conversations, UserOptionValue.all_conversations), (True, None)),
+            ((UserOptionValue.no_conversations, UserOptionValue.participating_only), (False, None)),
+            ((UserOptionValue.no_conversations, UserOptionValue.no_conversations), (False, {'disabled': True})),
         )
 
         def maybe_set_value(project, value):
@@ -158,12 +169,62 @@ class GroupSerializerTest(TestCase):
                     key='workflow:notifications',
                 )
 
-        for options, expected_result in combinations:
-            UserOption.objects.clear_cache()
+        for options, (is_subscribed, subscription_details) in combinations:
             default_value, project_value = options
+            UserOption.objects.clear_cache()
             maybe_set_value(None, default_value)
             maybe_set_value(group.project, project_value)
-            assert serialize(group, user)['isSubscribed'] is expected_result, 'expected {!r} for {!r}'.format(expected_result, options)
+            result = serialize(group, user)
+            assert result['isSubscribed'] is is_subscribed
+            assert result.get('subscriptionDetails') == subscription_details
+
+    def test_global_no_conversations_overrides_group_subscription(self):
+        user = self.create_user()
+        group = self.create_group()
+
+        GroupSubscription.objects.create(
+            user=user,
+            group=group,
+            project=group.project,
+            is_active=True,
+        )
+
+        UserOption.objects.set_value(
+            user=user,
+            project=None,
+            key='workflow:notifications',
+            value=UserOptionValue.no_conversations,
+        )
+
+        result = serialize(group, user)
+        assert not result['isSubscribed']
+        assert result['subscriptionDetails'] == {
+            'disabled': True,
+        }
+
+    def test_project_no_conversations_overrides_group_subscription(self):
+        user = self.create_user()
+        group = self.create_group()
+
+        GroupSubscription.objects.create(
+            user=user,
+            group=group,
+            project=group.project,
+            is_active=True,
+        )
+
+        UserOption.objects.set_value(
+            user=user,
+            project=group.project,
+            key='workflow:notifications',
+            value=UserOptionValue.no_conversations,
+        )
+
+        result = serialize(group, user)
+        assert not result['isSubscribed']
+        assert result['subscriptionDetails'] == {
+            'disabled': True,
+        }
 
     def test_no_user_unsubscribed(self):
         group = self.create_group()

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -84,6 +84,18 @@ class GetParticipantsTest(TestCase):
             user: GroupSubscriptionReason.comment,
         }
 
+    def test_excludes_global_no_conversations(self):
+        raise NotImplementedError
+
+    def test_excludes_project_no_conversations(self):
+        raise NotImplementedError
+
+    def test_includes_project_participating_only(self):
+        # TODO: This also needs to test to ensure the project setting overrides
+        # the global setting, and needs to ensure that this doesn't false
+        # positive due to a ID overlap.
+        raise NotImplementedError
+
     def test_excludes_project_participating_only(self):
         org = self.create_organization()
         team = self.create_team(organization=org)

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -208,24 +208,143 @@ class GetParticipantsTest(TestCase):
                 value=UserOptionValue.no_conversations,
             )
 
-    def test_project_participating_only(self):
+    def test_participating_only(self):
         org = self.create_organization()
         team = self.create_team(organization=org)
         project = self.create_project(team=team, organization=org)
         group = self.create_group(project=project)
-        user = self.create_user('foo@example.com')
+        user = self.create_user()
         self.create_member(user=user, organization=org, teams=[team])
 
-        UserOption.objects.set_value(
+        user_option_sequence = itertools.count(300)  # prevent accidental overlap with user id
+
+        def clear_workflow_options():
+            UserOption.objects.filter(
+                user=user,
+                key='workflow:notifications',
+            ).delete()
+
+        get_participants = functools.partial(
+            GroupSubscription.objects.get_participants,
+            group,
+        )
+
+        # Implicit subscription, ensure the project setting overrides the
+        # default global option.
+
+        with self.assertChanges(get_participants,
+                before={user: GroupSubscriptionReason.implicit},
+                after={}):
+            UserOption.objects.create(
+                id=next(user_option_sequence),
+                user=user,
+                project=project,
+                key='workflow:notifications',
+                value=UserOptionValue.participating_only,
+            )
+
+        clear_workflow_options()
+
+        # Implicit subscription, ensure the project setting overrides the
+        # explicit global option.
+
+        UserOption.objects.create(
+            id=next(user_option_sequence),
             user=user,
-            project=project,
+            project=None,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
+
+        with self.assertChanges(get_participants,
+                before={user: GroupSubscriptionReason.implicit},
+                after={}):
+            UserOption.objects.create(
+                id=next(user_option_sequence),
+                user=user,
+                project=project,
+                key='workflow:notifications',
+                value=UserOptionValue.no_conversations,
+            )
+
+        clear_workflow_options()
+
+        # Ensure the global default is applied.
+
+        UserOption.objects.create(
+            id=next(user_option_sequence),
+            user=user,
+            project=None,
             key='workflow:notifications',
             value=UserOptionValue.participating_only,
         )
 
-        users = GroupSubscription.objects.get_participants(group=group)
+        with self.assertChanges(get_participants,
+                before={},
+                after={user: GroupSubscriptionReason.comment}):
+            subscription = GroupSubscription.objects.create(
+                user=user,
+                group=group,
+                project=project,
+                is_active=True,
+                reason=GroupSubscriptionReason.comment,
+            )
 
-        assert users == {}
+        subscription.delete()
+        clear_workflow_options()
+
+        # Ensure the project setting overrides the global default.
+
+        UserOption.objects.create(
+            id=next(user_option_sequence),
+            user=user,
+            project=group.project,
+            key='workflow:notifications',
+            value=UserOptionValue.participating_only,
+        )
+
+        with self.assertChanges(get_participants,
+                before={},
+                after={user: GroupSubscriptionReason.comment}):
+            subscription = GroupSubscription.objects.create(
+                user=user,
+                group=group,
+                project=project,
+                is_active=True,
+                reason=GroupSubscriptionReason.comment,
+            )
+
+        subscription.delete()
+        clear_workflow_options()
+
+        # Ensure the project setting overrides the global setting.
+
+        UserOption.objects.create(
+            id=next(user_option_sequence),
+            user=user,
+            project=None,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
+
+        UserOption.objects.create(
+            id=next(user_option_sequence),
+            user=user,
+            project=group.project,
+            key='workflow:notifications',
+            value=UserOptionValue.participating_only,
+        )
+
+        with self.assertChanges(get_participants,
+                before={},
+                after={user: GroupSubscriptionReason.comment}):
+            subscription = GroupSubscription.objects.create(
+                user=user,
+                group=group,
+                project=project,
+                is_active=True,
+                reason=GroupSubscriptionReason.comment,
+            )
 
     def test_does_not_include_nonmember(self):
         org = self.create_organization()

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -346,6 +346,36 @@ class GetParticipantsTest(TestCase):
                 reason=GroupSubscriptionReason.comment,
             )
 
+        subscription.delete()
+        clear_workflow_options()
+
+        UserOption.objects.create(
+            id=next(user_option_sequence),
+            user=user,
+            project=None,
+            key='workflow:notifications',
+            value=UserOptionValue.participating_only,
+        )
+
+        UserOption.objects.create(
+            id=next(user_option_sequence),
+            user=user,
+            project=group.project,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
+
+        with self.assertChanges(get_participants,
+                before={user: GroupSubscriptionReason.implicit},
+                after={user: GroupSubscriptionReason.comment}):
+            subscription = GroupSubscription.objects.create(
+                user=user,
+                group=group,
+                project=project,
+                is_active=True,
+                reason=GroupSubscriptionReason.comment,
+            )
+
     def test_does_not_include_nonmember(self):
         org = self.create_organization()
         team = self.create_team(organization=org)

--- a/tests/sentry/web/frontend/test_account_notifications.py
+++ b/tests/sentry/web/frontend/test_account_notifications.py
@@ -2,12 +2,14 @@
 
 from __future__ import absolute_import
 
+import functools
 import six
 
+import mock
 from django.core.urlresolvers import reverse
 from exam import fixture
 
-from sentry.models import ProjectStatus, UserOption, UserOptionValue
+from sentry.models import ProjectStatus, UserOption
 from sentry.testutils import TestCase
 
 
@@ -67,7 +69,7 @@ class NotificationSettingsTest(TestCase):
             user=self.user, project=None
         )
 
-        assert options.get('workflow:notifications') == '0'
+        assert options.get('workflow:notifications') == '1'
 
         resp = self.client.post(self.path, {
             'workflow_notifications': '',
@@ -78,8 +80,18 @@ class NotificationSettingsTest(TestCase):
             user=self.user, project=None
         )
 
-        assert options.get('workflow:notifications') == \
-            UserOptionValue.participating_only
+        assert options.get('workflow:notifications', mock.sentinel.UNSET) == mock.sentinel.UNSET
+
+        with self.assertDoesNotChange(
+                functools.partial(
+                    UserOption.objects.get_value,
+                    user=self.user,
+                    project=None,
+                    key='workflow:notifications'
+                )):
+            resp = self.client.post(self.path, {
+                'workflow_notifications': 'invalid',
+            })
 
     def test_can_change_subscribe_by_default(self):
         self.login_as(self.user)

--- a/tests/sentry/web/frontend/test_account_notifications.py
+++ b/tests/sentry/web/frontend/test_account_notifications.py
@@ -3,9 +3,9 @@
 from __future__ import absolute_import
 
 import functools
-import six
 
 import mock
+import six
 from django.core.urlresolvers import reverse
 from exam import fixture
 


### PR DESCRIPTION
- Fixes a bug where users weren't receiving notifications in some scenarios. (This is essentially the same as GH-4653.)
- Adds the `UserOptionValue.no_conversations` option for workflow notifications.
- Adds `disabled` to the `GroupSerializer`'s `subscriptionDetails` return attribute when workflow notifications are disabled for a project.
- Removes the "Subscribe" button from the UI when workflow notifications are disabled from the UI, and changes the notification help text to explain that workflow notifications are disabled for the project (with a link to the user's notification settings.)
- Removes users from the `GroupSubscription.get_participants` result when they have disabled workflow notifications for the project.
- Updates the notifications forms to change the boolean checkbox into a three-choice select box.
- Updates and extends tests for various workflow notification scenarios.