### PR TITLE
Require configuration parameters to be passed for all Count-Min Sketch operations.

### DIFF
--- a/src/sentry/scripts/tsdb/cmsketch.lua
+++ b/src/sentry/scripts/tsdb/cmsketch.lua
@@ -11,7 +11,7 @@ potentially overcounting lower-frequency items due to hash collisions.
 This implementation extends the conventional Count-Min algorithm, adding an
 index that allows querying for the top N items that have been observed in the
 stream. The index also serves as the primary storage, reducing storage
-requirements and improving accuracy, auntil it's capacity is exceeded, at which
+requirements and improving accuracy, until it's capacity is exceeded, at which
 point the index data is used to initialize the estimation matrix. Once the
 index capacity as been exceeded and the estimation matrix has been initialized,
 the index of most frequent items is maintained using the estimates from the
@@ -23,9 +23,9 @@ The public API consists of three main methods:
 - ESTIMATE: used to query the number of times a specific item has been seen,
 - RANKED: used to query the top N items that have been recorded in a sketch.
 
-The named command to use is the first item passed as ``ARGV``. For commands
-that mutate data (`INCR`), the command is followed by the accuracy and storage
-parameters to use when initializing a new sketch:
+The named command to use is the first item passed as ``ARGV``.  The command is
+followed by the accuracy and storage parameters to use when initializing a new
+sketch:
 
 - DEPTH: number of rows for the estimation matrix,
 - WIDTH: number of columns for the estimation matrix,
@@ -38,7 +38,7 @@ The ``KEYS`` provided to each command are the two keys used for sketch storage:
 
 Multiple sketches can be provided to each command by providing another set of keys, e.g.
 
-    EVALSHA $SHA 6 1:config 1:index 1:estimates 2:config 2:index 2:estimates [...]
+    EVALSHA $SHA 4 1:index 1:estimates 2:index 2:estimates [...]
 
 (Whether a command returns a single result that encompasses all sketches, or a
 sequence of results that correspond to each sketch is dependent on the command
@@ -47,11 +47,11 @@ being called.)
 To add two items, "foo" with a score of 1, and "bar" with a score of 2 to two
 sketches with depth 5, width 64 and index capacity of 50:
 
-    EVALSHA $SHA 6 1:c 1:i 1:e 2:c 2:i 2:e INCR 5 64 50 1 foo 2 bar
+    EVALSHA $SHA 4 1:i 1:e 2:i 2:e INCR 5 64 50 1 foo 2 bar
 
-To query the top 5 items from the first sketch:
+To query the top 10 items from the first sketch:
 
-    EVALSHA $SHA 3 1:c 1:i 1:e RANKED 5
+    EVALSHA $SHA 2 1:i 1:e RANKED 5 64 50 10
 
 ]]--
 

--- a/src/sentry/scripts/tsdb/cmsketch.lua
+++ b/src/sentry/scripts/tsdb/cmsketch.lua
@@ -323,11 +323,7 @@ end
 
 local Command = {}
 
-function Command:new(fn, readonly)
-    if readonly == nil then
-        readonly = false
-    end
-
+function Command:new(fn)
     return function (keys, arguments)
         local configuration, arguments = (
             function (depth, width, index, ...)
@@ -388,8 +384,7 @@ return Router:new({
                 end,
                 sketches
             )
-        end,
-        false
+        end
     ),
 
     --[[
@@ -413,8 +408,7 @@ return Router:new({
                 end,
                 sketches
             )
-        end,
-        true
+        end
     ),
 
     --[[
@@ -516,7 +510,6 @@ return Router:new({
                 end
                 return trimmed
             end
-        end,
-        true
+        end
     )
 })(KEYS, ARGV)

--- a/src/sentry/scripts/tsdb/cmsketch.lua
+++ b/src/sentry/scripts/tsdb/cmsketch.lua
@@ -31,9 +31,6 @@ parameters to use when initializing a new sketch:
 - WIDTH: number of columns for the estimation matrix,
 - CAPACITY: maximum size of the index (to disable indexing entirely, set to 0.)
 
-(Configuration parameters are not required for readonly commands such as
-`ESTIMATE` and `RANKED`.)
-
 The ``KEYS`` provided to each command are the three keys used for sketch storage:
 
 - configuration key (bytes, serialized MessagePack data)
@@ -373,19 +370,16 @@ function Command:new(fn, readonly)
     end
 
     return function (keys, arguments)
-        local defaults = nil
-        if not readonly then
-            defaults, arguments = (
-                function (depth, width, index, ...)
-                    return {
-                        -- TODO: Actually validate these.
-                        depth=tonumber(depth),
-                        width=tonumber(width),
-                        index=tonumber(index)
-                    }, {...}
-                end
-            )(unpack(arguments))
-        end
+        local defaults, arguments = (
+            function (depth, width, index, ...)
+                return {
+                    -- TODO: Actually validate these.
+                    depth=tonumber(depth),
+                    width=tonumber(width),
+                    index=tonumber(index)
+                }, {...}
+            end
+        )(unpack(arguments))
 
         local sketches = {}
         for i = 1, #keys, 3 do

--- a/src/sentry/scripts/tsdb/cmsketch.lua
+++ b/src/sentry/scripts/tsdb/cmsketch.lua
@@ -201,7 +201,7 @@ function Sketch:coordinates(value)
 end
 
 function Sketch:exists()
-    return redis.call('EXISTS', self.estimates, self.index) > 0
+    return redis.call('EXISTS', self.index)
 end
 
 function Sketch:observations(coordinates)

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -385,7 +385,7 @@ class RedisTSDB(BaseTSDB):
         prefix = self.make_key(model, rollup, timestamp, key)
         return map(
             operator.methodcaller('format', prefix),
-            ('{}:c', '{}:i', '{}:e'),
+            ('{}:i', '{}:e'),
         )
 
     def record_frequency_multi(self, requests, timestamp=None):

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -433,7 +433,7 @@ class RedisTSDB(BaseTSDB):
 
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
-        arguments = ['RANKED']
+        arguments = ['RANKED'] + list(self.DEFAULT_SKETCH_PARAMETERS)
         if limit is not None:
             arguments.append(int(limit))
 
@@ -456,7 +456,7 @@ class RedisTSDB(BaseTSDB):
 
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
-        arguments = ['RANKED']
+        arguments = ['RANKED'] + list(self.DEFAULT_SKETCH_PARAMETERS)
         if limit is not None:
             arguments.append(int(limit))
 
@@ -485,16 +485,17 @@ class RedisTSDB(BaseTSDB):
 
         # Freeze ordering of the members (we'll need these later.)
         for key, members in items.items():
-            items[key] = tuple(members)
+            items[key] = list(members)
 
         commands = {}
 
+        arguments = ['ESTIMATE'] + list(self.DEFAULT_SKETCH_PARAMETERS)
         for key, members in items.items():
             ks = []
             for timestamp in series:
                 ks.extend(self.make_frequency_table_keys(model, rollup, timestamp, key))
 
-            commands[key] = [(CountMinScript, ks, ('ESTIMATE',) + members)]
+            commands[key] = [(CountMinScript, ks, arguments + members)]
 
         results = {}
 


### PR DESCRIPTION
This removes the persistent configuration key from the Count-Min Sketch storage, and requires the sketch parameters to be explicitly passed for all operations.

In practicality what this means is:

- we store one less highly redundant key for each sketch,
- all of the lazy configuration magic goes away, making changes to the data structure easier.

This comes with a few pretty significant caveats, but ones I think are probably worth making:

- if anybody blindly changes the tuning parameters *all of the data that is currently stored is subject to corruption*,
- there's no way to cleanly change the sketch parameters moving forward while maintaining data integrity without some additional legwork.

#nochanges