### PR TITLE
Serialize list of users rather than calling serialize on every user object

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -46,7 +46,7 @@ def get_users_for_commits(item_list):
         sentry_orgmember_set__organization_id=org_id
     )
     users = serialize(list(users))
-    users_by_id = dict((user['id'], user) for user in users)
+    users_by_id = {user['id']: user for user in users}
 
     # Figure out which email address matches to a user
     users_by_email = {}

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -45,13 +45,14 @@ def get_users_for_commits(item_list):
         id__in=[ue.user_id for ue in user_emails],
         sentry_orgmember_set__organization_id=org_id
     )
-    users_by_id = dict((user.id, serialize(user)) for user in users)
+    users = serialize(list(users))
+    users_by_id = dict((user['id'], user) for user in users)
 
     # Figure out which email address matches to a user
     users_by_email = {}
     for email in user_emails:
         if email.email not in users_by_email:
-            user = users_by_id.get(email.user_id, None)
+            user = users_by_id.get(six.text_type(email.user_id), None)
             # user can be None if there's a user associated
             # with user_email in separate organization
             if user:


### PR DESCRIPTION
This should save queries on the release serializer and hopefully make the releases page a bit faster

@macqueen @ckj @MaxBittker 