### PR TITLE
Automatic dsym file mapping

### DIFF
--- a/src/sentry/lang/native/dsymcache.py
+++ b/src/sentry/lang/native/dsymcache.py
@@ -27,11 +27,12 @@ class DSymCache(object):
     def get_global_path(self):
         return os.path.join(self.dsym_cache_path, 'global')
 
-    def fetch_dsyms(self, project, uuids):
+    def fetch_dsyms(self, project, uuids, on_dsym_file_referenced=None):
         bases = set()
         loaded = set()
         for image_uuid in uuids:
-            base = self.fetch_dsym(project, image_uuid)
+            base = self.fetch_dsym(project, image_uuid,
+                on_dsym_file_referenced=on_dsym_file_referenced)
             if base is not None:
                 loaded.add(image_uuid)
                 bases.add(base)
@@ -43,7 +44,7 @@ class DSymCache(object):
             os.utime(path, (now, now))
         return path
 
-    def fetch_dsym(self, project, image_uuid):
+    def fetch_dsym(self, project, image_uuid, on_dsym_file_referenced=None):
         image_uuid = image_uuid.lower()
         for path in self.get_project_path(project), self.get_global_path():
             base = self.get_project_path(project)
@@ -63,6 +64,8 @@ class DSymCache(object):
         if dsf.is_global:
             base = self.get_global_path()
         else:
+            if on_dsym_file_referenced is not None:
+                on_dsym_file_referenced(dsf)
             base = self.get_project_path(project)
         dsym = os.path.join(base, image_uuid)
 

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -12,14 +12,15 @@ from symsynd.heuristics import find_best_instruction
 from symsynd.utils import parse_addr
 
 from sentry import options
-from sentry.models import Project, EventError
+from sentry.models import Project, EventError, VersionDSymFile, DSymPlatform, \
+    DSymApp
 from sentry.plugins import Plugin2
 from sentry.lang.native.symbolizer import Symbolizer, SymbolicationFailed, \
     ImageLookup
 from sentry.lang.native.utils import \
     find_apple_crash_report_referenced_images, get_sdk_from_event, \
     get_sdk_from_apple_system_info, cpu_name_from_data, APPLE_SDK_MAPPING, \
-    rebase_addr
+    rebase_addr, version_build_from_data
 from sentry.lang.native.systemsymbols import lookup_system_symbols
 from sentry.stacktraces import StacktraceProcessor
 from sentry.reprocessing import report_processing_issue
@@ -442,9 +443,27 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             for pf in processing_task.iter_processable_frames(self)
             if pf.cache_value is None and pf.data['image_uuid'] is not None)
 
+        def on_referenced(dsym_file):
+            app_info = version_build_from_data(self.data)
+            if app_info is not None:
+                dsym_app = DSymApp.objects.create_or_update_app(
+                    sync_id=None,
+                    app_id=app_info.id,
+                    project=self.project,
+                    data={'name': app_info.name},
+                    platform=DSymPlatform.APPLE,
+                )
+                version_dsym_file, created = VersionDSymFile.objects.get_or_create(
+                    dsym_file=dsym_file,
+                    dsym_app=dsym_app,
+                    version=app_info.version,
+                    build=app_info.build,
+                )
+
         self.sym = Symbolizer(self.project, self.image_lookup,
                               cpu_name=self.cpu_name,
-                              referenced_images=referenced_images)
+                              referenced_images=referenced_images,
+                              on_dsym_file_referenced=on_referenced)
 
         # The symbolizer gets a reference to the debug meta's images so
         # when it resolves the missing vmaddrs it changes them in the data

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -116,7 +116,8 @@ def find_system_symbol(img, instruction_addr, sdk_info=None, cpu_name=None):
     )
 
 
-def make_symbolizer(project, image_lookup, referenced_images=None):
+def make_symbolizer(project, image_lookup, referenced_images=None,
+        on_dsym_file_referenced=None):
     """Creates a symbolizer for the given project and binary images.  If a
     list of referenced images is referenced (UUIDs) then only images
     needed by those frames are loaded.
@@ -127,7 +128,8 @@ def make_symbolizer(project, image_lookup, referenced_images=None):
     if to_load is None:
         to_load = image_lookup.get_uuids()
 
-    dsym_paths, loaded = dsymcache.fetch_dsyms(project, to_load)
+    dsym_paths, loaded = dsymcache.fetch_dsyms(project, to_load,
+        on_dsym_file_referenced=on_dsym_file_referenced)
 
     # We only want to pass the actually loaded symbols to the report
     # symbolizer to avoid the expensive FS operations that will otherwise
@@ -176,14 +178,15 @@ class Symbolizer(object):
     """
 
     def __init__(self, project, binary_images, referenced_images=None,
-                 cpu_name=None):
+                 cpu_name=None, on_dsym_file_referenced=None):
         if isinstance(binary_images, ImageLookup):
             self.image_lookup = binary_images
         else:
             self.image_lookup = ImageLookup(binary_images)
         self.symsynd_symbolizer = make_symbolizer(
             project, self.image_lookup,
-            referenced_images=referenced_images)
+            referenced_images=referenced_images,
+            on_dsym_file_referenced=on_dsym_file_referenced)
         self.cpu_name = cpu_name
 
     def resolve_missing_vmaddrs(self):

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -164,13 +164,13 @@ def version_build_from_data(data):
     app_context = data.get('contexts', {}).get('app', {})
     if app_context is not None:
         if (app_context.get('app_identifier', None) and
-                app_context.get('app_short_version', None) and
                 app_context.get('app_version', None) and
+                app_context.get('app_build', None) and
                 app_context.get('app_name', None)):
             return AppInfo(
                 app_context.get('app_identifier', None),
-                app_context.get('app_short_version', None),
                 app_context.get('app_version', None),
+                app_context.get('app_build', None),
                 app_context.get('app_name', None),
             )
     return None

--- a/src/sentry/static/sentry/app/components/events/contexts/app.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app.jsx
@@ -10,8 +10,8 @@ const AppContextType = React.createClass({
 
   render() {
     let {app_id, app_start_time, device_app_hash, build_type,
-      app_identifier, app_name, app_short_version,
-      app_version, ...data} = this.props.data;
+      app_identifier, app_name, app_version,
+      app_build, ...data} = this.props.data;
     return (
       <ContextBlock
         data={data}
@@ -22,8 +22,8 @@ const AppContextType = React.createClass({
           ['?Build Type', build_type],
           ['?Bundle ID', app_identifier],
           ['?Bundle Name', app_name],
-          ['?Version', app_short_version],
-          ['?Build', app_version],
+          ['?Version', app_version],
+          ['?Build', app_build],
         ]}
         alias={this.props.alias} />
     );

--- a/src/sentry/static/sentry/app/components/events/contexts/app.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app.jsx
@@ -9,8 +9,9 @@ const AppContextType = React.createClass({
   },
 
   render() {
-    let {app_id, app_start_time, device_app_hash,
-      build_type, ...data} = this.props.data;
+    let {app_id, app_start_time, device_app_hash, build_type,
+      app_identifier, app_name, app_short_version,
+      app_version, ...data} = this.props.data;
     return (
       <ContextBlock
         data={data}
@@ -19,6 +20,10 @@ const AppContextType = React.createClass({
           ['?Start Time', app_start_time],
           ['?Device', device_app_hash],
           ['?Build Type', build_type],
+          ['?Bundle ID', app_identifier],
+          ['?Bundle Name', app_name],
+          ['?Version', app_short_version],
+          ['?Build', app_version],
         ]}
         alias={this.props.alias} />
     );

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from sentry.lang.native.utils import get_sdk_from_event, cpu_name_from_data
+from sentry.lang.native.utils import get_sdk_from_event, cpu_name_from_data, \
+    version_build_from_data
 
 
 def test_get_sdk_from_event():
@@ -53,6 +54,54 @@ def test_cpu_name_from_data():
     })
 
     assert cpu_name == 'arm64'
+
+
+def test_version_build_from_data():
+
+    app_info = version_build_from_data({
+        'app': {
+            'app_version': "2",
+            'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
+            'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
+            'app_short_version': "1.0",
+            'app_identifier': "com.rokkincat.SentryExample",
+            'app_name': "SwiftExample",
+            'app_start_time': "2017-03-28T15:14:01Z",
+            'type': "app",
+            'build_type': "simulator"
+        }
+    })
+    assert app_info.version == '1.0'
+    assert app_info.build == '2'
+    assert app_info.name == 'SwiftExample'
+    assert app_info.id == 'com.rokkincat.SentryExample'
+
+    app_info = version_build_from_data({
+        'app': {
+            'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
+            'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
+            'app_short_version': "1.0",
+            'app_identifier': "com.rokkincat.SentryExample",
+            'app_name': "SwiftExample",
+            'app_start_time': "2017-03-28T15:14:01Z",
+            'type': "app",
+            'build_type': "simulator"
+        }
+    })
+    assert app_info is None
+
+    app_info = version_build_from_data({
+        'app': {
+            'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
+            'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
+            'app_identifier': "com.rokkincat.SentryExample",
+            'app_name': "SwiftExample",
+            'app_start_time': "2017-03-28T15:14:01Z",
+            'type': "app",
+            'build_type': "simulator"
+        }
+    })
+    assert app_info is None
 
 
 def test_cpu_name_from_data_inferred_type():

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -59,16 +59,18 @@ def test_cpu_name_from_data():
 def test_version_build_from_data():
 
     app_info = version_build_from_data({
-        'app': {
-            'app_version': "2",
-            'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
-            'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
-            'app_short_version': "1.0",
-            'app_identifier': "com.rokkincat.SentryExample",
-            'app_name': "SwiftExample",
-            'app_start_time': "2017-03-28T15:14:01Z",
-            'type': "app",
-            'build_type': "simulator"
+        'contexts': {
+            'app': {
+                'app_build': "2",
+                'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
+                'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
+                'app_version': "1.0",
+                'app_identifier': "com.rokkincat.SentryExample",
+                'app_name': "SwiftExample",
+                'app_start_time': "2017-03-28T15:14:01Z",
+                'type': "app",
+                'build_type': "simulator"
+            }
         }
     })
     assert app_info.version == '1.0'
@@ -77,28 +79,41 @@ def test_version_build_from_data():
     assert app_info.id == 'com.rokkincat.SentryExample'
 
     app_info = version_build_from_data({
-        'app': {
-            'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
-            'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
-            'app_short_version': "1.0",
-            'app_identifier': "com.rokkincat.SentryExample",
-            'app_name': "SwiftExample",
-            'app_start_time': "2017-03-28T15:14:01Z",
-            'type': "app",
-            'build_type': "simulator"
+        'contexts': {
+            'app': {
+                'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
+                'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
+                'app_version': "1.0",
+                'app_identifier': "com.rokkincat.SentryExample",
+                'app_name': "SwiftExample",
+                'app_start_time': "2017-03-28T15:14:01Z",
+                'type': "app",
+                'build_type': "simulator"
+            }
         }
     })
     assert app_info is None
 
     app_info = version_build_from_data({
-        'app': {
-            'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
-            'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
-            'app_identifier': "com.rokkincat.SentryExample",
-            'app_name': "SwiftExample",
-            'app_start_time': "2017-03-28T15:14:01Z",
-            'type': "app",
-            'build_type': "simulator"
+        'contexts': {
+            'app': {
+                'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
+                'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
+                'app_identifier': "com.rokkincat.SentryExample",
+                'app_name': "SwiftExample",
+                'app_start_time': "2017-03-28T15:14:01Z",
+                'type': "app",
+                'build_type': "simulator"
+            }
+        }
+    })
+    assert app_info is None
+
+    app_info = version_build_from_data({
+        'contexts': {
+            'bal': {
+                'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
+            }
         }
     })
     assert app_info is None


### PR DESCRIPTION
#nochanges 

This PR adds automatic dsym file matching ...
It creates a `DSymApp`, `VersionDSymFile` and associates it with `ProjectDsymFile`

This will result in automatic moving debug symbols from unreferenced to this:
<img width="1872" alt="screen shot 2017-03-29 at 10 33 30" src="https://cloud.githubusercontent.com/assets/363802/24445714/30e35f88-146b-11e7-9336-273eb739e8b0.png">

This also adds more app info to the context:
<img width="398" alt="screen shot 2017-03-29 at 10 34 04" src="https://cloud.githubusercontent.com/assets/363802/24445739/4576a9aa-146b-11e7-86f6-b94026e6d891.png">

Corresponding swift PR
https://github.com/getsentry/sentry-swift/pull/140