### PR TITLE
Add last commit for a release to the release overview view

### DIFF
--- a/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
+++ b/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
@@ -66,6 +66,13 @@ const CommitAuthorStats = React.createClass({
     });
   },
 
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.loading && !this.state.loading) {
+      this.removeTooltips();
+      this.attachTooltips();
+    }
+  },
+
   renderEmpty() {
     return <div className="box empty">{t('No authors in this release')}</div>;
   },
@@ -110,7 +117,11 @@ const CommitAuthorStats = React.createClass({
                 className="list-group-item list-group-item-sm list-group-avatar">
                 <div className="row row-flex row-center-vertically">
                   <div className="col-sm-8">
-                    <Avatar user={author} size={32} />
+                    <span
+                      className="avatar-grid-item m-b-0 tip"
+                      title={author.name + ' ' + author.email}>
+                      <Avatar user={author} size={32} />
+                    </span>
                     <CommitBar
                       totalCommits={commitList.length}
                       authorCommits={commitCount}

--- a/src/sentry/static/sentry/app/components/lastCommit.jsx
+++ b/src/sentry/static/sentry/app/components/lastCommit.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import Avatar from './avatar';
+import TimeSince from './timeSince';
+
+import {t} from '../locale';
+
+const LastCommit = React.createClass({
+  propTypes: {
+    lastCommit: React.PropTypes.object.isRequired,
+    headerClass: React.PropTypes.string
+  },
+
+  renderMessage(message) {
+    if (!message) {
+      return t('No message provided');
+    }
+
+    if (message.length > 100) {
+      let truncated = message.substr(0, 90);
+      let words = truncated.split(' ');
+      // try to not have elipsis mid-word
+      if (words.length > 1) {
+        words.pop();
+        truncated = words.join(' ');
+      }
+      return truncated + '...';
+    }
+    return message;
+  },
+
+  render() {
+    let {lastCommit, headerClass} = this.props;
+    let commitAuthor = lastCommit && lastCommit.author;
+    return (
+      <div>
+        <h6 className={headerClass}>Last commit</h6>
+        <div className="commit">
+          <div className="commit-avatar">
+            <Avatar user={commitAuthor || {username: '?'}} />
+          </div>
+          <div className="commit-message truncate">
+            {this.renderMessage(lastCommit.message)}
+          </div>
+          <div className="commit-meta">
+            <strong>
+              {(commitAuthor && commitAuthor.name) || t('Unknown Author')}
+            </strong>&nbsp;
+            <TimeSince date={lastCommit.dateCreated} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+});
+
+export default LastCommit;

--- a/src/sentry/static/sentry/app/components/lastCommit.jsx
+++ b/src/sentry/static/sentry/app/components/lastCommit.jsx
@@ -7,7 +7,7 @@ import {t} from '../locale';
 
 const LastCommit = React.createClass({
   propTypes: {
-    lastCommit: React.PropTypes.object.isRequired,
+    commit: React.PropTypes.object.isRequired,
     headerClass: React.PropTypes.string
   },
 
@@ -16,9 +16,10 @@ const LastCommit = React.createClass({
       return t('No message provided');
     }
 
-    if (message.length > 100) {
-      let truncated = message.substr(0, 90);
-      let words = truncated.split(' ');
+    let firstLine = message.split(/\n/)[0];
+    if (firstLine.length > 100) {
+      let truncated = firstLine.substr(0, 90);
+      let words = truncated.split(/ /);
       // try to not have elipsis mid-word
       if (words.length > 1) {
         words.pop();
@@ -26,12 +27,12 @@ const LastCommit = React.createClass({
       }
       return truncated + '...';
     }
-    return message;
+    return firstLine;
   },
 
   render() {
-    let {lastCommit, headerClass} = this.props;
-    let commitAuthor = lastCommit && lastCommit.author;
+    let {commit, headerClass} = this.props;
+    let commitAuthor = commit && commit.author;
     return (
       <div>
         <h6 className={headerClass}>Last commit</h6>
@@ -40,13 +41,13 @@ const LastCommit = React.createClass({
             <Avatar user={commitAuthor || {username: '?'}} />
           </div>
           <div className="commit-message truncate">
-            {this.renderMessage(lastCommit.message)}
+            {this.renderMessage(commit.message)}
           </div>
           <div className="commit-meta">
             <strong>
               {(commitAuthor && commitAuthor.name) || t('Unknown Author')}
             </strong>&nbsp;
-            <TimeSince date={lastCommit.dateCreated} />
+            <TimeSince date={commit.dateCreated} />
           </div>
         </div>
       </div>

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -212,7 +212,6 @@ const VersionHoverCard = React.createClass({
                 );
               })}
             </div>}
-
         </div>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -3,9 +3,10 @@ import _ from 'underscore';
 
 import Avatar from './avatar';
 
+import LastCommit from './lastCommit';
 import LoadingIndicator from './loadingIndicator';
 import LoadingError from './loadingError';
-import TimeSince from './timeSince';
+import TimeSince from './TimeSince';
 
 import {getShortVersion} from '../utils';
 import {t} from '../locale';
@@ -115,29 +116,10 @@ const VersionHoverCard = React.createClass({
     );
   },
 
-  renderMessage(message) {
-    if (!message) {
-      return t('No message provided');
-    }
-
-    if (message.length > 100) {
-      let truncated = message.substr(0, 90);
-      let words = truncated.split(' ');
-      // try to not have elipsis mid-word
-      if (words.length > 1) {
-        words.pop();
-        truncated = words.join(' ');
-      }
-      return truncated + '...';
-    }
-    return message;
-  },
-
   renderBody() {
     let {release, deploys} = this.state;
     let {version} = this.props;
     let lastCommit = release.lastCommit;
-    let commitAuthor = lastCommit && lastCommit.author;
     let shortVersion = getShortVersion(version);
 
     let recentDeploysByEnviroment = deploys.reduce(function(dbe, deploy) {
@@ -191,28 +173,7 @@ const VersionHoverCard = React.createClass({
             </div>
           </div>
           {lastCommit &&
-            <div>
-              <div className="divider">
-                <h6 className="commit-heading">Last commit</h6>
-              </div>
-              <div className="commit">
-                <div className="commit-avatar">
-                  <Avatar user={commitAuthor || {username: '?'}} />
-                </div>
-                <div className="commit-meta">
-                  <TimeSince
-                    date={lastCommit.dateCreated}
-                    className="pull-right text-light"
-                  />
-                  <strong>
-                    {(commitAuthor && commitAuthor.name) || t('Unknown Author')}
-                  </strong>
-                </div>
-                <div className="commit-message break-word">
-                  {this.renderMessage(lastCommit.message)}
-                </div>
-              </div>
-            </div>}
+            <LastCommit lastCommit={lastCommit} headerClass="commit-heading" />}
           {deploys.length > 0 &&
             <div>
               <div className="divider">
@@ -251,6 +212,7 @@ const VersionHoverCard = React.createClass({
                 );
               })}
             </div>}
+
         </div>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -172,8 +172,7 @@ const VersionHoverCard = React.createClass({
               </div>
             </div>
           </div>
-          {lastCommit &&
-            <LastCommit lastCommit={lastCommit} headerClass="commit-heading" />}
+          {lastCommit && <LastCommit commit={lastCommit} headerClass="commit-heading" />}
           {deploys.length > 0 &&
             <div>
               <div className="divider">

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -6,7 +6,7 @@ import Avatar from './avatar';
 import LastCommit from './lastCommit';
 import LoadingIndicator from './loadingIndicator';
 import LoadingError from './loadingError';
-import TimeSince from './TimeSince';
+import TimeSince from './timeSince';
 
 import {getShortVersion} from '../utils';
 import {t} from '../locale';

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
 import IconOpen from '../../icons/icon-open';
-import Avatar from '../../components/avatar';
+import LastCommit from '../../components/lastCommit';
 import IssueList from '../../components/issueList';
 import CommitAuthorStats from '../../components/commitAuthorStats';
 import ReleaseProjectStatSparkline from '../../components/releaseProjectStatSparkline';
@@ -114,29 +114,10 @@ const ReleaseOverview = React.createClass({
     return <div className="box empty">{t('None')}</div>;
   },
 
-  renderMessage(message) {
-    if (!message) {
-      return t('No message provided');
-    }
-
-    if (message.length > 100) {
-      let truncated = message.substr(0, 90);
-      let words = truncated.split(' ');
-      // try to not have elipsis mid-word
-      if (words.length > 1) {
-        words.pop();
-        truncated = words.join(' ');
-      }
-      return truncated + '...';
-    }
-    return message;
-  },
-
   render() {
     let {orgId, projectId, version} = this.props.params;
     let {release} = this.context;
     let lastCommit = release.lastCommit;
-    let commitAuthor = lastCommit && lastCommit.author;
 
     if (this.state.loading) return <LoadingIndicator />;
 
@@ -219,23 +200,7 @@ const ReleaseOverview = React.createClass({
             {hasRepos
               ? <div>
                   {lastCommit &&
-                    <div>
-                      <h6 className="nav-header">Last commit</h6>
-                      <div className="commit">
-                        <div className="commit-avatar">
-                          <Avatar user={commitAuthor || {username: '?'}} />
-                        </div>
-                        <div className="commit-message truncate">
-                          {this.renderMessage(lastCommit.message)}
-                        </div>
-                        <div className="commit-meta">
-                          <strong>
-                            {(commitAuthor && commitAuthor.name) || t('Unknown Author')}
-                          </strong>&nbsp;
-                          <TimeSince date={lastCommit.dateCreated} />
-                        </div>
-                      </div>
-                    </div>}
+                    <LastCommit lastCommit={lastCommit} headerClass="nav-header" />}
                   <CommitAuthorStats
                     orgId={orgId}
                     projectId={projectId}

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import LoadingIndicator from '../../components/loadingIndicator';
 import LoadingError from '../../components/loadingError';
 import IconOpen from '../../icons/icon-open';
+import Avatar from '../../components/avatar';
 import IssueList from '../../components/issueList';
 import CommitAuthorStats from '../../components/commitAuthorStats';
 import ReleaseProjectStatSparkline from '../../components/releaseProjectStatSparkline';
@@ -14,6 +15,10 @@ import ApiMixin from '../../mixins/apiMixin';
 import {t} from '../../locale';
 
 const ReleaseOverview = React.createClass({
+  contextTypes: {
+    release: React.PropTypes.object
+  },
+
   mixins: [ApiMixin],
 
   getInitialState() {
@@ -109,8 +114,29 @@ const ReleaseOverview = React.createClass({
     return <div className="box empty">{t('None')}</div>;
   },
 
+  renderMessage(message) {
+    if (!message) {
+      return t('No message provided');
+    }
+
+    if (message.length > 100) {
+      let truncated = message.substr(0, 90);
+      let words = truncated.split(' ');
+      // try to not have elipsis mid-word
+      if (words.length > 1) {
+        words.pop();
+        truncated = words.join(' ');
+      }
+      return truncated + '...';
+    }
+    return message;
+  },
+
   render() {
     let {orgId, projectId, version} = this.props.params;
+    let {release} = this.context;
+    let lastCommit = release.lastCommit;
+    let commitAuthor = lastCommit && lastCommit.author;
 
     if (this.state.loading) return <LoadingIndicator />;
 
@@ -192,6 +218,24 @@ const ReleaseOverview = React.createClass({
           <div className="col-sm-4">
             {hasRepos
               ? <div>
+                  {lastCommit &&
+                    <div>
+                      <h6 className="nav-header">Last commit</h6>
+                      <div className="commit">
+                        <div className="commit-avatar">
+                          <Avatar user={commitAuthor || {username: '?'}} />
+                        </div>
+                        <div className="commit-message truncate">
+                          {this.renderMessage(lastCommit.message)}
+                        </div>
+                        <div className="commit-meta">
+                          <strong>
+                            {(commitAuthor && commitAuthor.name) || t('Unknown Author')}
+                          </strong>&nbsp;
+                          <TimeSince date={lastCommit.dateCreated} />
+                        </div>
+                      </div>
+                    </div>}
                   <CommitAuthorStats
                     orgId={orgId}
                     projectId={projectId}

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -200,7 +200,7 @@ const ReleaseOverview = React.createClass({
             {hasRepos
               ? <div>
                   {lastCommit &&
-                    <LastCommit lastCommit={lastCommit} headerClass="nav-header" />}
+                    <LastCommit commit={lastCommit} headerClass="nav-header" />}
                   <CommitAuthorStats
                     orgId={orgId}
                     projectId={projectId}

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -131,3 +131,31 @@
     top: -4px;
   }
 }
+
+/**
+* Last Commit in Release Overview
+* ============================================================================
+*/
+
+.commit {
+  margin-top: 5px;
+  position: relative;
+  padding: 1px 0 0 25px;
+  font-size: 13px;
+
+  .commit-avatar {
+    position: absolute;
+    .square(19px);
+    top: 2px;
+    left: 0;
+
+    .avatar {
+      .square(19px);
+    }
+  }
+
+  .commit-message {
+    line-height: 1.4;
+    margin: 2px 0 5px;
+  }
+}

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -139,6 +139,7 @@
 
 .commit {
   margin-top: 5px;
+  margin-bottom: 20px;
   position: relative;
   padding: 1px 0 0 25px;
   font-size: 13px;

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -73,6 +73,39 @@
   .hovercard-body {
     padding: @hovercard-padding;
     min-height: 74px;
+
+    .commit-heading {
+      margin: 10px 0;
+    }
+
+    .commit {
+      margin-top: 5px;
+      margin-bottom: 0;
+      position: relative;
+      padding: 1px 0 0 25px;
+      font-size: 13px;
+
+      .commit-avatar {
+        position: absolute;
+        .square(19px);
+        top: 2px;
+        left: 0;
+
+        .avatar {
+          .square(19px);
+        }
+      }
+
+      .commit-message {
+        line-height: 1.4;
+        margin: 2px 0 5px;
+      }
+
+      .commit-meta {
+        font-size: 12px;
+        color: @70;
+      }
+    }
   }
 
   .divider {
@@ -129,42 +162,6 @@
 
     .tip {
       border-bottom: 0 !important;
-    }
-  }
-
-  .commit-heading {
-    margin: 10px 0;
-  }
-
-  .commit {
-    margin-top: 5px;
-    position: relative;
-    padding: 1px 0 0 38px;
-    font-size: 13px;
-
-    .commit-avatar {
-      position: absolute;
-      .square(30px);
-      top: 1px;
-      left: 0;
-
-      .avatar {
-        .square(30px);
-      }
-    }
-
-    .commit-message {
-      line-height: 1.4;
-      margin: 2px 0 5px;
-    }
-
-    .commit-meta {
-      font-size: 12px;
-      color: @70;
-
-      strong {
-        color: @gray-dark;
-      }
     }
   }
 


### PR DESCRIPTION
Surfaces the last commit affiliated with a release in the overview. Also makes tooltips work for CommitAuthorStats avatars.

entire overview:
![image](https://cloud.githubusercontent.com/assets/9269824/25408124/c6c931c4-29c1-11e7-8151-4041242d06fb.png)

closer up:
![image](https://cloud.githubusercontent.com/assets/9269824/25408149/db4a554c-29c1-11e7-9b9c-d33d0637b2d0.png)

#nochanges