### PR TITLE
Corrected scrub IP addresses field one-offs

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationSettings.jsx
+++ b/src/sentry/static/sentry/app/views/organizationSettings.jsx
@@ -259,12 +259,12 @@ const OrganizationSettingsForm = React.createClass({
           <BooleanField
             key="scrubIPAddresses"
             name="scrubIPAddresses"
-            label={t('Require Using Default Scrubbers')}
-            value={formData.requireDataScrubber}
-            help={t('Require the default scrubbers be applied to prevent things like passwords and credit cards from being stored for all projects.')}
+            label={t('Prevent Storing of IP Addresses')}
+            value={formData.scrubIPAddresses}
+            help={t('Preventing IP addresses from being stored for new events on all projects.')}
             required={false}
-            error={errors.requireDataScrubberDefaults}
-            onChange={this.onFieldChange.bind(this, 'requireDataScrubberDefaults')} />
+            error={errors.scrubIPAddresses}
+            onChange={this.onFieldChange.bind(this, 'scrubIPAddresses')} />
         </fieldset>
         <fieldset className="form-actions">
           <button type="submit" className="btn btn-primary"


### PR DESCRIPTION
I was updating my organization settings and noticed that there were 2 "Require Using Default Scrubbers" fields:

![selection_255](https://cloud.githubusercontent.com/assets/902488/23482794/329d1c0c-fe85-11e6-9e50-27b6addfa222.png)

After some poking around, it looks like the "Scrub IP Addresses" field was lost during the transition to JSX:

**Earlier:**

https://github.com/getsentry/sentry/blob/8.13.0/src/sentry/templates/sentry/organization-settings.html#L43

https://github.com/getsentry/sentry/blob/8.13.0/src/sentry/web/frontend/organization_settings.py#L73-L77

**Current:**

https://github.com/getsentry/sentry/blob/2d2dfbfc0bdd7fe1ce1dcb6a9c36f0289b531849/src/sentry/static/sentry/app/views/organizationSettings.jsx#L259-L267

In this PR:

- Corrected translation strings to "Scrub IP Address" counterparts
    - https://github.com/getsentry/sentry/blob/master/src/sentry/locale/en/LC_MESSAGES/django.po#L2801-L2803
    - https://github.com/getsentry/sentry/blob/master/src/sentry/locale/en/LC_MESSAGES/django.po#L2910-L2912
- Corrected field values to use `scrubIPAddresses` as expected by API
    - https://github.com/getsentry/sentry/blob/2d2dfbfc0bdd7fe1ce1dcb6a9c36f0289b531849/src/sentry/api/endpoints/organization_details.py#L37

**Notes:**

I didn't have time to fully get a Sentry environment set up for manual testing and the browser JS tests don't seem to cover this yet =/

/cc @getsentry/ui