### PR TITLE
api: show all project keys by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,12 @@ Schema Changes
 - Removed DSymSymbol
 - Removed GlobalDSymFile
 
+API Changes
+~~~~~~~~~~~
+
+- Project keys endpoint will include all available keys by default. Use
+  ``status=active`` to retain the old behavior.
+
 Version 8.17
 ------------
 

--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -53,12 +53,28 @@ class ProjectKeysEndpoint(ProjectEndpoint):
         :pparam string project_slug: the slug of the project the client keys
                                      belong to.
         """
-        keys = list(ProjectKey.objects.filter(
+        queryset = ProjectKey.objects.filter(
             project=project,
-            status=ProjectKeyStatus.ACTIVE,
             roles=ProjectKey.roles.store,
-        ))
-        return Response(serialize(keys, request.user))
+        )
+        status = request.GET.get('status')
+        if status == 'active':
+            queryset = queryset.filter(
+                status=ProjectKeyStatus.ACTIVE,
+            )
+        elif status == 'inactive':
+            queryset = queryset.filter(
+                status=ProjectKeyStatus.INACTIVE,
+            )
+        elif status:
+            queryset = queryset.none()
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by='-id',
+            on_results=lambda x: serialize(x, request.user),
+        )
 
     @attach_scenarios([create_key_scenario])
     def post(self, request, project):

--- a/src/sentry/static/sentry/app/views/projectKeys.jsx
+++ b/src/sentry/static/sentry/app/views/projectKeys.jsx
@@ -10,6 +10,7 @@ import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import {t, tct} from '../locale';
 import OrganizationState from '../mixins/organizationState';
+import Pagination from '../components/pagination';
 
 const KeyRow = React.createClass({
   propTypes: {
@@ -288,20 +289,23 @@ export default React.createClass({
     let {orgId, projectId} = this.props.params;
     let access = this.getAccess();
     return (
-      <div className="client-key-list">
-        {this.state.keyList.map(key => {
-          return (
-            <KeyRow
-              access={access}
-              key={key.id}
-              orgId={orgId}
-              projectId={projectId}
-              data={key}
-              onToggle={this.handleToggleKey.bind(this, key)}
-              onRemove={this.handleRemoveKey.bind(this, key)}
-            />
-          );
-        })}
+      <div>
+        <div className="client-key-list">
+          {this.state.keyList.map(key => {
+            return (
+              <KeyRow
+                access={access}
+                key={key.id}
+                orgId={orgId}
+                projectId={projectId}
+                data={key}
+                onToggle={this.handleToggleKey.bind(this, key)}
+                onRemove={this.handleRemoveKey.bind(this, key)}
+              />
+            );
+          })}
+        </div>
+        <Pagination pageLinks={this.state.pageLinks} />
       </div>
     );
   },


### PR DESCRIPTION
Right now when you disable a key, if you reload the page you can no longer see it. This resolves that issue.

It also switches the endpoint to use pagination.