### PR TITLE
Check for 'integrations' array in the SDK interface.

### DIFF
--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -49,11 +49,15 @@ class Sdk(Interface):
         if not version:
             raise InterfaceValidationError("No 'version' value")
 
+        integrations = data.get('integrations')
+        if integrations and not isinstance(integrations, list):
+            raise InterfaceValidationError("'integrations' must be a list")
+
         kwargs = {
             'name': trim(name, 128),
             'version': trim(version, 128),
             'client_ip': data.get('client_ip'),
-            'integrations': data.get('integrations'),
+            'integrations': integrations,
         }
         return cls(**kwargs)
 

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -34,8 +34,9 @@ class Sdk(Interface):
     The SDK used to transmit this event.
 
     >>> {
-    >>>     "name": "sentry-unity",
-    >>>     "version": "1.0"
+    >>>     "name": "sentry-java",
+    >>>     "version": "1.0",
+    >>>     "integrations": ["log4j"]
     >>> }
     """
     @classmethod
@@ -52,6 +53,7 @@ class Sdk(Interface):
             'name': trim(name, 128),
             'version': trim(version, 128),
             'client_ip': data.get('client_ip'),
+            'integrations': data.get('integrations'),
         }
         return cls(**kwargs)
 

--- a/tests/sentry/interfaces/test_sdk.py
+++ b/tests/sentry/interfaces/test_sdk.py
@@ -12,11 +12,13 @@ from sentry.testutils import TestCase
 class SdkTest(TestCase):
     def test_serialize_behavior(self):
         assert Sdk.to_python({
-            'name': 'sentry-unity',
+            'name': 'sentry-java',
             'version': '1.0',
+            'integrations': ['log4j']
         }).to_json() == {
-            'name': 'sentry-unity',
+            'name': 'sentry-java',
             'version': '1.0',
+            'integrations': ['log4j']
         }
 
     def test_missing_name(self):


### PR DESCRIPTION
New `integrations` field allows for an array of integrations/frameworks used to be listed per event.

Example: SDK is named `"sentry-java"` but integrations are `["spring", "logback"]`. Small feature to improve future analytics/debugging. We currently do `"sentry-java:logback"` today which is brittle. Expecting all SDKs to implement this in the future.