### PR TITLE
buffers: handle compat between buffer incr calls from before FK split

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -59,6 +59,13 @@ class Buffer(Service):
         if extra:
             update_kwargs.update(extra)
 
+        # TODO(mattrobenolt): Remove in 8.18
+        if model.__name__ == 'GroupTagValue':
+            try:
+                update_kwargs['project_id'] = update_kwargs.pop('project')
+            except KeyError:
+                pass
+
         _, created = model.objects.create_or_update(
             values=update_kwargs,
             **filters


### PR DESCRIPTION
Fixes SENTRY-3B5

This is kinda gross, but I can't think if another reasonable way to handle this without a ton of work. I'll just follow up by reverting this.

The old keys got pushed into buffers as `project` key, but they need to be translated back to `project_id`.