### PR TITLE
Strip whitespace from x-forwarded-for header

### DIFF
--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -19,7 +19,7 @@ class SetRemoteAddrFromForwardedFor(object):
         else:
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
             # Take just the first one.
-            real_ip = real_ip.split(",")[0]
+            real_ip = real_ip.split(",")[0].strip()
             if ':' in real_ip and '.' in real_ip:
                 # Strip the port number off of an IPv4 FORWARDED_FOR entry.
                 real_ip = real_ip.split(':', 1)[0]

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -31,6 +31,12 @@ class SetRemoteAddrFromForwardedForTestCase(TestCase):
         self.middleware.process_request(request)
         assert request.META['REMOTE_ADDR'] == '8.8.8.8'
 
+    def test_ipv4_whitespace(self):
+        request = HttpRequest()
+        request.META['HTTP_X_FORWARDED_FOR'] = '8.8.8.8:80 '
+        self.middleware.process_request(request)
+        assert request.META['REMOTE_ADDR'] == '8.8.8.8'
+
     def test_ipv6(self):
         request = HttpRequest()
         request.META['HTTP_X_FORWARDED_FOR'] = '2001:4860:4860::8888,2001:4860:4860::8844'


### PR DESCRIPTION
Using NetScaler as load balancer adds whitespace at the end of the
X-Forwarded-For header value, causing Sentry to include this whitespace
when extracting the IP.

This causes an error in Sentry of type 'invalid input syntax for type
inet' for some database operations.