### PR TITLE
ui: use SENTRY_GRAVATAR_BASE_URL setting

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import $ from 'jquery';
 import MD5 from 'crypto-js/md5';
+import ConfigStore from '../stores/configStore';
 import UserLetterAvatar from '../components/userLetterAvatar';
 
 const Avatar = React.createClass({
@@ -28,7 +29,7 @@ const Avatar = React.createClass({
   },
 
   buildGravatarUrl() {
-    let url = 'https://secure.gravatar.com/avatar/';
+    let url = ConfigStore.getConfig().gravatarBaseUrl + '/avatar/';
 
     url += MD5(this.props.user.email.toLowerCase());
 

--- a/src/sentry/templatetags/sentry_react.py
+++ b/src/sentry/templatetags/sentry_react.py
@@ -126,6 +126,7 @@ def get_react_config(context):
             'level': msg.tags,
         } for msg in messages],
         'isOnPremise': settings.SENTRY_ONPREMISE,
+        'gravatarBaseUrl': settings.SENTRY_GRAVATAR_BASE_URL,
     }
     if user and user.is_authenticated():
         context.update({


### PR DESCRIPTION
We weren't using this setting when rendering avatars in React, only
server-side.

Fixes GH-4711