### PR TITLE
ci: add codecov restrictions

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,14 +1,17 @@
 coverage:
   status:
     project:
-      default:
-        target: 0%
+      default: false
     patch:
-      default:
-        target: 0%
+      default: false
+      python:
+        paths:
+        - "src/sentry"
+        target: 90%
   ignore:
   - src/sentry/lint/.*
   - src/.*?/migrations/.*
   - src/.*?/south_migrations/.*
-
-comment: false
+comment:
+  layout: "diff, files"
+  behavior: default


### PR DESCRIPTION
This requires all Python code have 90% patch coverage. That means, any code you change/add needs to have 9 out of every 10 lines run automatically by the test suite. Generally that's an easy target, and the only challenge is legacy code (which still should have tests).

Putting this up for feedback on if we think this is a good direction to go.