### PR TITLE
api: don't allow filtering of a Falsey field value

### DIFF
--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -64,7 +64,7 @@ class SensitiveDataFilter(object):
         if include_defaults:
             fields += DEFAULT_SCRUBBED_FIELDS
         self.exclude_fields = set(exclude_fields)
-        self.fields = set(fields)
+        self.fields = set(filter(None, fields))
 
     def apply(self, data):
         # TODO(dcramer): move this into each interface

--- a/tests/sentry/utils/test_data_scrubber.py
+++ b/tests/sentry/utils/test_data_scrubber.py
@@ -355,3 +355,14 @@ class SensitiveDataFilterTest(TestCase):
         proc = SensitiveDataFilter(exclude_fields=['foobar'])
         proc.apply(data)
         assert data['extra'] == {'foobar': '123-45-6789'}
+
+    def test_empty_field(self):
+        data = {
+            'extra': {
+                'foobar': 'xxx',
+            },
+        }
+
+        proc = SensitiveDataFilter(fields=[''])
+        proc.apply(data)
+        assert data['extra'] == {'foobar': 'xxx'}


### PR DESCRIPTION
Not 100% sure how, but a user had a `sentry:sensitive_fields` value of
`[u'']` which caused every single value to be discarded and filtered.
Unclear how we got into this state, but this would prevent it from
causing harm for existing data that is stored this way.