### PR TITLE
New symsynd with inline symbolication

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Version 8.14 (Unreleased)
 - Added new internal processing interface that supports multiple processing steps per stacktrace (for instance JavaScript + native)
 - Add IE10 legacy browser filter
 - Added data migration to merge legacy releases
+- Added support for symbolizing inlined frames and added heuristics for fixing up native stacktraces.
 
 Version 8.13
 ------------

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'symsynd>=1.3.0,<2.0.0',
+    'symsynd>=2.0.0,<3.0.0',
     'toronado>=0.0.11,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'symsynd>=2.0.0,<3.0.0',
+    'symsynd>=2.1.0,<3.0.0',
     'toronado>=0.0.11,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -640,7 +640,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         self.populate_source_cache(frames)
         return True
 
-    def process_frame(self, frame, idx=None):
+    def process_frame(self, frame, stacktrace_info, idx):
         if not settings.SENTRY_SCRAPE_JAVASCRIPT_CONTEXT or \
            self.get_effective_platform(frame) != 'javascript':
             return

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -640,7 +640,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         self.populate_source_cache(frames)
         return True
 
-    def process_frame(self, frame):
+    def process_frame(self, frame, idx=None):
         if not settings.SENTRY_SCRAPE_JAVASCRIPT_CONTEXT or \
            self.get_effective_platform(frame) != 'javascript':
             return

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -381,7 +381,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
         # dict.
         return self.sym.resolve_missing_vmaddrs()
 
-    def process_frame(self, frame):
+    def process_frame(self, frame, idx=None):
         # XXX: warn on missing availability?
 
         # Only process frames here that are of supported platforms and

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -16,7 +16,6 @@ from sentry.lang.native.utils import \
     find_apple_crash_report_referenced_images, get_sdk_from_event, \
     find_stacktrace_referenced_images, get_sdk_from_apple_system_info, \
     APPLE_SDK_MAPPING
-from sentry.utils.native import parse_addr
 from sentry.stacktraces import StacktraceProcessor
 
 
@@ -426,6 +425,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             'instruction_addr': self.find_best_instruction(
                 frame, stacktrace_info, idx),
             'symbol_name': frame.get('function'),
+            'symbol_addr': frame.get('symbol_addr'),
         }
         in_app = self.sym.is_in_app(sym_input_frame)
 
@@ -477,10 +477,9 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             # find a different symbol than the client did.  However
             # our symbolizer cannot tell us where a symbol is so this
             # is the best we can do for now.  Maybe we kill it?
-            if frame.get('symbol_addr') is not None:
-                new_frame['instruction_offset'] = \
-                    parse_addr(frame['instruction_addr']) - \
-                    parse_addr(frame['symbol_addr'])
+            instruction_offset = sfrm.get('instruction_offset')
+            if instruction_offset is not None:
+                new_frame['instruction_offset'] = instruction_offset
             if sfrm.get('column') is not None:
                 new_frame['colno'] = sfrm['column']
             new_frame['package'] = sfrm['object_name'] \

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -472,7 +472,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                     new_frame['abs_path'])
             if sfrm.get('line') is not None:
                 new_frame['lineno'] = sfrm['line']
-            elif sfrm.get('symbol_addr') is not None:
+            elif frame.get('symbol_addr') is not None:
                 # XXX: this is technically incorrect because the instruction
                 # address might move away from the symbol address if we
                 # find a different symbol than the client did.  However

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -472,12 +472,12 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                     new_frame['abs_path'])
             if sfrm.get('line') is not None:
                 new_frame['lineno'] = sfrm['line']
-            elif frame.get('symbol_addr') is not None:
-                # XXX: this is technically incorrect because the instruction
-                # address might move away from the symbol address if we
-                # find a different symbol than the client did.  However
-                # our symbolizer cannot tell us where a symbol is so this
-                # is the best we can do for now.
+            # XXX: this is technically incorrect because the instruction
+            # address might move away from the symbol address if we
+            # find a different symbol than the client did.  However
+            # our symbolizer cannot tell us where a symbol is so this
+            # is the best we can do for now.  Maybe we kill it?
+            if frame.get('symbol_addr') is not None:
                 new_frame['instruction_offset'] = \
                     parse_addr(frame['instruction_addr']) - \
                     parse_addr(frame['symbol_addr'])

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -436,7 +436,10 @@ class NativeStacktraceProcessor(StacktraceProcessor):
         try:
             symbolicated_frames = self.sym.symbolize_frame(
                 sym_input_frame, self.sdk_info, symbolize_inlined=True)
+            if not symbolicated_frames:
+                return None, [raw_frame], []
         except SymbolicationFailed as e:
+            errors = []
             if e.is_user_fixable or e.is_sdk_failure:
                 errors.append({
                     'type': e.type,
@@ -479,13 +482,11 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                 or new_frame.get('package')
             new_frame['symbol_addr'] = '0x%x' % \
                 parse_addr(sfrm['symbol_addr'])
-            new_frame['instruction_addr'] = '0x%x' % parse_addr(
-                frame['instruction_addr'])
 
             new_frame['in_app'] = in_app
             new_frames.append(new_frame)
 
-        return new_frames, [raw_frame], errors
+        return new_frames, [raw_frame], []
 
 
 class NativePlugin(Plugin2):

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -472,11 +472,6 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                     new_frame['abs_path'])
             if sfrm.get('line') is not None:
                 new_frame['lineno'] = sfrm['line']
-            # XXX: this is technically incorrect because the instruction
-            # address might move away from the symbol address if we
-            # find a different symbol than the client did.  However
-            # our symbolizer cannot tell us where a symbol is so this
-            # is the best we can do for now.  Maybe we kill it?
             instruction_offset = sfrm.get('instruction_offset')
             if instruction_offset is not None:
                 new_frame['instruction_offset'] = instruction_offset

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -472,16 +472,19 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                     new_frame['abs_path'])
             if sfrm.get('line') is not None:
                 new_frame['lineno'] = sfrm['line']
-            else:
+            elif sfrm.get('symbol_addr') is not None:
+                # XXX: this is technically incorrect because the instruction
+                # address might move away from the symbol address if we
+                # find a different symbol than the client did.  However
+                # our symbolizer cannot tell us where a symbol is so this
+                # is the best we can do for now.
                 new_frame['instruction_offset'] = \
                     parse_addr(frame['instruction_addr']) - \
-                    parse_addr(sfrm['symbol_addr'])
+                    parse_addr(frame['symbol_addr'])
             if sfrm.get('column') is not None:
                 new_frame['colno'] = sfrm['column']
             new_frame['package'] = sfrm['object_name'] \
                 or new_frame.get('package')
-            new_frame['symbol_addr'] = '0x%x' % \
-                parse_addr(sfrm['symbol_addr'])
 
             new_frame['in_app'] = in_app
             new_frames.append(new_frame)

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -144,11 +144,11 @@ class Symbolizer(object):
         # will only load images that it can find dsyms for but we also
         # have system symbols which there are no dsyms for.
         self._image_addresses = []
-        self._image_references = {}
+        self.images = {}
         for img in binary_images:
             img_addr = parse_addr(img['image_addr'])
             self._image_addresses.append(img_addr)
-            self._image_references[img_addr] = img
+            self.images[img_addr] = img
         self._image_addresses.sort()
 
     def find_best_instruction(self, frame, meta=None):
@@ -167,7 +167,7 @@ class Symbolizer(object):
         changed_any = False
 
         loaded_images = self.symsynd_symbolizer.images
-        for image_addr, image in six.iteritems(self._image_references):
+        for image_addr, image in six.iteritems(self.images):
             if image.get('image_vmaddr') or not image.get('image_addr'):
                 continue
             image_info = loaded_images.get(image_addr)
@@ -192,7 +192,7 @@ class Symbolizer(object):
         """
         idx = bisect.bisect_left(self._image_addresses, parse_addr(addr))
         if idx > 0:
-            return self._image_references[self._image_addresses[idx - 1]]
+            return self.images[self._image_addresses[idx - 1]]
 
     def _process_frame(self, frame, img):
         rv = trim_frame(frame)

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -215,6 +215,11 @@ class Symbolizer(object):
                 rv['object_name'] = img['name']
             rv['uuid'] = img['uuid']
 
+        # XXX: this is technically incorrect because the instruction
+        # address might move away from the symbol address if we
+        # find a different symbol than the client did.  However
+        # our symbolizer cannot tell us where a symbol is so this
+        # is the best we can do for now.  Maybe we kill it?
         symbol_addr = frame.get('symbol_addr')
         if symbol_addr is not None:
             symbol_addr = parse_addr(symbol_addr)

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -214,6 +214,14 @@ class Symbolizer(object):
                ('/' not in rv['object_name'] and '/' in img['name']):
                 rv['object_name'] = img['name']
             rv['uuid'] = img['uuid']
+
+        symbol_addr = frame.get('symbol_addr')
+        if symbol_addr is not None:
+            symbol_addr = parse_addr(symbol_addr)
+            slide_value = img.get('image_vmaddr') or 0
+            rv['instruction_offset'] = parse_addr(frame['instruction_addr']) \
+                - slide_value - symbol_addr
+
         return rv
 
     def _get_frame_package(self, frame, img):

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -153,7 +153,7 @@ class Symbolizer(object):
 
         # This should always succeed but you never quite know.
         self.cpu_name = None
-        for img in six.itervalues(self.images.itervalues):
+        for img in six.itervalues(self.images):
             cpu_name = get_cpu_name(img['cpu_type'],
                                     img['cpu_subtype'])
             if self.cpu_name is None:

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -211,7 +211,7 @@ class Symbolizer(object):
         img = self.images.get(frame['object_addr'])
         return img is not None and self._is_app_frame(frame, img)
 
-    def symbolize_app_frame(self, frame, img):
+    def symbolize_app_frame(self, frame, img, meta=None):
         if frame['object_addr'] not in self.symsynd_symbolizer.images:
             if self._is_optional_app_bundled_framework(frame, img):
                 type = EventError.NATIVE_MISSING_OPTIONALLY_BUNDLED_DSYM
@@ -224,7 +224,7 @@ class Symbolizer(object):
 
         try:
             new_frame = self.symsynd_symbolizer.symbolize_frame(
-                frame, silent=False, demangle=False)
+                frame, silent=False, demangle=False, meta=meta)
         except SymbolicationError as e:
             raise SymbolicationFailed(
                 type=EventError.NATIVE_BAD_DSYM,
@@ -259,7 +259,7 @@ class Symbolizer(object):
                   object_name=img['name'])
         return self._process_frame(rv, img)
 
-    def symbolize_frame(self, frame, sdk_info=None):
+    def symbolize_frame(self, frame, sdk_info=None, meta=None):
         img = self.images.get(frame['object_addr'])
         if img is None:
             raise SymbolicationFailed(
@@ -272,9 +272,10 @@ class Symbolizer(object):
         if not self._is_app_bundled_frame(frame, img):
             return self.symbolize_system_frame(frame, img, sdk_info)
 
-        return self.symbolize_app_frame(frame, img)
+        return self.symbolize_app_frame(frame, img, meta)
 
     def symbolize_backtrace(self, backtrace, sdk_info=None):
+        # TODO: kill me
         rv = []
         errors = []
         idx = -1

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -33,7 +33,7 @@ class StacktraceProcessor(object):
     def get_effective_platform(self, frame):
         return frame.get('platform') or self.data['platform']
 
-    def process_frame(self, frame):
+    def process_frame(self, frame, idx=None):
         pass
 
 
@@ -119,13 +119,14 @@ def process_single_stacktrace(stacktrace_info, processors):
     processed_frames = []
     all_errors = []
 
-    for frame in stacktrace_info.stacktrace['frames']:
+    frame_count = len(stacktrace_info.stacktrace['frames'])
+    for idx, frame in enumerate(stacktrace_info.stacktrace['frames']):
         need_processed_frame = True
         need_raw_frame = True
         errors = None
         for processor in processors:
             try:
-                rv = processor.process_frame(frame)
+                rv = processor.process_frame(frame, frame_count - idx - 1)
                 if rv is None:
                     continue
             except Exception:

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -33,7 +33,7 @@ class StacktraceProcessor(object):
     def get_effective_platform(self, frame):
         return frame.get('platform') or self.data['platform']
 
-    def process_frame(self, frame, idx=None):
+    def process_frame(self, frame, stacktrace_info, idx):
         pass
 
 
@@ -126,7 +126,8 @@ def process_single_stacktrace(stacktrace_info, processors):
         errors = None
         for processor in processors:
             try:
-                rv = processor.process_frame(frame, frame_count - idx - 1)
+                rv = processor.process_frame(frame, stacktrace_info,
+                                             frame_count - idx - 1)
                 if rv is None:
                     continue
             except Exception:

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -28,7 +28,7 @@ def patched_symbolize_app_frame(self, frame, img, symbolize_inlined=False):
         'line': 42,
         'column': 23,
         'object_name': OBJECT_NAME,
-        'symbol_name': 'real_main'
+        'symbol_name': 'real_main',
     }]
 
 
@@ -40,6 +40,7 @@ def patched_symbolize_system_frame(self, frame, img, sdk_info,
         return [{
             'object_name': '/usr/lib/whatever.dylib',
             'symbol_name': 'whatever_system',
+            'instruction_offset': 4
         }]
     return []
 

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -28,8 +28,7 @@ def patched_symbolize_app_frame(self, frame, img, symbolize_inlined=False):
         'line': 42,
         'column': 23,
         'object_name': OBJECT_NAME,
-        'symbol_name': 'real_main',
-        'symbol_addr': '0x1000262a0',
+        'symbol_name': 'real_main'
     }]
 
 
@@ -41,7 +40,6 @@ def patched_symbolize_system_frame(self, frame, img, sdk_info,
         return [{
             'object_name': '/usr/lib/whatever.dylib',
             'symbol_name': 'whatever_system',
-            'symbol_addr': hex(6016),
         }]
     return []
 
@@ -107,6 +105,7 @@ class BasicResolvingFileTest(TestCase):
                                 {
                                     "function": "whatever_system",
                                     "instruction_addr": 6020,
+                                    "symbol_addr": 6016,
                                 },
                                 {
                                     "platform": "javascript",

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -21,28 +21,29 @@ SDK_INFO = {
 }
 
 
-def patched_symbolize_app_frame(self, frame, img):
-    if frame['instruction_addr'] == 4295123760:
-        return {
-            'filename': 'Foo.swift',
-            'line': 42,
-            'column': 23,
-            'object_name': OBJECT_NAME,
-            'symbol_name': 'real_main',
-            'symbol_addr': '0x1000262a0',
-            'instruction_addr': '0x100026330',
-        }
+def patched_symbolize_app_frame(self, frame, img, symbolize_inlined=False):
+    assert symbolize_inlined
+    return [{
+        'filename': 'Foo.swift',
+        'line': 42,
+        'column': 23,
+        'object_name': OBJECT_NAME,
+        'symbol_name': 'real_main',
+        'symbol_addr': '0x1000262a0',
+    }]
 
 
-def patched_symbolize_system_frame(self, frame, img, sdk_info):
+def patched_symbolize_system_frame(self, frame, img, sdk_info,
+                                   symbolize_inlined=False):
+    assert symbolize_inlined
     assert sdk_info == SDK_INFO
-    if frame['instruction_addr'] == 4295123360:
-        return {
+    if frame['instruction_addr'] == 6016:
+        return [{
             'object_name': '/usr/lib/whatever.dylib',
             'symbol_name': 'whatever_system',
-            'symbol_addr': '0x100026110',
-            'instruction_addr': '0x1000261a0',
-        }
+            'symbol_addr': hex(6016),
+        }]
+    return []
 
 
 class BasicResolvingFileTest(TestCase):
@@ -66,7 +67,7 @@ class BasicResolvingFileTest(TestCase):
                         "cpu_subtype": 0,
                         "uuid": "C05B4DDD-69A7-3840-A649-32180D341587",
                         "image_vmaddr": 4294967296,
-                        "image_addr": 4295098368,
+                        "image_addr": 4295121760,
                         "cpu_type": 16777228,
                         "image_size": 32768,
                         "name": OBJECT_NAME,
@@ -77,7 +78,7 @@ class BasicResolvingFileTest(TestCase):
                         "cpu_type": 16777228,
                         "uuid": "B78CB4FB-3A90-4039-9EFD-C58932803AE5",
                         "image_vmaddr": 0,
-                        "image_addr": 4295092368,
+                        "image_addr": 6000,
                         "cpu_type": 16777228,
                         "image_size": 32768,
                         'name': '/usr/lib/whatever.dylib',
@@ -93,25 +94,19 @@ class BasicResolvingFileTest(TestCase):
                                 {
                                     "function": "<redacted>",
                                     "abs_path": None,
-                                    "instruction_offset": 4,
                                     "package": "/usr/lib/system/libdyld.dylib",
                                     "filename": None,
-                                    "symbol_addr": "0x002ac28b4",
                                     "lineno": None,
                                     "in_app": False,
-                                    "instruction_addr": "0x002ac28b8"
+                                    "instruction_addr": 6010,
                                 },
                                 {
                                     "function": "main",
-                                    "instruction_addr": 4295123760,
-                                    "symbol_addr": 4295123616,
-                                    "image_addr": 4295098368
+                                    "instruction_addr": 4295123760
                                 },
                                 {
                                     "function": "whatever_system",
-                                    "instruction_addr": 4295123360,
-                                    "symbol_addr": 4295123216,
-                                    "image_addr": 4295092368
+                                    "instruction_addr": 6020,
                                 },
                                 {
                                     "platform": "javascript",
@@ -174,16 +169,16 @@ class BasicResolvingFileTest(TestCase):
         frames = bt['frames']
 
         assert frames[0]['function'] == '<redacted>'
-        assert frames[0]['instruction_addr'] == '0x002ac28b8'
+        assert frames[0]['instruction_addr'] == 6010
 
         assert frames[1]['function'] == 'real_main'
         assert frames[1]['lineno'] == 42
         assert frames[1]['colno'] == 23
         assert frames[1]['package'] == OBJECT_NAME
-        assert frames[1]['instruction_addr'] == '0x100026330'
+        assert frames[1]['instruction_addr'] == 4295123760
         assert frames[1].get('instruction_offset') is None
 
         assert frames[2]['function'] == 'whatever_system'
         assert frames[2]['package'] == '/usr/lib/whatever.dylib'
-        assert frames[2]['instruction_addr'] == '0x1000261a0'
-        assert frames[2].get('instruction_offset') == 144
+        assert frames[2]['instruction_addr'] == 6020
+        assert frames[2].get('instruction_offset') == 4


### PR DESCRIPTION
This pull request updates the symbolication support for latest symsynd
and supports inline frames and instruction address heuristics for most frames.

This might change grouping of existing frames so we should be careful
with pushing out the update and test it thorougly first.

NOTE: will require a bump to symsynd in the getsentry repo

#nochanges