### PR TITLE
Do not compose translation strings with concatenation

### DIFF
--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -200,7 +200,7 @@ def timesince(value, now=None):
         return _('just now')
     if value == _('1 day'):
         return _('yesterday')
-    return value + _(' ago')
+    return _('%s ago') % value
 
 
 @register.filter


### PR DESCRIPTION
Mark whole phrase for translation rather than single words
Many languages put their 'ago' before the time period