### PR TITLE
Commit list

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ API Changes
 
 - Added avatar and avatarType to ``/organizations/{org}/`` endpoint.
 - Provide commit and author information associated with a given release
+- Provide repository information for commits
 
 Version 8.12
 ------------

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -322,6 +322,9 @@ def main(num_events=1):
                 name='Example Repo',
                 provider='github',
                 external_id='example/example',
+                defaults={
+                    'url': 'https://github.com/example/example',
+                }
             )
 
             for commit_index, raw_commit in enumerate(raw_commits):

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -18,7 +18,7 @@ class CommitSerializer(Serializer):
         for item in item_list:
             result[item] = {
                 'repository': repository_objs.get(item.repository_id, {}),
-                'user': author_objs.get(item.author.email, {})
+                'user': author_objs.get(item.author_id, {})
             }
 
         return result

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -1,18 +1,61 @@
 from __future__ import absolute_import
 
-from sentry.api.serializers import Serializer, register
-from sentry.models import Commit
+from sentry.api.serializers import Serializer, register, serialize
+from sentry.db.models.query import in_iexact
+from sentry.models import Commit, Repository, UserEmail, User
 
 
 @register(Commit)
 class CommitSerializer(Serializer):
+    def get_attrs(self, item_list, user):
+
+        authors = set(c.author for c in item_list if c.author is not None)
+
+        user_emails = UserEmail.objects.filter(
+            in_iexact('email', [a.email for a in authors]),
+        ).order_by('id')
+        org_ids = set(item.organization_id for item in item_list)
+        assert len(org_ids) == 1
+        org_id = org_ids.pop()
+        users = User.objects.filter(
+            id__in=[ue.user_id for ue in user_emails],
+            sentry_orgmember_set__organization_id=org_id
+        )
+        users_by_id = dict((user.id, serialize(user)) for user in users)
+        users_by_email = {}
+        for email in user_emails:
+            if email.email in users_by_email:
+                pass
+            user = users_by_id.get(email.user_id)
+            users_by_email[email.email] = user
+
+        author_objs = {}
+        for author in authors:
+            author_objs[author.email] = users_by_email.get(author.email, {
+                "name": author.name,
+                "email": author.email
+            })
+
+        repositories = list(Repository.objects.filter(id__in=[c.repository_id for c in item_list]))
+        repository_objs = {}
+        for repository in repositories:
+            repository_objs[repository.id] = serialize(repository)
+        result = {}
+        for item in item_list:
+            result[item] = {
+                'repository': repository_objs.get(item.repository_id, {}),
+                'user': author_objs.get(item.author.email, {})
+            }
+
+        return result
+
     def serialize(self, obj, attrs, user):
-        return {
+        d = {
             'id': obj.key,
             'message': obj.message,
-            'author': {
-                'name': obj.author.name,
-                'email': obj.author.email,
-            } if obj.author else None,
             'dateCreated': obj.date_added,
+            'repository': attrs.get('repository', {}),
+            'author': attrs.get('user', {})
         }
+
+        return d

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -1,40 +1,14 @@
 from __future__ import absolute_import
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.db.models.query import in_iexact
-from sentry.models import Commit, Repository, UserEmail, User
+from sentry.models import Commit, Repository
+from sentry.api.serializers.models.release import get_users_for_commits
 
 
 @register(Commit)
 class CommitSerializer(Serializer):
     def get_attrs(self, item_list, user):
-
-        authors = set(c.author for c in item_list if c.author is not None)
-
-        user_emails = UserEmail.objects.filter(
-            in_iexact('email', [a.email for a in authors]),
-        ).order_by('id')
-        org_ids = set(item.organization_id for item in item_list)
-        assert len(org_ids) == 1
-        org_id = org_ids.pop()
-        users = User.objects.filter(
-            id__in=[ue.user_id for ue in user_emails],
-            sentry_orgmember_set__organization_id=org_id
-        )
-        users_by_id = dict((user.id, serialize(user)) for user in users)
-        users_by_email = {}
-        for email in user_emails:
-            if email.email in users_by_email:
-                pass
-            user = users_by_id.get(email.user_id)
-            users_by_email[email.email] = user
-
-        author_objs = {}
-        for author in authors:
-            author_objs[author.email] = users_by_email.get(author.email, {
-                "name": author.name,
-                "email": author.email
-            })
+        author_objs = get_users_for_commits(item_list)
 
         repositories = list(Repository.objects.filter(id__in=[c.repository_id for c in item_list]))
         repository_objs = {}

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -12,6 +12,47 @@ from sentry.db.models.query import in_iexact
 from sentry.models import Release, ReleaseCommit, ReleaseProject, TagValue, User, UserEmail
 
 
+def get_users_for_commits(item_list):
+
+    authors = set(c.author for c in item_list if c.author is not None)
+    if not len(authors):
+        return {}
+
+    # Filter users based on the emails provided in the commits
+    user_emails = UserEmail.objects.filter(
+        in_iexact('email', [a.email for a in authors]),
+    ).order_by('id')
+
+    org_ids = set(item.organization_id for item in item_list)
+    assert len(org_ids) == 1
+    org_id = org_ids.pop()
+
+    # Filter users belonging to the organization associated with
+    # the release
+    users = User.objects.filter(
+        id__in=[ue.user_id for ue in user_emails],
+        sentry_orgmember_set__organization_id=org_id
+    )
+    users_by_id = dict((user.id, serialize(user)) for user in users)
+
+    # Figure out which email address matches to a user
+    users_by_email = {}
+    for email in user_emails:
+        if email.email in users_by_email:
+            pass
+        user = users_by_id.get(email.user_id)
+        users_by_email[email.email] = user
+
+    author_objs = {}
+    for author in authors:
+        author_objs[author.email] = users_by_email.get(author.email, {
+            "name": author.name,
+            "email": author.email
+        })
+
+    return author_objs
+
+
 @register(Release)
 class ReleaseSerializer(Serializer):
     def _get_users_for_commits(self, release_commits, org_id):

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -50,10 +50,9 @@ def get_users_for_commits(item_list):
     # Figure out which email address matches to a user
     users_by_email = {}
     for email in user_emails:
-        if email.email in users_by_email:
-            pass
-        user = users_by_id.get(email.user_id)
-        users_by_email[email.email] = user
+        if email.email not in users_by_email:
+            user = users_by_id.get(email.user_id)
+            users_by_email[email.email] = user
 
     author_objs = {}
     for author in authors:

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -67,56 +67,6 @@ def get_users_for_commits(item_list):
 
 @register(Release)
 class ReleaseSerializer(Serializer):
-    def _get_users_for_commits(self, release_commits, org_id):
-        """
-        Returns a dictionary of author_id => user, if a Sentry
-        user object exists for that email. If there is no matching
-        Sentry user, a {user, email} dict representation of that
-        author is returned.
-
-        e.g.
-        {
-            1: serialized(<User id=1>),
-            2: {email: 'not-a-user@example.com', name: 'dunno'},
-            ...
-        }
-        """
-        authors = set(rc.commit.author for rc in release_commits if rc.commit.author is not None)
-        if not len(authors):
-            return {}
-
-        # Filter users based on the emails provided in the commits
-        user_emails = UserEmail.objects.filter(
-            in_iexact('email', [a.email for a in authors]),
-        ).order_by('id')
-
-        # Filter users belonging to the organization associated with
-        # the release
-        users = User.objects.filter(
-            id__in=[ue.user_id for ue in user_emails],
-            sentry_orgmember_set__organization_id=org_id
-        )
-        users_by_id = dict((user.id, serialize(user)) for user in users)
-
-        # Figure out which email address matches to a user
-        users_by_email = {}
-        for user_email in user_emails:
-            if user_email.email in users_by_email:
-                pass
-
-            user = users_by_id.get(user_email.user_id)
-            if user:
-                users_by_email[user_email.email] = user
-
-        author_objs = {}
-        for author in authors:
-            author_objs[author.id] = users_by_email.get(author.email, {
-                "name": author.name,
-                "email": author.email
-            })
-
-        return author_objs
-
     def _get_commit_metadata(self, item_list, user):
         """
         Returns a dictionary of release_id => commit metadata,

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -74,6 +74,16 @@ const ReleaseCommits = React.createClass({
     });
   },
 
+  emptyState() {
+    return(
+      <div className="box empty-stream">
+        <span className="icon icon-exclamation" />
+        <p>There are no commits associated with this release.</p>
+        {/* Todo: Should we link to repo settings from here?  */}
+      </div>
+    );
+  },
+
   render() {
     if (this.state.loading)
       return <LoadingIndicator/>;
@@ -82,6 +92,10 @@ const ReleaseCommits = React.createClass({
       return <LoadingError/>;
 
     let {commitList} = this.state;
+
+    if (!commitList.length)
+      return <this.emptyState/>;
+
     return (
       <div className="panel panel-default">
         <div className="panel-heading panel-heading-bold">

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
 import Avatar from '../../components/avatar';
+import TimeSince from '../../components/timeSince';
 
 import ApiMixin from '../../mixins/apiMixin';
 
@@ -22,7 +24,7 @@ const ReleaseCommit = React.createClass({
           <div className="col-xs-8 list-group-avatar">
             <Avatar user={this.props.author}/>
             <h5>{this.props.commitMessage}</h5>
-            <p><strong>{this.props.author.name}</strong> committed {this.props.commitDateCreated}</p>
+            <p><strong>{this.props.author.name}</strong> committed <TimeSince date={this.props.commitDateCreated} /></p>
           </div>
           <div className="col-xs-2"><span className="repo-label">{this.props.repository.name}</span></div>
           <div className="col-xs-2 align-right">

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -19,7 +19,7 @@ const ReleaseCommit = React.createClass({
             <h5>{this.props.commitMessage}</h5>
             <p><strong>benvinegar</strong> committed {this.props.commitDateCreated}</p>
           </div>
-          <div className="col-sm-2"><span className="badge">getsentry/sentry</span></div>
+          <div className="col-sm-2"><span className="repo-label">getsentry/sentry</span></div>
           <div className="col-sm-2 align-right">
             <a className="btn btn-default btn-sm"><span className="icon-mark-github"/>&nbsp; {this.props.shortId}</a>
           </div>

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -16,8 +16,8 @@ const ReleaseCommit = React.createClass({
         <div className="row row-center-vertically">
           <div className="col-sm-8 list-group-avatar">
             <img src="https://github.com/benvinegar.png" className="avatar"/>
-            <h5 className="m-b-0">{this.props.commitMessage}</h5>
-            <p className="m-b-0"><strong>benvinegar</strong> committed {this.props.commitDateCreated}</p>
+            <h5>{this.props.commitMessage}</h5>
+            <p><strong>benvinegar</strong> committed {this.props.commitDateCreated}</p>
           </div>
           <div className="col-sm-2"><span className="badge">getsentry/sentry</span></div>
           <div className="col-sm-2 align-right">

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -13,10 +13,16 @@ const ReleaseCommit = React.createClass({
   render() {
     return (
       <li className="list-group-item" key={this.props.commitId}>
-        <div className="row">
-          <div className="col-sm-2 col-xs-2"><strong>{this.props.shortId}</strong></div>
-          <div className="col-sm-7 col-xs-7">{this.props.commitMessage}</div>
-          <div className="col-sm-3 col-xs-3 align-right actions">{this.props.commitDateCreated}</div>
+        <div className="row row-center-vertically">
+          <div className="col-sm-8 list-group-avatar">
+            <img src="https://github.com/benvinegar.png" className="avatar"/>
+            <h5 className="m-b-0">{this.props.commitMessage}</h5>
+            <p className="m-b-0"><strong>benvinegar</strong> committed {this.props.commitDateCreated}</p>
+          </div>
+          <div className="col-sm-2"><span className="badge">getsentry/sentry</span></div>
+          <div className="col-sm-2 align-right">
+            <a className="btn btn-default btn-sm"><span className="icon-mark-github"/>&nbsp; {this.props.shortId}</a>
+          </div>
         </div>
       </li>
     );
@@ -70,13 +76,19 @@ const ReleaseCommits = React.createClass({
       <div className="panel panel-default">
         <div className="panel-heading panel-heading-bold">
           <div className="row">
-            <div className="col-sm-2 col-xs-2">{'SHA'}</div>
-            <div className="col-sm-5 col-xs-5">{'Message'}</div>
-            <div className="col-sm-3 col-xs-3 align-right actions">{'Date'}</div>
-            <div className="col-sm-2 col-xs-2 align-right actions">{'Author'}</div>
+
+            <div className="col-md-8">
+              Commit
+            </div>
+            <div className="col-md-2">
+              Repository
+            </div>
+            <div className="col-md-2 align-right">
+              SHA
+            </div>
           </div>
         </div>
-        <ul className="list-group commit-list">
+        <ul className="list-group list-group-lg commit-list">
           {commitList.map(commit => {
             let shortId = commit.id.slice(0, 7);
             return (

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -76,7 +76,7 @@ const ReleaseCommits = React.createClass({
 
   emptyState() {
     return(
-      <div className="box empty-stream">
+      <div className="box empty-stream m-y-0">
         <span className="icon icon-exclamation" />
         <p>There are no commits associated with this release.</p>
         {/* Todo: Should we link to repo settings from here?  */}

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -14,13 +14,13 @@ const ReleaseCommit = React.createClass({
     return (
       <li className="list-group-item" key={this.props.commitId}>
         <div className="row row-center-vertically">
-          <div className="col-sm-8 list-group-avatar">
+          <div className="col-xs-8 list-group-avatar">
             <img src="https://github.com/benvinegar.png" className="avatar"/>
             <h5>{this.props.commitMessage}</h5>
             <p><strong>benvinegar</strong> committed {this.props.commitDateCreated}</p>
           </div>
-          <div className="col-sm-2"><span className="repo-label">getsentry/sentry</span></div>
-          <div className="col-sm-2 align-right">
+          <div className="col-xs-2"><span className="repo-label">getsentry/sentry</span></div>
+          <div className="col-xs-2 align-right">
             <a className="btn btn-default btn-sm"><span className="icon-mark-github"/>&nbsp; {this.props.shortId}</a>
           </div>
         </div>
@@ -76,14 +76,13 @@ const ReleaseCommits = React.createClass({
       <div className="panel panel-default">
         <div className="panel-heading panel-heading-bold">
           <div className="row">
-
-            <div className="col-md-8">
+            <div className="col-xs-8">
               Commit
             </div>
-            <div className="col-md-2">
+            <div className="col-xs-2">
               Repository
             </div>
-            <div className="col-md-2 align-right">
+            <div className="col-xs-2 align-right">
               SHA
             </div>
           </div>

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
+import Avatar from '../../components/avatar';
+
 import ApiMixin from '../../mixins/apiMixin';
 
 const ReleaseCommit = React.createClass({
@@ -8,20 +10,26 @@ const ReleaseCommit = React.createClass({
     commitId: React.PropTypes.string,
     shortId: React.PropTypes.string,
     commitMessage: React.PropTypes.string,
-    commitDateCreated: React.PropTypes.string
+    commitDateCreated: React.PropTypes.string,
+    author: React.PropTypes.object,
+    repository: React.PropTypes.object,
+
   },
   render() {
     return (
       <li className="list-group-item" key={this.props.commitId}>
         <div className="row row-center-vertically">
           <div className="col-xs-8 list-group-avatar">
-            <img src="https://github.com/benvinegar.png" className="avatar"/>
+            <Avatar user={this.props.author}/>
             <h5>{this.props.commitMessage}</h5>
-            <p><strong>benvinegar</strong> committed {this.props.commitDateCreated}</p>
+            <p><strong>{this.props.author.name}</strong> committed {this.props.commitDateCreated}</p>
           </div>
-          <div className="col-xs-2"><span className="repo-label">getsentry/sentry</span></div>
+          <div className="col-xs-2"><span className="repo-label">{this.props.repository.name}</span></div>
           <div className="col-xs-2 align-right">
-            <a className="btn btn-default btn-sm"><span className="icon-mark-github"/>&nbsp; {this.props.shortId}</a>
+            <a className="btn btn-default btn-sm"
+               href={this.props.repository.url + '/' + this.props.commitId}
+               target="_blank"><span
+               className={'icon-mark-' + this.props.repository.provider.id}/>&nbsp; {this.props.shortId}</a>
           </div>
         </div>
       </li>
@@ -92,10 +100,13 @@ const ReleaseCommits = React.createClass({
             let shortId = commit.id.slice(0, 7);
             return (
               <ReleaseCommit
+                key={commit.id}
                 commitId={commit.id}
                 shortId={shortId}
+                author={commit.author}
                 commitMessage={commit.message}
                 commitDateCreated={commit.dateCreated}
+                repository={commit.repository}
                 />
             );
           })}

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -106,7 +106,6 @@
   a {
     color: @gray-dark;
 
-
     &:hover {
       color: @gray-darker;
     }

--- a/src/sentry/static/sentry/less/sentry-list-group.less
+++ b/src/sentry/static/sentry/less/sentry-list-group.less
@@ -9,19 +9,48 @@
   .list-group-item {
     padding: 10px 20px;
 
+
+    // When pairing title / description / meta use <hx> and <p>
+    h1, h2 {
+      font-size: 20px;
+    }
+
+    h3, h4, h5 {
+      font-size: 16px;
+      line-height: 1.1;
+    }
+
+    p {
+      font-size: 15px;
+      color: @80;
+      line-height: 1.3;
+    }
+
+    .list-group-avatar {
+      padding-left: 56px;
+      position: relative;
+
+      .avatar {
+        .square(36px);
+        position: absolute;
+        left: 10px;
+        border-radius: 3px;
+      }
+    }
+
     .list-group-actions {
       > .btn-group, > .btn {
         margin-left: 5px;
       }
       > .btn-group .btn,
-        .btn-group .btn+.btn,
-        .btn-group .btn+.btn-group,
-        .btn-group .btn-group+.btn,
-        .btn-group .btn-group+.btn-group {
-          margin-left: -1px;
-        }
+      .btn-group .btn+.btn,
+      .btn-group .btn+.btn-group,
+      .btn-group .btn-group+.btn,
+      .btn-group .btn-group+.btn-group {
+        margin-left: -1px;
       }
     }
+  }
 
   &.list-group-lg {
     .list-group-item {

--- a/src/sentry/static/sentry/less/sentry-list-group.less
+++ b/src/sentry/static/sentry/less/sentry-list-group.less
@@ -9,21 +9,26 @@
   .list-group-item {
     padding: 10px 20px;
 
-
-    // When pairing title / description / meta use <hx> and <p>
+    // When pairing title / description / meta use <h*>, <p>, and <p>
     h1, h2 {
-      font-size: 20px;
+      font-size: 18px;
     }
 
     h3, h4, h5 {
-      font-size: 16px;
-      line-height: 1.1;
+      margin: 1px 0;
+      font-size: 15px;
+      line-height: 1.25;
     }
 
     p {
-      font-size: 15px;
+      font-size: 13px;
       color: @80;
       line-height: 1.3;
+      margin-bottom: 5px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     .list-group-avatar {

--- a/src/sentry/static/sentry/less/sentry-list-group.less
+++ b/src/sentry/static/sentry/less/sentry-list-group.less
@@ -32,13 +32,13 @@
     }
 
     .list-group-avatar {
-      padding-left: 56px;
+      padding-left: 60px;
       position: relative;
 
       .avatar {
         .square(36px);
         position: absolute;
-        left: 10px;
+        left: 15px;
         border-radius: 3px;
       }
     }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2717,6 +2717,7 @@ ul.faces {
 .repo-label {
   .label;
   display: inline-block;
+  vertical-align: text-bottom;
   padding: 4px 8px 6px;
   line-height: 1;
   background: @40;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2646,7 +2646,7 @@ ul.faces {
 }
 
 /**
-* Project nav
+* Badge
 * ============================================================================
 */
 
@@ -2707,6 +2707,19 @@ ul.faces {
   vertical-align: baseline;
   border-radius: .25em;
   margin-left: 4px;
+}
+
+/**
+* Repository label
+* ============================================================================
+*/
+
+.repo-label {
+  .label;
+  display: inline-block;
+  padding: 4px 8px 6px;
+  line-height: 1;
+  background: @40;
 }
 
 /**

--- a/tests/sentry/api/serializers/test_commit.py
+++ b/tests/sentry/api/serializers/test_commit.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from uuid import uuid4
+
+from sentry.api.serializers import serialize
+from sentry.models import (Commit, CommitAuthor,
+    Release, ReleaseCommit, Repository)
+from sentry.testutils import TestCase
+
+
+class CommitSerializerTest(TestCase):
+    def test_simple(self):
+        user = self.create_user()
+        project = self.create_project()
+        release = Release.objects.create(
+            organization_id=project.organization_id,
+            version=uuid4().hex,
+        )
+        release.add_project(project)
+        repository = Repository.objects.create(
+            organization_id=project.organization_id,
+            name='test/test',
+        )
+        commit_author = CommitAuthor.objects.create(
+            name='stebe',
+            email='stebe@sentry.io',
+            organization_id=project.organization_id,
+        )
+        commit = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key='abc',
+            author=commit_author,
+            message='waddap',
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            release=release,
+            commit=commit,
+            order=1,
+        )
+        result = serialize(commit, user)
+
+        assert result['message'] == 'waddap'
+        assert result['repository']['name'] == 'test/test'
+        assert result['author'] == {'name': 'stebe', 'email': 'stebe@sentry.io'}

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -150,9 +150,9 @@ class ReleaseSerializerTest(TestCase):
     def test_get_single_user_from_email(self):
         user = User.objects.create(email='stebe@sentry.io')
         otheruser = User.objects.create(email='adifferentstebe@sentry.io')
-        UserEmail.objects.create(user=otheruser, email='stebe@sentry.io')
         project = self.create_project()
         self.create_member(user=user, organization=project.organization)
+        self.create_member(user=otheruser, organization=project.organization)
         release = Release.objects.create(
             organization_id=project.organization_id,
             version=uuid4().hex,


### PR DESCRIPTION
A richer commit list view that builds on the list-group changes made in #4827.

Avatar, commit author name, repository, and link to the commit are now available in the UI.
![screen shot 2017-01-25 at 6 29 22 pm](https://cloud.githubusercontent.com/assets/30713/22318036/4df8edba-e32c-11e6-83b4-7af39356c896.png)

The commit serializer has been updated to return the sentry user information associated with the commit author if a sentry user can be found for the author email. Repository information has also been made available in the commit API.

**Test Plan**
Make sure you have the `release-commits` feature switch enabled.

Run `bin/load-mocks`

Navigate to a mock project, go to the releases tab, select the first release, and click on the commits tab. 

cc @getsentry/ui @kjlundsgaard 
