### PR TITLE
Log error dict instead of relying on exc_info.

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -433,8 +433,7 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
 
                     # TODO(dcramer): we want to be less aggressive on disabling domains
                     cache.set(domain_key, error or '', 300)
-                    logger.warning('Disabling sources to %s for %ss', domain, 300,
-                                   exc_info=True)
+                    logger.warning('source.disabled', extra=error)
                     raise CannotFetchSource(error)
 
                 body = b''.join(contents)


### PR DESCRIPTION
We're sending a non-trivial amount of duplicated data through `exc_info` that can just be found with what we're sending to this user.

This also allows us to search by url too.