### PR TITLE
Added Client Keys to /api/

### DIFF
--- a/src/sentry/api/endpoints/user_dsns.py
+++ b/src/sentry/api/endpoints/user_dsns.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import
+
+import six
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from sentry import roles
+from sentry.api.serializers import serialize
+from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.models import Organization, OrganizationMember, \
+    ProjectKey, ProjectKeyStatus, Team
+
+
+def get_user_admin_teams(user, orgs):
+    teams = []
+    for org in orgs:
+        teams.extend(Team.objects.get_for_user(
+            organization=org,
+            user=user,
+        ))
+    return teams
+
+
+def get_dsns(user):
+    if user.is_authenticated():
+        orgs = Organization.objects.filter(
+            id__in=OrganizationMember.objects.filter(
+                user=user,
+                role__in=[r.id for r in roles.with_scope('project:read')],
+            ).values('organization')
+        )
+        teams = set(x.id for x in get_user_admin_teams(user, orgs))
+        orgs = set(x.id for x in orgs)
+
+        queryset = ProjectKey.objects.filter(
+            roles=ProjectKey.roles.store,
+            project__organization__members=user,
+            status=ProjectKeyStatus.ACTIVE
+        ).select_related('project', 'project__team', 'project__organization')
+    else:
+        queryset = ProjectKey.objects.none()
+
+    org_map = {}
+    projects_by_org = {}
+    keys_by_project = {}
+
+    for key in queryset:
+        if orgs is not None and key.project.organization.id not in orgs:
+            continue
+        if teams is not None and key.project.team.id not in teams:
+            continue
+        if key.project.organization_id not in org_map:
+            org_map[key.project.organization_id] = key.project.organization
+        projs = projects_by_org.setdefault(key.project.organization_id, {})
+        if key.project_id not in projs:
+            projs[key.project.id] = key.project
+        keys_by_project.setdefault(key.project.id, []).append(key)
+
+    results = []
+
+    for org in six.itervalues(org_map):
+        d = serialize(org, user)
+        d['projects'] = []
+        for project in six.itervalues(projects_by_org[org.id]):
+            pd = serialize(project, user)
+            pd['team'] = serialize(project.team, user)
+            pd['dsns'] = serialize(keys_by_project.get(project.id) or [], user)
+            d['projects'].append(pd)
+        d['projects'].sort(key=lambda x: (x['team']['name'].lower(), x['name'].lower()))
+        results.append(d)
+
+    return results
+
+
+class UserDsnsEndpoint(Endpoint):
+    authentication_classes = (
+        SessionAuthentication,
+    )
+    permission_classes = (
+        IsAuthenticated,
+    )
+
+    def get(self, request):
+        return Response(get_dsns(request.user))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -111,6 +111,7 @@ from .endpoints.user_authenticator_details import UserAuthenticatorDetailsEndpoi
 from .endpoints.user_identity_details import UserIdentityDetailsEndpoint
 from .endpoints.user_index import UserIndexEndpoint
 from .endpoints.user_details import UserDetailsEndpoint
+from .endpoints.user_dsns import UserDsnsEndpoint
 from .endpoints.user_organizations import UserOrganizationsEndpoint
 from .endpoints.event_file_committers import EventFileCommittersEndpoint
 
@@ -130,6 +131,9 @@ urlpatterns = patterns(
     url(r'^api-tokens/$',
         ApiTokensEndpoint.as_view(),
         name='sentry-api-0-api-tokens'),
+    url(r'^dsns/$',
+        UserDsnsEndpoint.as_view(),
+        name='sentry-api-0-user-dsns'),
 
     # Auth
     url(r'^auth/$',

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -11,6 +11,7 @@ import ApiApplicationDetails from './views/apiApplicationDetails';
 import ApiLayout from './views/apiLayout';
 import ApiNewToken from './views/apiNewToken';
 import ApiTokens from './views/apiTokens';
+import Dsns from './views/dsns';
 import Admin from './views/admin';
 import AdminBuffer from './views/adminBuffer';
 import AdminOrganizations from './views/adminOrganizations';
@@ -110,6 +111,7 @@ function routes() {
       <Route path="/api/" component={errorHandler(ApiLayout)}>
         <IndexRoute component={errorHandler(ApiTokens)} />
         <Route path="applications/" component={errorHandler(ApiApplications)} />
+        <Route path="keys/" component={errorHandler(Dsns)} />
         <Route
           path="applications/:appId/"
           component={errorHandler(ApiApplicationDetails)}

--- a/src/sentry/static/sentry/app/views/apiLayout.jsx
+++ b/src/sentry/static/sentry/app/views/apiLayout.jsx
@@ -12,6 +12,7 @@ const ApiDashboard = React.createClass({
         <ul className="nav nav-tabs border-bottom">
           <ListLink to="/api/" index={true}>{t('Auth Tokens')}</ListLink>
           <ListLink to="/api/applications/">{t('Applications')}</ListLink>
+          <ListLink to="/api/keys/">{t('Client Keys (DSN)')}</ListLink>
         </ul>
         {this.props.children}
       </NarrowLayout>

--- a/src/sentry/static/sentry/app/views/dsns.jsx
+++ b/src/sentry/static/sentry/app/views/dsns.jsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import DocumentTitle from 'react-document-title';
+import {Link} from 'react-router';
+
+import ApiMixin from '../mixins/apiMixin';
+import AutoSelectText from '../components/autoSelectText';
+import LoadingError from '../components/loadingError';
+import LoadingIndicator from '../components/loadingIndicator';
+import {t} from '../locale';
+
+const ProjectRow = React.createClass({
+  propTypes: {
+    onClick: React.PropTypes.func,
+    org: React.PropTypes.object.isRequired,
+    project: React.PropTypes.object.isRequired
+  },
+
+  mixins: [ApiMixin],
+
+  render() {
+    let {org, project} = this.props;
+
+    return (
+      <tr>
+        <td>
+          <h5 style={{cursor: 'pointer'}} onClick={this.props.onClick}>
+            {project.name} <small>{project.team.name}</small>
+          </h5>
+        </td>
+        <td style={{width: '32px'}}>
+          <Link
+            to={`/${org.slug}/${project.slug}/settings/keys/`}
+            className="btn btn-sm btn-default">
+            <span className="icon icon-wrench" />
+          </Link>
+        </td>
+      </tr>
+    );
+  }
+});
+
+const Dsns = React.createClass({
+  mixins: [ApiMixin],
+
+  getInitialState() {
+    return {
+      loading: true,
+      error: false,
+      selectedProject: null,
+      orgs: []
+    };
+  },
+
+  componentWillMount() {
+    this.fetchData();
+  },
+
+  remountComponent() {
+    this.setState(this.getInitialState(), this.fetchData);
+  },
+
+  fetchData() {
+    this.setState({
+      loading: true
+    });
+
+    this.api.request('/dsns/', {
+      success: (data, _, jqXHR) => {
+        this.setState({
+          loading: false,
+          error: false,
+          orgs: data
+        });
+      },
+      error: () => {
+        this.setState({
+          loading: false,
+          error: true
+        });
+      }
+    });
+  },
+
+  selectProject(projectId) {
+    this.setState({
+      selectedProject: this.state.selectedProject === projectId ? null : projectId
+    });
+  },
+
+  renderOrg(org) {
+    let children = [];
+    for (let project of org.projects) {
+      children.push(
+        <ProjectRow
+          onClick={() => this.selectProject(project.id)}
+          key={project.id}
+          org={org}
+          project={project}
+        />
+      );
+
+      if (this.state.selectedProject == project.id) {
+        for (let dsn of project.dsns) {
+          children.push(
+            <tr key={'dsn-' + dsn.id} className="deemphasized">
+              <td colSpan="2">
+                <h6 className="nav-header">{dsn.name}</h6>
+                <div className="form-group">
+                  <label>{t('DSN')}</label>
+                  <AutoSelectText className="form-control disabled">
+                    {dsn.dsn.secret}
+                  </AutoSelectText>
+                </div>
+                <div className="form-group">
+                  <label>{t('DSN (Public)')}</label>
+                  <AutoSelectText className="form-control disabled">
+                    {dsn.dsn.public}
+                  </AutoSelectText>
+                </div>
+              </td>
+            </tr>
+          );
+        }
+      }
+    }
+
+    return (
+      <div className="panel panel-default" key={org.id}>
+        <table className="table">
+          <thead>
+            <tr>
+              <th colSpan="2">{org.name}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {children}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
+
+  renderResults() {
+    let {orgs} = this.state;
+
+    if (orgs.length === 0) {
+      return (
+        <ul className="nav nav-stacked">
+          <li>{t('You have not created any client keys yet.')}</li>
+        </ul>
+      );
+    }
+
+    return (
+      <div>
+        {orgs.map(org => this.renderOrg(org))}
+      </div>
+    );
+  },
+
+  getTitle() {
+    return 'Client Keys (DSN) - Sentry';
+  },
+
+  render() {
+    return (
+      <DocumentTitle title={this.getTitle()}>
+        <div>
+          <p>
+            {t('Client Keys (also called DSN) allow you to submit events to Sentry.')}
+          </p>
+          <p>
+            {t(
+              `
+              These keys are manage in the project settings but for convenience
+              reasons we show you all keys here that you have access to.  Click
+              on a project to reveal the keys.`
+            )}
+          </p>
+
+          {this.state.loading
+            ? <LoadingIndicator />
+            : this.state.error
+                ? <LoadingError onRetry={this.fetchData} />
+                : this.renderResults()}
+        </div>
+      </DocumentTitle>
+    );
+  }
+});
+
+export default Dsns;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -218,7 +218,7 @@ dl.flat dd {
 /* Small button icons */
 
 .btn-sm {
-  .icon-arrow-down, .icon-arrow-right, .icon-arrow-left, .icon-refresh {
+  .icon-arrow-down, .icon-arrow-right, .icon-arrow-left, .icon-refresh, .icon-wrench {
     position: relative;
     font-size: 14px !important;
     top: 2px;
@@ -365,6 +365,10 @@ table.table {
       position: absolute;
       left: 20px;
     }
+  }
+
+  tr.deemphasized {
+    background: @white-darker;
   }
 
   &.closed {


### PR DESCRIPTION
This adds the client keys to our /api/ URL for the user's convenience.  The
idea is that we can link to a single page and users have all their stuff
there.  In particular this came up making the docs and CLI tools for
react-native where it can be quite hard to tell users where all the stuff is.

One thing to consider is that right now we only surface DSNs for users that
are admins. This however is weird because you can bypass that restriction
by going to the DSN URL directly (it's just unlinked). Is there a specific
reason we are not showing this for all members?

<img width="881" alt="screen shot 2017-05-21 at 13 02 43" src="https://cloud.githubusercontent.com/assets/7396/26283297/eb31b0b8-3e25-11e7-9b68-c0b3dfb4a5b5.png">
