### PR TITLE
[analytics] initial draft

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,11 @@
 Version 8.17 (Unreleased)
 -------------------------
 
+- Initial (internal) analytics abstraction.
+
 Version 8.16
 ------------
+
 - Added data migration to create UserEmail objects for users whose primary emails did not have them
 - Time series data (used by graphs and other features) is now updated when groups are merged.
 - Added distributions to the release system to better support mobile apps
@@ -19,6 +22,7 @@ Schema Changes
 
 API Changes
 ~~~~~~~~~~~
+
 - Deprecate `dateStarted` in releases endpoints
 
 Version 8.15

--- a/src/sentry/analytics/__init__.py
+++ b/src/sentry/analytics/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+from django.conf import settings
+
+from sentry import options
+from sentry.utils.services import LazyServiceWrapper
+
+from .base import Analytics  # NOQA
+from .event_manager import default_manager
+from .event import Attribute, Event  # NOQA
+
+
+def get_backend_path(backend):
+    try:
+        backend = settings.SENTRY_ANALYTICS_ALIASES[backend]
+    except KeyError:
+        pass
+    return backend
+
+
+backend = LazyServiceWrapper(Analytics,
+                             get_backend_path(options.get('analytics.backend')),
+                             options.get('analytics.options'))
+backend.expose(locals())
+
+register = default_manager.register

--- a/src/sentry/analytics/base.py
+++ b/src/sentry/analytics/base.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.utils.services import Service
+
+from .event_manager import default_manager
+
+
+class Analytics(Service):
+    __all__ = ('record', 'validate')
+
+    event_manager = default_manager
+
+    def record(self, event_or_event_type, instance=None, **kwargs):
+        """
+        >>> record(Event())
+        >>> record('organization.created', organization)
+        """
+        if isinstance(event_or_event_type, six.string_types):
+            event = self.event_manager.get(
+                event_or_event_type,
+            ).from_instance(instance, **kwargs)
+        else:
+            event = event_or_event_type
+        self.record_event(event)
+
+    def record_event(self, event):
+        """
+        >>> record_event(Event())
+        """
+
+    def setup(self):
+        # Load default event types
+        import sentry.analytics.events  # NOQA

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import, print_function
+
+import six
+
+from django.utils import timezone
+
+
+class Attribute(object):
+    __slots__ = ['name', 'type', 'required']
+
+    def __init__(self, name, type=six.text_type, required=True):
+        self.name = name
+        self.type = type
+        self.required = required
+
+
+class Event(object):
+    __slots__ = ['attributes', 'data', 'datetime', 'type']
+
+    type = None
+
+    attributes = ()
+
+    def __init__(self, type=None, datetime=None, **kwargs):
+        self.datetime = datetime or timezone.now()
+        if type is not None:
+            self.type = type
+
+        if self.type is None:
+            raise ValueError('Event is missing type')
+
+        data = {}
+        for attr in self.attributes:
+            if attr.required:
+                value = kwargs.pop(attr.name)
+            else:
+                value = kwargs.pop(attr.name, None)
+            data[attr.name] = attr.type(value) if value is not None else value
+
+        if kwargs:
+            raise ValueError(u'Unknown attributes: {}'.format(
+                ', '.join(kwargs.keys()),
+            ))
+
+        self.data = data
+
+    def serialize(self):
+        return dict({
+            'timestamp': int(self.datetime.isoformat('%s')),
+            'type': self.type,
+        }, **self.data)
+
+    @classmethod
+    def from_instance(cls, instance, **kwargs):
+        values = {}
+        for attr in cls.attributes:
+            values[attr.name] = (
+                kwargs.get(attr.name) or
+                getattr(instance, attr.name, None)
+            )
+        return cls(**values)

--- a/src/sentry/analytics/event_manager.py
+++ b/src/sentry/analytics/event_manager.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+__all__ = ('default_manager', 'EventManager')
+
+
+class EventManager(object):
+    def __init__(self):
+        self._event_types = {}
+
+    def register(self, event_cls):
+        """
+        >>> register(OrganizationCreatedEvent)
+        """
+        event_type = event_cls.type
+        if event_type in self._event_types:
+            assert self._event_types[event_type] == event_cls
+        else:
+            self._event_types[event_type] = event_cls
+
+    def get(self, type):
+        return self._event_types[type]
+
+
+default_manager = EventManager()

--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, print_function
+
+from sentry.utils.imports import import_submodules
+
+import_submodules(globals(), __name__, __path__)

--- a/src/sentry/analytics/events/organization_created.py
+++ b/src/sentry/analytics/events/organization_created.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import, print_function
+
+from sentry import analytics
+
+
+class OrganizationCreatedEvent(analytics.Event):
+    type = 'organization.created'
+
+    attributes = (
+        analytics.Attribute('id'),
+        analytics.Attribute('name'),
+        analytics.Attribute('slug'),
+        analytics.Attribute('actor_id', required=False),
+    )
+
+analytics.register(OrganizationCreatedEvent)

--- a/src/sentry/analytics/events/user_created.py
+++ b/src/sentry/analytics/events/user_created.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, print_function
+
+from sentry import analytics
+
+
+class UserCreatedEvent(analytics.Event):
+    type = 'user.created'
+
+    attributes = (
+        analytics.Attribute('id'),
+        analytics.Attribute('username'),
+        analytics.Attribute('email'),
+    )
+
+analytics.register(UserCreatedEvent)

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -7,7 +7,7 @@ from django.db.models import Count, Q, Sum
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
-from sentry import features, options, roles
+from sentry import analytics, features, options, roles
 from sentry.app import ratelimiter
 from sentry.api.base import DocSection, Endpoint
 from sentry.api.bases.organization import OrganizationPermission
@@ -214,6 +214,9 @@ class OrganizationIndexEndpoint(Endpoint):
                 event=AuditLogEntryEvent.ORG_ADD,
                 data=org.get_audit_log_data(),
             )
+
+            analytics.record('organization.created', org,
+                             actor_id=request.user.id if request.user.is_authenticated() else None)
 
             return Response(serialize(org, request.user), status=201)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/buffer/__init__.py
+++ b/src/sentry/buffer/__init__.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .base import Buffer  # NOQA
 
 
-backend = LazyBackendWrapper(Buffer, settings.SENTRY_BUFFER,
+backend = LazyServiceWrapper(Buffer, settings.SENTRY_BUFFER,
                              settings.SENTRY_BUFFER_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -14,6 +14,7 @@ from django.db.models import F
 
 from sentry.signals import buffer_incr_complete
 from sentry.tasks.process_buffer import process_incr
+from sentry.utils.services import Service
 
 
 class BufferMount(type):
@@ -24,7 +25,7 @@ class BufferMount(type):
 
 
 @six.add_metaclass(BufferMount)
-class Buffer(object):
+class Buffer(Service):
     """
     Buffers act as temporary stores for counters. The default implementation is just a passthru and
     does not actually buffer anything.
@@ -49,14 +50,6 @@ class Buffer(object):
             'filters': filters,
             'extra': extra,
         })
-
-    def validate(self):
-        """
-        Validates the settings for this backend (i.e. such as proper connection
-        info).
-
-        Raise ``InvalidConfiguration`` if there is a configuration error.
-        """
 
     def process_pending(self):
         return []

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -283,6 +283,8 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'rest_framework',
     'sentry',
+    'sentry.analytics',
+    'sentry.analytics.events',
     'sentry.nodestore',
     'sentry.search',
     'sentry.lang.javascript',
@@ -851,6 +853,10 @@ SENTRY_EMAIL_BACKEND_ALIASES = {
 SENTRY_FILESTORE_ALIASES = {
     'filesystem': 'django.core.files.storage.FileSystemStorage',
     's3': 'sentry.filestore.s3.S3Boto3Storage',
+}
+
+SENTRY_ANALYTICS_ALIASES = {
+    'noop': 'sentry.analytics.Analytics',
 }
 
 # set of backends that do not support needing SMTP mail.* settings

--- a/src/sentry/digests/__init__.py
+++ b/src/sentry/digests/__init__.py
@@ -4,13 +4,13 @@ from collections import namedtuple
 from django.conf import settings
 
 from sentry.utils.dates import to_datetime
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .backends.base import Backend  # NOQA
 from .backends.dummy import DummyBackend  # NOQA
 
 
-backend = LazyBackendWrapper(Backend, settings.SENTRY_DIGESTS,
+backend = LazyServiceWrapper(Backend, settings.SENTRY_DIGESTS,
                              settings.SENTRY_DIGESTS_OPTIONS,
                              (DummyBackend,))
 backend.expose(locals())

--- a/src/sentry/digests/backends/base.py
+++ b/src/sentry/digests/backends/base.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 
 from sentry.utils.imports import import_string
+from sentry.utils.services import Service
 
 
 logger = logging.getLogger('sentry.digests')
@@ -24,7 +25,7 @@ class InvalidState(Exception):
     """
 
 
-class Backend(object):
+class Backend(Service):
     """
     A digest backend coordinates the addition of records to timelines, as well
     as scheduling their digestion (processing.) This allows for summarizations
@@ -103,9 +104,6 @@ class Backend(object):
                 raise TypeError('No timeline capacity has been set, "truncation_chance" must be None.')
             else:
                 self.truncation_chance = 0.0
-
-    def validate(self):
-        pass
 
     def enabled(self, project):
         """

--- a/src/sentry/newsletter/__init__.py
+++ b/src/sentry/newsletter/__init__.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .base import Newsletter  # NOQA
 
 
-backend = LazyBackendWrapper(Newsletter, settings.SENTRY_NEWSLETTER,
+backend = LazyServiceWrapper(Newsletter, settings.SENTRY_NEWSLETTER,
                              settings.SENTRY_NEWSLETTER_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/newsletter/base.py
+++ b/src/sentry/newsletter/base.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
+from sentry.utils.services import Service
 
-class Newsletter(object):
+
+class Newsletter(Service):
     __all__ = ('is_enabled', 'get_subscriptions', 'update_subscription',
                'create_or_update_subscription')
 

--- a/src/sentry/nodestore/__init__.py
+++ b/src/sentry/nodestore/__init__.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .base import NodeStorage  # NOQA
 
 
-backend = LazyBackendWrapper(NodeStorage, settings.SENTRY_NODESTORE,
+backend = LazyServiceWrapper(NodeStorage, settings.SENTRY_NODESTORE,
                              settings.SENTRY_NODESTORE_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -14,18 +14,12 @@ from base64 import b64encode
 from threading import local
 from uuid import uuid4
 
+from sentry.utils.services import Service
 
-class NodeStorage(local):
+
+class NodeStorage(local, Service):
     __all__ = ('create', 'delete', 'delete_multi', 'get', 'get_multi', 'set',
                'set_multi', 'generate_id', 'cleanup', 'validate')
-
-    def validate(self):
-        """
-        Validates the settings for this backend (i.e. such as proper connection
-        info).
-
-        Raise ``InvalidConfiguration`` if there is a configuration error.
-        """
 
     def create(self, data):
         """

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -89,3 +89,7 @@ register('filestore.options', default={'location': '/tmp/sentry-files'}, flags=F
 register('symbolserver.enabled', default=False, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register('symbolserver.options', default={'url': 'http://127.0.0.1:3000'},
          flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+
+# Analytics
+register('analytics.backend', default='noop', flags=FLAG_NOSTORE)
+register('analytics.options', default={}, flags=FLAG_NOSTORE)

--- a/src/sentry/quotas/__init__.py
+++ b/src/sentry/quotas/__init__.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .base import Quota  # NOQA
 
 
-backend = LazyBackendWrapper(Quota, settings.SENTRY_QUOTAS,
+backend = LazyServiceWrapper(Quota, settings.SENTRY_QUOTAS,
                              settings.SENTRY_QUOTA_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -12,6 +12,7 @@ import six
 from django.conf import settings
 
 from sentry import options
+from sentry.utils.services import Service
 
 
 class RateLimit(object):
@@ -38,7 +39,7 @@ class RateLimited(RateLimit):
         super(RateLimited, self).__init__(True, **kwargs)
 
 
-class Quota(object):
+class Quota(Service):
     """
     Quotas handle tracking a project's event usage (at a per minute tick) and
     respond whether or not a project has been configured to throttle incoming
@@ -51,14 +52,6 @@ class Quota(object):
 
     def __init__(self, **options):
         pass
-
-    def validate(self):
-        """
-        Validates the settings for this backend (i.e. such as proper connection
-        info).
-
-        Raise ``InvalidConfiguration`` if there is a configuration error.
-        """
 
     def is_rate_limited(self, project):
         return NotRateLimited()

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .base import RateLimiter  # NOQA
 
 
-backend = LazyBackendWrapper(RateLimiter, settings.SENTRY_RATELIMITER,
+backend = LazyServiceWrapper(RateLimiter, settings.SENTRY_RATELIMITER,
                              settings.SENTRY_RATELIMITER_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/ratelimits/base.py
+++ b/src/sentry/ratelimits/base.py
@@ -1,18 +1,12 @@
 from __future__ import absolute_import
 
+from sentry.utils.services import Service
 
-class RateLimiter(object):
+
+class RateLimiter(Service):
     __all__ = ('is_limited', 'validate')
 
     window = 60
-
-    def validate(self):
-        """
-        Validates the settings for this backend (i.e. such as proper connection
-        info).
-
-        Raise ``InvalidConfiguration`` if there is a configuration error.
-        """
 
     def is_limited(self, key, limit, project=None, window=None):
         return False

--- a/src/sentry/receivers/analytics.py
+++ b/src/sentry/receivers/analytics.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+from django.db.models.signals import post_save
+
+from sentry import analytics
+from sentry.models import User
+
+
+def capture_signal(type):
+    def wrapped(instance, **kwargs):
+        analytics.record(type, instance)
+    return wrapped
+
+
+post_save.connect(
+    capture_signal('user.created'),
+    sender=User,
+    dispatch_uid='analytics.user.created',
+    weak=False,
+)

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -117,8 +117,11 @@ def configure():
     _, py, yaml = discover_configs()
 
     # TODO(mattrobenolt): Surface this also as a CLI option?
-    skip_backend_validation = 'SENTRY_SKIP_BACKEND_VALIDATION' in os.environ
-    configure(ctx, py, yaml, skip_backend_validation)
+    skip_service_validation = (
+        'SENTRY_SKIP_BACKEND_VALIDATION' in os.environ or
+        'SENTRY_SKIP_SERVICE_VALIDATION' in os.environ
+    )
+    configure(ctx, py, yaml, skip_service_validation)
 
 
 def get_prog():

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -89,7 +89,7 @@ def discover_configs():
     )
 
 
-def configure(ctx, py, yaml, skip_backend_validation=False):
+def configure(ctx, py, yaml, skip_service_validation=False):
     """
     Given the two different config files, set up the environment.
 
@@ -150,7 +150,7 @@ def configure(ctx, py, yaml, skip_backend_validation=False):
         'config_path': py,
         'settings': settings,
         'options': yaml,
-    }, skip_backend_validation=skip_backend_validation)
+    }, skip_service_validation=skip_service_validation)
     on_configure({'settings': settings})
 
     __installed = True

--- a/src/sentry/search/__init__.py
+++ b/src/sentry/search/__init__.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .base import SearchBackend  # NOQA
 
 
-backend = LazyBackendWrapper(SearchBackend, settings.SENTRY_SEARCH,
+backend = LazyServiceWrapper(SearchBackend, settings.SENTRY_SEARCH,
                              settings.SENTRY_SEARCH_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/search/base.py
+++ b/src/sentry/search/base.py
@@ -8,23 +8,17 @@ sentry.search.base
 
 from __future__ import absolute_import
 
+from sentry.utils.services import Service
+
 ANY = object()
 EMPTY = object()
 
 
-class SearchBackend(object):
+class SearchBackend(Service):
     __all__ = ('query', 'validate')
 
     def __init__(self, **options):
         pass
-
-    def validate(self):
-        """
-        Validates the settings for this backend (i.e. such as proper connection
-        info).
-
-        Raise ``InvalidConfiguration`` if there is a configuration error.
-        """
 
     def query(self, project, query=None, status=None, tags=None,
               bookmarked_by=None, assigned_to=None, first_release=None,

--- a/src/sentry/tsdb/__init__.py
+++ b/src/sentry/tsdb/__init__.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from sentry.utils.functional import LazyBackendWrapper
+from sentry.utils.services import LazyServiceWrapper
 
 from .base import BaseTSDB  # NOQA
 from .dummy import DummyTSDB
 
 
-backend = LazyBackendWrapper(BaseTSDB, settings.SENTRY_TSDB,
+backend = LazyServiceWrapper(BaseTSDB, settings.SENTRY_TSDB,
                              settings.SENTRY_TSDB_OPTIONS,
                              (DummyTSDB,))
 backend.expose(locals())

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from enum import Enum
 
 from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.services import Service
 
 ONE_MINUTE = 60
 ONE_HOUR = ONE_MINUTE * 60
@@ -74,7 +75,7 @@ class TSDBModel(Enum):
     frequent_environments_by_group = 408
 
 
-class BaseTSDB(object):
+class BaseTSDB(Service):
     __all__ = (
         'models', 'incr', 'incr_multi', 'get_range', 'get_rollups', 'get_sums',
         'rollup', 'validate',
@@ -96,14 +97,6 @@ class BaseTSDB(object):
             legacy_rollups = getattr(settings, 'SENTRY_TSDB_LEGACY_ROLLUPS', {})
 
         self.__legacy_rollups = legacy_rollups
-
-    def validate(self):
-        """
-        Validates the settings for this backend (i.e. such as proper connection
-        info).
-
-        Raise ``InvalidConfiguration`` if there is a configuration error.
-        """
 
     def get_rollups(self):
         return self.rollups

--- a/src/sentry/utils/functional.py
+++ b/src/sentry/utils/functional.py
@@ -1,12 +1,6 @@
 from __future__ import absolute_import
 
-import inspect
-
-from django.utils.functional import empty, LazyObject
-
-from sentry.utils import warnings
-
-from .imports import import_string
+from django.utils.functional import empty
 
 
 def extract_lazy_object(lo):
@@ -45,50 +39,3 @@ def apply_values(function, mapping):
             function(values),
         ),
     )
-
-
-class LazyBackendWrapper(LazyObject):
-    """
-    Lazyily instantiates a standard Sentry backend class.
-
-    >>> LazyBackendWrapper(BaseClass, 'path.to.import.Backend', {})
-
-    Provides an ``expose`` method for dumping public APIs to a context, such as
-    module locals:
-
-    >>> backend = LazyBackendWrapper(...)
-    >>> backend.expose(locals())
-    """
-    def __init__(self, backend_base, backend_path, options, dangerous=()):
-        super(LazyBackendWrapper, self).__init__()
-        self.__dict__.update({
-            '_backend': backend_path,
-            '_options': options,
-            '_base': backend_base,
-            '_dangerous': dangerous,
-        })
-
-    def __getattr__(self, name):
-        if self._wrapped is empty:
-            self._setup()
-        return getattr(self._wrapped, name)
-
-    def _setup(self):
-        backend = import_string(self._backend)
-        if backend in self._dangerous:
-            warnings.warn(
-                warnings.UnsupportedBackend(
-                    u'The {!r} backend for {} is not recommended '
-                    'for production use.'.format(self._backend, self._base)
-                )
-            )
-        instance = backend(**self._options)
-        self._wrapped = instance
-
-    def expose(self, context):
-        base = self._base
-        for key in base.__all__:
-            if inspect.ismethod(getattr(base, key)):
-                context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)
-            else:
-                context[key] = getattr(base, key)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -122,7 +122,8 @@ def pytest_configure(config):
 
     from sentry.runner.initializer import (
         bootstrap_options, configure_structlog, initialize_receivers, fix_south,
-        bind_cache_to_option_store)
+        bind_cache_to_option_store, setup_services
+    )
 
     bootstrap_options(settings)
     configure_structlog()
@@ -131,6 +132,7 @@ def pytest_configure(config):
     bind_cache_to_option_store()
 
     initialize_receivers()
+    setup_services()
 
     from sentry.plugins import plugins
     from sentry.plugins.utils import TestIssuePlugin2

--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+
+import inspect
+import itertools
+
+from django.utils.functional import empty, LazyObject
+
+from sentry.utils import warnings
+
+from .imports import import_string
+
+
+class Service(object):
+    __all__ = ()
+
+    def validate(self):
+        """
+        Validates the settings for this backend (i.e. such as proper connection
+        info).
+
+        Raise ``InvalidConfiguration`` if there is a configuration error.
+        """
+
+    def setup(self):
+        """
+        Initialize this service.
+        """
+
+
+class LazyServiceWrapper(LazyObject):
+    """
+    Lazyily instantiates a standard Sentry service class.
+
+    >>> LazyServiceWrapper(BaseClass, 'path.to.import.Backend', {})
+
+    Provides an ``expose`` method for dumping public APIs to a context, such as
+    module locals:
+
+    >>> service = LazyServiceWrapper(...)
+    >>> service.expose(locals())
+    """
+    def __init__(self, backend_base, backend_path, options, dangerous=()):
+        super(LazyServiceWrapper, self).__init__()
+        self.__dict__.update({
+            '_backend': backend_path,
+            '_options': options,
+            '_base': backend_base,
+            '_dangerous': dangerous,
+        })
+
+    def __getattr__(self, name):
+        if self._wrapped is empty:
+            self._setup()
+        return getattr(self._wrapped, name)
+
+    def _setup(self):
+        backend = import_string(self._backend)
+        assert issubclass(backend, Service)
+        if backend in self._dangerous:
+            warnings.warn(
+                warnings.UnsupportedBackend(
+                    u'The {!r} backend for {} is not recommended '
+                    'for production use.'.format(self._backend, self._base)
+                )
+            )
+        instance = backend(**self._options)
+        self._wrapped = instance
+
+    def expose(self, context):
+        base = self._base
+        for key in itertools.chain(base.__all__, ('validate', 'setup')):
+            if inspect.ismethod(getattr(base, key)):
+                context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)
+            else:
+                context[key] = getattr(base, key)

--- a/tests/sentry/analytics/__init__.py
+++ b/tests/sentry/analytics/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/analytics/test_base.py
+++ b/tests/sentry/analytics/test_base.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from sentry.analytics import Analytics
+from sentry.testutils import TestCase
+
+
+class DummyAnalytics(Analytics):
+    def __init__(self):
+        self.events = []
+        super(DummyAnalytics, self).__init__()
+
+    def record_event(self, event):
+        self.events.append(event)
+
+
+class AnalyticsTest(TestCase):
+    def test_record(self):
+        organization = self.create_organization()
+        provider = DummyAnalytics()
+        provider.record('organization.created', organization)
+        assert len(provider.events) == 1
+        event = provider.events.pop(0)
+        assert event.type == 'organization.created'
+        assert event.datetime
+        assert event.data['slug'] == organization.slug
+        assert not event.data['actor_id']
+
+    def test_record_with_attrs(self):
+        organization = self.create_organization()
+        provider = DummyAnalytics()
+        provider.record('organization.created', organization, actor_id=1)
+        assert len(provider.events) == 1
+        event = provider.events.pop(0)
+        assert event.type == 'organization.created'
+        assert event.datetime
+        assert event.data['slug'] == organization.slug
+        assert event.data['actor_id'] == '1'


### PR DESCRIPTION
This is an initial abstraction for analytics within Sentry.

```python
>>> analytics.record('organization.created', organization)
```

- add sentry.analytics backend
- add sentry.utils.service.Service base helper
- add ``setup()`` call to initializers
- rename backend to service
- ensure ``Service.setup`` is called during tests