### PR TITLE
Fix inviting team member when no teams available

### DIFF
--- a/src/sentry/templates/sentry/partial/members/_teams.html
+++ b/src/sentry/templates/sentry/partial/members/_teams.html
@@ -22,6 +22,6 @@
     </fieldset>
   </div>
 </div>
-{% else %}
+{% elif all_teams|length == 1 %}
     <input type="hidden" name="teams" value="{{ all_teams.0.id }}" />
 {% endif %}

--- a/src/sentry/web/frontend/create_organization_member.py
+++ b/src/sentry/web/frontend/create_organization_member.py
@@ -78,7 +78,7 @@ class CreateOrganizationMemberView(OrganizationView):
                 (r, r in allowed_roles)
                 for r in roles.get_all()
             ],
-            'all_teams': all_teams
+            'all_teams': list(all_teams),
         }
 
         return self.respond('sentry/create-organization-member.html', context)


### PR DESCRIPTION
This edge case wasn't covered in the template, causing a team to be
submit wtiht he form as an empty string, instead of nothing at all.
Resulting in trying to do `Team.objects.get(id='')`. And of course, the
error was swallowed since we weren't attempting to show anything here.

This was introduced with https://github.com/getsentry/sentry/pull/5096