### PR TITLE
Add "plugin.setSuspendState is not a function" to browser ext filters

### DIFF
--- a/src/sentry/filters/browser_extensions.py
+++ b/src/sentry/filters/browser_extensions.py
@@ -30,7 +30,10 @@ EXTENSION_EXC_VALUES = re.compile('|'.join((re.escape(x) for x in (
     'conduitPage',
     # Google Search app (iOS)
     # See: https://github.com/getsentry/raven-js/issues/756
-    'null is not an object (evaluating \'elt.parentNode\')'
+    'null is not an object (evaluating \'elt.parentNode\')',
+    # Dragon Web Extension from Nuance Communications
+    # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
+    'plugin.setSuspendState is not a function',
 ))), re.I)
 
 EXTENSION_EXC_SOURCES = re.compile('|'.join((

--- a/tests/sentry/filters/test_browser_extensions.py
+++ b/tests/sentry/filters/test_browser_extensions.py
@@ -51,6 +51,10 @@ class BrowserExtensionsFilterTest(TestCase):
         data = self.get_mock_data(exc_source='https://ff.kis.v2.scr.kaspersky-labs.com/14E4A3DB-9B72-1047-8296-E970532BF7B7/main.js')
         assert self.apply_filter(data)
 
+    def test_filters_dragon_web_extension(self):
+        data = self.get_mock_data(exc_value='plugin.setSuspendState is not a function')
+        assert self.apply_filter(data)
+
     def test_filters_chrome_extensions(self):
         data = self.get_mock_data(exc_source='chrome://my-extension/or/something')
         assert self.apply_filter(data)


### PR DESCRIPTION
Fixes getsentry/raven-js#835

See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481

cc @maxbittker @dcramer