### PR TITLE
Don't return all user emails in release serializer

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -59,10 +59,21 @@ def get_users_for_commits(item_list):
 
     author_objs = {}
     for author in authors:
-        author_objs[author.id] = users_by_email.get(author.email, {
-            "name": author.name,
-            "email": author.email
-        })
+        if users_by_email.get(author.email):
+            user_obj = users_by_email[author.email]
+            author_objs[author.id] = {
+                'name': user_obj['name'],
+                'username': user_obj['username'],
+                'email': user_obj['email'],
+                'avatarUrl': user_obj['avatarUrl'],
+                'avatar': user_obj['avatar'],
+                'id': user_obj['id']
+            }
+        else:
+            author_objs[author.id] = {
+                "name": author.name,
+                "email": author.email
+            }
 
     return author_objs
 


### PR DESCRIPTION
Returns fewer user attributes (so we don't get user's full list of emails, dateJoined, etc) in release serializer
@macqueen @ckj @mattrobenolt 