### PR TITLE
Don't require a module or filename to build a frame signature.

### DIFF
--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -322,11 +322,16 @@ def serialize_frame(frame):
         FRAME_FUNCTION_KEY: frame['function']
     }
 
-    module = frame.get('module')
-    if module:
-        attributes[FRAME_MODULE_KEY] = module
-    else:
-        attributes[FRAME_FILENAME_KEY] = frame['filename']
+    scopes = (
+        (FRAME_MODULE_KEY, 'module'),
+        (FRAME_FILENAME_KEY, 'filename'),
+    )
+
+    for key, name in scopes:
+        value = frame.get(name)
+        if value:
+            attributes[key] = value
+            break
 
     return FRAME_ITEM_SEPARATOR.join(
         map(


### PR DESCRIPTION
This prevented serializing built-in functions.

Fixes SENTRY-2RQ.