### PR TITLE
Lookup new SDK versions regardless of case.

### DIFF
--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -18,12 +18,11 @@ def get_with_prefix(d, k, default=None, delimiter=":"):
     """
 
     prefix = k.split(delimiter, 1)[0]
-    if k in d:
-        return d[k]
-    elif prefix in d:
-        return d[prefix]
-    else:
-        return default
+    for key in [k, k.lower(), prefix, prefix.lower()]:
+        if key in d:
+            return d[key]
+
+    return default
 
 
 class Sdk(Interface):

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -18,7 +18,11 @@ def get_with_prefix(d, k, default=None, delimiter=":"):
     """
 
     prefix = k.split(delimiter, 1)[0]
-    for key in [k, k.lower(), prefix, prefix.lower()]:
+    for key in [k, prefix]:
+        if key in d:
+            return d[key]
+
+        key = key.lower()
         if key in d:
             return d[key]
 


### PR DESCRIPTION
So we have some old SDKs like (for example) `Raven-Java` that wouldn't match the ones in our `SDK_VERSIONS` because of case. Figure we should still try to respect case by also check for `.lower()` versions in addition.