### PR TITLE
Fix source maps in local development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -182,7 +182,7 @@ var config = {
   },
   devtool: IS_PRODUCTION ?
     '#source-map' :
-    '#cheap-module-eval-source-map'
+    '#cheap-source-map'
 };
 
 if (IS_PRODUCTION) {


### PR DESCRIPTION
Alas, cheap-module-eval-source-map is broken in webpack 2 for whatever reason.

cc @mattrobenolt