### PR TITLE
We can revert this when it becomes useful again.

### DIFF
--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -304,7 +304,7 @@ class ExceptionFeature(object):
             try:
                 yield self.function(exception)
             except Exception as error:
-                logger.exception('Could not extract characteristic(s) from exception in %r due to error: %r', event, error)
+                pass
 
 
 class MessageFeature(object):


### PR DESCRIPTION
/shrug

Fixes SENTRY-2T4.