### PR TITLE
api: add Access-Control-Expose-Headers

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -159,6 +159,8 @@ class APIView(BaseView):
                 'Content-Type, Authentication'
             response['Access-Control-Allow-Methods'] = \
                 ', '.join(self._allowed_methods())
+            response['Access-Control-Expose-Headers'] = \
+                'X-Sentry-Error, Retry-After'
 
         return response
 


### PR DESCRIPTION
XHR requests need this to be able to read our debug headers

See: getsentry/raven-js#839