### PR TITLE
tests: add test coverage for celery beat schedule

### DIFF
--- a/tests/sentry/celery/__init__.py
+++ b/tests/sentry/celery/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -2,15 +2,13 @@ from __future__ import absolute_import
 
 import pytest
 from celery.beat import ScheduleEntry
-from sentry.celery import SentryCelery
+from sentry.celery import app
 from django.conf import settings
+
+app.loader.import_default_modules()
 
 
 @pytest.mark.parametrize('name,entry', settings.CELERYBEAT_SCHEDULE.items())
 def test_validate_celerybeat_schedule(name, entry):
-    app = SentryCelery('sentry')
-    app.config_from_object(settings)
-    app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
-    app.loader.import_default_modules()
     entry = ScheduleEntry(name=name, app=app, **entry)
     assert entry.task in app.tasks

--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+import pytest
+from celery.beat import ScheduleEntry
+from sentry.celery import SentryCelery
+from django.conf import settings
+
+
+@pytest.mark.parametrize('name,entry', settings.CELERYBEAT_SCHEDULE.items())
+def test_validate_celerybeat_schedule(name, entry):
+    app = SentryCelery('sentry')
+    app.config_from_object(settings)
+    app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+    app.loader.import_default_modules()
+    entry = ScheduleEntry(name=name, app=app, **entry)
+    assert entry.task in app.tasks


### PR DESCRIPTION
This should prevent at least two scenarios:

* Malformed task names.
* Malformed ScheduleEntry definitions.

```
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[send-ping-entry0] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[schedule-auto-resolution-entry1] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[clear-expired-snoozes-entry2] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[check-auth-entry3] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[send-beacon-entry4] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[flush-buffers-entry5] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[schedule-digests-entry6] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[collect-project-platforms-entry7] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[clear-expired-raw-events-entry8] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[schedule-weekly-organization-reports-entry9] PASSED
tests/sentry/celery/test_app.py::test_validate_celerybeat_schedule[sync-options-entry10] PASSED
```