### PR TITLE
Fix link

### DIFF
--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -82,8 +82,7 @@ const ReleaseProjectStatSparkline = React.createClass({
             <SparklinesLine style={{stroke: '#8f85d4', fill: 'none', strokeWidth: 3}} />
           </Sparklines>
         </div>
-        <Link
-          to={`/${orgId}/${project.slug}/releases/${encodeURIComponent(version)}/overview/`}>
+        <Link to={`/${orgId}/${project.slug}/releases/${encodeURIComponent(version)}/`}>
           <h6 className="m-b-0">
             {project.name}
           </h6>


### PR DESCRIPTION
The link from the Other Projects Affected sparkline in releases doesn't properly link to the other project's releases page.