### PR TITLE
Kill instruction_offset

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 8.14 (Unreleased)
 - Add IE10 legacy browser filter
 - Added data migration to merge legacy releases
 - Added support for symbolizing inlined frames and added heuristics for fixing up native stacktraces.
+- Removed instruction_offset as a frame attribute from stacktraces
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -321,11 +321,6 @@ class Frame(Interface):
         except AssertionError:
             raise InterfaceValidationError("Invalid value for 'in_app'")
 
-        instruction_offset = data.get('instruction_offset')
-        if instruction_offset is not None and \
-           not isinstance(instruction_offset, six.integer_types):
-            raise InterfaceValidationError("Invalid value for 'instruction_offset'")
-
         kwargs = {
             'abs_path': trim(abs_path, 2048),
             'filename': trim(filename, 256),
@@ -337,7 +332,6 @@ class Frame(Interface):
             'symbol': trim(symbol, 256),
             'symbol_addr': to_hex_addr(data.get('symbol_addr')),
             'instruction_addr': to_hex_addr(data.get('instruction_addr')),
-            'instruction_offset': instruction_offset,
             'in_app': in_app,
             'context_line': context_line,
             # TODO(dcramer): trim pre/post_context
@@ -423,7 +417,6 @@ class Frame(Interface):
             'package': self.package,
             'platform': self.platform,
             'instructionAddr': pad_hex_addr(self.instruction_addr, pad_addr),
-            'instructionOffset': self.instruction_offset,
             'symbolAddr': pad_hex_addr(self.symbol_addr, pad_addr),
             'function': self.function,
             'symbol': self.symbol,

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -168,9 +168,6 @@ def convert_stacktrace(frames, system=None, notable_addresses=None):
         # the beginning of the symbol.
         function = frame.get('symbol_name') or '<unknown>'
         lineno = frame.get('line')
-        offset = None
-        if not lineno:
-            offset = frame['instruction_addr'] - frame['symbol_addr']
 
         cframe = {
             'abs_path': fn,
@@ -183,7 +180,6 @@ def convert_stacktrace(frames, system=None, notable_addresses=None):
             'package': frame.get('object_name'),
             'symbol_addr': '0x%x' % frame['symbol_addr'],
             'instruction_addr': '0x%x' % frame['instruction_addr'],
-            'instruction_offset': offset,
             'lineno': lineno,
         }
         cframe['in_app'] = is_in_app(cframe, app_uuid)
@@ -472,9 +468,6 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                     new_frame['abs_path'])
             if sfrm.get('line') is not None:
                 new_frame['lineno'] = sfrm['line']
-            instruction_offset = sfrm.get('instruction_offset')
-            if instruction_offset is not None:
-                new_frame['instruction_offset'] = instruction_offset
             if sfrm.get('column') is not None:
                 new_frame['colno'] = sfrm['column']
             new_frame['package'] = sfrm['object_name'] \

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -215,18 +215,6 @@ class Symbolizer(object):
                 rv['object_name'] = img['name']
             rv['uuid'] = img['uuid']
 
-        # XXX: this is technically incorrect because the instruction
-        # address might move away from the symbol address if we
-        # find a different symbol than the client did.  However
-        # our symbolizer cannot tell us where a symbol is so this
-        # is the best we can do for now.  Maybe we kill it?
-        symbol_addr = frame.get('symbol_addr')
-        if symbol_addr is not None:
-            symbol_addr = parse_addr(symbol_addr)
-            slide_value = parse_addr(img.get('image_vmaddr') or 0)
-            rv['instruction_offset'] = parse_addr(frame['instruction_addr']) \
-                - slide_value - symbol_addr
-
         return rv
 
     def _get_frame_package(self, frame, img):

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -312,8 +312,6 @@ const Frame = React.createClass({
           </span>
           <span className="symbol">
             <code>{data.function || '<unknown>'}</code>
-            {data.instructionOffset &&
-              <span className="offset">{' + ' + data.instructionOffset}</span>}
             {data.filename &&
               <span className="filename">{data.filename}
                 {data.lineNo ? ':' + data.lineNo : ''}</span>}

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
@@ -108,9 +108,6 @@ export function getCocoaFrame(frame) {
     result += ljust(frame.instructionAddr, 12);
   }
   result += ' ' + (frame.function || frame.symbolAddr);
-  if (frame.instructionOffset) {
-    result += ' + ' + frame.instructionOffset;
-  }
   if (defined(frame.filename)) {
     result += ' (' + frame.filename;
     if (defined(frame.lineNo) && frame.lineNo >= 0) {

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -35,7 +35,6 @@ def test_legacy_stacktrace_converter():
          'function': 'objc_exception_throw',
          'in_app': False,
          'instruction_addr': '0x196857f80',
-         'instruction_offset': 56,
          'lineno': None,
          'package': 'libobjc.A.dylib',
          'symbol_addr': '0x196857f48'},
@@ -44,7 +43,6 @@ def test_legacy_stacktrace_converter():
          'function': '<redacted>',
          'in_app': False,
          'instruction_addr': '0x182300f5c',
-         'instruction_offset': 124,
          'lineno': None,
          'package': 'CoreFoundation',
          'symbol_addr': '0x182300ee0',
@@ -108,7 +106,6 @@ class BasicResolvingIntegrationTest(TestCase):
                                 {
                                     "function": "<redacted>",
                                     "abs_path": None,
-                                    "instruction_offset": 4,
                                     "package": "/usr/lib/system/libdyld.dylib",
                                     "filename": None,
                                     "symbol_addr": "0x002ac28b4",
@@ -216,7 +213,6 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[1].colno == 23
         assert frames[1].package == object_name
         assert frames[1].instruction_addr == '0x100026330'
-        assert frames[1].instruction_offset is None
         assert frames[1].in_app
 
         assert frames[2].platform == 'javascript'
@@ -225,7 +221,6 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[2].lineno == 268
         assert frames[2].colno == 16
         assert frames[2].filename == '../../sentry/scripts/views.js'
-        assert frames[2].instruction_offset is None
         assert frames[2].in_app
 
         assert len(event.interfaces['threads'].values) == 1
@@ -300,7 +295,6 @@ class BasicResolvingIntegrationTest(TestCase):
                                 {
                                     "function": "<redacted>",
                                     "abs_path": None,
-                                    "instruction_offset": 4,
                                     "package": "/usr/lib/system/libdyld.dylib",
                                     "filename": None,
                                     "symbol_addr": "0x002ac28b4",
@@ -386,7 +380,6 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[1].colno == 23
         assert frames[1].package == object_name
         assert frames[1].instruction_addr == '0x100020014'
-        assert frames[1].instruction_offset is None
         assert frames[1].in_app
 
         assert frames[2].function == 'other_main'
@@ -395,7 +388,6 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[2].colno == 23
         assert frames[2].package == object_name
         assert frames[2].instruction_addr == '0x10002001c'
-        assert frames[2].instruction_offset is None
         assert frames[2].in_app
 
         assert frames[3].platform == 'javascript'
@@ -404,7 +396,6 @@ class BasicResolvingIntegrationTest(TestCase):
         assert frames[3].lineno == 268
         assert frames[3].colno == 16
         assert frames[3].filename == '../../sentry/scripts/views.js'
-        assert frames[3].instruction_offset is None
         assert frames[3].in_app
 
         x = bt.get_api_context()

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -40,7 +40,6 @@ def patched_symbolize_system_frame(self, frame, img, sdk_info,
         return [{
             'object_name': '/usr/lib/whatever.dylib',
             'symbol_name': 'whatever_system',
-            'instruction_offset': 4
         }]
     return []
 
@@ -176,9 +175,7 @@ class BasicResolvingFileTest(TestCase):
         assert frames[1]['colno'] == 23
         assert frames[1]['package'] == OBJECT_NAME
         assert frames[1]['instruction_addr'] == 4295123760
-        assert frames[1].get('instruction_offset') is None
 
         assert frames[2]['function'] == 'whatever_system'
         assert frames[2]['package'] == '/usr/lib/whatever.dylib'
         assert frames[2]['instruction_addr'] == 6020
-        assert frames[2].get('instruction_offset') == 4


### PR DESCRIPTION
This removes the instruction_offset from the frame storage and the UI.  We
remove it because with the current symbolizer system we cannot get the
`symbol_addr` anyways which means that the offsets will be wrong for symbolized
frames.  For raw frames we now have the apple crash report format which calculates
that information more reliable.

In particular with the switch to the new symsynd version the values generated
are largely wrong and will confuse users.