### PR TITLE
Group commits by repository

### DIFF
--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Commit, Repository
 from sentry.api.serializers.models.release import get_users_for_commits
@@ -11,13 +13,14 @@ class CommitSerializer(Serializer):
         author_objs = get_users_for_commits(item_list)
 
         repositories = list(Repository.objects.filter(id__in=[c.repository_id for c in item_list]))
+        repositories = serialize(repositories)
         repository_objs = {}
         for repository in repositories:
-            repository_objs[repository.id] = serialize(repository)
+            repository_objs[repository['id']] = repository
         result = {}
         for item in item_list:
             result[item] = {
-                'repository': repository_objs.get(item.repository_id, {}),
+                'repository': repository_objs.get(six.text_type(item.repository_id), {}),
                 'user': author_objs.get(item.author_id, {})
             }
 

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -4,7 +4,8 @@ import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
 import Avatar from '../../components/avatar';
 import TimeSince from '../../components/timeSince';
-
+import DropdownLink from '../../components/dropdownLink';
+import MenuItem from '../../components/menuItem';
 import ApiMixin from '../../mixins/apiMixin';
 
 import {t} from '../../locale';
@@ -121,6 +122,28 @@ const ReleaseCommits = React.createClass({
     );
   },
 
+  renderCommitsForRepo(repoCommits) {
+    let commitList = repoCommits;
+    return (
+      <ul className="list-group list-group-lg commit-list">
+        {commitList.map(commit => {
+          return (
+            <ReleaseCommit
+              key={commit.id}
+              commitId={commit.id}
+              author={commit.author}
+              commitMessage={commit.message}
+              commitDateCreated={commit.dateCreated}
+              repository={commit.repository}
+            />
+          );
+        })}
+      </ul>
+    );
+  },
+
+  // renderCommitsForRepo() {},
+
   render() {
     if (this.state.loading) return <LoadingIndicator />;
 
@@ -130,35 +153,68 @@ const ReleaseCommits = React.createClass({
 
     if (!commitList.length) return <this.emptyState />;
 
+    let commitsByRepository = commitList.reduce(function(cbr, commit) {
+      let {repository} = commit;
+      if (!cbr.hasOwnProperty(repository.name)) {
+        cbr[repository.name] = [];
+      }
+
+      cbr[repository.name].push(commit);
+      return cbr;
+    }, {});
     return (
-      <div className="panel panel-default">
-        <div className="panel-heading panel-heading-bold">
-          <div className="row">
-            <div className="col-xs-8">
-              Commit
-            </div>
-            <div className="col-xs-2">
-              Repository
-            </div>
-            <div className="col-xs-2 align-right">
-              SHA
-            </div>
-          </div>
-        </div>
-        <ul className="list-group list-group-lg commit-list">
-          {commitList.map(commit => {
-            return (
-              <ReleaseCommit
-                key={commit.id}
-                commitId={commit.id}
-                author={commit.author}
-                commitMessage={commit.message}
-                commitDateCreated={commit.dateCreated}
-                repository={commit.repository}
+      <div>
+        <DropdownLink
+          caret={false}
+          className="btn btn-default btn-sm"
+          title={
+            <span>
+              Repositories
+              <span
+                className="icon-arrow-down"
+                style={{marginLeft: 3, marginRight: -3}}
               />
+            </span>
+          }
+        >
+          <MenuItem key="all">
+            <a onClick={console.log('click')}>
+              All Repositories
+            </a>
+          </MenuItem>
+          {Object.keys(commitsByRepository).map(repository => {
+            return (
+              <MenuItem key={commitsByRepository[repository].id} noAnchor={true}>
+                <a onClick={console.log('click')}>
+                  {repository}
+                </a>
+              </MenuItem>
             );
           })}
-        </ul>
+        </DropdownLink>
+        {Object.keys(commitsByRepository).map(repository => {
+          return (
+            <div>
+              <span>{repository}</span>
+              <div className="panel panel-default">
+                <div className="panel-heading panel-heading-bold">
+                  <div className="row">
+                    <div className="col-xs-8">
+                      Commit
+                    </div>
+                    <div className="col-xs-2">
+                      Repository
+                    </div>
+                    <div className="col-xs-2 align-right">
+                      SHA
+                    </div>
+                  </div>
+                </div>
+                {this.renderCommitsForRepo(commitsByRepository[repository])}
+              </div>
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -127,7 +127,7 @@ const ReleaseCommits = React.createClass({
   setActiveRepo(repo) {
     this.setState({
       activeRepo: repo,
-      title: repo
+      title: repo || 'All Repositories'
     });
   },
 
@@ -181,99 +181,80 @@ const ReleaseCommits = React.createClass({
     }, {});
     return (
       <div>
-        <DropdownLink
-          caret={false}
-          className="btn btn-default btn-sm"
-          title={
-            <span>
-              {this.state.title}
-              <span
-                className="icon-arrow-down"
-                style={{marginLeft: 3, marginRight: -3}}
-              />
-            </span>
-          }
-        >
-          <MenuItem key="all">
-            <a
-              onClick={() => {
-                this.setActiveRepo(null);
-              }}
-            >
-              All Repositories
-            </a>
-          </MenuItem>
-          {Object.keys(commitsByRepository).map(repository => {
-            return (
-              <MenuItem key={commitsByRepository[repository].id} noAnchor={true}>
-                <a
-                  onClick={() => {
-                    this.setActiveRepo(repository);
-                  }}
+        <div className="panel panel-default">
+          <div className="panel-heading panel-heading-bold">
+            <div className="row">
+              <div className="col-xs-8">
+                Commit
+              </div>
+              <div className="col-xs-2">
+                <DropdownLink
+                  caret={false}
+                  className="btn btn-default btn-sm"
+                  title={
+                    <span>
+                      {this.state.title}
+                      <span
+                        className="icon-arrow-down"
+                        style={{marginLeft: 3, marginRight: -3}}
+                      />
+                    </span>
+                  }
                 >
-                  {repository}
-                </a>
-              </MenuItem>
-            );
-          })}
-        </DropdownLink>
+                  <MenuItem key="all">
+                    <a
+                      onClick={() => {
+                        this.setActiveRepo(null);
+                      }}
+                    >
+                      All Repositories
+                    </a>
+                  </MenuItem>
+                  {Object.keys(commitsByRepository).map(repository => {
+                    return (
+                      <MenuItem key={commitsByRepository[repository].id} noAnchor={true}>
+                        <a
+                          onClick={() => {
+                            this.setActiveRepo(repository);
+                          }}
+                        >
+                          {repository}
+                        </a>
+                      </MenuItem>
+                    );
+                  })}
+                </DropdownLink>
+              </div>
+              <div className="col-xs-2 align-right">
+                SHA
+              </div>
+            </div>
+          </div>
+        </div>
         {!this.state.activeRepo
           ? Object.keys(commitsByRepository).map(repository => {
               let activeCommits = commitsByRepository[repository];
               return (
                 <div>
                   <span>{repository}</span>
-                  <div className="panel panel-default">
-                    <div className="panel-heading panel-heading-bold">
-                      <div className="row">
-                        <div className="col-xs-8">
-                          Commit
-                        </div>
-                        <div className="col-xs-2">
-                          Repository
-                        </div>
-                        <div className="col-xs-2 align-right">
-                          SHA
-                        </div>
-                      </div>
-                    </div>
-                    <ul className="list-group list-group-lg commit-list">
-                      {activeCommits.map(commit => {
-                        return (
-                          <ReleaseCommit
-                            key={commit.id}
-                            commitId={commit.id}
-                            author={commit.author}
-                            commitMessage={commit.message}
-                            commitDateCreated={commit.dateCreated}
-                            repository={commit.repository}
-                          />
-                        );
-                      })}
-                    </ul>
-                  </div>
+                  <ul className="list-group list-group-lg commit-list">
+                    {activeCommits.map(commit => {
+                      return (
+                        <ReleaseCommit
+                          key={commit.id}
+                          commitId={commit.id}
+                          author={commit.author}
+                          commitMessage={commit.message}
+                          commitDateCreated={commit.dateCreated}
+                          repository={commit.repository}
+                        />
+                      );
+                    })}
+                  </ul>
                 </div>
               );
             })
-          : <div>
-              <span>{this.state.activeRepo}</span>
-              <div className="panel panel-default">
-                <div className="panel-heading panel-heading-bold">
-                  <div className="row">
-                    <div className="col-xs-8">
-                      Commit
-                    </div>
-                    <div className="col-xs-2">
-                      Repository
-                    </div>
-                    <div className="col-xs-2 align-right">
-                      SHA
-                    </div>
-                  </div>
-                </div>
-                {this.renderCommitsForRepo()}
-              </div>
-            </div>}
+          : this.renderCommitsForRepo()}
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -149,11 +149,8 @@ const ReleaseCommits = React.createClass({
       <div className="panel panel-default">
         <div className="panel-heading panel-heading-bold">
           <div className="row">
-            <div className="col-xs-10">
-              Commits in {repo}
-            </div>
-            <div className="col-xs-2 align-right">
-              SHA
+            <div className="col-xs-12">
+              {repo}
             </div>
           </div>
         </div>

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -188,22 +188,19 @@ const ReleaseCommits = React.createClass({
       <div>
         <div className="heading">
           <div className="row">
-            <div className="col-xs-1">
+            <div className="commits-header col-xs-1">
               <h5>Commits</h5>
             </div>
-            <div className="col-xs-11 align-left">
+            <div className="commits-dropdown col-xs-11 align-left">
               {Object.keys(commitsByRepository).length > 1
-                ? <div className="col-xs-2">
+                ? <div className="commits-dropdown col-xs-2">
                     <DropdownLink
                       caret={false}
-                      className="btn btn-default btn-sm"
                       title={
-                        <span>
-                          <span
-                            className="icon-arrow-down"
-                            style={{marginLeft: 3, marginRight: -3}}
-                          />
-                        </span>
+                        <span
+                          className="icon-arrow-down dropdown"
+                          style={{marginLeft: 3, marginRight: -3}}
+                        />
                       }
                     >
                       <MenuItem
@@ -212,8 +209,9 @@ const ReleaseCommits = React.createClass({
                         onClick={() => {
                           this.setActiveRepo(null);
                         }}
+                        isActive={this.state.activeRepo === null}
                       >
-                        All Repositories
+                        <a>All Repositories</a>
                       </MenuItem>
                       {Object.keys(commitsByRepository).map(repository => {
                         return (
@@ -223,8 +221,9 @@ const ReleaseCommits = React.createClass({
                             onClick={() => {
                               this.setActiveRepo(repository);
                             }}
+                            isActive={this.state.activeRepo === repository}
                           >
-                            {repository}
+                            <a>{repository}</a>
                           </MenuItem>
                         );
                       })}

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -187,13 +187,13 @@ const ReleaseCommits = React.createClass({
     return (
       <div>
         <div className="heading">
-          <div className="row">
-            <div className="commits-header col-xs-1">
-              <h5>Commits</h5>
-            </div>
-            <div className="commits-dropdown col-xs-11 align-left">
-              {Object.keys(commitsByRepository).length > 1
-                ? <div className="commits-dropdown col-xs-2">
+          {Object.keys(commitsByRepository).length > 1
+            ? <div className="row">
+                <div className="commits-header col-xs-1">
+                  <h5>Commits</h5>
+                </div>
+                <div className="commits-dropdown col-xs-11 align-left">
+                  <div className="commits-dropdown col-xs-2">
                     <DropdownLink
                       caret={false}
                       title={
@@ -229,9 +229,9 @@ const ReleaseCommits = React.createClass({
                       })}
                     </DropdownLink>
                   </div>
-                : null}
-            </div>
-          </div>
+                </div>
+              </div>
+            : null}
         </div>
         {activeRepo
           ? this.renderCommitsForRepo(activeRepo)

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -82,8 +82,7 @@ const ReleaseCommits = React.createClass({
       loading: true,
       error: false,
       commitList: [],
-      activeRepo: null,
-      title: 'All Repositories'
+      activeRepo: null
     };
   },
 
@@ -123,8 +122,7 @@ const ReleaseCommits = React.createClass({
 
   setActiveRepo(repo) {
     this.setState({
-      activeRepo: repo,
-      title: repo || 'All Repositories'
+      activeRepo: repo
     });
   },
 

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -82,7 +82,8 @@ const ReleaseCommits = React.createClass({
       loading: true,
       error: false,
       commitList: [],
-      activeRepo: null
+      activeRepo: null,
+      title: 'All Repositories'
     };
   },
 
@@ -122,7 +123,8 @@ const ReleaseCommits = React.createClass({
 
   setActiveRepo(repo) {
     this.setState({
-      activeRepo: repo
+      activeRepo: repo,
+      title: repo || 'All Repositories'
     });
   },
 
@@ -183,47 +185,45 @@ const ReleaseCommits = React.createClass({
       <div>
         <div className="heading">
           {Object.keys(commitsByRepository).length > 1
-            ? <div className="row">
-                <div className="commits-header col-xs-1">
-                  <h5>Commits</h5>
-                </div>
-                <div className="commits-dropdown col-xs-11 align-left">
-                  <div className="commits-dropdown col-xs-2">
-                    <DropdownLink
-                      caret={false}
-                      title={
+            ? <div className="commits-dropdown align-left">
+                <div className="commits-dropdown">
+                  <DropdownLink
+                    caret={false}
+                    title={
+                      <h5>
+                        {this.state.title}
                         <span
                           className="icon-arrow-down dropdown"
                           style={{marginLeft: 3, marginRight: -3}}
                         />
-                      }
+                      </h5>
+                    }
+                  >
+                    <MenuItem
+                      key="all"
+                      noAnchor={true}
+                      onClick={() => {
+                        this.setActiveRepo(null);
+                      }}
+                      isActive={this.state.activeRepo === null}
                     >
-                      <MenuItem
-                        key="all"
-                        noAnchor={true}
-                        onClick={() => {
-                          this.setActiveRepo(null);
-                        }}
-                        isActive={this.state.activeRepo === null}
-                      >
-                        <a>All Repositories</a>
-                      </MenuItem>
-                      {Object.keys(commitsByRepository).map(repository => {
-                        return (
-                          <MenuItem
-                            key={commitsByRepository[repository].id}
-                            noAnchor={true}
-                            onClick={() => {
-                              this.setActiveRepo(repository);
-                            }}
-                            isActive={this.state.activeRepo === repository}
-                          >
-                            <a>{repository}</a>
-                          </MenuItem>
-                        );
-                      })}
-                    </DropdownLink>
-                  </div>
+                      <a>All Repositories</a>
+                    </MenuItem>
+                    {Object.keys(commitsByRepository).map(repository => {
+                      return (
+                        <MenuItem
+                          key={commitsByRepository[repository].id}
+                          noAnchor={true}
+                          onClick={() => {
+                            this.setActiveRepo(repository);
+                          }}
+                          isActive={this.state.activeRepo === repository}
+                        >
+                          <a>{repository}</a>
+                        </MenuItem>
+                      );
+                    })}
+                  </DropdownLink>
                 </div>
               </div>
             : null}

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -82,8 +82,7 @@ const ReleaseCommits = React.createClass({
       loading: true,
       error: false,
       commitList: [],
-      activeRepo: null,
-      title: 'All Repositories'
+      activeRepo: null
     };
   },
 
@@ -123,8 +122,7 @@ const ReleaseCommits = React.createClass({
 
   setActiveRepo(repo) {
     this.setState({
-      activeRepo: repo,
-      title: repo || 'All Repositories'
+      activeRepo: repo
     });
   },
 
@@ -186,12 +184,12 @@ const ReleaseCommits = React.createClass({
         <div className="heading">
           {Object.keys(commitsByRepository).length > 1
             ? <div className="commits-dropdown align-left">
-                <div className="commits-dropdown">
+                <div className="commits-dropdowng">
                   <DropdownLink
                     caret={false}
                     title={
                       <h5>
-                        {this.state.title}
+                        {this.state.activeRepo || 'All Repositories'}
                         <span
                           className="icon-arrow-down dropdown"
                           style={{marginLeft: 3, marginRight: -3}}

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -111,3 +111,20 @@
     margin: 0 0 4px 4px;
   }
 }
+
+/**
+* Commits Tab
+* ============================================================================
+*/
+.commits-header {
+  padding-right: 0;
+}
+
+.commits-dropdown {
+  padding-left: 0;
+
+  span.dropdown {
+    top: -1px;
+    color: @gray;
+  }
+}

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -116,15 +116,18 @@
 * Commits Tab
 * ============================================================================
 */
-.commits-header {
-  padding-right: 0;
-}
 
 .commits-dropdown {
   padding-left: 0;
+  a {
+    color: @gray-darkest;
+  }
 
   span.dropdown {
-    top: -1px;
-    color: @gray;
+    display:inline;
+  }
+
+  .dropdown-menu {
+    top: -4px;
   }
 }


### PR DESCRIPTION
To be consistent with the way the files changed are displayed on the releases overview, this groups commits by repository. Users can also use the dropdown to display commits from a particular release.

![screen shot 2017-04-19 at 4 20 24 pm](https://cloud.githubusercontent.com/assets/9269824/25206361/5eb4cfc0-251c-11e7-8425-46d87c6f1034.png)

@ckj @MaxBittker @macqueen @benvinegar 

#nochanges