### PR TITLE
Fix bad utils.logging export

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -109,7 +109,7 @@ export default {
     U2fSign: require('./components/u2fsign').default,
     utils: {
       errorHandler: require('./utils/errorHandler').default,
-      logging: require('./utils/logging').default,
+      logging: require('./utils/logging'),
     }
   }
 };


### PR DESCRIPTION
I made the wrong assumption that this was exporting a default export (like every other module).

cc @dcramer