### PR TITLE
Add `IMPORT` and `EXPORT` commands to similarity index.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ tests_require = [
     'cqlsh',
     # /cassandra
     'datadog',
+    'msgpack',
     'pytest-cov>=1.8.0,<1.9.0',
     'pytest-timeout>=0.5.0,<0.6.0',
     'pytest-xdist>=1.11.0,<1.12.0',

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ tests_require = [
     'cqlsh',
     # /cassandra
     'datadog',
-    'msgpack-python',
+    'msgpack-python<0.5.0',
     'pytest-cov>=1.8.0,<1.9.0',
     'pytest-timeout>=0.5.0,<0.6.0',
     'pytest-xdist>=1.11.0,<1.12.0',

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ tests_require = [
     'cqlsh',
     # /cassandra
     'datadog',
-    'msgpack',
+    'msgpack-python',
     'pytest-cov>=1.8.0,<1.9.0',
     'pytest-timeout>=0.5.0,<0.6.0',
     'pytest-xdist>=1.11.0,<1.12.0',

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -668,9 +668,7 @@ local commands = {
             local entries = build_variadic_argument_parser({
                 {'index', identity},
                 {'key', identity},
-                {'data', function (value)
-                    return cmsgpack.unpack(value)
-                end}
+                {'data', cmsgpack.unpack},
             })(arguments)
 
             for _, entry in ipairs(entries) do

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -722,6 +722,7 @@ local commands = {
                         -- The destination bucket frequency key may have not
                         -- existed previously, so we need to make sure we set
                         -- the expiration on it in case it is new.
+                        -- TODO(tkaemming): Only need to call this if we mutated anything
                         redis.call(
                             'EXPIREAT',
                             destination_bucket_frequency_key,

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -688,7 +688,6 @@ local commands = {
                             entry.key
                         )
 
-                        local touched = false
                         for bucket, count in pairs(buckets) do
                             local bucket_membership_key = get_bucket_membership_key(
                                 configuration.scope,
@@ -706,13 +705,13 @@ local commands = {
                                 bucket,
                                 count
                             )
-                            touched = true
                         end
 
                         -- The destination bucket frequency key may have not
                         -- existed previously, so we need to make sure we set
-                        -- the expiration on it in case it is new.
-                        if touched then
+                        -- the expiration on it in case it is new. (We only
+                        -- have to do this if there we changed any bucket counts.)
+                        if next(buckets) ~= nil then
                             redis.call(
                                 'EXPIREAT',
                                 destination_bucket_frequency_key,

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -626,6 +626,16 @@ local commands = {
             end
         end
     ),
+    IMPORT = takes_configuration(
+        function (configuration, arguments)
+            error("not implemented")
+        end
+    ),
+    EXPORT = takes_configuration(
+        function (configuration, arguments)
+            error("not implemented")
+        end
+    )
 }
 
 

--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -165,6 +165,28 @@ class MinHashIndex(object):
             arguments,
         )
 
+    def import_(self, scope, items, timestamp=None):
+        if timestamp is None:
+            timestamp = int(time.time())
+
+        arguments = [
+            'IMPORT',
+            timestamp,
+            len(self.bands),
+            self.interval,
+            self.retention,
+            scope,
+        ]
+
+        for idx, key, data in items:
+            arguments.extend([idx, key, data])
+
+        return index(
+            self.cluster.get_local_client_for_key(scope),
+            [],
+            arguments,
+        )
+
 
 FRAME_ITEM_SEPARATOR = b'\x00'
 FRAME_PAIR_SEPARATOR = b'\x01'

--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -143,6 +143,28 @@ class MinHashIndex(object):
             arguments,
         )
 
+    def export(self, scope, items, timestamp=None):
+        if timestamp is None:
+            timestamp = int(time.time())
+
+        arguments = [
+            'EXPORT',
+            timestamp,
+            len(self.bands),
+            self.interval,
+            self.retention,
+            scope,
+        ]
+
+        for idx, key in items:
+            arguments.extend([idx, key])
+
+        return index(
+            self.cluster.get_local_client_for_key(scope),
+            [],
+            arguments,
+        )
+
 
 FRAME_ITEM_SEPARATOR = b'\x00'
 FRAME_PAIR_SEPARATOR = b'\x01'

--- a/tests/sentry/test_similarity.py
+++ b/tests/sentry/test_similarity.py
@@ -158,6 +158,7 @@ class MinHashIndexTestCase(TestCase):
             assert len(band) == (retention + 1)
             assert sum(sum(dict(bucket_frequencies).values()) for index, bucket_frequencies in band) == 1
 
+        # Copy the data from key 1 to key 2.
         index.import_('example', [('index', 2, result[0])], timestamp=timestamp)
 
         assert index.export(
@@ -170,6 +171,7 @@ class MinHashIndexTestCase(TestCase):
             timestamp=timestamp
         )
 
+        # Copy the data again to key 2 (duplicating all of the data.)
         index.import_('example', [('index', 2, result[0])], timestamp=timestamp)
 
         result = index.export('example', [('index', 2)], timestamp=timestamp)

--- a/tests/sentry/test_similarity.py
+++ b/tests/sentry/test_similarity.py
@@ -156,7 +156,7 @@ class MinHashIndexTestCase(TestCase):
 
         for band in data:
             assert len(band) == (retention + 1)
-            assert sum(sum(int(count) for bucket, count in chunk) for _, chunk in band) == 1
+            assert sum(sum(dict(bucket_frequencies).values()) for index, bucket_frequencies in band) == 1
 
         index.import_('example', [('index', 2, result[0])], timestamp=timestamp)
 
@@ -180,4 +180,4 @@ class MinHashIndexTestCase(TestCase):
 
         for band in data:
             assert len(band) == (retention + 1)
-            assert sum(sum(int(count) for bucket, count in chunk) for _, chunk in band) == 2
+            assert sum(sum(dict(bucket_frequencies).values()) for index, bucket_frequencies in band) == 2

--- a/tests/sentry/test_similarity.py
+++ b/tests/sentry/test_similarity.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import time
+
+import msgpack
 import pytest
 
 from sentry.similarity import (
@@ -129,3 +132,52 @@ class MinHashIndexTestCase(TestCase):
         assert results[2][0] in ('3', '4')  # equidistant pairs, order doesn't really matter
         assert results[3][0] in ('3', '4')
         assert results[4][0] == '5'
+
+    def test_export_import(self):
+        bands = 2
+        retention = 12
+        index = MinHashIndex(
+            redis.clusters.get('default'),
+            0xFFFF,
+            bands,
+            2,
+            60 * 60,
+            retention,
+        )
+
+        index.record('example', '1', [('index', 'hello world')])
+
+        timestamp = int(time.time())
+        result = index.export('example', [('index', 1)], timestamp=timestamp)
+        assert len(result) == 1
+
+        data = msgpack.unpackb(result[0])
+        assert len(data) == bands
+
+        for band in data:
+            assert len(band) == (retention + 1)
+            assert sum(sum(int(count) for bucket, count in chunk) for _, chunk in band) == 1
+
+        index.import_('example', [('index', 2, result[0])], timestamp=timestamp)
+
+        assert index.export(
+            'example',
+            [('index', 1)],
+            timestamp=timestamp
+        ) == index.export(
+            'example',
+            [('index', 2)],
+            timestamp=timestamp
+        )
+
+        index.import_('example', [('index', 2, result[0])], timestamp=timestamp)
+
+        result = index.export('example', [('index', 2)], timestamp=timestamp)
+        assert len(result) == 1
+
+        data = msgpack.unpackb(result[0])
+        assert len(data) == bands
+
+        for band in data:
+            assert len(band) == (retention + 1)
+            assert sum(sum(int(count) for bucket, count in chunk) for _, chunk in band) == 2


### PR DESCRIPTION
This is basically a combination of several different independent changes:

- Abstracts out the pattern of `{index, key}` parsing for commands. I'd like to find an even more generic way to split out this pattern for handling different structures like `{index, key, data}`, but haven't figured out a clean way to do this yet. (Stay tuned!)
- Adds helper to make `HGETALL` responses return a mapping-style table rather than an list-style table.
- Adds `IMPORT` and `EXPORT` commands for extracting and loading group data from the database, as well as `MinHashIndex` methods for calling them. This allows for moving data across scopes, as well as provides a method for performing basic introspection of the data contained in the database.

#nochanges