### PR TITLE
Add ability to override the sample_rate on an individual basis.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -219,7 +219,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
 
     if timed:
         duration = int(time.time() - start_time)
-        metrics.timing('cleanup.duration', duration, instance=router)
+        metrics.timing('cleanup.duration', duration, instance=router, sample_rate=1.0)
         click.echo("Clean up took %s second(s)." % duration)
 
 


### PR DESCRIPTION
Up in the air about doing this, or just changing sentry.io's sample rate, but sparse metrics get pretty nerfed because of sentry.io's `0.1` rate.