### PR TITLE
avatars: fix avatar list on member page

### DIFF
--- a/src/sentry/templates/sentry/organization-members.html
+++ b/src/sentry/templates/sentry/organization-members.html
@@ -85,7 +85,7 @@
         {% for member, needs_sso, has_2fa in member_list %}
           <tr {% if member.role == request.GET.role %}class="member-role-highlight"{% endif %}>
             <td class="table-user-info">
-              {% avatar member %}
+              {% avatar member.user %}
               <h5><a href="{% url 'sentry-organization-member-settings' organization.slug member.id %}">
                 {{ member.get_display_name }}
               </a></h5>


### PR DESCRIPTION
We were passing in the OrganizationMember object in for avatar
generation, instead of the User object.

tbh not sure how this isn't causing more problems, but maybe it is and
we haven't seen it. But in theory, this could be pulling avatars for
different user accounts if the member.id matched someone elses
member.user.id.