### PR TITLE
[fix] Avoid incorrect grouping with raven-java

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -411,8 +411,8 @@ class Frame(Interface):
                 output.append('<function>')
             else:
                 output.append(remove_function_outliers(self.function))
-        elif self.lineno is not None:
-            output.append(self.lineno)
+            if self.lineno is not None:
+                output.append(self.lineno)
         return output
 
     def get_api_context(self, is_public=False, pad_addr=None):


### PR DESCRIPTION
This PR is to solve the issue https://github.com/getsentry/sentry/issues/5268, "Events of stacktrace interface without context_line wrongly grouped into same group".

@getsentry/java @getsentry/api