### PR TITLE
fix github url, default to not linking to other providers

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -19,6 +19,7 @@ const ReleaseCommit = React.createClass({
   },
 
   getCommitUrl() {
+    // TODO(jess): move this to plugins
     if (this.props.repository.provider.id === 'github') {
       return this.props.repository.url + '/commit/' + this.props.commitId;
     }

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -17,7 +17,15 @@ const ReleaseCommit = React.createClass({
     repository: React.PropTypes.object,
 
   },
+
+  getCommitUrl() {
+    if (this.props.repository.provider.id === 'github') {
+      return this.props.repository.url + '/commit/' + this.props.commitId;
+    }
+  },
+
   render() {
+    let commitUrl = this.getCommitUrl();
     return (
       <li className="list-group-item" key={this.props.commitId}>
         <div className="row row-center-vertically">
@@ -28,10 +36,12 @@ const ReleaseCommit = React.createClass({
           </div>
           <div className="col-xs-2"><span className="repo-label">{this.props.repository.name}</span></div>
           <div className="col-xs-2 align-right">
-            <a className="btn btn-default btn-sm"
-               href={this.props.repository.url + '/' + this.props.commitId}
-               target="_blank"><span
-               className={'icon-mark-' + this.props.repository.provider.id}/>&nbsp; {this.props.shortId}</a>
+            {commitUrl ?
+              <a className="btn btn-default btn-sm"
+                 href={commitUrl}
+                 target="_blank"><span
+                 className={'icon-mark-' + this.props.repository.provider.id}/>&nbsp; {this.props.shortId}</a> :
+              <span>{this.props.shortId}</span>}
           </div>
         </div>
       </li>


### PR DESCRIPTION
my repo urls are properly populated locally, so i'm guessing that was a separate bug that has already been fixed. we should probably just repair that data in production. the github url was slightly wrong though, so fixed that.