### PR TITLE
Release stats

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ API Changes
 ~~~~~~~~~~~
 
 - Added avatar and avatarType to ``/organizations/{org}/`` endpoint.
+- Provide commit and author information associated with a given release
 
 Version 8.12
 ------------

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -4,34 +4,38 @@ import six
 
 from django.db.models import Sum
 
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Release, ReleaseCommit, ReleaseProject, TagValue, User
 
 
 @register(Release)
 class ReleaseSerializer(Serializer):
-    def _get_commit_authors(self, item, user):
-        # TODO: feature switch
+    # O(a b c)
 
-        # for each release in item_list
-        # do a subquery and get their authors
-        # add authors to that item_list entry
-        releasecommits = ReleaseCommit.objects.filter(
-            release=item
-        ).select_related("commit")
-        authors = []
-        for releasecommit in releasecommits:
-            author = releasecommit.commit.author
-            try:
-                author = User.objects.get(email=author.email)
-            except MultipleObjectsReturned:
-                author = User.objects.filter(email=author.email).first()
-            except ObjectDoesNotExist:
-                pass
-            authors.append(serialize(author))
+    # for every release
+    #      for every release commit
+    #            for every author
+    # def _get_commit_authors(self, item_list, user):
+    #     # TODO: feature switch
 
-        return authors
+    #     # for each release in item_list
+    #     # do a subquery and get their authors
+    #     # add authors to that item_list entry
+    #     releasecommits = ReleaseCommit.objects.filter(
+    #         release=item
+    #     ).select_related("commit")
+    #     authors = []
+    #     for releasecommit in releasecommits:
+    #         author = releasecommit.commit.author
+    #         try:
+    #             author = User.objects.get(email=author.email)
+    #         except MultipleObjectsReturned:
+    #             author = User.objects.filter(email=author.email).first()
+    #         except ObjectDoesNotExist:
+    #             pass
+    #         authors.append(serialize(author))
+
+    #     return authors
 
     def get_attrs(self, item_list, user, *args, **kwargs):
         tags = {
@@ -63,22 +67,63 @@ class ReleaseSerializer(Serializer):
                                       .annotate(new_groups=Sum('new_groups'))
                                       .values_list('release_id', 'new_groups')
             )
+        release_commits = list(ReleaseCommit.objects.filter(
+            release__in=item_list).prefetch_related("commit__author"))
+
+        from collections import Counter, defaultdict
+        commit_count_by_release_id = Counter()
+        authors_by_release_id = defaultdict(dict)
+
+        author_emails = set(rc.commit.author.email for rc in release_commits)
+
+        # NOTE: Possible to return multiple User objects for a single email
+        users = list(User.objects.filter(email__in=author_emails))
+        users_by_email = {}
+        for user in users:
+            # Duplicates will clobber existing record in dict
+            users_by_email[user.email] = serialize(user)
+
+        for rc in release_commits:
+            # Count commits per release
+            commit_count_by_release_id[rc.release_id] += 1
+
+            # Accumulate authors per release
+            release_authors = authors_by_release_id[rc.release_id]
+            if rc.commit.author_id not in release_authors:
+                author = rc.commit.author
+                if author.email in users_by_email:
+                    # Author has a matching Sentry user
+                    release_authors[author.id] = users_by_email[author.email]
+                else:
+                    release_authors[author.id] = {
+                        "name": author.name,
+                        "email": author.email
+                    }
 
         result = {}
-        # if features.has('organizations:release-commits', actor=user):
-        # numCommits
-        # get number of subcommits
-        # num_commits = ReleaseCommit.objects.count(release_id=release.id)
         for item in item_list:
-            authors = self._get_commit_authors(item, user)
             result[item] = {
-                'authors': authors,
-                'author_count': len(authors),
-                'commit_count': ReleaseCommit.objects.filter(release=item).count(),
+                'commit_count': commit_count_by_release_id[item.id],
+                'author_count': 0,
+                'authors': authors_by_release_id[item.id].values(),
                 'tag': tags.get(item.version),
                 'owner': owners[six.text_type(item.owner_id)] if item.owner_id else None,
                 'new_groups': group_counts_by_release.get(item.id) or 0
             }
+
+        # if features.has('organizations:release-commits', actor=user):
+        # numCommits
+        # get number of subcommits
+        # num_commits = ReleaseCommit.objects.count(release_id=release.id)
+        #for item in item_list:
+        #authors = self._get_commit_authors(item_list, user)
+        # result[item] = {
+        #     'authors': authors,
+        #     'author_count': len(authors),
+        #     'commit_count': ReleaseCommit.objects.filter(release=item).count(),
+        #     'tag': tags.get(item.version),
+        #     'owner': owners[six.text_type(item.owner_id)] if item.owner_id else None,
+        # }
         return result
 
     def serialize(self, obj, attrs, user, *args, **kwargs):

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -82,7 +82,6 @@ class ReleaseSerializer(Serializer):
         If there are no commits, returns None.
         """
 
-        # TODO: change to select_related commit, author
         release_commits = list(ReleaseCommit.objects.filter(
             release__in=item_list).select_related("commit", "commit__author"))
 
@@ -153,7 +152,7 @@ class ReleaseSerializer(Serializer):
             result[item] = {
                 'tag': tags.get(item.version),
                 'owner': owners[six.text_type(item.owner_id)] if item.owner_id else None,
-                'new_groups': group_counts_by_release.get(item.id) or 0
+                'new_groups': group_counts_by_release.get(item.id) or 0,
                 'commit_count': 0,
                 'authors': [],
             }

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -14,70 +14,83 @@ from sentry.models import Release, ReleaseCommit, ReleaseProject, TagValue, User
 
 @register(Release)
 class ReleaseSerializer(Serializer):
-    # O(a b c)
+    def _get_users_for_commits(self, release_commits, org_id):
+        """
+        Returns a dictionary of author_email => user, if a Sentry
+        user object exists for that email. If there is no matching
+        user, no key/value pair in the dictionary is made.
 
-    # for every release
-    #      for every release commit
-    #            for every author
-    # def _get_commit_authors(self, item_list, user):
-    #     # TODO: feature switch
-
-    #     # for each release in item_list
-    #     # do a subquery and get their authors
-    #     # add authors to that item_list entry
-    #     releasecommits = ReleaseCommit.objects.filter(
-    #         release=item
-    #     ).select_related("commit")
-    #     authors = []
-    #     for releasecommit in releasecommits:
-    #         author = releasecommit.commit.author
-    #         try:
-    #             author = User.objects.get(email=author.email)
-    #         except MultipleObjectsReturned:
-    #             author = User.objects.filter(email=author.email).first()
-    #         except ObjectDoesNotExist:
-    #             pass
-    #         authors.append(serialize(author))
-
-    #     return authors
-    def _get_commit_metadata(self, item_list, user):
-        release_commits = list(ReleaseCommit.objects.filter(
-            release__in=item_list).prefetch_related("commit__author"))
-
-        commit_count_by_release_id = Counter()
-        authors_by_release_id = defaultdict(dict)
-
-        org_ids = set(item.organization_id for item in item_list)
-        assert len(org_ids) == 1
-        org_id = org_ids.pop()
-
-        author_emails = set([rc.commit.author.email for rc in release_commits if rc.commit.author is not None])
+        e.g.
+        {
+            'jane@example.com': <User id=1>,
+            ...
+        }
+        """
+        author_emails = {rc.commit.author.email for rc in release_commits if rc.commit.author is not None}
+        if not len(author_emails):
+            return {}
 
         # Filter users based on the emails provided in the commits
         # Filter those belonging to the organization associated with the release
         users = User.objects.filter(
             in_iexact('emails__email', author_emails),
             sentry_orgmember_set__organization_id=org_id
-        ).select_related('emails').distinct()
+        ).distinct()
 
         # Which email resulted in this user?
         # NOTE: If two users have same secondary email, only
         #       one will be credited as the author in UI
+        # TODO: fix 'emails.all()' subquery in loop
         users_by_email = {}
         for user in users:
             serialized_user = serialize(user)
             for email in user.emails.all():
                 users_by_email[email.email] = serialized_user
-        print users_by_email
+        return users_by_email
+
+    def _get_commit_metadata(self, item_list, user):
+        """
+        Returns a dictionary of release_id => commit metadata,
+        where each commit metadata dict contains commit_count
+        and an array of authors.
+
+        e.g.
+        {
+            1: {
+                'commit_count': 3,
+                'authors': [<User id=1>, <User id=2>]
+            },
+            ...
+        }
+
+        If there are no commits, returns None.
+        """
+
+        # TODO: change to select_related commit, author
+        release_commits = list(ReleaseCommit.objects.filter(
+            release__in=item_list).select_related("commit", "commit__author"))
+
+        if not len(release_commits):
+            return None
+
+        org_ids = set(item.organization_id for item in item_list)
+        assert len(org_ids) == 1
+        org_id = org_ids.pop()
+
+        users_by_email = self._get_users_for_commits(release_commits, org_id)
+        commit_count_by_release_id = Counter()
+        authors_by_release_id = defaultdict(dict)
+
         for rc in release_commits:
-            # Count commits per release
-            commit_count_by_release_id[rc.release_id] += 1
             # Accumulate authors per release
             release_authors = authors_by_release_id[rc.release_id]
 
-            if not rc.commit.author:
-                pass
-            elif rc.commit.author_id not in release_authors:
+            # Increment commit count per release
+            commit_count_by_release_id[rc.release_id] += 1
+
+            if rc.commit.author and \
+               rc.commit.author_id not in release_authors:
+
                 author = rc.commit.author
                 if author.email in users_by_email:
                     # Author has a matching Sentry user
@@ -92,7 +105,7 @@ class ReleaseSerializer(Serializer):
         for item in item_list:
             result[item] = {
                 'commit_count': commit_count_by_release_id[item.id],
-                'authors': authors_by_release_id[item.id].values(),
+                'authors': authors_by_release_id.get(item.id, {}).values(),
             }
         return result
 
@@ -135,8 +148,11 @@ class ReleaseSerializer(Serializer):
                 'tag': tags.get(item.version),
                 'owner': owners[six.text_type(item.owner_id)] if item.owner_id else None,
                 'new_groups': group_counts_by_release.get(item.id) or 0
+                'commit_count': 0,
+                'authors': [],
             }
-            result[item].update(release_metadata_attrs[item])
+            if release_metadata_attrs:
+                result[item].update(release_metadata_attrs[item])
 
         return result
 
@@ -152,8 +168,8 @@ class ReleaseSerializer(Serializer):
             'data': obj.data,
             'newGroups': attrs['new_groups'],
             'owner': attrs['owner'],
-            'commitCount': attrs['commit_count'],
-            'authors': attrs['authors'],
+            'commitCount': attrs.get('commit_count', 0),
+            'authors': attrs.get('authors', []),
         }
         if attrs['tag']:
             d.update({

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -39,6 +39,48 @@ class ReleaseSerializer(Serializer):
     #         authors.append(serialize(author))
 
     #     return authors
+    def _get_commit_metadata(self, item_list, user):
+        release_commits = list(ReleaseCommit.objects.filter(
+            release__in=item_list).prefetch_related("commit__author"))
+
+        commit_count_by_release_id = Counter()
+        authors_by_release_id = defaultdict(dict)
+
+        author_emails = set(rc.commit.author.email for rc in release_commits)
+
+        # TODO: Consider UserEmail models, organization filter
+        # NOTE: Possible to return multiple User objects for a single email
+        users = list(User.objects.filter(email__in=author_emails))
+        users_by_email = {}
+        for user in users:
+            # Duplicates will clobber existing record in dict
+            users_by_email[user.email] = serialize(user)
+
+        for rc in release_commits:
+            # Count commits per release
+            commit_count_by_release_id[rc.release_id] += 1
+
+            # Accumulate authors per release
+            release_authors = authors_by_release_id[rc.release_id]
+            if rc.commit.author_id not in release_authors:
+                author = rc.commit.author
+                if author.email in users_by_email:
+                    # Author has a matching Sentry user
+                    release_authors[author.id] = users_by_email[author.email]
+                else:
+                    release_authors[author.id] = {
+                        "name": author.name,
+                        "email": author.email
+                    }
+
+        result = {}
+        for item in item_list:
+            result[item] = {
+                'commit_count': commit_count_by_release_id[item.id],
+                'author_count': 0,
+                'authors': authors_by_release_id[item.id].values(),
+            }
+        return result
 
     def get_attrs(self, item_list, user, *args, **kwargs):
         tags = {
@@ -70,62 +112,18 @@ class ReleaseSerializer(Serializer):
                                       .annotate(new_groups=Sum('new_groups'))
                                       .values_list('release_id', 'new_groups')
             )
-        release_commits = list(ReleaseCommit.objects.filter(
-            release__in=item_list).prefetch_related("commit__author"))
 
-        commit_count_by_release_id = Counter()
-        authors_by_release_id = defaultdict(dict)
-
-        author_emails = set(rc.commit.author.email for rc in release_commits)
-
-        # NOTE: Possible to return multiple User objects for a single email
-        users = list(User.objects.filter(email__in=author_emails))
-        users_by_email = {}
-        for user in users:
-            # Duplicates will clobber existing record in dict
-            users_by_email[user.email] = serialize(user)
-
-        for rc in release_commits:
-            # Count commits per release
-            commit_count_by_release_id[rc.release_id] += 1
-
-            # Accumulate authors per release
-            release_authors = authors_by_release_id[rc.release_id]
-            if rc.commit.author_id not in release_authors:
-                author = rc.commit.author
-                if author.email in users_by_email:
-                    # Author has a matching Sentry user
-                    release_authors[author.id] = users_by_email[author.email]
-                else:
-                    release_authors[author.id] = {
-                        "name": author.name,
-                        "email": author.email
-                    }
+        release_metadata_attrs = self._get_commit_metadata(item_list, user)
 
         result = {}
         for item in item_list:
             result[item] = {
-                'commit_count': commit_count_by_release_id[item.id],
-                'author_count': 0,
-                'authors': authors_by_release_id[item.id].values(),
                 'tag': tags.get(item.version),
                 'owner': owners[six.text_type(item.owner_id)] if item.owner_id else None,
                 'new_groups': group_counts_by_release.get(item.id) or 0
             }
+            result[item].update(release_metadata_attrs[item])
 
-        # if features.has('organizations:release-commits', actor=user):
-        # numCommits
-        # get number of subcommits
-        # num_commits = ReleaseCommit.objects.count(release_id=release.id)
-        # for item in item_list:
-        # authors = self._get_commit_authors(item_list, user)
-        # result[item] = {
-        #     'authors': authors,
-        #     'author_count': len(authors),
-        #     'commit_count': ReleaseCommit.objects.filter(release=item).count(),
-        #     'tag': tags.get(item.version),
-        #     'owner': owners[six.text_type(item.owner_id)] if item.owner_id else None,
-        # }
         return result
 
     def serialize(self, obj, attrs, user, *args, **kwargs):

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -4,6 +4,9 @@ import six
 
 from django.db.models import Sum
 
+
+from collections import Counter, defaultdict
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Release, ReleaseCommit, ReleaseProject, TagValue, User
 
@@ -70,7 +73,6 @@ class ReleaseSerializer(Serializer):
         release_commits = list(ReleaseCommit.objects.filter(
             release__in=item_list).prefetch_related("commit__author"))
 
-        from collections import Counter, defaultdict
         commit_count_by_release_id = Counter()
         authors_by_release_id = defaultdict(dict)
 
@@ -115,8 +117,8 @@ class ReleaseSerializer(Serializer):
         # numCommits
         # get number of subcommits
         # num_commits = ReleaseCommit.objects.count(release_id=release.id)
-        #for item in item_list:
-        #authors = self._get_commit_authors(item_list, user)
+        # for item in item_list:
+        # authors = self._get_commit_authors(item_list, user)
         # result[item] = {
         #     'authors': authors,
         #     'author_count': len(authors),

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -8,7 +8,7 @@ from django.db.models import Sum
 from collections import Counter, defaultdict
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.models import Release, ReleaseCommit, ReleaseProject, TagValue, User
+from sentry.models import Release, ReleaseCommit, ReleaseProject, TagValue, UserEmail
 
 
 @register(Release)
@@ -50,11 +50,11 @@ class ReleaseSerializer(Serializer):
 
         # TODO: Consider UserEmail models, organization filter
         # NOTE: Possible to return multiple User objects for a single email
-        users = list(User.objects.filter(email__in=author_emails))
+        useremails = list(UserEmail.objects.filter(email__in=author_emails))
         users_by_email = {}
-        for user in users:
+        for useremail in useremails:
             # Duplicates will clobber existing record in dict
-            users_by_email[user.email] = serialize(user)
+            users_by_email[useremail.email] = serialize(useremail.user)
 
         for rc in release_commits:
             # Count commits per release

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -46,7 +46,7 @@ class ReleaseSerializer(Serializer):
         commit_count_by_release_id = Counter()
         authors_by_release_id = defaultdict(dict)
 
-        author_emails = set(rc.commit.author.email for rc in release_commits)
+        author_emails = set(rc.commit.author.email for rc in release_commits if rc.commit.author is not None)
 
         # TODO: Consider UserEmail models, organization filter
         # NOTE: Possible to return multiple User objects for a single email
@@ -59,10 +59,12 @@ class ReleaseSerializer(Serializer):
         for rc in release_commits:
             # Count commits per release
             commit_count_by_release_id[rc.release_id] += 1
-
             # Accumulate authors per release
             release_authors = authors_by_release_id[rc.release_id]
-            if rc.commit.author_id not in release_authors:
+
+            if not rc.commit.author:
+                pass
+            elif rc.commit.author_id not in release_authors:
                 author = rc.commit.author
                 if author.email in users_by_email:
                     # Author has a matching Sentry user

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -35,7 +35,7 @@ class ReleaseSerializer(Serializer):
         # Filter users based on the emails provided in the commits
         user_emails = UserEmail.objects.filter(
             in_iexact('email', [a.email for a in authors]),
-        )
+        ).order_by('id')
 
         # Filter users belonging to the organization associated with
         # the release

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -77,7 +77,6 @@ class ReleaseSerializer(Serializer):
         for item in item_list:
             result[item] = {
                 'commit_count': commit_count_by_release_id[item.id],
-                'author_count': 0,
                 'authors': authors_by_release_id[item.id].values(),
             }
         return result
@@ -139,7 +138,6 @@ class ReleaseSerializer(Serializer):
             'newGroups': attrs['new_groups'],
             'owner': attrs['owner'],
             'commitCount': attrs['commit_count'],
-            'authorCount': attrs['author_count'],
             'authors': attrs['authors'],
         }
         if attrs['tag']:

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Avatar from './avatar';
+
+const ReleaseStats = React.createClass({
+  propTypes: {
+    release: React.PropTypes.object,
+  },
+
+  render() {
+    let release = this.props.release;
+    return (
+      <div className="release-info">
+        <div><b>{release.commitCount} commits by {release.authors.length} authors</b></div>
+        {release.authors.map(author => {
+          return <Avatar user={author}/>;
+        })}
+      </div>
+    );
+  }
+});
+
+export default ReleaseStats;

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Avatar from './avatar';
 import TooltipMixin from '../mixins/tooltip';
+import {t} from '../locale';
 
 const ReleaseStats = React.createClass({
   propTypes: {
@@ -15,13 +16,15 @@ const ReleaseStats = React.createClass({
 
   render() {
     let release = this.props.release;
+    let commitCount = release.commitCount;
+    let authorCount = release.authors.length;
     return (
       <div className="release-info">
-        <div><b>{release.commitCount} commits by {release.authors.length} authors</b></div>
+        <div><b>{commitCount}{t(' commits by ')}{authorCount}{t(' authors')}</b></div>
         {release.authors.map(author => {
           return (
             <span className="assignee-selector tip"
-                 title={author.name + ' ' + author.email }>
+                 title={author.name + ' ' + author.email}>
               <Avatar user={author}/>
             </span>
           );

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -18,6 +18,9 @@ const ReleaseStats = React.createClass({
     let release = this.props.release;
     let commitCount = release.commitCount;
     let authorCount = release.authors.length;
+    if (commitCount === 0) {
+      return null;
+    }
     return (
       <div className="release-info">
         <div><b>{commitCount}{t(' commits by ')}{authorCount}{t(' authors')}</b></div>

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import Avatar from './avatar';
+import TooltipMixin from '../mixins/tooltip';
 
 const ReleaseStats = React.createClass({
   propTypes: {
     release: React.PropTypes.object,
   },
+
+  mixins: [
+    TooltipMixin({
+      selector: '.tip'
+    }),
+  ],
 
   render() {
     let release = this.props.release;
@@ -12,7 +19,12 @@ const ReleaseStats = React.createClass({
       <div className="release-info">
         <div><b>{release.commitCount} commits by {release.authors.length} authors</b></div>
         {release.authors.map(author => {
-          return <Avatar user={author}/>;
+          return (
+            <span className="assignee-selector tip"
+                 title={author.name + ' ' + author.email }>
+              <Avatar user={author}/>
+            </span>
+          );
         })}
       </div>
     );

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
@@ -19,11 +19,15 @@ const ReleaseList = React.createClass({
             return (
               <li className="release" key={release.version}>
                 <div className="row">
-                  <div className="col-sm-8 col-xs-6">
+                  <div className="col-sm-6 col-xs-4">
                     <h4><Version orgId={orgId} projectId={projectId} version={release.version} /></h4>
                     <div className="release-meta">
                       <span className="icon icon-clock"></span> <TimeSince date={release.dateCreated} />
                     </div>
+                  </div>
+                  <div className="col-sm-2 col-xs-2">
+                    <div>{release.commitCount} commits by {release.authorCount} authors</div>
+                    {release.authors.map(author => {return <div>{author.name}</div>; })}
                   </div>
                   <div className="col-sm-2 col-xs-3 release-stats stream-count">
                     <Count className="release-count" value={release.newGroups} />

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReleaseStats from '../../components/releaseStats';
 import Count from '../../components/count';
 import TimeSince from '../../components/timeSince';
 import Version from '../../components/version';
@@ -26,8 +27,7 @@ const ReleaseList = React.createClass({
                     </div>
                   </div>
                   <div className="col-sm-2 col-xs-2">
-                    <div>{release.commitCount} commits by {release.authorCount} authors</div>
-                    {release.authors.map(author => {return <div>{author.name}</div>; })}
+                    <ReleaseStats release={release}/>
                   </div>
                   <div className="col-sm-2 col-xs-3 release-stats stream-count">
                     <Count className="release-count" value={release.newGroups} />

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -5,6 +5,7 @@ import DocumentTitle from 'react-document-title';
 import ListLink from '../components/listLink';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
+import Avatar from '../components/avatar';
 import ProjectState from '../mixins/projectState';
 import TimeSince from '../components/timeSince';
 import Version from '../components/version';
@@ -92,18 +93,27 @@ const ReleaseDetails = React.createClass({
 
     let release = this.state.release;
     let {orgId, projectId} = this.props.params;
-
     return (
       <DocumentTitle title={this.getTitle()}>
         <div>
           <div className="release-details">
             <div className="row">
-              <div className="col-sm-6 col-xs-12">
+              <div className="col-sm-4 col-xs-12">
                 <h3>{t('Release')} <strong><Version orgId={orgId} projectId={projectId} version={release.version} anchor={false} /></strong></h3>
                 <div className="release-meta">
                   <span className="icon icon-clock"></span> <TimeSince date={release.dateCreated} />
                 </div>
               </div>
+              {(new Set(this.context.organization.features)).has('release-commits') &&
+              <div className="col-sm-2 hidden-xs">
+                <div className="release-info">
+                  <span><b>{release.commitCount} commits by {release.authorCount} authors</b></span>
+                  {release.authors.map(author => {
+                    return <Avatar user={author}/>;
+                  })}
+                </div>
+              </div>
+              }
               <div className="col-sm-2 hidden-xs">
                 <div className="release-stats">
                   <h6 className="nav-header">{t('New Issues')}</h6>

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -5,7 +5,7 @@ import DocumentTitle from 'react-document-title';
 import ListLink from '../components/listLink';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
-import Avatar from '../components/avatar';
+import ReleaseStats from '../components/releaseStats';
 import ProjectState from '../mixins/projectState';
 import TimeSince from '../components/timeSince';
 import Version from '../components/version';
@@ -106,12 +106,7 @@ const ReleaseDetails = React.createClass({
               </div>
               {(new Set(this.context.organization.features)).has('release-commits') &&
               <div className="col-sm-2 hidden-xs">
-                <div className="release-info">
-                  <span><b>{release.commitCount} commits by {release.authorCount} authors</b></span>
-                  {release.authors.map(author => {
-                    return <Avatar user={author}/>;
-                  })}
-                </div>
+                <ReleaseStats release={release}/>
               </div>
               }
               <div className="col-sm-2 hidden-xs">

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -104,11 +104,9 @@ const ReleaseDetails = React.createClass({
                   <span className="icon icon-clock"></span> <TimeSince date={release.dateCreated} />
                 </div>
               </div>
-              {(new Set(this.context.organization.features)).has('release-commits') &&
               <div className="col-sm-2 hidden-xs">
                 <ReleaseStats release={release}/>
               </div>
-              }
               <div className="col-sm-2 hidden-xs">
                 <div className="release-stats">
                   <h6 className="nav-header">{t('New Issues')}</h6>

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
-import moment from 'moment';
 import ApiMixin from '../../mixins/apiMixin';
 
 const ReleaseCommit = React.createClass({

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -72,8 +72,9 @@ const ReleaseCommits = React.createClass({
         <div className="panel-heading panel-heading-bold">
           <div className="row">
             <div className="col-sm-2 col-xs-2">{'SHA'}</div>
-            <div className="col-sm-7 col-xs-7">{'Message'}</div>
-            <div className="col-sm-3 col-xs-3 align-right">{'Date'}</div>
+            <div className="col-sm-5 col-xs-5">{'Message'}</div>
+            <div className="col-sm-3 col-xs-3 align-right actions">{'Date'}</div>
+            <div className="col-sm-2 col-xs-2 align-right actions">{'Author'}</div>
           </div>
         </div>
         <ul className="list-group commit-list">

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
-
+import moment from 'moment';
 import ApiMixin from '../../mixins/apiMixin';
 
 const ReleaseCommit = React.createClass({

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -94,10 +94,6 @@ class ReleaseSerializerTest(TestCase):
             organization_id=project.organization_id,
             repository_id=1,
             key='abc',
-<<<<<<< HEAD
-            date_added='2016-12-14T23:37:37.166Z',
-=======
->>>>>>> 1e99fa9... Don't specify date at all in test commit
             author=commit_author,
             message='waddap',
         )
@@ -134,7 +130,10 @@ class ReleaseSerializerTest(TestCase):
             organization_id=project.organization_id,
             repository_id=1,
             key='abc',
+<<<<<<< HEAD
             date_added='2016-12-14T23:37:37.166Z',
+=======
+>>>>>>> 668068d... Try again to fix test by removing specified date from test commit
             author=commit_author,
             message='waddap',
         )

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -130,10 +130,6 @@ class ReleaseSerializerTest(TestCase):
             organization_id=project.organization_id,
             repository_id=1,
             key='abc',
-<<<<<<< HEAD
-            date_added='2016-12-14T23:37:37.166Z',
-=======
->>>>>>> 668068d... Try again to fix test by removing specified date from test commit
             author=commit_author,
             message='waddap',
         )
@@ -146,7 +142,10 @@ class ReleaseSerializerTest(TestCase):
         )
 
         result = serialize(release, user)
-        assert result['authors'] == [serialize(user)]
+        result_author = result['authors'][0]
+        assert int(result_author['id']) == user.id
+        assert result_author['email'] == user.email
+        assert result_author['username'] == user.username
 
     def test_get_single_user_from_email(self):
         user = User.objects.create(email='stebe@sentry.io')

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -181,4 +181,7 @@ class ReleaseSerializerTest(TestCase):
 
         result = serialize(release, user)
         assert len(result['authors']) == 1
-        assert result['authors'] == [serialize(user)] or [serialize(otheruser)]
+        result_author = result['authors'][0]
+        assert int(result_author['id']) == user.id or int(result_author['id']) == otheruser.id
+        assert result_author['email'] == user.email or result_author['email'] == otheruser.email
+        assert result_author['username'] == user.username or result_author['username'] == otheruser.username

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
-from sentry.models import Release, ReleaseProject, TagValue
+from sentry.models import Release, ReleaseProject, TagValue, Commit, CommitAuthor, ReleaseCommit
 from sentry.testutils import TestCase
 
 
@@ -37,6 +37,26 @@ class ReleaseSerializerTest(TestCase):
             last_seen=timezone.now(),
             times_seen=5,
         )
+        commit_author = CommitAuthor.objects.create(
+            name='stebe',
+            email='stebe@sentry.io',
+            organization_id=project.organization_id,
+        )
+        commit = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=1,
+            key='abc',
+            date_added='2016-12-14T23:37:37.166Z',
+            author=commit_author,
+            message='waddap',
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            release=release,
+            commit=commit,
+            order=1,
+        )
 
         result = serialize(release, user)
         assert result['version'] == release.version
@@ -45,6 +65,8 @@ class ReleaseSerializerTest(TestCase):
         assert result['newGroups'] == 2
         assert result['firstEvent']
         assert result['lastEvent']
+        assert result['commitCount'] == 1
+        assert result['authors'] == [{'name': 'stebe', 'email': 'stebe@sentry.io'}]
 
         result = serialize(release, user, project=project)
         # should be groups from one project

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -182,6 +182,6 @@ class ReleaseSerializerTest(TestCase):
         result = serialize(release, user)
         assert len(result['authors']) == 1
         result_author = result['authors'][0]
-        assert int(result_author['id']) == user.id or int(result_author['id']) == otheruser.id
-        assert result_author['email'] == user.email or result_author['email'] == otheruser.email
-        assert result_author['username'] == user.username or result_author['username'] == otheruser.username
+        assert int(result_author['id']) == user.id
+        assert result_author['email'] == user.email
+        assert result_author['username'] == user.username

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -47,7 +47,6 @@ class ReleaseSerializerTest(TestCase):
             organization_id=project.organization_id,
             repository_id=1,
             key='abc',
-            date_added='2016-12-14T23:37:37.166Z',
             author=commit_author,
             message='waddap',
         )
@@ -95,7 +94,10 @@ class ReleaseSerializerTest(TestCase):
             organization_id=project.organization_id,
             repository_id=1,
             key='abc',
+<<<<<<< HEAD
             date_added='2016-12-14T23:37:37.166Z',
+=======
+>>>>>>> 1e99fa9... Don't specify date at all in test commit
             author=commit_author,
             message='waddap',
         )
@@ -168,7 +170,6 @@ class ReleaseSerializerTest(TestCase):
             organization_id=project.organization_id,
             repository_id=1,
             key='abc',
-            date_added='2016-12-14T23:37:37.166Z',
             author=commit_author,
             message='waddap',
         )


### PR DESCRIPTION
Provides commit count, number of authors, and avatars associated with commit authors in the release.

@getsentry/product 

![image](https://cloud.githubusercontent.com/assets/9269824/22261755/01ed182e-e223-11e6-97b9-e6b4d9c17a8a.png)
