### PR TITLE
api: don't return back Access-Control-Allow-Origin: null

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -226,7 +226,16 @@ class APIView(BaseView):
             )
 
         if origin:
-            response['Access-Control-Allow-Origin'] = origin
+            if origin == 'null':
+                # If an Origin is `null`, but we got this far, that means
+                # we've gotten past our CORS check for some reason. But the
+                # problem is that we can't return "null" as a valid response
+                # to `Access-Control-Allow-Origin` and we don't have another
+                # value to work with, so just allow '*' since they've gotten
+                # this far.
+                response['Access-Control-Allow-Origin'] = '*'
+            else:
+                response['Access-Control-Allow-Origin'] = origin
 
         return response
 


### PR DESCRIPTION
In the event that we've successfully passed our CORS check, but the
actual Origin value is "null", we should return back "*". The string
"null" is invalid and browsers will complain with:

"Origin null is not allowed by Access-Control-Allow-Origin"

Refs https://github.com/getsentry/raven-js/issues/628

/cc @LewisJEllis 