### PR TITLE
Use newer sentry-cli for reprocessing script

### DIFF
--- a/src/sentry/templates/sentry/reprocessing-script.sh
+++ b/src/sentry/templates/sentry/reprocessing-script.sh
@@ -1,6 +1,9 @@
-{% load i18n %}{% autoescape off %}#!/bin/sh
+{% load i18n %}{% autoescape off %}#!/bin/bash
 set -eu
 SIGN=$'\033[2m>\033[0m'
+DOWNLOAD_VERSION=1.8.0
+MIN_VERSION=1.8.0
+MIN_INT_VERSION=`echo $MIN_VERSION|awk -F. '{ printf("%04d%04d%04d\n", $1, $2, $3) }'`
 
 {% if not token %}
 echo 'error: the link you followed expired.'
@@ -12,21 +15,38 @@ echo "{% blocktrans count issues=issues|length %}Looking for {{ issues }} missin
 {% endfor %}
 echo
 
-DOWNLOAD_URL="https://github.com/getsentry/sentry-cli/releases/download/1.7.0/sentry-cli-Darwin-x86_64"
-TEMP_FILE=`mktemp "${TMPDIR:-/tmp}/.sentrycli.XXXXXXXX"`
-cleanup() {
-  rm -f "$TEMP_FILE"
-}
-trap cleanup EXIT
-echo "$SIGN Fetching sentry-cli utility"
-download_start=`date +%s`
-curl -SL --progress-bar "$DOWNLOAD_URL" -o "$TEMP_FILE" 2>&1 | tr -u '#' '█'
-chmod +x "$TEMP_FILE"
-download_end=`date +%s`
-CLI="$TEMP_FILE"
-echo -n $'\033[2A\033[K'
-echo "$SIGN Fetched sentry-cli utility in $((download_end-download_start))s"
-echo -n $'\033[K'
+HAVE_SENTRY_CLI=0
+if hash sentry-cli 2> /dev/null; then
+  INSTALLED_VERSION=`sentry-cli --version|awk '{print $2}'|awk -F. '{ printf("%04d%04d%04d\n", $1, $2, $3) }'`
+  if (( 10#$INSTALLED_VERSION >= 10#$MIN_INT_VERSION )); then
+    HAVE_SENTRY_CLI=1
+    CLI=sentry-cli
+  fi
+fi
+
+if [ "$HAVE_SENTRY_CLI" == "0" ]; then
+  DOWNLOAD_URL="https://github.com/getsentry/sentry-cli/releases/download/$DOWNLOAD_VERSION/sentry-cli-Darwin-x86_64"
+  TEMP_FILE=`mktemp "${TMPDIR:-/tmp}/.sentrycli.XXXXXXXX"`
+  cleanup() {
+    rm -f "$TEMP_FILE"
+  }
+  trap cleanup EXIT
+  echo "$SIGN Fetching sentry-cli utility"
+  download_start=`date +%s`
+  if ! curl -fSL --progress-bar "$DOWNLOAD_URL" -o "$TEMP_FILE" 2>&1; then
+    echo "error: could not download sentry-cli"
+    exit 1
+  fi
+  chmod +x "$TEMP_FILE"
+  download_end=`date +%s`
+  CLI="$TEMP_FILE"
+  echo -n $'\033[2A\033[K'
+  echo "$SIGN Fetched sentry-cli utility in $((download_end-download_start))s"
+  echo -n $'\033[K'
+else
+  echo "$SIGN Using installed sentry-cli utility"
+fi
+
 echo "$SIGN Looking for debug symbols"
 
 export SENTRY_AUTH_TOKEN="{{ token }}"


### PR DESCRIPTION
This uses sentry-cli 1.8.0 (once it's released) for reprocessing
and also will use an already installed sentry-cli if it has that
version or newer.

This will skip over files that do not contain dwarf data which
solves issues with us uploading incorrect files at times.

(This also removes the tr hack which broke handling of 404 errors)

See https://github.com/getsentry/sentry-cli/pull/61