### PR TITLE
Scope number new issues in release to specified project

### DIFF
--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -27,9 +27,9 @@ const VersionHoverCard = React.createClass({
   },
 
   componentDidMount() {
-    let {orgId, version} = this.props;
+    let {orgId, projectId, version} = this.props;
 
-    let path = `/organizations/${orgId}/releases/${version}/`;
+    let path = `/projects/${orgId}/${projectId}/releases/${version}/`;
     this.api.request(path, {
       method: 'GET',
       success: (data, _, jqXHR) => {


### PR DESCRIPTION
Makes `VersionHoverCard` show the number of new issues for a specific project rather than organization wide new issue count for a release.

@benvinegar  