### PR TITLE
migration: fix 0285 by explicitly just dropping null constraint

### DIFF
--- a/src/sentry/south_migrations/0285_auto__chg_field_release_project_id__chg_field_releasefile_project_id.py
+++ b/src/sentry/south_migrations/0285_auto__chg_field_release_project_id__chg_field_releasefile_project_id.py
@@ -3,30 +3,38 @@ from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+from sentry.utils.db import is_postgres
 
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
 
-        # Changing field 'Release.project_id'
-        db.alter_column('sentry_release', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+        if is_postgres():
+            # Changing field 'Release.project_id'
+            db.execute("ALTER TABLE sentry_release ALTER COLUMN project_id DROP NOT NULL")
 
-        # Changing field 'ReleaseFile.project_id'
-        db.alter_column('sentry_releasefile', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+            # Changing field 'ReleaseFile.project_id'
+            db.execute("ALTER TABLE sentry_releasefile ALTER COLUMN project_id DROP NOT NULL")
+        else:
+            # Changing field 'Release.project_id'
+            db.alter_column('sentry_release', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+
+            # Changing field 'ReleaseFile.project_id'
+            db.alter_column('sentry_releasefile', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
 
     def backwards(self, orm):
 
         # User chose to not deal with backwards NULL issues for 'Release.project_id'
         raise RuntimeError("Cannot reverse this migration. 'Release.project_id' and its values cannot be restored.")
-        
+
         # The following code is provided here to aid in writing a correct migration
         # Changing field 'Release.project_id'
         db.alter_column('sentry_release', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
 
         # User chose to not deal with backwards NULL issues for 'ReleaseFile.project_id'
         raise RuntimeError("Cannot reverse this migration. 'ReleaseFile.project_id' and its values cannot be restored.")
-        
+
         # The following code is provided here to aid in writing a correct migration
         # Changing field 'ReleaseFile.project_id'
         db.alter_column('sentry_releasefile', 'project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())


### PR DESCRIPTION
South is trying to do too much magic here and causing a deadlock