### PR TITLE
Releases touch up

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-bootstrap": "^0.29.5",
     "react-document-title": "1.0.4",
     "react-dom": "15.3.2",
+    "react-icon-base": "^2.0.4",
     "react-lazy-load": "3.0.10",
     "react-router": "2.8.1",
     "react-sparklines": "1.6.0",

--- a/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
+++ b/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
@@ -112,13 +112,13 @@ const CommitAuthorStats = React.createClass({
           let {author, commitCount} = commitAuthor;
           return (
             <li className="list-group-item list-group-item-sm list-group-avatar">
-              <div className="row">
+              <div className="row row-flex row-center-vertically">
                 <div className="col-sm-8">
                   <Avatar user={author} size={32} />
                   <CommitBar totalCommits={commitList.length} authorCommits={commitCount}/>
                 </div>
                 <div className="col-sm-4 align-right">
-                  <small>{commitCount}</small>
+                  {commitCount}
                 </div>
               </div>
             </li>

--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Avatar from '../components/avatar';
+import IconFileGeneric from '../icons/icon-file-generic';
 
 import TooltipMixin from '../mixins/tooltip';
 import ApiMixin from '../mixins/apiMixin';
@@ -28,9 +29,12 @@ const FileChange = React.createClass({
     let {filename, authors, types} = this.props;
     types = Array.from(types);
     return (
-      <li className="list-group-item list-group-item-sm ">
-        <div className="row">
-          <div className="col-sm-9 truncate"><small>{filename}</small></div>
+      <li className="list-group-item list-group-item-sm release-file-change">
+        <div className="row row-flex row-center-vertically">
+          <div className="col-sm-9 truncate">
+            <IconFileGeneric className="icon-file-generic" size={15}/>
+            <span className="file-name">{filename}</span>
+          </div>
           <div className="col-sm-3 avatar-grid align-right">
           {authors.map(author => {
               return (

--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -88,8 +88,8 @@ const ReleaseProjectStatSparkline = React.createClass({
           <h6 className="m-b-0">
             {project.name}
           </h6>
-          <p className="m-b-0">
-            {newIssueCount > 0 ? tn('%d New Issue', '%d New Issues', newIssueCount) : t('No New Issues')}
+          <p className="m-b-0 text-muted">
+            <small>{newIssueCount > 0 ? tn('%d new issue', '%d new issues', newIssueCount) : t('No new issues')}</small>
           </p>
         </Link>
       </li>

--- a/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
@@ -52,29 +52,31 @@ const RepositoryFileSummary = React.createClass({
     let numCollapsed = fileCount - files.length;
     let canCollapse = fileCount > MAX;
     return(
-      <ul className="list-group list-group-striped m-b-2">
-      <h6>
-        {tn(('%d file changed in ' + repository), ('%d files changed in ' + repository), fileCount)}
-      </h6>
-      {files.map(filename => {
-        let {id, authors, types} = fileChangeSummary[filename];
-        return (
-          <FileChange
-            key={id}
-            filename={filename}
-            authors={Object.values(authors)}
-            types={types}
-            />
-        );
-      })}
-      {numCollapsed > 0 && <Collapsed onClick={this.onCollapseToggle} count={numCollapsed}/>}
-      {numCollapsed === 0 && canCollapse &&
-        <li className="list-group-item list-group-item-sm align-center">
-          <span className="icon-container"></span>
-          <a onClick={this.onCollapseToggle}>{t('Collapse')}</a>
-        </li>
-      }
-      </ul>);
+      <div>
+        <h5>
+          {tn(('%d file changed in ' + repository), ('%d files changed in ' + repository), fileCount)}
+        </h5>
+        <ul className="list-group list-group-striped m-b-2">
+        {files.map(filename => {
+          let {id, authors, types} = fileChangeSummary[filename];
+          return (
+            <FileChange
+              key={id}
+              filename={filename}
+              authors={Object.values(authors)}
+              types={types}
+              />
+          );
+        })}
+        {numCollapsed > 0 && <Collapsed onClick={this.onCollapseToggle} count={numCollapsed}/>}
+        {numCollapsed === 0 && canCollapse &&
+          <li className="list-group-item list-group-item-sm align-center">
+            <span className="icon-container"></span>
+            <a onClick={this.onCollapseToggle}>{t('Collapse')}</a>
+          </li>
+        }
+        </ul>
+      </div>);
 }
 });
 

--- a/src/sentry/static/sentry/app/icons/icon-file-generic.js
+++ b/src/sentry/static/sentry/app/icons/icon-file-generic.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import Icon from 'react-icon-base';
 
-const IconFileGeneric = props => (
+function IconFileGeneric(props) {
+  return(
     <Icon viewBox="0 0 15 15" {...props}>
       <g stroke="currentColor" fill="none">
-          <path d="M13.5,3.5 L13.5,12.9968907 C13.5,13.827035 12.8204455,14.5 12.0044548,14.5 L2.99554521,14.5 C2.1695784,14.5 1.5,13.8247509 1.5,13.0017548 L1.5,1.99824524 C1.5,1.17078724 2.17667683,0.5 3.00687434,0.5 L10.502848,0.5 L13.5,3.5 Z" id="file" strokeLinejoin="round"></path>
-          <path d="M10.5,0.5 L10.5,3.5" id="line-1"></path>
-          <path d="M13.5,3.5 L10.5,3.5" id="line-2"></path>
-          <path d="M4.5,4.5 L7.5,4.5" id="line-3" strokeLinejoin="round"></path>
-          <path d="M4.5,7.5 L10.5,7.5" id="line-4" strokeLinejoin="round"></path>
-          <path d="M4.5,10.5 L10.5,10.5" id="line-5" strokeLinejoin="round"></path>
+        <path d="M13.5,3.5 L13.5,12.9968907 C13.5,13.827035 12.8204455,14.5 12.0044548,14.5 L2.99554521,14.5 C2.1695784,14.5 1.5,13.8247509 1.5,13.0017548 L1.5,1.99824524 C1.5,1.17078724 2.17667683,0.5 3.00687434,0.5 L10.502848,0.5 L13.5,3.5 Z" id="file" strokeLinejoin="round" />
+        <path d="M10.5,0.5 L10.5,3.5" id="line-1" />
+        <path d="M13.5,3.5 L10.5,3.5" id="line-2" />
+        <path d="M4.5,4.5 L7.5,4.5" id="line-3" strokeLinejoin="round" />
+        <path d="M4.5,7.5 L10.5,7.5" id="line-4" strokeLinejoin="round" />
+        <path d="M4.5,10.5 L10.5,10.5" id="line-5" strokeLinejoin="round" />
       </g>
     </Icon>
-)
+  );
+}
 
 export default IconFileGeneric;

--- a/src/sentry/static/sentry/app/icons/icon-file-generic.js
+++ b/src/sentry/static/sentry/app/icons/icon-file-generic.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Icon from 'react-icon-base';
+
+const IconFileGeneric = props => (
+    <Icon viewBox="0 0 15 15" {...props}>
+      <g stroke="currentColor" fill="none">
+          <path d="M13.5,3.5 L13.5,12.9968907 C13.5,13.827035 12.8204455,14.5 12.0044548,14.5 L2.99554521,14.5 C2.1695784,14.5 1.5,13.8247509 1.5,13.0017548 L1.5,1.99824524 C1.5,1.17078724 2.17667683,0.5 3.00687434,0.5 L10.502848,0.5 L13.5,3.5 Z" id="file" strokeLinejoin="round"></path>
+          <path d="M10.5,0.5 L10.5,3.5" id="line-1"></path>
+          <path d="M13.5,3.5 L10.5,3.5" id="line-2"></path>
+          <path d="M4.5,4.5 L7.5,4.5" id="line-3" strokeLinejoin="round"></path>
+          <path d="M4.5,7.5 L10.5,7.5" id="line-4" strokeLinejoin="round"></path>
+          <path d="M4.5,10.5 L10.5,10.5" id="line-5" strokeLinejoin="round"></path>
+      </g>
+    </Icon>
+)
+
+export default IconFileGeneric;

--- a/src/sentry/static/sentry/app/icons/icon-open.js
+++ b/src/sentry/static/sentry/app/icons/icon-open.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import Icon from 'react-icon-base';
 
-const IconOpen = props => (
+function IconOpen(props) {
+  return(
     <Icon viewBox="0 0 15 15" {...props}>
       <g stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M14.5,8.5 L14.5,13.1823525 C14.5,13.9100691 13.9162615,14.5 13.182914,14.5 L1.81708601,14.5 C1.08967949,14.5 0.5,13.9162615 0.5,13.182914 L0.5,1.81708601 C0.5,1.08967949 1.09439142,0.5 1.80585884,0.5 L6.5,0.5" id="outer-path"></path>
-          <path d="M7.5,7.5 L14.5,0.5" id="line"></path>
-          <polyline id="arrow" points="9.5 0.5 14.5 0.5 14.5 5.5"></polyline>
+        <path d="M14.5,8.5 L14.5,13.1823525 C14.5,13.9100691 13.9162615,14.5 13.182914,14.5 L1.81708601,14.5 C1.08967949,14.5 0.5,13.9162615 0.5,13.182914 L0.5,1.81708601 C0.5,1.08967949 1.09439142,0.5 1.80585884,0.5 L6.5,0.5" id="outer-path" />
+        <path d="M7.5,7.5 L14.5,0.5" id="line" />
+        <polyline id="arrow" points="9.5 0.5 14.5 0.5 14.5 5.5" />
       </g>
     </Icon>
-)
+  );
+}
 
 export default IconOpen;

--- a/src/sentry/static/sentry/app/icons/icon-open.js
+++ b/src/sentry/static/sentry/app/icons/icon-open.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Icon from 'react-icon-base';
+
+const IconOpen = props => (
+    <Icon viewBox="0 0 15 15" {...props}>
+      <g stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14.5,8.5 L14.5,13.1823525 C14.5,13.9100691 13.9162615,14.5 13.182914,14.5 L1.81708601,14.5 C1.08967949,14.5 0.5,13.9162615 0.5,13.182914 L0.5,1.81708601 C0.5,1.08967949 1.09439142,0.5 1.80585884,0.5 L6.5,0.5" id="outer-path"></path>
+          <path d="M7.5,7.5 L14.5,0.5" id="line"></path>
+          <polyline id="arrow" points="9.5 0.5 14.5 0.5 14.5 5.5"></polyline>
+      </g>
+    </Icon>
+)
+
+export default IconOpen;

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
+import IconOpen from '../../icons/icon-open';
 import IssueList from '../../components/issueList';
 import CommitAuthorStats from '../../components/commitAuthorStats';
 import ReleaseProjectStatSparkline from '../../components/releaseProjectStatSparkline';
@@ -225,11 +226,13 @@ const ReleaseOverview = React.createClass({
                   let query = encodeURIComponent(`environment:${deploy.environment} release:${version}`);
                   return (
                     <li key={deploy.id}>
-                      <a href={`/${orgId}/${projectId}/?query=${query}`}>
+                      <a href={`/${orgId}/${projectId}/?query=${query}`} title={t('View in stream')}>
                         <div className="row row-flex row-center-vertically">
                           <div className="col-xs-6">
-                            <span className="repo-label" style={{verticalAlign: 'bottom'}}>{deploy.environment}</span>
-                            <small><span className="icon-open" style={{opacity: '.4', paddingLeft: 8}} /></small>
+                            <span className="repo-label" style={{verticalAlign: 'bottom'}}>
+                              {deploy.environment}
+                              <IconOpen className="icon-open" size={11} style={{marginLeft: 6}}/>
+                            </span>
                           </div>
                           <div className="col-xs-6 align-right">
                             <small><TimeSince date={deploy.dateFinished}/></small>

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -83,7 +83,6 @@
   height: 6px;
   border-radius: 2px;
   background-color: @green;
-  margin-top: 9px;
 }
 
 /**

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -85,3 +85,30 @@
   background-color: @green;
   margin-top: 9px;
 }
+
+/**
+* Release file change list
+* ============================================================================
+*/
+
+.release-file-change {
+  .file-name {
+    font-size: 14px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+  .icon-file-generic {
+    color: @40;
+    margin-right: 7px;
+  }
+
+  .avatar {
+    display: block;
+    width: 23px !important;
+    height: 23px !important;
+  }
+
+  .avatar-grid-item {
+    margin: 0 0 4px 4px;
+  }
+}

--- a/src/sentry/static/sentry/less/sentry-list-group.less
+++ b/src/sentry/static/sentry/less/sentry-list-group.less
@@ -18,9 +18,10 @@
 
     &.list-group-item-sm {
       padding: 5px 10px;
+      min-height: 36px;
 
       &.list-group-avatar {
-        padding-left: 38px;
+        padding-left: 36px;
         position: relative;
 
         div[class^="col-"] {
@@ -30,7 +31,7 @@
         .avatar {
           .square(20px);
           position: absolute;
-          left: 10px;
+          left: 8px;
           top: 7px;
         }
       }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2791,7 +2791,7 @@ ul.faces {
   .label;
   display: inline-block;
   vertical-align: text-bottom;
-  padding: 4px 8px 6px;
+  padding: 5px 8px;
   line-height: 1;
   background: @40;
 }


### PR DESCRIPTION
This PR does a handful of things:

- Addresses design feedback collected in https://github.com/getsentry/getsentry/issues/900
- Adds our first embedded svg components
- Adds the `react-icon-base` dependency for the svg components to extend

Note: the svg icons (codename: sentricons) will probably end up as their own package and be managed outside of this repo moving forward.

**Before:**

![releases_touch_up_before](https://cloud.githubusercontent.com/assets/30713/24573454/1e461b12-1638-11e7-8a58-fe3c9af5300c.png)

**After:**

![releases_touch_up_after](https://cloud.githubusercontent.com/assets/30713/24573460/2c31e274-1638-11e7-9eaa-7b3d73ec5c56.png)



@macqueen @kjlundsgaard @benvinegar @MaxBittker @mattrobenolt 
