### PR TITLE
Reduce react-native stacktrace clutter

### DIFF
--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -191,6 +191,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             # backend.  We only assemble the bare minimum we need here.
             instruction_addr = processable_frame.data['instruction_addr']
             in_app = self.sym.is_in_app(instruction_addr)
+            in_app = (in_app and not self.sym.is_internal_function(raw_frame.get('function')))
             if raw_frame.get('in_app') is None:
                 raw_frame['in_app'] = in_app
             img_uuid = processable_frame.data['image_uuid']
@@ -260,7 +261,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             if sfrm.get('package'):
                 new_frame['package'] = sfrm['package']
             if new_frame.get('in_app') is None:
-                new_frame['in_app'] = in_app
+                new_frame['in_app'] = (in_app and not self.sym.is_internal_function(new_frame['function']))
             new_frames.append(new_frame)
 
         return new_frames, [raw_frame], []

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -37,6 +37,8 @@ _support_framework = re.compile(r'''(?x)
 SIM_PATH = '/Developer/CoreSimulator/Devices/'
 SIM_APP_PATH = '/Containers/Bundle/Application/'
 
+_internal_function_re = re.compile(r'(kscm_|kscrash_|KSCrash |SentryClient |RNSentry )')
+
 KNOWN_GARBAGE_SYMBOLS = set([
     '_mh_execute_header',
     '<redacted>',
@@ -266,3 +268,6 @@ class Symbolizer(object):
     def is_in_app(self, instruction_addr):
         img = self.image_lookup.find_image(instruction_addr)
         return img is not None and self._is_app_frame(instruction_addr, img)
+
+    def is_internal_function(self, function):
+        return _internal_function_re.search(function) is not None

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -721,3 +721,163 @@ class InAppHonoringResolvingIntegrationTest(TestCase):
         assert long_frames[0]['instructionAddr'] == '0x002ac28b8'
         assert long_frames[1]['instructionAddr'] == '0x100020014'
         assert long_frames[2]['instructionAddr'] == '0x10002001c'
+
+    @patch.object(Symbolizer, '_symbolize_app_frame', sym_app_frame)
+    def test_in_app_function_name(self):
+        object_name = (
+            "/var/containers/Bundle/Application/"
+            "B33C37A8-F933-4B6B-9FFA-152282BFDF13/"
+            "SentryTest.app/SentryTest"
+        )
+        # '/var/containers/Bundle/Application/',
+        # '/private/var/containers/Bundle/Application/',
+        # (kscm_|kscrash_|KSCrash |SentryClient |RNSentry )
+        event_data = {
+            "sentry.interfaces.User": {
+                "ip_address": "31.172.207.97"
+            },
+            "extra": {},
+            "project": self.project.id,
+            "platform": "cocoa",
+            "debug_meta": {
+                "images": [
+                    {
+                        "type": "apple",
+                        "cpu_subtype": 0,
+                        "uuid": "C05B4DDD-69A7-3840-A649-32180D341587",
+                        "image_vmaddr": 4294967296,
+                        "image_addr": 4295098368,
+                        "cpu_type": 16777228,
+                        "image_size": 32768,
+                        "name": object_name,
+                    }
+                ]
+            },
+            "contexts": {
+                "os": {
+                    "name": "iOS",
+                    "version": "9.3.0"
+                }
+            },
+            "sentry.interfaces.Exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "[RNSentry ]",
+                                    "abs_path": None,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "instruction_addr": 4295098388,
+                                },
+                                {
+                                    "function": "[SentryClient ]",
+                                    "abs_path": None,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "instruction_addr": 4295098388,
+                                },
+                                {
+                                    "function": "[kscrash_]",
+                                    "abs_path": None,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "instruction_addr": 4295098388,
+                                },
+                                {
+                                    "function": "[kscm_]",
+                                    "abs_path": None,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "instruction_addr": 4295098388,
+                                },
+                                {
+                                    "function": "[KSCrash ]",
+                                    "abs_path": None,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "instruction_addr": 4295098388,
+                                },
+                                {
+                                    "function": "[KSCrash]",
+                                    "abs_path": None,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "instruction_addr": 4295098388,
+                                },
+                                {
+                                    "function": "[KSCrashy]",
+                                    "abs_path": None,
+                                    "package": "/usr/lib/system/libdyld.dylib",
+                                    "filename": None,
+                                    "symbol_addr": "0x002ac28b4",
+                                    "lineno": None,
+                                    "instruction_addr": 4295098388,
+                                },
+                            ]
+                        },
+                        "type": "NSRangeException",
+                        "mechanism": {
+                            "posix_signal": {
+                                "signal": 6,
+                                "code": 0,
+                                "name": "SIGABRT",
+                                "code_name": None
+                            },
+                            "type": "cocoa",
+                            "mach_exception": {
+                                "subcode": 0,
+                                "code": 0,
+                                "exception": 10,
+                                "exception_name": "EXC_CRASH"
+                            }
+                        },
+                        "value": (
+                            "*** -[__NSArray0 objectAtIndex:]: index 3 "
+                            "beyond bounds for empty NSArray"
+                        )
+                    }
+                ]
+            },
+            "contexts": {
+                "device": {
+                    "model_id": "N102AP",
+                    "model": "iPod7,1",
+                    "arch": "arm64",
+                    "family": "iPod"
+                },
+                "os": {
+                    "version": "9.3.2",
+                    "rooted": False,
+                    "build": "13F69",
+                    "name": "iOS"
+                }
+            }
+        }
+        resp = self._postWithHeader(event_data)
+        assert resp.status_code == 200
+
+        event = Event.objects.get()
+
+        bt = event.interfaces['sentry.interfaces.Exception'].values[0].stacktrace
+        frames = bt.frames
+        assert not frames[0].in_app
+        assert not frames[1].in_app
+        assert not frames[2].in_app
+        assert not frames[3].in_app
+        assert not frames[4].in_app
+        assert frames[5].in_app
+        assert frames[6].in_app


### PR DESCRIPTION
With our new release we link Sentry and KSCrash as a static lib which prevents our in app detection for frameworks.
This adds a regex for function names
This:

<img width="1037" alt="screen shot 2017-06-14 at 14 57 24" src="https://user-images.githubusercontent.com/363802/27134337-8d508408-5115-11e7-8847-b89a2497942d.png">


Becomes this:
<img width="1038" alt="screen shot 2017-06-14 at 14 57 13" src="https://user-images.githubusercontent.com/363802/27134325-84c8ccaa-5115-11e7-9bb7-2786be4577a8.png">

#nochanges