### PR TITLE
csp: hard block ms-browser-extension

### DIFF
--- a/src/sentry/utils/csp.py
+++ b/src/sentry/utils/csp.py
@@ -73,6 +73,12 @@ ALLOWED_DIRECTIVES = frozenset((
     # 'sandbox',
 ))
 
+# URIs that are pure noise and will never be actionable
+DISALLOWED_BLOCKED_URIS = frozenset((
+    'about',
+    'ms-browser-extension',
+))
+
 
 def is_valid_csp_report(report, project=None):
     # Some reports from Chrome report blocked-uri as just 'about'.
@@ -82,7 +88,7 @@ def is_valid_csp_report(report, project=None):
         return False
 
     blocked_uri = report.get('blocked_uri')
-    if blocked_uri == 'about':
+    if blocked_uri in DISALLOWED_BLOCKED_URIS:
         return False
 
     source_file = report.get('source_file')

--- a/tests/sentry/utils/test_csp.py
+++ b/tests/sentry/utils/test_csp.py
@@ -10,6 +10,7 @@ from sentry.utils.csp import is_valid_csp_report
     {'effective_directive': 'lolnotreal'},
     {'effective_directive': 'style-src'},
     {'effective_directive': 'style-src', 'blocked_uri': 'about'},
+    {'effective_directive': 'style-src', 'blocked_uri': 'ms-browser-extension'},
     {'effective_directive': 'style-src', 'source_file': 'chrome-extension://fdsa'},
     {'effective_directive': 'style-src', 'source_file': 'http://localhost:8000'},
     {'effective_directive': 'style-src', 'source_file': 'http://localhost'},


### PR DESCRIPTION
Similar to `about`, which was already blocked, reports that come through
as `ms-browser-extension` aren't even a uri. The value is literally just
that, meaning there's no other way for a user to block this.

As a user brought up, this is not anything actionable and won't overlap
with a valid report that someone would want to see since it's coming
from an IE extension.