### PR TITLE
`RedisQuota.get_usage` is partitioned by organization, not project.

### DIFF
--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -86,7 +86,7 @@ class RedisQuota(Quota):
             ))
         return results
 
-    def get_usage(self, project, quotas, timestamp=None):
+    def get_usage(self, organization, quotas, timestamp=None):
         if timestamp is None:
             timestamp = time()
 
@@ -113,7 +113,7 @@ class RedisQuota(Quota):
                 functools.partial(
                     get_usage_for_quota,
                     client.target_key(
-                        six.text_type(project.organization.pk),
+                        six.text_type(organization.pk),
                     ),
                 ),
                 quotas,

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -86,7 +86,7 @@ class RedisQuota(Quota):
             ))
         return results
 
-    def get_usage(self, organization, quotas, timestamp=None):
+    def get_usage(self, organization_id, quotas, timestamp=None):
         if timestamp is None:
             timestamp = time()
 
@@ -113,7 +113,7 @@ class RedisQuota(Quota):
                 functools.partial(
                     get_usage_for_quota,
                     client.target_key(
-                        six.text_type(organization.pk),
+                        six.text_type(organization_id),
                     ),
                 ),
                 quotas,

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -149,7 +149,7 @@ class RedisQuotaTest(TestCase):
         quotas = self.quota.get_quotas(self.project)
 
         assert self.quota.get_usage(
-            self.project,
+            self.project.organization_id,
             quotas + [
                 BasicRedisQuota(
                     key='unlimited',


### PR DESCRIPTION
Oops, references GH-5548 and GH-5530.