### PR TITLE
Make user mailto links open in a new window

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -21,7 +21,7 @@ const UserContextType = React.createClass({
       'Email',
       <pre>
         {user.email}
-        <a href={`mailto:${user.email}`} className="external-icon">
+        <a href={`mailto:${user.email}`} target="_blank" className="external-icon">
           <em className="icon-envelope" />
         </a>
       </pre>

--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -114,7 +114,7 @@ const GroupTagValues = React.createClass({
               }
             </Link>
             {tagValue.email &&
-              <a href={`mailto:${tagValue.email}`} className="external-icon">
+              <a href={`mailto:${tagValue.email}`} target="_blank" className="external-icon">
                 <em className="icon-envelope" />
               </a>
             }


### PR DESCRIPTION
(RFC) This commit *should* turn the various user email links such as the one in the screenshot below into links opening in a new window.

![image](https://cloud.githubusercontent.com/assets/235410/24836255/c429d6e8-1d1f-11e7-894f-4d15295786ae.png)

It's a bit of behaviour that annoys me a ton in Sentry right now and it's kinda customary to have mailto links open in a new window. If an external email client is configured, nothing will change, but if a webapp (such as gmail) is configured, then it will open gmail in a new tab rather than overriding the Sentry tab.

I don't know how much stuff is affected by this change though.