### PR TITLE
Use Python vscode extension for flake8 linting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
         "dzannotti.vscode-babel-coloring",
         "esbenp.prettier-vscode",
         "donjayamanne.python",
-        "jaysonsantos.vscode-flake8",
         "dbaeumer.vscode-eslint"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
 
     "[javascript]": {
         "editor.formatOnSave": true
-    }
+    },
+
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2153/26667036/0100113e-4658-11e7-8a6b-286788405b19.png)

* Was running pylint AND flake8 for me
* Removes the need for an additional extension