### PR TITLE
move release commits endpoint to organization path

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Schema Changes
 ~~~~~~~~~~~~~~
 
 - Added ``Deploy`` model
+- Added OrganizationReleaseCommitsEndpoint
 
 Version 8.14.1
 --------------
@@ -67,7 +68,6 @@ Schema Changes
 - Added ``Project.flags`` column.
 - Added not null constraint to ``Environment.organization_id`` column.
 - Removed not null constraint on ``Environment.project_id`` and ``ReleaseEnvironment.project_id`` columns
-- Added Organization Release Commits endpoint
 
 Version 8.13
 ------------

--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,7 @@ Schema Changes
 - Added ``Project.flags`` column.
 - Added not null constraint to ``Environment.organization_id`` column.
 - Removed not null constraint on ``Environment.project_id`` and ``ReleaseEnvironment.project_id`` columns
+- Added Organization Release Commits endpoint
 
 Version 8.13
 ------------

--- a/CHANGES
+++ b/CHANGES
@@ -11,12 +11,12 @@ API Changes
 - Added CommitFileChangeEndpoint
 - Added IssuesResolvedInReleaseEndpoint
 - Added ReleaseDeploysEndpoint
+- Added OrganizationReleaseCommitsEndpoint
 
 Schema Changes
 ~~~~~~~~~~~~~~
 
 - Added ``Deploy`` model
-- Added OrganizationReleaseCommitsEndpoint
 
 Version 8.14.1
 --------------

--- a/src/sentry/api/endpoints/organization_release_commits.py
+++ b/src/sentry/api/endpoints/organization_release_commits.py
@@ -1,34 +1,31 @@
 from __future__ import absolute_import
 
 from sentry.api.base import DocSection
-from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import Release, ReleaseCommit
 
 
-class ReleaseCommitsEndpoint(ProjectEndpoint):
+class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
     doc_section = DocSection.RELEASES
-    permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request, project, version):
+    def get(self, request, organization, version):
         """
-        List a Release's Commits
-        ````````````````````````
+        List an Organization Release's Commits
+        ``````````````````````````````````````
 
         Retrieve a list of commits for a given release.
 
         :pparam string organization_slug: the slug of the organization the
                                           release belongs to.
-        :pparam string project_slug: the slug of the project to list the
-                                     release files of.
         :pparam string version: the version identifier of the release.
         :auth: required
         """
         try:
             release = Release.objects.get(
-                organization_id=project.organization_id,
-                projects=project,
+                organization_id=organization.id,
+                projects=self.get_allowed_projects(request, organization),
                 version=version,
             )
         except Release.DoesNotExist:

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from sentry.api.base import DocSection
+from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.models import Release, ReleaseCommit
+
+
+class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
+    doc_section = DocSection.RELEASES
+    permission_classes = (ProjectReleasePermission,)
+
+    def get(self, request, project, version):
+        """
+        List a Project Release's Commits
+        ````````````````````````````````
+
+        Retrieve a list of commits for a given release.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to list the
+                                     release files of.
+        :pparam string version: the version identifier of the release.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id,
+                projects=project,
+                version=version,
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        queryset = ReleaseCommit.objects.filter(
+            release=release,
+        ).select_related('commit', 'commit__author')
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by='order',
+            on_results=lambda x: serialize([rc.commit for rc in x], request.user),
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -46,6 +46,7 @@ from .endpoints.organization_releases import OrganizationReleasesEndpoint
 from .endpoints.organization_release_details import OrganizationReleaseDetailsEndpoint
 from .endpoints.organization_release_files import OrganizationReleaseFilesEndpoint
 from .endpoints.organization_release_file_details import OrganizationReleaseFileDetailsEndpoint
+from .endpoints.organization_release_commits import OrganizationReleaseCommitsEndpoint
 from .endpoints.organization_repositories import OrganizationRepositoriesEndpoint
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
@@ -81,12 +82,12 @@ from .endpoints.project_users import ProjectUsersEndpoint
 from .endpoints.project_user_reports import ProjectUserReportsEndpoint
 from .endpoints.project_processingissues import ProjectProcessingIssuesEndpoint
 from .endpoints.project_reprocessing import ProjectReprocessingEndpoint
-from .endpoints.release_commits import ReleaseCommitsEndpoint
 from .endpoints.filechange import CommitFileChangeEndpoint
 from .endpoints.issues_resolved_in_release import IssuesResolvedInReleaseEndpoint
 from .endpoints.project_release_details import ProjectReleaseDetailsEndpoint
 from .endpoints.project_release_files import ProjectReleaseFilesEndpoint
 from .endpoints.project_release_file_details import ProjectReleaseFileDetailsEndpoint
+from .endpoints.project_release_commits import ProjectReleaseCommitsEndpoint
 from .endpoints.release_deploys import ReleaseDeploysEndpoint
 from .endpoints.dsym_files import DSymFilesEndpoint, GlobalDSymFilesEndpoint, \
     UnknownDSymFilesEndpoint, UnknownGlobalDSymFilesEndpoint
@@ -223,6 +224,9 @@ urlpatterns = patterns(
     url(r'^organizations/(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/deploys/$',
         ReleaseDeploysEndpoint.as_view(),
         name='sentry-api-0-organization-release-deploys'),
+    url(r'^organizations/(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/commits/$',
+        OrganizationReleaseCommitsEndpoint.as_view(),
+        name='sentry-api-0-organization-release-commits'),
     url(r'^organizations/(?P<organization_slug>[^\/]+)/stats/$',
         OrganizationStatsEndpoint.as_view(),
         name='sentry-api-0-organization-stats'),
@@ -308,8 +312,8 @@ urlpatterns = patterns(
         ProjectReleaseDetailsEndpoint.as_view(),
         name='sentry-api-0-project-release-details'),
     url(r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/commits/$',
-        ReleaseCommitsEndpoint.as_view(),
-        name='sentry-api-0-release-commits'),
+        ProjectReleaseCommitsEndpoint.as_view(),
+        name='sentry-api-0-project-release-commits'),
     url(r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/resolved/$',
         IssuesResolvedInReleaseEndpoint.as_view(),
         name='sentry-api-0-release-resolved'),

--- a/tests/sentry/api/endpoints/test_organization_release_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_release_commits.py
@@ -42,9 +42,8 @@ class ReleaseCommitsListTest(APITestCase):
             commit=commit2,
             order=0,
         )
-        url = reverse('sentry-api-0-release-commits', kwargs={
+        url = reverse('sentry-api-0-organization-release-commits', kwargs={
             'organization_slug': project.organization.slug,
-            'project_slug': project.slug,
             'version': release.version,
         })
 

--- a/tests/sentry/api/endpoints/test_project_release_commits.py
+++ b/tests/sentry/api/endpoints/test_project_release_commits.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import Commit, Release, ReleaseCommit, Repository
+from sentry.testutils import APITestCase
+
+
+class ReleaseCommitsListTest(APITestCase):
+    def test_simple(self):
+        project = self.create_project(
+            name='foo',
+        )
+        release = Release.objects.create(
+            organization_id=project.organization_id,
+            version='1',
+        )
+        release.add_project(project)
+        repo = Repository.objects.create(
+            organization_id=project.organization_id,
+            name=project.name,
+        )
+        commit = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repo.id,
+            key='a' * 40,
+        )
+        commit2 = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repo.id,
+            key='b' * 40,
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            release=release,
+            commit=commit,
+            order=1,
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            release=release,
+            commit=commit2,
+            order=0,
+        )
+        url = reverse('sentry-api-0-project-release-commits', kwargs={
+            'organization_slug': project.organization.slug,
+            'project_slug': project.slug,
+            'version': release.version,
+        })
+
+        self.login_as(user=self.user)
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert response.data[0]['id'] == commit2.key
+        assert response.data[1]['id'] == commit.key


### PR DESCRIPTION
moves https://docs.sentry.io/api/releases/get-release-commits/ 

depends on https://github.com/getsentry/sentry/pull/4775. tests will fail until that can be merged/rebased in because i need `OrganizationReleasesBaseEndpoint` from that pr.

cc @benvinegar @ckj 