### PR TITLE
dev: don't report load-mocks errors to ourselves

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -450,4 +450,12 @@ if __name__ == '__main__':
 
     (options, args) = parser.parse_args()
 
-    main(num_events=options.num_events)
+    try:
+        main(num_events=options.num_events)
+    except Exception:
+        # Avoid reporting any issues recursively back into Sentry
+        import traceback
+        import sys
+
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
This can mask other issues if reporting the error itself failed. And
anyways, it's not valuable to report back into local Sentry here.