### PR TITLE
Add slider disabled state

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/rangeField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/rangeField.jsx
@@ -16,6 +16,10 @@ export default class RangeField extends InputField {
 
   attachSlider() {
     let $value = jQuery('<span class="value" />');
+    let suffixClassNames = '';
+    if (this.props.disabled) {
+      suffixClassNames += ' disabled';
+    }
     jQuery(ReactDOM.findDOMNode(this.refs.input)).on('slider:ready', (e, data) => {
       let value = parseInt(data.value, 10);
       $value.appendTo(data.el);
@@ -30,6 +34,7 @@ export default class RangeField extends InputField {
       step: this.props.step,
       snap: this.props.snap,
       allowedValues: this.props.allowedValues,
+      classSuffix: suffixClassNames
     });
   }
 

--- a/src/sentry/static/sentry/less/includes/simple-slider.less
+++ b/src/sentry/static/sentry/less/includes/simple-slider.less
@@ -33,4 +33,27 @@
     color: @60;
     text-align: right;
   }
+
+  &.disabled {
+    cursor: not-allowed;
+
+    &:after {
+      content: "";
+      display: block;
+      position: absolute;
+      background: rgba(255,255,255, .1);
+      top: -2px;
+      left: -8px;
+      bottom: -2px;
+      right: -8px;
+    }
+
+    > .dragger {
+      background: @gray-lightest;
+    }
+
+    > .track {
+      background: lighten(@white-darkest, 3);
+    }
+  }
 }


### PR DESCRIPTION
Looks like this. Not pictured: a 'not-allowed' cursor on hover.

![screen shot 2017-01-09 at 4 47 24 pm](https://cloud.githubusercontent.com/assets/30713/21789648/687bbada-d68b-11e6-91ef-45eebe4ce75e.png)

I used simple-slider's `classSuffix` property to pass the disabled class when the prop is set. I don't think it was meant for that, but it works.

cc @getsentry/ui 
