### PR TITLE
db/deletion: use a precomputed now()

### DIFF
--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -21,8 +21,9 @@ class BulkDeleteQuery(object):
 
         where = []
         if self.dtfield and self.days is not None:
-            where.append("{} < now() - interval '{} days'".format(
+            where.append("{} < timestamp '{}'".format(
                 quote_name(self.dtfield),
+                (timezone.now() - timedelta(days=self.days)).isoformat(),
                 self.days,
             ))
         if self.project_id:


### PR DESCRIPTION
When we rely on a server side "now()", every query gets a new value,
meaning, we have a sliding window between each iteration. Because of
this sliding window, it's sometimes slow for the job to actually end if
new rows keep falling into the window for deletion.

Switching to an absolute time will prevent this from happening.