### PR TITLE
webpack: detect if node-zopfli is installed before attemping to use it

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -185,16 +185,30 @@ var config = {
     '#cheap-module-eval-source-map'
 };
 
+
+function hasZopfli() {
+  return (
+    // npm@2
+    fs.existsSync('node_modules/compression-webpack-plugin/node_modules/node-zopfli') ||
+    // npm@3
+    fs.existsSync('node_modules/node-zopfli')
+  );
+}
+
 // This compression-webpack-plugin generates pre-compressed files
 // ending in .gz, to be picked up and served by our internal static media
 // server as well as nginx when paired with the gzip_static module.
 if (IS_PRODUCTION) {
+  var algorithm = hasZopfli() ? 'zopfli' : 'gzip';
   config.plugins.push(new (require('compression-webpack-plugin'))({
     // zopfli gives us a better gzip compression
     // See: http://googledevelopers.blogspot.com/2013/02/compress-data-more-densely-with-zopfli.html
-    algorithm: 'zopfli',
+    algorithm: algorithm,
     regExp: /\.(js|map|css|svg|html|txt|ico|eot|ttf)$/,
   }));
+  if (algorithm === 'gzip') {
+    console.warn('!! missing node-zopfli, so falling back to gzip.');
+  }
 }
 
 module.exports = config;


### PR DESCRIPTION
zopfli is not required by any means, especially for local development
and CI. So if there's an issue installing this, we should just avoid
attempting to compress rather than error all over the place. This keeps
the error to just a simple warning instead so we're aware and can see
this if something were to fail in a production build, but won't affect
any other environment.

Also, note that this is explicitly checking against paths rather than
testing with a `require()` since with npm@2, the dependency is actually
a sub-dependnecy of `compression-webpack-plugin` and can't be `require`d
from outside that module. So it doesn't help to test that. And with
npm@3, the module gets flatted to the top level, so we need to check
both places.

I'll replicate this to `sentry-plugins` too.