### PR TITLE
fix MultipleObjectsReturned errors when querying for releases

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -8,7 +8,7 @@ from sentry.api.permissions import ScopedPermission
 from sentry.app import raven
 from sentry.auth import access
 from sentry.models import (
-    Organization, OrganizationMemberTeam, OrganizationStatus, Project, Team
+    Organization, OrganizationMemberTeam, OrganizationStatus, Project, ReleaseProject, Team
 )
 from sentry.models.apikey import ROOT_KEY
 from sentry.utils import auth
@@ -111,3 +111,9 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
                 team__organization_id=organization.id,
             ).values_list('team_id', flat=True)
         return Project.objects.filter(team_id__in=allowed_teams)
+
+    def has_release_permission(self, request, organization, release):
+        return ReleaseProject.objects.filter(
+            release=release,
+            project__in=self.get_allowed_projects(request, organization),
+        ).exists()

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
@@ -65,11 +66,13 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         try:
             release = Release.objects.get(
                 organization_id=organization.id,
-                projects__in=self.get_allowed_projects(request, organization),
                 version=version,
             )
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise PermissionDenied
 
         return Response(serialize(release, request.user))
 
@@ -100,11 +103,13 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         try:
             release = Release.objects.get(
                 organization_id=organization,
-                projects__in=self.get_allowed_projects(request, organization),
                 version=version,
             )
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise PermissionDenied
 
         serializer = ReleaseSerializer(data=request.DATA, partial=True)
 
@@ -161,11 +166,13 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         try:
             release = Release.objects.get(
                 organization_id=organization.id,
-                projects__in=self.get_allowed_projects(request, organization),
                 version=version,
             )
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise PermissionDenied
 
         # we don't want to remove the first_release metadata on the Group, and
         # while people might want to kill a release (maybe to remove files),

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import posixpath
 
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
@@ -48,11 +49,13 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         try:
             release = Release.objects.get(
                 organization_id=organization.id,
-                projects=self.get_allowed_projects(request, organization),
                 version=version,
             )
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise PermissionDenied
 
         try:
             releasefile = ReleaseFile.objects.get(
@@ -88,11 +91,13 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         try:
             release = Release.objects.get(
                 organization_id=organization.id,
-                projects=self.get_allowed_projects(request, organization),
                 version=version,
             )
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise PermissionDenied
 
         try:
             releasefile = ReleaseFile.objects.get(
@@ -133,11 +138,13 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         try:
             release = Release.objects.get(
                 organization_id=organization.id,
-                projects=self.get_allowed_projects(request, organization),
                 version=version,
             )
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise PermissionDenied
 
         try:
             releasefile = ReleaseFile.objects.get(


### PR DESCRIPTION
The many to many query i was using can return duplicate records (so was returning two of the same release if there were to projects).  I also figured it'd be good to differentiate between permission denied and the release not existing, so fixed that here too.

#nochanges

@kjlundsgaard cc @benvinegar @ckj 