### PR TITLE
Frame Caching for Cocoa

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'symsynd>=2.1.0,<3.0.0',
+    'symsynd>=2.3.0,<3.0.0',
     'toronado>=0.0.11,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ install_requires = [
     'statsd>=3.1.0,<3.2.0',
     'structlog==16.1.0',
     'South==1.0.1',
-    'symsynd>=2.3.0,<3.0.0',
+    'symsynd>=2.2.0,<3.0.0',
     'toronado>=0.0.11,<0.1.0',
     'ua-parser>=0.6.1,<0.8.0',
     'urllib3>=1.14,<1.17',

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -625,7 +625,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             ])
         return frames
 
-    def preprocess_related_data(self, processing_task):
+    def preprocess_step(self, processing_task):
         frames = self.get_valid_frames()
         if not frames:
             logger.debug('Event %r has no frames with enough context to '

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -625,7 +625,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             ])
         return frames
 
-    def preprocess_related_data(self, task):
+    def preprocess_related_data(self, processing_task):
         frames = self.get_valid_frames()
         if not frames:
             logger.debug('Event %r has no frames with enough context to '

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -647,7 +647,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             platform == 'javascript'
         )
 
-    def process_frame(self, processable_frame):
+    def process_frame(self, processable_frame, processing_task):
         frame = processable_frame.frame
         last_token = None
         token = None

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -625,7 +625,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             ])
         return frames
 
-    def preprocess_related_data(self):
+    def preprocess_related_data(self, task):
         frames = self.get_valid_frames()
         if not frames:
             logger.debug('Event %r has no frames with enough context to '
@@ -647,7 +647,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             platform == 'javascript'
         )
 
-    def process_frame(self, processable_frame):
+    def process_frame(self, processable_frame, task):
         frame = processable_frame.frame
         last_token = None
         token = None

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -647,7 +647,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             platform == 'javascript'
         )
 
-    def process_frame(self, processable_frame, processing_task):
+    def process_frame(self, processable_frame):
         frame = processable_frame.frame
         last_token = None
         token = None

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -640,11 +640,15 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         self.populate_source_cache(frames)
         return True
 
-    def process_frame(self, frame, stacktrace_info, idx):
-        if not settings.SENTRY_SCRAPE_JAVASCRIPT_CONTEXT or \
-           self.get_effective_platform(frame) != 'javascript':
-            return
+    def handles_frame(self, frame, stacktrace_info):
+        platform = frame.get('platform') or self.data.get('platform')
+        return (
+            settings.SENTRY_SCRAPE_JAVASCRIPT_CONTEXT and
+            platform == 'javascript'
+        )
 
+    def process_frame(self, processable_frame):
+        frame = processable_frame.frame
         last_token = None
         token = None
 

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -647,7 +647,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             platform == 'javascript'
         )
 
-    def process_frame(self, processable_frame, task):
+    def process_frame(self, processable_frame, processing_task):
         frame = processable_frame.frame
         last_token = None
         token = None

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -397,7 +397,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             'instruction_addr' not in frame
         )
 
-    def preprocess_frame(self, processable_frame, processing_task):
+    def preprocess_frame(self, processable_frame):
         instr_addr = self.find_best_instruction(processable_frame)
         img = self.sym.find_image(instr_addr)
 

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -460,7 +460,6 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                 'object_name': frame.get('package'),
                 'instruction_addr': processable_frame.data['instruction_addr'],
                 'symbol_name': frame.get('function'),
-                'symbol_addr': frame.get('symbol_addr'),
             }
             in_app = self.sym.is_in_app(sym_input_frame)
             raw_frame['in_app'] = in_app
@@ -484,13 +483,10 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                                  exc_info=True)
                 return None, [raw_frame], errors
 
-            processable_frame.set_cache_value({
-                'in_app': in_app,
-                'symbolicated_frames': symbolicated_frames,
-            })
+            processable_frame.set_cache_value([in_app, symbolicated_frames])
         else:
-            raw_frame['in_app'] = in_app = processable_frame.cache_value['in_app']
-            symbolicated_frames = processable_frame.cache_value['symbolicated_frames']
+            in_app, symbolicated_frames = processable_frame.cache_value
+            raw_frame['in_app'] = in_app
 
         for sfrm in symbolicated_frames:
             symbol = sfrm.get('symbol_name') or \

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -362,7 +362,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             self.sym.close()
             self.sym = None
 
-    def preprocess_related_data(self):
+    def preprocess_related_data(self, task):
         if not self.available:
             return False
 
@@ -411,7 +411,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             'instruction_addr' not in frame
         )
 
-    def process_frame(self, processable_frame):
+    def process_frame(self, processable_frame, task):
         frame = processable_frame.frame
         errors = []
 

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -417,12 +417,15 @@ class NativeStacktraceProcessor(StacktraceProcessor):
         if img is not None:
             processable_frame.set_cache_key_from_values((
                 FRAME_CACHE_VERSION,
-                processable_frame.data['instruction_addr'],
-                img['uuid'],
+                # Because the images can move around, we want to rebase
+                # the address for the cache key to be within the image
+                # the same way as we do it in the symbolizer.
+                (parse_addr(img['image_vmaddr']) +
+                 instr_addr - parse_addr(img['image_addr'])),
+                img['uuid'].lower(),
                 img['cpu_type'],
                 img['cpu_subtype'],
                 img['image_size'],
-                img['image_addr']
             ))
 
     def preprocess_step(self, processing_task):

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -411,7 +411,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             'instruction_addr' not in frame
         )
 
-    def process_frame(self, processable_frame, task):
+    def process_frame(self, processable_frame, processing_task):
         frame = processable_frame.frame
         errors = []
 

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -347,7 +347,6 @@ def preprocess_apple_crash_event(data):
 
 
 class NativeStacktraceProcessor(StacktraceProcessor):
-    platforms = ('cocoa',)
 
     def __init__(self, *args, **kwargs):
         StacktraceProcessor.__init__(self, *args, **kwargs)

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -397,7 +397,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
         return (
             platform == 'cocoa' and
             self.available and
-            'instruction_addr' not in frame
+            'instruction_addr' in frame
         )
 
     def preprocess_frame(self, processable_frame):

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -362,7 +362,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             self.sym.close()
             self.sym = None
 
-    def preprocess_related_data(self, task):
+    def preprocess_related_data(self, processing_task):
         if not self.available:
             return False
 

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -108,7 +108,7 @@ def find_system_symbol(img, instruction_addr, sdk_info=None, cpu_name=None):
     )
 
 
-def make_symbolizer(project, binary_images, referenced_images=None):
+def make_symbolizer(project, image_lookup, referenced_images=None):
     """Creates a symbolizer for the given project and binary images.  If a
     list of referenced images is referenced (UUIDs) then only images
     needed by those frames are loaded.
@@ -117,7 +117,7 @@ def make_symbolizer(project, binary_images, referenced_images=None):
 
     to_load = referenced_images
     if to_load is None:
-        to_load = [x['uuid'] for x in binary_images]
+        to_load = image_lookup.get_uuids()
 
     dsym_paths, loaded = dsymcache.fetch_dsyms(project, to_load)
 
@@ -125,11 +125,41 @@ def make_symbolizer(project, binary_images, referenced_images=None):
     # symbolizer to avoid the expensive FS operations that will otherwise
     # happen.
     user_images = []
-    for img in binary_images:
+    for img in image_lookup.iter_images():
         if img['uuid'] in loaded:
             user_images.append(img)
 
     return ReportSymbolizer(driver, dsym_paths, user_images)
+
+
+class ImageLookup(object):
+
+    def __init__(self, images):
+        self._image_addresses = []
+        self.images = {}
+        for img in images:
+            img_addr = parse_addr(img['image_addr'])
+            self._image_addresses.append(img_addr)
+            self.images[img_addr] = img
+        self._image_addresses.sort()
+
+    def iter_images(self):
+        return six.itervalues(self.images)
+
+    def get_uuids(self):
+        return list(self.iter_uuids())
+
+    def iter_uuids(self):
+        for img in self.iter_images():
+            yield img['uuid']
+
+    def find_image(self, addr):
+        """Given an instruction address this locates the image this address
+        is contained in.
+        """
+        idx = bisect.bisect_left(self._image_addresses, parse_addr(addr))
+        if idx > 0:
+            return self.images[self._image_addresses[idx - 1]]
 
 
 class Symbolizer(object):
@@ -139,31 +169,14 @@ class Symbolizer(object):
 
     def __init__(self, project, binary_images, referenced_images=None,
                  cpu_name=None):
+        if isinstance(binary_images, ImageLookup):
+            self.image_lookup = binary_images
+        else:
+            self.image_lookup = ImageLookup(binary_images)
         self.symsynd_symbolizer = make_symbolizer(
-            project, binary_images, referenced_images=referenced_images)
-
-        # This is a duplication from symsynd.  The reason is that symsynd
-        # will only load images that it can find dsyms for but we also
-        # have system symbols which there are no dsyms for.
-        self._image_addresses = []
-        self.images = {}
-        for img in binary_images:
-            img_addr = parse_addr(img['image_addr'])
-            self._image_addresses.append(img_addr)
-            self.images[img_addr] = img
-        self._image_addresses.sort()
-
-        # This should always succeed but you never quite know.
+            project, self.image_lookup,
+            referenced_images=referenced_images)
         self.cpu_name = cpu_name
-        if self.cpu_name is None:
-            for img in six.itervalues(self.images):
-                cpu_name = get_cpu_name(img['cpu_type'],
-                                        img['cpu_subtype'])
-                if self.cpu_name is None:
-                    self.cpu_name = cpu_name
-                elif self.cpu_name != cpu_name:
-                    self.cpu_name = None
-                    break
 
     def resolve_missing_vmaddrs(self):
         """When called this changes the vmaddr on all contained images from
@@ -174,7 +187,7 @@ class Symbolizer(object):
         changed_any = False
 
         loaded_images = self.symsynd_symbolizer.images
-        for image_addr, image in six.iteritems(self.images):
+        for image_addr, image in six.iteritems(self.image_lookup.images):
             if image.get('image_vmaddr') or not image.get('image_addr'):
                 continue
             image_info = loaded_images.get(image_addr)
@@ -194,14 +207,6 @@ class Symbolizer(object):
 
     def close(self):
         self.symsynd_symbolizer.driver.close()
-
-    def find_image(self, addr):
-        """Given an instruction address this locates the image this address
-        is contained in.
-        """
-        idx = bisect.bisect_left(self._image_addresses, parse_addr(addr))
-        if idx > 0:
-            return self.images[self._image_addresses[idx - 1]]
 
     def _process_frame(self, frame, img):
         rv = trim_frame(frame)
@@ -248,7 +253,7 @@ class Symbolizer(object):
         return _sim_platform_re.search(fn) is not None
 
     def is_in_app(self, frame):
-        img = self.find_image(frame['instruction_addr'])
+        img = self.image_lookup.find_image(frame['instruction_addr'])
         return img is not None and self._is_app_frame(frame, img)
 
     def symbolize_app_frame(self, frame, img, symbolize_inlined=False):
@@ -345,7 +350,7 @@ class Symbolizer(object):
                 message='Found multiple architectures.'
             )
 
-        img = self.find_image(frame['instruction_addr'])
+        img = self.image_lookup.find_image(frame['instruction_addr'])
         if img is None:
             raise SymbolicationFailed(
                 type=EventError.NATIVE_UNKNOWN_IMAGE

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -165,15 +165,6 @@ class Symbolizer(object):
                     self.cpu_name = None
                     break
 
-    def find_best_instruction(self, frame, meta=None):
-        """Finds the best instruction for a given frame."""
-        # If we have no images or cpu name we cannot possibly fix the
-        # instruction here.
-        if not self.images or self.cpu_name is None:
-            return parse_addr(frame['instruction_addr'])
-        return self.symsynd_symbolizer.find_best_instruction(
-            frame['instruction_addr'], cpu_name=self.cpu_name, meta=meta)
-
     def resolve_missing_vmaddrs(self):
         """When called this changes the vmaddr on all contained images from
         the information in the dsym files (if there is no vmaddr already).

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -332,7 +332,7 @@ class Symbolizer(object):
 
         rv = self._process_frame(dict(frame,
             symbol_name=symbol, filename=None, line=0, column=0,
-            uuid=img['uuid'], object_name=img['name']), img)
+            object_name=img['name']), img)
 
         # We actually do not support inline symbolication for system
         # frames, so we just only ever return a single frame here.  Maybe

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import six
 import logging
 
+from symsynd.macho.arch import get_cpu_name
+
 from sentry.interfaces.contexts import DeviceContextType
 
 
@@ -136,3 +138,17 @@ def cpu_name_from_data(data):
         arch = device.get('arch')
         if isinstance(arch, six.string_types):
             return arch
+
+    # TODO: kill this here.  we want to not support that going forward
+    unique_cpu_name = None
+    images = (data.get('debug_meta') or {}).get('images') or []
+    for img in images:
+        cpu_name = get_cpu_name(img['cpu_type'],
+                                img['cpu_subtype'])
+        if unique_cpu_name is None:
+            unique_cpu_name = cpu_name
+        elif unique_cpu_name != cpu_name:
+            unique_cpu_name = None
+            break
+
+    return unique_cpu_name

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -42,22 +42,6 @@ def find_apple_crash_report_referenced_images(binary_images, threads):
     return list(to_load)
 
 
-def find_stacktrace_referenced_images(debug_images, stacktraces):
-    image_map = {}
-    for image in debug_images:
-        image_map[image['image_addr']] = image['uuid']
-
-    to_load = set()
-    for stacktrace in stacktraces:
-        for frame in stacktrace['frames']:
-            if 'image_addr' in frame:
-                img_uuid = image_map.get(frame['image_addr'])
-                if img_uuid is not None:
-                    to_load.add(img_uuid)
-
-    return list(to_load)
-
-
 def find_all_stacktraces(data):
     """Given a data dictionary from an event this returns all
     relevant stacktraces in a list.  If a frame contains a raw_stacktrace

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -18,17 +18,79 @@ from six import integer_types, text_type
 logger = logging.getLogger(__name__)
 
 
-ProcessableFrame = namedtuple('ProcessableFrame', [
-    'frame', 'idx', 'processor', 'stacktrace_info', 'cache_key'])
 StacktraceInfo = namedtuple('StacktraceInfo', [
     'stacktrace', 'container', 'platforms'])
 
 
+class ProcessableFrame(object):
+
+    def __init__(self, frame, idx, processor, stacktrace_info):
+        self.frame = frame
+        self.idx = idx
+        self.processor = processor
+        self.stacktrace_info = stacktrace_info
+        self.data = None
+        self.cache_key = None
+        self.cache_value = None
+
+    def __contains__(self, key):
+        return key in self.frame
+
+    def __getitem__(self, key):
+        return self.frame[key]
+
+    def get(self, key, default=None):
+        return self.frame.get(key, default)
+
+    def set_cache_value(self, value):
+        if self.cache_key is not None:
+            cache.set(self.cache_key, value, 3600)
+            return True
+        return False
+
+    def set_cache_key_from_values(self, values):
+        if values is None:
+            self.cache_key = None
+            return
+
+        h = hashlib.md5()
+        h.update((u'%s\xff' % self.processor.__class__.__name__).encode('utf-8'))
+
+        def _hash_value(value):
+            if value is None:
+                h.update(b'\x00')
+            elif value is True:
+                h.update(b'\x01')
+            elif value is False:
+                h.update(b'\x02')
+            elif isinstance(value, integer_types):
+                h.update(b'\x03' + text_type(value).encode('ascii') + b'\x00')
+            elif isinstance(value, (tuple, list)):
+                h.update(b'\x04' + text_type(len(value)).encode('utf-8'))
+                for item in value:
+                    _hash_value(item)
+            elif isinstance(value, dict):
+                h.update(b'\x05' + text_type(len(value)).encode('utf-8'))
+                for k, v in six.iteritems(value):
+                    _hash_value(k)
+                    _hash_value(v)
+            elif isinstance(value, bytes):
+                h.update(b'\x06' + value + b'\x00')
+            elif isinstance(value, text_type):
+                h.update(b'\x07' + value.encode('utf-8') + b'\x00')
+            else:
+                raise TypeError('Invalid value for frame cache')
+
+        for value in values:
+            _hash_value(value)
+
+        self.cache_key = 'pf:%s' % h.hexdigest()
+
+
 class StacktraceProcessingTask(object):
 
-    def __init__(self, processable_stacktraces, frame_cache, processors):
+    def __init__(self, processable_stacktraces, processors):
         self.processable_stacktraces = processable_stacktraces
-        self.frame_cache = frame_cache
         self.processors = processors
 
     def iter_processors(self):
@@ -37,13 +99,11 @@ class StacktraceProcessingTask(object):
     def iter_processable_stacktraces(self):
         return six.iteritems(self.processable_stacktraces)
 
-    def get_frame_cache_data(self, processing_frame):
-        if processing_frame.cache_key:
-            return self.frame_cache.get(processing_frame.cache_key)
-
-    def set_frame_cache_data(self, processing_frame, value):
-        if processing_frame.cache_key:
-            cache.set(processing_frame.cache_key, value, 3600)
+    def iter_processable_frames(self, processor=None):
+        for frames in self.iter_processable_stacktraces():
+            for frame in frames:
+                if processor is None or frame.processor == processor:
+                    yield frame
 
 
 class StacktraceProcessor(object):
@@ -58,22 +118,35 @@ class StacktraceProcessor(object):
     def close(self):
         pass
 
-    def get_frame_cache_attributes(self):
-        return None
-
-    def get_frame_cache_values(self, frame):
-        attributes = self.get_frame_cache_attributes()
-        if attributes is not None:
-            return [(attr, frame.get(attr)) for attr in attributes]
-
-    def preprocess_related_data(self, processing_task):
-        return False
-
     def handles_frame(self, frame, stacktrace_info):
+        """Returns true if this processor can handle this frame.  This is the
+        earliest check and operates on a raw frame and stacktrace info.  If
+        this returns `True` a processable frame is created.
+        """
         return False
+
+    def preprocess_frame(self, processable_frame):
+        """After a processable frame has been created this method is invoked
+        to give the processor a chance to store additional data to the frame
+        if wanted.  In particular a cache key can be set here.
+        """
+        pass
 
     def process_frame(self, processable_frame, processing_task):
-        pass
+        """Processes the processable frame and returns a tuple of three
+        lists: ``(frames, raw_frames, errors)`` where frames is the list of
+        processed frames, raw_frames is the list of raw unprocessed frames
+        (which however can also be modified if needed) as well as a list of
+        optional errors.  Each one of the items can be `None` in which case
+        the original input frame is assumed.
+        """
+
+    def preprocess_step(self, processing_task):
+        """After frames are preprocesed but before frame processing kicks in
+        the preprocessing step is run.  This already has access to the cache
+        values on the frames.
+        """
+        return False
 
 
 def find_stacktraces_in_data(data):
@@ -150,48 +223,6 @@ def get_processors_for_stacktraces(data, infos):
     return processors
 
 
-def _get_frame_cache_key(processor, frame):
-    values = processor.get_frame_cache_values(frame)
-    if values is None:
-        return None
-
-    h = hashlib.md5()
-    h.update((u'%s\xff' % processor.__class__.__name__).encode('utf-8'))
-
-    def _hash_value(value):
-        if value is None:
-            h.update(b'\x00')
-        elif value is True:
-            h.update(b'\x01')
-        elif value is False:
-            h.update(b'\x02')
-        elif isinstance(value, integer_types):
-            h.update(b'\x03' + text_type(value).encode('ascii') + b'\x00')
-        elif isinstance(value, (tuple, list)):
-            h.update(b'\x04' + text_type(len(value)).encode('utf-8'))
-            for item in value:
-                _hash_value(item)
-        elif isinstance(value, dict):
-            h.update(b'\x05' + text_type(len(value)).encode('utf-8'))
-            for k, v in six.iteritems(value):
-                _hash_value(k)
-                _hash_value(v)
-        elif isinstance(value, bytes):
-            h.update(b'\x06' + value + b'\x00')
-        elif isinstance(value, text_type):
-            h.update(b'\x07' + value.encode('utf-8') + b'\x00')
-        else:
-            raise TypeError('Invalid value for frame cache')
-
-    for attr_name, value in values:
-        h.update((u'\xff%s|' % attr_name).encode('utf-8'))
-        value = frame.get(attr_name)
-        h.update(attr_name.encode('ascii') + b'\x00')
-        _hash_value(value)
-
-    return h.hexdigest()
-
-
 def get_processable_frames(stacktrace_info, processors):
     """Returns thin wrappers around the frames in a stacktrace associated
     with the processor for it.
@@ -204,7 +235,7 @@ def get_processable_frames(stacktrace_info, processors):
         if processor is not None:
             rv.append(ProcessableFrame(
                 frame, frame_count - idx - 1, processor,
-                stacktrace_info, _get_frame_cache_key(processor, frame)))
+                stacktrace_info))
     return rv
 
 
@@ -277,6 +308,7 @@ def get_stacktrace_processing_task(infos, processors):
     for info in infos:
         processable_frames = get_processable_frames(info, processors)
         for processable_frame in processable_frames:
+            processable_frame.processor.preprocess_frame(processable_frame)
             by_processor.setdefault(processable_frame.processor, []) \
                 .append(processable_frame)
             by_stacktrace_info.setdefault(processable_frame.stacktrace_info, []) \
@@ -284,9 +316,12 @@ def get_stacktrace_processing_task(infos, processors):
             if processable_frame.cache_key is not None:
                 to_lookup[processable_frame.cache_key] = processable_frame
 
+    frame_cache = lookup_frame_cache(to_lookup)
+    for cache_key, processable_frame in six.iteritems(to_lookup):
+        processable_frames.cache_value = frame_cache.get(cache_key)
+
     return StacktraceProcessingTask(
         processable_stacktraces=by_stacktrace_info,
-        frame_cache=lookup_frame_cache(to_lookup),
         processors=by_processor
     )
 
@@ -312,7 +347,7 @@ def process_stacktraces(data, make_processors=None):
 
         # Preprocess step
         for processor in processing_task.iter_processors():
-            if processor.preprocess_related_data(processing_task):
+            if processor.preprocess_step(processing_task):
                 changed = True
 
         # Process all stacktraces

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -103,7 +103,7 @@ class StacktraceProcessingTask(object):
         return six.iteritems(self.processable_stacktraces)
 
     def iter_processable_frames(self, processor=None):
-        for frames in self.iter_processable_stacktraces():
+        for _, frames in self.iter_processable_stacktraces():
             for frame in frames:
                 if processor is None or frame.processor == processor:
                     yield frame
@@ -257,6 +257,7 @@ def process_single_stacktrace(processing_task, stacktrace_info,
                 processable_frame, processing_task)
         except Exception:
             logger.exception('Failed to process frame')
+            rv = None
         expand_processed, expand_raw, errors = rv or (None, None, None)
 
         if expand_processed is not None:
@@ -321,7 +322,7 @@ def get_stacktrace_processing_task(infos, processors):
 
     frame_cache = lookup_frame_cache(to_lookup)
     for cache_key, processable_frame in six.iteritems(to_lookup):
-        processable_frames.cache_value = frame_cache.get(cache_key)
+        processable_frame.cache_value = frame_cache.get(cache_key)
 
     return StacktraceProcessingTask(
         processable_stacktraces=by_stacktrace_info,

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 StacktraceInfo = namedtuple('StacktraceInfo', [
     'stacktrace', 'container', 'platforms'])
+StacktraceInfo.__hash__ = lambda x: id(x)
+StacktraceInfo.__eq__ = lambda a, b: a is b
+StacktraceInfo.__ne__ = lambda a, b: a is not b
 
 
 class ProcessableFrame(object):

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -5,11 +5,10 @@ import hashlib
 
 from collections import namedtuple
 
-from django.core.cache import cache
-
 from sentry.models import Project
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
+from sentry.utils.cache import cache
 
 import six
 from six import integer_types, text_type
@@ -87,7 +86,8 @@ class ProcessableFrame(object):
         for value in values:
             _hash_value(value)
 
-        self.cache_key = 'pf:%s' % h.hexdigest()
+        self.cache_key = rv = 'pf:%s' % h.hexdigest()
+        return rv
 
 
 class StacktraceProcessingTask(object):


### PR DESCRIPTION
This pull request adds frame caching. It adds both a generic system that can be used my processors and a concrete implementation for native stacks.

This PR intentionally does not add support for frame caching for JavaScript but this should be easy to add.

Notes for reviewers:

* checksum generation for input data (cache key)
* expiration?
* changes to instruction addr heuristics

Notes for deploy: this bumps symsynd, also bump getsentry pin.

#nochanges