### PR TITLE
Correct interval expiration time and clarify retention behavior.

### DIFF
--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -142,7 +142,10 @@ local function get_active_indices(interval, retention, timestamp)
 end
 
 local function get_index_expiration_time(interval, retention, index)
-    return (index + retention) * interval
+    return (
+        (index + 1)  -- upper bound of this interval
+        + retention
+    ) * interval
 end
 
 
@@ -152,7 +155,7 @@ local configuration_parser = build_argument_parser({
     {"timestamp", parse_integer},
     {"bands", parse_integer},
     {"interval", parse_integer},
-    {"retention", parse_integer},
+    {"retention", parse_integer},  -- how many previous intervals to store (does not include current interval)
     {"scope", function (value)
         assert(value ~= nil)
         return value

--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -350,7 +350,7 @@ features = FeatureSet(
         8,
         2,
         60 * 60 * 24 * 30,
-        4,
+        3,
     ),
     BidirectionalMapping({
         'exception:message:character-shingles': 'a',


### PR DESCRIPTION
Previously, the expiration was being calculated based on the lower bound of the interval, which would lead to data being evicted sooner than what might be expected.