### PR TITLE
Add memory and Storage info for Apple Devices

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Version 8.13 (Unreleased)
 - start using ReleaseProject and Release.organization instead of Release.project
 - Project quotas are no longer available, and must now be configured via the organizational rate limits.
 - Quotas implementation now requires a tuple of maximum rate and interval window.
+- Add memory and storage information for apple devices
 
 Version 8.12
 ------------

--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import ContextBlock from './contextBlock';
-import {defined} from '../../../utils';
+import {defined, formatBytes} from '../../../utils';
 
 const DeviceContextType = React.createClass({
   propTypes: {
@@ -9,9 +9,28 @@ const DeviceContextType = React.createClass({
     data: React.PropTypes.object.isRequired,
   },
 
+  formatMemory(memorySize, freeMemory, usableMemory) {
+    if (!Number.isInteger(memorySize) ||
+       !Number.isInteger(freeMemory) ||
+       !Number.isInteger(usableMemory)) {
+      return null;
+    }
+    return `Total: ${formatBytes(memorySize)} / Usable: ${formatBytes(usableMemory)} / Free: ${formatBytes(freeMemory)}`;
+  },
+
+  formatStorage(storageSize) {
+    if (!Number.isInteger(storageSize))
+      return null;
+
+    return `${formatBytes(storageSize)}`;
+  },
+
   render() {
     let {name, family, model, model_id, arch, battery_level, orientation,
+      simulator, memorySize, freeMemory, usableMemory, storageSize,
       ...data} = this.props.data;
+      let memory = this.formatMemory(memorySize, freeMemory, usableMemory);
+      let storage = this.formatStorage(storageSize);
     return (
       <ContextBlock
         data={data}
@@ -23,6 +42,9 @@ const DeviceContextType = React.createClass({
           ['?Battery Level', defined(battery_level)
             ? `${battery_level}%` : null],
           ['?Orientation', orientation],
+          ['?Memory', memory],
+          ['?Capacity', storage],
+          ['?Simulator', simulator],
         ]}
         alias={this.props.alias} />
     );

--- a/src/sentry/static/sentry/app/components/fileSize.jsx
+++ b/src/sentry/static/sentry/app/components/fileSize.jsx
@@ -1,29 +1,14 @@
 import React from 'react';
+import {formatBytes} from '../utils';
 
 const FileSize = React.createClass({
   propTypes: {
     bytes: React.PropTypes.number.isRequired
   },
 
-  units: ['KB','MB','GB','TB','PB','EB','ZB','YB'],
-
-  formatBytes: function(bytes) {
-      let thresh = 1024;
-      if (bytes < thresh) {
-        return bytes + ' B';
-      }
-
-      let u = -1;
-      do {
-        bytes /= thresh;
-        ++u;
-      } while (bytes >= thresh);
-      return bytes.toFixed(1) + ' ' + this.units[u];
-  },
-
   render: function() {
     return (
-      <span>{this.formatBytes(this.props.bytes)}</span>
+      <span>{formatBytes(this.props.bytes)}</span>
     );
   }
 });

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -205,6 +205,21 @@ export default {
     });
   },
 
+  formatBytes(bytes) {
+    let units = ['KB','MB','GB','TB','PB','EB','ZB','YB'];
+    let thresh = 1024;
+    if (bytes < thresh) {
+      return bytes + ' B';
+    }
+
+    let u = -1;
+    do {
+      bytes /= thresh;
+      ++u;
+    } while (bytes >= thresh);
+    return bytes.toFixed(1) + ' ' + units[u];
+  },
+
   arrayIsEqual: arrayIsEqual,
   objectMatchesSubset: objectMatchesSubset,
   compareArrays: compareArrays,


### PR DESCRIPTION
<img width="976" alt="hehehe__this_is_totes_not_useful" src="https://cloud.githubusercontent.com/assets/363802/22016299/1646034e-dca6-11e6-9591-5d58e380e67f.png">

Will be added in `sentry-swift` `1.4.4`