### PR TITLE
auth: Move logout action to POST instead of GET

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/userNav.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/userNav.jsx
@@ -4,6 +4,7 @@ import DropdownLink from '../dropdownLink';
 import Avatar from '../avatar';
 import MenuItem from '../menuItem';
 import {t} from '../../locale';
+import auth from '../../utils/auth';
 
 const UserNav = React.createClass({
   contextTypes: {
@@ -41,7 +42,7 @@ const UserNav = React.createClass({
         {user.isSuperuser &&
           <MenuItem {...to('/manage/')}>{t('Admin')}</MenuItem>
         }
-        <MenuItem href="/auth/logout/">{t('Sign out')}</MenuItem>
+        <MenuItem onSelect={auth.signOut} href="/auth/logout/">{t('Sign out')}</MenuItem>
       </DropdownLink>
     );
   }

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -1,25 +1,9 @@
 import jQuery from 'jquery';
 
 import plugins from './plugins';
+import cookies from './utils/cookies';
 
 const csrfCookieName = window.csrfCookieName || 'sc';
-
-// setup jquery for CSRF tokens
-function getCookie(name) {
-  let cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-    let cookies = document.cookie.split(';');
-    for (let i = 0; i < cookies.length; i++) {
-      let cookie = jQuery.trim(cookies[i]);
-      // Does this cookie string begin with the name we want?
-      if (cookie.substring(0, name.length + 1) == (name + '=')) {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
-  }
-  return cookieValue;
-}
 
 function csrfSafeMethod(method) {
   // these HTTP methods do not require CSRF protection
@@ -29,7 +13,7 @@ function csrfSafeMethod(method) {
 jQuery.ajaxSetup({
   beforeSend: function(xhr, settings) {
     if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-      xhr.setRequestHeader('X-CSRFToken', getCookie(csrfCookieName));
+      xhr.setRequestHeader('X-CSRFToken', cookies.get(csrfCookieName));
     }
   }
 });

--- a/src/sentry/static/sentry/app/utils/auth.jsx
+++ b/src/sentry/static/sentry/app/utils/auth.jsx
@@ -1,0 +1,16 @@
+import cookies from './cookies';
+
+export default {
+  signOut: function () {
+    let form = document.createElement('form');
+    form.setAttribute('method', 'post');
+    form.setAttribute('action', '/auth/logout/');
+    let input = document.createElement('input');
+    input.setAttribute('name', 'csrfmiddlewaretoken');
+    input.setAttribute('value', cookies.get(window.csrfCookieName || 'sc'));
+    input.setAttribute('type', 'hidden');
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
+  }
+};

--- a/src/sentry/static/sentry/app/utils/cookies.jsx
+++ b/src/sentry/static/sentry/app/utils/cookies.jsx
@@ -1,0 +1,17 @@
+export default {
+  get: function (name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+      let cookies = document.cookie.split(';');
+      for (let i = 0; i < cookies.length; i++) {
+        let cookie = jQuery.trim(cookies[i]);
+        // Does this cookie string begin with the name we want?
+        if (cookie.substring(0, name.length + 1) == (name + '=')) {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return cookieValue;
+  }
+};

--- a/src/sentry/templates/sentry/bases/account.html
+++ b/src/sentry/templates/sentry/bases/account.html
@@ -13,7 +13,10 @@
 <div class="box box-modal">
   <div class="box-header">
     <div class="pull-right">
-      <a href="{% url 'sentry-logout' %}">{% trans "Sign out" %}</a>
+      <form id='form-logout' action="{% url 'sentry-logout' %}" method="post">
+        {% csrf_token %}
+        <a href="{% url 'sentry-logout' %}" onclick="return document.getElementById('form-logout').submit() || false">{% trans "Sign out" %}</a>
+      </form>
     </div>
     <a href="/">
       <span class="icon-sentry-logo"></span>

--- a/src/sentry/templates/sentry/bases/modal.html
+++ b/src/sentry/templates/sentry/bases/modal.html
@@ -15,7 +15,10 @@
         {% block modal_header_signout %}
           {% if request.user.is_authenticated %}
             <div class="pull-right">
-              <a href="{% url 'sentry-logout' %}">{% trans "Sign out" %}</a>
+              <form id='form-logout' action="{% url 'sentry-logout' %}" method="post">
+                {% csrf_token %}
+                <a href="{% url 'sentry-logout' %}" onclick="return document.getElementById('form-logout').submit() || false">{% trans "Sign out" %}</a>
+              </form>
             </div>
           {% endif %}
         {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -126,7 +126,12 @@
               {% if request.is_superuser %}
                 <li><a href="{% url 'sentry-admin-overview' %}">{% trans "Admin" %}</a></li>
               {% endif %}
-              <li><a href="{% url 'sentry-logout' %}">{% trans "Sign out" %}</a></li>
+              <li>
+                <form id='form-logout' action="{% url 'sentry-logout' %}" method="post">
+                  {% csrf_token %}
+                  <a href="{% url 'sentry-logout' %}" onclick="return document.getElementById('form-logout').submit() || false">{% trans "Sign out" %}</a>
+                </form>
+              </li>
             </ul>
           </div>
         </div>

--- a/src/sentry/templates/sentry/logout.html
+++ b/src/sentry/templates/sentry/logout.html
@@ -1,0 +1,18 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Logout" %} | {{ block.super }}{% endblock %}
+
+{% block modal_header_signout %}{% endblock %}
+
+{% block auth_main %}
+<form class="form-stacked" method="post">
+  {% csrf_token %}
+  <div class="p-b-2 align-center" style="margin-top: 25px">
+    <button class="btn btn-primary">Sign out of this session</button>
+    <button class="btn btn-default" name="all" value="1">Sign out all sessions</button>
+  </div>
+</form>
+{% endblock %}

--- a/src/sentry/web/frontend/auth_logout.py
+++ b/src/sentry/web/frontend/auth_logout.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from django.contrib.auth import logout, REDIRECT_FIELD_NAME
 from django.contrib.auth.models import AnonymousUser
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
 from sudo.utils import is_safe_url
 
 from sentry.web.frontend.base import BaseView
@@ -11,10 +13,26 @@ from sentry.utils import auth
 class AuthLogoutView(BaseView):
     auth_required = False
 
-    def handle(self, request):
+    def redirect(self, request):
         next = request.GET.get(REDIRECT_FIELD_NAME, '')
         if not is_safe_url(next, host=request.get_host()):
             next = auth.get_login_url()
+        return super(AuthLogoutView, self).redirect(next)
+
+    def dispatch(self, request):
+        if not request.user.is_authenticated():
+            return self.redirect(request)
+        return super(AuthLogoutView, self).dispatch(request)
+
+    def get(self, request):
+        return self.respond('sentry/logout.html')
+
+    @method_decorator(csrf_protect)
+    def post(self, request):
+        if 'all' in request.POST:
+            # Rotate all session tokens
+            request.user.refresh_session_nonce(request)
+            request.user.save()
         logout(request)
         request.user = AnonymousUser()
-        return self.redirect(next)
+        return self.redirect(request)

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -4,6 +4,7 @@ from django.core.urlresolvers import reverse
 from exam import fixture
 from six.moves.urllib.parse import quote
 
+from sentry.models import User
 from sentry.testutils import TestCase
 
 
@@ -15,12 +16,14 @@ class AuthLogoutTest(TestCase):
     def test_logs_user_out(self):
         self.login_as(self.user)
 
-        resp = self.client.get(self.path)
+        session_nonce = self.user.session_nonce
+        resp = self.client.post(self.path)
         assert resp.status_code == 302
         assert list(self.client.session.keys()) == []
+        assert User.objects.get(id=self.user.id).session_nonce == session_nonce
 
     def test_same_behavior_with_anonymous_user(self):
-        resp = self.client.get(self.path)
+        resp = self.client.post(self.path)
         assert resp.status_code == 302
         assert list(self.client.session.keys()) == []
 
@@ -28,15 +31,29 @@ class AuthLogoutTest(TestCase):
         self.login_as(self.user)
 
         next = '/welcome'
-        resp = self.client.get(self.path + '?next=' + next)
+        resp = self.client.post(self.path + '?next=' + next)
         assert resp.status_code == 302
         assert resp.get('Location', '').endswith(next)
 
     def test_doesnt_redirect_to_external_next_url(self):
+        self.login_as(self.user)
+
         next = "http://example.com"
-        self.client.get(self.path + '?next=' + quote(next))
+        self.client.post(self.path + '?next=' + quote(next))
 
         resp = self.client.get(self.path)
         assert resp.status_code == 302
         assert next not in resp['Location']
         assert resp['Location'] == 'http://testserver/auth/login/'
+
+    def test_logout_all_sessions(self):
+        self.login_as(self.user)
+        session_nonce = self.user.session_nonce
+        resp = self.client.post(self.path, data={'all': '1'})
+        assert resp.status_code == 302
+        assert User.objects.get(id=self.user.id).session_nonce != session_nonce
+
+    def test_logout_get(self):
+        self.login_as(self.user)
+        resp = self.client.get(self.path)
+        self.assertTemplateUsed(resp, 'sentry/logout.html')


### PR DESCRIPTION
* Prevents being able to use a GET request to forcefully log someone
out. Otherwise, it's too easy to be annoying and coerce this behavior.
* POST is blocked behind a CSRF token to prevent the above as well.

![image](https://cloud.githubusercontent.com/assets/375744/24385084/d78dcc92-131c-11e7-9521-dec488bebb2e.png)
