### PR TITLE
Correct logging behavior in logAjaxError

### DIFF
--- a/src/sentry/static/sentry/app/utils/logging.jsx
+++ b/src/sentry/static/sentry/app/utils/logging.jsx
@@ -10,7 +10,7 @@ export function logException(ex, context) {
 
 export function logAjaxError(error, context) {
   let errorString = error.responseJSON ?
-    error.responseJSON.detail || error.responseJSON.toString() :
+    (error.responseJSON.detail || JSON.stringify(error.responseJSON, null, 2)) :
     error.responseText ?
       error.responseText.substr(0, 255) :
       '<unknown response>'; // occassionally responseText is undefined


### PR DESCRIPTION
Calling .toString() on a JSON object simply gives us [object Object], whereas we want the actual JSON value.