### PR TITLE
show better preheader text for issue emails

### DIFF
--- a/src/sentry/templates/sentry/emails/activity/generic.html
+++ b/src/sentry/templates/sentry/emails/activity/generic.html
@@ -10,6 +10,14 @@
   {{ block.super }}
 {% endblock %}
 
+{% block preheader %}
+  {% if group %}
+    {% include "sentry/emails/_group.html" %}
+  {% else %}
+    {{ block.super }}
+  {% endif %}
+{% endblock %}
+
 {% block main %}
 
   {% block activity %}


### PR DESCRIPTION
Right now the preheader text I'm getting is
"View on Sentry Sentry Regression Sentry"

I'd like it to be the top line right under ON THIS ISSUE, e.g.
"AssertionError /a/{domain}/receiver/secure/{app_id}/"

I don't have a very complete understanding of the inheritance hierarchy of the email templates, so let me know if I'm putting this in the wrong one.