### PR TITLE
Update aggregate fields for source group during unmerge.

### DIFF
--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -286,6 +286,18 @@ class UnmergeTestCase(TestCase):
                 batch_size=5,
             )
 
+        assert list(
+            Group.objects.filter(id=source.id).values_list(
+                'times_seen',
+                'first_seen',
+                'last_seen',
+            )
+        ) == [(
+            10,
+            now + shift(0),
+            now + shift(9),
+        )]
+
         source_activity = Activity.objects.get(
             group_id=source.id,
             type=Activity.UNMERGE_SOURCE,
@@ -294,6 +306,18 @@ class UnmergeTestCase(TestCase):
         destination = Group.objects.get(
             id=source_activity.data['destination_id'],
         )
+
+        assert list(
+            Group.objects.filter(id=destination.id).values_list(
+                'times_seen',
+                'first_seen',
+                'last_seen',
+            )
+        ) == [(
+            7,
+            now + shift(10),
+            now + shift(16),
+        )]
 
         assert source_activity.data == {
             'destination_id': destination.id,


### PR DESCRIPTION
This also repairs the [initial and backfill fields](https://github.com/getsentry/sentry/blob/92bb1058a0a9f5451cf509912e9966b491fff3a9/src/sentry/tasks/unmerge.py#L75-L112) for the source group during unmerging. (Previously, this only was used to update field values on the destination group.) This ensures that fields like `times_seen`, `score`, `first_seen`, etc. are derived from only the events that remain in the source group after the operation is completed.