### PR TITLE
Create releases if missing in JS code path.

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from sentry import http
 from sentry.interfaces.stacktrace import Stacktrace
-from sentry.models import EventError, Release, ReleaseFile
+from sentry.models import EventError, ReleaseFile
 from sentry.utils.cache import cache
 from sentry.utils.files import compress_file
 from sentry.utils.hashlib import md5_text
@@ -491,13 +491,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                          'fetch remote source', self.data['event_id'])
             return False
 
-        if self.data.get('release'):
-            self.release = Release.get(
-                project=self.project,
-                version=self.data['release'],
-            )
-            if self.data.get('dist'):
-                self.dist = self.release.get_dist(self.data['dist'])
+        self.release = self.get_release(create=True)
+        if self.data.get('dist') and self.release:
+            self.dist = self.release.get_dist(self.data['dist'])
+
         self.populate_source_cache(frames)
         return True
 


### PR DESCRIPTION
For cases where stacktrace processing activates for events that never
had a release created we currently do not associate releases at all.
This was shown to be an issue after we added distribution support
which now fails on missing releases.

This fixes SENTRY-3BN