### PR TITLE
Bump raven-js to 3.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "platformicons": "0.1.1",
     "po-catalog-loader": "^1.2.0",
     "query-string": "2.4.2",
-    "raven-js": "3.12.1",
+    "raven-js": "3.13.0",
     "react": "15.3.2",
     "react-addons-css-transition-group": "15.3.2",
     "react-addons-pure-render-mixin": "15.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4258,9 +4258,9 @@ range-parser@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@3.9.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.9.1.tgz#d0482100849ea0ab91058308dfa1ec97bc073bac"
+raven-js@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.13.0.tgz#baf9d7f913524e8782578e766931194dba2ac93a"
   dependencies:
     json-stringify-safe "^5.0.1"
 


### PR DESCRIPTION
cc @getsentry/javascript 