### PR TITLE
auth: Add a maximum length to passwords

### DIFF
--- a/src/sentry/auth/password_validation.py
+++ b/src/sentry/auth/password_validation.py
@@ -104,6 +104,33 @@ class MinimumLengthValidator(object):
         ) % {'min_length': self.min_length}
 
 
+class MaximumLengthValidator(object):
+    """
+    Validate whether the password is of a maximum length.
+    """
+    def __init__(self, max_length=256):
+        self.max_length = max_length
+
+    def validate(self, password):
+        if len(password) > self.max_length:
+            raise ValidationError(
+                ungettext(
+                    "This password is too long. It must contain no more than %(max_length)d character.",
+                    "This password is too long. It must contain no more than %(max_length)d characters.",
+                    self.max_length
+                ),
+                code='password_too_long',
+                params={'max_length': self.max_length},
+            )
+
+    def get_help_text(self):
+        return ungettext(
+            "Your password must contain no more than %(max_length)d character.",
+            "Your password must contain no more than %(max_length)d characters.",
+            self.max_length
+        ) % {'max_length': self.max_length}
+
+
 class NumericPasswordValidator(object):
     """
     Validate whether the password is alphanumeric.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -344,6 +344,12 @@ AUTH_PASSWORD_VALIDATORS = [
             'min_length': 6,
         },
     },
+    {
+        'NAME': 'sentry.auth.password_validation.MaximumLengthValidator',
+        'OPTIONS': {
+            'max_length': 256,
+        },
+    },
 ]
 
 SOCIAL_AUTH_USER_MODEL = AUTH_USER_MODEL = 'sentry.User'


### PR DESCRIPTION
This comes up enough as a security issue that I'm going to fix it even
though it's hardly a measurable issue for us.

The argument is: without a limit here, the hashing algorithm can be
exploited by giving it tons of data.

For sentry.io, this limit is effectively set to 5MB, since that's the
max file size that can be uploaded through normal requests. After
testing, a password of this size has hardly any affect on us and would
be _really_ hard to abuse via this vector. But regardless, to make
people stop, it's unrealistic that anyone would have a password more
than 256 characters and it just stops any potential here. 1Password's
longest password it can generate is 64 characters, for example.