### PR TITLE
Prevent author from returning null and add test cases

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -51,8 +51,11 @@ def get_users_for_commits(item_list):
     users_by_email = {}
     for email in user_emails:
         if email.email not in users_by_email:
-            user = users_by_id.get(email.user_id)
-            users_by_email[email.email] = user
+            user = users_by_id.get(email.user_id, None)
+            # user can be None if there's a user associated
+            # with user_email in separate organization
+            if user:
+                users_by_email[email.email] = user
 
     author_objs = {}
     for author in authors:

--- a/tests/sentry/api/serializers/test_commit.py
+++ b/tests/sentry/api/serializers/test_commit.py
@@ -47,3 +47,33 @@ class CommitSerializerTest(TestCase):
         assert result['message'] == 'waddap'
         assert result['repository']['name'] == 'test/test'
         assert result['author'] == {'name': 'stebe', 'email': 'stebe@sentry.io'}
+
+    def test_no_author(self):
+        user = self.create_user()
+        project = self.create_project()
+        release = Release.objects.create(
+            organization_id=project.organization_id,
+            version=uuid4().hex,
+        )
+        release.add_project(project)
+        repository = Repository.objects.create(
+            organization_id=project.organization_id,
+            name='test/test',
+        )
+        commit = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key='abc',
+            message='waddap',
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            release=release,
+            commit=commit,
+            order=1,
+        )
+
+        result = serialize(commit, user)
+
+        assert result['author'] == {}


### PR DESCRIPTION
Fixes https://sentry.io/sentry/javascript/issues/211293824/

The issue was that a UserEmail could be associated with a commit author email, but if the user was not in the organization, no user object would be associated with the email.