### PR TITLE
Fix link to django database docs

### DIFF
--- a/docs/installation/python/index.rst
+++ b/docs/installation/python/index.rst
@@ -155,6 +155,8 @@ change certain things, such as the database connection:
 
     # for more information on DATABASES, see the Django configuration at:
     # https://docs.djangoproject.com/en/stable/ref/databases/
+    # note that this may refer to a different Django version than what
+    # Sentry uses, so there may be some discrepancies 
     DATABASES = {
         'default': {
             'ENGINE': 'sentry.db.postgres',

--- a/docs/installation/python/index.rst
+++ b/docs/installation/python/index.rst
@@ -154,7 +154,7 @@ change certain things, such as the database connection:
     # ~/.sentry/sentry.conf.py
 
     # for more information on DATABASES, see the Django configuration at:
-    # https://docs.djangoproject.com/en/1.6/ref/databases/
+    # https://docs.djangoproject.com/en/stable/ref/databases/
     DATABASES = {
         'default': {
             'ENGINE': 'sentry.db.postgres',


### PR DESCRIPTION
Looks like Django eventually removes the docs for no longer supported versions. In this particular case, I think it's fine to just reference the stable docs.