### PR TITLE
Move similarity indexing to Lua.

### DIFF
--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -286,7 +286,7 @@ local commands = {
                         )
                         table.insert(
                             results,
-                            tonumber(redis.call('ZINCRBY', bucket_frequency_key, 1, bucket))
+                            tonumber(redis.call('HINCRBY', bucket_frequency_key, bucket, 1))
                         )
                         redis.call('EXPIREAT', bucket_frequency_key, expiration)
                     end
@@ -320,17 +320,14 @@ local commands = {
                                 time_series,
                                 function (time)
                                     return redis.call(
-                                        'ZRANGE',
+                                        'HGETALL',
                                         get_bucket_frequency_key(
                                             configuration.scope,
                                             index,
                                             time,
                                             band,
                                             key
-                                        ),
-                                        0,
-                                        -1,
-                                        'WITHSCORES'
+                                        )
                                     )
                                 end
                             ),
@@ -493,11 +490,8 @@ local commands = {
                         )
 
                         local response = redis.call(
-                            'ZRANGE',
-                            source_bucket_frequency_key,
-                            0,
-                            -1,
-                            'WITHSCORES'
+                            'HGETALL',
+                            source_bucket_frequency_key
                         )
                         for i = 1, #response, 2 do
                             local bucket, count = unpack(table.slice(response, i, i + 1))
@@ -518,10 +512,10 @@ local commands = {
 
                             -- Merge the counter values into the destination frequencies.
                             redis.call(
-                                'ZINCRBY',
+                                'HINCRBY',
                                 destination_bucket_frequency_key,
-                                count,
-                                bucket
+                                bucket,
+                                count
                             )
                         end
 
@@ -583,11 +577,8 @@ local commands = {
                         )
 
                         local response = redis.call(
-                            'ZRANGE',
-                            source_bucket_frequency_key,
-                            0,
-                            -1,
-                            'WITHSCORES'
+                            'HGETALL',
+                            source_bucket_frequency_key
                         )
 
                         for i = 1, #response, 2 do

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -206,7 +206,7 @@ end
 local function scale_to_total(values)
     local result = {}
     local total = 0
-    for key, value in pairs(valuess) do
+    for key, value in pairs(values) do
         total = total + value
     end
     for key, value in pairs(values) do

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -11,7 +11,7 @@ groups that contain many different characteristic sets.
 
 This is modeled as two data structures:
 
-- A bucket frequency sorted set, which maintains a count of what buckets
+- A bucket frequency hash, which maintains a count of what buckets
     have been recorded -- and how often -- in a ``(band, key)`` pair. This
     data can be used to identify what buckets a key is a member of, and also
     used to identify the degree of bucket similarity when comparing with data
@@ -159,7 +159,7 @@ local function takes_configuration(command)
 end
 
 
--- 
+-- Key Generation
 
 local function get_bucket_frequency_key(scope, index, time, band, item)
     return string.format(

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -26,7 +26,7 @@ This is modeled as two data structures:
 -- Try and enable script effects replication if we're using Redis 3.2 or
 -- greater. This is wrapped in `pcall` so that we can continue to support older
 -- Redis versions while using this feature if it's available.
-if not pcall(function () redis.replicate_commands() end) then
+if not pcall(redis.replicate_commands) then
     redis.log(redis.LOG_DEBUG, 'Could not enable script effects replication.')
 end
 

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -1,0 +1,627 @@
+--[[
+
+Implements an index that can be used to efficiently search for items that
+share similar characteristics.
+
+This implementation is based on MinHash (which is used quickly identify
+similar items and estimate the Jaccard similarity of their characteristic
+sets) but this implementation extends the typical design to add the ability
+to record items by an arbitrary key. This allows querying for similar
+groups that contain many different characteristic sets.
+
+This is modeled as two data structures:
+
+- A bucket frequency sorted set, which maintains a count of what buckets
+    have been recorded -- and how often -- in a ``(band, key)`` pair. This
+    data can be used to identify what buckets a key is a member of, and also
+    used to identify the degree of bucket similarity when comparing with data
+    associated with another key.
+- A bucket membership set, which maintains a record of what keys have been
+    record in a ``(band, bucket)`` pair. This data can be used to identify
+    what other keys may be similar to the lookup key (but not the degree of
+    similarity.)
+
+]]--
+local function range(start, stop)
+    local result = {}
+    for i = start, stop do
+        table.insert(result, i)
+    end
+    return result
+end
+
+function table.ifilter(t, f)
+    local result = {}
+    for i, value in ipairs(t) do
+        if f(value) then
+            table.insert(result, value)
+        end
+    end
+    return result
+end
+
+function table.imap(t, f)
+    local result = {}
+    for i, value in ipairs(t) do
+        result[i] = f(value)
+    end
+    return result
+end
+
+function table.ireduce(t, f, i)
+    if i == nil then
+        i = {}
+    end
+    local result = i
+    for i, value in ipairs(t) do
+        result = f(result, value)
+    end
+    return result
+end
+
+function table.izip(...)
+    local args = {...}
+    local n = math.max(
+        unpack(
+            table.imap(
+                args,
+                function (t) return #t end
+            )
+        )
+    )
+    local result = {}
+    for i = 1, n do
+        local item = {}
+        for j = 1, #args do
+            table.insert(item, args[j][i])
+        end
+        table.insert(result, item)
+    end
+    return result
+end
+
+function table.slice(t, start, stop)
+    -- NOTE: ``stop`` is inclusive!
+    local result = {}
+    for i = start or 1, stop or #t do
+        table.insert(result, t[i])
+    end
+    return result
+end
+
+
+-- Argument Parsing and Validation
+
+local function parse_number(value)
+    local result = tonumber(value)
+    assert(result ~= nil, 'got nil, expected number')
+    return result
+end
+
+local function parse_integer(value)
+    local result = parse_number(value)
+    assert(result % 1 == 0, 'got float, expected integer')
+    return result
+end
+
+local function build_argument_parser(fields)
+    return function (arguments)
+        local results = {}
+        for i = 1, #fields do
+            local name, parser = unpack(fields[i])
+            local value = arguments[i]
+            local ok, result = pcall(parser, value)
+            if not ok then
+                error(string.format('received invalid argument for %q in position %s with value %q; %s', name, i, value, result))
+            else
+                results[name] = result
+            end
+        end
+        return results, table.slice(arguments, #fields + 1)
+    end
+end
+
+
+-- Time Series
+
+local function get_active_indices(interval, retention, timestamp)
+    local result = {}
+    local upper = math.floor(timestamp / interval)
+    for i = upper - retention, upper do
+        table.insert(result, i)
+    end
+    return result
+end
+
+local function get_index_expiration_time(interval, retention, index)
+    return (index + retention) * interval
+end
+
+
+-- Generic Configuration
+
+local configuration_parser = build_argument_parser({
+    {"timestamp", parse_integer},
+    {"bands", parse_integer},
+    {"interval", parse_integer},
+    {"retention", parse_integer},
+    {"scope", function (value)
+        assert(value ~= nil)
+        return value
+    end}
+})
+
+local function takes_configuration(command)
+    return function(arguments)
+        local configuration, arguments = configuration_parser(arguments)
+        return command(configuration, arguments)
+    end
+end
+
+
+-- 
+
+local function get_bucket_frequency_key(scope, index, time, band, item)
+    return string.format(
+        '%s:%s:f:%s:%s:%s:%s',
+        'sim',
+        scope,
+        index,
+        time,
+        band,
+        item
+    )
+end
+
+local function get_bucket_membership_key(scope, index, time, band, bucket)
+    return string.format(
+        '%s:%s:m:%s:%s:%s:%s',
+        'sim',
+        scope,
+        index,
+        time,
+        band,
+        bucket
+    )
+end
+
+local function get_manhattan_distance(target, other)
+    local keys = {}
+    for k, _ in pairs(target) do
+        keys[k] = true
+    end
+
+    for k, _ in pairs(other) do
+        keys[k] = true
+    end
+
+    local total = 0
+    for k, _ in pairs(keys) do
+        total = total + math.abs((target[k] or 0) - (other[k] or 0))
+    end
+
+    return total
+end
+
+local function scale_to_total(value)
+    local result = {}
+    local total = 0
+    for k, v in pairs(value) do
+        total = total + v
+    end
+    for k, v in pairs(value) do
+        result[k] = v / total
+    end
+    return result
+end
+
+
+-- Command Parsing
+
+local commands = {
+    RECORD = takes_configuration(
+        function (configuration, arguments)
+            local key = arguments[1]
+
+            local entries = table.ireduce(
+                table.slice(arguments, 2),
+                function (state, token)
+                    if state.active == nil then
+                        -- When there is no active entry, we need to initialize
+                        -- a new one. The first token is the index identifier.
+                        state.active = {index = token, buckets = {}}
+                    else
+                        -- If there is an active entry, we need to add the
+                        -- current token to the feature list.
+                        table.insert(state.active.buckets, token)
+
+                        -- When we've seen the same number of buckets as there
+                        -- are bands, we're done recording and need to mark the
+                        -- current entry as completed, and reset the current
+                        -- active entry.
+                        if #state.active.buckets == configuration.bands then
+                            table.insert(state.completed, state.active)
+                            state.active = nil
+                        end
+                    end
+                    return state
+                end,
+                {active = nil, completed = {}}
+            )
+
+            -- If there are any entries in progress when we are completed, that
+            -- means the input was in an incorrect format and we should error
+            -- before we record any bad data.
+            assert(entries.active == nil, 'unexpected end of input')
+
+            local time = math.floor(configuration.timestamp / configuration.interval)
+            local expiration = get_index_expiration_time(
+                configuration.interval,
+                configuration.retention,
+                time
+            )
+
+            return table.imap(
+                entries.completed,
+                function (entry)
+                    local results = {}
+
+                    for band, bucket in ipairs(entry.buckets) do
+                        local bucket_membership_key = get_bucket_membership_key(
+                            configuration.scope,
+                            entry.index,
+                            time,
+                            band,
+                            bucket
+                        )
+                        redis.call('SADD', bucket_membership_key, key)
+                        redis.call('EXPIREAT', bucket_membership_key, expiration)
+
+                        local bucket_frequency_key = get_bucket_frequency_key(
+                            configuration.scope,
+                            entry.index,
+                            time,
+                            band,
+                            key
+                        )
+                        table.insert(
+                            results,
+                            tonumber(redis.call('ZINCRBY', bucket_frequency_key, 1, bucket))
+                        )
+                        redis.call('EXPIREAT', bucket_frequency_key, expiration)
+                    end
+
+                    return results
+                end
+            )
+        end
+    ),
+    QUERY = takes_configuration(
+        function (configuration, arguments)
+            local item_key = arguments[1]
+            local indices = table.slice(arguments, 2)
+
+            local time_series = get_active_indices(
+                configuration.interval,
+                configuration.retention,
+                configuration.timestamp
+            )
+
+            -- Fetch all of the bucket frequencies for a key from a specific
+            -- index from all active time series chunks. This returns a table
+            -- containing n tables (where n is the number of bands) mapping
+            -- bucket identifiers to counts.
+            local fetch_bucket_frequencies = function (index, key)
+                return table.imap(
+                    range(1, configuration.bands),
+                    function (band)
+                        return table.ireduce(
+                            table.imap(
+                                time_series,
+                                function (time)
+                                    return redis.call(
+                                        'ZRANGE',
+                                        get_bucket_frequency_key(
+                                            configuration.scope,
+                                            index,
+                                            time,
+                                            band,
+                                            key
+                                        ),
+                                        0,
+                                        -1,
+                                        'WITHSCORES'
+                                    )
+                                end
+                            ),
+                            function (result, response)
+                                for i = 1, #response, 2 do
+                                    local bucket, count = unpack(table.slice(response, i, i + 1))
+                                    result[bucket] = (result[bucket] or 0) + count
+                                end
+                                return result
+                            end,
+                            {}
+                        )
+                    end
+                )
+            end
+
+            local fetch_candidates = function (index, frequencies)
+                local candidates = {}  -- acts as a set
+                for band, buckets in ipairs(frequencies) do
+                    for bucket, count in pairs(buckets) do
+                        for _, time in ipairs(time_series) do
+                            -- Fetch all other items that have been
+                            -- added to the same bucket in this bad
+                            -- during this time period.
+                            local members = redis.call(
+                                'SMEMBERS',
+                                get_bucket_membership_key(
+                                    configuration.scope,
+                                    index,
+                                    time,
+                                    band,
+                                    bucket
+                                )
+                            )
+                            for _, member in ipairs(members) do
+                                candidates[member] = true
+                            end
+                        end
+                    end
+                end
+                return candidates
+            end
+
+            return table.imap(
+                indices,
+                function (index)
+                    local item_frequencies = fetch_bucket_frequencies(index, item_key)
+
+                    local candidates = fetch_candidates(index, item_frequencies)
+                    local candidate_frequencies = {}
+                    for candidate_key, _ in pairs(candidates) do
+                        candidate_frequencies[candidate_key] = fetch_bucket_frequencies(
+                            index,
+                            candidate_key
+                        )
+                    end
+
+                    local results = {}
+                    for key, value in pairs(candidate_frequencies) do
+                        table.insert(
+                            results,
+                            {
+                                key,
+                                table.ireduce(
+                                    table.imap(
+                                        table.izip(
+                                            item_frequencies,
+                                            value
+                                        ),
+                                        function (v)
+                                            local dist = get_manhattan_distance(
+                                                scale_to_total(v[1]),
+                                                scale_to_total(v[2])
+                                            )
+                                            return 1 - (dist / 2)
+                                        end
+                                    ),
+                                    function (total, item)
+                                        return total + item
+                                    end,
+                                    0
+                                ) / configuration.bands
+                            }
+                        )
+                    end
+
+                    table.sort(
+                        results,
+                        function (left, right)
+                            return left[2] > right[2]
+                        end
+                    )
+
+                    return table.imap(
+                        results,
+                        function (item)
+                            return {
+                                item[1],
+                                string.format('%f', item[2]),
+                            }
+                        end
+                    )
+                end
+            )
+        end
+    ),
+    MERGE = takes_configuration(
+        function (configuration, arguments)
+            local destination_key = arguments[1]
+            local entries = table.ireduce(
+                table.slice(arguments, 2),
+                function (state, token)
+                    if state.active == nil then
+                        state.active = {
+                            index = token,
+                            key = nil,
+                        }
+                    else
+                        assert(token ~= destination_key, 'cannot merge destination into itself')
+                        state.active.key = token
+                        table.insert(
+                            state.completed,
+                            state.active
+                        )
+                        state.active = nil
+                    end
+                    return state
+                end,
+                {active = nil, completed = {}}
+            )
+            assert(entries.active == nil, 'unexpected end of input')
+
+            local time_series = get_active_indices(
+                configuration.interval,
+                configuration.retention,
+                configuration.timestamp
+            )
+
+            for _, source in ipairs(entries.completed) do
+                for band = 1, configuration.bands do
+                    for _, time in ipairs(time_series) do
+                        local source_bucket_frequency_key = get_bucket_frequency_key(
+                            configuration.scope,
+                            source.index,
+                            time,
+                            band,
+                            source.key
+                        )
+                        local destination_bucket_frequency_key = get_bucket_frequency_key(
+                            configuration.scope,
+                            source.index,
+                            time,
+                            band,
+                            destination_key
+                        )
+                        local expiration_time = get_index_expiration_time(
+                            configuration.interval,
+                            configuration.retention,
+                            time
+                        )
+
+                        local response = redis.call(
+                            'ZRANGE',
+                            source_bucket_frequency_key,
+                            0,
+                            -1,
+                            'WITHSCORES'
+                        )
+                        for i = 1, #response, 2 do
+                            local bucket, count = unpack(table.slice(response, i, i + 1))
+
+                            -- Remove the source from the bucket membership
+                            -- set, and add the destination to the membership
+                            -- set.
+                            local bucket_membership_key = get_bucket_membership_key(
+                                configuration.scope,
+                                source.index,
+                                time,
+                                band,
+                                bucket
+                            )
+                            redis.call('SREM', bucket_membership_key, source.key)
+                            redis.call('SADD', bucket_membership_key, destination_key)
+                            redis.call('EXPIREAT', bucket_membership_key, expiration_time)
+
+                            -- Merge the counter values into the destination frequencies.
+                            redis.call(
+                                'ZINCRBY',
+                                destination_bucket_frequency_key,
+                                count,
+                                bucket
+                            )
+                        end
+
+                        -- The destination bucket frequency key may have not
+                        -- existed previously, so we need to make sure we set
+                        -- the expiration on it in case it is new.
+                        redis.call(
+                            'EXPIREAT',
+                            destination_bucket_frequency_key,
+                            expiration_time
+                        )
+
+                        -- We no longer need the source frequencies.
+                        redis.call('DEL', source_bucket_frequency_key)
+                    end
+                end
+            end
+        end
+    ),
+    DELETE = takes_configuration(
+        function (configuration, arguments)
+            local entries = table.ireduce(
+                arguments,
+                function (state, token)
+                    if state.active == nil then
+                        state.active = {
+                            index = token,
+                            key = nil,
+                        }
+                    else
+                        state.active.key = token
+                        table.insert(
+                            state.completed,
+                            state.active
+                        )
+                        state.active = nil
+                    end
+                    return state
+                end,
+                {active = nil, completed = {}}
+            )
+            assert(entries.active == nil, 'unexpected end of input')
+
+            local time_series = get_active_indices(
+                configuration.interval,
+                configuration.retention,
+                configuration.timestamp
+            )
+
+            for _, source in ipairs(entries.completed) do
+                for band = 1, configuration.bands do
+                    for _, time in ipairs(time_series) do
+                        local source_bucket_frequency_key = get_bucket_frequency_key(
+                            configuration.scope,
+                            source.index,
+                            time,
+                            band,
+                            source.key
+                        )
+
+                        local response = redis.call(
+                            'ZRANGE',
+                            source_bucket_frequency_key,
+                            0,
+                            -1,
+                            'WITHSCORES'
+                        )
+
+                        for i = 1, #response, 2 do
+                            local bucket, count = unpack(table.slice(response, i, i + 1))
+                            redis.call(
+                                'SREM',
+                                get_bucket_membership_key(
+                                    configuration.scope,
+                                    source.index,
+                                    time,
+                                    band,
+                                    bucket
+                                ),
+                                source.key
+                            )
+                        end
+
+                        -- We no longer need the source frequencies.
+                        redis.call('DEL', source_bucket_frequency_key)
+                    end
+                end
+            end
+        end
+    )
+}
+
+
+local command_parser = build_argument_parser({
+    {"command", function (value)
+        local command = commands[value]
+        assert(command ~= nil)
+        return command
+    end},
+})
+
+local parsed, arguments = command_parser(ARGV)
+return parsed.command(arguments)

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -22,6 +22,14 @@ This is modeled as two data structures:
     similarity.)
 
 ]]--
+
+-- Try and enable script effects replication if we're using Redis 3.2 or
+-- greater. This is wrapped in `pcall` so that we can continue to support older
+-- Redis versions while using this feature if it's available.
+if not pcall(function () redis.replicate_commands() end) then
+    redis.log(redis.LOG_DEBUG, 'Could not enable script effects replication.')
+end
+
 local function range(start, stop)
     local result = {}
     for i = start, stop do

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -203,14 +203,14 @@ local function get_manhattan_distance(target, other)
     return total
 end
 
-local function scale_to_total(value)
+local function scale_to_total(values)
     local result = {}
     local total = 0
-    for k, v in pairs(value) do
-        total = total + v
+    for key, value in pairs(valuess) do
+        total = total + value
     end
-    for k, v in pairs(value) do
-        result[k] = v / total
+    for key, value in pairs(values) do
+        result[key] = value / total
     end
     return result
 end

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -333,7 +333,7 @@ local commands = {
                             ),
                             function (result, response)
                                 for i = 1, #response, 2 do
-                                    local local bucket, count = response[i], response[i + 1]
+                                    local bucket, count = response[i], response[i + 1]
                                     result[bucket] = (result[bucket] or 0) + count
                                 end
                                 return result

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -333,7 +333,7 @@ local commands = {
                             ),
                             function (result, response)
                                 for i = 1, #response, 2 do
-                                    local bucket, count = unpack(table.slice(response, i, i + 1))
+                                    local local bucket, count = response[i], response[i + 1]
                                     result[bucket] = (result[bucket] or 0) + count
                                 end
                                 return result
@@ -349,9 +349,9 @@ local commands = {
                 for band, buckets in ipairs(frequencies) do
                     for bucket, count in pairs(buckets) do
                         for _, time in ipairs(time_series) do
-                            -- Fetch all other items that have been
-                            -- added to the same bucket in this bad
-                            -- during this time period.
+                            -- Fetch all other items that have been added to
+                            -- the same bucket in this band during this time
+                            -- period.
                             local members = redis.call(
                                 'SMEMBERS',
                                 get_bucket_membership_key(
@@ -494,7 +494,7 @@ local commands = {
                             source_bucket_frequency_key
                         )
                         for i = 1, #response, 2 do
-                            local bucket, count = unpack(table.slice(response, i, i + 1))
+                            local bucket, count = response[i], response[i + 1]
 
                             -- Remove the source from the bucket membership
                             -- set, and add the destination to the membership
@@ -582,7 +582,7 @@ local commands = {
                         )
 
                         for i = 1, #response, 2 do
-                            local bucket, count = unpack(table.slice(response, i, i + 1))
+                            local bucket = response[i]
                             redis.call(
                                 'SREM',
                                 get_bucket_membership_key(

--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 
 import itertools
 import logging
-import math
 import operator
 import struct
+import time
 from collections import Sequence
 
 import mmh3
@@ -13,117 +13,25 @@ from django.conf import settings
 from sentry.utils import redis
 from sentry.utils.datastructures import BidirectionalMapping
 from sentry.utils.iterators import shingle
+from sentry.utils.redis import load_script
+
+
+index = load_script('similarity/index.lua')
 
 
 logger = logging.getLogger('sentry.similarity')
 
 
-def scale_to_total(value):
-    """\
-    Convert a mapping of distinct quantities to a mapping of proportions of the
-    total quantity.
-    """
-    total = float(sum(value.values()))
-    return {k: (v / total) for k, v in value.items()}
-
-
-def get_euclidian_distance(target, other):
-    """\
-    Calculate the N-dimensional Euclidian between two mappings.
-
-    The mappings are used to represent sparse arrays -- if a key is not present
-    in both mappings, it's assumed to be 0 in the mapping where it is missing.
-    """
-    return math.sqrt(
-        sum(
-            (target.get(k, 0) - other.get(k, 0)) ** 2
-            for k in set(target) | set(other)
-        )
-    )
-
-
-def get_manhattan_distance(target, other):
-    """\
-    Calculate the N-dimensional Manhattan distance between two mappings.
-
-    The mappings are used to represent sparse arrays -- if a key is not present
-    in both mappings, it's assumed to be 0 in the mapping where it is missing.
-
-    The result of this function will be expressed as the distance between the
-    caller and a 5:2 ratio of rye whiskey to sweet Italian vermouth, with a
-    dash of bitters.
-    """
-    return sum(
-        abs(target.get(k, 0) - other.get(k, 0))
-        for k in set(target) | set(other)
-    )
-
-
-formats = sorted([
-    (2 ** 8 - 1, 'B'),
-    (2 ** 16 - 1, 'H'),
-    (2 ** 32 - 1, 'L'),
-    (2 ** 64 - 1, 'Q'),
-])
-
-
-def get_number_format(size, width=1):
-    """\
-    Returns a ``Struct`` object that can be used packs (and unpack) a number no
-    larger than the provided size into to an efficient binary representation.
-    """
-    assert size > 0
-
-    for maximum, format in formats:
-        if maximum >= size:
-            return struct.Struct('>%s' % (format * width))
-
-    raise ValueError('No registered formatter can handle the provided value.')
-
-
 class MinHashIndex(object):
-    """\
-    Implements an index that can be used to efficiently search for items that
-    share similar characteristics.
-
-    This implementation is based on MinHash (which is used quickly identify
-    similar items and estimate the Jaccard similarity of their characteristic
-    sets) but this implementation extends the typical design to add the ability
-    to record items by an arbitrary key. This allows querying for similar
-    groups that contain many different characteristic sets.
-
-    The ``rows`` parameter is the size of the hash ring used to collapse the
-    domain of all tokens to a fixed-size range. The total size of the LSH
-    signature is ``bands * buckets``. These attributes control the distribution
-    of data within the index, and modifying them after data has already been
-    written will cause data loss and/or corruption.
-
-    This is modeled as two data structures:
-
-    - A bucket frequency sorted set, which maintains a count of what buckets
-      have been recorded -- and how often -- in a ``(band, key)`` pair. This
-      data can be used to identify what buckets a key is a member of, and also
-      used to identify the degree of bucket similarity when comparing with data
-      associated with another key.
-    - A bucket membership set, which maintains a record of what keys have been
-      record in a ``(band, bucket)`` pair. This data can be used to identify
-      what other keys may be similar to the lookup key (but not the degree of
-      similarity.)
-    """
-    BUCKET_MEMBERSHIP = b'\x00'
-    BUCKET_FREQUENCY = b'\x01'
-
-    def __init__(self, cluster, rows, bands, buckets):
-        self.namespace = b'sim'
-
+    def __init__(self, cluster, rows, bands, buckets, interval, retention):
         self.cluster = cluster
         self.rows = rows
 
         sequence = itertools.count()
         self.bands = [[next(sequence) for j in xrange(buckets)] for i in xrange(bands)]
-
-        self.__band_format = get_number_format(bands)
-        self.__bucket_format = get_number_format(rows, buckets)
+        self.buckets = buckets
+        self.interval = interval
+        self.retention = retention
 
     def get_signature(self, value):
         """Generate a signature for a value."""
@@ -140,168 +48,100 @@ class MinHashIndex(object):
             self.bands,
         )
 
-    def get_similarity(self, target, other):
-        """\
-        Calculate the degree of similarity between two bucket frequency
-        sequences which represent two different keys.
+    def query(self, scope, key, indices, timestamp=None):
+        if timestamp is None:
+            timestamp = int(time.time())
 
-        This is mainly an implementation detail for sorting query results, but
-        is exposed publically for testing. This method assumes all input
-        values have already been normalized using ``scale_to_total``.
-        """
-        assert len(target) == len(other)
-        assert len(target) == len(self.bands)
-        return sum(
-            map(
-                lambda (left, right): 1 - (
-                    get_manhattan_distance(
-                        left,
-                        right,
-                    ) / 2.0
-                ),
-                zip(target, other)
+        arguments = [
+            'QUERY',
+            timestamp,
+            len(self.bands),
+            self.interval,
+            self.retention,
+            scope,
+            key,
+        ]
+
+        arguments.extend(indices)
+
+        return [
+            [(item, float(score)) for item, score in result]
+            for result in
+            index(
+                self.cluster.get_local_client_for_key(scope),
+                [],
+                arguments,
             )
-        ) / len(target)
+        ]
 
-    def query(self, scope, key):
-        """\
-        Find other entries that are similar to the one repesented by ``key``.
+    def record(self, scope, key, items, timestamp=None):
+        if timestamp is None:
+            timestamp = int(time.time())
 
-        This returns an sequence of ``(key, estimated similarity)`` pairs,
-        where a similarity score of 1 is completely similar, and a similarity
-        score of 0 is completely dissimilar. The result sequence is ordered
-        from most similar to least similar. (For example, the search key itself
-        isn't filtered from the result and will always have a similarity of 1,
-        typically making it the first result.)
-        """
-        def fetch_bucket_frequencies(keys):
-            """Fetch the bucket frequencies for each band for each provided key."""
-            with self.cluster.map() as client:
-                responses = {
-                    key: map(
-                        lambda band: client.zrange(
-                            b'{}:{}:{}:{}:{}'.format(
-                                self.namespace,
-                                scope,
-                                self.BUCKET_FREQUENCY,
-                                self.__band_format.pack(band),
-                                key,
-                            ),
-                            0,
-                            -1,
-                            desc=True,
-                            withscores=True,
-                        ),
-                        range(len(self.bands)),
-                    ) for key in keys
-                }
+        arguments = [
+            'RECORD',
+            timestamp,
+            len(self.bands),
+            self.interval,
+            self.retention,
+            scope,
+            key,
+        ]
 
-            result = {}
-            for key, promises in responses.items():
-                # Resolve each promise, and scale the number of observations
-                # for each bucket to [0,1] value (the proportion of items
-                # observed in that band that belong to the bucket for the key.)
-                result[key] = map(
-                    lambda promise: scale_to_total({
-                        self.__bucket_format.unpack(k): v for k, v in promise.value
-                    }),
-                    promises,
-                )
+        for idx, features in items:
+            arguments.append(idx)
+            arguments.extend([','.join(map('{}'.format, band)) for band in self.get_signature(features)])
 
-            return result
-
-        def fetch_candidates(signature):
-            """Fetch all the similar candidates for a given signature."""
-            with self.cluster.map() as client:
-                responses = map(
-                    lambda (band, buckets): map(
-                        lambda bucket: client.smembers(
-                            b'{}:{}:{}:{}:{}'.format(
-                                self.namespace,
-                                scope,
-                                self.BUCKET_MEMBERSHIP,
-                                self.__band_format.pack(band),
-                                self.__bucket_format.pack(*bucket),
-                            )
-                        ),
-                        buckets,
-                    ),
-                    enumerate(signature),
-                )
-
-            # Resolve all of the promises for each band and reduce them into a
-            # single set per band.
-            return map(
-                lambda band: reduce(
-                    lambda values, promise: values | promise.value,
-                    band,
-                    set(),
-                ),
-                responses,
-            )
-
-        target_frequencies = fetch_bucket_frequencies([key])[key]
-
-        # Flatten the results of each band into a single set. (In the future we
-        # might want to change this to only calculate the similarity for keys
-        # that show up in some threshold number of bands.)
-        candidates = reduce(
-            lambda total, band: total | band,
-            fetch_candidates(target_frequencies),
-            set(),
+        return index(
+            self.cluster.get_local_client_for_key(scope),
+            [],
+            arguments,
         )
 
-        return sorted(
-            map(
-                lambda (key, candidate_frequencies): (
-                    key,
-                    self.get_similarity(
-                        target_frequencies,
-                        candidate_frequencies,
-                    ),
-                ),
-                fetch_bucket_frequencies(candidates).items(),
-            ),
-            key=lambda (key, similarity): (similarity * -1, key),
+    def merge(self, scope, destination, items, timestamp=None):
+        if timestamp is None:
+            timestamp = int(time.time())
+
+        arguments = [
+            'MERGE',
+            timestamp,
+            len(self.bands),
+            self.interval,
+            self.retention,
+            scope,
+            destination,
+        ]
+
+        for idx, source in items:
+            arguments.extend([idx, source])
+
+        return index(
+            self.cluster.get_local_client_for_key(scope),
+            [],
+            arguments,
         )
 
-    def record_multi(self, items):
-        """\
-        Records the presence of a set of characteristics within a group for a
-        batch of items. Each item should be represented by a 3-tuple of
-        ``(scope, key, characteristics)``.
-        """
-        with self.cluster.map() as client:
-            for scope, key, characteristics in items:
-                for band, buckets in enumerate(self.get_signature(characteristics)):
-                    buckets = self.__bucket_format.pack(*buckets)
-                    client.sadd(
-                        b'{}:{}:{}:{}:{}'.format(
-                            self.namespace,
-                            scope,
-                            self.BUCKET_MEMBERSHIP,
-                            self.__band_format.pack(band),
-                            buckets,
-                        ),
-                        key,
-                    )
-                    client.zincrby(
-                        b'{}:{}:{}:{}:{}'.format(
-                            self.namespace,
-                            scope,
-                            self.BUCKET_FREQUENCY,
-                            self.__band_format.pack(band),
-                            key,
-                        ),
-                        buckets,
-                        1,
-                    )
+    def delete(self, scope, items, timestamp=None):
+        if timestamp is None:
+            timestamp = int(time.time())
 
-    def record(self, scope, key, characteristics):
-        """Records the presence of a set of characteristics within a group."""
-        return self.record_multi([
-            (scope, key, characteristics),
-        ])
+        arguments = [
+            'DELETE',
+            timestamp,
+            len(self.bands),
+            self.interval,
+            self.retention,
+            scope,
+        ]
+
+        for idx, key in items:
+            arguments.extend([idx, key])
+
+        return index(
+            self.cluster.get_local_client_for_key(scope),
+            [],
+            arguments,
+        )
 
 
 FRAME_ITEM_SEPARATOR = b'\x00'
@@ -444,45 +284,42 @@ class FeatureSet(object):
         self.index = index
         self.aliases = aliases
         self.features = features
-        self.__number_format = get_number_format(0xFFFFFFFF)
         assert set(self.aliases) == set(self.features)
 
     def record(self, event):
         items = []
         for label, feature in self.features.items():
-            alias = self.aliases[label]
-            scope = ':'.join((
-                alias,
-                self.__number_format.pack(event.project_id),
-            ))
             for characteristics in feature.extract(event):
-                if characteristics:
+                if characteristics:  # TODO: ???
                     items.append((
-                        scope,
-                        self.__number_format.pack(event.group_id),
+                        self.aliases[label],
                         characteristics,
                     ))
-        return self.index.record_multi(items)
+        return self.index.record(
+            '{}'.format(event.project_id),
+            '{}'.format(event.group_id),
+            items,
+        )
 
     def query(self, group):
-        key = self.__number_format.pack(group.id)
+        features = list(self.features.keys())
 
-        results = {}
-        for label in self.features.keys():
-            alias = self.aliases[label]
-            scope = ':'.join((
-                alias,
-                self.__number_format.pack(group.project_id),
-            ))
+        results = self.index.query(
+            '{}'.format(group.project_id),
+            '{}'.format(group.id),
+            [self.aliases[label] for label in features],
+        )
 
-            for id, score in self.index.query(scope, key):
-                results.setdefault(
-                    self.__number_format.unpack(id)[0],
+        items = {}
+        for feature, result in zip(features, results):
+            for item, score in result:
+                items.setdefault(
+                    int(item),
                     {},
-                )[label] = score
+                )[feature] = score
 
         return sorted(
-            results.items(),
+            items.items(),
             key=lambda (id, features): sum(features.values()),
             reverse=True,
         )
@@ -512,12 +349,14 @@ features = FeatureSet(
         0xFFFF,
         8,
         2,
+        60 * 60 * 24 * 30,
+        4,
     ),
     BidirectionalMapping({
-        'exception:message:character-shingles': '\x00',
-        'exception:stacktrace:application-chunks': '\x01',
-        'exception:stacktrace:pairs': '\x02',
-        'message:message:character-shingles': '\x03',
+        'exception:message:character-shingles': 'a',
+        'exception:stacktrace:application-chunks': 'b',
+        'exception:stacktrace:pairs': 'c',
+        'message:message:character-shingles': 'd',
     }),
     {
         'exception:message:character-shingles': ExceptionFeature(

--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -290,7 +290,7 @@ class FeatureSet(object):
         items = []
         for label, feature in self.features.items():
             for characteristics in feature.extract(event):
-                if characteristics:  # TODO: ???
+                if characteristics:
                     items.append((
                         self.aliases[label],
                         characteristics,

--- a/tests/sentry/test_similarity.py
+++ b/tests/sentry/test_similarity.py
@@ -1,156 +1,13 @@
 from __future__ import absolute_import
 
-import math
-
 import pytest
 
 from sentry.similarity import (
-    MinHashIndex, get_exception_frames, get_euclidian_distance,
-    get_manhattan_distance, get_number_format, get_frame_signature,
-    scale_to_total, serialize_frame,
+    MinHashIndex, get_exception_frames, get_frame_signature,
+    serialize_frame,
 )
 from sentry.testutils import TestCase
 from sentry.utils import redis
-
-
-def test_get_euclidian_distance():
-    assert get_euclidian_distance({}, {}) == 0
-
-    assert get_euclidian_distance(
-        {'a': 1},
-        {'a': 1},
-    ) == 0
-
-    assert get_euclidian_distance(
-        {'a': 1, 'b': 0},
-        {'a': 0, 'b': 1},
-    ) == math.sqrt(2)
-
-    assert get_euclidian_distance(
-        {'a': 1},
-        {'b': 1},
-    ) == math.sqrt(2)
-
-
-def test_get_manhattan_distance():
-    assert get_manhattan_distance({}, {}) == 0
-
-    assert get_manhattan_distance(
-        {'a': 1},
-        {'a': 1},
-    ) == 0
-
-    assert get_manhattan_distance(
-        {'a': 1},
-        {'b': 1},
-    ) == get_manhattan_distance(
-        {'a': 1},
-        {'b': 0.5, 'c': 0.5},
-    ) == 2
-
-    assert get_manhattan_distance(
-        {'a': 1},
-        {'a': 1, 'b': 1},
-    ) == 1
-
-    assert get_manhattan_distance(
-        {'a': 1, 'b': 0},
-        {'a': 0, 'b': 1},
-    ) == 2
-
-    assert get_manhattan_distance(
-        {'a': 1},
-        {'b': 1},
-    ) == 2
-
-
-def test_get_similarity():
-    index = MinHashIndex(None, 0xFFFF, 1, 1)
-
-    assert index.get_similarity(
-        [{'a': 1}],
-        [{'a': 0.5, 'b': 0.25, 'c': 0.25}],
-    ) == 0.5
-
-    assert index.get_similarity(
-        [{'a': 1}],
-        [{'b': 0.5, 'c': 0.5}],
-    ) == 0
-
-    index = MinHashIndex(None, 0xFFFF, 2, 1)
-
-    assert index.get_similarity(
-        [
-            {'a': 1},
-            {'a': 1},
-        ],
-        [
-            {'a': 1},
-            {'a': 1},
-        ],
-    ) == 1.0
-
-    assert index.get_similarity(
-        [
-            {'a': 1},
-            {'a': 1},
-        ],
-        [
-            {'b': 1},
-            {'b': 1},
-        ],
-    ) == 0
-
-    assert index.get_similarity(
-        [
-            {'a': 1},
-            {'b': 1},
-        ],
-        [
-            {'b': 1},
-            {'b': 1},
-        ],
-    ) == 0.5
-
-    with pytest.raises(AssertionError):
-        assert index.get_similarity(
-            range(10),
-            range(10),
-        )
-
-    with pytest.raises(AssertionError):
-        assert index.get_similarity(
-            range(1),
-            range(10),
-        )
-
-
-def test_scale_to_total():
-    assert scale_to_total({}) == {}
-
-    assert scale_to_total({
-        'a': 10,
-        'b': 10,
-    }) == {
-        'a': 0.5,
-        'b': 0.5,
-    }
-
-
-def test_get_number_format():
-    assert get_number_format(0xFF).pack(0xFF) == '\xff'
-    assert get_number_format(0xFF + 1).pack(0xFF) == '\x00\xff'
-
-    assert get_number_format(0xFFFF).pack(0xFFFF) == '\xff\xff'
-    assert get_number_format(0xFFFF + 1).pack(0xFFFF) == '\x00\x00\xff\xff'
-
-    assert get_number_format(0xFFFFFFFF).pack(0xFFFFFFFF) == '\xff\xff\xff\xff'
-    assert get_number_format(0xFFFFFFFF + 1).pack(0xFFFFFFFF) == '\x00\x00\x00\x00\xff\xff\xff\xff'
-
-    assert get_number_format(0xFFFFFFFFFFFFFFFF).pack(0xFFFFFFFFFFFFFFFF) == '\xff\xff\xff\xff\xff\xff\xff\xff'
-
-    with pytest.raises(ValueError):
-        assert get_number_format(0xFFFFFFFFFFFFFFFF + 1)
 
 
 def test_get_exception_frames():
@@ -255,16 +112,18 @@ class MinHashIndexTestCase(TestCase):
             0xFFFF,
             8,
             2,
+            60 * 60,
+            12,
         )
 
-        index.record('example', '1', 'hello world')
-        index.record('example', '2', 'hello world')
-        index.record('example', '3', 'jello world')
-        index.record('example', '4', 'yellow world')
-        index.record('example', '4', 'mellow world')
-        index.record('example', '5', 'pizza world')
+        index.record('example', '1', [('index', 'hello world')])
+        index.record('example', '2', [('index', 'hello world')])
+        index.record('example', '3', [('index', 'jello world')])
+        index.record('example', '4', [('index', 'yellow world')])
+        index.record('example', '4', [('index', 'mellow world')])
+        index.record('example', '5', [('index', 'pizza world')])
 
-        results = index.query('example', '1')
+        results = index.query('example', '1', ['index'])[0]
         assert results[0] == ('1', 1.0)
         assert results[1] == ('2', 1.0)  # identical contents
         assert results[2][0] in ('3', '4')  # equidistant pairs, order doesn't really matter


### PR DESCRIPTION
This is to support atomic merge and delete operations, which previously were subject to a significant race condition, and also changes the storage model to write and read data in a time series structure to support evicting old data and preventing the data set from growing infinitely large.

Aside from the fact that this ports nearly all of the in complex code from Python to Lua, there are a few other changes worth noting — many of which I'll add inline, but here are some higher level points that aren't associated with a specific chunk of code:

- All data within a "scope" (in the usage here, this means a project) is collocated on a single Redis database. This could theoretically lead to a higher probability of hot spots if several project with a high number of unique groups exist on the same database. This also makes concrete the limitation that only operations that are performed within the same scope can be performed atomically. Previously, there were no guarantees.
- This removes a lot of the integer byte packing from the Lua code — mainly since I didn't want to pass another configuration parameter to each command invocation. This can easily change if we'd like to save a couple bytes per key. (I'm personally torn on whether or not that is worth the complexity.)
- There's still no good story around unit testing Lua scripts, so a lot of the testing code was removed.

#nochanges 😎 