### PR TITLE
List files by repository

### DIFF
--- a/src/sentry/api/serializers/models/filechange.py
+++ b/src/sentry/api/serializers/models/filechange.py
@@ -14,8 +14,7 @@ class CommitFileChangeSerializer(Serializer):
         author_objs = get_users_for_commits(commits)
         commits_by_id = {commit.id: commit for commit in commits}
 
-        repositories = Repository.objects.filter(id__in=[commit.repository_id for commit in commits])
-        repo_names_by_id = {repository.id: repository.name for repository in repositories}
+        repo_names_by_id = dict(Repository.objects.filter(id__in=[commit.repository_id for commit in commits]).values_list('id', 'name'))
 
         result = {}
         for item in item_list:
@@ -23,7 +22,7 @@ class CommitFileChangeSerializer(Serializer):
             result[item] = {
                 'user': author_objs.get(commit.author_id, {}),
                 'message': commit.message,
-                'repository_name': repo_names_by_id[commit.repository_id]
+                'repository_name': repo_names_by_id.get(commit.repository_id)
             }
 
         return result

--- a/src/sentry/api/serializers/models/filechange.py
+++ b/src/sentry/api/serializers/models/filechange.py
@@ -13,13 +13,17 @@ class CommitFileChangeSerializer(Serializer):
         commits = Commit.objects.filter(id__in=[f.commit_id for f in item_list]).select_related('author')
         author_objs = get_users_for_commits(commits)
         commits_by_id = {commit.id: commit for commit in commits}
+
+        repositories = Repository.objects.filter(id__in=[commit.repository_id for commit in commits])
+        repo_names_by_id = {repository.id: repository.name for repository in repositories}
+
         result = {}
         for item in item_list:
             commit = commits_by_id[item.commit_id]
             result[item] = {
                 'user': author_objs.get(commit.author_id, {}),
                 'message': commit.message,
-                'repository_name': Repository.objects.get(id=commit.repository_id).name
+                'repository_name': repo_names_by_id[commit.repository_id]
             }
 
         return result

--- a/src/sentry/api/serializers/models/filechange.py
+++ b/src/sentry/api/serializers/models/filechange.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import Commit, CommitFileChange
+from sentry.models import Commit, CommitFileChange, Repository
 from sentry.api.serializers.models.release import get_users_for_commits
 
 
@@ -18,7 +18,8 @@ class CommitFileChangeSerializer(Serializer):
             commit = commits_by_id[item.commit_id]
             result[item] = {
                 'user': author_objs.get(commit.author_id, {}),
-                'message': commit.message
+                'message': commit.message,
+                'repository_name': Repository.objects.get(id=commit.repository_id).name
             }
 
         return result
@@ -26,9 +27,10 @@ class CommitFileChangeSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
             'id': six.text_type(obj.id),
-            'org_id': obj.organization_id,
+            'orgId': obj.organization_id,
             'author': attrs.get('user', {}),
-            'commit_message': attrs.get('message', ''),
+            'commitMessage': attrs.get('message', ''),
             'filename': obj.filename,
-            'type': obj.type
+            'type': obj.type,
+            'repoName': attrs.get('repository_name', ''),
         }

--- a/src/sentry/api/serializers/models/filechange.py
+++ b/src/sentry/api/serializers/models/filechange.py
@@ -10,11 +10,13 @@ from sentry.api.serializers.models.release import get_users_for_commits
 @register(CommitFileChange)
 class CommitFileChangeSerializer(Serializer):
     def get_attrs(self, item_list, user):
-        commits = Commit.objects.filter(id__in=[f.commit_id for f in item_list]).select_related('author')
+        commits = list(Commit.objects.filter(id__in=[f.commit_id for f in item_list]).select_related('author'))
         author_objs = get_users_for_commits(commits)
         commits_by_id = {commit.id: commit for commit in commits}
 
-        repo_names_by_id = dict(Repository.objects.filter(id__in=[commit.repository_id for commit in commits]).values_list('id', 'name'))
+        repo_names_by_id = dict(Repository.objects.filter(
+            id__in=[commit.repository_id for commit in commits]
+        ).values_list('id', 'name'))
 
         result = {}
         for item in item_list:

--- a/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
@@ -50,7 +50,7 @@ const RepositoryFileSummary = React.createClass({
       files = files.slice(0, MAX);
     }
     let numCollapsed = fileCount - files.length;
-
+    let canCollapse = fileCount > MAX;
     return(
       <ul className="list-group list-group-striped m-b-2">
       <h6>{fileCount} {fileCount !== 1 ? t('files ') : t('file ')} {t('changed in ')} {repository}</h6>
@@ -66,6 +66,12 @@ const RepositoryFileSummary = React.createClass({
         );
       })}
       {numCollapsed > 0 && <Collapsed onClick={this.onCollapseToggle} count={numCollapsed}/>}
+      {numCollapsed === 0 && canCollapse &&
+        <li className="list-group-item list-group-item-sm align-center">
+          <span className="icon-container"></span>
+          <a onClick={this.onCollapseToggle}>Collapse</a>
+        </li>
+      }
       </ul>);
 }
 });

--- a/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import FileChange from './fileChange';
+import {t} from '../locale';
+
+function Collapsed(props) {
+  return (
+    <li className="list-group-item list-group-item-sm align-center">
+      <span className="icon-container">
+      </span>
+      <a onClick={props.onClick}>Show {props.count} collapsed files</a>
+    </li>
+  );
+}
+
+Collapsed.propTypes = {
+  onClick: React.PropTypes.func.isRequired,
+  count: React.PropTypes.number.isRequired
+};
+
+const RepositoryFileSummary = React.createClass({
+  propTypes: {
+    fileChangeSummary: React.PropTypes.object,
+    repository: React.PropTypes.string,
+  },
+
+  statics: {
+    MAX_WHEN_COLLAPSED: 5
+  },
+
+  getInitialState() {
+    return {
+      loading: true,
+      collapsed: true,
+    };
+  },
+
+  onCollapseToggle() {
+    this.setState({
+      collapsed: !this.state.collapsed
+    });
+  },
+
+  render() {
+    let {repository, fileChangeSummary} = this.props;
+    const MAX = RepositoryFileSummary.MAX_WHEN_COLLAPSED;
+    let files = Object.keys(fileChangeSummary);
+    let fileCount = files.length;
+    files.sort();
+    if (this.state.collapsed && fileCount > MAX) {
+      files = files.slice(0, MAX);
+    }
+    let numCollapsed = fileCount - files.length;
+
+    return(
+      <ul className="list-group list-group-striped m-b-2">
+      <h6>{fileCount} {fileCount !== 1 ? t('files ') : t('file ')} {t('changed in ')} {repository}</h6>
+      {files.map(filename => {
+      let {id, authors, types} = fileChangeSummary[filename];
+        return (
+          <FileChange
+            key={id}
+            filename={filename}
+            authors={Object.values(authors)}
+            types={types}
+            />
+        );
+      })}
+      {numCollapsed > 0 && <Collapsed onClick={this.onCollapseToggle} count={numCollapsed}/>}
+      </ul>);
+}
+});
+
+export default RepositoryFileSummary;

--- a/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import FileChange from './fileChange';
-import {t} from '../locale';
+import {tn} from '../locale';
 
 function Collapsed(props) {
   return (
     <li className="list-group-item list-group-item-sm align-center">
       <span className="icon-container">
       </span>
-      <a onClick={props.onClick}>Show {props.count} collapsed files</a>
+      <a onClick={props.onClick}>{tn(('Show ' + props.count + ' collapsed file'), ('Show ' + props.count + ' collapsed files'), props.count)}</a>
     </li>
   );
 }
@@ -53,9 +53,11 @@ const RepositoryFileSummary = React.createClass({
     let canCollapse = fileCount > MAX;
     return(
       <ul className="list-group list-group-striped m-b-2">
-      <h6>{fileCount} {fileCount !== 1 ? t('files ') : t('file ')} {t('changed in ')} {repository}</h6>
+      <h6>
+        {fileCount} {tn((' file changed in ' + repository), (' files changed in ' + repository), fileCount)}
+      </h6>
       {files.map(filename => {
-      let {id, authors, types} = fileChangeSummary[filename];
+        let {id, authors, types} = fileChangeSummary[filename];
         return (
           <FileChange
             key={id}

--- a/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import FileChange from './fileChange';
-import {tn} from '../locale';
+import {t, tn} from '../locale';
 
 function Collapsed(props) {
   return (
     <li className="list-group-item list-group-item-sm align-center">
       <span className="icon-container">
       </span>
-      <a onClick={props.onClick}>{tn(('Show ' + props.count + ' collapsed file'), ('Show ' + props.count + ' collapsed files'), props.count)}</a>
+      <a onClick={props.onClick}>{tn(('Show %d collapsed file'), ('Show %d collapsed files'), props.count)}</a>
     </li>
   );
 }
@@ -54,7 +54,7 @@ const RepositoryFileSummary = React.createClass({
     return(
       <ul className="list-group list-group-striped m-b-2">
       <h6>
-        {fileCount} {tn((' file changed in ' + repository), (' files changed in ' + repository), fileCount)}
+        {tn(('%d file changed in ' + repository), ('%d files changed in ' + repository), fileCount)}
       </h6>
       {files.map(filename => {
         let {id, authors, types} = fileChangeSummary[filename];
@@ -71,7 +71,7 @@ const RepositoryFileSummary = React.createClass({
       {numCollapsed === 0 && canCollapse &&
         <li className="list-group-item list-group-item-sm align-center">
           <span className="icon-container"></span>
-          <a onClick={this.onCollapseToggle}>Collapse</a>
+          <a onClick={this.onCollapseToggle}>{t('Collapse')}</a>
         </li>
       }
       </ul>);

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -3,37 +3,18 @@ import React from 'react';
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
 import IssueList from '../../components/issueList';
-import FileChange from '../../components/fileChange';
 import CommitAuthorStats from '../../components/commitAuthorStats';
 import ReleaseProjectStatSparkline from '../../components/releaseProjectStatSparkline';
+import RepositoryFileSummary from '../../components/repositoryFileSummary';
 import TimeSince from '../../components/timeSince';
 
 import ApiMixin from '../../mixins/apiMixin';
 
 import {t} from '../../locale';
 
-function Collapsed(props) {
-  return (
-    <li className="list-group-item list-group-item-sm align-center">
-      <span className="icon-container">
-      </span>
-      <a onClick={props.onClick}>Show {props.count} collapsed files</a>
-    </li>
-  );
-}
-
-Collapsed.propTypes = {
-  onClick: React.PropTypes.func.isRequired,
-  count: React.PropTypes.number.isRequired
-};
-
 const ReleaseOverview = React.createClass({
 
   mixins: [ApiMixin],
-
-  statics: {
-    MAX_WHEN_COLLAPSED: 5
-  },
 
   getInitialState() {
     return {
@@ -41,7 +22,6 @@ const ReleaseOverview = React.createClass({
       error: false,
       projects: [],
       fileList: [],
-      collapsed: true,
       deploys: [],
       hasRepos: false,
     };
@@ -129,12 +109,6 @@ const ReleaseOverview = React.createClass({
     return <div className="box empty">{t('None')}</div>;
   },
 
-  onCollapseToggle() {
-    this.setState({
-      collapsed: !this.state.collapsed
-    });
-  },
-
   render() {
     let {orgId, projectId, version} = this.props.params;
 
@@ -148,7 +122,7 @@ const ReleaseOverview = React.createClass({
 
     // convert list of individual file changes (can be
     // multiple changes to a single file) into a per-file
-    // summary
+    // summary grouped by repository
     let filesByRepository = fileList.reduce(function (fbr, file) {
       let {filename, repoName, author, type} = file;
       if (!fbr.hasOwnProperty(repoName)) {
@@ -165,31 +139,7 @@ const ReleaseOverview = React.createClass({
 
       return fbr;
     }, {});
-    console.log(filesByRepository);
-    let fileChangeSummary = fileList.reduce(function (summary, fileChange) {
-      let {author, type, filename} = fileChange;
-      if (!summary.hasOwnProperty(filename)) {
-        summary[filename] = {
-          authors: {}, types: new Set(), repos: new Set(),
-        };
-      }
 
-      summary[filename].authors[author.email] = author;
-      summary[filename].types.add(type);
-
-      return summary;
-    }, {});
-    // console.log(fileChangeSummary);
-    let fileCount = Object.keys(fileChangeSummary).length;
-
-    // const MAX = ReleaseOverview.MAX_WHEN_COLLAPSED;
-
-    // let files = Object.keys(fileChangeSummary);
-    // files.sort();
-    // if (this.state.collapsed && fileCount > MAX) {
-    //   files = files.slice(0, MAX);
-    // }
-    // let numCollapsed = fileCount - files.length;
     let deploys = this.state.deploys;
     return (
       <div>
@@ -222,25 +172,10 @@ const ReleaseOverview = React.createClass({
               />
             {hasRepos &&
               <div>
-                <h5>{fileCount} Files Changed</h5>
                 {Object.keys(filesByRepository).map(repository => {
-                  let files = Object.keys(filesByRepository[repository]);
-                  files.sort();
-                  return(
-                    <ul className="list-group list-group-striped m-b-2">
-                    <h6>{repository}: </h6>
-                    {files.map(filename => {
-                    let {id, authors, types} = filesByRepository[repository][filename];
-                      return (
-                        <FileChange
-                          key={id}
-                          filename={filename}
-                          authors={Object.values(authors)}
-                          types={types}
-                          />
-                      );
-                    })}
-                    </ul>);
+                  return (<RepositoryFileSummary
+                            repository={repository}
+                            fileChangeSummary={filesByRepository[repository]}/>);
                 })}
               </div>
             }

--- a/tests/sentry/api/serializers/test_commit_filechange.py
+++ b/tests/sentry/api/serializers/test_commit_filechange.py
@@ -51,7 +51,7 @@ class CommitFileChangeSerializerTest(TestCase):
         result = serialize(cfc, user)
 
         assert result['filename'] == '.gitignore'
-        assert result['commit_message'] == 'waddap'
+        assert result['commitMessage'] == 'waddap'
         assert result['author'] == {'name': 'stebe', 'email': 'stebe@sentry.io'}
 
     def test_no_author(self):


### PR DESCRIPTION
Separates the files in Files Changed list for the Release Overview tab by their respective repositories

Now looks more like:
![screen shot 2017-03-23 at 5 33 23 pm](https://cloud.githubusercontent.com/assets/9269824/24275766/24322b00-0fef-11e7-93df-158b3e9a7691.png)

Design suggestions welcome/appreciated.
@ckj @macqueen  @MaxBittker @benvinegar 

#nochanges