### PR TITLE
Fix raw apple crash reports with threads = null

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -46,15 +46,8 @@ class EventAppleCrashReportEndpoint(Endpoint):
                 'message': 'Only cocoa events can return an apple crash report',
             }, status=403)
 
-        threads = event.data.get(
-            'sentry.interfaces.threads',
-            event.data.get('threads'
-        )).get('values')
-
-        exception = event.data.get(
-            'sentry.interfaces.Exception',
-            event.data.get('exception'
-        )).get('values')
+        threads = (event.data.get('threads') or {}).get('values')
+        exception = (event.data.get('sentry.interfaces.Exception') or {}).get('values')
 
         symbolicated = (request.GET.get('minified') not in ('1', 'true'))
         debug_images = None

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -94,7 +94,7 @@ class AppleCrashReport(object):
 
     def get_threads_apple_string(self):
         rv = []
-        for thread in self.threads:
+        for thread in self.threads or []:
             thread_string = self.get_thread_apple_string(thread)
             if thread_string is not None:
                 rv.append(thread_string)


### PR DESCRIPTION
In some cases it was possible that the raw crash report see a None
value for threads or exception in which case it was falling over
instead of silently failing.

Fixes SENTRY-2MZ