### PR TITLE
ui: first pass at AsyncView

### DIFF
--- a/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
+++ b/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import DocumentTitle from 'react-document-title';
 
+import AsyncView from './asyncView';
 import ApiMixin from '../mixins/apiMixin';
 import IndicatorStore from '../stores/indicatorStore';
-import LoadingError from '../components/loadingError';
-import LoadingIndicator from '../components/loadingIndicator';
 import {t} from '../locale';
 
 const AuthorizationRow = React.createClass({
@@ -81,58 +79,24 @@ const AuthorizationRow = React.createClass({
   }
 });
 
-const AccountAuthorizations = React.createClass({
-  mixins: [ApiMixin],
+class AccountAuthorizations extends AsyncView {
+  getEndpoint() {
+    return '/api-authorizations/';
+  }
 
-  getInitialState() {
-    return {
-      loading: true,
-      error: false,
-      authorizationList: []
-    };
-  },
-
-  componentWillMount() {
-    this.fetchData();
-  },
-
-  remountComponent() {
-    this.setState(this.getInitialState(), this.fetchData);
-  },
-
-  fetchData() {
-    this.setState({
-      loading: true
-    });
-
-    this.api.request('/api-authorizations/', {
-      success: (data, _, jqXHR) => {
-        this.setState({
-          loading: false,
-          error: false,
-          authorizationList: data
-        });
-      },
-      error: () => {
-        this.setState({
-          loading: false,
-          error: true
-        });
-      }
-    });
-  },
+  getTitle() {
+    return 'Approved Applications - Sentry';
+  }
 
   onRevoke(authorization) {
     this.setState({
-      authorizationList: this.state.authorizationList.filter(
-        a => a.id !== authorization.id
-      )
+      data: this.state.data.filter(a => a.id !== authorization.id)
     });
-  },
+  }
 
   renderResults() {
-    let {authorizationList} = this.state;
-    if (authorizationList.length === 0) {
+    let {data} = this.state;
+    if (data.length === 0) {
       return (
         <table className="table">
           <tbody>
@@ -151,7 +115,7 @@ const AccountAuthorizations = React.createClass({
         <h4>Approved Applications</h4>
         <table className="table">
           <tbody>
-            {authorizationList.map(authorization => {
+            {data.map(authorization => {
               return (
                 <AuthorizationRow
                   key={authorization.id}
@@ -164,33 +128,23 @@ const AccountAuthorizations = React.createClass({
         </table>
       </div>
     );
-  },
+  }
 
-  getTitle() {
-    return 'Approved Applications - Sentry';
-  },
-
-  render() {
+  renderBody() {
     return (
-      <DocumentTitle title={this.getTitle()}>
-        <div>
-          {this.state.loading
-            ? <LoadingIndicator />
-            : this.state.error
-                ? <LoadingError onRetry={this.fetchData} />
-                : this.renderResults()}
-          <p>
-            <small>
-              You can manage your own applications via the
-              {' '}
-              <a href="/api/">API dashboard</a>
-              .
-            </small>
-          </p>
-        </div>
-      </DocumentTitle>
+      <div>
+        {this.renderResults()}
+        <p>
+          <small>
+            You can manage your own applications via the
+            {' '}
+            <a href="/api/">API dashboard</a>
+            .
+          </small>
+        </p>
+      </div>
     );
   }
-});
+}
 
 export default AccountAuthorizations;

--- a/src/sentry/static/sentry/app/views/asyncView.jsx
+++ b/src/sentry/static/sentry/app/views/asyncView.jsx
@@ -1,0 +1,128 @@
+import DocumentTitle from 'react-document-title';
+import React from 'react';
+import underscore from 'underscore';
+
+import LoadingIndicator from '../components/loadingIndicator';
+import RouteError from './routeError';
+import {Client} from '../api';
+
+class AsyncView extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.fetchData = AsyncView.errorHandler(this, this.fetchData.bind(this));
+    this.render = AsyncView.errorHandler(this, this.render.bind(this));
+
+    this.state = this.getDefaultState();
+  }
+
+  componentWillMount() {
+    this.api = new Client();
+    this.fetchData();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!underscore.isEqual(this.props.params, nextProps.params)) {
+      this.remountComponent();
+    }
+  }
+
+  componentWillUnmount() {
+    this.api.clear();
+  }
+
+  // XXX: cant call this getInitialState as React whines
+  getDefaultState() {
+    return {
+      data: null,
+      loading: true,
+      error: false
+    };
+  }
+
+  remountComponent() {
+    this.setState(this.getDefaultState(), this.fetchData);
+  }
+
+  // TODO(dcramer): we'd like to support multiple initial api requests
+  fetchData() {
+    let endpoint = this.getEndpoint();
+    if (!endpoint) {
+      this.setState({
+        loading: false,
+        error: false
+      });
+    } else {
+      this.api.request(endpoint, {
+        method: 'GET',
+        params: this.getEndpointParams(),
+        success: (data, _, jqXHR) => {
+          this.setState({
+            loading: false,
+            error: false,
+            data: data
+          });
+        },
+        error: () => {
+          this.setState({
+            loading: false,
+            error: true
+          });
+        }
+      });
+    }
+  }
+
+  getEndpointParams() {
+    return {};
+  }
+
+  getEndpoint() {
+    return null;
+  }
+
+  getTitle() {
+    return 'Sentry';
+  }
+
+  renderLoading() {
+    return <LoadingIndicator />;
+  }
+
+  renderError(err) {
+    return <RouteError error={err} component={this} onRetry={this.remountComponent} />;
+  }
+
+  render() {
+    return (
+      <DocumentTitle title={this.getTitle()}>
+        {this.state.loading
+          ? this.renderLoading()
+          : this.state.error ? this.renderError() : this.renderBody()}
+      </DocumentTitle>
+    );
+  }
+}
+
+AsyncView.errorHandler = (component, fn) => {
+  return function(...args) {
+    try {
+      return fn(...args);
+    } catch (err) {
+      /*eslint no-console:0*/
+      setTimeout(() => {
+        throw err;
+      });
+      component.setState({
+        error: err
+      });
+      return null;
+    }
+  };
+};
+
+AsyncView.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
+
+export default AsyncView;

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -4,7 +4,9 @@ import React from 'react';
 
 const RouteError = React.createClass({
   propTypes: {
-    error: React.PropTypes.object.isRequired
+    error: React.PropTypes.object.isRequired,
+    // not used yet, but future proofing
+    onRetry: React.PropTypes.func
   },
 
   componentWillMount() {


### PR DESCRIPTION
This does a few things that we dont do today (and DRYs up code):

- handles async errors (fetchData errors) better so they can render our standard 500 template (including User Feedback)
- makes DocumentTitle highly accessible so most pages SHOULD implement it (we could even enforce it).
- automatically handles prop changes and remounts the component (we do this in some cases, but not universal)

Future changes might be:

- Make it so we can fetch multiple endpoints worth of data before loading
- Compatibility with any other standard mixins (e.g. tooltips)

If we agree on this direction we can start replacing all views (pages) with classes that inherit this.

![screenshot 2017-06-16 13 04 30](https://user-images.githubusercontent.com/23610/27242959-7ba6c0c0-5294-11e7-9ba1-40383ac53228.png)

![screenshot 2017-06-16 13 05 22](https://user-images.githubusercontent.com/23610/27242960-7bb5e06e-5294-11e7-9908-59d05d6ce30b.png)

