### PR TITLE
[releases] handle missing commit message/author, fix release project sparklines

### DIFF
--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -7,7 +7,7 @@ import LoadingError from '../components/loadingError';
 
 import ApiMixin from '../mixins/apiMixin';
 
-import {tn} from '../locale';
+import {t, tn} from '../locale';
 
 const ReleaseProjectStatSparkline = React.createClass({
   propTypes: {
@@ -88,11 +88,9 @@ const ReleaseProjectStatSparkline = React.createClass({
           <h6 className="m-b-0">
             {project.name}
           </h6>
-          {newIssueCount > 0 &&
-            <p className="m-b-0">
-              {tn('%d New Issue', '%d New Issues', newIssueCount)}
-            </p>
-          }
+          <p className="m-b-0">
+            {newIssueCount > 0 ? tn('%d New Issue', '%d New Issues', newIssueCount) : t('No New Issues')}
+          </p>
         </Link>
       </li>
     );

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -7,6 +7,8 @@ import TimeSince from '../../components/timeSince';
 
 import ApiMixin from '../../mixins/apiMixin';
 
+import {t} from '../../locale';
+
 const ReleaseCommit = React.createClass({
   propTypes: {
     commitId: React.PropTypes.string,
@@ -15,7 +17,6 @@ const ReleaseCommit = React.createClass({
     commitDateCreated: React.PropTypes.string,
     author: React.PropTypes.object,
     repository: React.PropTypes.object,
-
   },
 
   getCommitUrl() {
@@ -32,8 +33,8 @@ const ReleaseCommit = React.createClass({
         <div className="row row-center-vertically">
           <div className="col-xs-8 list-group-avatar">
             <Avatar user={this.props.author}/>
-            <h5>{this.props.commitMessage}</h5>
-            <p><strong>{this.props.author.name}</strong> committed <TimeSince date={this.props.commitDateCreated} /></p>
+            <h5>{this.props.commitMessage || t('No message provided')}</h5>
+            <p><strong>{this.props.author.name || t('Unknown author')}</strong> committed <TimeSince date={this.props.commitDateCreated} /></p>
           </div>
           <div className="col-xs-2"><span className="repo-label">{this.props.repository.name}</span></div>
           <div className="col-xs-2 align-right">


### PR DESCRIPTION
makes this:
![screenshot 2017-03-27 11 07 13](https://cloud.githubusercontent.com/assets/5026776/24371348/5ac5b95a-12df-11e7-9a2c-1f55d86ce171.png)

look like this:
![screenshot 2017-03-27 11 07 57](https://cloud.githubusercontent.com/assets/5026776/24371355/629a0a46-12df-11e7-8b18-1d8c3c4f159f.png)

and this:
![screenshot 2017-03-27 11 15 02](https://cloud.githubusercontent.com/assets/5026776/24371386/6fdd6e46-12df-11e7-8781-0eb50e94f447.png)

look like this:
![screenshot 2017-03-27 11 15 26](https://cloud.githubusercontent.com/assets/5026776/24371393/784c3b3e-12df-11e7-9927-f06375228cd8.png)
