### PR TITLE
csv: encode each row before writing to csv file

### DIFF
--- a/src/sentry/web/frontend/mixins/csv.py
+++ b/src/sentry/web/frontend/mixins/csv.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import csv
 import six
 
+from django.utils.encoding import force_bytes
 from django.http import StreamingHttpResponse
 
 # Python 2 doesn't support unicode with CSV, but Python 3 does via
@@ -12,7 +13,7 @@ if six.PY3:
         return row
 else:
     def encode_row(row):
-        return [six.text_type(e).encode('utf-8') for e in row]
+        return map(force_bytes, row)
 
 
 # csv.writer doesn't provide a non-file interface
@@ -40,7 +41,7 @@ class CsvMixin(object):
         pseudo_buffer = Echo()
         writer = csv.writer(pseudo_buffer)
         response = StreamingHttpResponse(
-            (writer.writerow(r) for r in row_iter()),
+            (writer.writerow(encode_row(r)) for r in row_iter()),
             content_type='text/csv',
         )
         response['Content-Disposition'] = \

--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -9,7 +9,7 @@ from sentry.testutils import TestCase
 
 class GroupTagExportTest(TestCase):
     def test_simple(self):
-        key, value = 'foo', 'bar'
+        key, value = 'foo', u'b\xe4r'
 
         # Drop microsecond value for MySQL
         now = timezone.now().replace(microsecond=0)


### PR DESCRIPTION
We had the utility function to do this... but weren't using it.

Also changed to use `django.utils.encoding:force_bytes` since that
encompasses the logic we were doing already.

Fixes SENTRY-2F5