### PR TITLE
mark groups as resolved when commits are associated with releases

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Version 8.15 (Unreleased)
 - Added support for the new symbol server system to support native SDKs better.
 - Added deploy email
 - Added OAuth2 support to the web API.
+- Resolve issues when commits with ``Fixes SHORTID`` are included in releases
 
 API Changes
 ~~~~~~~~~~~


### PR DESCRIPTION
this finishes the `fixed in <sentry-short-id>` flow so groups will actually be marked as resolved

cc @benvinegar @kjlundsgaard @ckj @MaxBittker 