### PR TITLE
Route index_tag_events into TRIGGER_TASKS so it can live with its friends.

### DIFF
--- a/src/sentry/queue/routers.py
+++ b/src/sentry/queue/routers.py
@@ -16,6 +16,7 @@ TRIGGER_TASKS = set([
     'sentry.tasks.post_process.plugin_post_process_group',
     'sentry.tasks.post_process.record_affected_user',
     'sentry.tasks.post_process.record_affected_code',
+    'sentry.tasks.post_process.index_event_tags',
 ])
 
 

--- a/src/sentry/queue/routers.py
+++ b/src/sentry/queue/routers.py
@@ -16,7 +16,7 @@ TRIGGER_TASKS = set([
     'sentry.tasks.post_process.plugin_post_process_group',
     'sentry.tasks.post_process.record_affected_user',
     'sentry.tasks.post_process.record_affected_code',
-    'sentry.tasks.post_process.index_event_tags',
+    'sentry.tasks.index_event_tags',
 ])
 
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -156,7 +156,7 @@ def record_affected_user(event, **kwargs):
 
 
 @instrumented_task(
-    name='sentry.tasks.post_process.index_event_tags',
+    name='sentry.tasks.index_event_tags',
     default_retry_delay=60 * 5, max_retries=None)
 def index_event_tags(organization_id, project_id, event_id, tags, group_id=None,
                      **kwargs):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -156,7 +156,7 @@ def record_affected_user(event, **kwargs):
 
 
 @instrumented_task(
-    name='sentry.tasks.index_event_tags',
+    name='sentry.tasks.post_process.index_event_tags',
     default_retry_delay=60 * 5, max_retries=None)
 def index_event_tags(organization_id, project_id, event_id, tags, group_id=None,
                      **kwargs):


### PR DESCRIPTION
I'm not completely sure about the implications of moving an already frequently-scheduled task into a different queue, so let me know if anything else in here should change.