### PR TITLE
Return '*' when origin actually is null

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -227,17 +227,16 @@ class APIView(BaseView):
                 **kwargs
             )
 
-        if origin:
-            if origin == 'null':
-                # If an Origin is `null`, but we got this far, that means
-                # we've gotten past our CORS check for some reason. But the
-                # problem is that we can't return "null" as a valid response
-                # to `Access-Control-Allow-Origin` and we don't have another
-                # value to work with, so just allow '*' since they've gotten
-                # this far.
-                response['Access-Control-Allow-Origin'] = '*'
-            else:
-                response['Access-Control-Allow-Origin'] = origin
+        if origin is None:
+            # If an Origin is `null`, but we got this far, that means
+            # we've gotten past our CORS check for some reason. But the
+            # problem is that we can't return "null" as a valid response
+            # to `Access-Control-Allow-Origin` and we don't have another
+            # value to work with, so just allow '*' since they've gotten
+            # this far.
+            response['Access-Control-Allow-Origin'] = '*'
+        else:
+            response['Access-Control-Allow-Origin'] = origin
 
         api_called.send(project=project, sender=self)
         return response


### PR DESCRIPTION
# Motivation
We are getting this error:
```
No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'null' is therefore not allowed access.
```
When requesting from `file://`,
similar to https://github.com/getsentry/raven-js/issues/628

As my investigation, Sentry always responds without `Access-Control-Allow-Origin` header in my case.

Because of this https://github.com/getsentry/sentry/blob/master/src/sentry/utils/http.py#L237
```python
def origin_from_request(request):
    """
    Returns either the Origin or Referer value from the request headers,
    ignoring "null" Origins.
    """
    rv = request.META.get('HTTP_ORIGIN', 'null')
    # In some situation, an Origin header may be the literal value
    # "null". This means that the Origin header was stripped for
    # privacy reasons, but we should ignore this value entirely.
    # Behavior is specified in RFC6454. In either case, we should
    # treat a "null" Origin as a nonexistent one and fallback to Referer.
    if rv in ('', 'null'):
        rv = origin_from_url(request.META.get('HTTP_REFERER'))
    return rv
```

If the origin is `'null'` and `request.META.get('HTTP_REFERER')` is `None`, then `origin` gets `None` actually.

```python
origin = self.origin_from_request(request)
```

What do you think? @benvinegar @mattrobenolt 

Related PR https://github.com/getsentry/sentry/commit/f5762b718656eff101ffc53df08fc0031c7c3895
