### PR TITLE
Sentry Web API tokens page ready for mobiles

### DIFF
--- a/src/sentry/static/sentry/app/views/apiDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/apiDashboard.jsx
@@ -159,7 +159,7 @@ const ApiDashboard = React.createClass({
 
           <p><small>psst. Looking for the <strong>DSN</strong> for an SDK? You'll find that under <strong>[Project] &raquo; Settings &raquo; Client Keys</strong>.</small></p>
 
-          <table className="table">
+          <table className="table" style={{wordBreak: 'break-word'}}>
             <tbody>
               {(this.state.loading ?
                 <tr><td colSpan="2"><LoadingIndicator /></td></tr>


### PR DESCRIPTION
This PR relates https://sentry.io/api/ page small screens

Before PR:
<img width="599" alt="screen shot 2017-03-03 at 00 50 33" src="https://cloud.githubusercontent.com/assets/3473150/23529213/cb986ba4-ffad-11e6-8fda-93210562ad04.png">

After PR:
<img width="610" alt="screen shot 2017-03-03 at 00 51 05" src="https://cloud.githubusercontent.com/assets/3473150/23529227/dc3ab73c-ffad-11e6-92ce-ec2bd75149e4.png">

