### PR TITLE
load-mocks: fix tsdb reference after refactor

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -14,7 +14,8 @@ from pytz import utc
 from random import randint
 from uuid import uuid4
 
-from sentry import buffer, tsdb, roles
+from sentry import buffer, roles
+from sentry.tsdb import backend as tsdb
 from sentry.models import (
     Activity, Broadcast, File, GroupMeta, Organization, OrganizationAccessRequest,
     OrganizationMember, Project, Release, ReleaseFile, Team, User, UserReport,


### PR DESCRIPTION
> AttributeError: 'module' object has no attribute 'record_frequency_multi'