### PR TITLE
Do not fail on broken frames in error handling

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -695,8 +695,8 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 token = None
                 all_errors.append({
                     'type': EventError.JS_INVALID_SOURCEMAP_LOCATION,
-                    'column': frame['colno'],
-                    'row': frame['lineno'],
+                    'column': frame.get('colno'),
+                    'row': frame.get('lineno'),
                     'source': frame['abs_path'],
                     'sourcemap': sourcemap_label,
                 })


### PR DESCRIPTION
This resolves an issue where the error handling code in the
processor would assume a well formed frame which is not
necessarily true.

This fixes SENTRY-2R9