### PR TITLE
default to release overview page for early adopters

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -163,6 +163,7 @@ function routes() {
           <Route path="dashboard/" component={errorHandler(ProjectDashboard)} />
           <Route path="events/" component={errorHandler(ProjectEvents)} />
           <Route path="releases/" component={errorHandler(ProjectReleases)} />
+          {/* TODO(jess): take this out when we release releases to everyone */}
           <Route name="releaseDetails" path="releases/:version/" component={errorHandler(ReleaseDetails)}
                  getIndexRoute={(partialNextState, cb) => {
                   let client = new this.api.Client();

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -163,8 +163,22 @@ function routes() {
           <Route path="dashboard/" component={errorHandler(ProjectDashboard)} />
           <Route path="events/" component={errorHandler(ProjectEvents)} />
           <Route path="releases/" component={errorHandler(ProjectReleases)} />
-          <Route name="releaseDetails" path="releases/:version/" component={errorHandler(ReleaseDetails)}>
-            <IndexRoute component={errorHandler(ReleaseNewEvents)} />
+          <Route name="releaseDetails" path="releases/:version/" component={errorHandler(ReleaseDetails)}
+                 getIndexRoute={(partialNextState, cb) => {
+                  let client = new this.api.Client();
+                  let orgId = partialNextState.params.orgId;
+                  client.request(`/organizations/${orgId}/`, {
+                      method: 'GET',
+                      success: (data, _, jqXHR) => {
+                        if (new Set(data.features).has('release-commits')) {
+                          cb(null, {component: errorHandler(ReleaseOverview)});
+                        } else {
+                          cb(null, {component: errorHandler(ReleaseNewEvents)});
+                        }
+                      }
+                  });
+                 }}>
+            <Route path="new-events/" component={errorHandler(ReleaseNewEvents)} />
             <Route path="overview/" component={errorHandler(ReleaseOverview)} />
             <Route path="all-events/" component={errorHandler(ReleaseAllEvents)} />
             <Route path="artifacts/" component={errorHandler(ReleaseArtifacts)} />

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -93,6 +93,8 @@ const ReleaseDetails = React.createClass({
 
     let release = this.state.release;
     let {orgId, projectId} = this.props.params;
+    let hasReleases = (new Set(this.context.organization.features)).has('release-commits');
+    let basePath = `/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/`;
     return (
       <DocumentTitle title={this.getTitle()}>
         <div>
@@ -135,14 +137,20 @@ const ReleaseDetails = React.createClass({
               </div>
             </div>
             <ul className="nav nav-tabs">
-              {(new Set(this.context.organization.features)).has('release-commits') &&
+              {hasReleases &&
                 <ListLink
-                    to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/overview/`}>{t('Overview')}</ListLink>
-              }
-              <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/`} isActive={(loc) => {
+                    to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/overview/`} isActive={(loc) => {
                 // react-router isActive will return true for any route that is part of the active route
                 // e.g. parent routes. To avoid matching on sub-routes, insist on strict path equality.
-                return loc.pathname === this.props.location.pathname;
+                return (hasReleases && this.props.location.pathname === basePath) ||
+                       (loc.pathname === this.props.location.pathname);
+              }}>{t('Overview')}</ListLink>
+              }
+              <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/new-events/`} isActive={(loc) => {
+                // react-router isActive will return true for any route that is part of the active route
+                // e.g. parent routes. To avoid matching on sub-routes, insist on strict path equality.
+                return (!hasReleases && this.props.location.pathname === basePath) ||
+                       (loc.pathname === this.props.location.pathname);
               }}>{t('New Issues')}</ListLink>
               <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/all-events/`}>{t('All Issues')}</ListLink>
               <ListLink to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/artifacts/`}>{t('Artifacts')}</ListLink>


### PR DESCRIPTION
isActive logic got somewhat gross, but couldn't think of a better way to deal with that

cc @ckj 