### PR TITLE
Do not fail on updating releases

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -223,10 +223,12 @@ class Release(Model):
         from sentry.models import Commit, ReleaseHeadCommit, Repository
         from sentry.plugins import bindings
 
+        # TODO: this does the wrong thing unless you are on the most
+        # recent release.  Add a timestamp compare?
         prev_release = type(self).objects.filter(
             organization_id=self.organization_id,
             projects__in=self.projects.all(),
-        ).order_by('-date_added').first()
+        ).exclude(version=self.version).order_by('-date_added').first()
 
         commit_list = []
 

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -117,6 +117,11 @@ class UpdateReleaseDetailsTest(APITestCase):
         project = self.create_project(team=team1, organization=org)
         project2 = self.create_project(team=team2, organization=org)
 
+        base_release = Release.objects.create(
+            organization_id=org.id,
+            version='000000000',
+        )
+        base_release.add_project(project)
         release = Release.objects.create(
             organization_id=org.id,
             version='abcabcabc',
@@ -131,6 +136,18 @@ class UpdateReleaseDetailsTest(APITestCase):
         self.create_member(teams=[team1], user=user, organization=org)
 
         self.login_as(user=user)
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': base_release.version,
+        })
+        self.client.put(url, {
+            'ref': 'master',
+            'headCommits': [
+                {'currentId': '0' * 40, 'repository': repo.name},
+                {'currentId': '0' * 40, 'repository': repo2.name},
+            ],
+        })
 
         url = reverse('sentry-api-0-organization-release-details', kwargs={
             'organization_slug': org.slug,
@@ -201,6 +218,12 @@ class UpdateReleaseDetailsTest(APITestCase):
         project = self.create_project(team=team1, organization=org)
         project2 = self.create_project(team=team2, organization=org)
 
+        base_release = Release.objects.create(
+            organization_id=org.id,
+            version='000000000',
+        )
+        base_release.add_project(project)
+
         release = Release.objects.create(
             organization_id=org.id,
             version='abcabcabc',
@@ -215,6 +238,18 @@ class UpdateReleaseDetailsTest(APITestCase):
         self.create_member(teams=[team1], user=user, organization=org)
 
         self.login_as(user=user)
+
+        url = reverse('sentry-api-0-organization-release-details', kwargs={
+            'organization_slug': org.slug,
+            'version': base_release.version,
+        })
+        self.client.put(url, {
+            'ref': 'master',
+            'headCommits': [
+                {'currentId': '0' * 40, 'repository': repo.name},
+                {'currentId': '0' * 40, 'repository': repo2.name},
+            ],
+        })
 
         url = reverse('sentry-api-0-organization-release-details', kwargs={
             'organization_slug': org.slug,

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -467,6 +467,14 @@ class OrganizationReleaseCreateTest(APITestCase):
         url = reverse('sentry-api-0-organization-releases', kwargs={
             'organization_slug': org.slug
         })
+        self.client.post(url, data={
+            'version': '1',
+            'refs': [
+                {'commit': '0' * 40, 'repository': repo.name},
+                {'commit': '0' * 40, 'repository': repo2.name},
+            ],
+            'projects': [project.slug]
+        })
         response = self.client.post(url, data={
             'version': '1.2.1',
             'refs': [
@@ -527,6 +535,14 @@ class OrganizationReleaseCreateTest(APITestCase):
 
         url = reverse('sentry-api-0-organization-releases', kwargs={
             'organization_slug': org.slug
+        })
+        self.client.post(url, data={
+            'version': '1',
+            'headCommits': [
+                {'currentId': '0' * 40, 'repository': repo.name},
+                {'currentId': '0' * 40, 'repository': repo2.name},
+            ],
+            'projects': [project.slug]
         })
         response = self.client.post(url, data={
             'version': '1.2.1',
@@ -732,6 +748,13 @@ class OrganizationReleaseCreateTest(APITestCase):
             'organization_slug': org.slug
         })
 
+        response = self.client.post(url, data={
+            'version': '1',
+            'headCommits': [
+                {'currentId': 'b' * 40, 'repository': repo2.name},
+            ],
+            'projects': [project1.slug]
+        }, HTTP_AUTHORIZATION='Bearer {}'.format(api_token.token))
         response = self.client.post(url, data={
             'version': '1.2.1',
             'headCommits': [


### PR DESCRIPTION
This change is necessary as otherwise the system always compares with the
same release if you set commits with the update API.