### PR TITLE
Disable user registration by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -737,7 +737,7 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 SENTRY_CLIENT = 'sentry.utils.raven.SentryInternalClient'
 
 SENTRY_FEATURES = {
-    'auth:register': True,
+    'auth:register': False,
     'organizations:api-keys': False,
     'organizations:create': True,
     'organizations:repos': True,


### PR DESCRIPTION
As the following *pull requests* and *issues* show, disabling the user registration seems to be one of the most wanted features for self hosted server. 

[Add Env parameter to allow Register](https://github.com/getsentry/docker-sentry/pull/100)
[Make user registration configurable by ENV var](https://github.com/getsentry/docker-sentry/pull/43)
[Add SENTRY_ALLOW_REGISTRATION environment variable](https://github.com/getsentry/docker-sentry/pull/97)
[add new environment variable to disable registration](https://github.com/getsentry/docker-sentry/pull/103)
[Can not disable user registration](https://github.com/getsentry/sentry/issues/1453)
[How to disable user register on self hosted server ?](https://github.com/getsentry/sentry/issues/2663)

Adding the ability to do so to the *ENV variables* was often discussed and denied. My approach is therefore different: **Disable user registration by default.**

I guess that disabling user registration is configured in a lot, if not the most sentry setups, as it is a huge security risk **NOT** to do so.