### PR TITLE
Publicize incr_internal and have client-api only incr_internal.

### DIFF
--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -40,7 +40,7 @@ def _sampled_value(value):
     return value
 
 
-def _incr_internal(key, instance=None, tags=None, amount=1):
+def incr_internal(key, instance=None, tags=None, amount=1):
     from sentry import tsdb
 
     if _should_sample():
@@ -59,7 +59,7 @@ def _incr_internal(key, instance=None, tags=None, amount=1):
 
 def incr(key, amount=1, instance=None, tags=None):
     sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-    _incr_internal(key, instance, tags, amount)
+    incr_internal(key, instance, tags, amount)
     try:
         backend.incr(key, instance, tags, amount, sample_rate)
     except Exception:

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -130,22 +130,22 @@ class APIView(BaseView):
 
         # TODO(dcramer): it'd be nice if we had an incr_multi method so
         # tsdb could optimize this
-        metrics.incr('client-api.all-versions.requests')
-        metrics.incr('client-api.all-versions.responses.%s' % (
+        metrics.incr_internal('client-api.all-versions.requests')
+        metrics.incr_internal('client-api.all-versions.responses.%s' % (
             response.status_code,
         ))
-        metrics.incr('client-api.all-versions.responses.%sxx' % (
+        metrics.incr_internal('client-api.all-versions.responses.%sxx' % (
             six.text_type(response.status_code)[0],
         ))
 
         if helper.context.version:
-            metrics.incr('client-api.v%s.requests' % (
+            metrics.incr_internal('client-api.v%s.requests' % (
                 helper.context.version,
             ))
-            metrics.incr('client-api.v%s.responses.%s' % (
+            metrics.incr_internal('client-api.v%s.responses.%s' % (
                 helper.context.version, response.status_code
             ))
-            metrics.incr('client-api.v%s.responses.%sxx' % (
+            metrics.incr_internal('client-api.v%s.responses.%sxx' % (
                 helper.context.version, six.text_type(response.status_code)[0]
             ))
 


### PR DESCRIPTION
These metrics account for 57 total metric paths in an hour, and are not useful enough to forward to metrics stores outside of sentry.