### PR TITLE
Fix modal header margins

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -3062,12 +3062,13 @@ ul.radio-inputs {
     border-bottom: 1px solid @trim;
     border-radius: 7px 7px 0 0;
     padding: 20px 30px;
-    margin: -20px -20px 20px;
+    margin: -30px -30px 20px;
 
     h1, h2, h3, h4, h5, h6 {
-      font-size: 18px;
+      font-size: 20px;
       font-weight: 600;
       margin-bottom: 0;
+      line-height: 1.1;
     }
 
     .close {
@@ -3092,6 +3093,10 @@ ul.radio-inputs {
       border-radius: 3px;
       border: 1px solid @trim;
       box-shadow: 0 1px 1px rgba(0,0,0, .08);
+    }
+
+    .form-actions {
+      margin-bottom: 0;
     }
   }
 


### PR DESCRIPTION
I updated modal padding and box shadow a couple weeks ago and didn't adjust the negative margins on modal-headers to match. This fixes that.

Looks like:
![screen shot 2017-05-25 at 1 22 39 pm](https://cloud.githubusercontent.com/assets/30713/26468973/445ca876-414d-11e7-838e-a93c44c7ce90.png)
