### PR TITLE
Get cpu type from device context and clean up code

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -35,16 +35,14 @@ def format_index_expr(format_string, data):
         six.text_type(format_string), (), data).strip())
 
 
-def contexttype(name):
-    def decorator(cls):
-        cls.type = name
-        context_types[name] = cls
-        return cls
-    return decorator
+def contexttype(cls):
+    context_types[cls.type] = cls
+    return cls
 
 
 class ContextType(object):
     indexed_fields = None
+    type = None
 
     def __init__(self, alias, data):
         self.alias = alias
@@ -61,6 +59,25 @@ class ContextType(object):
         rv['type'] = self.type
         return rv
 
+    @classmethod
+    def values_for_data(cls, data):
+        contexts = data.get('contexts') or {}
+        rv = []
+        for context in six.itervalues(contexts):
+            if context.get('type') == cls.type:
+                rv.append(context)
+        return rv
+
+    @classmethod
+    def primary_value_for_data(cls, data):
+        contexts = data.get('contexts') or {}
+        val = contexts.get(cls.type)
+        if val and val.get('type') == cls.type:
+            return val
+        rv = cls.values_for_data(data)
+        if len(rv) == 1:
+            return rv[0]
+
     def iter_tags(self):
         if self.indexed_fields:
             for field, f_string in six.iteritems(self.indexed_fields):
@@ -76,13 +93,14 @@ class ContextType(object):
 
 
 # TODO(dcramer): contexts need to document/describe expected (optional) fields
-@contexttype('default')
+@contexttype
 class DefaultContextType(ContextType):
-    pass
+    type = 'default'
 
 
-@contexttype('device')
+@contexttype
 class DeviceContextType(ContextType):
+    type = 'device'
     indexed_fields = {
         '': u'{model}',
         'family': u'{family}',
@@ -90,16 +108,18 @@ class DeviceContextType(ContextType):
     # model_id, arch
 
 
-@contexttype('runtime')
+@contexttype
 class RuntimeContextType(ContextType):
+    type = 'runtime'
     indexed_fields = {
         '': u'{name} {version}',
         'name': u'{name}',
     }
 
 
-@contexttype('browser')
+@contexttype
 class BrowserContextType(ContextType):
+    type = 'browser'
     indexed_fields = {
         '': u'{name} {version}',
         'name': u'{name}',
@@ -107,8 +127,9 @@ class BrowserContextType(ContextType):
     # viewport
 
 
-@contexttype('os')
+@contexttype
 class OsContextType(ContextType):
+    type = 'os'
     indexed_fields = {
         '': u'{name} {version}',
         'name': u'{name}',

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -365,13 +365,11 @@ class NativeStacktraceProcessor(StacktraceProcessor):
         if not self.available:
             return False
 
-        is_debug_build = self.debug_meta.get('is_debug_build')
         referenced_images = find_stacktrace_referenced_images(
             self.debug_meta['images'], [
                 x.stacktrace for x in self.stacktrace_infos])
         self.sym = Symbolizer(self.project, self.debug_meta['images'],
-                              referenced_images=referenced_images,
-                              is_debug_build=is_debug_build)
+                              referenced_images=referenced_images)
 
         # The symbolizer gets a reference to the debug meta's images so
         # when it resolves the missing vmaddrs it changes them in the data

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -15,7 +15,7 @@ from sentry.lang.native.symbolizer import Symbolizer, SymbolicationFailed
 from sentry.lang.native.utils import \
     find_apple_crash_report_referenced_images, get_sdk_from_event, \
     find_stacktrace_referenced_images, get_sdk_from_apple_system_info, \
-    APPLE_SDK_MAPPING
+    cpu_name_from_data, APPLE_SDK_MAPPING
 from sentry.stacktraces import StacktraceProcessor
 from sentry.constants import NATIVE_UNKNOWN_STRING
 
@@ -286,6 +286,7 @@ def preprocess_apple_crash_event(data):
     referenced_images = find_apple_crash_report_referenced_images(
         crash_report['binary_images'], raw_threads.values())
     sym = Symbolizer(project, crash_report['binary_images'],
+                     cpu_name=cpu_name_from_data(data),
                      referenced_images=referenced_images)
 
     try:

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+import six
 import logging
+
+from sentry.interfaces.contexts import DeviceContextType
 
 
 logger = logging.getLogger(__name__)
@@ -140,3 +143,12 @@ def get_sdk_from_apple_system_info(info):
         'version_minor': system_version[1],
         'version_patchlevel': system_version[2],
     }
+
+
+def cpu_name_from_data(data):
+    """Returns the CPU name from the given data if it exists."""
+    device = DeviceContextType.primary_value_for_data(data)
+    if device:
+        arch = device.get('arch')
+        if isinstance(arch, six.string_types):
+            return arch

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.lang.native.utils import get_sdk_from_event
+from sentry.lang.native.utils import get_sdk_from_event, cpu_name_from_data
 
 
 def test_get_sdk_from_event():
@@ -36,3 +36,33 @@ def test_get_sdk_from_event():
     assert sdk_info['version_major'] == 9
     assert sdk_info['version_minor'] == 3
     assert sdk_info['version_patchlevel'] == 1
+
+
+def test_cpu_name_from_data():
+    cpu_name = cpu_name_from_data({
+        'contexts': {
+            'device': {
+                'type': 'device',
+                'arch': 'arm64'
+            },
+            'device2': {
+                'type': 'device',
+                'arch': 'arm7'
+            },
+        }
+    })
+
+    assert cpu_name == 'arm64'
+
+
+def test_cpu_name_from_data_inferred_type():
+    cpu_name = cpu_name_from_data({
+        'contexts': {
+            'some_device': {
+                'type': 'device',
+                'arch': 'arm64'
+            }
+        }
+    })
+
+    assert cpu_name == 'arm64'


### PR DESCRIPTION
This also removes some now unused functionality in the symbolizer
and cleans up the contexts.

#nochanges