### PR TITLE
Soften release version regex

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import re
 
 from django.db import IntegrityError, transaction
 
@@ -15,9 +14,6 @@ from sentry.api.serializers.rest_framework import CommitSerializer, ListField
 from sentry.models import Activity, Release
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.utils.apidocs import scenario, attach_scenarios
-
-
-_VERSION_NEWLINE_RE = re.compile(r'[^\S ]')
 
 
 @scenario('CreateNewRelease')
@@ -46,19 +42,13 @@ def list_releases_scenario(runner):
 
 
 class ReleaseSerializer(serializers.Serializer):
-    version = serializers.RegexField(r'[a-zA-Z0-9\-_\. \(\)]', max_length=64, required=True)
+    version = serializers.RegexField(r'^[a-zA-Z0-9\-_\. \(\)]$', max_length=64, required=True)
     ref = serializers.CharField(max_length=64, required=False)
     url = serializers.URLField(required=False)
     owner = UserField(required=False)
     dateStarted = serializers.DateTimeField(required=False)
     dateReleased = serializers.DateTimeField(required=False)
     commits = ListField(child=CommitSerializer(), required=False)
-
-    def validate_version(self, attrs, source):
-        value = attrs[source]
-        if _VERSION_NEWLINE_RE.search(value):
-            raise serializers.ValidationError('Enter a valid value')
-        return attrs
 
 
 class ProjectReleasesEndpoint(ProjectEndpoint):

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -42,7 +42,7 @@ def list_releases_scenario(runner):
 
 
 class ReleaseSerializer(serializers.Serializer):
-    version = serializers.RegexField(r'^[a-zA-Z0-9\-_\. \(\)]$', max_length=64, required=True)
+    version = serializers.RegexField(r'^[a-zA-Z0-9\-_\. \(\)]+$', max_length=64, required=True)
     ref = serializers.CharField(max_length=64, required=False)
     url = serializers.URLField(required=False)
     owner = UserField(required=False)

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -42,7 +42,8 @@ def list_releases_scenario(runner):
 
 
 class ReleaseSerializer(serializers.Serializer):
-    version = serializers.RegexField(r'^[a-zA-Z0-9\-_\. \(\)]+$', max_length=64, required=True)
+    version = serializers.RegexField(r'^[a-zA-Z0-9\-_\. \(\)]+\Z',
+                                     max_length=64, required=True)
     ref = serializers.CharField(max_length=64, required=False)
     url = serializers.URLField(required=False)
     owner = UserField(required=False)

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -113,6 +113,29 @@ class ProjectReleaseCreateTest(APITestCase):
         assert release.organization == project.organization
         assert release.projects.first() == project
 
+    def test_ios_release(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project(name='foo')
+
+        url = reverse('sentry-api-0-project-releases', kwargs={
+            'organization_slug': project.organization.slug,
+            'project_slug': project.slug,
+        })
+        response = self.client.post(url, data={
+            'version': '1.2.1 (123)',
+        })
+
+        assert response.status_code == 201, response.content
+        assert response.data['version']
+
+        release = Release.objects.get(
+            version=response.data['version'],
+        )
+        assert not release.owner
+        assert release.organization == project.organization
+        assert release.projects.first() == project
+
     def test_duplicate(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
For iOS we should support build numbers for Releases which look basically like this ...

`1.2.3 (1337)`

So there is a short version string `1.2.3`
And a build number `1337` 
which uniquely identify a release.

This PR softens the regex in order to allow a POST with this string.

