### PR TITLE
Collapse filechange

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Version 8.15 (Unreleased)
 -------------------------
+- Added overview for a release to view a breakdown of files changes, commit authors, new issues, and issues resolved
 
 API Changes
 ~~~~~~~~~~~

--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -31,7 +31,7 @@ const FileChange = React.createClass({
       <li className="list-group-item list-group-item-sm ">
         <div className="row">
           <div className="col-sm-9"><small>{filename}</small></div>
-          <div className="col-sm-3 avatar-grid">
+          <div className="col-sm-3 avatar-grid align-right">
           {authors.map(author => {
               return (
                 <span className="avatar-grid-item m-b-0 tip"

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -30,7 +30,7 @@ const ReleaseOverview = React.createClass({
   mixins: [ApiMixin],
 
   statics: {
-    MAX_WHEN_COLLAPSED: 10
+    MAX_WHEN_COLLAPSED: 2
   },
 
   getInitialState() {
@@ -131,7 +131,7 @@ const ReleaseOverview = React.createClass({
     let files = Object.keys(fileChangeSummary);
     files.sort();
     if (this.state.collapsed && fileCount > MAX) {
-      files = files.slice(-MAX);
+      files = files.slice(0, MAX);
     }
     let numCollapsed = fileCount - files.length;
 

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -30,7 +30,7 @@ const ReleaseOverview = React.createClass({
   mixins: [ApiMixin],
 
   statics: {
-    MAX_WHEN_COLLAPSED: 2
+    MAX_WHEN_COLLAPSED: 5
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -139,21 +139,6 @@ const ReleaseOverview = React.createClass({
       <div>
         <div className="row" style={{paddingTop: 10}}>
           <div className="col-sm-8">
-            <h5>{fileCount} Files Changed</h5>
-            <ul className="list-group list-group-striped m-b-2">
-              {files.map(filename => {
-                return (
-                  <FileChange
-                    key={fileChangeSummary[filename].id}
-                    filename={filename}
-                    authors={Object.values(fileChangeSummary[filename].authors)}
-                    types={fileChangeSummary[filename].types}
-                    />
-                );
-              })}
-              {numCollapsed > 0 && <Collapsed onClick={this.onCollapseToggle} count={numCollapsed}/>}
-            </ul>
-
             <h5>{t('Issues Resolved in this Release')}</h5>
             <IssueList
               endpoint={`/projects/${orgId}/${projectId}/releases/${version}/resolved/`}
@@ -164,7 +149,6 @@ const ReleaseOverview = React.createClass({
               params={{orgId: orgId}}
               className="m-b-2"
               />
-
             <h5>{t('New Issues in this Release')}</h5>
             <IssueList
               endpoint={`/projects/${orgId}/${projectId}/issues/`}
@@ -180,6 +164,20 @@ const ReleaseOverview = React.createClass({
               params={{orgId: orgId}}
               className="m-b-2"
               />
+            <h5>{fileCount} Files Changed</h5>
+            <ul className="list-group list-group-striped m-b-2">
+              {files.map(filename => {
+                return (
+                  <FileChange
+                    key={fileChangeSummary[filename].id}
+                    filename={filename}
+                    authors={Object.values(fileChangeSummary[filename].authors)}
+                    types={fileChangeSummary[filename].types}
+                    />
+                );
+              })}
+              {numCollapsed > 0 && <Collapsed onClick={this.onCollapseToggle} count={numCollapsed}/>}
+            </ul>
           </div>
           <div className="col-sm-4">
             <CommitAuthorStats

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -13,7 +13,7 @@ import {t} from '../../locale';
 
 function Collapsed(props) {
   return (
-    <li className="list-group-item list-group-item-sm">
+    <li className="list-group-item list-group-item-sm align-center">
       <span className="icon-container">
       </span>
       <a onClick={props.onClick}>Show {props.count} collapsed files</a>


### PR DESCRIPTION
Sets a max number of files to display and collapses remaining files in the filechange list for a release.
Limit is currently set to 5, but the example below has the limit at 2, because I only have 4 mock files.

![screen shot 2017-03-03 at 3 43 29 pm](https://cloud.githubusercontent.com/assets/9269824/23573046/3020dd5c-0028-11e7-9ca0-585cd37dc2db.png)
