### PR TITLE
Also match on release files without query strings

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -228,7 +228,7 @@ def fetch_release_file(filename, release):
     if filename is not None:
         filename_no_query = filename.split('?')[0]
         if filename_no_query != filename:
-            filename_idents.append(filename_no_query)
+            filename_idents.append(ReleaseFile.get_ident(filename_no_query))
 
         # Reconstruct url without protocol + host
         # e.g. http://example.com/foo?bar => ~/foo?bar


### PR DESCRIPTION
This changes the logic for release file matching so that it will also
try to resolve files without query string.

This is necessary for react-native where all minified files add some
garbage into the query string for the minified file.