### PR TITLE
Add inline-frame hint

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -257,7 +257,7 @@ const Frame = React.createClass({
 
   leadsToApp() {
     return !this.props.data.inApp && this.props.nextFrame
-      && this.props.nextFrame.InApp;
+      && this.props.nextFrame.inApp;
   },
 
   isInlineFrame() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -23,7 +23,8 @@ export function trimPackage(pkg) {
 const Frame = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired,
-    nextFrameInApp: React.PropTypes.bool,
+    nextFrame: React.PropTypes.object,
+    prevFrame: React.PropTypes.object,
     platform: React.PropTypes.string,
     isExpanded: React.PropTypes.bool,
     emptySourceNotation: React.PropTypes.bool,
@@ -255,7 +256,14 @@ const Frame = React.createClass({
   },
 
   leadsToApp() {
-    return !this.props.data.inApp && this.props.nextFrameInApp;
+    return !this.props.data.inApp && this.props.nextFrame
+      && this.props.nextFrame.InApp;
+  },
+
+  isInlineFrame() {
+    return this.props.prevFrame &&
+      this.getPlatform() == (this.props.prevFrame.platform || this.props.platform) &&
+      this.props.data.instructionAddr == this.props.prevFrame.instructionAddr;
   },
 
   renderLeadHint() {
@@ -315,6 +323,11 @@ const Frame = React.createClass({
             {data.filename &&
               <span className="filename">{data.filename}
                 {data.lineNo ? ':' + data.lineNo : ''}</span>}
+            {this.isInlineFrame() ?
+              <a key="inline" className="tip" data-title={_.escape(_('Inlined frame'))}>
+                {' '}<span className="icon-question" />
+              </a>
+              : null}
             {this.renderExpander()}
           </span>
         </div>

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -68,6 +68,7 @@ const StacktraceContent = React.createClass({
     let frames = [];
     let nRepeats = 0;
     data.frames.forEach((frame, frameIdx) => {
+      let prevFrame = data.frames[frameIdx - 1];
       let nextFrame = data.frames[frameIdx + 1];
       let repeatedFrame = nextFrame &&
        frame.lineNo === nextFrame.lineNo &&
@@ -85,7 +86,8 @@ const StacktraceContent = React.createClass({
             isExpanded={expandFirstFrame && lastFrameIdx === frameIdx}
             emptySourceNotation={lastFrameIdx === frameIdx && frameIdx === 0}
             isOnlyFrame={this.props.data.frames.length === 1}
-            nextFrameInApp={nextFrame && nextFrame.inApp}
+            nextFrame={nextFrame}
+            prevFrame={prevFrame}
             platform={this.props.platform}
             timesRepeated={nRepeats}/>
         );


### PR DESCRIPTION
For frames expanded from inlining we render a hint that this happened so
that users are not confused.  This was brought up by crashprobe.