### PR TITLE
buffers: implementation for generic callbacks

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -39,7 +39,8 @@ class Buffer(object):
     """
     __all__ = ('incr', 'process_incr', 'process_pending', 'validate', 'apply', 'process_cb')
 
-    registry = {}
+    def __init__(self):
+        self.registry = {}
 
     def register_cb(self, name, cb):
         self.registry[name] = cb

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -37,7 +37,7 @@ class Buffer(object):
     This is useful in situations where a single event might be happening so fast that the queue cant
     keep up with the updates.
     """
-    __all__ = ('incr', 'process_incr', 'process_pending', 'validate', 'apply', 'process_cb')
+    __all__ = ('incr', 'process', 'process_incr', 'process_pending', 'validate', 'apply', 'process_cb')
 
     def __init__(self):
         self.registry = {}
@@ -108,3 +108,9 @@ class Buffer(object):
         except KeyError:
             raise NotImplementedError
         cb(value=value)
+
+    def process(self, model, columns, filters, extra=None):
+        import warnings
+        warnings.warn('buffer.process is deprecated, use buffer.process_incr',
+                      DeprecationWarning)
+        self.process_incr(model, columns, filters, extra)

--- a/src/sentry/buffer/inprocess.py
+++ b/src/sentry/buffer/inprocess.py
@@ -18,4 +18,7 @@ class InProcessBuffer(Buffer):
               in development and testing environments.
     """
     def incr(self, model, columns, filters, extra=None):
-        self.process(model, columns, filters, extra)
+        self.process_incr(model, columns, filters, extra)
+
+    def apply(self, name, value):
+        self.process_cb(name, value)

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -165,7 +165,7 @@ class RedisBuffer(Buffer):
     def process_pending_cb(self):
         client = self.cluster.get_routing_client()
 
-        for name in self.registry.iterkeys():
+        for name in six.iterkeys(self.registry):
             pending_key = self._make_cb_key(name)
             lock_key = self._make_lock_key(pending_key)
             # prevent a stampede due to celerybeat + periodic task

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -42,4 +42,12 @@ def process_incr(**kwargs):
     """
     from sentry import buffer
 
-    buffer.process(**kwargs)
+    buffer.process_incr(**kwargs)
+
+
+@instrumented_task(
+    name='sentry.tasks.process_buffer.process_cb')
+def process_cb(**kwargs):
+    from sentry import buffer
+
+    buffer.process_cb(**kwargs)

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -29,13 +29,13 @@ class BufferTest(TestCase):
         group = Group.objects.create(project=Project(id=1))
         columns = {'times_seen': 1}
         filters = {'id': group.id, 'project_id': 1}
-        self.buf.process(Group, columns, filters)
+        self.buf.process_incr(Group, columns, filters)
         assert Group.objects.get(id=group.id).times_seen == group.times_seen + 1
 
     def test_process_saves_data_without_existing_row(self):
         columns = {'times_seen': 1}
         filters = {'message': 'foo bar', 'project_id': 1}
-        self.buf.process(Group, columns, filters)
+        self.buf.process_incr(Group, columns, filters)
         group = Group.objects.get(message='foo bar')
         # the default value for times_seen is 1, so we actually end up
         # incrementing it to 2 here
@@ -48,7 +48,7 @@ class BufferTest(TestCase):
         filters = {'id': group.id, 'project_id': 1}
         # strip micrseconds because MySQL doesn't seem to handle them correctly
         the_date = (timezone.now() + timedelta(days=5)).replace(microsecond=0)
-        self.buf.process(Group, columns, filters, {'last_seen': the_date})
+        self.buf.process_incr(Group, columns, filters, {'last_seen': the_date})
         group_ = Group.objects.get(id=group.id)
         assert group_.times_seen == group.times_seen + 1
         assert group_.last_seen.replace(microsecond=0) == the_date
@@ -70,6 +70,6 @@ class BufferTest(TestCase):
 
         columns = {'new_groups': 1}
         filters = {'id': release_project.id}
-        self.buf.process(ReleaseProject, columns, filters)
+        self.buf.process_incr(ReleaseProject, columns, filters)
         release_project_ = ReleaseProject.objects.get(id=release_project.id)
         assert release_project_.new_groups == 1

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -19,7 +19,7 @@ class RedisBufferTest(TestCase):
     def test_coerce_val_handles_unicode(self):
         assert self.buf._coerce_val(u'\u201d') == '”'
 
-    @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
+    @mock.patch('sentry.buffer.redis.RedisBuffer._make_incr_key', mock.Mock(return_value='foo'))
     @mock.patch('sentry.buffer.redis.process_incr')
     def test_process_pending(self, process_incr):
         with self.buf.cluster.map() as client:
@@ -32,8 +32,8 @@ class RedisBufferTest(TestCase):
         client = self.buf.cluster.get_routing_client()
         assert client.zrange('b:p', 0, -1) == []
 
-    @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
-    @mock.patch('sentry.buffer.base.Buffer.process')
+    @mock.patch('sentry.buffer.redis.RedisBuffer._make_incr_key', mock.Mock(return_value='foo'))
+    @mock.patch('sentry.buffer.base.Buffer.process_incr')
     def test_process_does_bubble_up(self, process):
         client = self.buf.cluster.get_routing_client()
         client.hmset('foo', {
@@ -45,10 +45,10 @@ class RedisBufferTest(TestCase):
         columns = {'times_seen': 2}
         filters = {'pk': 1}
         extra = {'foo': 'bar'}
-        self.buf.process('foo')
+        self.buf.process_incr('foo')
         process.assert_called_once_with(Group, columns, filters, extra)
 
-    @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
+    @mock.patch('sentry.buffer.redis.RedisBuffer._make_incr_key', mock.Mock(return_value='foo'))
     @mock.patch('sentry.buffer.redis.process_incr', mock.Mock())
     def test_incr_saves_to_redis(self):
         client = self.buf.cluster.get_routing_client()

--- a/tests/sentry/tasks/process_buffer/tests.py
+++ b/tests/sentry/tasks/process_buffer/tests.py
@@ -9,7 +9,7 @@ from sentry.testutils import TestCase
 
 
 class ProcessIncrTest(TestCase):
-    @mock.patch('sentry.buffer.backend.process')
+    @mock.patch('sentry.buffer.backend.process_incr')
     def test_calls_process(self, process):
         model = mock.Mock()
         columns = {'times_seen': 1}


### PR DESCRIPTION
```
>>> buffer.register_cb('foo.bar', do_stuff)
>>> buffer.apply('foo.bar', value='1')
```

/cc @macqueen 

Throwing this up for early feedback on implementation. The idea is that we can buffer multiple calls with a simple argument.

So in our immediate need, we'd want to buffer up calls to the GitHub API. We'd have a simple value, their GitHub username as input.

So we'd use this somethign like:

```python

def github_resolve_username(value):
  # make API call with value (username)

buffer.register_cb('github.resolve_username', github_resolve_username)

buffer.apply('github.resolve_username', value='mattrobenolt')
```

This then piggy backs off normal buffer flushing periodically.

The implementation is a simple redis `SET` since all we care about is unique elements.

TODO: add `__doc__`s and tests if @tkaemming isn't mad about this.