### PR TITLE
[api] handle mismatched oauth scope sets in authorize

### DIFF
--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -133,7 +133,7 @@ class OAuthAuthorizeView(BaseView):
             matched_sets = set()
             for scope_set in settings.SENTRY_SCOPE_SETS:
                 for scope, description in scope_set:
-                    if scope_set in matched_sets:
+                    if scope_set in matched_sets and scope in pending_scopes:
                         pending_scopes.remove(scope)
                     elif scope in pending_scopes:
                         permissions.append(description)

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -225,6 +225,25 @@ class OAuthAuthorizeCodeTest(TestCase):
         authorization = ApiAuthorization.objects.get(id=authorization.id)
         assert sorted(authorization.get_scopes()) == ['org:read', 'org:write']
 
+    def test_approve_flow_non_scope_set(self):
+        self.login_as(self.user)
+
+        ApiAuthorization.objects.create(
+            user=self.user,
+            application=self.application,
+        )
+
+        resp = self.client.get('{}?response_type=code&client_id={}&scope=member:read member:admin'.format(
+            self.path,
+            self.application.client_id,
+        ))
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/oauth-authorize.html')
+        assert resp.context['application'] == self.application
+        assert resp.context['scopes'] == ['member:read', 'member:admin']
+        assert resp.context['permissions'] == ['Read, write, and admin access to organization members.']
+
 
 class OAuthAuthorizeTokenTest(TestCase):
     @fixture


### PR DESCRIPTION
Fixes SENTRY-37D