### PR TITLE
Prefer username instead of email

### DIFF
--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -80,7 +80,7 @@ const GroupTagValues = React.createClass({
   },
 
   getUserDisplayName(item) {
-    return item.email || item.username || item.identifier || item.ipAddress || item.value;
+    return item.username || item.email || item.identifier || item.ipAddress || item.value;
   },
 
   render() {


### PR DESCRIPTION
If the tagValue has email data, it will show a link with an envelope icon. If a user has username, we can display username instead of email.