### PR TITLE
Add Slack to the list of filtered web crawlers

### DIFF
--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -30,6 +30,10 @@ CRAWLERS = re.compile(r'|'.join((
     r'bot[\/\s\)\;]',
     # Generic spider
     r'spider[\/\s\)\;]',
+    # Slack - see https://api.slack.com/robots
+    r'Slack',
+    # Twitter - see https://dev.twitter.com/cards/getting-started#crawling
+    r'Twitterbot',
 )), re.I)
 
 

--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -32,8 +32,6 @@ CRAWLERS = re.compile(r'|'.join((
     r'spider[\/\s\)\;]',
     # Slack - see https://api.slack.com/robots
     r'Slack',
-    # Twitter - see https://dev.twitter.com/cards/getting-started#crawling
-    r'Twitterbot',
 )), re.I)
 
 

--- a/tests/sentry/filters/test_web_crawlers.py
+++ b/tests/sentry/filters/test_web_crawlers.py
@@ -28,3 +28,17 @@ class WebCrawlersFilterTest(TestCase):
     def test_does_not_filter_chrome(self):
         data = self.get_mock_data('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36')
         assert not self.apply_filter(data)
+
+    def test_filters_twitterbot(self):
+        data = self.get_mock_data('Twitterbot/1.0')
+        assert self.apply_filter(data)
+
+    def test_filters_slack(self):
+        data = self.get_mock_data('Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)')
+        assert self.apply_filter(data)
+
+        data = self.get_mock_data('Slack-ImgProxy 0.19 (+https://api.slack.com/robots)')
+        assert self.apply_filter(data)
+
+        data = self.get_mock_data('Slackbot 1.0(+https://api.slack.com/robots)')
+        assert self.apply_filter(data)


### PR DESCRIPTION
This adds Slack to the list of filtered web crawlers. Slack lists 3 different user agents for their crawlers and the `Slack` regex covers all 3 (https://api.slack.com/robots).

Filtering Twitter's crawler was suggested in #5284, but this should already be filtered by the generic `bot[\/\s\)\;]` regex. I added tests for this just to ensure that it is actually filtered.

Fixes https://github.com/getsentry/sentry/issues/5284