### PR TITLE
[search] various improvements/fixes around datetimes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@ Version 8.12 (Unreleased)
 - Added data migration to backfill legacy release file and environment data
 - Allow gziped/deflated JavaScript artifacts to be uploaded through the API.
 - Shared issue view no longer shows SDK.
+- Added ``activeSince`` to search (uses ``active_at``).
+- Added ``firstSeen`` to search (uses ``first_seen``).
+- Added ``lastSeen`` to search (uses ``last_seen``).
+- Added ``firstRelease`` to search (uses ``first_release``).
+- Fixed usage (and propagation) of ``Group.first_release``.
+- The + and - datetime search helpers now work with ranges (e.g. ``<=``).
 
 SDKs
 ~~~~

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -142,7 +142,7 @@ class GroupSerializer(Serializer):
 
         result = {}
         for item in item_list:
-            active_date = item.active_at or item.last_seen
+            active_date = item.active_at or item.first_seen
 
             annotations = []
             for plugin in plugins.for_project(project=item.project, version=1):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -556,6 +556,7 @@ class EventManager(object):
             'level': level,
             'last_seen': date,
             'first_seen': date,
+            'active_at': date,
             'data': {
                 'last_received': event.data.get('received') or float(event.datetime.strftime('%s')),
                 'type': event_type.key,

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -73,6 +73,8 @@ class DjangoSearchBackend(SearchBackend):
                         last_seen_to=None, last_seen_to_inclusive=True,
                         date_from=None, date_from_inclusive=True,
                         date_to=None, date_to_inclusive=True,
+                        active_at_from=None, active_at_from_inclusive=True,
+                        active_at_to=None, active_at_to_inclusive=True,
                         cursor=None, limit=None):
         from sentry.models import Event, Group, GroupSubscription, GroupStatus
 
@@ -167,6 +169,20 @@ class DjangoSearchBackend(SearchBackend):
                     params['last_seen__lte'] = last_seen_to
                 else:
                     params['last_seen__lt'] = last_seen_to
+            queryset = queryset.filter(**params)
+
+        if active_at_from or active_at_to:
+            params = {}
+            if active_at_from:
+                if active_at_from_inclusive:
+                    params['active_at__gte'] = active_at_from
+                else:
+                    params['active_at__gt'] = active_at_from
+            if active_at_to:
+                if active_at_to_inclusive:
+                    params['active_at__lte'] = active_at_to
+                else:
+                    params['active_at__lt'] = active_at_to
             queryset = queryset.filter(**params)
 
         if date_from or date_to:

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -95,6 +95,10 @@ def parse_datetime_value(value):
 
 
 def _parse_datetime_value(value):
+    # this one is fuzzy, and not entirely correct
+    if value.startswith(('-', '+')):
+        return parse_datetime_range(value)
+
     # timezones are not supported and are assumed UTC
     if value[-1] == 'Z':
         value = value[:-1]
@@ -166,6 +170,7 @@ reserved_tag_names = frozenset([
     'bookmarks',
     'subscribed',
     'first-release',
+    'firstRelease',
     'release',
     'level',
     'user',
@@ -173,7 +178,10 @@ reserved_tag_names = frozenset([
     'user.ip',
     'has',
     'age',
+    'firstSeen',
+    'activeSince',
     'last_seen',
+    'lastSeen',
     'environment',
     'browser',
     'device',
@@ -274,7 +282,7 @@ def parse_query(project, query, user):
                 results['bookmarked_by'] = parse_user_value(value, user)
             elif key == 'subscribed':
                 results['subscribed_by'] = parse_user_value(value, user)
-            elif key == 'first-release':
+            elif key in ('first-release', 'firstRelease'):
                 results['first_release'] = parse_release(project, value)
             elif key == 'release':
                 results['tags']['sentry:release'] = parse_release(project, value)
@@ -291,10 +299,12 @@ def parse_query(project, query, user):
                 elif value == 'release':
                     value = 'sentry:release'
                 results['tags'][value] = ANY
-            elif key == 'age':
+            elif key in ('age', 'firstSeen'):
                 results.update(get_date_params(value, 'age_from', 'age_to'))
-            elif key == 'last_seen':
+            elif key in ('last_seen', 'lastSeen'):
                 results.update(get_date_params(value, 'last_seen_from', 'last_seen_to'))
+            elif key == 'activeSince':
+                results.update(get_date_params(value, 'active_at_from', 'active_at_to'))
             elif key.startswith('user.'):
                 results['tags']['sentry:user'] = get_user_tag(
                     project, key.split('.', 1)[1], value)

--- a/src/sentry/utils/javascript.py
+++ b/src/sentry/utils/javascript.py
@@ -145,7 +145,7 @@ class GroupTransformer(Transformer):
         for g in objects:
             g.is_bookmarked = g.pk in bookmarks
             g.historical_data = [x[1] for x in historical_data.get(g.id, [])]
-            active_date = g.active_at or g.last_seen
+            active_date = g.active_at or g.first_seen
             g.has_seen = seen_groups.get(g.id, active_date) > active_date
             g.annotations = []
             for key in sorted(tag_keys):

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -178,6 +178,13 @@ class ParseQueryTest(TestCase):
         assert result['age_to'] > timezone.now() - timedelta(hours=13)
         assert result['age_to'] < timezone.now() - timedelta(hours=11)
 
+    def test_first_seen_range(self):
+        result = self.parse_query('firstSeen:-24h firstSeen:+12h')
+        assert result['age_from'] > timezone.now() - timedelta(hours=25)
+        assert result['age_from'] < timezone.now() - timedelta(hours=23)
+        assert result['age_to'] > timezone.now() - timedelta(hours=13)
+        assert result['age_to'] < timezone.now() - timedelta(hours=11)
+
     def test_date_range(self):
         result = self.parse_query('event.timestamp:>2016-01-01 event.timestamp:<2016-01-02')
         assert result['date_from'] == datetime(2016, 1, 1, tzinfo=timezone.utc)
@@ -200,6 +207,20 @@ class ParseQueryTest(TestCase):
         assert result['date_from_inclusive']
         assert result['date_to'] == date_value + timedelta(minutes=6)
         assert not result['date_to_inclusive']
+
+    def test_active_range(self):
+        result = self.parse_query('activeSince:-24h activeSince:+12h')
+        assert result['active_at_from'] > timezone.now() - timedelta(hours=25)
+        assert result['active_at_from'] < timezone.now() - timedelta(hours=23)
+        assert result['active_at_to'] > timezone.now() - timedelta(hours=13)
+        assert result['active_at_to'] < timezone.now() - timedelta(hours=11)
+
+    def test_last_seen_range(self):
+        result = self.parse_query('lastSeen:-24h lastSeen:+12h')
+        assert result['last_seen_from'] > timezone.now() - timedelta(hours=25)
+        assert result['last_seen_from'] < timezone.now() - timedelta(hours=23)
+        assert result['last_seen_to'] > timezone.now() - timedelta(hours=13)
+        assert result['last_seen_to'] < timezone.now() - timedelta(hours=11)
 
     def test_has_tag(self):
         result = self.parse_query('has:foo')


### PR DESCRIPTION
- add activeSince to search
- add firstSeen to search
- add lastSeen to search
- add firstRelease to search
- fix usage of active_at in seen by checks
- populate active_at on new groups
- support +/- date helpers in range queries (e.g. ``age:<=-1d``)