### PR TITLE
api: limit group queries to a max of 100 results

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -19,12 +19,13 @@ quote_name = connections['default'].ops.quote_name
 
 
 class BasePaginator(object):
-    def __init__(self, queryset, order_by):
+    def __init__(self, queryset, order_by, max_limit=100):
         if order_by.startswith('-'):
             self.key, self.desc = order_by[1:], True
         else:
             self.key, self.desc = order_by, False
         self.queryset = queryset
+        self.max_limit = max_limit
 
     def _build_queryset(self, value, is_prev):
         queryset = self.queryset
@@ -87,6 +88,8 @@ class BasePaginator(object):
         if cursor is None:
             cursor = Cursor(0, 0, 0)
 
+        limit = min(limit, self.max_limit)
+
         if cursor.value:
             cursor_value = self.value_from_cursor(cursor)
         else:
@@ -148,6 +151,8 @@ class OffsetPaginator(BasePaginator):
         # value is page limit
         if cursor is None:
             cursor = Cursor(0, 0, 0)
+
+        limit = min(limit, self.max_limit)
 
         queryset = self.queryset
         if self.desc:

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -3,10 +3,29 @@ from __future__ import absolute_import
 import pytest
 
 from sentry.api.paginator import (
-    DateTimePaginator, OffsetPaginator
+    Paginator, DateTimePaginator, OffsetPaginator
 )
 from sentry.models import User
 from sentry.testutils import TestCase
+
+
+class PaginatorTest(TestCase):
+    cls = Paginator
+
+    def test_max_limit(self):
+        self.create_user('foo@example.com')
+        self.create_user('bar@example.com')
+        self.create_user('baz@example.com')
+
+        queryset = User.objects.all()
+
+        paginator = self.cls(queryset, 'id', max_limit=10)
+        result = paginator.get_result(limit=2, cursor=None)
+        assert len(result) == 2
+
+        paginator = self.cls(queryset, 'id', max_limit=1)
+        result = paginator.get_result(limit=2, cursor=None)
+        assert len(result) == 1
 
 
 class OffsetPaginatorTest(TestCase):


### PR DESCRIPTION
This was entirely unbounded and would result in requests timing out.