### PR TITLE
Add `InsufficientContext` and expected errors to similarity.

### DIFF
--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -304,7 +304,7 @@ class ExceptionFeature(object):
             try:
                 yield self.function(exception)
             except Exception as error:
-                pass
+                logger.exception('Could not extract characteristic(s) from exception in %r due to error: %r', event, error)
 
 
 class MessageFeature(object):

--- a/src/sentry/similarity.py
+++ b/src/sentry/similarity.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import
 import itertools
 import logging
 import operator
-import six
 import struct
 import time
 from collections import Sequence
 
 import mmh3
+import six
 from django.conf import settings
 
 from sentry.utils import redis
@@ -16,7 +16,6 @@ from sentry.utils.datastructures import BidirectionalMapping
 from sentry.utils.dates import to_timestamp
 from sentry.utils.iterators import shingle
 from sentry.utils.redis import load_script
-
 
 index = load_script('similarity/index.lua')
 

--- a/tests/sentry/test_similarity.py
+++ b/tests/sentry/test_similarity.py
@@ -7,8 +7,8 @@ import pytest
 
 from sentry.models import Event
 from sentry.similarity import (
-    InsufficientContext, MinHashIndex, get_exception_frames, get_frame_signature,
-    serialize_frame, ExceptionFeature
+    ExceptionFeature, InsufficientContext, MinHashIndex, get_exception_frames,
+    get_frame_signature, serialize_frame
 )
 from sentry.testutils import TestCase
 from sentry.utils import redis

--- a/tests/sentry/test_similarity.py
+++ b/tests/sentry/test_similarity.py
@@ -5,9 +5,10 @@ import time
 import msgpack
 import pytest
 
+from sentry.models import Event
 from sentry.similarity import (
-    MinHashIndex, get_exception_frames, get_frame_signature,
-    serialize_frame,
+    InsufficientContext, MinHashIndex, get_exception_frames, get_frame_signature,
+    serialize_frame, ExceptionFeature
 )
 from sentry.testutils import TestCase
 from sentry.utils import redis
@@ -106,6 +107,69 @@ def test_get_frame_signature():
         'context_line': u'\N{SNOWMAN}',
         'post_context': [u'\N{BLACK SNOWMAN}'],
     })
+
+    with pytest.raises(InsufficientContext):
+        get_frame_signature({})
+
+    with pytest.raises(InsufficientContext):
+        get_frame_signature({
+            'pre_context': ['pre'],
+            'post_context': ['post'],
+        })
+
+
+def test_exception_feature():
+    good_frame = {
+        'function': 'name',
+        'module': 'module',
+    }
+
+    bad_frame = {}
+
+    assert serialize_frame(good_frame)
+    with pytest.raises(InsufficientContext):
+        serialize_frame(bad_frame)
+
+    feature = ExceptionFeature(
+        lambda exception: map(
+            serialize_frame,
+            get_exception_frames(exception),
+        ),
+    )
+
+    def build_event(frames):
+        return Event(
+            data={
+                'sentry.interfaces.Exception': {
+                    'values': [
+                        {
+                            'stacktrace': {
+                                'frames': frames,
+                            },
+                        },
+                    ],
+                },
+            },
+        )
+
+    assert list(
+        feature.extract(
+            build_event([
+                good_frame,
+            ]),
+        )
+    ) == [
+        [serialize_frame(good_frame)],
+    ]
+
+    assert list(
+        feature.extract(
+            build_event([
+                good_frame,
+                bad_frame,
+            ]),
+        )
+    ) == []
 
 
 class MinHashIndexTestCase(TestCase):


### PR DESCRIPTION
Does what it says on the tin. Actually fixes SENTRY-2T4.

See also: GH-5379

#nochanges 