### PR TITLE
Sets start_sha to None by default

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -42,7 +42,9 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
             continue
 
         # if previous commit isn't provided, try to get from
-        # previous release otherwise, give up
+        # previous release otherwise, try to get
+        # recent commits from provider api
+        start_sha = None
         if ref.get('previousCommit'):
             start_sha = ref['previousCommit']
         elif prev_release:
@@ -53,9 +55,7 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                     repository_id=repo.id,
                 ).values_list('key', flat=True)[0]
             except IndexError:
-                continue
-        else:
-            continue
+                pass
 
         end_sha = ref['commit']
         provider = provider_cls(id=repo.provider)


### PR DESCRIPTION
 Sets start_sha to None by default so that rather than giving up initially, the provider can still try to get recent commits when no `previousCommit` is provided or no previous release is found.

Relies on https://github.com/getsentry/sentry-plugins/pull/172 to be merged first