### PR TITLE
stop using project column on release related models

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Version 8.13 (Unreleased)
 - Added individual filters for legacy browsers to improve customization of error filtering based on browser versions
 
 - Support for setting a custom security header for javascript fetching.
+- start using ReleaseProject and Release.organization instead of Release.project
 
 - Project quotas are no longer available, and must now be configured via the organizational rate limits.
 - Quotas implementation now requires a tuple of maximum rate and interval window.

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -267,12 +267,9 @@ def main(num_events=1):
 
             release, created = Release.objects.get_or_create(
                 version=sha1(uuid4().bytes).hexdigest(),
-                project=project,
-                defaults={'organization_id': project.organization_id}
+                organization=project.organization_id
             )
-
-            if created:
-                release.add_project(project)
+            release.add_project(project)
 
             ReleaseFile.objects.get_or_create(
                 project=project,

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -272,7 +272,7 @@ def main(num_events=1):
             release.add_project(project)
 
             ReleaseFile.objects.get_or_create(
-                project=project,
+                organization_id=project.organization_id,
                 release=release,
                 name='an-example.js',
                 file=File.objects.get_or_create(
@@ -310,7 +310,6 @@ def main(num_events=1):
 
             ReleaseCommit.objects.get_or_create(
                 organization_id=org.id,
-                project_id=project.id,
                 release=release,
                 commit=commit,
                 order=0,

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -266,20 +266,22 @@ def main(num_events=1):
             )
 
             with transaction.atomic():
-                release_qs = Release.objects.filter(
+                has_release = Release.objects.filter(
                     version=sha1(uuid4().bytes).hexdigest(),
-                    organization_id=project.organization_id
-                )
-                if release_qs:
-                    release = release_qs.filter(projects=project).first()
-                    if not release:
-                        release = release_qs.first()
-                else:
-                    release = Release.objects.create(
+                    organization_id=project.organization_id,
+                    projects=project
+                ).exists()
+                if not has_release:
+                    release = Release.objects.filter(
                         version=sha1(uuid4().bytes).hexdigest(),
-                        organization_id=project.organization_id
-                    )
-            release.add_project(project)
+                        organization_id=project.organization_id,
+                    ).first()
+                    if not release:
+                        release = Release.objects.create(
+                            version=sha1(uuid4().bytes).hexdigest(),
+                            organization_id=project.organization_id
+                        )
+                    release.add_project(project)
 
             ReleaseFile.objects.get_or_create(
                 organization_id=project.organization_id,

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -265,10 +265,20 @@ def main(num_events=1):
                 }
             )
 
-            release, created = Release.objects.get_or_create(
-                version=sha1(uuid4().bytes).hexdigest(),
-                organization=project.organization_id
-            )
+            with transaction.atomic():
+                release_qs = Release.objects.filter(
+                    version=sha1(uuid4().bytes).hexdigest(),
+                    organization_id=project.organization_id
+                )
+                if release_qs:
+                    release = release_qs.filter(projects=project).first()
+                    if not release:
+                        release = release_qs.first()
+                else:
+                    release = Release.objects.create(
+                        version=sha1(uuid4().bytes).hexdigest(),
+                        organization_id=project.organization_id
+                    )
             release.add_project(project)
 
             ReleaseFile.objects.get_or_create(

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -21,7 +21,8 @@ class EventDetailsEndpoint(Endpoint):
             return None
         try:
             release = Release.objects.get(
-                project=event.project,
+                projects=event.project,
+                organization_id=event.project.organization_id,
                 version=version,
             )
         except Release.DoesNotExist:

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -133,7 +133,8 @@ class GroupDetailsEndpoint(GroupEndpoint):
     def _get_release_info(self, request, group, version):
         try:
             release = Release.objects.get(
-                project=group.project,
+                projects=group.project,
+                organization_id=group.project.organization_id,
                 version=version,
             )
         except Release.DoesNotExist:

--- a/src/sentry/api/endpoints/group_environment_details.py
+++ b/src/sentry/api/endpoints/group_environment_details.py
@@ -42,7 +42,7 @@ class GroupEnvironmentDetailsEndpoint(GroupEndpoint):
             group_id=group.id,
             environment=environment.name,
             release_id=ReleaseEnvironment.objects.filter(
-                project_id=group.project_id,
+                organization_id=group.project.organization_id,
                 environment_id=environment.id,
             ).order_by('-first_seen').values_list('release_id', flat=True).first(),
         ).first()

--- a/src/sentry/api/endpoints/group_environment_details.py
+++ b/src/sentry/api/endpoints/group_environment_details.py
@@ -42,6 +42,7 @@ class GroupEnvironmentDetailsEndpoint(GroupEndpoint):
             group_id=group.id,
             environment=environment.name,
             release_id=ReleaseEnvironment.objects.filter(
+                project_id=group.project_id,
                 organization_id=group.project.organization_id,
                 environment_id=environment.id,
             ).order_by('-first_seen').values_list('release_id', flat=True).first(),

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -357,7 +357,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         if result.get('status') == 'resolvedInNextRelease':
             try:
                 release = Release.objects.filter(
-                    project=project,
+                    projects=project,
+                    organization_id=project.organization_id
                 ).order_by('-date_added')[0]
             except IndexError:
                 return Response('{"detail": "No release data present in the system to indicate form a basis for \'Next Release\'"}', status=400)

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -142,24 +142,29 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
                 # experiences
                 release = Release.objects.filter(
                     organization_id=project.organization_id,
-                    version=result['version']
+                    version=result['version'],
+                    projects=project
                 ).first()
+                created = False
                 if release:
-                    created = False
                     was_released = bool(release.date_released)
                 else:
-                    release, created = Release.objects.create(
+                    release = Release.objects.filter(
                         organization_id=project.organization_id,
                         version=result['version'],
-                        ref=result.get('ref'),
-                        url=result.get('url'),
-                        owner=result.get('owner'),
-                        date_started=result.get('dateStarted'),
-                        date_released=result.get('dateReleased'),
-                    ), True
+                    ).first()
+                    if not release:
+                        release, created = Release.objects.create(
+                            organization_id=project.organization_id,
+                            version=result['version'],
+                            ref=result.get('ref'),
+                            url=result.get('url'),
+                            owner=result.get('owner'),
+                            date_started=result.get('dateStarted'),
+                            date_released=result.get('dateReleased'),
+                        ), True
                     was_released = False
-
-            release.add_project(project)
+                    release.add_project(project)
 
             commit_list = result.get('commits')
             if commit_list:

--- a/src/sentry/api/endpoints/release_commits.py
+++ b/src/sentry/api/endpoints/release_commits.py
@@ -27,7 +27,8 @@ class ReleaseCommitsEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:

--- a/src/sentry/api/endpoints/release_details.py
+++ b/src/sentry/api/endpoints/release_details.py
@@ -83,7 +83,8 @@ class ReleaseDetailsEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:
@@ -119,7 +120,8 @@ class ReleaseDetailsEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:
@@ -182,7 +184,8 @@ class ReleaseDetailsEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:

--- a/src/sentry/api/endpoints/release_file_details.py
+++ b/src/sentry/api/endpoints/release_file_details.py
@@ -103,7 +103,8 @@ class ReleaseFileDetailsEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:
@@ -145,7 +146,8 @@ class ReleaseFileDetailsEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:
@@ -192,7 +194,8 @@ class ReleaseFileDetailsEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:

--- a/src/sentry/api/endpoints/release_files.py
+++ b/src/sentry/api/endpoints/release_files.py
@@ -86,7 +86,8 @@ class ReleaseFilesEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:
@@ -135,7 +136,8 @@ class ReleaseFilesEndpoint(ProjectEndpoint):
         """
         try:
             release = Release.objects.get(
-                project=project,
+                organization_id=project.organization_id,
+                projects=project,
                 version=version,
             )
         except Release.DoesNotExist:
@@ -178,7 +180,7 @@ class ReleaseFilesEndpoint(ProjectEndpoint):
         try:
             with transaction.atomic():
                 releasefile = ReleaseFile.objects.create(
-                    organization_id=release.project.organization_id,
+                    organization_id=release.organization_id,
                     project=release.project,
                     release=release,
                     file=file,

--- a/src/sentry/api/endpoints/release_files.py
+++ b/src/sentry/api/endpoints/release_files.py
@@ -181,7 +181,6 @@ class ReleaseFilesEndpoint(ProjectEndpoint):
             with transaction.atomic():
                 releasefile = ReleaseFile.objects.create(
                     organization_id=release.organization_id,
-                    project=release.project,
                     release=release,
                     file=file,
                     name=full_name,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.models import Release, TagValue
+from sentry.models import Release, ReleaseProject, TagValue
 
 
 @register(Release)
@@ -12,7 +12,9 @@ class ReleaseSerializer(Serializer):
         tags = {
             tk.value: tk
             for tk in TagValue.objects.filter(
-                project=item_list[0].project,
+                project_id__in=ReleaseProject.objects.filter(
+                    release__in=item_list
+                ).values_list('project_id', flat=True),
                 key='sentry:release',
                 value__in=[o.version for o in item_list],
             )

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -677,6 +677,7 @@ class EventManager(object):
                 return event
 
             index_event_tags.delay(
+                organization_id=project.organization_id,
                 project_id=project.id,
                 group_id=group.id,
                 event_id=event.id,

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -184,7 +184,7 @@ class Organization(Model):
     def merge_to(from_org, to_org):
         from sentry.models import (
             ApiKey, AuditLogEntry, OrganizationMember, OrganizationMemberTeam,
-            Project, Team
+            Project, Release, Team
         )
 
         for from_member in OrganizationMember.objects.filter(organization=from_org):
@@ -232,7 +232,7 @@ class Organization(Model):
                     slug=project.slug,
                 )
 
-        for model in (ApiKey, AuditLogEntry):
+        for model in (ApiKey, AuditLogEntry, Release):
             model.objects.filter(
                 organization=from_org,
             ).update(organization=to_org)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -183,8 +183,8 @@ class Organization(Model):
 
     def merge_to(from_org, to_org):
         from sentry.models import (
-            ApiKey, AuditLogEntry, OrganizationMember, OrganizationMemberTeam,
-            Project, Release, Team
+            ApiKey, AuditLogEntry, Commit, OrganizationMember, OrganizationMemberTeam,
+            Project, Release, ReleaseCommit, ReleaseEnvironment, ReleaseFile, Team
         )
 
         for from_member in OrganizationMember.objects.filter(organization=from_org):
@@ -232,10 +232,17 @@ class Organization(Model):
                     slug=project.slug,
                 )
 
-        for model in (ApiKey, AuditLogEntry, Release):
+        # TODO(jess): figure out how to merge Releases and related models
+        # once we add organization, version unique constraint
+        for model in (ApiKey, AuditLogEntry, Release, ReleaseFile):
             model.objects.filter(
                 organization=from_org,
             ).update(organization=to_org)
+
+        for model in (Commit, ReleaseCommit, ReleaseEnvironment):
+            model.objects.filter(
+                organization_id=from_org.id,
+            ).update(organization_id=to_org.id)
 
     # TODO: Make these a mixin
     def update_option(self, *args, **kwargs):

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -67,11 +67,12 @@ class Release(Model):
 
     @classmethod
     def get_cache_key(cls, project_id, version):
+        # TODO(jess): update this to use organization id when adding
+        # unique on Release for organization, version
         return 'release:2:%s:%s' % (project_id, md5_text(version).hexdigest())
 
     @classmethod
     def get(cls, project, version):
-        # TODO: should this be cached by organization now?
         cache_key = cls.get_cache_key(project.id, version)
 
         release = cache.get(cache_key)
@@ -93,7 +94,6 @@ class Release(Model):
 
     @classmethod
     def get_or_create(cls, project, version, date_added):
-        # TODO: should this be cached by organization now?
         cache_key = cls.get_cache_key(project.id, version)
 
         release = cache.get(cache_key)

--- a/src/sentry/models/releasecommit.py
+++ b/src/sentry/models/releasecommit.py
@@ -8,8 +8,8 @@ from sentry.db.models import (
 class ReleaseCommit(Model):
     __core__ = False
 
-    organization_id = BoundedPositiveIntegerField(db_index=True, null=True)
-    project_id = BoundedPositiveIntegerField(db_index=True)
+    organization_id = BoundedPositiveIntegerField(db_index=True)
+    project_id = BoundedPositiveIntegerField(db_index=True, null=True)
     release = FlexibleForeignKey('sentry.Release')
     commit = FlexibleForeignKey('sentry.Commit')
     order = BoundedPositiveIntegerField()

--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -13,8 +13,8 @@ from sentry.db.models import (
 class ReleaseEnvironment(Model):
     __core__ = False
 
-    organization_id = BoundedPositiveIntegerField(db_index=True, null=True)
-    project_id = BoundedPositiveIntegerField(db_index=True)
+    organization_id = BoundedPositiveIntegerField(db_index=True)
+    project_id = BoundedPositiveIntegerField(db_index=True, null=True)
     release_id = BoundedPositiveIntegerField(db_index=True)
     environment_id = BoundedPositiveIntegerField(db_index=True)
     first_seen = models.DateTimeField(default=timezone.now)

--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -45,7 +45,6 @@ class ReleaseEnvironment(Model):
                 with transaction.atomic():
                     instance, created = cls.objects.create(
                         release_id=release.id,
-                        project_id=project.id,
                         organization_id=project.organization_id,
                         environment_id=environment.id,
                         first_seen=datetime,
@@ -54,7 +53,7 @@ class ReleaseEnvironment(Model):
             except IntegrityError:
                 instance, created = cls.objects.get(
                     release_id=release.id,
-                    project_id=project.id,
+                    organization_id=project.organization_id,
                     environment_id=environment.id,
                 ), False
             cache.set(cache_key, instance, 3600)

--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -14,7 +14,7 @@ class ReleaseEnvironment(Model):
     __core__ = False
 
     organization_id = BoundedPositiveIntegerField(db_index=True)
-    project_id = BoundedPositiveIntegerField(db_index=True, null=True)
+    project_id = BoundedPositiveIntegerField(db_index=True)
     release_id = BoundedPositiveIntegerField(db_index=True)
     environment_id = BoundedPositiveIntegerField(db_index=True)
     first_seen = models.DateTimeField(default=timezone.now)
@@ -45,6 +45,7 @@ class ReleaseEnvironment(Model):
                 with transaction.atomic():
                     instance, created = cls.objects.create(
                         release_id=release.id,
+                        project_id=project.id,
                         organization_id=project.organization_id,
                         environment_id=environment.id,
                         first_seen=datetime,
@@ -53,6 +54,7 @@ class ReleaseEnvironment(Model):
             except IntegrityError:
                 instance, created = cls.objects.get(
                     release_id=release.id,
+                    project_id=project.id,
                     organization_id=project.organization_id,
                     environment_id=environment.id,
                 ), False

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -22,8 +22,8 @@ class ReleaseFile(Model):
     """
     __core__ = False
 
-    organization = FlexibleForeignKey('sentry.Organization', null=True)
-    project = FlexibleForeignKey('sentry.Project')
+    organization = FlexibleForeignKey('sentry.Organization')
+    project = FlexibleForeignKey('sentry.Project', null=True)
     release = FlexibleForeignKey('sentry.Release')
     file = FlexibleForeignKey('sentry.File')
     ident = models.CharField(max_length=40)

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -107,7 +107,6 @@ class ReleaseHook(object):
 
                 ReleaseCommit.objects.create(
                     organization_id=project.organization_id,
-                    project_id=project.id,
                     release=release,
                     commit=commit,
                     order=idx,

--- a/src/sentry/plugins/sentry_mail/activity/release.py
+++ b/src/sentry/plugins/sentry_mail/activity/release.py
@@ -12,7 +12,8 @@ class ReleaseActivityEmail(ActivityEmail):
         super(ReleaseActivityEmail, self).__init__(activity)
         try:
             self.release = Release.objects.get(
-                project=self.project,
+                organization_id=self.project.organization_id,
+                projects=self.project,
                 version=activity.data['version'],
             )
         except Release.DoesNotExist:

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -16,8 +16,8 @@ def ensure_release_exists(instance, created, **kwargs):
 
     try:
         with transaction.atomic():
+            # TODO: org/version unique constraint required for this to work as intended
             release = Release.objects.create(
-                project=instance.project,
                 organization_id=instance.project.organization_id,
                 version=instance.value,
                 date_added=instance.first_seen,

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -15,27 +15,26 @@ def ensure_release_exists(instance, created, **kwargs):
         return
 
     with transaction.atomic():
-        release_qs = Release.objects.filter(
+        affected = Release.objects.filter(
             organization_id=instance.project.organization_id,
-            version=instance.value
-        )
-        release = Release.objects.filter(
-            organization_id=instance.project.organization_id,
-            version=instance.value
-        ).first()
-        if release_qs:
-            release = release_qs.filter(projects=instance.project).first()
-            if not release:
-                release = release_qs.first()
-            release.update(date_added=instance.first_seen)
-        else:
-            release = Release.objects.create(
+            version=instance.value,
+            projects=instance.project
+        ).update(date_added=instance.first_seen)
+        if not affected:
+            release = Release.objects.filter(
                 organization_id=instance.project.organization_id,
-                version=instance.value,
-                date_added=instance.first_seen,
-            )
-            instance.update(data={'release_id': release.id})
-    release.add_project(instance.project)
+                version=instance.value
+            ).first()
+            if release:
+                release.update(date_added=instance.first_seen)
+            else:
+                release = Release.objects.create(
+                    organization_id=instance.project.organization_id,
+                    version=instance.value,
+                    date_added=instance.first_seen,
+                )
+                instance.update(data={'release_id': release.id})
+            release.add_project(instance.project)
 
 
 def resolve_group_resolutions(instance, created, **kwargs):

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -36,7 +36,6 @@ class DjangoSearchBackend(SearchBackend):
 
         # for each remaining tag, find matches contained in our
         # existing set, pruning it down each iteration
-
         for k, v in tag_lookups:
             if v is EMPTY:
                 return None

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -36,6 +36,7 @@ class DjangoSearchBackend(SearchBackend):
 
         # for each remaining tag, find matches contained in our
         # existing set, pruning it down each iteration
+
         for k, v in tag_lookups:
             if v is EMPTY:
                 return None
@@ -131,7 +132,7 @@ class DjangoSearchBackend(SearchBackend):
             if first_release is EMPTY:
                 return queryset.none()
             queryset = queryset.filter(
-                first_release__project=project,
+                first_release__organization_id=project.organization_id,
                 first_release__version=first_release,
             )
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -21,7 +21,8 @@ def parse_release(project, value):
     # TODO(dcramer): add environment support
     if value == 'latest':
         value = Release.objects.filter(
-            project=project,
+            organization_id=project.organization_id,
+            projects=project,
         ).extra(select={
             'sort': 'COALESCE(date_released, date_added)',
         }).order_by('-sort').values_list('version', flat=True).first()

--- a/src/sentry/south_migrations/0284_auto__chg_field_release_project__chg_field_release_organization__chg_f.py
+++ b/src/sentry/south_migrations/0284_auto__chg_field_release_project__chg_field_release_organization__chg_f.py
@@ -1,0 +1,760 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Release.project'
+        db.alter_column('sentry_release', 'project_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Project'], null=True))
+
+        # Changing field 'Release.organization'
+        db.alter_column('sentry_release', 'organization_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Organization']))
+
+        # Changing field 'ReleaseFile.project'
+        db.alter_column('sentry_releasefile', 'project_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Project'], null=True))
+
+        # Changing field 'ReleaseFile.organization'
+        db.alter_column('sentry_releasefile', 'organization_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Organization']))
+
+        # Changing field 'ReleaseCommit.organization_id'
+        db.alter_column('sentry_releasecommit', 'organization_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'ReleaseCommit.project_id'
+        db.alter_column('sentry_releasecommit', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+
+        # Changing field 'ReleaseEnvironment.organization_id'
+        db.alter_column('sentry_environmentrelease', 'organization_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'ReleaseEnvironment.project_id'
+        db.alter_column('sentry_environmentrelease', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+
+    def backwards(self, orm):
+
+        # User chose to not deal with backwards NULL issues for 'Release.project'
+        raise RuntimeError("Cannot reverse this migration. 'Release.project' and its values cannot be restored.")
+
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'Release.project'
+        db.alter_column('sentry_release', 'project_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Project']))
+
+        # Changing field 'Release.organization'
+        db.alter_column('sentry_release', 'organization_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Organization'], null=True))
+
+        # User chose to not deal with backwards NULL issues for 'ReleaseFile.project'
+        raise RuntimeError("Cannot reverse this migration. 'ReleaseFile.project' and its values cannot be restored.")
+
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'ReleaseFile.project'
+        db.alter_column('sentry_releasefile', 'project_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Project']))
+
+        # Changing field 'ReleaseFile.organization'
+        db.alter_column('sentry_releasefile', 'organization_id', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(to=orm['sentry.Organization'], null=True))
+
+        # Changing field 'ReleaseCommit.organization_id'
+        db.alter_column('sentry_releasecommit', 'organization_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+
+        # User chose to not deal with backwards NULL issues for 'ReleaseCommit.project_id'
+        raise RuntimeError("Cannot reverse this migration. 'ReleaseCommit.project_id' and its values cannot be restored.")
+
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'ReleaseCommit.project_id'
+        db.alter_column('sentry_releasecommit', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'ReleaseEnvironment.organization_id'
+        db.alter_column('sentry_environmentrelease', 'organization_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+
+        # User chose to not deal with backwards NULL issues for 'ReleaseEnvironment.project_id'
+        raise RuntimeError("Cannot reverse this migration. 'ReleaseEnvironment.project_id' and its values cannot be restored.")
+
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'ReleaseEnvironment.project_id'
+        db.alter_column('sentry_environmentrelease', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+    models = {
+        'sentry.activity': {
+            'Meta': {'object_name': 'Activity'},
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True'})
+        },
+        'sentry.apikey': {
+            'Meta': {'object_name': 'ApiKey'},
+            'allowed_origins': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32'}),
+            'label': ('django.db.models.fields.CharField', [], {'default': "'Default'", 'max_length': '64', 'blank': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'key_set'", 'to': "orm['sentry.Organization']"}),
+            'scopes': ('django.db.models.fields.BigIntegerField', [], {'default': 'None'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
+        },
+        'sentry.apitoken': {
+            'Meta': {'object_name': 'ApiToken'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ApiKey']", 'null': 'True'}),
+            'scopes': ('django.db.models.fields.BigIntegerField', [], {'default': 'None'}),
+            'token': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.auditlogentry': {
+            'Meta': {'object_name': 'AuditLogEntry'},
+            'actor': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'blank': 'True', 'related_name': "'audit_actors'", 'null': 'True', 'to': "orm['sentry.User']"}),
+            'actor_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ApiKey']", 'null': 'True', 'blank': 'True'}),
+            'actor_label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'event': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'target_object': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'target_user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'blank': 'True', 'related_name': "'audit_targets'", 'null': 'True', 'to': "orm['sentry.User']"})
+        },
+        'sentry.authenticator': {
+            'Meta': {'unique_together': "(('user', 'type'),)", 'object_name': 'Authenticator', 'db_table': "'auth_authenticator'"},
+            'config': ('sentry.db.models.fields.pickle.UnicodePickledObjectField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedAutoField', [], {'primary_key': 'True'}),
+            'last_used_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.authidentity': {
+            'Meta': {'unique_together': "(('auth_provider', 'ident'), ('auth_provider', 'user'))", 'object_name': 'AuthIdentity'},
+            'auth_provider': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.AuthProvider']"}),
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'last_synced': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_verified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.authprovider': {
+            'Meta': {'object_name': 'AuthProvider'},
+            'config': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'default_global_access': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'default_role': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '50'}),
+            'default_teams': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.Team']", 'symmetrical': 'False', 'blank': 'True'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_sync': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']", 'unique': 'True'}),
+            'provider': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'sync_time': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'})
+        },
+        'sentry.broadcast': {
+            'Meta': {'object_name': 'Broadcast'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_expires': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2016, 12, 27, 0, 0)', 'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'link': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'upstream_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'})
+        },
+        'sentry.broadcastseen': {
+            'Meta': {'unique_together': "(('broadcast', 'user'),)", 'object_name': 'BroadcastSeen'},
+            'broadcast': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Broadcast']"}),
+            'date_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.commit': {
+            'Meta': {'unique_together': "(('repository_id', 'key'),)", 'object_name': 'Commit', 'index_together': "(('repository_id', 'date_added'),)"},
+            'author': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.CommitAuthor']", 'null': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'message': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'repository_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.commitauthor': {
+            'Meta': {'unique_together': "(('organization_id', 'email'),)", 'object_name': 'CommitAuthor'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'sentry.commitfilechange': {
+            'Meta': {'unique_together': "(('commit', 'filename'),)", 'object_name': 'CommitFileChange'},
+            'commit': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Commit']"}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '1'})
+        },
+        'sentry.counter': {
+            'Meta': {'object_name': 'Counter', 'db_table': "'sentry_projectcounter'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'unique': 'True'}),
+            'value': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.dsymbundle': {
+            'Meta': {'object_name': 'DSymBundle'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'object': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.DSymObject']"}),
+            'sdk': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.DSymSDK']"})
+        },
+        'sentry.dsymobject': {
+            'Meta': {'object_name': 'DSymObject'},
+            'cpu_name': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'object_path': ('django.db.models.fields.TextField', [], {'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '36', 'db_index': 'True'}),
+            'vmaddr': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'vmsize': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'})
+        },
+        'sentry.dsymsdk': {
+            'Meta': {'object_name': 'DSymSDK', 'index_together': "[('version_major', 'version_minor', 'version_patchlevel', 'version_build')]"},
+            'dsym_type': ('django.db.models.fields.CharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'sdk_name': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'version_build': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'version_major': ('django.db.models.fields.IntegerField', [], {}),
+            'version_minor': ('django.db.models.fields.IntegerField', [], {}),
+            'version_patchlevel': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'sentry.dsymsymbol': {
+            'Meta': {'unique_together': "[('object', 'address')]", 'object_name': 'DSymSymbol'},
+            'address': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'object': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.DSymObject']"}),
+            'symbol': ('django.db.models.fields.TextField', [], {})
+        },
+        'sentry.environment': {
+            'Meta': {'unique_together': "(('project_id', 'name'),)", 'object_name': 'Environment'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.event': {
+            'Meta': {'unique_together': "(('project_id', 'event_id'),)", 'object_name': 'Event', 'db_table': "'sentry_message'", 'index_together': "(('group_id', 'datetime'),)"},
+            'data': ('sentry.db.models.fields.node.NodeField', [], {'null': 'True', 'blank': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'db_column': "'message_id'"}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'time_spent': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'null': 'True'})
+        },
+        'sentry.eventmapping': {
+            'Meta': {'unique_together': "(('project_id', 'event_id'),)", 'object_name': 'EventMapping'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.eventtag': {
+            'Meta': {'unique_together': "(('event_id', 'key_id', 'value_id'),)", 'object_name': 'EventTag', 'index_together': "(('project_id', 'key_id', 'value_id'), ('group_id', 'key_id', 'value_id'))"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'event_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'value_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.eventuser': {
+            'Meta': {'unique_together': "(('project', 'ident'), ('project', 'hash'))", 'object_name': 'EventUser', 'index_together': "(('project', 'email'), ('project', 'username'), ('project', 'ip_address'))"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True'}),
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'})
+        },
+        'sentry.file': {
+            'Meta': {'object_name': 'File'},
+            'blob': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'legacy_blob'", 'null': 'True', 'to': "orm['sentry.FileBlob']"}),
+            'blobs': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.FileBlob']", 'through': "orm['sentry.FileBlobIndex']", 'symmetrical': 'False'}),
+            'checksum': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True'}),
+            'headers': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'path': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'size': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'sentry.fileblob': {
+            'Meta': {'object_name': 'FileBlob'},
+            'checksum': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'path': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'size': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'})
+        },
+        'sentry.fileblobindex': {
+            'Meta': {'unique_together': "(('file', 'blob', 'offset'),)", 'object_name': 'FileBlobIndex'},
+            'blob': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.FileBlob']"}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'offset': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.globaldsymfile': {
+            'Meta': {'object_name': 'GlobalDSymFile'},
+            'cpu_name': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'object_name': ('django.db.models.fields.TextField', [], {}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'})
+        },
+        'sentry.group': {
+            'Meta': {'unique_together': "(('project', 'short_id'),)", 'object_name': 'Group', 'db_table': "'sentry_groupedmessage'", 'index_together': "(('project', 'first_release'),)"},
+            'active_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'culprit': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'db_column': "'view'", 'blank': 'True'}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True', 'blank': 'True'}),
+            'first_release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.NullBooleanField', [], {'default': 'False', 'null': 'True', 'blank': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'level': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '40', 'db_index': 'True', 'blank': 'True'}),
+            'logger': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64', 'db_index': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'num_comments': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'resolved_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'score': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'default': '0'}),
+            'short_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'time_spent_count': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'default': '0'}),
+            'time_spent_total': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'default': '0'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '1', 'db_index': 'True'})
+        },
+        'sentry.groupassignee': {
+            'Meta': {'object_name': 'GroupAssignee', 'db_table': "'sentry_groupasignee'"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'assignee_set'", 'unique': 'True', 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'assignee_set'", 'to': "orm['sentry.Project']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'sentry_assignee_set'", 'to': "orm['sentry.User']"})
+        },
+        'sentry.groupbookmark': {
+            'Meta': {'unique_together': "(('project', 'user', 'group'),)", 'object_name': 'GroupBookmark'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'bookmark_set'", 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'bookmark_set'", 'to': "orm['sentry.Project']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'sentry_bookmark_set'", 'to': "orm['sentry.User']"})
+        },
+        'sentry.groupemailthread': {
+            'Meta': {'unique_together': "(('email', 'group'), ('email', 'msgid'))", 'object_name': 'GroupEmailThread'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'groupemail_set'", 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'msgid': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'groupemail_set'", 'to': "orm['sentry.Project']"})
+        },
+        'sentry.grouphash': {
+            'Meta': {'unique_together': "(('project', 'hash'),)", 'object_name': 'GroupHash'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'null': 'True'}),
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'})
+        },
+        'sentry.groupmeta': {
+            'Meta': {'unique_together': "(('group', 'key'),)", 'object_name': 'GroupMeta'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'sentry.groupredirect': {
+            'Meta': {'object_name': 'GroupRedirect'},
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'previous_group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'unique': 'True'})
+        },
+        'sentry.grouprelease': {
+            'Meta': {'unique_together': "(('group_id', 'release_id', 'environment'),)", 'object_name': 'GroupRelease'},
+            'environment': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'release_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'sentry.groupresolution': {
+            'Meta': {'object_name': 'GroupResolution'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'unique': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.grouprulestatus': {
+            'Meta': {'unique_together': "(('rule', 'group'),)", 'object_name': 'GroupRuleStatus'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_active': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'rule': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Rule']"}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'})
+        },
+        'sentry.groupseen': {
+            'Meta': {'unique_together': "(('user', 'group'),)", 'object_name': 'GroupSeen'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'db_index': 'False'})
+        },
+        'sentry.groupsnooze': {
+            'Meta': {'object_name': 'GroupSnooze'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'unique': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'until': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'sentry.groupsubscription': {
+            'Meta': {'unique_together': "(('group', 'user'),)", 'object_name': 'GroupSubscription'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'subscription_set'", 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'subscription_set'", 'to': "orm['sentry.Project']"}),
+            'reason': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.grouptagkey': {
+            'Meta': {'unique_together': "(('project', 'group', 'key'),)", 'object_name': 'GroupTagKey'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.grouptagvalue': {
+            'Meta': {'unique_together': "(('group', 'key', 'value'),)", 'object_name': 'GroupTagValue', 'db_table': "'sentry_messagefiltervalue'", 'index_together': "(('project', 'key', 'value', 'last_seen'),)"},
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'grouptag'", 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'grouptag'", 'null': 'True', 'to': "orm['sentry.Project']"}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        'sentry.lostpasswordhash': {
+            'Meta': {'object_name': 'LostPasswordHash'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'unique': 'True'})
+        },
+        'sentry.option': {
+            'Meta': {'object_name': 'Option'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'value': ('sentry.db.models.fields.pickle.UnicodePickledObjectField', [], {})
+        },
+        'sentry.organization': {
+            'Meta': {'object_name': 'Organization'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'default_role': ('django.db.models.fields.CharField', [], {'default': "'member'", 'max_length': '32'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '1'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'org_memberships'", 'symmetrical': 'False', 'through': "orm['sentry.OrganizationMember']", 'to': "orm['sentry.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.organizationaccessrequest': {
+            'Meta': {'unique_together': "(('team', 'member'),)", 'object_name': 'OrganizationAccessRequest'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'member': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.OrganizationMember']"}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Team']"})
+        },
+        'sentry.organizationmember': {
+            'Meta': {'unique_together': "(('organization', 'user'), ('organization', 'email'))", 'object_name': 'OrganizationMember'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'has_global_access': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'member_set'", 'to': "orm['sentry.Organization']"}),
+            'role': ('django.db.models.fields.CharField', [], {'default': "'member'", 'max_length': '32'}),
+            'teams': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.Team']", 'symmetrical': 'False', 'through': "orm['sentry.OrganizationMemberTeam']", 'blank': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'max_length': '64', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '50', 'blank': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'blank': 'True', 'related_name': "'sentry_orgmember_set'", 'null': 'True', 'to': "orm['sentry.User']"})
+        },
+        'sentry.organizationmemberteam': {
+            'Meta': {'unique_together': "(('team', 'organizationmember'),)", 'object_name': 'OrganizationMemberTeam', 'db_table': "'sentry_organizationmember_teams'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organizationmember': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.OrganizationMember']"}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Team']"})
+        },
+        'sentry.organizationonboardingtask': {
+            'Meta': {'unique_together': "(('organization', 'task'),)", 'object_name': 'OrganizationOnboardingTask'},
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'task': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True'})
+        },
+        'sentry.organizationoption': {
+            'Meta': {'unique_together': "(('organization', 'key'),)", 'object_name': 'OrganizationOption', 'db_table': "'sentry_organizationoptions'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'value': ('sentry.db.models.fields.pickle.UnicodePickledObjectField', [], {})
+        },
+        'sentry.project': {
+            'Meta': {'unique_together': "(('team', 'slug'), ('organization', 'slug'))", 'object_name': 'Project'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'first_event': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'forced_color': ('django.db.models.fields.CharField', [], {'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Team']"})
+        },
+        'sentry.projectbookmark': {
+            'Meta': {'unique_together': "(('project_id', 'user'),)", 'object_name': 'ProjectBookmark'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.projectdsymfile': {
+            'Meta': {'unique_together': "(('project', 'uuid'),)", 'object_name': 'ProjectDSymFile'},
+            'cpu_name': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'object_name': ('django.db.models.fields.TextField', [], {}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '36'})
+        },
+        'sentry.projectkey': {
+            'Meta': {'object_name': 'ProjectKey'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'key_set'", 'to': "orm['sentry.Project']"}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'unique': 'True', 'null': 'True'}),
+            'roles': ('django.db.models.fields.BigIntegerField', [], {'default': '1'}),
+            'secret_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'unique': 'True', 'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
+        },
+        'sentry.projectoption': {
+            'Meta': {'unique_together': "(('project', 'key'),)", 'object_name': 'ProjectOption', 'db_table': "'sentry_projectoptions'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'value': ('sentry.db.models.fields.pickle.UnicodePickledObjectField', [], {})
+        },
+        'sentry.projectplatform': {
+            'Meta': {'unique_together': "(('project_id', 'platform'),)", 'object_name': 'ProjectPlatform'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.release': {
+            'Meta': {'unique_together': "(('project', 'version'),)", 'object_name': 'Release'},
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_released': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_started': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'new_groups': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'owner': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True', 'blank': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'projects': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'releases'", 'symmetrical': 'False', 'through': "orm['sentry.ReleaseProject']", 'to': "orm['sentry.Project']"}),
+            'ref': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'sentry.releasecommit': {
+            'Meta': {'unique_together': "(('release', 'commit'), ('release', 'order'))", 'object_name': 'ReleaseCommit'},
+            'commit': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Commit']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'order': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.releaseenvironment': {
+            'Meta': {'unique_together': "(('project_id', 'release_id', 'environment_id'),)", 'object_name': 'ReleaseEnvironment', 'db_table': "'sentry_environmentrelease'"},
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'release_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'sentry.releasefile': {
+            'Meta': {'unique_together': "(('release', 'ident'),)", 'object_name': 'ReleaseFile'},
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.releaseproject': {
+            'Meta': {'unique_together': "(('project', 'release'),)", 'object_name': 'ReleaseProject', 'db_table': "'sentry_release_project'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.repository': {
+            'Meta': {'unique_together': "(('organization_id', 'name'), ('organization_id', 'provider', 'external_id'))", 'object_name': 'Repository'},
+            'config': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'provider': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True'})
+        },
+        'sentry.rule': {
+            'Meta': {'object_name': 'Rule'},
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
+        },
+        'sentry.savedsearch': {
+            'Meta': {'unique_together': "(('project', 'name'),)", 'object_name': 'SavedSearch'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'query': ('django.db.models.fields.TextField', [], {})
+        },
+        'sentry.savedsearchuserdefault': {
+            'Meta': {'unique_together': "(('project', 'user'),)", 'object_name': 'SavedSearchUserDefault', 'db_table': "'sentry_savedsearch_userdefault'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'savedsearch': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.SavedSearch']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.tagkey': {
+            'Meta': {'unique_together': "(('project', 'key'),)", 'object_name': 'TagKey', 'db_table': "'sentry_filterkey'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.tagvalue': {
+            'Meta': {'unique_together': "(('project', 'key', 'value'),)", 'object_name': 'TagValue', 'db_table': "'sentry_filtervalue'"},
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True', 'blank': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        'sentry.team': {
+            'Meta': {'unique_together': "(('organization', 'slug'),)", 'object_name': 'Team'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.user': {
+            'Meta': {'object_name': 'User', 'db_table': "'auth_user'"},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_managed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_password_expired': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_password_change': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_column': "'first_name'", 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'session_nonce': ('django.db.models.fields.CharField', [], {'max_length': '12', 'null': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'})
+        },
+        'sentry.useravatar': {
+            'Meta': {'object_name': 'UserAvatar'},
+            'avatar_type': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'avatar'", 'unique': 'True', 'to': "orm['sentry.User']"})
+        },
+        'sentry.useremail': {
+            'Meta': {'unique_together': "(('user', 'email'),)", 'object_name': 'UserEmail'},
+            'date_hash_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'emails'", 'to': "orm['sentry.User']"}),
+            'validation_hash': ('django.db.models.fields.CharField', [], {'default': "u'zRneZlZYUDwSLskIM8PJXv4kS7MBpU7K'", 'max_length': '32'})
+        },
+        'sentry.useroption': {
+            'Meta': {'unique_together': "(('user', 'project', 'key'),)", 'object_name': 'UserOption'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"}),
+            'value': ('sentry.db.models.fields.pickle.UnicodePickledObjectField', [], {})
+        },
+        'sentry.userreport': {
+            'Meta': {'unique_together': "(('project', 'event_id'),)", 'object_name': 'UserReport', 'index_together': "(('project', 'event_id'), ('project', 'date_added'))"},
+            'comments': ('django.db.models.fields.TextField', [], {}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        }
+    }
+
+    complete_apps = ['sentry']

--- a/src/sentry/south_migrations/0284_auto__chg_field_release_project__chg_field_release_organization__chg_f.py
+++ b/src/sentry/south_migrations/0284_auto__chg_field_release_project__chg_field_release_organization__chg_f.py
@@ -30,9 +30,6 @@ class Migration(SchemaMigration):
         # Changing field 'ReleaseEnvironment.organization_id'
         db.alter_column('sentry_environmentrelease', 'organization_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
 
-        # Changing field 'ReleaseEnvironment.project_id'
-        db.alter_column('sentry_environmentrelease', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
-
     def backwards(self, orm):
 
         # User chose to not deal with backwards NULL issues for 'Release.project'
@@ -67,13 +64,6 @@ class Migration(SchemaMigration):
 
         # Changing field 'ReleaseEnvironment.organization_id'
         db.alter_column('sentry_environmentrelease', 'organization_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
-
-        # User chose to not deal with backwards NULL issues for 'ReleaseEnvironment.project_id'
-        raise RuntimeError("Cannot reverse this migration. 'ReleaseEnvironment.project_id' and its values cannot be restored.")
-
-        # The following code is provided here to aid in writing a correct migration
-        # Changing field 'ReleaseEnvironment.project_id'
-        db.alter_column('sentry_environmentrelease', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
 
     models = {
         'sentry.activity': {
@@ -158,7 +148,7 @@ class Migration(SchemaMigration):
         'sentry.broadcast': {
             'Meta': {'object_name': 'Broadcast'},
             'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'date_expires': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2016, 12, 27, 0, 0)', 'null': 'True', 'blank': 'True'}),
+            'date_expires': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2017, 1, 17, 0, 0)', 'null': 'True', 'blank': 'True'}),
             'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
             'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
             'link': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
@@ -617,7 +607,7 @@ class Migration(SchemaMigration):
             'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
             'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
             'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
-            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
             'release_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'})
         },
         'sentry.releasefile': {
@@ -734,7 +724,7 @@ class Migration(SchemaMigration):
             'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
             'is_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'emails'", 'to': "orm['sentry.User']"}),
-            'validation_hash': ('django.db.models.fields.CharField', [], {'default': "u'zRneZlZYUDwSLskIM8PJXv4kS7MBpU7K'", 'max_length': '32'})
+            'validation_hash': ('django.db.models.fields.CharField', [], {'default': "u'R6zOiWKMO0GUE2e6HGMyFwPxDqc7hR7E'", 'max_length': '32'})
         },
         'sentry.useroption': {
             'Meta': {'unique_together': "(('user', 'project', 'key'),)", 'object_name': 'UserOption'},

--- a/src/sentry/tasks/clear_expired_resolutions.py
+++ b/src/sentry/tasks/clear_expired_resolutions.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 
 from sentry.models import (
-    Activity, GroupResolution, GroupResolutionStatus, Project, Release
+    Activity, GroupResolution, GroupResolutionStatus, Release
 )
 from sentry.tasks.base import instrumented_task
 
@@ -22,12 +22,8 @@ def clear_expired_resolutions(release_id):
     except Release.DoesNotExist:
         return
 
-    project = Project.objects.get_from_cache(
-        id=release.project_id,
-    )
-
     resolution_list = GroupResolution.objects.filter(
-        release__project=project,
+        release__projects=release.projects.all(),
         release__date_added__lt=release.date_added,
     ).exclude(
         release=release,

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -27,7 +27,8 @@ logger = logging.getLogger('sentry.deletions.async')
 def delete_organization(object_id, transaction_id=None, continuous=True, **kwargs):
     from sentry.models import (
         Organization, OrganizationMember, OrganizationStatus, Team, TeamStatus,
-        Commit, CommitAuthor, CommitFileChange, Release, Repository
+        Commit, CommitAuthor, CommitFileChange, Release, ReleaseCommit, ReleaseEnvironment,
+        ReleaseFile, Repository
     )
 
     try:
@@ -53,7 +54,8 @@ def delete_organization(object_id, transaction_id=None, continuous=True, **kwarg
         return
 
     model_list = (
-        OrganizationMember, CommitFileChange, Commit, CommitAuthor, Repository, Release
+        OrganizationMember, CommitFileChange, Commit, CommitAuthor,
+        Repository, Release, ReleaseCommit, ReleaseEnvironment, ReleaseFile
     )
 
     has_more = delete_objects(
@@ -125,8 +127,8 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
         GroupEmailThread, GroupHash, GroupMeta, GroupRelease, GroupResolution,
         GroupRuleStatus, GroupSeen, GroupSubscription, GroupSnooze, GroupTagKey,
         GroupTagValue, Project, ProjectBookmark, ProjectKey, ProjectStatus,
-        ReleaseProject, ReleaseFile, SavedSearchUserDefault, SavedSearch, TagKey,
-        TagValue, UserReport, ReleaseEnvironment, Environment, ReleaseCommit
+        ReleaseProject, SavedSearchUserDefault, SavedSearch, TagKey,
+        TagValue, UserReport, Environment
     )
 
     try:
@@ -156,7 +158,7 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
         GroupEmailThread, GroupHash, GroupRelease, GroupRuleStatus, GroupSeen,
         GroupSubscription, GroupTagKey, GroupTagValue, ProjectBookmark,
         ProjectKey, TagKey, TagValue, SavedSearchUserDefault, SavedSearch,
-        UserReport, ReleaseEnvironment, Environment, ReleaseCommit
+        UserReport, Environment
     )
     for model in model_list:
         has_more = bulk_delete_objects(model, project_id=p.id, transaction_id=transaction_id, logger=logger)
@@ -192,7 +194,7 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
 
     # Release needs to handle deletes after Group is cleaned up as the foreign
     # key is protected
-    model_list = (Group, ReleaseFile, ReleaseProject)
+    model_list = (Group, ReleaseProject)
     for model in model_list:
         has_more = bulk_delete_objects(model, project_id=p.id, transaction_id=transaction_id, logger=logger)
         if has_more:

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('sentry.deletions.async')
 def delete_organization(object_id, transaction_id=None, continuous=True, **kwargs):
     from sentry.models import (
         Organization, OrganizationMember, OrganizationStatus, Team, TeamStatus,
-        Commit, CommitAuthor, CommitFileChange, Release, ReleaseCommit, ReleaseEnvironment,
+        Commit, CommitAuthor, CommitFileChange, Release, ReleaseCommit,
         ReleaseFile, Repository
     )
 
@@ -55,7 +55,7 @@ def delete_organization(object_id, transaction_id=None, continuous=True, **kwarg
 
     model_list = (
         OrganizationMember, CommitFileChange, Commit, CommitAuthor,
-        Repository, Release, ReleaseCommit, ReleaseEnvironment, ReleaseFile
+        Repository, Release, ReleaseCommit, ReleaseFile
     )
 
     has_more = delete_objects(
@@ -127,8 +127,8 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
         GroupEmailThread, GroupHash, GroupMeta, GroupRelease, GroupResolution,
         GroupRuleStatus, GroupSeen, GroupSubscription, GroupSnooze, GroupTagKey,
         GroupTagValue, Project, ProjectBookmark, ProjectKey, ProjectStatus,
-        ReleaseProject, SavedSearchUserDefault, SavedSearch, TagKey,
-        TagValue, UserReport, Environment
+        ReleaseEnvironment, ReleaseProject, SavedSearchUserDefault, SavedSearch,
+        TagKey, TagValue, UserReport, Environment
     )
 
     try:
@@ -158,7 +158,7 @@ def delete_project(object_id, transaction_id=None, continuous=True, **kwargs):
         GroupEmailThread, GroupHash, GroupRelease, GroupRuleStatus, GroupSeen,
         GroupSubscription, GroupTagKey, GroupTagValue, ProjectBookmark,
         ProjectKey, TagKey, TagValue, SavedSearchUserDefault, SavedSearch,
-        UserReport, Environment
+        UserReport, ReleaseEnvironment, Environment
     )
     for model in model_list:
         has_more = bulk_delete_objects(model, project_id=p.id, transaction_id=transaction_id, logger=logger)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -158,7 +158,7 @@ def record_affected_user(event, **kwargs):
 @instrumented_task(
     name='sentry.tasks.index_event_tags',
     default_retry_delay=60 * 5, max_retries=None)
-def index_event_tags(project_id, event_id, tags, group_id=None, **kwargs):
+def index_event_tags(organization_id, project_id, event_id, tags, group_id=None, **kwargs):
     from sentry.models import EventTag, Project, TagKey, TagValue
 
     Raven.tags_context({
@@ -172,7 +172,7 @@ def index_event_tags(project_id, event_id, tags, group_id=None, **kwargs):
         )
 
         tagvalue, _ = TagValue.objects.get_or_create(
-            project=Project(id=project_id),
+            project=Project(id=project_id, organization_id=organization_id),
             key=key,
             value=value,
         )

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -308,13 +308,11 @@ class MockUtils(object):
         from sentry.models import Release, Activity
         if version is None:
             version = os.urandom(20).encode('hex')
-        release, created = Release.objects.get_or_create(
+        release = Release.objects.get_or_create(
             version=version,
-            project=project,
-            defaults={'organization_id': project.organization_id}
+            organization_id=project.organization_id,
         )
-        if created:
-            release.add_project(project)
+        release.add_project(project)
         Activity.objects.create(
             type=Activity.RELEASE,
             project=project,

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -338,7 +338,7 @@ class MockUtils(object):
         )
         f.putfile(StringIO(contents or ''))
         return ReleaseFile.objects.create(
-            project=project,
+            organization_id=project.organization_id,
             release=release,
             file=f,
             name=path

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -310,20 +310,22 @@ class MockUtils(object):
         if version is None:
             version = os.urandom(20).encode('hex')
         with transaction.atomic():
-            release_qs = Release.objects.filter(
+            release = Release.objects.filter(
                 version=version,
                 organization_id=project.organization_id,
-            )
-            if release_qs:
-                release = release_qs.filter(projects=project).first()
-                if not release:
-                    release = release_qs.first()
-            else:
-                release = Release.objects.create(
+                projects=project
+            ).first()
+            if not release:
+                release = Release.objects.filter(
                     version=version,
                     organization_id=project.organization_id,
-                )
-        release.add_project(project)
+                ).first()
+                if not release:
+                    release = Release.objects.create(
+                        version=version,
+                        organization_id=project.organization_id,
+                    )
+                release.add_project(project)
         Activity.objects.create(
             type=Activity.RELEASE,
             project=project,

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -30,7 +30,6 @@ class GroupDetailsTest(APITestCase):
 
         group = self.create_group()
         release = Release.objects.create(
-            project=group.project,
             organization_id=group.project.organization_id,
             version='1.0',
         )

--- a/tests/sentry/api/endpoints/test_group_environment_details.py
+++ b/tests/sentry/api/endpoints/test_group_environment_details.py
@@ -48,7 +48,6 @@ class GroupEnvironmentDetailsTest(APITestCase):
         )
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='abcdef',
         )

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -337,8 +337,7 @@ class GroupUpdateTest(APITestCase):
         assert new_group4.status == GroupStatus.UNRESOLVED
 
     def test_set_resolved_in_next_release(self):
-        release = Release.objects.create(project=self.project,
-                                         organization_id=self.project.organization_id,
+        release = Release.objects.create(organization_id=self.project.organization_id,
                                          version='a')
         release.add_project(self.project)
 

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -1,16 +1,22 @@
 from __future__ import absolute_import
 
+import json
+
 from datetime import timedelta
 from uuid import uuid4
 
+
 import six
+from six.moves.urllib.parse import quote
+
 from django.utils import timezone
 from exam import fixture
 from mock import patch
 
 from sentry.models import (
-    Activity, EventMapping, Group, GroupBookmark, GroupHash, GroupResolution,
-    GroupSeen, GroupSnooze, GroupStatus, GroupSubscription, Release
+    Activity, EventMapping, Group, GroupBookmark, GroupHash, GroupTagValue,
+    GroupResolution, GroupSeen, GroupSnooze, GroupStatus, GroupSubscription,
+    Release
 )
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import parse_link_header
@@ -219,6 +225,62 @@ class GroupListTest(APITestCase):
                                    format='json')
         assert response.status_code == 200
         assert len(response.data) == 0
+
+    def test_lookup_by_first_release(self):
+        self.login_as(self.user)
+        project = self.project
+        project2 = self.create_project(name='baz',
+                                       organization=project.organization)
+        release = Release.objects.create(organization=project.organization,
+                                         version='12345')
+        release.add_project(project)
+        release.add_project(project2)
+        group = self.create_group(checksum='a' * 32,
+                                  project=project,
+                                  first_release=release)
+        self.create_group(checksum='b' * 32,
+                          project=project2,
+                          first_release=release)
+        url = '%s?query=%s' % (self.path, quote('first-release:"%s"' % release.version))
+        response = self.client.get(url, format='json')
+        issues = json.loads(response.content)
+        assert response.status_code == 200
+        assert len(issues) == 1
+        assert int(issues[0]['id']) == group.id
+
+    def test_lookup_by_release(self):
+        self.login_as(self.user)
+        project = self.project
+        project2 = self.create_project(name='baz',
+                                       organization=project.organization)
+        release = Release.objects.create(organization=project.organization,
+                                         version='12345')
+        release.add_project(project)
+        release.add_project(project2)
+        group = self.create_group(checksum='a' * 32,
+                                  project=project)
+        group2 = self.create_group(checksum='b' * 32,
+                                   project=project2)
+        GroupTagValue.objects.create(
+            project=project,
+            group=group,
+            key='sentry:release',
+            value=release.version
+        )
+
+        GroupTagValue.objects.create(
+            project=project2,
+            group=group2,
+            key='sentry:release',
+            value=release.version
+        )
+
+        url = '%s?query=%s' % (self.path, quote('release:"%s"' % release.version))
+        response = self.client.get(url, format='json')
+        issues = json.loads(response.content)
+        assert response.status_code == 200
+        assert len(issues) == 1
+        assert int(issues[0]['id']) == group.id
 
 
 class GroupUpdateTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -5,7 +5,6 @@ import json
 from datetime import timedelta
 from uuid import uuid4
 
-
 import six
 from six.moves.urllib.parse import quote
 

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -16,7 +16,6 @@ class ProjectReleaseListTest(APITestCase):
         project2 = self.create_project(team=team, name='bar')
 
         release1 = Release.objects.create(
-            project=project1,
             organization_id=project1.organization_id,
             version='1',
             date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
@@ -24,7 +23,6 @@ class ProjectReleaseListTest(APITestCase):
         release1.add_project(project1)
 
         release2 = Release.objects.create(
-            project=project1,
             organization_id=project1.organization_id,
             version='2',
             date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
@@ -32,7 +30,6 @@ class ProjectReleaseListTest(APITestCase):
         release2.add_project(project1)
 
         release3 = Release.objects.create(
-            project=project1,
             organization_id=project1.organization_id,
             version='3',
             date_added=datetime(2013, 8, 12, 3, 8, 24, 880386),
@@ -41,7 +38,6 @@ class ProjectReleaseListTest(APITestCase):
         release3.add_project(project1)
 
         release4 = Release.objects.create(
-            project=project2,
             organization_id=project2.organization_id,
             version='1',
         )
@@ -66,7 +62,6 @@ class ProjectReleaseListTest(APITestCase):
         project = self.create_project(team=team, name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='foobar',
             date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
@@ -107,7 +102,6 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.data['version']
 
         release = Release.objects.get(
-            project=project,
             version=response.data['version'],
         )
         assert not release.owner
@@ -120,7 +114,6 @@ class ProjectReleaseCreateTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(version='1.2.1',
-                                         project=project,
                                          organization_id=project.organization_id)
         release.add_project(project)
 
@@ -177,7 +170,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.data['version'] == '1.2.3'
 
         release = Release.objects.get(
-            project=project,
+            organization_id=project.organization_id,
             version=response.data['version'],
         )
         assert not release.owner
@@ -200,7 +193,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.data['version']
 
         release = Release.objects.get(
-            project=project,
+            organization_id=project.organization_id,
             version=response.data['version'],
         )
         assert release.owner == self.user
@@ -226,7 +219,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.data['version']
 
         release = Release.objects.get(
-            project=project,
+            organization_id=project.organization_id,
             version=response.data['version'],
         )
 

--- a/tests/sentry/api/endpoints/test_release_commits.py
+++ b/tests/sentry/api/endpoints/test_release_commits.py
@@ -32,14 +32,12 @@ class ReleaseCommitsListTest(APITestCase):
         )
         ReleaseCommit.objects.create(
             organization_id=project.organization_id,
-            project_id=project.id,
             release=release,
             commit=commit,
             order=1,
         )
         ReleaseCommit.objects.create(
             organization_id=project.organization_id,
-            project_id=project.id,
             release=release,
             commit=commit2,
             order=0,

--- a/tests/sentry/api/endpoints/test_release_commits.py
+++ b/tests/sentry/api/endpoints/test_release_commits.py
@@ -12,7 +12,6 @@ class ReleaseCommitsListTest(APITestCase):
             name='foo',
         )
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )

--- a/tests/sentry/api/endpoints/test_release_details.py
+++ b/tests/sentry/api/endpoints/test_release_details.py
@@ -15,7 +15,6 @@ class ReleaseDetailsTest(APITestCase):
 
         project = self.create_project(name='foo')
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -38,7 +37,6 @@ class UpdateReleaseDetailsTest(APITestCase):
 
         project = self.create_project(name='foo')
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -63,7 +61,6 @@ class UpdateReleaseDetailsTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -96,7 +93,6 @@ class UpdateReleaseDetailsTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -130,7 +126,6 @@ class ReleaseDeleteTest(APITestCase):
 
         project = self.create_project(name='foo')
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -162,7 +157,6 @@ class ReleaseDeleteTest(APITestCase):
 
         project = self.create_project(name='foo')
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )

--- a/tests/sentry/api/endpoints/test_release_details.py
+++ b/tests/sentry/api/endpoints/test_release_details.py
@@ -132,7 +132,6 @@ class ReleaseDeleteTest(APITestCase):
         release.add_project(project)
         ReleaseFile.objects.create(
             organization_id=project.organization_id,
-            project=project,
             release=release,
             file=File.objects.create(
                 name='application.js',

--- a/tests/sentry/api/endpoints/test_release_details.py
+++ b/tests/sentry/api/endpoints/test_release_details.py
@@ -14,11 +14,15 @@ class ReleaseDetailsTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project(name='foo')
+        project2 = self.create_project(name='bar',
+                                       organization=project.organization)
+
         release = Release.objects.create(
             organization_id=project.organization_id,
             version='1',
         )
         release.add_project(project)
+        release.add_project(project2)
 
         url = reverse('sentry-api-0-release-details', kwargs={
             'organization_slug': project.organization.slug,
@@ -36,11 +40,15 @@ class UpdateReleaseDetailsTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project(name='foo')
+        project2 = self.create_project(name='bar',
+                                       organization=project.organization)
+
         release = Release.objects.create(
             organization_id=project.organization_id,
             version='1',
         )
         release.add_project(project)
+        release.add_project(project2)
 
         url = reverse('sentry-api-0-release-details', kwargs={
             'organization_slug': project.organization.slug,
@@ -59,12 +67,15 @@ class UpdateReleaseDetailsTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project(name='foo')
+        project2 = self.create_project(name='bar',
+                                       organization=project.organization)
 
         release = Release.objects.create(
             organization_id=project.organization_id,
             version='1',
         )
         release.add_project(project)
+        release.add_project(project2)
 
         url = reverse('sentry-api-0-release-details', kwargs={
             'organization_slug': project.organization.slug,
@@ -91,12 +102,15 @@ class UpdateReleaseDetailsTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project(name='foo')
+        project2 = self.create_project(name='bar',
+                                       organization=project.organization)
 
         release = Release.objects.create(
             organization_id=project.organization_id,
             version='1',
         )
         release.add_project(project)
+        release.add_project(project2)
 
         url = reverse('sentry-api-0-release-details', kwargs={
             'organization_slug': project.organization.slug,
@@ -125,11 +139,14 @@ class ReleaseDeleteTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project(name='foo')
+        project2 = self.create_project(name='bar',
+                                       organization=project.organization)
         release = Release.objects.create(
             organization_id=project.organization_id,
             version='1',
         )
         release.add_project(project)
+        release.add_project(project2)
         ReleaseFile.objects.create(
             organization_id=project.organization_id,
             release=release,
@@ -155,11 +172,14 @@ class ReleaseDeleteTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project(name='foo')
+        project2 = self.create_project(name='baz',
+                                       organization=project.organization)
         release = Release.objects.create(
             organization_id=project.organization_id,
             version='1',
         )
         release.add_project(project)
+        release.add_project(project2)
         self.create_group(first_release=release)
 
         url = reverse('sentry-api-0-release-details', kwargs={

--- a/tests/sentry/api/endpoints/test_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_release_file_details.py
@@ -15,7 +15,6 @@ class ReleaseFileDetailsTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -50,7 +49,6 @@ class ReleaseFileDetailsTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -98,7 +96,6 @@ class ReleaseFileUpdateTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )

--- a/tests/sentry/api/endpoints/test_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_release_file_details.py
@@ -22,7 +22,6 @@ class ReleaseFileDetailsTest(APITestCase):
 
         releasefile = ReleaseFile.objects.create(
             organization_id=project.organization_id,
-            project=project,
             release=release,
             file=File.objects.create(
                 name='application.js',
@@ -103,7 +102,6 @@ class ReleaseFileUpdateTest(APITestCase):
 
         releasefile = ReleaseFile.objects.create(
             organization_id=project.organization_id,
-            project=project,
             release=release,
             file=File.objects.create(
                 name='application.js',
@@ -146,7 +144,6 @@ class ReleaseFileDeleteTest(APITestCase):
 
         releasefile = ReleaseFile.objects.create(
             organization_id=project.organization_id,
-            project=project,
             release=release,
             file=File.objects.create(
                 name='application.js',

--- a/tests/sentry/api/endpoints/test_release_files.py
+++ b/tests/sentry/api/endpoints/test_release_files.py
@@ -14,7 +14,6 @@ class ReleaseFilesListTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -51,7 +50,6 @@ class ReleaseFileCreateTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -86,7 +84,6 @@ class ReleaseFileCreateTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -110,7 +107,6 @@ class ReleaseFileCreateTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -136,7 +132,6 @@ class ReleaseFileCreateTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )
@@ -163,7 +158,6 @@ class ReleaseFileCreateTest(APITestCase):
         project = self.create_project(name='foo')
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='1',
         )

--- a/tests/sentry/api/endpoints/test_release_files.py
+++ b/tests/sentry/api/endpoints/test_release_files.py
@@ -21,7 +21,6 @@ class ReleaseFilesListTest(APITestCase):
 
         releasefile = ReleaseFile.objects.create(
             organization_id=project.organization_id,
-            project=project,
             release=release,
             file=File.objects.create(
                 name='application.js',

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -49,7 +49,6 @@ class GroupSerializerTest(TestCase):
 
     def test_resolved_in_next_release(self):
         release = Release.objects.create(
-            project=self.project,
             organization_id=self.project.organization_id,
             version='a',
         )
@@ -69,7 +68,6 @@ class GroupSerializerTest(TestCase):
 
     def test_resolved_in_next_release_expired_resolution(self):
         release = Release.objects.create(
-            project=self.project,
             organization_id=self.project.organization_id,
             version='a',
         )

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -15,14 +15,13 @@ class ReleaseSerializerTest(TestCase):
         user = self.create_user()
         project = self.create_project()
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version=uuid4().hex,
             new_groups=1,
         )
         release.add_project(project)
         TagValue.objects.create(
-            project=release.project,
+            project=project,
             key='sentry:release',
             value=release.version,
             first_seen=timezone.now(),
@@ -46,7 +45,6 @@ class ReleaseSerializerTest(TestCase):
         user = self.create_user()
         project = self.create_project()
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version=uuid4().hex,
         )

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -455,7 +455,6 @@ class JavascriptIntegrationTest(TestCase):
     def test_expansion_via_release_artifacts(self):
         project = self.project
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='abc',
         )

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -475,7 +475,6 @@ class JavascriptIntegrationTest(TestCase):
         ReleaseFile.objects.create(
             name='~/{}?foo=bar'.format(f_minified.name),
             release=release,
-            project=project,
             organization_id=project.organization_id,
             file=f_minified,
         )
@@ -493,7 +492,6 @@ class JavascriptIntegrationTest(TestCase):
         ReleaseFile.objects.create(
             name='http://example.com/{}'.format(f1.name),
             release=release,
-            project=project,
             organization_id=project.organization_id,
             file=f1,
         )
@@ -510,7 +508,6 @@ class JavascriptIntegrationTest(TestCase):
         ReleaseFile.objects.create(
             name='http://example.com/{}'.format(f2.name),
             release=release,
-            project=project,
             organization_id=project.organization_id,
             file=f2,
         )
@@ -529,7 +526,6 @@ class JavascriptIntegrationTest(TestCase):
         ReleaseFile.objects.create(
             name='~/{}'.format(f2.name),  # intentionally using f2.name ("file2.js")
             release=release,
-            project=project,
             organization_id=project.organization_id,
             file=f2_empty,
         )
@@ -546,7 +542,6 @@ class JavascriptIntegrationTest(TestCase):
         ReleaseFile.objects.create(
             name='http://example.com/{}'.format(f_sourcemap.name),
             release=release,
-            project=project,
             organization_id=project.organization_id,
             file=f_sourcemap,
         )

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -52,7 +52,6 @@ class FetchReleaseFileTest(TestCase):
         ReleaseFile.objects.create(
             name='file.min.js',
             release=release,
-            project=project,
             organization_id=project.organization_id,
             file=file,
         )

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -35,7 +35,6 @@ class FetchReleaseFileTest(TestCase):
     def test_unicode(self):
         project = self.project
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='abc',
         )
@@ -142,8 +141,7 @@ class FetchFileTest(TestCase):
             None,
         )
 
-        release = Release.objects.create(project=self.project,
-                                         version='1',
+        release = Release.objects.create(version='1',
                                          organization_id=self.project.organization_id)
         release.add_project(self.project)
 

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -111,7 +111,6 @@ class GroupTest(TestCase):
         project = self.create_project()
         release = Release.objects.create(
             version='a',
-            project=project,
             organization_id=project.organization_id,
         )
         release.add_project(project)

--- a/tests/sentry/models/test_grouprelease.py
+++ b/tests/sentry/models/test_grouprelease.py
@@ -12,7 +12,6 @@ class GetOrCreateTest(TestCase):
         project = self.create_project()
         group = self.create_group(project=project)
         release = Release.objects.create(version='abc',
-                                         project=project,
                                          organization_id=project.organization_id)
         release.add_project(project)
         env = Environment.objects.create(project_id=project.id, name='prod')

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.models import (
-    OrganizationMember, OrganizationMemberTeam, Project, Team
+    OrganizationMember, OrganizationMemberTeam, Project, Release, Team
 )
 from sentry.testutils import TestCase
 
@@ -17,6 +17,8 @@ class OrganizationTest(TestCase):
             team=from_team_two,
             slug='bizzy',
         )
+        from_release = Release.objects.create(version='abcabcabc',
+                                              organization=from_org)
         from_user = self.create_user('baz@example.com')
         other_user = self.create_user('bizbaz@example.com')
         self.create_member(organization=from_org, user=from_user)
@@ -84,6 +86,8 @@ class OrganizationTest(TestCase):
         assert to_project_two.slug == 'bizzy'
         assert to_project_two.organization == to_org
         assert to_project_two.team == to_team_two
+
+        assert Release.objects.get(id=from_release.id).organization == to_org
 
     def test_get_default_owner(self):
         user = self.create_user('foo@example.com')

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 from sentry.models import (
-    OrganizationMember, OrganizationMemberTeam, Project, Release, Team
+    Commit, File, OrganizationMember, OrganizationMemberTeam,
+    Project, Release, ReleaseCommit, ReleaseEnvironment,
+    ReleaseFile, Team
 )
 from sentry.testutils import TestCase
 
@@ -19,6 +21,30 @@ class OrganizationTest(TestCase):
         )
         from_release = Release.objects.create(version='abcabcabc',
                                               organization=from_org)
+        from_release_file = ReleaseFile.objects.create(
+            release=from_release,
+            organization=from_org,
+            file=File.objects.create(name='foo.py', type='.py'),
+            ident='abcdefg',
+            name='foo.py'
+        )
+        from_commit = Commit.objects.create(
+            organization_id=from_org.id,
+            repository_id=1,
+            key='abcdefg'
+        )
+        from_release_commit = ReleaseCommit.objects.create(
+            release=from_release,
+            commit=from_commit,
+            order=1,
+            organization_id=from_org.id,
+        )
+        from_release_environment = ReleaseEnvironment.objects.create(
+            release_id=from_release.id,
+            project_id=from_project_two.id,
+            organization_id=from_org.id,
+            environment_id=1
+        )
         from_user = self.create_user('baz@example.com')
         other_user = self.create_user('bizbaz@example.com')
         self.create_member(organization=from_org, user=from_user)
@@ -88,6 +114,12 @@ class OrganizationTest(TestCase):
         assert to_project_two.team == to_team_two
 
         assert Release.objects.get(id=from_release.id).organization == to_org
+        assert ReleaseFile.objects.get(id=from_release_file.id).organization == to_org
+        assert Commit.objects.get(id=from_commit.id).organization_id == to_org.id
+        assert ReleaseCommit.objects.get(id=from_release_commit.id).organization_id == to_org.id
+        assert ReleaseEnvironment.objects.get(
+            id=from_release_environment.id
+        ).organization_id == to_org.id
 
     def test_get_default_owner(self):
         user = self.create_user('foo@example.com')

--- a/tests/sentry/models/test_releaseenvironment.py
+++ b/tests/sentry/models/test_releaseenvironment.py
@@ -28,7 +28,6 @@ class GetOrCreateTest(TestCase):
             datetime=datetime,
         )
 
-        assert relenv.project_id == project.id
         assert relenv.organization_id == project.organization_id
         assert relenv.release_id == release.id
         assert relenv.environment_id == env.id

--- a/tests/sentry/models/test_releaseenvironment.py
+++ b/tests/sentry/models/test_releaseenvironment.py
@@ -13,7 +13,6 @@ class GetOrCreateTest(TestCase):
         datetime = timezone.now()
 
         release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='abcdef',
         )

--- a/tests/sentry/plugins/interfaces/test_releasehook.py
+++ b/tests/sentry/plugins/interfaces/test_releasehook.py
@@ -24,7 +24,7 @@ class StartReleaseTest(TestCase):
         hook.start_release(version)
 
         release = Release.objects.get(
-            project=project,
+            organization_id=project.organization_id,
             version=version,
         )
         assert release.date_started
@@ -33,13 +33,15 @@ class StartReleaseTest(TestCase):
     def test_update_release(self):
         project = self.create_project()
         version = 'bbee5b51f84611e4b14834363b8514c2'
-        Release.objects.create(project=project, version=version)
+        r = Release.objects.create(organization_id=project.organization_id, version=version)
+        r.add_project(project)
 
         hook = ReleaseHook(project)
         hook.start_release(version)
 
         release = Release.objects.get(
-            project=project,
+            organization_id=project.organization_id,
+            projects=project,
             version=version,
         )
         assert release.date_started
@@ -55,7 +57,7 @@ class FinishReleaseTest(TestCase):
         hook.finish_release(version)
 
         release = Release.objects.get(
-            project=project,
+            organization_id=project.organization_id,
             version=version,
         )
         assert release.date_released
@@ -64,13 +66,14 @@ class FinishReleaseTest(TestCase):
     def test_update_release(self):
         project = self.create_project()
         version = 'bbee5b51f84611e4b14834363b8514c2'
-        Release.objects.create(project=project, version=version)
+        r = Release.objects.create(organization_id=project.organization_id, version=version)
+        r.add_project(project)
 
         hook = ReleaseHook(project)
         hook.start_release(version)
 
         release = Release.objects.get(
-            project=project,
+            projects=project,
             version=version,
         )
         assert release.date_started
@@ -98,7 +101,7 @@ class SetCommitsTest(TestCase):
         hook.set_commits(version, data_list)
 
         release = Release.objects.get(
-            project=project,
+            projects=project,
             version=version,
         )
         commit_list = list(Commit.objects.filter(

--- a/tests/sentry/plugins/interfaces/test_releasehook.py
+++ b/tests/sentry/plugins/interfaces/test_releasehook.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 
 __all__ = ['ReleaseHook']
 
-from sentry.models import Commit, Release
+from sentry.models import Commit, Release, ReleaseProject
 from sentry.plugins import ReleaseHook
 from sentry.testutils import TestCase
 
@@ -29,6 +29,7 @@ class StartReleaseTest(TestCase):
         )
         assert release.date_started
         assert release.organization
+        assert ReleaseProject.objects.get(release=release, project=project)
 
     def test_update_release(self):
         project = self.create_project()
@@ -62,6 +63,7 @@ class FinishReleaseTest(TestCase):
         )
         assert release.date_released
         assert release.organization
+        assert ReleaseProject.objects.get(release=release, project=project)
 
     def test_update_release(self):
         project = self.create_project()

--- a/tests/sentry/plugins/mail/activity/test_release.py
+++ b/tests/sentry/plugins/mail/activity/test_release.py
@@ -70,14 +70,12 @@ class ReleaseTestCase(TestCase):
         )
         ReleaseCommit.objects.create(
             organization_id=self.project.organization_id,
-            project_id=self.project.id,
             release=self.release,
             commit=self.commit,
             order=0,
         )
         ReleaseCommit.objects.create(
             organization_id=self.project.organization_id,
-            project_id=self.project.id,
             release=self.release,
             commit=self.commit2,
             order=1,

--- a/tests/sentry/plugins/mail/activity/test_release.py
+++ b/tests/sentry/plugins/mail/activity/test_release.py
@@ -40,7 +40,6 @@ class ReleaseTestCase(TestCase):
         )
         self.release = Release.objects.create(
             version='a' * 40,
-            project_id=self.project.id,
             organization_id=self.project.organization_id,
             date_released=timezone.now(),
         )

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -21,9 +21,8 @@ class EnsureReleaseExistsTest(TestCase):
             id=tv.data['release_id']
         )
         assert release.version == tv.value
-        assert release.project == self.project
-        assert release.organization == self.project.organization
         assert release.projects.first() == self.project
+        assert release.organization == self.project.organization
 
         # ensure we dont hit some kind of error saving it again
         tv.save()
@@ -34,7 +33,6 @@ class ResolveGroupResolutions(TestCase):
     def test_simple(self, mock_delay):
         release = Release.objects.create(
             version='a',
-            project=self.project,
             organization_id=self.project.organization_id,
         )
         release.add_project(self.project)

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -81,13 +81,12 @@ class ParseQueryTest(TestCase):
 
     def test_first_release_latest(self):
         old = Release.objects.create(
-            project=self.project,
             organization_id=self.project.organization_id,
             version='a'
         )
         old.add_project(self.project)
         new = Release.objects.create(
-            project=self.project, version='b',
+            version='b',
             organization_id=self.project.organization_id,
             date_released=old.date_added + timedelta(minutes=1),
         )
@@ -102,13 +101,12 @@ class ParseQueryTest(TestCase):
 
     def test_release_latest(self):
         old = Release.objects.create(
-            project=self.project,
             organization_id=self.project.organization_id,
             version='a'
         )
         old.add_project(self.project)
         new = Release.objects.create(
-            project=self.project, version='b',
+            version='b',
             organization_id=self.project.organization_id,
             date_released=old.date_added + timedelta(minutes=1),
         )

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -77,6 +77,7 @@ class IndexEventTagsTest(TestCase):
                 event_id=event.id,
                 group_id=group.id,
                 project_id=self.project.id,
+                organization_id=self.project.organization_id,
                 tags=[('foo', 'bar'), ('biz', 'baz')],
             )
 
@@ -113,6 +114,7 @@ class IndexEventTagsTest(TestCase):
                 event_id=event.id,
                 group_id=group.id,
                 project_id=self.project.id,
+                organization_id=self.project.organization_id,
                 tags=[('foo', 'bar'), ('biz', 'baz')],
             )
 

--- a/tests/sentry/tasks/test_clear_expired_resolutions.py
+++ b/tests/sentry/tasks/test_clear_expired_resolutions.py
@@ -19,7 +19,6 @@ class ClearExpiredResolutionsTest(TestCase):
         project = self.create_project()
 
         old_release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='a',
         )
@@ -43,7 +42,6 @@ class ClearExpiredResolutionsTest(TestCase):
         )
 
         new_release = Release.objects.create(
-            project=project,
             organization_id=project.organization_id,
             version='b',
             date_added=timezone.now() + timedelta(minutes=1),

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -103,7 +103,6 @@ class DeleteProjectTest(TestCase):
         GroupAssignee.objects.create(group=group, project=project, user=self.user)
         GroupMeta.objects.create(group=group, key='foo', value='bar')
         release = Release.objects.create(version='a' * 32,
-                                         project=project,
                                          organization_id=project.organization_id)
         release.add_project(project)
         GroupResolution.objects.create(group=group, release=release)

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -305,7 +305,6 @@ class EventManagerTest(TransactionTestCase):
 
         old_release = Release.objects.create(
             version='a',
-            project=self.project,
             organization_id=self.project.organization_id,
             date_added=timezone.now() - timedelta(minutes=30),
         )
@@ -442,7 +441,7 @@ class EventManagerTest(TransactionTestCase):
         manager = EventManager(self.make_event(release='1.0'))
         event = manager.save(1)
 
-        release = Release.objects.get(version='1.0', project=event.project_id)
+        release = Release.objects.get(version='1.0', projects=event.project_id)
 
         assert GroupRelease.objects.filter(
             release_id=release.id,
@@ -460,7 +459,7 @@ class EventManagerTest(TransactionTestCase):
             event_id='a' * 32))
         event = manager.save(1)
 
-        release = Release.objects.get(version='1.0', project=event.project_id)
+        release = Release.objects.get(version='1.0', projects=event.project_id)
 
         assert GroupRelease.objects.filter(
             release_id=release.id,
@@ -473,7 +472,7 @@ class EventManagerTest(TransactionTestCase):
             event_id='b' * 32))
         event = manager.save(1)
 
-        release = Release.objects.get(version='1.0', project=event.project_id)
+        release = Release.objects.get(version='1.0', projects=event.project_id)
 
         assert GroupRelease.objects.filter(
             release_id=release.id,


### PR DESCRIPTION
models involved are `Release`, `ReleaseCommit`, `ReleaseFile`, `ReleaseEnvironment`

for each of those I also removed not null constraint on project column and added it to org

I still need to:
- ~~fix `Organization.merge_to`~~
- ~~figure out what to do about unique constraint on `Release` for org/version and probably `ReleaseEnvironment` for org id/release id/environment id (and could use some input on that)~~

cc @benvinegar @kjlundsgaard @ckj 