### PR TITLE
Alter realtime issue streaming behaviour

### DIFF
--- a/src/sentry/static/sentry/app/utils/cursorPoller.jsx
+++ b/src/sentry/static/sentry/app/utils/cursorPoller.jsx
@@ -7,15 +7,8 @@ class CursorPoller {
     this.options = options;
     this._timeoutId = null;
     this._active = true;
-    this._baseDelay = 3000;
-    this._maxDelay = 60000;
-    this._reqsWithoutData = 0;
+    this._delay = 3000;
     this._pollingEndpoint = options.endpoint;
-  }
-
-  getDelay() {
-    let delay = this._baseDelay * (this._reqsWithoutData + 1);
-    return Math.min(delay, this._maxDelay);
   }
 
   setEndpoint(url) {
@@ -25,7 +18,7 @@ class CursorPoller {
   enable() {
     this._active = true;
     if (!this._timeoutId) {
-      this._timeoutId = window.setTimeout(this.poll.bind(this), this.getDelay());
+      this._timeoutId = window.setTimeout(this.poll.bind(this), this._delay);
     }
   }
 
@@ -49,26 +42,13 @@ class CursorPoller {
           return;
         }
 
-        // if theres no data, nothing changes
-        if (!data.length) {
-          this._reqsWithoutData += 1;
-          return;
-        }
-
-        if (this._reqsWithoutData > 0) {
-          this._reqsWithoutData -= 1;
-        }
-
-        let links = parseLinkHeader(jqXHR.getResponseHeader('Link'));
-        this._pollingEndpoint = links.previous.href;
-
         this.options.success(data, jqXHR.getResponseHeader('Link'));
       },
       complete: () => {
         this._lastRequest = null;
 
         if (this._active) {
-          this._timeoutId = window.setTimeout(this.poll.bind(this), this.getDelay());
+          this._timeoutId = window.setTimeout(this.poll.bind(this), this._delay);
         }
       }
     });
@@ -76,4 +56,3 @@ class CursorPoller {
 }
 
 export default CursorPoller;
-

--- a/src/sentry/static/sentry/app/utils/streamManager.jsx
+++ b/src/sentry/static/sentry/app/utils/streamManager.jsx
@@ -35,6 +35,17 @@ class StreamManager {
     return this;
   }
 
+  replace(items = []) {
+    items = [].concat(items);
+    items = items.filter((item) => item.hasOwnProperty('id'));
+
+    this.idList = items.map((item) => item.id);
+
+    this.store.reset();
+    this.store.add(items);
+    return this;
+  }
+
   getAllItems() {
     return this.store.getAllItems().slice().sort((a, b) => {
       return this.idList.indexOf(a.id) - this.idList.indexOf(b.id);
@@ -56,4 +67,3 @@ class StreamManager {
 }
 
 export default StreamManager;
-

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -365,7 +365,9 @@ const Stream = React.createClass({
     // Only resume polling if we're on the first page of results
     let links = parseLinkHeader(this.state.pageLinks);
     if (links && !links.previous.results && this.state.realtimeActive) {
-      this._poller.setEndpoint(links.previous.href);
+      // XXX: Remove cursor param from this URL...
+      const endpoint = links.previous.href.replace(/\&cursor=\d+\:\d+\:\d+/, '');
+      this._poller.setEndpoint(endpoint);
       this._poller.enable();
     }
   },
@@ -395,7 +397,7 @@ const Stream = React.createClass({
   },
 
   onRealtimePoll(data, links) {
-    this._streamManager.unshift(data);
+    this._streamManager.replace(data);
     if (!utils.valueIsEqual(this.state.pageLinks, links, true)) {
       this.setState({
         pageLinks: links,


### PR DESCRIPTION
I've altered the real time behaviour of the issue list. I'm looking for some feedback/thoughts on how I might get something like this merged in.

#### What I have changed:

  - Instead of trying to fetch new issues and using `unshift`, fetch all issues and `replace`.
  - The case where there is no data is now totally valid, so don't ignore it.

#### What this achieves:

  - Solves stream polling failures: https://github.com/getsentry/sentry/issues/4689
  - Resolving issues now causes them to disappear (across all tabs!)

#### Problems/Potential problems:

  - The list updates every three seconds, so if there is a high churn of events then the list may "jump around".
  - Hacky cursor param removal.