### PR TITLE
ui: fix autoselecttext for deprecated API

### DIFF
--- a/src/sentry/static/sentry/app/components/autoSelectText.jsx
+++ b/src/sentry/static/sentry/app/components/autoSelectText.jsx
@@ -22,7 +22,9 @@ const AutoSelectText = React.createClass({
     } else if (window.getSelection) {
       let range = document.createRange();
       range.selectNode(node);
-      window.getSelection().addRange(range);
+      let selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
     }
   },
 


### PR DESCRIPTION
See: https://www.chromestatus.com/features/6680566019653632

In latest Chome beta, clicking somewhere that triggers this behavior has
stopped working and instead spits out a warning to console:

> autoSelectText.jsx:25 [Deprecation] The behavior that Selection.addRange() merges existing Range and the specified Range was removed. See https://www.chromestatus.com/features/6680566019653632 for more details.

It appears that we need to explicitly clear all existing ranges before
trying to select something new now.