### PR TITLE
Use user-defined prefix when generating activity email subjects.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Version 8.13 (Unreleased)
 - Add memory and storage information for apple devices
 - The legacy API keys feature is now disabled by default.
 - Show Images Loaded section for cocoa events with version number.
+- Fixed bug where workflow notification subject may not include a custom email prefix.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/plugins/sentry_mail/activity/base.py
+++ b/src/sentry/plugins/sentry_mail/activity/base.py
@@ -25,7 +25,7 @@ class ActivityEmail(object):
     def _get_subject_prefix(self):
         prefix = ProjectOption.objects.get_value(
             project=self.project,
-            key='subject_prefix',
+            key='mail:subject_prefix',
         )
         if not prefix:
             prefix = options.get('mail.subject-prefix')
@@ -109,6 +109,12 @@ class ActivityEmail(object):
             group.get_level_display().upper(),
             group.title
         )
+
+    def get_subject_with_prefix(self):
+        return u'{}{}'.format(
+            self._get_subject_prefix(),
+            self.get_subject(),
+        ).encode('utf-8')
 
     def get_context(self):
         description = self.get_description()
@@ -239,12 +245,6 @@ class ActivityEmail(object):
         context = self.get_base_context()
         context.update(self.get_context())
 
-        subject_prefix = self._get_subject_prefix()
-
-        subject = (u'{}{}'.format(
-            subject_prefix,
-            self.get_subject(),
-        )).encode('utf-8')
         template = self.get_template()
         html_template = self.get_html_template()
         email_type = self.get_email_type()
@@ -265,7 +265,7 @@ class ActivityEmail(object):
                 })
 
             msg = MessageBuilder(
-                subject=subject,
+                subject=self.get_subject_with_prefix(),
                 template=template,
                 html_template=html_template,
                 headers=headers,

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -395,3 +395,18 @@ class ActivityEmailTestCase(TestCase):
         )
 
         assert set(email.get_participants()) == set([user])
+
+    def test_get_subject(self):
+        group, (user,) = self.get_fixture_data(1)
+
+        email = ActivityEmail(
+            Activity(
+                project=group.project,
+                group=group,
+            )
+        )
+
+        with mock.patch('sentry.models.ProjectOption.objects.get_value') as get_value:
+            get_value.side_effect = lambda project, key, default=None: \
+                "[Example prefix] " if key == "mail:subject_prefix" else default
+            assert email.get_subject_with_prefix().startswith('[Example prefix] ')


### PR DESCRIPTION
This was supposed to be happening before, but never actually worked. This works for alerts and digests since it uses `Plugin.get_option`, which automatically prefixes it with the `mail:` plugin key.