### PR TITLE
Add flexbox support to alignment utility classes

### DIFF
--- a/src/sentry/static/sentry/less/type.less
+++ b/src/sentry/static/sentry/less/type.less
@@ -102,14 +102,17 @@ th, dt, strong {
 
 .align-left {
   text-align: left;
+  justify-content: flex-start;
 }
 
 .align-center {
   text-align: center;
+  justify-content: center;
 }
 
 .align-right {
   text-align: right;
+  justify-content: flex-end;
 }
 
 hr {


### PR DESCRIPTION
These classes will now work on elements with `display: flex` applied.