### PR TITLE
Remove UglifyJS warnings from travis output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -185,15 +185,22 @@ var config = {
     '#cheap-module-eval-source-map'
 };
 
-// This compression-webpack-plugin generates pre-compressed files
-// ending in .gz, to be picked up and served by our internal static media
-// server as well as nginx when paired with the gzip_static module.
 if (IS_PRODUCTION) {
+  // This compression-webpack-plugin generates pre-compressed files
+  // ending in .gz, to be picked up and served by our internal static media
+  // server as well as nginx when paired with the gzip_static module.
   config.plugins.push(new (require('compression-webpack-plugin'))({
     algorithm: function(buffer, options, callback) {
       require('zlib').gzip(buffer, callback);
     },
     regExp: /\.(js|map|css|svg|html|txt|ico|eot|ttf)$/,
+  }));
+
+  // Disable annoying UglifyJS warnings that pollute Travis log output
+  config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+    compress: {
+      warnings: false
+    }
   }));
 }
 


### PR DESCRIPTION
The warnings look like this and always ignored by users / pollute Travis output:

```
Condition always false [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:37,0]
Dropping side-effect-free statement [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:37,0]
Condition always false [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:151,0]
Dropping unreachable code [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:151,0]
Declarations in unreachable code! [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:152,0]
Dropping unused variable payload [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:152,0]
Condition always false [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:168,0]
Dropping unreachable code [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:168,0]
Declarations in unreachable code! [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:169,0]
Dropping unused variable payload [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:169,0]
Condition always false [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:183,0]
Dropping unreachable code [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:184,0]
Condition always false [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:214,0]
Dropping unreachable code [/home/travis/build/getsentry/sentry/~/react/lib/DOMPropertyOperations.js:215,0]
```

cc @mattrobenolt