### PR TITLE
Widen issue stats column to make room for short ids

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -114,7 +114,7 @@ const GroupHeader = React.createClass({
     return (
       <div className={className}>
         <div className="row">
-          <div className="col-sm-8">
+          <div className="col-sm-7">
             <h3>
               <GroupTitle data={group} />
             </h3>
@@ -141,7 +141,7 @@ const GroupHeader = React.createClass({
               })}
             </div>
           </div>
-          <div className="col-sm-4 stats">
+          <div className="col-sm-5 stats">
             <div className="flex flex-justify-right">
               {group.shortId && this.getFeatures().has('callsigns') &&
                 <div className="short-id-box count align-right">


### PR DESCRIPTION
This adjusts the issue stats column to make room for short id's now that they're live for everyone.

![short-id-space](https://cloud.githubusercontent.com/assets/30713/24814269/d853c4d0-1b85-11e7-8b5e-4a1a587ca12e.gif)

@getsentry/product 