### PR TITLE
javascript: Allow any sourcemap encodings

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, print_function
 
 __all__ = ['JavaScriptStacktraceProcessor']
 
-import codecs
 import logging
 import re
 import base64
@@ -494,16 +493,6 @@ def fetch_file(url, project=None, release=None, allow_scraping=True):
     return UrlResult(url, result[0], result[1], result[3])
 
 
-def is_utf8(encoding):
-    if encoding is None:
-        return True
-    try:
-        return codecs.lookup(encoding).name == 'utf-8'
-    except LookupError:
-        # Encoding is entirely unknown, so definitely not utf-8
-        return False
-
-
 def fetch_sourcemap(url, project=None, release=None, allow_scraping=True):
     if is_data_uri(url):
         try:
@@ -519,15 +508,6 @@ def fetch_sourcemap(url, project=None, release=None, allow_scraping=True):
         result = fetch_file(url, project=project, release=release,
                             allow_scraping=allow_scraping)
         body = result.body
-
-        # This is just a quick sanity check, but doesn't guarantee
-        if not is_utf8(result.encoding):
-            error = {
-                'type': EventError.JS_INVALID_SOURCE_ENCODING,
-                'value': 'utf8',
-                'url': expose_url(url),
-            }
-            raise CannotFetchSource(error)
 
     try:
         return view_from_json(body)

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -273,16 +273,6 @@ class FetchSourcemapTest(TestCase):
             fetch_sourcemap('data:application/json;base64,xxx')
 
     @responses.activate
-    def test_simple_non_utf8(self):
-        responses.add(responses.GET, 'http://example.com', body='{}',
-                      content_type='application/json; charset=NOPE')
-
-        with pytest.raises(CannotFetchSource) as exc:
-            fetch_sourcemap('http://example.com')
-
-        assert exc.value.data['type'] == EventError.JS_INVALID_SOURCE_ENCODING
-
-    @responses.activate
     def test_garbage_json(self):
         responses.add(responses.GET, 'http://example.com', body='xxxx',
                       content_type='application/json')


### PR DESCRIPTION
When requesting a file from the internet, `get_encoding_from_headers`
does different behaviors depending on what the Content-Type actually is.

If there's no charset explicitly defined, and the Content-Type is a text
based, it spits back an assumed Latin-1 encoding of `ISO-8859-1`, but
otherwise, it returns `None`. So in the case if someone having a
misconfigured Content-Type for their `.map` files and potentially
sending back `text/plain`, we were getting a Latin-1 encoding and then
saying the file was bad when it was perfectly acceptable to use.

This defers all logic into JSON parsing and just waits on that to blow
up.

/cc @benvinegar 