### PR TITLE
Fix duplicate authors in releases

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -97,13 +97,20 @@ class ReleaseSerializer(Serializer):
         commit_count_by_release_id = Counter()
         authors_by_release_id = defaultdict(dict)
         latest_commit_by_release_id = {}
+        set_of_users = set()
 
         for rc in release_commits:
             # Accumulate authors per release
             author = rc.commit.author
+
             if author:
-                authors_by_release_id[rc.release_id][author.id] = \
-                    users_by_email[author.id]
+                author_user = users_by_email[author.id]
+                if author_user.get('id') and author_user['id'] in set_of_users:
+                    pass
+                else:
+                    authors_by_release_id[rc.release_id][author.id] = \
+                        users_by_email[author.id]
+                author_user.get('id') and set_of_users.add(author_user['id'])
 
             # Increment commit count per release
             commit_count_by_release_id[rc.release_id] += 1

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -97,7 +97,12 @@ class ReleaseSerializer(Serializer):
         commit_count_by_release_id = Counter()
         authors_by_release_id = defaultdict(dict)
         latest_commit_by_release_id = {}
-        set_of_users = set()
+
+        # it's possible to have duplicate users in users_by_email
+        # when CommitAuthor objects are different
+        # but emails are associated to the same user, so
+        # this is to prevent duplicate users from being returned
+        authors_seen_in_release = defaultdict(set)
 
         for rc in release_commits:
             # Accumulate authors per release
@@ -105,12 +110,12 @@ class ReleaseSerializer(Serializer):
 
             if author:
                 author_user = users_by_email[author.id]
-                if author_user.get('id') and author_user['id'] in set_of_users:
+                if author_user.get('id') and author_user['id'] in authors_seen_in_release[rc.release_id]:
                     pass
                 else:
                     authors_by_release_id[rc.release_id][author.id] = \
                         users_by_email[author.id]
-                author_user.get('id') and set_of_users.add(author_user['id'])
+                author_user.get('id') and authors_seen_in_release[rc.release_id].add(author_user['id'])
 
             # Increment commit count per release
             commit_count_by_release_id[rc.release_id] += 1


### PR DESCRIPTION
Fixes an issue in which a user could appear multiple times in the release authors list. This was occurring when there were multiple commits associated with a sentry user in a release with differing commit author emails.

@macqueen @benvinegar @MaxBittker @ckj 