### PR TITLE
Add logging statements to UI controlled email mutations.

### DIFF
--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -413,6 +413,11 @@ def disconnect_identity(request, identity_id):
             settings.AUTH_PROVIDER_LABELS.get(backend_name, backend_name),
         )
     )
+    logger.info('user.identity.disconnect', extra={
+        'user_id': request.user.id,
+        'ip_address': request.META['REMOTE_ADDR'],
+        'usersocialauth_id': identity_id,
+    })
     return HttpResponseRedirect(reverse('sentry-account-settings-identities'))
 
 

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -7,6 +7,8 @@ sentry.web.frontend.accounts
 """
 from __future__ import absolute_import
 
+import logging
+
 import six
 
 from django.conf import settings
@@ -37,6 +39,8 @@ from sentry.web.forms.accounts import (
 )
 from sentry.web.helpers import render_to_response
 from sentry.utils import auth
+
+logger = logging.getLogger('sentry.accounts')
 
 
 def send_password_recovery_mail(user):
@@ -166,6 +170,12 @@ def start_confirm_email(request):
         request.user.send_confirm_emails()
         unverified_emails = [e.email for e in request.user.get_unverified_emails()]
         msg = _('A verification email has been sent to %s.') % (', ').join(unverified_emails)
+        for email in unverified_emails:
+            logger.info('user.email.start_confirm', extra={
+                'user_id': request.user.id,
+                'ip_address': request.META['REMOTE_ADDR'],
+                'email': email,
+            })
     else:
         msg = _('Your email (%s) has already been verified.') % request.user.email
     messages.add_message(request, messages.SUCCESS, msg)
@@ -189,6 +199,11 @@ def confirm_email(request, user_id, hash):
         email.validation_hash = ''
         email.save()
         email_verified.send(email=email.email, sender=email)
+        logger.info('user.email.confirm', extra={
+            'user_id': user_id,
+            'ip_address': request.META['REMOTE_ADDR'],
+            'email': email.email,
+        })
     messages.add_message(request, level, msg)
     return HttpResponseRedirect(reverse('sentry-account-settings-emails'))
 
@@ -419,6 +434,12 @@ def show_emails(request):
         email = request.POST.get('email')
         del_email = UserEmail.objects.filter(user=user, email=email)
         del_email.delete()
+        logger.info('user.email.remove', extra={
+            'user_id': user.id,
+            'ip_address': request.META['REMOTE_ADDR'],
+            'email': email,
+        })
+
         return HttpResponseRedirect(request.path)
 
     if email_form.is_valid():
@@ -444,6 +465,11 @@ def show_emails(request):
                 user_email.set_hash()
                 user_email.save()
                 user.send_confirm_email_singular(user_email)
+                logger.info('user.email.add', extra={
+                    'user_id': user.id,
+                    'ip_address': request.META['REMOTE_ADDR'],
+                    'email': user_email.email,
+                })
                 msg = _('A confirmation email has been sent to %s.') % user_email.email
                 messages.add_message(
                     request,
@@ -466,6 +492,11 @@ def show_emails(request):
                 new_email.save()
             # send confirmation emails to any non verified emails
             user.send_confirm_email_singular(new_email)
+            logger.info('user.email.add', extra={
+                'user_id': user.id,
+                'ip_address': request.META['REMOTE_ADDR'],
+                'email': new_email.email,
+            })
             msg = _('A confirmation email has been sent to %s.') % new_email.email
             messages.add_message(
                 request,


### PR DESCRIPTION
This is a follow up to a ticket in zendesk where comparing historical actions via logs did not give a fully detailed sequence of events. 

Hopefully with future cases, this is no longer an issue.

ccing @webartifex and @serebrov because it was their original inquiry that inspired this.