### PR TITLE
change these logging keys because they arent bigints

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -592,7 +592,7 @@ class EventManager(object):
                     project=project, group=group, event_id=event_id)
         except IntegrityError:
             self.logger.info('duplicate.found', exc_info=True, extra={
-                'event_id': event_id,
+                'event_uuid': event_id,
                 'project_id': project.id,
                 'group_id': group.id,
                 'model': EventMapping.__name__,
@@ -669,7 +669,7 @@ class EventManager(object):
                     event.save()
             except IntegrityError:
                 self.logger.info('duplicate.found', exc_info=True, extra={
-                    'event_id': event_id,
+                    'event_uuid': event_id,
                     'project_id': project.id,
                     'group_id': group.id,
                     'model': Event.__name__,


### PR DESCRIPTION
This creates a conflict in fielddata for es, making the `event_id` field unsearchable.