### PR TITLE
Exclude user generated tags in search query

### DIFF
--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -139,12 +139,22 @@ class DjangoSearchBackend(SearchBackend):
             )
 
         if tags:
-            matches = self._tags_to_filter(project, tags)
-            if not matches:
-                return queryset.none()
-            queryset = queryset.filter(
-                id__in=matches,
-            )
+            filter_tags = {k:v for k,v in tags.iteritems() if k[0] != '-'}
+            exclude_tags = {k[1:]:v for k,v in tags.iteritems() if k[0] == '-'}
+            if filter_tags:
+                matches = self._tags_to_filter(project, filter_tags)
+                if not matches:
+                    return queryset.none()
+                queryset = queryset.filter(
+                    id__in=matches,
+                )
+            if exclude_tags:
+                matches = self._tags_to_filter(project, exclude_tags)
+                if not matches:
+                    return queryset.none()
+                queryset = queryset.exclude(
+                    id__in=matches,
+                )
 
         if age_from or age_to:
             params = {}

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -139,8 +139,8 @@ class DjangoSearchBackend(SearchBackend):
             )
 
         if tags:
-            filter_tags = {k:v for k,v in tags.iteritems() if k[0] != '-'}
-            exclude_tags = {k[1:]:v for k,v in tags.iteritems() if k[0] == '-'}
+            filter_tags = {k: v for k, v in six.iteritems(tags) if k[0] != '-'}
+            exclude_tags = {k[1:]: v for k, v in six.iteritems(tags) if k[0] == '-'}
             if filter_tags:
                 matches = self._tags_to_filter(project, filter_tags)
                 if not matches:

--- a/src/sentry/static/sentry/app/stores/streamTagStore.jsx
+++ b/src/sentry/static/sentry/app/stores/streamTagStore.jsx
@@ -56,7 +56,13 @@ const StreamTagStore = Reflux.createStore({
   },
 
   getTag(tagName) {
-    return this.tags[tagName];
+    if (tagName[0] == '-') {
+        if (this.tags[tagName.substr(1)].predefined)
+            return undefined;
+        return this.tags[tagName.substr(1)];
+    }
+    else
+        return this.tags[tagName];
   },
 
   getAllTags() {

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -167,6 +167,14 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project1, tags={'env': 'staging', 'server': 'bar.example.com'})
         assert len(results) == 0
 
+    def test_tags_excluded(self):
+        results = self.backend.query(self.project1, tags={'-env': 'production'})
+        assert len(results) == 1
+        assert results[0] == self.group2
+
+        results = self.backend.query(self.project1, tags={'-env': 'staging', 'server': 'example.com'})
+        assert len(results) == 1
+
     def test_bookmarked_by(self):
         results = self.backend.query(self.project1, bookmarked_by=self.user)
         assert len(results) == 1

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -175,6 +175,13 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project1, tags={'-env': 'staging', 'server': 'example.com'})
         assert len(results) == 1
 
+        results = self.backend.query(self.project1, tags={'-env': 'staging', 'env': 'staging'})
+        assert len(results) == 0
+
+        results = self.backend.query(self.project1, tags={'env': 'production', '-env': 'staging'})
+        assert len(results) == 1
+        assert results[0] == self.group1
+
     def test_bookmarked_by(self):
         results = self.backend.query(self.project1, bookmarked_by=self.user)
         assert len(results) == 1


### PR DESCRIPTION
Basically, allow tag names in the query parser to be prefixed with "-" (for instance, "-level:error"). Then teach the search backend to split the tags into two categories: filtered and excluded, and modify the subquery accordingly. Also update autocomplete so that "-is:" or "-has:" are not accepted.

Fixes: #2646 

