### PR TITLE
cleanup: Add order by to eventmapping cleanup

### DIFF
--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -8,11 +8,12 @@ from sentry.utils import db
 
 
 class BulkDeleteQuery(object):
-    def __init__(self, model, project_id=None, dtfield=None, days=None):
+    def __init__(self, model, project_id=None, dtfield=None, days=None, order_by=None):
         self.model = model
         self.project_id = int(project_id) if project_id else None
         self.dtfield = dtfield
         self.days = int(days) if days is not None else None
+        self.order_by = order_by
         self.using = router.db_for_write(model)
 
     def execute_postgres(self, chunk_size=10000):
@@ -32,18 +33,34 @@ class BulkDeleteQuery(object):
         else:
             where_clause = ''
 
+        if self.order_by:
+            if self.order_by[0] == '-':
+                direction = 'desc'
+                order_field = self.order_by[1:]
+            else:
+                direction = 'asc'
+                order_field = self.order_by
+            order_clause = 'order by {} {}'.format(
+                quote_name(order_field),
+                direction,
+            )
+        else:
+            order_clause = ''
+
         query = """
             delete from {table}
             where id = any(array(
                 select id
                 from {table}
                 {where}
+                {order}
                 limit {chunk_size}
             ));
         """.format(
             table=self.model._meta.db_table,
             chunk_size=chunk_size,
             where=where_clause,
+            order=order_clause,
         )
 
         return self._continuous_query(query)

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -155,6 +155,7 @@ def cleanup(days, project, concurrency, silent, model, router):
             dtfield='date_added',
             days=min(days, 7),
             project_id=project_id,
+            order_by='-date_added'
         ).execute()
 
     # Clean up FileBlob instances which are no longer used and aren't super


### PR DESCRIPTION
Postgres really wants this. Without it, it's doing full sequence scans.
Applying an order by coercing is to scan the index nicely and
efficiently.