### PR TITLE
update docs and status code in project release endpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -153,7 +153,8 @@ class ProjectReleaseCreateTest(APITestCase):
             'version': '1.2.1',
         })
 
-        assert response.status_code == 208, response.content
+        # since project2 was added, should be 201
+        assert response.status_code == 201, response.content
         assert Release.objects.filter(
             version='1.2.1',
             organization_id=project.organization_id


### PR DESCRIPTION
- updates docs to make it more clear that releases now can be shared across multiple projects in an organization
- changes status code from 208 to 201 if release already existed but project hadn't been associated