### PR TITLE
Strip dotted release versions in UI

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 _sha1_re = re.compile(r'^[a-f0-9]{40}$')
+_dotted_path_prefix_re = re.compile(r'^([a-z][a-z0-9-]+)(\.[a-z][a-z0-9-]+)+-')
 
 
 class ReleaseProject(Model):
@@ -195,9 +196,13 @@ class Release(Model):
 
     @property
     def short_version(self):
-        if _sha1_re.match(self.version):
-            return self.version[:12]
-        return self.version
+        version = self.version
+        match = _dotted_path_prefix_re.match(version)
+        if match is not None:
+            version = version[match.end():]
+        if _sha1_re.match(version):
+            return version[:12]
+        return version
 
     def add_dist(self, name, date_added=None):
         from sentry.models import Distribution

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -224,7 +224,14 @@ export function formatBytes(bytes) {
 }
 
 export function getShortVersion(version) {
-  return version.match(/^[a-f0-9]{40}$/) ? version.substr(0, 12) : version;
+  let match = version.match(/^(?:[a-z][a-z0-9-]+)(?:\.[a-z][a-z0-9-]+)+-(.*)$/);
+  if (match) {
+    version = match[1];
+  }
+  if (version.match(/^[a-f0-9]{40}$/)) {
+    version = version.substr(0, 12);
+  }
+  return version;
 }
 
 /**


### PR DESCRIPTION
For releases that are prefixed with a dotted path (as we have on mobile) this path
is stripped off for display now.

This converts for instance `com.reactnativeexample-1.0` to `1.0`.