### PR TITLE
releases: populate author ahead of use

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -108,7 +108,7 @@ class ReleaseSerializer(Serializer):
         if commit_ids:
             commit_list = list(Commit.objects.filter(
                 id__in=commit_ids,
-            ))
+            ).select_related('author'))
             commits = {
                 c.id: d for c, d in izip(commit_list, serialize(commit_list, user))
             }


### PR DESCRIPTION
Commit.author is referenced within the Commit serializer, so this ensures that we're not doing an O(N) query when populating the lastCommit attribute of Release.