### PR TITLE
add organization release endpoints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Version 8.13
 - Added configurable subject templates for individual alert emails (`mail:subject_template` option).
 - Added data migration to populate ReleaseProject.new_groups
 - Added support for managing newsletter subscriptions with Sentry.io
+- Added OrganizationReleasesEndpoint
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 8.14 (Unreleased)
 - [BREAKING] Quotas must now instantiate RateLimited and NotRateLimited return values.
 - [BREAKING] Redis quota implementations now return BasicRedisQuota instead of tuples.
 - Commits using the ``Fixes SHORTID`` annotation will now be tracked appropriately.
+- Added OrganizationReleasesEndpoint
 
 Schema Changes
 ~~~~~~~~~~~~~~
@@ -16,7 +17,6 @@ Schema Changes
 - Added unique index on ``Release(organization_id, version)``
 - Removed unique index on ``Release(project_id, version)``
 - Added ``GroupCommitResolution`` model.
-- Added OrganizationReleasesEndpoint
 
 Version 8.13
 ------------

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Schema Changes
 - Added unique index on ``Release(organization_id, version)``
 - Removed unique index on ``Release(project_id, version)``
 - Added ``GroupCommitResolution`` model.
+- Added OrganizationReleasesEndpoint
 
 Version 8.13
 ------------
@@ -35,7 +36,6 @@ Version 8.13
 - Added configurable subject templates for individual alert emails (`mail:subject_template` option).
 - Added data migration to populate ReleaseProject.new_groups
 - Added support for managing newsletter subscriptions with Sentry.io
-- Added OrganizationReleasesEndpoint
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -7,7 +7,9 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import ScopedPermission
 from sentry.app import raven
 from sentry.auth import access
-from sentry.models import Organization, OrganizationStatus
+from sentry.models import (
+    Organization, OrganizationMemberTeam, OrganizationStatus, Project, Team
+)
 from sentry.models.apikey import ROOT_KEY
 from sentry.utils import auth
 
@@ -90,3 +92,22 @@ class OrganizationEndpoint(Endpoint):
 
         kwargs['organization'] = organization
         return (args, kwargs)
+
+
+class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationReleasePermission,)
+
+    def get_allowed_projects(self, request, organization):
+        if not request.user.is_authenticated():
+            return []
+
+        if request.is_superuser() or organization.flags.allow_joinleave:
+            allowed_teams = Team.objects.filter(
+                organization=organization
+            ).values_list('id', flat=True)
+        else:
+            allowed_teams = OrganizationMemberTeam.objects.filter(
+                organizationmember__user=request.user,
+                team__organization_id=organization.id,
+            ).values_list('team_id', flat=True)
+        return Project.objects.filter(team_id__in=allowed_teams)

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -56,13 +56,15 @@ class OrganizationPermission(ScopedPermission):
         return any(request.access.has_scope(s) for s in allowed_scopes)
 
 
-# TODO(jess): does the 'project:releases' permission need to be renamed?
+# These are based on ProjectReleasePermission
+# additional checks to limit actions to releases
+# associated with projects people have access to
 class OrganizationReleasePermission(OrganizationPermission):
     scope_map = {
-        'GET': ['org:read', 'org:write', 'org:delete', 'project:releases'],
-        'POST': ['org:write', 'org:delete', 'project:releases'],
-        'PUT': ['org:write', 'org:delete', 'project:releases'],
-        'DELETE': ['org:delete', 'project:releases'],
+        'GET': ['project:read', 'project:write', 'project:delete', 'project:releases'],
+        'POST': ['project:write', 'project:delete', 'project:releases'],
+        'PUT': ['project:write', 'project:delete', 'project:releases'],
+        'DELETE': ['project:delete', 'project:releases'],
     }
 
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -56,6 +56,16 @@ class OrganizationPermission(ScopedPermission):
         return any(request.access.has_scope(s) for s in allowed_scopes)
 
 
+# TODO(jess): does the 'project:releases' permission need to be renamed?
+class OrganizationReleasePermission(OrganizationPermission):
+    scope_map = {
+        'GET': ['org:read', 'org:write', 'org:delete', 'project:releases'],
+        'POST': ['org:write', 'org:delete', 'project:releases'],
+        'PUT': ['org:write', 'org:delete', 'project:releases'],
+        'DELETE': ['org:delete', 'project:releases'],
+    }
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission,)
 

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -63,8 +63,6 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            # TODO(jess): fix this if merging of legacy releases
-            # hasn't happened yet
             release = Release.objects.get(
                 organization_id=organization.id,
                 projects__in=self.get_allowed_projects(request, organization),
@@ -100,8 +98,6 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            # TODO(jess): fix this if merging of legacy releases
-            # hasn't happened yet
             release = Release.objects.get(
                 organization_id=organization,
                 projects__in=self.get_allowed_projects(request, organization),
@@ -163,8 +159,6 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            # TODO(jess): fix this if merging of legacy releases
-            # hasn't happened yet
             release = Release.objects.get(
                 organization_id=organization.id,
                 projects__in=self.get_allowed_projects(request, organization),

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -1,0 +1,155 @@
+from __future__ import absolute_import
+
+from django.db import IntegrityError, transaction
+
+from rest_framework.response import Response
+
+from .project_releases import ReleaseSerializer
+from sentry.api.base import DocSection
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework import ListField
+from sentry.models import Activity, Project, Release, ReleaseProject
+
+
+class ReleaseSerializerWithProjects(ReleaseSerializer):
+    projects = ListField()
+
+
+class OrganizationReleasesEndpoint(OrganizationEndpoint):
+    doc_section = DocSection.RELEASES
+    permission_classes = (OrganizationReleasePermission,)
+
+    def get(self, request, organization):
+        """
+        List an Organizations Releases
+        ``````````````````````````````
+        Return a list of releases for a given organization.
+
+        :pparam string organization_slug: the organization short name
+        :qparam string query: this parameter can be used to create a
+                              "starts with" filter for the version.
+        """
+        query = request.GET.get('query')
+
+        queryset = Release.objects.filter(
+            organization=organization,
+        ).select_related('owner')
+
+        if query:
+            queryset = queryset.filter(
+                version__istartswith=query,
+            )
+
+        queryset = queryset.extra(select={
+            'sort': 'COALESCE(date_released, date_added)',
+        })
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by='-sort',
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+        )
+
+    def post(self, request, organization):
+        """
+        Create a New Release
+        ````````````````````
+        Create a new release for the given Organization.  Releases are used by
+        Sentry to improve its error reporting abilities by correlating
+        first seen events with the release that might have introduced the
+        problem.
+        Releases are also necessary for sourcemaps and other debug features
+        that require manual upload for functioning well.
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :param string version: a version identifier for this release.  Can
+                               be a version number, a commit hash etc.
+        :param string ref: an optional commit reference.  This is useful if
+                           a tagged version has been provided.
+        :param url url: a URL that points to the release.  This can be the
+                        path to an online interface to the sourcecode
+                        for instance.
+        :param array projects: a list of project slugs that are involved in
+                               this release
+        :param datetime dateStarted: an optional date that indicates when the
+                                     release process started.
+        :param datetime dateReleased: an optional date that indicates when
+                                      the release went live.  If not provided
+                                      the current time is assumed.
+        :auth: required
+        """
+        serializer = ReleaseSerializerWithProjects(data=request.DATA)
+
+        if serializer.is_valid():
+            result = serializer.object
+
+            projects = Project.objects.filter(organization=organization,
+                                              slug__in=result['projects'])
+            invalid_projects = set(result['projects']) - {p.slug for p in projects}
+            if invalid_projects:
+                # TODO: make sure the error format matches serializer errors
+                return Response({'projects': 'Invalid project slugs'}, status=400)
+
+            with transaction.atomic():
+                # release creation is idempotent to simplify user
+                # experiences
+                release = Release.objects.filter(
+                    organization_id=organization.id,
+                    version=result['version']
+                ).first()
+                if release:
+                    created = False
+                else:
+                    release, created = Release.objects.create(
+                        organization_id=organization.id,
+                        version=result['version'],
+                        ref=result.get('ref'),
+                        url=result.get('url'),
+                        owner=result.get('owner'),
+                        date_started=result.get('dateStarted'),
+                        date_released=result.get('dateReleased'),
+                    ), True
+
+            new_projects = []
+            for project in projects:
+                try:
+                    with transaction.atomic():
+                        ReleaseProject.objects.create(project=project, release=release)
+                except IntegrityError:
+                    pass
+                else:
+                    new_projects.append(project)
+
+            if release.date_released:
+                for project in new_projects:
+                    activity = Activity.objects.create(
+                        type=Activity.RELEASE,
+                        project=project,
+                        ident=result['version'],
+                        data={'version': result['version']},
+                        datetime=release.date_released,
+                    )
+                    activity.send_notification()
+
+            # TODO(jess): fix release hook to work with multiple projects
+            # commit_list = result.get('commits')
+            # if commit_list:
+            #     hook = ReleaseHook(project)
+            #     # TODO(dcramer): handle errors with release payloads
+            #     hook.set_commits(release.version, commit_list)
+
+            if not created:
+                # This is the closest status code that makes sense, and we want
+                # a unique 2xx response code so people can understand when
+                # behavior differs.
+                #   208 Already Reported (WebDAV; RFC 5842)
+                status = 208
+            else:
+                status = 201
+
+            return Response(serialize(release, request.user), status=status)
+        return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -1,0 +1,210 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+from rest_framework.response import Response
+
+from sentry.api.base import DocSection
+from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework import CommitSerializer, ListField
+from sentry.models import Activity, Group, Release, ReleaseFile
+from sentry.plugins.interfaces.releasehook import ReleaseHook
+from sentry.utils.apidocs import scenario, attach_scenarios
+
+ERR_RELEASE_REFERENCED = "This release is referenced by active issues and cannot be removed."
+
+
+@scenario('RetrieveRelease')
+def retrieve_release_scenario(runner):
+    runner.request(
+        method='GET',
+        path='/projects/%s/%s/releases/%s/' % (
+            runner.org.slug, runner.default_project.slug,
+            runner.default_release.version)
+    )
+
+
+@scenario('UpdateRelease')
+def update_release_scenario(runner):
+    release = runner.utils.create_release(runner.default_project,
+                                          runner.me, version='3000')
+    runner.request(
+        method='PUT',
+        path='/projects/%s/%s/releases/%s/' % (
+            runner.org.slug, runner.default_project.slug,
+            release.version),
+        data={
+            'url': 'https://vcshub.invalid/user/project/refs/deadbeef1337',
+            'ref': 'deadbeef1337'
+        }
+    )
+
+# TODO(dcramer): this can't work with the current fixtures
+# as an existing Group references the Release
+# @scenario('DeleteRelease')
+# def delete_release_scenario(runner):
+#     release = runner.utils.create_release(runner.default_project,
+#                                           runner.me, version='4000')
+#     runner.request(
+#         method='DELETE',
+#         path='/projects/%s/%s/releases/%s/' % (
+#             runner.org.slug, runner.default_project.slug,
+#             release.version)
+#     )
+
+
+class ReleaseSerializer(serializers.Serializer):
+    ref = serializers.CharField(max_length=64, required=False)
+    url = serializers.URLField(required=False)
+    dateStarted = serializers.DateTimeField(required=False)
+    dateReleased = serializers.DateTimeField(required=False)
+    commits = ListField(child=CommitSerializer(), required=False)
+
+
+class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
+    doc_section = DocSection.RELEASES
+    permission_classes = (ProjectReleasePermission,)
+
+    @attach_scenarios([retrieve_release_scenario])
+    def get(self, request, project, version):
+        """
+        Retrieve a Project's Release
+        ````````````````````````````
+
+        Return details on an individual release.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to retrieve the
+                                     release of.
+        :pparam string version: the version identifier of the release.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id,
+                projects=project,
+                version=version,
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return Response(serialize(release, request.user, project=project))
+
+    @attach_scenarios([update_release_scenario])
+    def put(self, request, project, version):
+        """
+        Update a Project's Release
+        ``````````````````````````
+
+        Update a release.  This can change some metadata associated with
+        the release (the ref, url, and dates).
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to change the
+                                     release of.
+        :pparam string version: the version identifier of the release.
+        :param string ref: an optional commit reference.  This is useful if
+                           a tagged version has been provided.
+        :param url url: a URL that points to the release.  This can be the
+                        path to an online interface to the sourcecode
+                        for instance.
+        :param datetime dateStarted: an optional date that indicates when the
+                                     release process started.
+        :param datetime dateReleased: an optional date that indicates when
+                                      the release went live.  If not provided
+                                      the current time is assumed.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id,
+                projects=project,
+                version=version,
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        serializer = ReleaseSerializer(data=request.DATA, partial=True)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        result = serializer.object
+
+        was_released = bool(release.date_released)
+
+        kwargs = {}
+        if result.get('dateStarted'):
+            kwargs['date_started'] = result['dateStarted']
+        if result.get('dateReleased'):
+            kwargs['date_released'] = result['dateReleased']
+        if result.get('ref'):
+            kwargs['ref'] = result['ref']
+        if result.get('url'):
+            kwargs['url'] = result['url']
+
+        if kwargs:
+            release.update(**kwargs)
+
+        commit_list = result.get('commits')
+        if commit_list:
+            hook = ReleaseHook(project)
+            # TODO(dcramer): handle errors with release payloads
+            hook.set_commits(release.version, commit_list)
+
+        if (not was_released and release.date_released):
+            activity = Activity.objects.create(
+                type=Activity.RELEASE,
+                project=project,
+                ident=release.version,
+                data={'version': release.version},
+                datetime=release.date_released,
+            )
+            activity.send_notification()
+
+        return Response(serialize(release, request.user))
+
+    # @attach_scenarios([delete_release_scenario])
+    def delete(self, request, project, version):
+        """
+        Delete a Project's Release
+        ``````````````````````````
+
+        Permanently remove a release and all of its files.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to delete the
+                                     release of.
+        :pparam string version: the version identifier of the release.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id,
+                projects=project,
+                version=version,
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        # we don't want to remove the first_release metadata on the Group, and
+        # while people might want to kill a release (maybe to remove files),
+        # removing the release is prevented
+        if Group.objects.filter(first_release=release).exists():
+            return Response({"detail": ERR_RELEASE_REFERENCED}, status=400)
+
+        # TODO(dcramer): this needs to happen in the queue as it could be a long
+        # and expensive operation
+        file_list = ReleaseFile.objects.filter(
+            release=release,
+        ).select_related('file')
+        for releasefile in file_list:
+            releasefile.file.delete()
+            releasefile.delete()
+        release.delete()
+
+        return Response(status=204)

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -104,8 +104,8 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
     @attach_scenarios([create_new_release_scenario])
     def post(self, request, project):
         """
-        Create a New Release
-        ````````````````````
+        Create a New Release for a Project
+        ``````````````````````````````````
 
         Create a new release and/or associate a project with a release.
         Release versions that are the same across multiple projects

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -41,6 +41,7 @@ from .endpoints.organization_member_team_details import OrganizationMemberTeamDe
 from .endpoints.organization_onboarding_tasks import OrganizationOnboardingTaskEndpoint
 from .endpoints.organization_index import OrganizationIndexEndpoint
 from .endpoints.organization_projects import OrganizationProjectsEndpoint
+from .endpoints.organization_releases import OrganizationReleasesEndpoint
 from .endpoints.organization_repositories import OrganizationRepositoriesEndpoint
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
@@ -196,6 +197,9 @@ urlpatterns = patterns(
     url(r'^organizations/(?P<organization_slug>[^\/]+)/repos/(?P<repo_id>[^\/]+)/commits/$',
         OrganizationRepositoryCommitsEndpoint.as_view(),
         name='sentry-api-0-organization-repository-commits'),
+    url(r'^organizations/(?P<organization_slug>[^\/]+)/releases/$',
+        OrganizationReleasesEndpoint.as_view(),
+        name='sentry-api-0-organization-releases'),
     url(r'^organizations/(?P<organization_slug>[^\/]+)/stats/$',
         OrganizationStatsEndpoint.as_view(),
         name='sentry-api-0-organization-stats'),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -42,6 +42,7 @@ from .endpoints.organization_onboarding_tasks import OrganizationOnboardingTaskE
 from .endpoints.organization_index import OrganizationIndexEndpoint
 from .endpoints.organization_projects import OrganizationProjectsEndpoint
 from .endpoints.organization_releases import OrganizationReleasesEndpoint
+from .endpoints.organization_release_details import OrganizationReleaseDetailsEndpoint
 from .endpoints.organization_repositories import OrganizationRepositoriesEndpoint
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
@@ -76,7 +77,7 @@ from .endpoints.project_tagkey_values import ProjectTagKeyValuesEndpoint
 from .endpoints.project_users import ProjectUsersEndpoint
 from .endpoints.project_user_reports import ProjectUserReportsEndpoint
 from .endpoints.release_commits import ReleaseCommitsEndpoint
-from .endpoints.release_details import ReleaseDetailsEndpoint
+from .endpoints.project_release_details import ProjectReleaseDetailsEndpoint
 from .endpoints.release_files import ReleaseFilesEndpoint
 from .endpoints.release_file_details import ReleaseFileDetailsEndpoint
 from .endpoints.dsym_files import DSymFilesEndpoint, GlobalDSymFilesEndpoint, \
@@ -200,6 +201,9 @@ urlpatterns = patterns(
     url(r'^organizations/(?P<organization_slug>[^\/]+)/releases/$',
         OrganizationReleasesEndpoint.as_view(),
         name='sentry-api-0-organization-releases'),
+    url(r'^organizations/(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/$',
+        OrganizationReleaseDetailsEndpoint.as_view(),
+        name='sentry-api-0-organization-release-details'),
     url(r'^organizations/(?P<organization_slug>[^\/]+)/stats/$',
         OrganizationStatsEndpoint.as_view(),
         name='sentry-api-0-organization-stats'),
@@ -282,8 +286,8 @@ urlpatterns = patterns(
         ProjectReleasesEndpoint.as_view(),
         name='sentry-api-0-project-releases'),
     url(r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/$',
-        ReleaseDetailsEndpoint.as_view(),
-        name='sentry-api-0-release-details'),
+        ProjectReleaseDetailsEndpoint.as_view(),
+        name='sentry-api-0-project-release-details'),
     url(r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/commits/$',
         ReleaseCommitsEndpoint.as_view(),
         name='sentry-api-0-release-commits'),

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -16,7 +16,6 @@ from django.utils import timezone
 from sentry.models import Activity, Release
 
 
-
 class ReleaseHook(object):
     def __init__(self, project):
         self.project = project

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -10,22 +10,16 @@ from __future__ import absolute_import, print_function
 
 __all__ = ['ReleaseHook']
 
-import re
-
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from sentry.models import (
-    Activity, Commit, CommitAuthor, Release, ReleaseCommit, Repository
-)
+from sentry.models import Activity, Release
+
 
 
 class ReleaseHook(object):
     def __init__(self, project):
         self.project = project
-
-    def _to_email(self, name):
-        return re.sub(r'[^a-zA-Z0-9\-_\.]*', '', name).lower() + '@localhost'
 
     def start_release(self, version, **values):
         values.setdefault('date_started', timezone.now())
@@ -68,61 +62,7 @@ class ReleaseHook(object):
             )
         release.add_project(project)
 
-        with transaction.atomic():
-            # TODO(dcramer): would be good to optimize the logic to avoid these
-            # deletes but not overly important
-            ReleaseCommit.objects.filter(
-                release=release,
-            ).delete()
-
-            authors = {}
-            repos = {}
-            for idx, data in enumerate(commit_list):
-                repo_name = data.get('repository') or 'project-{}'.format(project.id)
-                if repo_name not in repos:
-                    repos[repo_name] = repo = Repository.objects.get_or_create(
-                        organization_id=project.organization_id,
-                        name=repo_name,
-                    )[0]
-                else:
-                    repo = repos[repo_name]
-
-                author_email = data.get('author_email')
-                if author_email is None and data.get('author_name'):
-                    author_email = self._to_email(data['author_name'])
-
-                if not author_email:
-                    author = None
-                elif author_email not in authors:
-                    authors[author_email] = author = CommitAuthor.objects.get_or_create(
-                        organization_id=project.organization_id,
-                        email=author_email,
-                        defaults={
-                            'name': data.get('author_name'),
-                        }
-                    )[0]
-                    if data.get('author_name') and author.name != data['author_name']:
-                        author.update(name=data['author_name'])
-                else:
-                    author = authors[author_email]
-
-                commit = Commit.objects.get_or_create(
-                    organization_id=project.organization_id,
-                    repository_id=repo.id,
-                    key=data['id'],
-                    defaults={
-                        'message': data.get('message'),
-                        'author': author,
-                        'date_added': data.get('timestamp') or timezone.now(),
-                    }
-                )[0]
-
-                ReleaseCommit.objects.create(
-                    organization_id=project.organization_id,
-                    release=release,
-                    commit=commit,
-                    order=idx,
-                )
+        release.set_commits(commit_list)
 
     def finish_release(self, version, **values):
         values.setdefault('date_released', timezone.now())

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -1,0 +1,267 @@
+from __future__ import absolute_import
+
+from datetime import datetime
+from django.core.urlresolvers import reverse
+
+from sentry.models import (
+    Activity, File, Release, ReleaseCommit, ReleaseFile, ReleaseProject
+)
+from sentry.testutils import APITestCase
+
+
+class ReleaseDetailsTest(APITestCase):
+    def test_simple(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+
+        project = self.create_project(team=team1, organization=org)
+        project2 = self.create_project(team=team2, organization=org)
+
+        release = Release.objects.create(
+            organization_id=org.id,
+            version='abcabcabc',
+        )
+        release2 = Release.objects.create(
+            organization_id=org.id,
+            version='12345678',
+        )
+        release.add_project(project)
+        release2.add_project(project2)
+
+        self.create_member(teams=[team1], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        ReleaseProject.objects.filter(
+            project=project,
+            release=release
+        ).update(new_groups=5)
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release.version,
+        })
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.data['version'] == release.version
+        assert response.data['newGroups'] == 5
+
+        # no access
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release2.version,
+        })
+        response = self.client.get(url)
+        assert response.status_code == 404
+
+
+class UpdateReleaseDetailsTest(APITestCase):
+    def test_simple(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+
+        project = self.create_project(team=team1, organization=org)
+        project2 = self.create_project(team=team2, organization=org)
+
+        release = Release.objects.create(
+            organization_id=org.id,
+            version='abcabcabc',
+        )
+        release2 = Release.objects.create(
+            organization_id=org.id,
+            version='12345678',
+        )
+        release.add_project(project)
+        release2.add_project(project2)
+
+        self.create_member(teams=[team1], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release.version,
+        })
+        response = self.client.put(url, {'ref': 'master'})
+
+        assert response.status_code == 200, response.content
+        assert response.data['version'] == release.version
+
+        release = Release.objects.get(id=release.id)
+        assert release.ref == 'master'
+
+        # no access
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release2.version,
+        })
+        response = self.client.put(url, {'ref': 'master'})
+        assert response.status_code == 404
+
+    def test_commits(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team = self.create_team(organization=org)
+
+        project = self.create_project(team=team, organization=org)
+
+        release = Release.objects.create(
+            organization_id=org.id,
+            version='abcabcabc',
+        )
+
+        release.add_project(project)
+
+        self.create_member(teams=[team], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release.version,
+        })
+        response = self.client.put(url, data={
+            'commits': [
+                {'id': 'a' * 40},
+                {'id': 'b' * 40},
+            ],
+        })
+
+        assert response.status_code == 200, (response.status_code, response.content)
+
+        rc_list = list(ReleaseCommit.objects.filter(
+            release=release,
+        ).select_related('commit', 'commit__author').order_by('order'))
+        assert len(rc_list) == 2
+        for rc in rc_list:
+            assert rc.organization_id == org.id
+
+    def test_activity_generation(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team = self.create_team(organization=org)
+
+        project = self.create_project(team=team, organization=org)
+
+        release = Release.objects.create(
+            organization_id=org.id,
+            version='abcabcabc',
+        )
+
+        release.add_project(project)
+
+        self.create_member(teams=[team], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release.version,
+        })
+        response = self.client.put(url, data={
+            'dateReleased': datetime.utcnow().isoformat() + 'Z',
+        })
+
+        assert response.status_code == 200, (response.status_code, response.content)
+
+        release = Release.objects.get(id=release.id)
+        assert release.date_released
+
+        activity = Activity.objects.filter(
+            type=Activity.RELEASE,
+            project=project,
+            ident=release.version,
+        )
+        assert activity.exists()
+
+
+class ReleaseDeleteTest(APITestCase):
+    def test_simple(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team = self.create_team(organization=org)
+
+        project = self.create_project(team=team, organization=org)
+
+        release = Release.objects.create(
+            organization_id=org.id,
+            version='abcabcabc',
+        )
+
+        release.add_project(project)
+
+        self.create_member(teams=[team], user=user, organization=org)
+
+        self.login_as(user=user)
+        release_file = ReleaseFile.objects.create(
+            organization_id=project.organization_id,
+            release=release,
+            file=File.objects.create(
+                name='application.js',
+                type='release.file',
+            ),
+            name='http://example.com/application.js'
+        )
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release.version,
+        })
+        response = self.client.delete(url)
+
+        assert response.status_code == 204, response.content
+
+        assert not Release.objects.filter(id=release.id).exists()
+        assert not ReleaseFile.objects.filter(id=release_file.id).exists()
+
+    def test_existing_group(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team = self.create_team(organization=org)
+
+        project = self.create_project(team=team, organization=org)
+
+        release = Release.objects.create(
+            organization_id=org.id,
+            version='abcabcabc',
+        )
+
+        release.add_project(project)
+        self.create_group(first_release=release)
+
+        self.create_member(teams=[team], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': release.version,
+        })
+        response = self.client.delete(url)
+
+        assert response.status_code == 400, response.content
+
+        assert Release.objects.filter(id=release.id).exists()

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1,0 +1,174 @@
+from __future__ import absolute_import
+
+from datetime import datetime
+from django.core.urlresolvers import reverse
+
+from sentry.models import Activity, Release, ReleaseProject
+from sentry.testutils import APITestCase
+
+
+class OrganizationReleaseListTest(APITestCase):
+    def test_simple(self):
+        self.login_as(user=self.user)
+        org = self.create_organization()
+        org2 = self.create_organization()
+
+        release1 = Release.objects.create(
+            organization_id=org.id,
+            version='1',
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
+        )
+
+        release2 = Release.objects.create(
+            organization_id=org.id,
+            version='2',
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
+        )
+
+        release3 = Release.objects.create(
+            organization_id=org.id,
+            version='3',
+            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386),
+            date_released=datetime(2013, 8, 15, 3, 8, 24, 880386),
+        )
+
+        Release.objects.create(
+            organization_id=org2.id,
+            version='1',
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
+        )
+
+        url = reverse('sentry-api-0-organization-releases', kwargs={
+            'organization_slug': org.slug
+        })
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+        assert response.data[0]['version'] == release3.version
+        assert response.data[1]['version'] == release2.version
+        assert response.data[2]['version'] == release1.version
+
+    def test_query_filter(self):
+        self.login_as(user=self.user)
+        org = self.create_organization()
+
+        release = Release.objects.create(
+            organization_id=org.id,
+            version='foobar',
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
+        )
+
+        Release.objects.create(
+            organization_id=org.id,
+            version='sdfsdfsdf',
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
+        )
+
+        url = reverse('sentry-api-0-organization-releases', kwargs={
+            'organization_slug': org.slug
+        })
+        response = self.client.get(url + '?query=foo', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['version'] == release.version
+
+        response = self.client.get(url + '?query=bar', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
+
+class OrganizationReleaseCreateTest(APITestCase):
+    def test_minimal(self):
+        self.login_as(user=self.user)
+        org = self.create_organization()
+
+        project = self.create_project(name='foo', organization=org)
+        project2 = self.create_project(name='bar', organization=org)
+
+        url = reverse('sentry-api-0-organization-releases', kwargs={
+            'organization_slug': org.slug,
+        })
+        response = self.client.post(url, data={
+            'version': '1.2.1',
+            'projects': [project.slug, project2.slug]
+        })
+
+        assert response.status_code == 201, response.content
+        assert response.data['version']
+
+        release = Release.objects.get(
+            version=response.data['version'],
+        )
+        assert not release.owner
+        assert release.organization == org
+        assert ReleaseProject.objects.filter(
+            release=release, project=project
+        ).exists()
+        assert ReleaseProject.objects.filter(
+            release=release, project=project2
+        ).exists()
+
+    def test_duplicate(self):
+        self.login_as(user=self.user)
+
+        org = self.create_organization()
+
+        release = Release.objects.create(version='1.2.1',
+                                         organization=org)
+
+        project = self.create_project(name='foo', organization=org)
+
+        url = reverse('sentry-api-0-organization-releases', kwargs={
+            'organization_slug': org.slug,
+        })
+
+        response = self.client.post(url, data={
+            'version': '1.2.1',
+            'projects': [project.slug]
+        })
+
+        assert response.status_code == 208, response.content
+        assert Release.objects.filter(
+            version='1.2.1', organization=org
+        ).count() == 1
+        # make sure project was added
+        assert ReleaseProject.objects.filter(
+            release=release, project=project
+        ).exists()
+
+    def test_activity(self):
+        self.login_as(user=self.user)
+
+        org = self.create_organization()
+
+        release = Release.objects.create(version='1.2.1',
+                                         date_released=datetime.utcnow(),
+                                         organization=org)
+
+        project = self.create_project(name='foo', organization=org)
+        release.add_project(project)
+        project2 = self.create_project(name='bar', organization=org)
+
+        url = reverse('sentry-api-0-organization-releases', kwargs={
+            'organization_slug': org.slug,
+        })
+
+        response = self.client.post(url, data={
+            'version': '1.2.1',
+            'projects': [project.slug, project2.slug]
+        })
+
+        assert response.status_code == 208, response.content
+        assert not Activity.objects.filter(
+            type=Activity.RELEASE,
+            project=project,
+            ident=release.version
+        ).exists()
+        assert Activity.objects.filter(
+            type=Activity.RELEASE,
+            project=project2,
+            ident=release.version
+        ).exists()

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -229,7 +229,8 @@ class OrganizationReleaseCreateTest(APITestCase):
             'projects': [project.slug]
         })
 
-        assert response.status_code == 208, response.content
+        # should be 201 because project was added
+        assert response.status_code == 201, response.content
         assert Release.objects.filter(
             version='1.2.1', organization=org
         ).count() == 1
@@ -270,10 +271,17 @@ class OrganizationReleaseCreateTest(APITestCase):
 
         response = self.client.post(url, data={
             'version': '1.2.1',
+            'projects': [project.slug]
+        })
+        assert response.status_code == 208, response.content
+
+        response = self.client.post(url, data={
+            'version': '1.2.1',
             'projects': [project.slug, project2.slug]
         })
 
-        assert response.status_code == 208, response.content
+        # should be 201 because 1 project was added
+        assert response.status_code == 201, response.content
         assert not Activity.objects.filter(
             type=Activity.RELEASE,
             project=project,

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -29,7 +29,7 @@ class ReleaseDetailsTest(APITestCase):
             release=release
         ).update(new_groups=5)
 
-        url = reverse('sentry-api-0-release-details', kwargs={
+        url = reverse('sentry-api-0-project-release-details', kwargs={
             'organization_slug': project.organization.slug,
             'project_slug': project.slug,
             'version': release.version,
@@ -56,7 +56,7 @@ class UpdateReleaseDetailsTest(APITestCase):
         release.add_project(project)
         release.add_project(project2)
 
-        url = reverse('sentry-api-0-release-details', kwargs={
+        url = reverse('sentry-api-0-project-release-details', kwargs={
             'organization_slug': project.organization.slug,
             'project_slug': project.slug,
             'version': release.version,
@@ -83,7 +83,7 @@ class UpdateReleaseDetailsTest(APITestCase):
         release.add_project(project)
         release.add_project(project2)
 
-        url = reverse('sentry-api-0-release-details', kwargs={
+        url = reverse('sentry-api-0-project-release-details', kwargs={
             'organization_slug': project.organization.slug,
             'project_slug': project.slug,
             'version': release.version,
@@ -118,7 +118,7 @@ class UpdateReleaseDetailsTest(APITestCase):
         release.add_project(project)
         release.add_project(project2)
 
-        url = reverse('sentry-api-0-release-details', kwargs={
+        url = reverse('sentry-api-0-project-release-details', kwargs={
             'organization_slug': project.organization.slug,
             'project_slug': project.slug,
             'version': release.version,
@@ -163,7 +163,7 @@ class ReleaseDeleteTest(APITestCase):
             name='http://example.com/application.js'
         )
 
-        url = reverse('sentry-api-0-release-details', kwargs={
+        url = reverse('sentry-api-0-project-release-details', kwargs={
             'organization_slug': project.organization.slug,
             'project_slug': project.slug,
             'version': release.version,
@@ -188,7 +188,7 @@ class ReleaseDeleteTest(APITestCase):
         release.add_project(project2)
         self.create_group(first_release=release)
 
-        url = reverse('sentry-api-0-release-details', kwargs={
+        url = reverse('sentry-api-0-project-release-details', kwargs={
             'organization_slug': project.organization.slug,
             'project_slug': project.slug,
             'version': release.version,


### PR DESCRIPTION
Implements the following for organization releases:
- Create a New Release
- Delete a Release
- List an Organization’s Releases
- Retrieve a Release
- Update a Release

as is, depends on https://github.com/getsentry/sentry/pull/4847

cc @ckj @benvinegar @kjlundsgaard @dcramer 