### PR TITLE
Add title with full timestamp to breadcrumb time element

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -48,13 +48,14 @@ const Breadcrumb = React.createClass({
   },
 
   render() {
+    let {crumb} = this.props;
     return (
       <li className={this.getClassName()}>
         <span className="icon-container">
           <span className="icon"/>
         </span>
-        <span className="dt">
-          {moment(this.props.crumb.timestamp).format('HH:mm:ss')}
+        <span className="dt" title="{moment(crumb.timestamp).format()}">
+          {moment(crumb.timestamp).format('HH:mm:ss')}
         </span>
         {this.renderType()}
       </li>


### PR DESCRIPTION
This PR adds `title` element with `crumb.timestamp` formatted according to ISO 8601 as a value.
With this change it's possible see the date of the breadcrumb, not only the time like it's atm.