### PR TITLE
Add stripeToken to default scrubbed fields

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -174,6 +174,7 @@ DEFAULT_SCRUBBED_FIELDS = (
     'auth',
     'credentials',
     'mysql_pwd',
+    'stripeToken',
 )
 
 NOT_SCRUBBED_VALUES = set([


### PR DESCRIPTION
As discussed on irc.

`stripeToken` is a variable present in [POSTs from Stripe's API](https://stripe.com/docs/charges), which will be present on web apps using Stripe as a payment gateway. They are a stand-in for a validated credit card; although they aren't as valuable as a valid CC number, they're still sensitive information as, if not immediately consumed, they can be stolen by other users in order to authorize adding a payment source or a charge to an account.