### PR TITLE
Track the last seen non-sampled event ID for `GroupHash` records.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -823,6 +823,14 @@ class EventManager(object):
 
             group_is_new = False
 
+        # Keep a set of all of the hashes that are relevant for this event and
+        # belong to the destination group so that we can record this as the
+        # last processed event for each. (We can't just update every
+        # ``GroupHash`` instance, since we only want to record this for events
+        # that not only include the hash but were also placed into the
+        # associated group.)
+        relevant_group_hashes = set([instance for instance in all_hashes if instance.group_id == group.id])
+
         # If all hashes are brand new we treat this event as new
         is_new = False
         new_hashes = [h for h in all_hashes if h.group_id is None]
@@ -842,6 +850,11 @@ class EventManager(object):
 
             if group_is_new and len(new_hashes) == len(all_hashes):
                 is_new = True
+
+            # XXX: This can lead to invalid results due to a race condition and
+            # lack of referential integrity enforcement, see above comment(s)
+            # about "hash stealing".
+            relevant_group_hashes.update(new_hashes)
 
         # XXX(dcramer): it's important this gets called **before** the aggregate
         # is processed as otherwise values like last_seen will get mutated
@@ -869,6 +882,13 @@ class EventManager(object):
             is_sample = False
         else:
             is_sample = can_sample
+
+        if not is_sample:
+            GroupHash.record_last_processed_event_id(
+                project.id,
+                [h.id for h in relevant_group_hashes],
+                event.event_id,
+            )
 
         return group, is_new, is_regression, is_sample
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -761,14 +761,13 @@ class EventManager(object):
         return euser
 
     def _find_hashes(self, project, hash_list):
-        matches = []
-        for hash in hash_list:
-            ghash, _ = GroupHash.objects.get_or_create(
+        return map(
+            lambda hash: GroupHash.objects.get_or_create(
                 project=project,
                 hash=hash,
-            )
-            matches.append((ghash.group_id, ghash.hash))
-        return matches
+            )[0],
+            hash_list,
+        )
 
     def _ensure_hashes_merged(self, group, hash_list):
         # TODO(dcramer): there is a race condition with selecting/updating

--- a/tests/sentry/models/test_grouphash.py
+++ b/tests/sentry/models/test_grouphash.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+from sentry.models import GroupHash
+from sentry.testutils import TestCase
+
+
+class GroupTest(TestCase):
+    def test_fetch_and_record_last_processed_event_id(self):
+        group = self.group
+
+        grouphash = GroupHash.objects.create(
+            project=group.project,
+            group=group,
+            hash='xyz',
+        )
+
+        GroupHash.record_last_processed_event_id(
+            grouphash.project_id,
+            [grouphash.id],
+            'event',
+        )
+
+        assert GroupHash.fetch_last_processed_event_id(
+            grouphash.project_id,
+            [grouphash.id, -1],
+        ) == ['event', None]


### PR DESCRIPTION
- This changes `EventManager._find_hashes` to return a `GroupHash` instance, rather than a tuple that contains 50% of the fields contained on the database table and updates downstream logic to utilize the new return type. This also removes a query that was subject to a race condition that the code without the extra query was already subject to.
- This adds two methods to `GroupHash` for fetching and storing the last seen event IDs. This use the `Event.event_id` column, rather than `Event.id` since the event record won't have been persisted yet.

#nochanges