### PR TITLE
Correctly handle unicode inputs and missing context lines in `get_frame_signature`.

### DIFF
--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -322,11 +322,11 @@ def get_frame_signature(frame, lines=5):
     return struct.pack(
         '>i',
         mmh3.hash(
-            '\n'.join(
-                frame.get('pre_context', [])[-lines:] +
+            u'\n'.join(
+                (frame.get('pre_context') or [])[-lines:] +
                 [frame['context_line']] +
-                frame.get('post_context', [])[:lines]
-            )
+                (frame.get('post_context') or [])[:lines]
+            ).encode('utf8')
         ),
     )
 

--- a/tests/sentry/test_similarity.py
+++ b/tests/sentry/test_similarity.py
@@ -6,8 +6,8 @@ import pytest
 
 from sentry.similarity import (
     MinHashIndex, get_exception_frames, get_euclidian_distance,
-    get_manhattan_distance, get_number_format, scale_to_total,
-    serialize_frame,
+    get_manhattan_distance, get_number_format, get_frame_signature,
+    scale_to_total, serialize_frame,
 )
 from sentry.testutils import TestCase
 from sentry.utils import redis
@@ -220,6 +220,32 @@ def test_serialize_frame():
             'pre_context': ['foo'],
             'post_context': ['baz'],
         })
+
+
+def test_get_frame_signature():
+    assert get_frame_signature({
+        'context_line': 'bar'
+    }) == get_frame_signature({
+        'pre_context': None,
+        'context_line': 'bar',
+        'post_context': None,
+    }) == get_frame_signature({
+        'pre_context': [],
+        'context_line': 'bar',
+        'post_context': [],
+    })
+
+    get_frame_signature({
+        'pre_context': ['foo'],
+        'context_line': 'bar',
+        'post_context': ['baz'],
+    })
+
+    get_frame_signature({
+        'pre_context': [u'\N{SNOWMAN WITHOUT SNOW}'],
+        'context_line': u'\N{SNOWMAN}',
+        'post_context': [u'\N{BLACK SNOWMAN}'],
+    })
 
 
 class MinHashIndexTestCase(TestCase):


### PR DESCRIPTION
Fixes SENTRY-2T5, SENTRY-2TA.