### PR TITLE
Update panels to use our colors instead of bootstrap's

### DIFF
--- a/src/sentry/static/sentry/less/sentry-panel.less
+++ b/src/sentry/static/sentry/less/sentry-panel.less
@@ -6,6 +6,12 @@
 //
 
 .panel {
+  .panel-heading {
+    h1, h2, h3, h4, h5, h6 {
+      font-size: 16px;
+      margin: 0;
+    }
+  }
   .panel-heading-bold {
     color: @60;
     font-size: 13px;

--- a/src/sentry/static/sentry/less/variables.less
+++ b/src/sentry/static/sentry/less/variables.less
@@ -10,6 +10,26 @@
 
 @import "./palette.less";
 
+//== Form states and alerts
+//
+//## Define colors for form feedback states and, by default, alerts.
+
+@state-success-text:             darken(#3c763d, 14);
+@state-success-bg:               @alert-success-bg-color;
+@state-success-border:           @alert-success-border-color;
+
+@state-info-text:                darken(@blue-dark, 24);
+@state-info-bg:                  @alert-info-bg-color;
+@state-info-border:              @alert-info-border-color;
+
+@state-warning-text:             darken(#8a6d3b, 12);
+@state-warning-bg:               @alert-warning-bg-color;
+@state-warning-border:           @alert-warning-border-color;
+
+@state-danger-text:              darken(#a94442, 18);
+@state-danger-bg:                @alert-danger-bg-color;
+@state-danger-border:            @alert-danger-border-color;
+
 // Sidebar
 //
 // Sets up sidebar offsets


### PR DESCRIPTION
This uses our alert state colors for panels instead of bootstrap's defaults.

![screen shot 2017-01-26 at 4 54 52 pm](https://cloud.githubusercontent.com/assets/30713/22356790/bdd57c90-e3e8-11e6-8ebf-732dbbccecb4.png)

@getsentry/ui @MaxBittker 