### PR TITLE
remove click dependency from integrationdocs

### DIFF
--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -7,7 +7,6 @@ import sys
 import json
 import logging
 
-from click import echo
 import sentry
 
 BASE_URL = 'https://docs.sentry.io/hosted/_platforms/{}'
@@ -44,6 +43,12 @@ the latest list of integrations and serve them in your local Sentry install.
 """
 
 logger = logging.getLogger('sentry')
+
+
+def echo(what):
+    sys.stdout.write(what)
+    sys.stdout.write('\n')
+    sys.stdout.flush()
 
 
 def dump_doc(path, data):


### PR DESCRIPTION
This doesn't exactly mirror behavior of click.echo, but it's close
enough for our purposes since this was intended to replace `print`
initially.