### PR TITLE
Consistent panel heading and body padding

### DIFF
--- a/src/sentry/static/sentry/less/variables.less
+++ b/src/sentry/static/sentry/less/variables.less
@@ -31,7 +31,9 @@
 // Overrides Bootstrap defaults
 
 
-@panel-default-heading-bg:  @white-dark;
+@panel-default-heading-bg:    @white-dark;
 @panel-footer-bg:             @white-dark;
 @panel-default-border:        @trim;
 @panel-inner-border:          @trim;
+@panel-body-padding:          20px;
+@panel-heading-padding:       10px 20px;


### PR DESCRIPTION
Override bootstrap's default panel padding to avoid mis-aligned panel content.

@getsentry/ui 