### PR TITLE
utils: don't allow progressbar to exceed maxval when updating

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -137,7 +137,12 @@ class WithProgressBar(object):
             pbar.start()
             for idx, item in enumerate(self.iterator):
                 yield item
-                pbar.update(idx)
+                # It's possible that we've exceeded the maxval, but instead
+                # of exploding on a ValueError, let's just cap it so we don't.
+                # this could happen if new rows were added between calculating `count()`
+                # and actually beginning iteration where we're iterating slightly more
+                # than we thought.
+                pbar.update(min(idx, self.count))
             pbar.finish()
 
 


### PR DESCRIPTION
This condition can happen with `RangeQuerySetWrapperWithProgressBar`
since we rely on `QuerySet.count()` to determine the `maxval`, but if we
have inserted new rows since checking `count()` it's easily possible
that we'll exceed the maxval. When this happens, progressbar raises a
hard `ValueError` and aborts. I'd rather us chill at 100% for a bit
while we iterate through the rest of the rows instead of aborting a
running migration, for example.