### PR TITLE
newsletter: add initial support and backends

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Version 8.13 (Unreleased)
 - Fixed bug where workflow notification subject may not include a custom email prefix.
 - Added configurable subject templates for individual alert emails (`mail:subject_template` option).
 - Added data migration to populate ReleaseProject.new_groups
+- Added support for managing newsletter subscriptions with Sentry.io
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/app.py
+++ b/src/sentry/app.py
@@ -51,6 +51,7 @@ quotas = get_instance('SENTRY_QUOTAS', settings.SENTRY_QUOTA_OPTIONS)
 nodestore = get_instance('SENTRY_NODESTORE', settings.SENTRY_NODESTORE_OPTIONS)
 ratelimiter = get_instance('SENTRY_RATELIMITER', settings.SENTRY_RATELIMITER_OPTIONS)
 search = get_instance('SENTRY_SEARCH', settings.SENTRY_SEARCH_OPTIONS)
+newsletter = get_instance('SENTRY_NEWSLETTER', settings.SENTRY_NEWSLETTER_OPTIONS)
 
 from sentry.tsdb.dummy import DummyTSDB
 tsdb = get_instance('SENTRY_TSDB', settings.SENTRY_TSDB_OPTIONS, (DummyTSDB,))

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -890,6 +890,9 @@ SENTRY_SEARCH_OPTIONS = {}
 SENTRY_TSDB = 'sentry.tsdb.dummy.DummyTSDB'
 SENTRY_TSDB_OPTIONS = {}
 
+SENTRY_NEWSLETTER = 'sentry.newsletter.base.Newsletter'
+SENTRY_NEWSLETTER_OPTIONS = {}
+
 # rollups must be ordered from highest granularity to lowest
 SENTRY_TSDB_ROLLUPS = (
     # (time in seconds, samples to keep)

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -41,6 +41,9 @@ class UserEmail(Model):
     def hash_is_valid(self):
         return self.validation_hash and self.date_hash_added > timezone.now() - timedelta(hours=48)
 
+    def is_primary(self):
+        return self.user.email == self.email
+
     @classmethod
     def get_primary_email(self, user):
         return UserEmail.objects.get_or_create(

--- a/src/sentry/newsletter/__init__.py
+++ b/src/sentry/newsletter/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/newsletter/base.py
+++ b/src/sentry/newsletter/base.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+
+class Newsletter(object):
+    DEFAULT_LIST_ID = 1
+
+    enabled = False
+
+    def is_enabled(self):
+        return self.enabled
+
+    def get_subscriptions(self, user):
+        return None
+
+    def update_subscription(self, user, **kwargs):
+        return None
+
+    def create_or_update_subscription(self, user, **kwargs):
+        kwargs['create'] = True
+        return self.update_subscription(user, **kwargs)

--- a/src/sentry/newsletter/remote.py
+++ b/src/sentry/newsletter/remote.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+import logging
+from uuid import uuid4
+from hashlib import sha1
+
+from sentry.http import safe_urlopen
+from sentry.newsletter.base import Newsletter
+from sentry.utils import json
+
+logger = logging.getLogger('sentry.newsletter')
+
+
+def get_install_id():
+    from sentry import options
+    install_id = options.get('sentry:install-id')
+    if not install_id:
+        install_id = sha1(uuid4().bytes).hexdigest()
+        options.set('sentry:install-id', install_id)
+    return install_id
+
+
+class RemoteNewsletter(Newsletter):
+    enabled = True
+    endpoint = 'https://sentry.io/remote/newsletter/subscription/'
+
+    def __init__(self, endpoint=None):
+        if endpoint is not None:
+            self.endpoint = endpoint
+
+    def update_subscription(self, user, **kwargs):
+        kwargs['user_id'] = user.id
+        kwargs['email'] = user.email
+        kwargs['referral'] = 'onpremise'
+        kwargs['install_id'] = get_install_id()
+        try:
+            response = safe_urlopen(
+                self.endpoint,
+                method='POST',
+                headers={'Content-Type': 'application/json'},
+                data=json.dumps(kwargs),
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception:
+            logger.exception('update.failed')
+            return None
+
+    def get_subscriptions(self, user):
+        try:
+            response = safe_urlopen(
+                self.endpoint,
+                method='GET',
+                params={
+                    'user_id': user.id,
+                    'install_id': get_install_id(),
+                },
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception:
+            logger.exception('fetch.failed')
+            return None

--- a/src/sentry/receivers/useremail.py
+++ b/src/sentry/receivers/useremail.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import
 
 from django.db import IntegrityError
 from django.db.models.signals import post_save
+from django.utils import timezone
 
 from sentry.models import User, UserEmail
+from sentry.signals import email_verified
 
 
 def create_user_email(instance, created, **kwargs):
@@ -19,3 +21,20 @@ post_save.connect(
     dispatch_uid="create_user_email",
     weak=False
 )
+
+
+@email_verified.connect(weak=False)
+def verify_newsletter_subscription(sender, **kwargs):
+    from sentry.app import newsletter
+
+    if not newsletter.enabled:
+        return
+
+    if not sender.is_primary():
+        return
+
+    newsletter.update_subscription(
+        sender.user,
+        verified=True,
+        verified_date=timezone.now(),
+    )

--- a/src/sentry/templates/sentry/account/subscriptions.html
+++ b/src/sentry/templates/sentry/account/subscriptions.html
@@ -1,0 +1,46 @@
+{% extends "sentry/bases/account.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% load sentry_auth %}
+{% load sentry_helpers %}
+
+{% block title %}{% trans "Subscriptions" %} | {{ block.super }}{% endblock %}
+
+{% block main %}
+    {% if not email.is_verified %}
+      <div class="alert alert-warning alert-block">
+        {% trans "Your email address has not been verified. " %}
+        <form action="{% url 'sentry-account-confirm-email-send' %}" method="post" class="email-alert-button">
+          {% csrf_token %}
+          <input type="hidden" name="email" value="{{ email.email }}">
+          <button type="submit" name="primary-email" class="btn-link">{% trans "Resend Verification Email." %}</button>
+        </form>
+      </div>
+    {% endif %}
+
+    <legend class="m-t-0">Subscriptions</legend>
+    {% for subscription in subscriptions.subscriptions %}
+        <div class="row">
+            <div class="col-md-9">
+                <h5>{{ subscription.list_name }}</h5>
+            </div>
+            <div class="col-md-3 align-right" style="padding-right: 25px">
+                <div data-list-id="{{ subscription.list_id }}" class="switch switch-lg{% if subscription.subscribed %} switch-on{% endif %}" role="checkbox">
+                    <span class="switch-toggle"></span>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+
+    <script>
+    $('div.switch').click(function(){
+        var $e = $(this);
+        $e.toggleClass('switch-on');
+        $.post('{% url 'sentry-account-settings-subscriptions' %}', {
+            'subscribed': $e.hasClass('switch-on') ? '1' : '0',
+            'listId': $e.data('list-id')
+        });
+    });
+    </script>
+{% endblock %}

--- a/src/sentry/templates/sentry/account/subscriptions.html
+++ b/src/sentry/templates/sentry/account/subscriptions.html
@@ -21,7 +21,7 @@
 
     <legend class="m-t-0">Subscriptions</legend>
     {% for subscription in subscriptions.subscriptions %}
-        <div class="row">
+        <div class="row p-b-1">
             <div class="col-md-9">
                 <h5>{{ subscription.list_name }}</h5>
             </div>

--- a/src/sentry/templates/sentry/bases/account.html
+++ b/src/sentry/templates/sentry/bases/account.html
@@ -41,6 +41,9 @@
           <li{% if page == 'identities' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-identities' %}">{% trans "Identities" %}</a></li>
         {% endif %}
         <li{% if page == 'security' %} class="active"{% endif %}><a href="{% url 'sentry-account-security' %}">{% trans "Security" %}</a></li>
+        {% if has_newsletters %}
+          <li{% if page == 'subscriptions' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-subscriptions' %}">{% trans "Subscriptions" %}</a></li>
+        {% endif %}
       </ul>
     {% endblock %}
 

--- a/src/sentry/web/frontend/account_security.py
+++ b/src/sentry/web/frontend/account_security.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.app import newsletter
 from sentry.models import Authenticator
 from sentry.utils.auth import get_auth_providers
 from sentry.web.frontend.base import BaseView
@@ -11,4 +12,5 @@ class AccountSecurityView(BaseView):
             'page': 'security',
             'has_2fa': Authenticator.objects.user_has_2fa(request.user),
             'AUTH_PROVIDERS': get_auth_providers(),
+            'has_newsletters': newsletter.is_enabled,
         })

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -277,6 +277,8 @@ urlpatterns += patterns(
         name='sentry-account-settings-appearance'),
     url(r'^account/settings/identities/$', accounts.list_identities,
         name='sentry-account-settings-identities'),
+    url(r'^account/settings/subscriptions/$', accounts.manage_subscriptions,
+        name='sentry-account-settings-subscriptions'),
     url(r'^account/settings/identities/(?P<identity_id>[^\/]+)/disconnect/$',
         accounts.disconnect_identity,
         name='sentry-account-disconnect-identity'),


### PR DESCRIPTION
This adds a new `newsletter` app abstraction so we can swap out the implementation for hosted Sentry so it doesn't have to rely on http.

### TODO

- [x] Add page into account settings to manage subscription preferences

![image](https://cloud.githubusercontent.com/assets/375744/22486388/316c3de6-e7be-11e6-85fe-8f652904f83d.png)
