### PR TITLE
Upgrade Prettier to 1.2.2, enable --jsx-bracket-same-line=true

### DIFF
--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -36,7 +36,7 @@ def js_format(file_list=None):
 
     # Get Prettier version from package.json
     package_version = None
-    package_json_path = os.path.join((project_root), 'package.json')
+    package_json_path = os.path.join(project_root, 'package.json')
     with open(package_json_path) as package_json:
         try:
             package_version = json.load(package_json)['devDependencies']['prettier']

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -4,8 +4,10 @@ from __future__ import absolute_import
 import os
 import sys
 import subprocess
+import json
 
 from glob import glob
+from click import echo
 
 from sentry.lint.engine import check_files, get_js_files
 
@@ -18,7 +20,6 @@ if 'VIRTUAL_ENV' in os.environ:
         '%s/lib/*/site-packages' % os.environ['VIRTUAL_ENV'])[0]
     sys.path.insert(0, site_packages)
 
-
 PRETTIER_VERSION = "1.2.2"
 
 def js_format(file_list=None):
@@ -30,16 +31,23 @@ def js_format(file_list=None):
     prettier_path = os.path.join(project_root, 'node_modules', '.bin', 'prettier')
 
     if not os.path.exists(prettier_path):
-        from click import echo
-        echo('!! Skipping JavaScript formatting because prettier is not installed.')
+        echo('!! Skipping JavaScript formatting because prettier is not installed.', err=True)
         return False
 
-    proc = subprocess.Popen([prettier_path, '--version'], stdout=subprocess.PIPE)
-    proc.wait()
-    prettier_version = proc.stdout.readline().rstrip()
-    if prettier_version != PRETTIER_VERSION:
-        from click import echo
-        echo('!! Prettier is out of date. Please run `yarn install`.')
+    # Get Prettier version from package.json
+    package_version = None
+    package_json_path = os.path.join((project_root), 'package.json')
+    with open(package_json_path) as package_json:
+        try:
+            package_version = json.load(package_json)['devDependencies']['prettier']
+        except KeyError:
+            echo('!! Prettier missing from package.json', err=True)
+            return False
+
+    prettier_version = subprocess.check_output([prettier_path, '--version']).rstrip()
+    if prettier_version != package_version:
+        echo('!! Prettier is out of date: %s (expected %s). Please run `yarn install`.' \
+            % (prettier_version, package_version), err=True)
         return False
 
     js_file_list = get_js_files(file_list)

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 
 import os
 import sys
+import subprocess
 
 from glob import glob
-from subprocess import Popen
 
 from sentry.lint.engine import check_files, get_js_files
 
@@ -18,6 +18,8 @@ if 'VIRTUAL_ENV' in os.environ:
         '%s/lib/*/site-packages' % os.environ['VIRTUAL_ENV'])[0]
     sys.path.insert(0, site_packages)
 
+
+PRETTIER_VERSION = "1.2.2"
 
 def js_format(file_list=None):
     """
@@ -32,12 +34,22 @@ def js_format(file_list=None):
         echo('!! Skipping JavaScript formatting because prettier is not installed.')
         return False
 
+    proc = subprocess.Popen([prettier_path, '--version'], stdout=subprocess.PIPE)
+    proc.wait()
+    prettier_version = proc.stdout.readline().rstrip()
+    if prettier_version != PRETTIER_VERSION:
+        from click import echo
+        echo('!! Prettier is out of date. Please run `yarn install`.')
+        return False
+
     js_file_list = get_js_files(file_list)
 
     has_errors = False
     if js_file_list:
-        status = Popen([prettier_path, '--write', '--single-quote', '--bracket-spacing=false', '--print-width=90']
-                       + js_file_list).wait()
+        status = subprocess.Popen([prettier_path, '--write', '--single-quote',
+            '--bracket-spacing=false', '--print-width=90', '--jsx-bracket-same-line=true'] +
+            js_file_list
+        ).wait()
         has_errors = status != 0
 
     return has_errors

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.1",
     "phantomjs-prebuilt": "2.1.14",
-    "prettier": "^1.2.2",
+    "prettier": "1.2.2",
     "sinon": "1.17.2",
     "sinon-chai": "2.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.1",
     "phantomjs-prebuilt": "2.1.14",
-    "prettier": "1.1.0",
+    "prettier": "^1.2.2",
     "sinon": "1.17.2",
     "sinon-chai": "2.8.0"
   }

--- a/src/sentry/static/sentry/app/components/activity/feed.jsx
+++ b/src/sentry/static/sentry/app/components/activity/feed.jsx
@@ -42,7 +42,8 @@ const ActivityFeed = React.createClass({
     let location = this.props.location;
     let nextLocation = nextProps.location;
     if (
-      location.pathname != nextLocation.pathname || location.search != nextLocation.search
+      location.pathname != nextLocation.pathname ||
+      location.search != nextLocation.search
     ) {
       this.remountComponent();
     }

--- a/src/sentry/static/sentry/app/components/activity/note.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note.jsx
@@ -34,8 +34,7 @@ const Note = React.createClass({
               <LinkWithConfirmation
                 className="danger"
                 message={t('Are you sure you wish to delete this comment?')}
-                onConfirm={onDelete}
-              >
+                onConfirm={onDelete}>
                 {t('Remove')}
               </LinkWithConfirmation>
             </span>}

--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -32,8 +32,7 @@ const AlertMessage = React.createClass({
             type="button"
             className="close"
             aria-label={t('Close')}
-            onClick={this.closeAlert}
-          >
+            onClick={this.closeAlert}>
             <span aria-hidden="true">×</span>
           </button>
           <span className="icon" />

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -196,8 +196,7 @@ const AssigneeSelector = React.createClass({
         <MenuItem
           key={item.id}
           disabled={loading}
-          onSelect={this.assignTo.bind(this, item)}
-        >
+          onSelect={this.assignTo.bind(this, item)}>
           <Avatar user={item} className="avatar" size={48} />
           {this.highlight(item.name || item.email, this.state.filter)}
         </MenuItem>
@@ -231,8 +230,7 @@ const AssigneeSelector = React.createClass({
                   assignedTo
                     ? <Avatar user={assignedTo} className="avatar" size={48} />
                     : <span className="icon-user" />
-                }
-              >
+                }>
                 <MenuItem noAnchor={true} key="filter">
                   <input
                     type="text"
@@ -248,8 +246,7 @@ const AssigneeSelector = React.createClass({
                       key="clear"
                       className="clear-assignee"
                       disabled={!loading}
-                      onSelect={this.clearAssignTo}
-                    >
+                      onSelect={this.clearAssignTo}>
                       <span className="icon-circle-cross" /> {t('Clear Assignee')}
                     </MenuItem>
                   : ''}

--- a/src/sentry/static/sentry/app/components/bases/pluginComponentBase.jsx
+++ b/src/sentry/static/sentry/app/components/bases/pluginComponentBase.jsx
@@ -27,7 +27,7 @@ class PluginComponentBase extends React.Component {
       'onSaveError',
       'onSaveComplete',
       'renderField'
-    ].map(method => this[method] = this[method].bind(this));
+    ].map(method => (this[method] = this[method].bind(this)));
 
     if (this.fetchData) {
       this.fetchData = this.onLoad.bind(this, this.fetchData.bind(this));

--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -75,8 +75,7 @@ const CompactIssueHeader = React.createClass({
             <span>
               <Link
                 to={`/${orgId}/${projectId}/issues/${data.id}/activity/`}
-                className="comments"
-              >
+                className="comments">
                 <span className="icon icon-comments" />
                 <span className="tag-count">{data.numComments}</span>
               </Link>
@@ -197,21 +196,18 @@ const CompactIssue = React.createClass({
               topLevelClasses="more-menu"
               className="more-menu-toggle"
               caret={false}
-              title={title}
-            >
+              title={title}>
               <li>
                 <a
                   onClick={this.onUpdate.bind(this, {
                     status: issue.status !== 'resolved' ? 'resolved' : 'unresolved'
-                  })}
-                >
+                  })}>
                   <span className="icon-checkmark" />
                 </a>
               </li>
               <li>
                 <a
-                  onClick={this.onUpdate.bind(this, {isBookmarked: !issue.isBookmarked})}
-                >
+                  onClick={this.onUpdate.bind(this, {isBookmarked: !issue.isBookmarked})}>
                   <span className="icon-star-solid" />
                 </a>
               </li>

--- a/src/sentry/static/sentry/app/components/confirms/numberConfirm.jsx
+++ b/src/sentry/static/sentry/app/components/confirms/numberConfirm.jsx
@@ -50,8 +50,7 @@ const NumberConfirm = React.createClass({
         animation={true}
         backdrop="static"
         enforceFocus={true}
-        bsSize="sm"
-      >
+        bsSize="sm">
         <Modal.Header closeButton>
           <Modal.Title>{t('Please enter your code:')}</Modal.Title>
         </Modal.Header>

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -117,8 +117,7 @@ const ContextData = React.createClass({
               (valueInfo.isString ? 'val-string' : 'val-repr') +
                 (valueInfo.isStripped ? ' val-stripped' : '') +
                 (valueInfo.isMultiLine ? ' val-string-multiline' : '')
-            }
-          >
+            }>
             {valueInfo.repr}
           </span>
         ];

--- a/src/sentry/static/sentry/app/components/customSnoozeModal.jsx
+++ b/src/sentry/static/sentry/app/components/customSnoozeModal.jsx
@@ -107,8 +107,7 @@ const CustomSnoozeModal = React.createClass({
           <button
             type="button"
             className="btn btn-default"
-            onClick={this.props.onCanceled}
-          >
+            onClick={this.props.onCanceled}>
             {t('Cancel')}
           </button>
           <button type="button" className="btn btn-primary" onClick={this.snoozeClicked}>

--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -73,8 +73,7 @@ const DropdownLink = React.createClass({
         <a
           className={classNames(this.props.className, className)}
           data-toggle="dropdown"
-          ref="dropdownToggle"
-        >
+          ref="dropdownToggle">
           {this.props.title}
           {this.props.caret && <i className="icon-arrow-down" />}
         </a>

--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -118,8 +118,7 @@ const ContextChunk = React.createClass({
         event={evt}
         key={`context-${alias}`}
         type={`context-${alias}`}
-        title={this.renderTitle(Component)}
-      >
+        title={this.renderTitle(Component)}>
         <Component alias={alias} data={value} />
       </GroupEventDataSection>
     );

--- a/src/sentry/static/sentry/app/components/events/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/device.jsx
@@ -35,8 +35,7 @@ const DeviceInterface = React.createClass({
         event={event}
         type="device"
         title={t('Device')}
-        wrapTitle={true}
-      >
+        wrapTitle={true}>
         <table className="table key-value">
           <tbody>
             {data.name &&

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -37,8 +37,7 @@ const EventErrors = React.createClass({
         group={this.props.group}
         event={this.props.event}
         type="errors"
-        className="errors"
-      >
+        className="errors">
         <span className="icon icon-alert" />
         <p>
           <a className="pull-right" onClick={this.toggle}>

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -94,8 +94,7 @@ const EventEntries = React.createClass({
             group={group}
             event={evt}
             type={entry.type}
-            title={entry.type}
-          >
+            title={entry.type}>
             <p>{t('There was an error rendering this data.')}</p>
           </EventDataSection>
         );

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -29,8 +29,7 @@ const EventTags = React.createClass({
         event={this.props.event}
         title={t('Tags')}
         type="tags"
-        className="p-b-1"
-      >
+        className="p-b-1">
         <Pills className="no-margin">
           {tags.map(tag => {
             return (
@@ -39,8 +38,7 @@ const EventTags = React.createClass({
                   to={{
                     pathname: `/${orgId}/${projectId}/`,
                     query: {query: `${tag.key}:"${tag.value}"`}
-                  }}
-                >
+                  }}>
                   {deviceNameMapper(tag.value)}
                 </Link>
                 {isUrl(tag.value) &&

--- a/src/sentry/static/sentry/app/components/events/extraData.jsx
+++ b/src/sentry/static/sentry/app/components/events/extraData.jsx
@@ -24,8 +24,7 @@ const EventExtraData = React.createClass({
         group={this.props.group}
         event={this.props.event}
         type="extra"
-        title={t('Additional Data')}
-      >
+        title={t('Additional Data')}>
         <KeyValueList data={extraDataArray} isContextData={true} />
       </EventDataSection>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
@@ -216,8 +216,7 @@ const BreadcrumbsInterface = React.createClass({
         event={evt}
         type={this.props.type}
         title={title}
-        wrapTitle={false}
-      >
+        wrapTitle={false}>
         <ul className="crumbs">
           {numCollapsed > 0 &&
             <Collapsed onClick={this.onCollapseToggle} count={numCollapsed} />}

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/summaryLine.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/summaryLine.jsx
@@ -62,8 +62,7 @@ const SummaryLine = React.createClass({
       <div
         className={className}
         onClick={this.onToggle}
-        ref={this.makeSummariesGreatAgain}
-      >
+        ref={this.makeSummariesGreatAgain}>
         {this.props.children}
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -100,8 +100,7 @@ const CrashHeader = React.createClass({
               onClick={this.toggleOrder}
               className="tip"
               title={t('Toggle stacktrace order')}
-              style={{borderBottom: '1px dotted #aaa'}}
-            >
+              style={{borderBottom: '1px dotted #aaa'}}>
               {newestFirst ? t('most recent call first') : t('most recent call last')}
             </a>)
           </small>
@@ -112,20 +111,17 @@ const CrashHeader = React.createClass({
               className={
                 (stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'
               }
-              onClick={this.setStackView.bind(this, 'app')}
-            >
+              onClick={this.setStackView.bind(this, 'app')}>
               {t('App Only')}
             </a>}
           <a
             className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.setStackView.bind(this, 'full')}
-          >
+            onClick={this.setStackView.bind(this, 'full')}>
             {t('Full')}
           </a>
           <a
             className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.setStackView.bind(this, 'raw')}
-          >
+            onClick={this.setStackView.bind(this, 'raw')}>
             {t('Raw')}
           </a>
         </div>
@@ -136,8 +132,7 @@ const CrashHeader = React.createClass({
               className={
                 (stackType === 'original' ? 'active' : '') + ' btn btn-default btn-sm'
               }
-              onClick={() => this.setStackType('original')}
-            >
+              onClick={() => this.setStackType('original')}>
               {this.getOriginalButtonLabel()}
             </a>,
             <a
@@ -145,8 +140,7 @@ const CrashHeader = React.createClass({
               className={
                 (stackType === 'minified' ? 'active' : '') + ' btn btn-default btn-sm'
               }
-              onClick={() => this.setStackType('minified')}
-            >
+              onClick={() => this.setStackType('minified')}>
               {this.getMinifiedButtonLabel()}
             </a>
           ]}

--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
@@ -53,20 +53,17 @@ const CSPInterface = React.createClass({
         <div className="btn-group">
           <a
             className={(view === 'report' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.toggleView.bind(this, 'report')}
-          >
+            onClick={this.toggleView.bind(this, 'report')}>
             {t('Report')}
           </a>
           <a
             className={(view === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.toggleView.bind(this, 'raw')}
-          >
+            onClick={this.toggleView.bind(this, 'raw')}>
             {t('Raw')}
           </a>
           <a
             className={(view === 'help' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.toggleView.bind(this, 'help')}
-          >
+            onClick={this.toggleView.bind(this, 'help')}>
             {t('Help')}
           </a>
         </div>
@@ -82,8 +79,7 @@ const CSPInterface = React.createClass({
         event={event}
         type="csp"
         title={title}
-        wrapTitle={false}
-      >
+        wrapTitle={false}>
         {children}
       </GroupEventDataSection>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -51,8 +51,7 @@ const DebugMetaInterface = React.createClass({
             group={this.props.group}
             event={this.props.event}
             type="packages"
-            title={t('Images Loaded')}
-          >
+            title={t('Images Loaded')}>
             <ClippedBox>
               <KeyValueList data={images} isSorted={false} />
             </ClippedBox>

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -60,8 +60,7 @@ const ExceptionInterface = React.createClass({
         event={event}
         type={this.props.type}
         title={title}
-        wrapTitle={false}
-      >
+        wrapTitle={false}>
         <CrashContent
           group={group}
           event={event}

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -144,8 +144,7 @@ const Frame = React.createClass({
           <a
             key="real-filename"
             className="in-at tip real-filename"
-            data-title={_.escape(data.filename)}
-          >
+            data-title={_.escape(data.filename)}>
             <span className="icon-question" />
           </a>
         );
@@ -197,8 +196,7 @@ const Frame = React.createClass({
         <a
           key="original-src"
           className="in-at tip original-src"
-          data-title={this.renderOriginalSourceInfo()}
-        >
+          data-title={this.renderOriginalSourceInfo()}>
           <span className="icon-question" />
         </a>
       );
@@ -269,8 +267,7 @@ const Frame = React.createClass({
         key="expander"
         title={t('Toggle context')}
         onClick={this.toggleContext}
-        className="btn btn-sm btn-default btn-toggle"
-      >
+        className="btn btn-sm btn-default btn-toggle">
         <span className={this.state.isExpanded ? 'icon-minus' : 'icon-plus'} />
       </a>
     );
@@ -322,8 +319,7 @@ const Frame = React.createClass({
       return (
         <span
           className="repeated-frames"
-          title={`Frame repeated ${this.props.timesRepeated} times`}
-        >
+          title={`Frame repeated ${this.props.timesRepeated} times`}>
           <span className="icon-refresh" />
           <span>{this.props.timesRepeated}</span>
         </span>

--- a/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
@@ -20,8 +20,7 @@ const MessageInterface = React.createClass({
         group={this.props.group}
         event={this.props.event}
         type="message"
-        title={t('Message')}
-      >
+        title={t('Message')}>
         <pre
           className="plain"
           dangerouslySetInnerHTML={{

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -87,8 +87,7 @@ const RawExceptionContent = React.createClass({
           downloadButton = (
             <a
               href={this.api.baseUrl + this.getAppleCrashReportEndpoint() + `&download=1`}
-              className="btn btn-default btn-sm pull-right"
-            >
+              className="btn btn-default btn-sm pull-right">
               Download
             </a>
           );

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -69,15 +69,13 @@ const RequestInterface = React.createClass({
         <div key="view-buttons" className="btn-group">
           <a
             className={(view === 'rich' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.toggleView.bind(this, 'rich')}
-          >
+            onClick={this.toggleView.bind(this, 'rich')}>
             {/* Translators: this means "rich" rendering (fancy tables) */
             t('Rich')}
           </a>
           <a
             className={(view === 'curl' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.toggleView.bind(this, 'curl')}
-          >
+            onClick={this.toggleView.bind(this, 'curl')}>
             <code>{'curl'}</code>
           </a>
         </div>
@@ -109,8 +107,7 @@ const RequestInterface = React.createClass({
         type={this.props.type}
         title={title}
         wrapTitle={false}
-        className="request"
-      >
+        className="request">
         {view === 'curl'
           ? <pre>{getCurlCommand(data)}</pre>
           : <RichHttpContent data={data} />}

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -70,8 +70,7 @@ const StacktraceInterface = React.createClass({
         event={evt}
         type={this.props.type}
         title={title}
-        wrapTitle={false}
-      >
+        wrapTitle={false}>
         <CrashContent
           group={group}
           event={evt}

--- a/src/sentry/static/sentry/app/components/events/interfaces/template.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/template.jsx
@@ -22,8 +22,7 @@ const TemplateInterface = React.createClass({
         group={this.props.group}
         event={this.props.event}
         type={this.props.type}
-        title={<div>{t('Template')}</div>}
-      >
+        title={<div>{t('Template')}</div>}>
         <div className="traceback no-exception">
           <ul>
             <Frame data={this.props.data} isExpanded={true} />

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -253,8 +253,7 @@ const ThreadsInterface = React.createClass({
           btnGroup={true}
           caret={true}
           className="btn btn-default btn-sm"
-          title={getThreadTitle(activeThread, this.props.event, true)}
-        >
+          title={getThreadTitle(activeThread, this.props.event, true)}>
           {this.props.data.values.map((thread, idx) => {
             return (
               <MenuItem key={idx} noAnchor={true}>
@@ -292,8 +291,7 @@ const ThreadsInterface = React.createClass({
         event={evt}
         type={this.props.type}
         title={title}
-        wrapTitle={false}
-      >
+        wrapTitle={false}>
         <Thread
           group={group}
           data={activeThread}

--- a/src/sentry/static/sentry/app/components/events/packageData.jsx
+++ b/src/sentry/static/sentry/app/components/events/packageData.jsx
@@ -25,8 +25,7 @@ const EventPackageData = React.createClass({
         group={this.props.group}
         event={this.props.event}
         type="packages"
-        title={t('Packages')}
-      >
+        title={t('Packages')}>
         <ClippedBox>
           <KeyValueList data={packages} />
         </ClippedBox>

--- a/src/sentry/static/sentry/app/components/events/reprocessingHint.jsx
+++ b/src/sentry/static/sentry/app/components/events/reprocessingHint.jsx
@@ -80,8 +80,7 @@ const ReprocessingHint = React.createClass({
         group={this.props.group}
         event={this.props.event}
         type="hint"
-        className="errors hint"
-      >
+        className="errors hint">
         <span className="icon icon-question event" />
         <p>
           <a className="pull-right" onClick={this.hide}>{t('Dismiss')}</a>
@@ -123,8 +122,7 @@ const ReprocessingHint = React.createClass({
       <ReactCSSTransitionGroup
         transitionName="hint"
         transitionEnterTimeout={500}
-        transitionLeaveTimeout={500}
-      >
+        transitionLeaveTimeout={500}>
         {shouldRender ? this.renderHint() : null}
       </ReactCSSTransitionGroup>
     );

--- a/src/sentry/static/sentry/app/components/events/sdk.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdk.jsx
@@ -20,8 +20,7 @@ const EventSdk = React.createClass({
         event={event}
         type="sdk"
         title={t('SDK')}
-        wrapTitle={true}
-      >
+        wrapTitle={true}>
         <table className="table key-value">
           <tbody>
             <tr key="name">

--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -40,8 +40,7 @@ const FileChange = React.createClass({
               return (
                 <span
                   className="avatar-grid-item m-b-0 tip"
-                  title={author.name + ' ' + author.email}
-                >
+                  title={author.name + ' ' + author.email}>
                   <Avatar user={author} />
                 </span>
               );

--- a/src/sentry/static/sentry/app/components/footer.jsx
+++ b/src/sentry/static/sentry/app/components/footer.jsx
@@ -27,8 +27,7 @@ const Footer = React.createClass({
             <a
               className="hidden-xs"
               href="https://github.com/getsentry/sentry"
-              rel="noreferrer"
-            >
+              rel="noreferrer">
               {t('Contribute')}
             </a>
             {config.isOnPremise &&

--- a/src/sentry/static/sentry/app/components/forms/form.jsx
+++ b/src/sentry/static/sentry/app/components/forms/form.jsx
@@ -32,8 +32,7 @@ const Form = React.createClass({
           <button
             className="btn btn-primary"
             disabled={this.props.submitDisabled}
-            type="submit"
-          >
+            type="submit">
             {this.props.submitLabel}
           </button>
           {this.props.extraButton}

--- a/src/sentry/static/sentry/app/components/forms/passwordField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.jsx
@@ -32,7 +32,8 @@ class PasswordField extends InputField {
   componentWillReceiveProps(nextProps) {
     // close edit mode after successful save
     if (
-      this.props.formState === FormState.SAVING && nextProps.formState === FormState.READY
+      this.props.formState === FormState.SAVING &&
+      nextProps.formState === FormState.READY
     ) {
       this.setState({
         editing: false

--- a/src/sentry/static/sentry/app/components/forms/select2Field.jsx
+++ b/src/sentry/static/sentry/app/components/forms/select2Field.jsx
@@ -15,8 +15,7 @@ class Select2Field extends InputField {
         disabled={this.props.disabled}
         required={this.props.required}
         multiple={this.props.multiple || false}
-        value={this.state.value}
-      >
+        value={this.state.value}>
         {(this.props.choices || []).map(choice => {
           return (
             <option key={choice[0]} value={choice[0]}>

--- a/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
@@ -82,8 +82,7 @@ const IssuePluginActions = React.createClass({
       button = (
         <button
           className={'btn btn-default btn-sm btn-plugin-' + plugin.slug}
-          onClick={this.openModal.bind(this, allowedActions[0])}
-        >
+          onClick={this.openModal.bind(this, allowedActions[0])}>
           {toTitleCase(allowedActions[0]) + ' ' + plugin.title + ' Issue'}
         </button>
       );
@@ -101,8 +100,7 @@ const IssuePluginActions = React.createClass({
                   style={{marginLeft: 3, marginRight: -3}}
                 />
               </span>
-            }
-          >
+            }>
             {allowedActions.map(action => {
               return (
                 <MenuItem key={action} noAnchor={true}>
@@ -125,8 +123,7 @@ const IssuePluginActions = React.createClass({
           onHide={this.closeModal}
           animation={false}
           backdrop="static"
-          enforceFocus={false}
-        >
+          enforceFocus={false}>
           <Modal.Header closeButton>
             <Modal.Title>{plugin.title + ' Issue'}</Modal.Title>
           </Modal.Header>

--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -156,15 +156,13 @@ const GroupReleaseStats = React.createClass({
         <h6>
           <span>
             <DropdownLink
-              title={environment ? toTitleCase(environment) : DEFAULT_ENV_NAME}
-            >
+              title={environment ? toTitleCase(environment) : DEFAULT_ENV_NAME}>
               {envList.map(e => {
                 return (
                   <MenuItem
                     key={e.name}
                     isActive={environment === e.name}
-                    onClick={this.switchEnv.bind(this, e.name)}
-                  >
+                    onClick={this.switchEnv.bind(this, e.name)}>
                     {toTitleCase(e.name) || DEFAULT_ENV_NAME}
                   </MenuItem>
                 );

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -92,8 +92,7 @@ const SeenInfo = React.createClass({
                 ? <VersionHoverCard
                     orgId={orgId}
                     projectId={projectId}
-                    version={release.version}
-                  >
+                    version={release.version}>
                     <Version
                       orgId={orgId}
                       projectId={projectId}

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -146,8 +146,7 @@ const GroupSidebar = React.createClass({
         <p className="help-block">{this.getNotificationText()}</p>
         <a
           className={`btn btn-default btn-subscribe ${group.isSubscribed && 'subscribed'}`}
-          onClick={this.toggleSubscription}
-        >
+          onClick={this.toggleSubscription}>
           <span className="icon-signal" />
           {' '}
           {group.isSubscribed ? t('Unsubscribe') : t('Subscribe')}

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -114,8 +114,7 @@ const SuggestedOwners = React.createClass({
               })}
             </ul>
           </div>
-        )}
-      >
+        )}>
         <Avatar user={author} />
       </span>
     );

--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -115,8 +115,7 @@ const TagDistributionMeter = React.createClass({
                   '</div>' +
                   pctLabel +
                   '%'
-              }
-            >
+              }>
               <span className="tag-description">
                 <span className="tag-percentage">{pctLabel}%</span>
                 <span className="tag-label">{deviceNameMapper(value.name)}</span>
@@ -130,8 +129,7 @@ const TagDistributionMeter = React.createClass({
             className="segment segment-9"
             style={{width: otherPct + '%'}}
             to={`/${orgId}/${projectId}/issues/${this.props.group.id}/tags/${this.props.tag}/`}
-            title={'Other<br/>' + otherPctLabel + '%'}
-          >
+            title={'Other<br/>' + otherPctLabel + '%'}>
             <span className="tag-description">
               <span className="tag-percentage">{otherPctLabel}%</span>
               <span className="tag-label">{t('Other')}</span>

--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -53,7 +53,8 @@ const GroupList = React.createClass({
 
   componentDidUpdate(prevProps) {
     if (
-      prevProps.orgId !== this.props.orgId || prevProps.projectId !== this.props.projectId
+      prevProps.orgId !== this.props.orgId ||
+      prevProps.projectId !== this.props.projectId
     ) {
       this.fetchData();
     }

--- a/src/sentry/static/sentry/app/components/indicators.jsx
+++ b/src/sentry/static/sentry/app/components/indicators.jsx
@@ -22,8 +22,7 @@ const Indicators = React.createClass({
         <ReactCSSTransitionGroup
           transitionName="toast"
           transitionEnter={false}
-          transitionLeaveTimeout={500}
-        >
+          transitionLeaveTimeout={500}>
           {this.state.items.map(indicator => {
             if (indicator.type === 'error' || indicator.type === 'success') {
               return (

--- a/src/sentry/static/sentry/app/components/issueList.jsx
+++ b/src/sentry/static/sentry/app/components/issueList.jsx
@@ -45,7 +45,8 @@ const IssueList = React.createClass({
     if (!location) return;
 
     if (
-      location.pathname != nextLocation.pathname || location.search != nextLocation.search
+      location.pathname != nextLocation.pathname ||
+      location.search != nextLocation.search
     ) {
       this.remountComponent();
     }

--- a/src/sentry/static/sentry/app/components/issues/snoozeAction.jsx
+++ b/src/sentry/static/sentry/app/components/issues/snoozeAction.jsx
@@ -46,8 +46,7 @@ const SnoozeAction = React.createClass({
         title={this.props.tooltip}
         className={this.props.className}
         disabled={this.props.disabled}
-        onClick={this.toggleModal}
-      >
+        onClick={this.toggleModal}>
         <span>{t('zZz')}</span>
 
         <Modal
@@ -55,8 +54,7 @@ const SnoozeAction = React.createClass({
           title={t('Please confirm')}
           animation={false}
           onHide={this.closeModal}
-          bsSize="sm"
-        >
+          bsSize="sm">
           <div className="modal-body">
             <h5>{t('How long should we ignore this issue?')}</h5>
             <ul className="nav nav-stacked nav-pills">

--- a/src/sentry/static/sentry/app/components/letterAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/letterAvatar.jsx
@@ -64,8 +64,7 @@ const LetterAvatar = React.createClass({
           fontSize="65"
           style={{dominantBaseline: 'central'}}
           textAnchor="middle"
-          fill="#FFFFFF"
-        >
+          fill="#FFFFFF">
           {this.getInitials()}
         </text>
       </svg>

--- a/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
+++ b/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
@@ -46,15 +46,13 @@ const LinkWithConfirmation = React.createClass({
         className={className}
         disabled={this.props.disabled}
         onClick={this.onToggle}
-        title={this.props.title}
-      >
+        title={this.props.title}>
         {this.props.children}
         <Modal
           show={this.state.isModalOpen}
           title={t('Please confirm')}
           animation={false}
-          onHide={this.onToggle}
-        >
+          onHide={this.onToggle}>
           <div className="modal-body">
             <p><strong>{this.props.message}</strong></p>
           </div>

--- a/src/sentry/static/sentry/app/components/loadingError.jsx
+++ b/src/sentry/static/sentry/app/components/loadingError.jsx
@@ -26,8 +26,7 @@ const LoadingError = React.createClass({
             <a
               onClick={this.props.onRetry}
               className="btn btn-default btn-sm"
-              style={{marginLeft: 5}}
-            >
+              style={{marginLeft: 5}}>
               {t('Retry')}
             </a>}
         </p>

--- a/src/sentry/static/sentry/app/components/menuItem.jsx
+++ b/src/sentry/static/sentry/app/components/menuItem.jsx
@@ -35,8 +35,7 @@ const MenuItem = React.createClass({
           title={this.props.title}
           onClick={this.handleClick}
           className={this.props.linkClassName}
-          tabIndex="-1"
-        >
+          tabIndex="-1">
           {this.props.children}
         </Link>
       );
@@ -47,8 +46,7 @@ const MenuItem = React.createClass({
         onClick={this.handleClick}
         href={this.props.href}
         className={this.props.linkClassName}
-        tabIndex="-1"
-      >
+        tabIndex="-1">
         {this.props.children}
       </a>
     );
@@ -76,8 +74,7 @@ const MenuItem = React.createClass({
         title={null}
         href={null}
         className={classNames(this.props.className, classes)}
-        onClick={this.props.onClick}
-      >
+        onClick={this.props.onClick}>
         {children}
       </li>
     );

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -48,14 +48,12 @@ const OrganizationIssueList = React.createClass({
               to={path}
               className={
                 'btn btn-sm btn-default' + (status === 'unresolved' ? ' active' : '')
-              }
-            >
+              }>
               {t('Unresolved')}
             </Link>
             <Link
               to={{pathname: path, query: {status: ''}}}
-              className={'btn btn-sm btn-default' + (status === '' ? ' active' : '')}
-            >
+              className={'btn btn-sm btn-default' + (status === '' ? ' active' : '')}>
               {t('All Issues')}
             </Link>
           </div>

--- a/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
@@ -28,30 +28,26 @@ const HomeContainer = React.createClass({
               ? <a
                   href={`/organizations/${org.slug}/projects/new/`}
                   className="btn btn-primary"
-                  style={{marginRight: 5}}
-                >
+                  style={{marginRight: 5}}>
                   {t('New Project')}
                 </a>
               : <a
                   className="btn btn-primary btn-disabled tip"
                   data-placement="bottom"
                   title={t('You do not have enough permission to create new projects')}
-                  style={{marginRight: 5}}
-                >
+                  style={{marginRight: 5}}>
                   {t('New Project')}
                 </a>}
             {access.has('team:write')
               ? <a
                   href={`/organizations/${org.slug}/teams/new/`}
-                  className="btn btn-primary"
-                >
+                  className="btn btn-primary">
                   {t('New Team')}
                 </a>
               : <a
                   className="btn btn-primary btn-disabled tip"
                   data-placement="bottom"
-                  title={t('You do not have enough permission to create new teams')}
-                >
+                  title={t('You do not have enough permission to create new teams')}>
                   {t('New Team')}
                 </a>}
           </div>

--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -39,8 +39,7 @@ const HomeSidebar = React.createClass({
             isActive={() => {
               // return true if path matches /organizations/slug-name/teams/ OR /organizations/slug-name/all-teams/
               return /^\/[^\/]+\/$/.test(this.context.location.pathname);
-            }}
-          >
+            }}>
             {t('Dashboard')}
           </ListLink>
           <ListLink
@@ -50,8 +49,7 @@ const HomeSidebar = React.createClass({
               return /^\/organizations\/[^\/]+\/(teams|all-teams)\/$/.test(
                 this.context.location.pathname
               );
-            }}
-          >
+            }}>
             {t('Projects & Teams')}
           </ListLink>
           {access.has('org:read') &&

--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -40,8 +40,7 @@ const Pagination = React.createClass({
               query: {...location.query, cursor: links.previous.cursor}
             }}
             className={previousPageClassName}
-            disabled={links.previous.results === false}
-          >
+            disabled={links.previous.results === false}>
             <span title={t('Previous')} className="icon-arrow-left" />
           </Link>
           <Link
@@ -50,8 +49,7 @@ const Pagination = React.createClass({
               query: {...location.query, cursor: links.next.cursor}
             }}
             className={nextPageClassName}
-            disabled={links.next.results === false}
-          >
+            disabled={links.next.results === false}>
             <span title={t('Next')} className="icon-arrow-right" />
           </Link>
         </div>

--- a/src/sentry/static/sentry/app/components/projectHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/index.jsx
@@ -77,8 +77,7 @@ const ProjectHeader = React.createClass({
                   ? 'btn btn-sm btn-default active'
                   : 'btn btn-sm btn-default'
               }
-              href={`/${org.slug}/${project.slug}/settings/`}
-            >
+              href={`/${org.slug}/${project.slug}/settings/`}>
               <span className="icon icon-settings" /> {t('Project Settings')}
             </a>}
         </div>

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -296,8 +296,7 @@ const ProjectSelector = React.createClass({
             title=""
             topLevelClasses="project-dropdown"
             onOpen={this.onOpen}
-            onClose={this.onClose}
-          >
+            onClose={this.onClose}>
             <li className="project-filter" key="_filter">
               <input
                 value={this.state.filter}

--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -83,8 +83,7 @@ const ReleaseProjectStatSparkline = React.createClass({
           </Sparklines>
         </div>
         <Link
-          to={`/${orgId}/${project.slug}/releases/${encodeURIComponent(version)}/overview/`}
-        >
+          to={`/${orgId}/${project.slug}/releases/${encodeURIComponent(version)}/overview/`}>
           <h6 className="m-b-0">
             {project.name}
           </h6>

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -37,8 +37,7 @@ const ReleaseStats = React.createClass({
             return (
               <span
                 className="avatar-grid-item tip"
-                title={author.name + ' ' + author.email}
-              >
+                title={author.name + ' ' + author.email}>
                 <Avatar user={author} />
               </span>
             );

--- a/src/sentry/static/sentry/app/components/resultGrid.jsx
+++ b/src/sentry/static/sentry/app/components/resultGrid.jsx
@@ -35,8 +35,7 @@ const Filter = React.createClass({
         key=""
         isActive={this.props.value === '' || !this.props.value}
         to={this.props.path}
-        query={query}
-      >
+        query={query}>
         Any
       </MenuItem>
     );
@@ -56,8 +55,7 @@ const Filter = React.createClass({
               key={item[0]}
               isActive={this.props.value === item[0]}
               to={this.props.path}
-              query={query}
-            >
+              query={query}>
               {item[1]}
             </MenuItem>
           );
@@ -104,8 +102,7 @@ const SortBy = React.createClass({
               isActive={this.props.value === item[0]}
               key={item[0]}
               to={this.props.path}
-              query={query}
-            >
+              query={query}>
               {item[1]}
             </MenuItem>
           );

--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -113,8 +113,7 @@ const Broadcasts = React.createClass({
         <a
           className="broadcasts-toggle"
           onClick={this.onShowPanel}
-          title="Updates from Sentry"
-        >
+          title="Updates from Sentry">
           <span className="icon icon-globe" />
           {this.getUnseenIds() > 0 && <span className="activity-indicator" />}
         </a>
@@ -122,8 +121,7 @@ const Broadcasts = React.createClass({
           this.props.currentPanel == 'broadcasts' &&
           <SidebarPanel
             title={t('Recent updates from Sentry')}
-            hidePanel={this.props.hidePanel}
-          >
+            hidePanel={this.props.hidePanel}>
             {loading
               ? <LoadingIndicator />
               : broadcasts.length === 0

--- a/src/sentry/static/sentry/app/components/sidebar/incidents.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/incidents.jsx
@@ -44,8 +44,7 @@ const Incidents = React.createClass({
           status &&
           <SidebarPanel
             title={t('Recent status updates')}
-            hidePanel={this.props.hidePanel}
-          >
+            hidePanel={this.props.hidePanel}>
             <ul className="incident-list list-unstyled">
               {status.incidents.map(incident => (
                 <li className="incident-item" key={incident.id}>

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -44,8 +44,7 @@ const OnboardingStatus = React.createClass({
       <li
         className={
           this.props.currentPanel == 'todos' ? 'onboarding active' : 'onboarding'
-        }
-      >
+        }>
         <div className="onboarding-progress-bar" onClick={this.props.onShowPanel}>
           <div className="slider" style={style} />
         </div>
@@ -53,8 +52,7 @@ const OnboardingStatus = React.createClass({
           this.props.currentPanel == 'todos' &&
           <SidebarPanel
             title="Getting Started with Sentry"
-            hidePanel={this.props.hidePanel}
-          >
+            hidePanel={this.props.hidePanel}>
             <TodoList />
           </SidebarPanel>}
       </li>
@@ -214,8 +212,7 @@ const Sidebar = React.createClass({
                 !config.isOnPremise
                   ? `/organizations/${org.slug}/support/`
                   : 'https://forum.sentry.io/'
-              }
-            >
+              }>
               <span className="icon icon-support" />
             </a>
           </li>

--- a/src/sentry/static/sentry/app/components/sidebar/organizationSelector.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/organizationSelector.jsx
@@ -63,8 +63,7 @@ const OrganizationSelector = React.createClass({
                 return (
                   <li
                     className={activeOrg.id === org.id ? 'org active' : 'org'}
-                    key={org.slug}
-                  >
+                    key={org.slug}>
                     {this.getLinkNode(
                       org,
                       <LetterAvatar displayName={org.name} identifier={org.slug} />,

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -219,8 +219,7 @@ const StackedBarChart = React.createClass({
         <span
           key={i}
           className={this.props.barClasses[i]}
-          style={{height: pct + '%', bottom: prevPct + '%'}}
-        >
+          style={{height: pct + '%', bottom: prevPct + '%'}}>
           {y}
         </span>
       );
@@ -232,8 +231,7 @@ const StackedBarChart = React.createClass({
         key={point.x}
         className="chart-column tip"
         data-point-index={pointIdx}
-        style={{width: pointWidth}}
-      >
+        style={{width: pointWidth}}>
         {pts}
       </a>
     );

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -168,8 +168,7 @@ const StreamGroup = React.createClass({
                 <li>
                   <Link
                     to={`/${orgId}/${projectId}/issues/${id}/activity/`}
-                    className="comments"
-                  >
+                    className="comments">
                     <span className="icon icon-comments" />
                     <span className="tag-count">{data.numComments}</span>
                   </Link>
@@ -180,8 +179,7 @@ const StreamGroup = React.createClass({
                     to={{
                       pathname: `/${orgId}/${projectId}/`,
                       query: {query: 'logger:' + data.logger}
-                    }}
-                  >
+                    }}>
                     {data.logger}
                   </Link>
                 </li>}

--- a/src/sentry/static/sentry/app/components/switch.jsx
+++ b/src/sentry/static/sentry/app/components/switch.jsx
@@ -33,8 +33,7 @@ const Switch = React.createClass({
         className={switchClasses}
         onClick={this.props.isDisabled ? null : this.props.toggle}
         role="checkbox"
-        aria-checked={this.props.isActive}
-      >
+        aria-checked={this.props.isActive}>
         <span className="switch-toggle" />
       </div>
     );

--- a/src/sentry/static/sentry/app/components/timeSince.jsx
+++ b/src/sentry/static/sentry/app/components/timeSince.jsx
@@ -79,8 +79,7 @@ const TimeSince = React.createClass({
       <time
         dateTime={date.toISOString()}
         title={moment(date).format(format)}
-        className={this.props.className}
-      >
+        className={this.props.className}>
         {this.state.relative}
       </time>
     );

--- a/src/sentry/static/sentry/app/components/truncate.jsx
+++ b/src/sentry/static/sentry/app/components/truncate.jsx
@@ -57,8 +57,7 @@ const Truncate = React.createClass({
         onMouseOver={this.onFocus}
         onMouseOut={this.onBlur}
         onFocus={this.onFocus}
-        onBlur={this.onBlur}
-      >
+        onBlur={this.onBlur}>
         <span className="short-value">{shortValue}</span>
         {isTruncated && <span className="full-value">{value}</span>}
       </span>

--- a/src/sentry/static/sentry/app/components/u2finterface.jsx
+++ b/src/sentry/static/sentry/app/components/u2finterface.jsx
@@ -186,8 +186,7 @@ const U2fInterface = React.createClass({
           'u2f-box' +
             (this.state.hasBeenTapped ? ' tapped' : '') +
             (this.state.deviceFailure ? ' device-failure' : '')
-        }
-      >
+        }>
         <div className="device-animation-frame">
           <div className="device-failed" />
           <div className="device-animation" />

--- a/src/sentry/static/sentry/app/components/u2fsign.jsx
+++ b/src/sentry/static/sentry/app/components/u2fsign.jsx
@@ -21,8 +21,7 @@ const U2fSign = React.createClass({
       <U2fInterface
         challengeData={this.props.challengeData}
         silentIfUnsupported={displayMode === 'sudo'}
-        flowMode={'sign'}
-      >
+        flowMode={'sign'}>
         <p>
           {displayMode === 'signin'
             ? t(

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -157,8 +157,7 @@ const VersionHoverCard = React.createClass({
                             return (
                               <span
                                 className="avatar-grid-item tip"
-                                title={author.name + ' ' + author.email}
-                              >
+                                title={author.name + ' ' + author.email}>
                                 <Avatar user={author} />
                               </span>
                             );

--- a/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
@@ -186,8 +186,7 @@ class IssueActions extends PluginComponentBase {
             <Form
               onSubmit={this.createIssue}
               submitLabel={t('Create Issue')}
-              footerClass=""
-            >
+              footerClass="">
               {this.state.createFieldList.map(field => {
                 if (field.has_autocomplete) {
                   field = Object.assign(

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -149,8 +149,7 @@ function routes() {
         />
         <Route
           path="/organizations/:orgId/teams/:teamId/"
-          component={errorHandler(TeamDetails)}
-        >
+          component={errorHandler(TeamDetails)}>
           <IndexRedirect to="settings/" />
           <Route path="settings/" component={errorHandler(TeamSettings)} />
           <Route path="members/" component={errorHandler(TeamMembers)} />
@@ -158,8 +157,7 @@ function routes() {
 
         <Route
           path="/organizations/:orgId/all-teams/"
-          component={errorHandler(OrganizationTeams)}
-        >
+          component={errorHandler(OrganizationTeams)}>
           <IndexRoute component={errorHandler(AllTeamsList)} />
         </Route>
         <Route
@@ -197,8 +195,7 @@ function routes() {
 
         <Route
           path=":projectId/getting-started/"
-          component={errorHandler(ProjectGettingStarted)}
-        >
+          component={errorHandler(ProjectGettingStarted)}>
           <IndexRoute component={errorHandler(ProjectInstallOverview)} />
           <Route path=":platform/" component={errorHandler(ProjectInstallPlatform)} />
         </Route>
@@ -227,8 +224,7 @@ function routes() {
                   }
                 }
               });
-            }}
-          >
+            }}>
             <Route path="new-events/" component={errorHandler(ReleaseNewEvents)} />
             <Route path="overview/" component={errorHandler(ReleaseOverview)} />
             <Route path="all-events/" component={errorHandler(ReleaseAllEvents)} />
@@ -263,8 +259,7 @@ function routes() {
           <Route
             path="issues/:groupId/"
             component={errorHandler(GroupDetails)}
-            ignoreScrollBehavior
-          >
+            ignoreScrollBehavior>
             <IndexRoute component={errorHandler(GroupEventDetails)} />
 
             <Route path="activity/" component={errorHandler(GroupActivity)} />

--- a/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
+++ b/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
@@ -72,8 +72,7 @@ const AuthorizationRow = React.createClass({
           <a
             onClick={this.onRevoke.bind(this, authorization)}
             className={btnClassName}
-            disabled={this.state.loading}
-          >
+            disabled={this.state.loading}>
             <span className="icon icon-trash" />
           </a>
         </td>

--- a/src/sentry/static/sentry/app/views/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/apiApplications.jsx
@@ -72,8 +72,7 @@ const ApiApplicationRow = React.createClass({
           <a
             onClick={this.onRemove.bind(this, app)}
             className={btnClassName}
-            disabled={this.state.loading}
-          >
+            disabled={this.state.loading}>
             <span className="icon icon-trash" />
           </a>
         </td>
@@ -193,8 +192,7 @@ const ApiApplications = React.createClass({
           <div className="form-actions" style={{textAlign: 'right'}}>
             <a
               className="btn btn-primary ref-create-application"
-              onClick={this.createApplication}
-            >
+              onClick={this.createApplication}>
               {t('Create New Application')}
             </a>
           </div>

--- a/src/sentry/static/sentry/app/views/apiNewToken.jsx
+++ b/src/sentry/static/sentry/app/views/apiNewToken.jsx
@@ -121,15 +121,13 @@ const TokenForm = React.createClass({
           <button
             className="btn btn-default"
             disabled={isSaving}
-            onClick={this.props.onCancel}
-          >
+            onClick={this.props.onCancel}>
             {t('Cancel')}
           </button>
           <button
             type="submit"
             className="btn btn-primary pull-right"
-            disabled={isSaving}
-          >
+            disabled={isSaving}>
             {t('Save Changes')}
           </button>
         </fieldset>

--- a/src/sentry/static/sentry/app/views/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/apiTokens.jsx
@@ -74,8 +74,7 @@ const ApiTokenRow = React.createClass({
           <a
             onClick={this.onRemove.bind(this, token)}
             className={btnClassName}
-            disabled={this.state.loading}
-          >
+            disabled={this.state.loading}>
             <span className="icon icon-trash" />
           </a>
         </td>

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -145,15 +145,13 @@ const GroupActions = React.createClass({
                     className={resolveClassName + ' tip'}
                     title={t(
                       'This event is resolved due to the Auto Resolve configuration for this project'
-                    )}
-                  >
+                    )}>
                     <span className="icon-checkmark" />
                   </a>
                 : <a
                     className={resolveClassName}
                     title={t('Unresolve')}
-                    onClick={this.onUpdate.bind(this, {status: 'unresolved'})}
-                  >
+                    onClick={this.onUpdate.bind(this, {status: 'unresolved'})}>
                     <span className="icon-checkmark" />
                   </a>
             : [
@@ -161,8 +159,7 @@ const GroupActions = React.createClass({
                   key="resolve-button"
                   className={resolveClassName}
                   title={t('Resolve')}
-                  onClick={this.onUpdate.bind(this, {status: 'resolved'})}
-                >
+                  onClick={this.onUpdate.bind(this, {status: 'resolved'})}>
                   <span className="icon-checkmark" style={{marginRight: 5}} />
                   {t('Resolve')}
                 </a>,
@@ -171,15 +168,13 @@ const GroupActions = React.createClass({
                   caret={true}
                   className={resolveClassName}
                   topLevelClasses={resolveDropdownClasses}
-                  title=""
-                >
+                  title="">
                   <MenuItem noAnchor={true}>
                     {hasRelease
                       ? <a
                           onClick={this.onUpdate.bind(this, {
                             status: 'resolvedInNextRelease'
-                          })}
-                        >
+                          })}>
                           <strong>{t('Resolved in next release')}</strong>
                           <div className="help-text">
                             {t(
@@ -192,8 +187,7 @@ const GroupActions = React.createClass({
                           className="disabled tip"
                           title={t(
                             'Set up release tracking in order to use this feature.'
-                          )}
-                        >
+                          )}>
                           <strong>{t('Resolved in next release.')}</strong>
                           <div className="help-text">
                             {t(
@@ -210,8 +204,7 @@ const GroupActions = React.createClass({
             ? <a
                 className={ignoreClassName}
                 title={t('Remove Ignored Status')}
-                onClick={this.onUpdate.bind(this, {status: 'unresolved'})}
-              >
+                onClick={this.onUpdate.bind(this, {status: 'unresolved'})}>
                 {t('Ignore')}
               </a>
             : <DropdownLink
@@ -225,8 +218,7 @@ const GroupActions = React.createClass({
                       style={{marginLeft: 3, marginRight: -3}}
                     />
                   </span>
-                }
-              >
+                }>
                 <MenuItem noAnchor={true}>
                   <a onClick={this.onSnooze.bind(this, Snooze['30MINUTES'])}>
                     {t('for 30 minutes')}
@@ -261,8 +253,7 @@ const GroupActions = React.createClass({
           <a
             className={bookmarkClassName}
             title={t('Bookmark')}
-            onClick={this.onToggleBookmark}
-          >
+            onClick={this.onToggleBookmark}>
             <span className="icon-star-solid" />
           </a>
         </div>
@@ -273,8 +264,7 @@ const GroupActions = React.createClass({
             message={t(
               'Deleting this event is permanent. Are you sure you wish to continue?'
             )}
-            onConfirm={this.onDelete}
-          >
+            onConfirm={this.onDelete}>
             <span className="icon-trash" />
           </LinkWithConfirmation>
         </div>
@@ -307,8 +297,7 @@ const GroupActions = React.createClass({
         {!hasIssueTracking &&
           <a
             href={`/${this.getOrganization().slug}/${this.getProject().slug}/settings/issue-tracking/`}
-            className={'btn btn-default btn-sm btn-config-issue-tracking'}
-          >
+            className={'btn btn-default btn-sm btn-config-issue-tracking'}>
             {t('Link Issue Tracker')}
           </a>}
       </div>

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -92,8 +92,7 @@ let GroupEventToolbar = React.createClass({
             key="oldest"
             to={`/${orgId}/${projectId}/issues/${groupId}/events/oldest/`}
             className="btn btn-default"
-            title={t('Oldest')}
-          >
+            title={t('Oldest')}>
             <span className="icon-skip-back" />
           </Link>
         : <a key="oldest" className="btn btn-default disabled">
@@ -103,8 +102,7 @@ let GroupEventToolbar = React.createClass({
         ? <Link
             key="prev"
             to={`/${orgId}/${projectId}/issues/${groupId}/events/${evt.previousEventID}/`}
-            className="btn btn-default"
-          >
+            className="btn btn-default">
             {t('Older')}
           </Link>
         : <a key="prev" className="btn btn-default disabled">{t('Older')}</a>,
@@ -112,8 +110,7 @@ let GroupEventToolbar = React.createClass({
         ? <Link
             key="next"
             to={`/${orgId}/${projectId}/issues/${groupId}/events/${evt.nextEventID}/`}
-            className="btn btn-default"
-          >
+            className="btn btn-default">
             {t('Newer')}
           </Link>
         : <a key="next" className="btn btn-default disabled">{t('Newer')}</a>,
@@ -122,8 +119,7 @@ let GroupEventToolbar = React.createClass({
             key="latest"
             to={`/${orgId}/${projectId}/issues/${groupId}/events/latest/`}
             className="btn btn-default"
-            title={t('Newest')}
-          >
+            title={t('Newest')}>
             <span className="icon-skip-forward" />
           </Link>
         : <a key="latest" className="btn btn-default disabled">

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -130,8 +130,7 @@ const GroupHeader = React.createClass({
                     to={{
                       pathname: `/${orgId}/${projectId}/`,
                       query: {query: 'logger:' + group.logger}
-                    }}
-                  >
+                    }}>
                     {group.logger}
                   </Link>
                 </span>}
@@ -194,8 +193,7 @@ const GroupHeader = React.createClass({
 
               // Because react-router 1.0 removes router.isActive(route)
               return pathname === rootGroupPath || /events\/\w+\/$/.test(pathname);
-            }}
-          >
+            }}>
             {t('Details')}
           </ListLink>
           <ListLink to={`/${orgId}/${projectId}/issues/${groupId}/activity/`}>

--- a/src/sentry/static/sentry/app/views/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/groupTagValues.jsx
@@ -108,8 +108,7 @@ const GroupTagValues = React.createClass({
               to={{
                 pathname: `/${orgId}/${projectId}/`,
                 query: {query: `${tagKey.key}:"${tagValue.value}"`}
-              }}
-            >
+              }}>
               {tagKey.key === 'user'
                 ? [
                     <Avatar user={tagValue} size={20} className="avatar" />,
@@ -123,8 +122,7 @@ const GroupTagValues = React.createClass({
               <a
                 href={`mailto:${tagValue.email}`}
                 target="_blank"
-                className="external-icon"
-              >
+                className="external-icon">
                 <em className="icon-envelope" />
               </a>}
             {isUrl(tagValue.value) &&

--- a/src/sentry/static/sentry/app/views/groupTags.jsx
+++ b/src/sentry/static/sentry/app/views/groupTags.jsx
@@ -82,8 +82,7 @@ const GroupTags = React.createClass({
                 to={{
                   pathname: `/${orgId}/${projectId}/`,
                   query: {query: tag.key + ':' + '"' + tagValue.value + '"'}
-                }}
-              >
+                }}>
                 <span className="tag-bar-background" style={{width: pct + '%'}} />
                 <span className="tag-bar-label">{deviceNameMapper(tagValue.name)}</span>
                 <span className="tag-bar-count"><Count value={tagValue.count} /></span>
@@ -99,8 +98,7 @@ const GroupTags = React.createClass({
                 <span className="pull-right">
                   <Link
                     className="btn btn-default btn-sm"
-                    to={`/${orgId}/${projectId}/issues/${groupId}/tags/${tag.key}/`}
-                  >
+                    to={`/${orgId}/${projectId}/issues/${groupId}/tags/${tag.key}/`}>
                     {t('More Details')}
                   </Link>
                 </span>

--- a/src/sentry/static/sentry/app/views/organizationAuditLog.jsx
+++ b/src/sentry/static/sentry/app/views/organizationAuditLog.jsx
@@ -159,8 +159,7 @@ const OrganizationAuditLog = React.createClass({
                     name="event"
                     onChange={this.onEventSelect}
                     value={currentEventType}
-                    style={{width: 250}}
-                  >
+                    style={{width: 250}}>
                     <option key="any" value="">{t('Any')}</option>
                     {EVENT_TYPES.map(eventType => {
                       return <option key={eventType}>{eventType}</option>;

--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -50,8 +50,7 @@ const AssignedIssues = React.createClass({
           <a
             className="btn btn-sm btn-default"
             style={{marginLeft: 5}}
-            onClick={this.refresh}
-          >
+            onClick={this.refresh}>
             <span className="icon icon-refresh" />
           </a>
         </div>
@@ -102,8 +101,7 @@ const NewIssues = React.createClass({
           <a
             className="btn btn-sm btn-default"
             style={{marginLeft: 5}}
-            onClick={this.refresh}
-          >
+            onClick={this.refresh}>
             <span className="icon icon-refresh" />
           </a>
         </div>
@@ -238,8 +236,7 @@ const Activity = React.createClass({
           <a
             className="btn btn-sm btn-default"
             style={{marginLeft: 5}}
-            onClick={this.refresh}
-          >
+            onClick={this.refresh}>
             <span className="icon icon-refresh" />
           </a>
         </div>

--- a/src/sentry/static/sentry/app/views/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRepositories.jsx
@@ -30,7 +30,7 @@ class AddRepositoryLink extends PluginComponentBase {
     });
 
     ['onOpen', 'onCancel', 'formSubmit', 'changeField'].map(
-      method => this[method] = this[method].bind(this)
+      method => (this[method] = this[method].bind(this))
     );
   }
 
@@ -164,16 +164,14 @@ class AddRepositoryLink extends PluginComponentBase {
             type="button"
             className="btn btn-default"
             onClick={this.onCancel}
-            disabled={state === FormState.SAVING}
-          >
+            disabled={state === FormState.SAVING}>
             {t('Cancel')}
           </button>
           <button
             type="button"
             className="btn btn-primary"
             onClick={this.onSubmit}
-            disabled={state === FormState.SAVING}
-          >
+            disabled={state === FormState.SAVING}>
             {t('Save Changes')}
           </button>
         </div>
@@ -333,8 +331,7 @@ const OrganizationRepositories = React.createClass({
           <DropdownLink
             topLevelClasses="anchor-right"
             className="btn btn-primary btn-sm"
-            title={t('Add Repository')}
-          >
+            title={t('Add Repository')}>
             {this.state.repoConfig.providers.map(provider => {
               return (
                 <MenuItem noAnchor={true} key={provider.id}>
@@ -392,15 +389,13 @@ const OrganizationRepositories = React.createClass({
                           {repo.status === 'visible'
                             ? <button
                                 onClick={this.deleteRepo.bind(this, repo)}
-                                className="btn btn-default btn-xs"
-                              >
+                                className="btn btn-default btn-xs">
                                 <span className="icon icon-trash" />
                               </button>
                             : <button
                                 onClick={this.deleteRepo.bind(this, repo)}
                                 disabled={true}
-                                className="btn btn-default btn-xs btn-disabled"
-                              >
+                                className="btn btn-default btn-xs btn-disabled">
                                 <span className="icon icon-trash" />
                               </button>}
                         </td>
@@ -421,8 +416,7 @@ const OrganizationRepositories = React.createClass({
               <p className="m-b-1">
                 <a
                   className="btn btn-default"
-                  href="https://docs.sentry.io/learn/releases/"
-                >
+                  href="https://docs.sentry.io/learn/releases/">
                   Learn more
                 </a>
               </p>

--- a/src/sentry/static/sentry/app/views/organizationSettings.jsx
+++ b/src/sentry/static/sentry/app/views/organizationSettings.jsx
@@ -301,8 +301,7 @@ const OrganizationSettingsForm = React.createClass({
           <button
             type="submit"
             className="btn btn-primary"
-            disabled={isSaving || !this.state.hasChanges}
-          >
+            disabled={isSaving || !this.state.hasChanges}>
             {t('Save Changes')}
           </button>
         </fieldset>

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
@@ -100,8 +100,7 @@ const AllTeamsRow = React.createClass({
             : team.isMember
                 ? <a
                     className="leave-team btn btn-default btn-sm"
-                    onClick={this.leaveTeam}
-                  >
+                    onClick={this.leaveTeam}>
                     {t('Leave Team')}
                   </a>
                 : team.isPending
@@ -119,8 +118,7 @@ const AllTeamsRow = React.createClass({
             <Link
               className="btn btn-default btn-sm"
               to={`/organizations/${orgId}/teams/${team.slug}/settings/`}
-              style={{marginLeft: 5}}
-            >
+              style={{marginLeft: 5}}>
               {t('Team Settings')}
             </Link>}
         </td>

--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -90,8 +90,7 @@ const ExpandedTeamList = React.createClass({
             {access.has('team:write') &&
               <Link
                 className="team-settings"
-                to={`/organizations/${orgId}/teams/${team.slug}/settings/`}
-              >
+                to={`/organizations/${orgId}/teams/${team.slug}/settings/`}>
                 {t('Team Settings')}
               </Link>}
           </div>
@@ -133,8 +132,7 @@ const ExpandedTeamList = React.createClass({
             <a
               onClick={this.toggleBookmark.bind(this, project)}
               className="tip"
-              data-isbookmarked={project.isBookmarked}
-            >
+              data-isbookmarked={project.isBookmarked}>
               {project.isBookmarked
                 ? <span className="icon-star-solid bookmark" />
                 : <span className="icon-star-outline bookmark" />}

--- a/src/sentry/static/sentry/app/views/projectAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertRules.jsx
@@ -203,8 +203,7 @@ const ProjectAlertRules = React.createClass({
       <div>
         <a
           href={`/${orgId}/${projectId}/settings/alerts/rules/new/`}
-          className="btn pull-right btn-primary btn-sm"
-        >
+          className="btn pull-right btn-primary btn-sm">
           <span className="icon-plus" />
           {t('New Alert Rule')}
         </a>

--- a/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
@@ -134,8 +134,7 @@ const DigestSettings = React.createClass({
               <button
                 type="submit"
                 className="btn btn-primary"
-                disabled={isSaving || !hasChanges}
-              >
+                disabled={isSaving || !hasChanges}>
                 {t('Save Changes')}
               </button>
             </fieldset>
@@ -242,8 +241,7 @@ const GeneralSettings = React.createClass({
               <button
                 type="submit"
                 className="btn btn-primary"
-                disabled={isSaving || !hasChanges}
-              >
+                disabled={isSaving || !hasChanges}>
                 {t('Save Changes')}
               </button>
             </fieldset>
@@ -279,8 +277,7 @@ const InactivePlugins = React.createClass({
                 <li key={plugin.id}>
                   <button
                     onClick={this.enablePlugin.bind(this, plugin)}
-                    className={`ref-plugin-enable-${plugin.id}`}
-                  >
+                    className={`ref-plugin-enable-${plugin.id}`}>
                     {plugin.name}
                   </button>
                 </li>
@@ -368,8 +365,7 @@ const ProjectAlertSettings = React.createClass({
       <div>
         <a
           href={`/${orgId}/${projectId}/settings/alerts/rules/new/`}
-          className="btn pull-right btn-primary btn-sm"
-        >
+          className="btn pull-right btn-primary btn-sm">
           <span className="icon-plus" />
           {t('New Alert Rule')}
         </a>

--- a/src/sentry/static/sentry/app/views/projectCspSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectCspSettings.jsx
@@ -148,7 +148,8 @@ const ProjectCspSettings = React.createClass({
     let location = this.props.location;
     let nextLocation = nextProps.location;
     if (
-      location.pathname != nextLocation.pathname || location.search != nextLocation.search
+      location.pathname != nextLocation.pathname ||
+      location.search != nextLocation.search
     ) {
       this.remountComponent();
     }

--- a/src/sentry/static/sentry/app/views/projectDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard.jsx
@@ -122,8 +122,7 @@ const ProjectDashboard = React.createClass({
                 className={
                   'btn btn-sm btn-default' +
                     (statsPeriod === PERIOD_HOUR ? ' active' : '')
-                }
-              >
+                }>
                 {t('1 hour')}
               </Link>
               <Link
@@ -134,8 +133,7 @@ const ProjectDashboard = React.createClass({
                 active={statsPeriod === PERIOD_DAY}
                 className={
                   'btn btn-sm btn-default' + (statsPeriod === PERIOD_DAY ? ' active' : '')
-                }
-              >
+                }>
                 {t('1 day')}
               </Link>
               <Link
@@ -146,8 +144,7 @@ const ProjectDashboard = React.createClass({
                 className={
                   'btn btn-sm btn-default' +
                     (statsPeriod === PERIOD_WEEK ? ' active' : '')
-                }
-              >
+                }>
                 {t('1 week')}
               </Link>
             </div>

--- a/src/sentry/static/sentry/app/views/projectDebugSymbols.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugSymbols.jsx
@@ -174,8 +174,7 @@ const ProjectDebugSymbols = React.createClass({
                   let row = (
                     <li
                       className="group hoverable"
-                      onClick={() => this.setActive(app.id, version, builds)}
-                    >
+                      onClick={() => this.setActive(app.id, version, builds)}>
                       <div className="row">
                         <div className="col-xs-8 event-details">
                           <h3 className="truncate">{version}</h3>
@@ -243,8 +242,7 @@ const ProjectDebugSymbols = React.createClass({
         <li
           className="group hoverable"
           key={build}
-          onClick={() => this.openModal(build, dsyms)}
-        >
+          onClick={() => this.openModal(build, dsyms)}>
           <div className="row">
             <div className="col-xs-8 event-details">
               <div className="event-message">
@@ -365,8 +363,7 @@ const ProjectDebugSymbols = React.createClass({
           animation={false}
           backdrop="static"
           enforceFocus={false}
-          bsSize="lg"
-        >
+          bsSize="lg">
           <Modal.Header closeButton>
             <Modal.Title>
               {this.state.activeVersion} ({this.state.activeBuild})

--- a/src/sentry/static/sentry/app/views/projectEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/index.jsx
@@ -151,8 +151,7 @@ const ProjectEvents = React.createClass({
           <td>
             <h5>
               <Link
-                to={`/${orgId}/${projectId}/issues/${event.groupID}/events/${event.id}/`}
-              >
+                to={`/${orgId}/${projectId}/issues/${event.groupID}/events/${event.id}/`}>
                 {this.getEventTitle(event)}
               </Link>
             </h5>

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -300,8 +300,7 @@ const ProjectFiltersSettingsForm = React.createClass({
             <button
               type="submit"
               className="btn btn-sm btn-primary"
-              disabled={isSaving || !this.state.hasChanged}
-            >
+              disabled={isSaving || !this.state.hasChanged}>
               {t('Save Changes')}
             </button>
 

--- a/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
@@ -34,8 +34,7 @@ const LanguageNav = React.createClass({
           <span
             style={{
               display: isVisible ? 'block' : 'none'
-            }}
-          >
+            }}>
             {this.props.children}
           </span>
         </ul>

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -84,8 +84,7 @@ const ProjectInstallPlatform = React.createClass({
       <Link
         key={platform}
         to={`/${orgId}/${projectId}/settings/install/${platform}/`}
-        className="list-group-item"
-      >
+        className="list-group-item">
         {display || platform}
       </Link>
     );
@@ -100,8 +99,7 @@ const ProjectInstallPlatform = React.createClass({
             <LanguageNav
               key={p_item.id}
               name={p_item.name}
-              active={platform && platform.id === p_item.id}
-            >
+              active={platform && platform.id === p_item.id}>
               {p_item.integrations.map(i_item => {
                 return this.getPlatformLink(
                   i_item.id,
@@ -161,8 +159,7 @@ const ProjectInstallPlatform = React.createClass({
             <p>
               <Link
                 to={`/${orgId}/${projectId}/#welcome`}
-                className="btn btn-primary btn-lg"
-              >
+                className="btn btn-primary btn-lg">
                 {t('Got it! Take me to the Issue Stream.')}
               </Link>
             </p>}

--- a/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
@@ -263,12 +263,18 @@ const ProjectProcessingIssues = React.createClass({
       fixLinkBlock = (
         <div className="panel panel-info">
           <div className="panel-heading">
-          <h3>{t('Having trouble uploading debug symbols? We can help!')}</h3>
+            <h3>{t('Having trouble uploading debug symbols? We can help!')}</h3>
           </div>
           <div className="panel-body">
             <div className="form-group" style={{marginBottom: 0}}>
-              <label>{t('Paste this command into your shell and we\'ll attempt to upload the missing symbols from your machine:')}</label>
-              <div className="form-control disabled auto-select" style={{marginBottom: 6}}>
+              <label>
+                {t(
+                  'Paste this command into your shell and we\'ll attempt to upload the missing symbols from your machine:'
+                )}
+              </label>
+              <div
+                className="form-control disabled auto-select"
+                style={{marginBottom: 6}}>
                 curl -sL {fixLink} | bash
               </div>
             </div>

--- a/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
+++ b/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
@@ -121,8 +121,7 @@ const SavedSearchRow = React.createClass({
             <a
               className="btn btn-sm btn-default"
               onClick={this.handleRemove}
-              disabled={this.state.loading}
-            >
+              disabled={this.state.loading}>
               <span className="icon icon-trash" /> &nbsp;{t('Remove')}
             </a>
           </td>}

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -90,8 +90,7 @@ const ProjectSettings = React.createClass({
             <li><a href={`${settingsUrlRoot}/`}>{t('General')}</a></li>
             <ListLink
               to={`/${orgId}/${projectId}/settings/alerts/`}
-              isActive={loc => path.indexOf(loc.pathname) === 0}
-            >
+              isActive={loc => path.indexOf(loc.pathname) === 0}>
               {t('Alerts')}
             </ListLink>
             {features.has('quotas') &&
@@ -111,8 +110,7 @@ const ProjectSettings = React.createClass({
             </ListLink>
             <ListLink
               className="badged"
-              to={`/${orgId}/${projectId}/settings/processing-issues/`}
-            >
+              to={`/${orgId}/${projectId}/settings/processing-issues/`}>
               {t('Processing Issues')}
               {processingIssues > 0 &&
                 <Badge
@@ -128,8 +126,7 @@ const ProjectSettings = React.createClass({
               isActive={loc => {
                 // Because react-router 1.0 removes router.isActive(route)
                 return path === rootInstallPath || /install\/[\w\-]+\/$/.test(path);
-              }}
-            >
+              }}>
               {t('Error Tracking')}
             </ListLink>
             {isEarlyAdopter &&

--- a/src/sentry/static/sentry/app/views/projectUserReportSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectUserReportSettings.jsx
@@ -152,7 +152,8 @@ const ProjectUserReportSettings = React.createClass({
     let location = this.props.location;
     let nextLocation = nextProps.location;
     if (
-      location.pathname != nextLocation.pathname || location.search != nextLocation.search
+      location.pathname != nextLocation.pathname ||
+      location.search != nextLocation.search
     ) {
       this.remountComponent();
     }

--- a/src/sentry/static/sentry/app/views/projectUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/projectUserReports.jsx
@@ -179,8 +179,7 @@ const ProjectUserReports = React.createClass({
           id={issue.id}
           data={issue}
           orgId={orgId}
-          projectId={projectId}
-        >
+          projectId={projectId}>
           <div className="activity-container" style={{margin: '10px 0 5px'}}>
             <ul className="activity">
               <li className="activity-note" style={{paddingBottom: 0}}>
@@ -221,14 +220,12 @@ const ProjectUserReports = React.createClass({
                 to={path}
                 className={
                   'btn btn-sm btn-default' + (status === 'unresolved' ? ' active' : '')
-                }
-              >
+                }>
                 {t('Unresolved')}
               </Link>
               <Link
                 to={{pathname: path, query: {status: ''}}}
-                className={'btn btn-sm btn-default' + (status === '' ? ' active' : '')}
-              >
+                className={'btn btn-sm btn-default' + (status === '' ? ' active' : '')}>
                 {t('All Issues')}
               </Link>
             </div>

--- a/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
@@ -17,8 +17,7 @@ const ReleaseAllEvents = React.createClass({
             to={{
               pathname: `/${orgId}/${projectId}/`,
               query: {query: 'release:' + this.context.release.version}
-            }}
-          >
+            }}>
             <span className="icon icon-open" />
             {t('View all events seen in this release in the stream')}
           </Link>

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -153,24 +153,21 @@ const ReleaseArtifacts = React.createClass({
                                 this.getFilesEndpoint() +
                                 `${file.id}/?download=1`
                             }
-                            className="btn btn-sm btn-default"
-                          >
+                            className="btn btn-sm btn-default">
                             <span className="icon icon-open" />
                           </a>
                         : <div
                             className="btn btn-sm btn-default disabled tip"
                             title={t(
                               'You do not have the required permission to download this artifact.'
-                            )}
-                          >
+                            )}>
                             <span className="icon icon-open" />
                           </div>}
                       <LinkWithConfirmation
                         className="btn btn-sm btn-default"
                         title={t('Delete artifact')}
                         message={t('Are you sure you want to remove this artifact?')}
-                        onConfirm={this.handleRemove.bind(this, file.id)}
-                      >
+                        onConfirm={this.handleRemove.bind(this, file.id)}>
 
                         <span className="icon icon-trash" />
                       </LinkWithConfirmation>

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -166,8 +166,7 @@ const ReleaseDetails = React.createClass({
                       (hasReleases && this.props.location.pathname === basePath) ||
                       loc.pathname === this.props.location.pathname
                     );
-                  }}
-                >
+                  }}>
                   {t('Overview')}
                 </ListLink>}
               <ListLink
@@ -179,25 +178,21 @@ const ReleaseDetails = React.createClass({
                     (!hasReleases && this.props.location.pathname === basePath) ||
                     loc.pathname === this.props.location.pathname
                   );
-                }}
-              >
+                }}>
                 {t('New Issues')}
               </ListLink>
               <ListLink
-                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/all-events/`}
-              >
+                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/all-events/`}>
                 {t('All Issues')}
               </ListLink>
               <ListLink
-                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/artifacts/`}
-              >
+                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/artifacts/`}>
                 {t('Artifacts')}
               </ListLink>
 
               {new Set(this.context.organization.features).has('release-commits') &&
                 <ListLink
-                  to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/commits/`}
-                >
+                  to={`/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}/commits/`}>
                   {t('Commits')}
                 </ListLink>}
             </ul>

--- a/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
@@ -17,8 +17,7 @@ const ReleaseNewEvents = React.createClass({
             to={{
               pathname: `/${orgId}/${projectId}/`,
               query: {query: 'first-release:' + this.context.release.version}
-            }}
-          >
+            }}>
             <span className="icon icon-open" />
             {t('View new events seen in this release in the stream')}
           </Link>

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -195,16 +195,14 @@ const ReleaseCommits = React.createClass({
                           style={{marginLeft: 3, marginRight: -3}}
                         />
                       </h5>
-                    }
-                  >
+                    }>
                     <MenuItem
                       key="all"
                       noAnchor={true}
                       onClick={() => {
                         this.setActiveRepo(null);
                       }}
-                      isActive={this.state.activeRepo === null}
-                    >
+                      isActive={this.state.activeRepo === null}>
                       <a>All Repositories</a>
                     </MenuItem>
                     {Object.keys(commitsByRepository).map(repository => {
@@ -215,8 +213,7 @@ const ReleaseCommits = React.createClass({
                           onClick={() => {
                             this.setActiveRepo(repository);
                           }}
-                          isActive={this.state.activeRepo === repository}
-                        >
+                          isActive={this.state.activeRepo === repository}>
                           <a>{repository}</a>
                         </MenuItem>
                       );

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -237,14 +237,12 @@ const ReleaseOverview = React.createClass({
                       <li key={deploy.id}>
                         <a
                           href={`/${orgId}/${projectId}/?query=${query}`}
-                          title={t('View in stream')}
-                        >
+                          title={t('View in stream')}>
                           <div className="row row-flex row-center-vertically">
                             <div className="col-xs-6">
                               <span
                                 className="repo-label"
-                                style={{verticalAlign: 'bottom'}}
-                              >
+                                style={{verticalAlign: 'bottom'}}>
                                 {deploy.environment}
                                 <IconOpen
                                   className="icon-open"

--- a/src/sentry/static/sentry/app/views/requiredAdminActions/setCallsigns.jsx
+++ b/src/sentry/static/sentry/app/views/requiredAdminActions/setCallsigns.jsx
@@ -174,8 +174,7 @@ const SetCallsignsAction = React.createClass({
               <div className={className} key={project.projectId}>
                 <label
                   htmlFor={inputId}
-                  className="col-sm-6 col-sm-offset-2 control-label"
-                >
+                  className="col-sm-6 col-sm-offset-2 control-label">
                   {project.teamName} / {project.projectName}
                 </label>
                 <div className="col-sm-2">
@@ -195,8 +194,7 @@ const SetCallsignsAction = React.createClass({
               type="button"
               onClick={this.onSubmit}
               className="btn btn-primary btn-lg"
-              disabled={!canSubmit}
-            >
+              disabled={!canSubmit}>
               {t('Set Call Signs')}
             </button>
           </div>

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -53,8 +53,7 @@ const RouteError = React.createClass({
             Give it a few seconds and <a
               onClick={() => {
                 window.location.href = window.location.href;
-              }}
-            >
+              }}>
               reload the page
             </a>.
           </li>

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -141,8 +141,7 @@ const RuleEditor = React.createClass({
                     className={this.hasError('actionMatch') ? ' error' : ''}
                     value={actionMatch}
                     style={{width: 80}}
-                    required={true}
-                  >
+                    required={true}>
                     <option value="all">{t('all')}</option>
                     <option value="any">{t('any')}</option>
                     <option value="none">{t('none')}</option>
@@ -196,8 +195,7 @@ const RuleEditor = React.createClass({
                         className={this.hasError('frequency') ? ' error' : ''}
                         value={frequency}
                         style={{width: 150}}
-                        required={true}
-                      >
+                        required={true}>
                         <option value="5">{t('5 minutes')}</option>
                         <option value="10">{t('10 minutes')}</option>
                         <option value="30">{t('30 minutes')}</option>

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -638,8 +638,7 @@ const Stream = React.createClass({
           <p>
             <Link
               to={`/${org.slug}/${project.slug}/getting-started/`}
-              className="btn btn-primary btn-lg"
-            >
+              className="btn btn-primary btn-lg">
               {t('Installation Instructions')}
             </Link>
           </p>

--- a/src/sentry/static/sentry/app/views/stream/actionLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actionLink.jsx
@@ -107,16 +107,14 @@ const ActionLink = React.createClass({
         className={className}
         disabled={this.props.disabled}
         onClick={this.handleClick}
-        data-placement="bottom"
-      >
+        data-placement="bottom">
         {this.props.children}
 
         <Modal
           show={this.state.isModalOpen}
           title={t('Please confirm')}
           animation={false}
-          onHide={this.handleToggle}
-        >
+          onHide={this.handleToggle}>
           <div className="modal-body">
             <p><strong>{confirmationQuestion}</strong></p>
             {this.props.extraDescription}

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -208,8 +208,7 @@ const StreamActions = React.createClass({
                 }
                 tooltip={t('Set Status to Resolved')}
                 onlyIfBulk={true}
-                selectAllActive={this.state.pageSelected}
-              >
+                selectAllActive={this.state.pageSelected}>
                 <span className="icon-checkmark" style={{marginRight: 5}} />
                 {t('Resolve')}
               </ActionLink>
@@ -218,8 +217,7 @@ const StreamActions = React.createClass({
                 className="btn btn-default btn-sm action-resolve"
                 topLevelClasses="resolve-dropdown"
                 disabled={!this.state.anySelected}
-                title=""
-              >
+                title="">
                 <MenuItem noAnchor={true}>
                   {hasRelease
                     ? <ActionLink
@@ -253,8 +251,7 @@ const StreamActions = React.createClass({
                                 )
                         }
                         onlyIfBulk={true}
-                        selectAllActive={this.state.pageSelected}
-                      >
+                        selectAllActive={this.state.pageSelected}>
                         <strong>{t('Resolved in next release')}</strong>
                         <div className="help-text">
                           {t(
@@ -265,8 +262,9 @@ const StreamActions = React.createClass({
                     : <a
                         href={releaseTrackingUrl}
                         className="disabled tip"
-                        title={t('Set up release tracking in order to use this feature.')}
-                      >
+                        title={t(
+                          'Set up release tracking in order to use this feature.'
+                        )}>
                         <strong>{t('Resolved in next release.')}</strong>
                         <div className="help-text">
                           {t(
@@ -308,8 +306,7 @@ const StreamActions = React.createClass({
                 }
                 tooltip={t('Add to Bookmarks')}
                 onlyIfBulk={true}
-                selectAllActive={this.state.pageSelected}
-              >
+                selectAllActive={this.state.pageSelected}>
                 <i aria-hidden="true" className="icon-star-solid" />
               </ActionLink>
             </div>
@@ -319,8 +316,7 @@ const StreamActions = React.createClass({
                 btnGroup={true}
                 caret={false}
                 className="btn btn-sm btn-default hidden-xs action-more"
-                title={<span className="icon-ellipsis" />}
-              >
+                title={<span className="icon-ellipsis" />}>
                 <MenuItem noAnchor={true}>
                   <ActionLink
                     className="action-merge"
@@ -349,8 +345,7 @@ const StreamActions = React.createClass({
                               count
                             )
                     }
-                    selectAllActive={this.state.pageSelected}
-                  >
+                    selectAllActive={this.state.pageSelected}>
                     {t('Merge Events')}
                   </ActionLink>
                 </MenuItem>
@@ -383,8 +378,7 @@ const StreamActions = React.createClass({
                             )
                     }
                     onlyIfBulk={true}
-                    selectAllActive={this.state.pageSelected}
-                  >
+                    selectAllActive={this.state.pageSelected}>
                     {t('Remove from Bookmarks')}
                   </ActionLink>
                 </MenuItem>
@@ -419,8 +413,7 @@ const StreamActions = React.createClass({
                     }
                     onlyIfBulk={true}
                     selectAllActive={this.state.pageSelected}
-                    groupIds={this.props.groupIds}
-                  >
+                    groupIds={this.props.groupIds}>
                     {t('Set status to: Unresolved')}
                   </ActionLink>
                 </MenuItem>
@@ -453,8 +446,7 @@ const StreamActions = React.createClass({
                             )
                     }
                     onlyIfBulk={true}
-                    selectAllActive={this.state.pageSelected}
-                  >
+                    selectAllActive={this.state.pageSelected}>
                     {t('Set status to: Ignored')}
                   </ActionLink>
                 </MenuItem>
@@ -473,8 +465,7 @@ const StreamActions = React.createClass({
                       )}
                     confirmLabel={count =>
                       tn('Delete %d selected issue', 'Delete %d selected issues', count)}
-                    selectAllActive={this.state.pageSelected}
-                  >
+                    selectAllActive={this.state.pageSelected}>
                     {t('Delete Events')}
                   </ActionLink>
                 </MenuItem>
@@ -484,8 +475,7 @@ const StreamActions = React.createClass({
             <div className="btn-group">
               <a
                 className="btn btn-default btn-sm hidden-xs realtime-control"
-                onClick={this.onRealtimeChange}
-              >
+                onClick={this.onRealtimeChange}>
                 {this.props.realtimeActive
                   ? <span className="icon icon-pause" />
                   : <span className="icon icon-play" />}

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -79,8 +79,7 @@ const StreamFilters = React.createClass({
               />
               <a
                 className="btn btn-default toggle-stream-sidebar"
-                onClick={this.props.onSidebarToggle}
-              >
+                onClick={this.props.onSidebarToggle}>
                 <span className="icon-filter" />
               </a>
             </div>

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -107,8 +107,7 @@ const SaveSearchButton = React.createClass({
         className={this.props.className}
         disabled={this.props.disabled}
         onClick={this.onToggle}
-        style={this.props.style}
-      >
+        style={this.props.style}>
         {this.props.children}
 
         <Modal show={this.state.isModalOpen} animation={false} onHide={this.onToggle}>
@@ -157,8 +156,7 @@ const SaveSearchButton = React.createClass({
                 type="button"
                 className="btn btn-default"
                 disabled={isSaving}
-                onClick={this.onToggle}
-              >
+                onClick={this.onToggle}>
                 {t('Cancel')}
               </button>
               <button type="submit" className="btn btn-primary" disabled={isSaving}>
@@ -220,16 +218,14 @@ const SavedSearchSelector = React.createClass({
                 <SaveSearchButton
                   className="btn btn-sm btn-default"
                   onSave={this.props.onSavedSearchCreate}
-                  {...this.props}
-                >
+                  {...this.props}>
                   {t('Save Current Search')}
                 </SaveSearchButton>
               </div>
               <div className="col-md-5">
                 <Link
                   to={`/${orgId}/${projectId}/settings/saved-searches/`}
-                  className="btn btn-sm btn-default"
-                >
+                  className="btn btn-sm btn-default">
                   {t('Manage')}
                 </Link>
               </div>

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -229,7 +229,8 @@ const SearchBar = React.createClass({
     let cursor = this.getCursorPosition();
 
     if (
-      cursor === this.state.query.length && this.state.query.charAt(cursor - 1) !== ' '
+      cursor === this.state.query.length &&
+      this.state.query.charAt(cursor - 1) !== ' '
     ) {
       // If the cursor lands at the end of the input value, and the preceding character
       // is not whitespace, then add a space and move the cursor beyond that space.

--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -60,8 +60,7 @@ const SearchDropdown = React.createClass({
                       'search-autocomplete-item',
                       item.active && 'active'
                     )}
-                    onClick={this.onClick.bind(this, item.value)}
-                  >
+                    onClick={this.onClick.bind(this, item.value)}>
                     <span className={classNames('icon', item.className)} />
                     <h4>
                       {item.title && item.title + ' - '}

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -29,8 +29,7 @@ const SortOptions = React.createClass({
       <MenuItem
         onSelect={this.onSelect}
         eventKey={key}
-        isActive={this.state.sortKey === key}
-      >
+        isActive={this.state.sortKey === key}>
         {this.getSortLabel(key)}
       </MenuItem>
     );

--- a/src/sentry/static/sentry/app/views/teamDetails.jsx
+++ b/src/sentry/static/sentry/app/views/teamDetails.jsx
@@ -29,7 +29,8 @@ const TeamDetails = React.createClass({
   componentWillReceiveProps(nextProps) {
     let params = this.props.params;
     if (
-      nextProps.params.teamId !== params.teamId || nextProps.params.orgId !== params.orgId
+      nextProps.params.teamId !== params.teamId ||
+      nextProps.params.orgId !== params.orgId
     ) {
       this.setState(
         {
@@ -92,8 +93,7 @@ const TeamDetails = React.createClass({
           <DropdownLink
             topLevelClasses="pull-right anchor-right"
             className="dropdown-menu-right"
-            title={t('More')}
-          >
+            title={t('More')}>
             <MenuItem href={`${routePrefix}/remove/`}>{t('Remove Team')}</MenuItem>
           </DropdownLink>}
 

--- a/src/sentry/static/sentry/app/views/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/teamMembers.jsx
@@ -25,7 +25,8 @@ const TeamMembers = React.createClass({
   componentWillReceiveProps(nextProps) {
     let params = this.props.params;
     if (
-      nextProps.params.teamId !== params.teamId || nextProps.params.orgId !== params.orgId
+      nextProps.params.teamId !== params.teamId ||
+      nextProps.params.orgId !== params.orgId
     ) {
       this.setState(
         {
@@ -71,14 +72,12 @@ const TeamMembers = React.createClass({
           {access.has('org:write')
             ? <a
                 className="btn btn-primary btn-sm pull-right"
-                href={`${memberPrefix}/new/`}
-              >
+                href={`${memberPrefix}/new/`}>
                 <span className="icon-plus" /> {t('Invite Member')}
               </a>
             : <a
                 className="btn btn-primary btn-sm btn-disabled tip pull-right"
-                title={t('You do not have enough permission to add new members')}
-              >
+                title={t('You do not have enough permission to add new members')}>
                 <span className="icon-plus" /> {t('Invite Member')}
               </a>}
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4261,9 +4261,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.1.0.tgz#9d6ad005703efefa66b6999b8916bfc6afeaf9f8"
+prettier@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.2.2.tgz#22d17c1132faaaea1f1d4faea31f19f7a1959f3e"
   dependencies:
     ast-types "0.9.8"
     babel-code-frame "6.22.0"


### PR DESCRIPTION
After this merges, everyone needs to:

* `yarn install` to upgrade Prettier to 1.2.2
* If you're using Prettier in your text editor, enable the `jsx-bracket-same-line` Prettier option.

Note I added a little check to the `pre-commit` hook that verifies Prettier is up to date before running it. This could use some work, and maybe just yarn install on your behalf. Thoughts? (cc @mattrobenolt @mitsuhiko) My goal is to avoid a situation where somebody regresses style on an entire file because they're running an old version of Prettier.

cc @getsentry/javascript