### PR TITLE
http: handle origins that don't have a hostname

### DIFF
--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -159,15 +159,14 @@ def is_valid_origin(origin, project=None, allowed=None):
 
     parsed = urlparse(origin)
 
-    # There is no hostname, so the header is probably invalid
     if parsed.hostname is None:
-        return False
-
-    try:
-        parsed_hostname = parsed.hostname.encode('idna')
-    except UnicodeError:
-        # We sometimes shove in some garbage input here, so just opting to ignore and carry on
-        parsed_hostname = parsed.hostname
+        parsed_hostname = ''
+    else:
+        try:
+            parsed_hostname = parsed.hostname.encode('idna')
+        except UnicodeError:
+            # We sometimes shove in some garbage input here, so just opting to ignore and carry on
+            parsed_hostname = parsed.hostname
 
     if parsed.port:
         domain_matches = (

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -219,6 +219,18 @@ class IsValidOriginTestCase(TestCase):
         result = self.isValidOrigin('http://example.com:1234', ['*:1234'])
         assert result is True
 
+    def test_without_hostname(self):
+        result = self.isValidOrigin('foo://', ['foo://*'])
+        assert result is True
+        result = self.isValidOrigin('foo://', ['foo://'])
+        assert result is True
+        result = self.isValidOrigin('foo://', ['example.com'])
+        assert result is False
+        result = self.isValidOrigin('foo://a', ['foo://'])
+        assert result is False
+        result = self.isValidOrigin('foo://a', ['foo://*'])
+        assert result is True
+
 
 class IsValidIPTestCase(TestCase):
     def is_valid_ip(self, ip, inputs):


### PR DESCRIPTION
This mostly affects CSP reports where blocked-uri's might be something
like:

`webviewprogressproxy://` with no hostname at all.

Prior to this, this would always be accepted and there was not a filter
rule you could apply to this to make it be blocked.

This turned out to be a poor assumption that all uris would have a
hostname that we cared about.