### PR TITLE
layout: don't show sentry version when not ONPREMISE

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -227,7 +227,7 @@
           <a href="https://github.com/getsentry/sentry" rel="noreferrer">{% trans "Contribute" %}</a>
           {% if ONPREMISE %}<a href="/out/">{% trans "Migrate to SaaS" %}</a>{% endif %}
         </div>
-        <div class="version pull-left">Sentry {{ sentry_version.current }} {% if sentry_version.update_available %}<a href="#" title="You're running an old version of Sentry, did you know {{ sentry_version.latest }} is available?" class="tip icon-circle-arrow-up">&nbsp;</a>{% endif %}</div>
+        {% if ONPREMISE %}<div class="version pull-left">Sentry {{ sentry_version.current }} {% if sentry_version.update_available %}<a href="#" title="You're running an old version of Sentry, did you know {{ sentry_version.latest }} is available?" class="tip icon-circle-arrow-up">&nbsp;</a>{% endif %}</div>{% endif %}
         <a href="/" class="icon-sentry-logo"></a>
         {% endblock %}
       </div>


### PR DESCRIPTION
This allows us to hide the version for sentry.io. imo it's a bit silly
and doesn't make sense in our case. We're always a `.dev0` release, and
users of sentry.io don't need to know or care what version we're running
since it's always latest.

I also don't have a strong opinion here, so if we want to maintain the version, that's fine too. Just seemed awkward for me.