### PR TITLE
Adding close and resolve to commit regex

### DIFF
--- a/src/sentry/models/commit.py
+++ b/src/sentry/models/commit.py
@@ -10,7 +10,7 @@ from sentry.db.models import (
 )
 from sentry.utils.cache import memoize
 
-_fixes_re = re.compile(r'\bFixes\s+([A-Za-z0-9_\-\s\,]+)\b', re.I)
+_fixes_re = re.compile(r'\b(Fix|Fixes|Fixed|Close|Closes|Closed|Resolve|Resolves|Resolved)\s+([A-Za-z0-9_\-\s\,]+)\b', re.I)
 _short_id_re = re.compile(r'\b([A-Z0-9_-]+-[A-Z0-9]+)\b', re.I)
 
 
@@ -58,7 +58,7 @@ class Commit(Model):
 
         results = set()
         for fmatch in _fixes_re.finditer(self.message):
-            for smatch in _short_id_re.finditer(fmatch.group(1)):
+            for smatch in _short_id_re.finditer(fmatch.group(2)):
                 short_id = smatch.group(1)
                 try:
                     group = Group.objects.by_qualified_short_id(

--- a/src/sentry/models/commit.py
+++ b/src/sentry/models/commit.py
@@ -10,7 +10,7 @@ from sentry.db.models import (
 )
 from sentry.utils.cache import memoize
 
-_fixes_re = re.compile(r'\b(Fix|Fixes|Fixed|Close|Closes|Closed|Resolve|Resolves|Resolved)\s+([A-Za-z0-9_\-\s\,]+)\b', re.I)
+_fixes_re = re.compile(r'\b(?:Fix|Fixes|Fixed|Close|Closes|Closed|Resolve|Resolves|Resolved)\s+([A-Za-z0-9_\-\s\,]+)\b', re.I)
 _short_id_re = re.compile(r'\b([A-Z0-9_-]+-[A-Z0-9]+)\b', re.I)
 
 
@@ -58,7 +58,7 @@ class Commit(Model):
 
         results = set()
         for fmatch in _fixes_re.finditer(self.message):
-            for smatch in _short_id_re.finditer(fmatch.group(2)):
+            for smatch in _short_id_re.finditer(fmatch.group(1)):
                 short_id = smatch.group(1)
                 try:
                     group = Group.objects.by_qualified_short_id(

--- a/tests/sentry/models/test_commit.py
+++ b/tests/sentry/models/test_commit.py
@@ -32,6 +32,36 @@ class FindReferencedGroupsTest(TestCase):
         assert group in groups
         assert group2 in groups
 
+        commit = Commit.objects.create(
+            key=sha1(uuid4().hex).hexdigest(),
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            message='Foo Biz\n\Resolved {} {}'.format(
+                group.qualified_short_id,
+                group2.qualified_short_id,
+            ),
+        )
+
+        groups = commit.find_referenced_groups()
+        assert len(groups) == 2
+        assert group in groups
+        assert group2 in groups
+
+        commit = Commit.objects.create(
+            key=sha1(uuid4().hex).hexdigest(),
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            message='Foo Biz\n\Close {} {}'.format(
+                group.qualified_short_id,
+                group2.qualified_short_id,
+            ),
+        )
+
+        groups = commit.find_referenced_groups()
+        assert len(groups) == 2
+        assert group in groups
+        assert group2 in groups
+
     def test_multiple_matches_comma_separated(self):
         group = self.create_group()
         group2 = self.create_group()


### PR DESCRIPTION
Mimicking [GitHub's syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) for resolving issues with commit.