### PR TITLE
defend against non-string device tag values

### DIFF
--- a/src/sentry/static/sentry/app/utils/deviceNameMapper.jsx
+++ b/src/sentry/static/sentry/app/utils/deviceNameMapper.jsx
@@ -1,7 +1,8 @@
 import iOSDeviceList from 'ios-device-list';
+import {isString} from 'underscore';
 
 export default function(model) {
-  if (!model || typeof model !== 'string') {
+  if (!model || !isString(model)) {
     return null;
   }
   const modelIdentifier = model.split(' ')[0];

--- a/src/sentry/static/sentry/app/utils/deviceNameMapper.jsx
+++ b/src/sentry/static/sentry/app/utils/deviceNameMapper.jsx
@@ -1,7 +1,7 @@
 import iOSDeviceList from 'ios-device-list';
 
 export default function(model) {
-  if (!model) {
+  if (!model || typeof model !== 'string') {
     return null;
   }
   const modelIdentifier = model.split(' ')[0];


### PR DESCRIPTION
fixes JAVASCRIPT-22M


root cause is an object being passed to this function under rare conditions I don't yet understand. this will keep the page usable in the meantime 
![screenshot 2017-05-11 16 45 07](https://cloud.githubusercontent.com/assets/5915546/25976377/4ff3b178-3669-11e7-8a9f-de272f47a773.png)
https://sentry.io/share/issue/31313237362e323731303733313434/