### PR TITLE
api: prevent time_spent value from overflowing

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -29,6 +29,7 @@ from sentry.constants import (
     CLIENT_RESERVED_ATTRS, DEFAULT_LOG_LEVEL, LOG_LEVELS_MAP,
     MAX_TAG_VALUE_LENGTH, MAX_TAG_KEY_LENGTH, VALID_PLATFORMS
 )
+from sentry.db.models import BoundedIntegerField
 from sentry.interfaces.base import get_interface, InterfaceValidationError
 from sentry.interfaces.csp import Csp
 from sentry.event_manager import EventManager
@@ -692,6 +693,25 @@ class ClientApiHelper(object):
                     'value': data['environment'],
                 })
                 del data['environment']
+
+        if data.get('time_spent'):
+            try:
+                data['time_spent'] = int(data['time_spent'])
+            except (ValueError, TypeError):
+                data['errors'].append({
+                    'type': EventError.INVALID_DATA,
+                    'name': 'time_spent',
+                    'value': data['time_spent'],
+                })
+                del data['time_spent']
+            else:
+                if data['time_spent'] > BoundedIntegerField.MAX_VALUE:
+                    data['errors'].append({
+                        'type': EventError.VALUE_TOO_LONG,
+                        'name': 'time_spent',
+                        'value': data['time_spent'],
+                    })
+                    del data['time_spent']
 
         return data
 

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -387,6 +387,32 @@ class ValidateDataTest(BaseAPITest):
         })
         assert data.get('environment') == '42'
 
+    def test_time_spent_too_large(self):
+        data = self.helper.validate_data(self.project, {
+            'time_spent': 2147483647 + 1,
+        })
+        assert not data.get('time_spent')
+        assert len(data['errors']) == 1
+        assert data['errors'][0]['type'] == 'value_too_long'
+        assert data['errors'][0]['name'] == 'time_spent'
+        assert data['errors'][0]['value'] == 2147483647 + 1
+
+    def test_time_spent_invalid(self):
+        data = self.helper.validate_data(self.project, {
+            'time_spent': 'lol',
+        })
+        assert not data.get('time_spent')
+        assert len(data['errors']) == 1
+        assert data['errors'][0]['type'] == 'invalid_data'
+        assert data['errors'][0]['name'] == 'time_spent'
+        assert data['errors'][0]['value'] == 'lol'
+
+    def test_time_spent_non_int(self):
+        data = self.helper.validate_data(self.project, {
+            'time_spent': '123',
+        })
+        assert data['time_spent'] == 123
+
 
 class SafelyLoadJSONStringTest(BaseAPITest):
     def test_valid_payload(self):


### PR DESCRIPTION
Without capping the int size here, it can overflow the int4 column in
the database causing the Event to fail saving.