### PR TITLE
Fix encoding issue with email subject rendering.

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -274,9 +274,9 @@ class Event(Model):
         return truncatechars(
             template.safe_substitute(
                 EventSubjectTemplateData(self),
-            ).encode('utf-8'),
+            ),
             128,
-        )
+        ).encode('utf-8')
 
 
 class EventSubjectTemplate(string.Template):


### PR DESCRIPTION
This was naively truncating the bytestring, which means it could be
truncating on a multi-byte character. `truncatechars` will handle this
correctly, as long as it's given a `unicode` object instead of a `str`.