### PR TITLE
enable callsigns for everyone, get rid of release-emails feature check

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -740,13 +740,12 @@ SENTRY_FEATURES = {
     'organizations:create': True,
     'organizations:repos': False,
     'organizations:sso': True,
-    'organizations:callsigns': False,
+    'organizations:callsigns': True,
     'organizations:release-commits': False,
     'projects:global-events': False,
     'projects:plugins': True,
     'projects:dsym': False,
     'projects:sample-events': True,
-    'workflow:release-emails': False,
 }
 
 # Default time zone for localization in the UI.

--- a/src/sentry/plugins/sentry_mail/activity/release.py
+++ b/src/sentry/plugins/sentry_mail/activity/release.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 from django.db.models import Count
 
-from sentry import features
 from sentry.db.models.query import in_iexact
 from sentry.models import (
     CommitFileChange, Deploy, Environment, Group,
@@ -113,7 +112,6 @@ class ReleaseActivityEmail(ActivityEmail):
                 ),
                 is_active=True,
             ).distinct()
-            if features.has('workflow:release-emails', project=self.project, actor=user)
         }
 
     def get_users_by_teams(self):

--- a/tests/sentry/plugins/mail/activity/test_release.py
+++ b/tests/sentry/plugins/mail/activity/test_release.py
@@ -110,28 +110,27 @@ class ReleaseTestCase(TestCase):
             )
         )
 
-        with self.feature('workflow:release-emails'):
-            assert email.get_participants() == {
-                self.user: GroupSubscriptionReason.committed,
-            }
+        assert email.get_participants() == {
+            self.user: GroupSubscriptionReason.committed,
+        }
 
-            context = email.get_context()
-            assert context['environment'] == 'production'
-            assert context['repos'][0]['commits'] == [
-                (self.commit, self.user),
-                (self.commit2, self.user2),
-            ]
-            user_context = email.get_user_context(self.user)
-            # make sure this only includes projects user has access to
-            assert len(user_context['projects']) == 1
-            assert user_context['projects'][0][0] == self.project
+        context = email.get_context()
+        assert context['environment'] == 'production'
+        assert context['repos'][0]['commits'] == [
+            (self.commit, self.user),
+            (self.commit2, self.user2),
+        ]
+        user_context = email.get_user_context(self.user)
+        # make sure this only includes projects user has access to
+        assert len(user_context['projects']) == 1
+        assert user_context['projects'][0][0] == self.project
 
-            with self.tasks():
-                email.send()
+        with self.tasks():
+            email.send()
 
-            assert len(mail.outbox) == 1
-            msg = mail.outbox[-1]
-            assert msg.to == [self.user.email]
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[-1]
+        assert msg.to == [self.user.email]
 
     def test_doesnt_generate_on_no_release(self):
         email = ReleaseActivityEmail(


### PR DESCRIPTION
cc @MaxBittker @benvinegar @kjlundsgaard @ckj 

max is working on directing early adopters to overview, and i've got some getsentry changes to switch stuff to early adopters too