### PR TITLE
Add getsentry-ldap-auth to the plugins list

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -62,6 +62,7 @@ The following plugins are available and maintained by members of the Sentry comm
 * `sentry-fogbugz <https://github.com/glasslion/sentry-fogbugz>`_
 * `sentry-groveio <https://github.com/mattrobenolt/sentry-groveio>`_
 * `sentry-irccat <https://github.com/russss/sentry-irccat>`_
+* `sentry-ldap <https://github.com/Banno/getsentry-ldap-auth>`_
 * `sentry-lighthouse <https://github.com/gthb/sentry-lighthouse>`_
 * `sentry-notifico <https://github.com/lukegb/sentry-notifico>`_
 * `sentry-searchbutton <https://github.com/timmyomahony/sentry-searchbutton>`_


### PR DESCRIPTION
I'm surprised no one has submitted that before, as I would think it would be more popular