### PR TITLE
Do not fail on missing cpu name

### DIFF
--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -166,7 +166,9 @@ class Symbolizer(object):
 
     def find_best_instruction(self, frame, meta=None):
         """Finds the best instruction for a given frame."""
-        if not self.images:
+        # If we have no images or cpu name we cannot possibly fix the
+        # instruction here.
+        if not self.images or self.cpu_name is None:
             return parse_addr(frame['instruction_addr'])
         return self.symsynd_symbolizer.find_best_instruction(
             frame['instruction_addr'], cpu_name=self.cpu_name, meta=meta)


### PR DESCRIPTION
This catches missing cpu names in the instruction fixup code.  While
this should never happen it does appear we have clients live that
do not send a cpu name or conflicting values.

Fixes SENTRY-2R6