### PR TITLE
Improve perf of JS tests, fix proptype warnings

### DIFF
--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import {mount} from 'enzyme';
 import AssigneeSelector from 'app/components/assigneeSelector';
 
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -75,7 +75,7 @@ describe('AssigneeSelector', function() {
         expect(putSessionUserFirst([USER_1, USER_2])).toEqual([USER_2, USER_1]);
       });
 
-      it('should return the same member list if the session user isn\'t present', function() {
+      it("should return the same member list if the session user isn't present", function() {
         this.sandbox.stub(ConfigStore, 'get').withArgs('user').returns({
           id: 555,
           name: 'Here Comes a New Challenger',
@@ -89,96 +89,86 @@ describe('AssigneeSelector', function() {
 
   describe('onFilterKeyDown()', function() {
     beforeEach(function() {
-      let assigneeSelector = (this.assigneeSelector = TestUtils.renderIntoDocument(
+      let assigneeSelector = (this.assigneeSelector = mount(
         <AssigneeSelector id="1337" />
       ));
 
-      this.sandbox.stub(assigneeSelector, 'assignTo');
+      this.assignTo = this.sandbox.stub(assigneeSelector.instance(), 'assignTo');
     });
 
     it('should assign the first filtered member when the Enter key is pressed and filter is truthy', function() {
       let assigneeSelector = this.assigneeSelector;
-      assigneeSelector.state.filter = 'Jane';
+      assigneeSelector.setState({filter: 'Jane'});
 
-      TestUtils.Simulate.keyDown(assigneeSelector.refs.filter, {
-        key: 'Enter',
-        keyCode: 13,
-        which: 13
-      });
-      expect(assigneeSelector.assignTo.calledOnce).toBeTruthy;
-      expect(assigneeSelector.assignTo.lastCall.args[0]).toHaveProperty(
-        'name',
-        'Jane Doe'
-      );
+      assigneeSelector
+        .ref('filter')
+        .simulate('keyDown', {key: 'Enter', keyCode: 13, which: 13});
+
+      expect(this.assignTo.calledOnce).toBeTruthy;
+      expect(this.assignTo.lastCall.args[0]).toHaveProperty('name', 'Jane Doe');
     });
 
     it('should do nothing when the Enter key is pressed, but filter is the empty string', function() {
       let assigneeSelector = this.assigneeSelector;
-      assigneeSelector.state.filter = '';
+      assigneeSelector.setState({filter: ''});
 
-      TestUtils.Simulate.keyDown(assigneeSelector.refs.filter, {
-        key: 'Enter',
-        keyCode: 13,
-        which: 13
-      });
-      expect(assigneeSelector.assignTo.notCalled).toBeTruthy;
+      assigneeSelector
+        .ref('filter')
+        .simulate('keyDown', {key: 'Enter', keyCode: 13, which: 13});
+
+      expect(this.assignTo.notCalled).toBeTruthy;
     });
 
     it('should do nothing if a non-Enter key is pressed', function() {
       let assigneeSelector = this.assigneeSelector;
-      assigneeSelector.state.filter = 'Jane';
+      assigneeSelector.setState({filter: 'Jane'});
 
-      TestUtils.Simulate.keyDown(assigneeSelector.refs.filter, {
-        key: 'h',
-        keyCode: 72,
-        which: 72
-      });
-      expect(assigneeSelector.assignTo.notCalled).toBeTruthy;
+      assigneeSelector
+        .ref('filter')
+        .simulate('keyDown', {key: 'h', keyCode: 72, which: 72});
+      expect(this.assignTo.notCalled).toBeTruthy;
     });
   });
 
   describe('onFilterKeyUp()', function() {
     beforeEach(function() {
-      this.assigneeSelector = TestUtils.renderIntoDocument(
-        <AssigneeSelector id="1337" />
-      );
+      this.assigneeSelector = mount(<AssigneeSelector id="1337" />);
     });
 
     it('should close the dropdown when keyup is triggered with the Escape key', function() {
       let assigneeSelector = this.assigneeSelector;
-      this.sandbox.stub(assigneeSelector.refs.dropdown, 'close');
+      let closeStub = this.sandbox.stub(
+        assigneeSelector.instance().refs.dropdown,
+        'close'
+      );
 
-      TestUtils.Simulate.keyUp(assigneeSelector.refs.filter, {key: 'Escape'});
+      assigneeSelector.ref('filter').simulate('keyUp', {key: 'Escape'});
 
-      expect(assigneeSelector.refs.dropdown.close.calledOnce).toBeTruthy;
+      expect(closeStub.calledOnce).toBeTruthy;
     });
 
     it('should update the local filter state if any other key is pressed', function() {
       let assigneeSelector = this.assigneeSelector;
 
-      TestUtils.Simulate.keyUp(assigneeSelector.refs.filter, {target: {value: 'foo'}});
-      expect(assigneeSelector.state.filter).toEqual('foo');
+      assigneeSelector.ref('filter').simulate('keyUp', {target: {value: 'foo'}});
+      expect(assigneeSelector.state('filter')).toEqual('foo');
     });
   });
 
   describe('componentDidUpdate()', function() {
     beforeEach(function() {
-      this.assigneeSelector = TestUtils.renderIntoDocument(
-        <AssigneeSelector id="1337" />
-      );
+      this.assigneeSelector = mount(<AssigneeSelector id="1337" />);
     });
 
-    it('should destroy old assignee tooltip and create a new assignee tooltip', function(
-      done
-    ) {
-      this.sandbox.spy(this.assigneeSelector, 'attachTooltips');
-      this.sandbox.spy(this.assigneeSelector, 'removeTooltips');
+    it('should destroy old assignee tooltip and create a new assignee tooltip', function() {
+      let instance = this.assigneeSelector.instance();
+      this.sandbox.spy(instance, 'attachTooltips');
+      this.sandbox.spy(instance, 'removeTooltips');
 
-      this.assigneeSelector.setState({assignedTo: USER_1}, () => {
-        expect(this.assigneeSelector.attachTooltips.calledOnce).toBeTruthy;
-        expect(this.assigneeSelector.removeTooltips.calledOnce).toBeTruthy;
-        done();
-      });
+      this.assigneeSelector.setState({assignedTo: USER_1});
+
+      expect(instance.attachTooltips.calledOnce).toBeTruthy;
+      expect(instance.removeTooltips.calledOnce).toBeTruthy;
     });
   });
 });

--- a/tests/js/spec/components/contextData.spec.jsx
+++ b/tests/js/spec/components/contextData.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 
 import ContextData from 'app/components/contextData';
 
@@ -8,7 +8,7 @@ describe('ContextData', function() {
     describe('strings', function() {
       it('should render urls w/ an additional <a> link', function() {
         const URL = 'https://example.org/foo/bar/';
-        let wrapper = mount(<ContextData data={URL} />);
+        let wrapper = shallow(<ContextData data={URL} />);
 
         expect(wrapper.find('span').at(0).text()).toEqual(URL);
         expect(wrapper.find('a').at(0).prop('href')).toEqual(URL);

--- a/tests/js/spec/components/letterAvatar.spec.jsx
+++ b/tests/js/spec/components/letterAvatar.spec.jsx
@@ -16,7 +16,7 @@ describe('LetterAvatar', function() {
     displayName: 'foo@example.com'
   };
   const USER_4 = {
-    identifier: 2,
+    identifier: '2',
     displayName: ''
   };
   const USER_5 = {

--- a/tests/js/spec/components/stackedBarChart.spec.jsx
+++ b/tests/js/spec/components/stackedBarChart.spec.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 
-import BarChart from 'app/components/barChart';
+import StackedBarChart from 'app/components/stackedBarChart';
 
-describe('BarChart', function() {
+describe('StackedBarChart', function() {
   describe('render()', function() {
     it('renders with points data', function() {
       let points = [
-        {x: 1439766000, y: 10},
-        {x: 1439769600, y: 20},
-        {x: 1439773200, y: 30}
+        {x: 1439766000, y: [10]},
+        {x: 1439769600, y: [20]},
+        {x: 1439773200, y: [30]}
       ];
 
-      let wrapper = mount(<BarChart points={points} />);
+      let wrapper = shallow(<StackedBarChart points={points} />);
       let columns = wrapper.find('.chart-column');
 
       expect(columns).toHaveProperty('length', 3);
@@ -23,16 +23,16 @@ describe('BarChart', function() {
 
     it('renders with points and markers', function() {
       let points = [
-        {x: 1439769600, y: 10},
-        {x: 1439773200, y: 20},
-        {x: 1439776800, y: 30}
+        {x: 1439769600, y: [10]},
+        {x: 1439773200, y: [20]},
+        {x: 1439776800, y: [30]}
       ];
       let markers = [
         {x: 1439769600, className: 'first-seen', label: 'first seen'}, // matches first point
         {x: 1439776800, className: 'last-seen', label: 'last seen'} // matches last point
       ];
 
-      let wrapper = mount(<BarChart points={points} markers={markers} />);
+      let wrapper = shallow(<StackedBarChart points={points} markers={markers} />);
       let columns = wrapper.find('a');
 
       expect(columns).toHaveProperty('length', 5);
@@ -46,13 +46,13 @@ describe('BarChart', function() {
     });
 
     it('renders with points and markers, when first and last seen are same data point', function() {
-      let points = [{x: 1439776800, y: 30}];
+      let points = [{x: 1439776800, y: [30]}];
       let markers = [
         {x: 1439776800, className: 'first-seen', label: 'first seen'},
         {x: 1439776800, className: 'last-seen', label: 'last seen'}
       ];
 
-      let wrapper = mount(<BarChart points={points} markers={markers} />);
+      let wrapper = shallow(<StackedBarChart points={points} markers={markers} />);
       let columns = wrapper.find('a');
 
       expect(columns).toHaveProperty('length', 3);

--- a/tests/js/spec/components/userLetterAvatar.spec.jsx
+++ b/tests/js/spec/components/userLetterAvatar.spec.jsx
@@ -4,20 +4,20 @@ import UserLetterAvatar from 'app/components/userLetterAvatar';
 
 describe('LetterAvatar', function() {
   const USER_1 = {
-    id: 1,
+    id: '1',
     name: 'Jane Doe',
     email: 'janedoe@example.com'
   };
   const USER_2 = {
-    id: 2,
+    id: '2',
     email: 'johnsmith@example.com'
   };
   const USER_3 = {
-    id: 2,
+    id: '2',
     username: 'foo@example.com'
   };
   const USER_4 = {
-    id: 2
+    id: '2'
   };
   const USER_5 = {
     ip_address: '127.0.0.1'
@@ -72,7 +72,7 @@ describe('LetterAvatar', function() {
       this.letterAvatar = TestUtils.renderIntoDocument(
         <UserLetterAvatar user={USER_4} />
       );
-      expect(this.letterAvatar.getIdentifier()).toEqual(2);
+      expect(this.letterAvatar.getIdentifier()).toEqual('2');
     });
 
     it('should use ip address', function() {

--- a/tests/js/spec/views/projectReleases.spec.jsx
+++ b/tests/js/spec/views/projectReleases.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import {shallow} from 'enzyme';
 
 import {browserHistory} from 'react-router';
 import stubReactComponents from '../../helpers/stubReactComponent';
@@ -22,9 +22,7 @@ describe('ProjectReleases', function() {
       params: {orgId: '123', projectId: '456'},
       location: {query: {per_page: 0, query: 'derp'}}
     };
-    this.projectReleases = TestUtils.renderIntoDocument(
-      <ProjectReleases {...this.props} />
-    );
+    this.projectReleases = shallow(<ProjectReleases {...this.props} />);
   });
 
   afterEach(function() {
@@ -41,7 +39,7 @@ describe('ProjectReleases', function() {
 
   describe('getInitialState()', function() {
     it('should take query state from query string', function() {
-      expect(this.projectReleases.state.query).toEqual('derp');
+      expect(this.projectReleases.state('query')).toEqual('derp');
     });
   });
 
@@ -49,7 +47,7 @@ describe('ProjectReleases', function() {
     it('should change query string with new search parameter', function() {
       let projectReleases = this.projectReleases;
 
-      projectReleases.onSearch('searchquery');
+      projectReleases.instance().onSearch('searchquery');
 
       expect(browserHistory.pushState.calledOnce).toBeTruthy;
       expect(browserHistory.pushState.args[0]).toEqual([
@@ -64,7 +62,7 @@ describe('ProjectReleases', function() {
 
   describe('componentWillReceiveProps()', function() {
     it('should update state with latest query pulled from query string', function() {
-      let projectReleases = this.projectReleases;
+      let projectReleases = this.projectReleases.instance();
 
       let setState = this.sandbox.stub(projectReleases, 'setState');
 

--- a/tests/js/spec/views/stream.spec.jsx
+++ b/tests/js/spec/views/stream.spec.jsx
@@ -89,7 +89,7 @@ describe('Stream', function() {
         expect(CursorPoller.prototype.setEndpoint.notCalled).toBeTruthy();
       });
 
-      it('should not enable the poller if the \'previous\' link has results', function() {
+      it("should not enable the poller if the 'previous' link has results", function() {
         let stream = this.wrapper.instance();
         stream.state.pageLinks =
           '<http://127.0.0.1:8000/api/0/projects/sentry/ludic-science/issues/?cursor=1443575731:0:1>; rel="previous"; results="true"; cursor="1443575731:0:1", ' +
@@ -149,7 +149,7 @@ describe('Stream', function() {
     it('displays an error when component has errored', function() {
       let wrapper = this.wrapper;
       wrapper.setState({
-        error: true,
+        error: 'Something bad happened',
         loading: false,
         dataLoading: false
       });


### PR DESCRIPTION
Besides fixing propType warnings (which cleans terminal output, see below), this patch improves performance by using `shallow` renderer instead of `mount` where possible.

**Benchmarks**


| Run  | 1 | 2 | 3
| ------------- | ------- | --- | --- |
| **Before**  |  15.276s | 14.6s | 18.888s |
| **After**  | 9.118s | 8.564s | 8.517s |

notbad.jpg

---

Console output after changes:

```
(sentry)➜  sentry git:(js-test-cleanup) npm test

> Sentry@0.0.0 test /Users/benvinegar/Projects/sentry
> NODE_ENV=test node_modules/.bin/jest tests/js/spec

 PASS  tests/js/spec/views/stream/searchBar.spec.jsx
 PASS  tests/js/spec/components/assigneeSelector.spec.jsx
 PASS  tests/js/spec/views/stream.spec.jsx
 PASS  tests/js/spec/views/groupActivity/index.spec.jsx
 PASS  tests/js/spec/views/releaseArtifacts.spec.jsx
 PASS  tests/js/spec/views/projectReleases.spec.jsx
 PASS  tests/js/spec/views/organizationTeams.spec.jsx
 PASS  tests/js/spec/components/eventsPerHour.spec.jsx
 PASS  tests/js/spec/components/events/interfaces/richHttpContent.spec.jsx
 PASS  tests/js/spec/components/events/interfaces/breadcrumbComponents/breadcrumbs.spec.jsx
 PASS  tests/js/spec/views/projectInstall/platform.spec.jsx
 PASS  tests/js/spec/views/stream/actions.spec.jsx
 PASS  tests/js/spec/components/avatarCropper.spec.jsx
 PASS  tests/js/spec/views/ruleEditor/ruleNodeList.spec.jsx
 PASS  tests/js/spec/components/stackedBarChart.spec.jsx
 PASS  tests/js/spec/views/stream/actionLink.spec.jsx
 PASS  tests/js/spec/views/groupDetails/seenBy.spec.jsx
 PASS  tests/js/spec/components/events/interfaces/breadcrumbComponents/httpRenderer.spec.jsx
 PASS  tests/js/spec/components/group/tagDistributionMeter.spec.jsx
 PASS  tests/js/spec/components/issues/snoozeAction.spec.jsx
 PASS  tests/js/spec/components/avatar.spec.jsx
 PASS  tests/js/spec/components/contextData.spec.jsx
 PASS  tests/js/spec/components/events/interfaces/rawStacktraceContent.spec.jsx
 PASS  tests/js/spec/components/events/interfaces/keyValueList.spec.jsx
 PASS  tests/js/spec/components/events/interfaces/frame.spec.jsx
 PASS  tests/js/spec/components/userLetterAvatar.spec.jsx
 PASS  tests/js/spec/stores/selectedGroupStore.spec.js
 PASS  tests/js/spec/api.spec.jsx
 PASS  tests/js/spec/components/letterAvatar.spec.jsx
 PASS  tests/js/spec/components/dropdownLink.spec.jsx
 PASS  tests/js/spec/utils/streamManager.spec.js
 PASS  tests/js/spec/stores/alertStore.spec.js
 PASS  tests/js/spec/components/events/interfaces/utils.spec.jsx
 PASS  tests/js/spec/stores/groupStore.spec.jsx
 PASS  tests/js/spec/stores/streamTagStore.spec.jsx
 PASS  tests/js/spec/utils/logging.spec.jsx
 PASS  tests/js/spec/utils/marked.spec.jsx
 PASS  tests/js/spec/utils/utils.spec.jsx
 PASS  tests/js/spec/utils/stream.spec.jsx
 PASS  tests/js/spec/helpers/formatters.spec.jsx

Test Suites: 40 passed, 40 total
Tests:       222 passed, 222 total
Snapshots:   0 total
Time:        10.13s
Ran all test suites matching "tests/js/spec".
```