### PR TITLE
Fix query routing for TSDB distinct counter and frequency table delete operations.

### DIFF
--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -31,7 +31,7 @@ class RedisTSDBTest(TestCase):
         )
 
     def tearDown(self):
-        with self.db.cluster.fanout('all') as client:
+        with self.db.cluster.all() as client:
             client.flushdb()
 
     def test_make_counter_key(self):

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -25,7 +25,14 @@ class RedisTSDBTest(TestCase):
             ),
             vnodes=64,
             enable_frequency_sketches=True,
+            hosts={
+                i - 6: {'db': i} for i in xrange(6, 9)
+            },
         )
+
+    def tearDown(self):
+        with self.db.cluster.fanout('all') as client:
+            client.flushdb()
 
     def test_make_counter_key(self):
         result = self.db.make_counter_key(TSDBModel.project, 1368889980, 1)


### PR DESCRIPTION
This was an oversight as part of GH-5317, and wasn't caught in tests because the test suite didn't actually run the tests against multiple databases. The easiest way to test this (other than depending on the tests to have the correct behavior) is to cross-reference the routing logic in the other mutation commands and make sure it's consistent.