### PR TITLE
Fix grammar in weekly e-mail report

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -408,7 +408,7 @@
                         {% if percentage >= 1000 %}{{ percentage|floatformat:"0" }}{% else %}{{ percentage|floatformat:"-1" }}{% endif %}%
                     {% endwith %}
                     </div>
-                    <small>{% if change >= 0 %}more{% else %}less{% endif %} than {{ label }}</small>
+                    <small>{% if change >= 0 %}more{% else %}fewer{% endif %} than {{ label }}</small>
                   {% else %}
                     <small class="empty">There is not enough data to compare to {{ label }}.</small>
                   {% endif %}


### PR DESCRIPTION
I noticed this in the weekly e-mail report:

> the respective section is labeled "Events Seen This Week" - since "events" is countable, "fewer" is more correct

⚠️️ Note that I remain entirely ignorant about Sentry's internals, so I have no idea whether this template is also being used in some other context with non-countable entities.

PS: Please excuse my pedantry.