### PR TITLE
Make debugmeta render with missing release

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -26,7 +26,7 @@ const DebugMetaInterface = React.createClass({
       if (img.major_version == 0 &&
         img.minor_version == 0 &&
         img.revision_version == 0) { // we show the version
-        version = `${evt.release.version}`;
+        version = evt.release && evt.release.version || 'unknown';
       } else
         version = `${img.major_version}.${img.minor_version}.${img.revision_version}`;
     } else


### PR DESCRIPTION
Did not expect this could happen currently because releases are always sent
from the client with iOS but apparently that is not correct.  Made the UI
more resilient now.

Fixes JAVASCRIPT-1QQ