### PR TITLE
Merge time series data as part of group merge operation.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Version 8.15 (Unreleased)
 - Resolve issues when commits with ``Fixes SHORTID`` are included in releases
 - Added support for associating debug symbols with iTunes applications and builds.
 - Added the ability to claim unassigned issues when resolving them.
+- Time series data (used by graphs and other features) is now updated when groups are merged.
 
 API Changes
 ~~~~~~~~~~~

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -13,6 +13,7 @@ import logging
 from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
 
+from sentry.app import tsdb
 from sentry.similarity import features
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.deletion import delete_group
@@ -93,6 +94,8 @@ def merge_group(from_object_id=None, to_object_id=None, transaction_id=None,
         return
 
     features.merge(new_group, [group], allow_unsafe=True)
+    for model in [tsdb.models.group]:
+        tsdb.merge(model, new_group.id, [group.id])
 
     previous_group_id = group.id
 

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -94,8 +94,12 @@ def merge_group(from_object_id=None, to_object_id=None, transaction_id=None,
         return
 
     features.merge(new_group, [group], allow_unsafe=True)
+
     for model in [tsdb.models.group]:
         tsdb.merge(model, new_group.id, [group.id])
+
+    for model in [tsdb.models.users_affected_by_group]:
+        tsdb.merge_distinct_counts(model, new_group.id, [group.id])
 
     previous_group_id = group.id
 

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -101,6 +101,9 @@ def merge_group(from_object_id=None, to_object_id=None, transaction_id=None,
     for model in [tsdb.models.users_affected_by_group]:
         tsdb.merge_distinct_counts(model, new_group.id, [group.id])
 
+    for model in [tsdb.models.frequent_releases_by_group, tsdb.models.frequent_environments_by_group]:
+        tsdb.merge_frequencies(model, new_group.id, [group.id])
+
     previous_group_id = group.id
 
     group.delete()

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -226,6 +226,12 @@ class BaseTSDB(object):
         for model, key in items:
             self.incr(model, key, timestamp, count)
 
+    def merge(self, model, destination, sources, timestamp=None):
+        """
+        Transfer all counters from the source keys to the destination key.
+        """
+        raise NotImplementedError
+
     def get_range(self, model, keys, start, end, rollup=None):
         """
         To get a range of data for group ID=[1, 2, 3]:
@@ -298,6 +304,13 @@ class BaseTSDB(object):
         """
         raise NotImplementedError
 
+    def merge_distinct_counts(self, model, destination, sources, timestamp=None):
+        """
+        Transfer all distinct counters from the source keys to the
+        destination key.
+        """
+        raise NotImplementedError
+
     def record_frequency_multi(self, requests, timestamp=None):
         """
         Record items in a frequency table.
@@ -358,5 +371,12 @@ class BaseTSDB(object):
         Results are returned as a mapping, where the key is the key requested
         and the value is a mapping of ``{item: score, ...}`` containing the
         total score of items over the interval.
+        """
+        raise NotImplementedError
+
+    def merge_frequencies(self, model, destination, sources, timestamp=None):
+        """
+        Transfer all frequency tables from the source keys to the destination
+        key.
         """
         raise NotImplementedError

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -17,6 +17,9 @@ class DummyTSDB(BaseTSDB):
     def incr(self, model, key, timestamp=None, count=1):
         pass
 
+    def merge(self, model, destination, sources, timestamp=None):
+        pass
+
     def get_range(self, model, keys, start, end, rollup=None):
         _, series = self.get_optimal_rollup_series(start, end, rollup)
         return {k: [(ts, 0) for ts in series] for k in keys}
@@ -33,6 +36,9 @@ class DummyTSDB(BaseTSDB):
 
     def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
         return 0
+
+    def merge_distinct_counts(self, model, destination, sources, timestamp=None):
+        pass
 
     def record_frequency_multi(self, requests, timestamp=None):
         pass
@@ -63,3 +69,6 @@ class DummyTSDB(BaseTSDB):
         for key, members in items.items():
             results[key] = {member: 0.0 for member in members}
         return results
+
+    def merge_frequencies(self, model, destination, sources, timestamp=None):
+        pass


### PR DESCRIPTION
Adds merge methods for counters, distinct counters, and frequency tables to the abstract backend, the dummy backend, the in-memory backend, and the Redis backend.

These operations are not atomic, as they may cross database boundaries.

Fixes GH-3136.