### PR TITLE
Implement `InMemoryTSDB.get_most_frequent_series`.

### DIFF
--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -192,6 +192,19 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
+    def get_most_frequent_series(self, model, keys, start, end=None, rollup=None, limit=None):
+        rollup, series = self.get_optimal_rollup_series(start, end, rollup)
+
+        results = {}
+        for key in keys:
+            result = results[key] = []
+            source = self.frequencies[model][key]
+            for timestamp in series:
+                data = source[self.normalize_ts_to_rollup(timestamp, rollup)]
+                result.append((timestamp, dict(data.most_common(limit))))
+
+        return results
+
     def get_frequency_series(self, model, items, start, end=None, rollup=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 


### PR DESCRIPTION
This is [defined in the base implementation](https://github.com/getsentry/sentry/blob/56cbd66eab3282e3cb5f01d87ebdbc1b8ae2cd3e/src/sentry/tsdb/base.py#L356-L368) but it looks like I forgot to implement it with 19eaf9b3a280f98d3a18f9ba8332f5344d374ab5.