### PR TITLE
nodestore/riak: pass along correct querystring during multiget

### DIFF
--- a/src/sentry/nodestore/riak/client.py
+++ b/src/sentry/nodestore/riak/client.py
@@ -108,7 +108,7 @@ class RiakClient(object):
         """
         # Each request is paired with a thread.Event to signal when it is finished
         requests = [
-            (key, self.build_url(bucket, key, {'foo': 'bar'}), Event())
+            (key, self.build_url(bucket, key, kwargs), Event())
             for key in keys
         ]
 


### PR DESCRIPTION
Someone let this slide through code review long ago. I blame them fully.

This means all of requests for a multiget were getting `?foo=bar` appended to them. This didn't cause a problem, but it meant that the intended behavior of passing `?r=1` wasn't happening, which affects the read quorum.

In reality for us though, this has 0 impact because the bucket itself has a default read quorum of "one" anyways. I just happened to notice this incorrect behavior in logs.