### PR TITLE
make localhost url filter actually work

### DIFF
--- a/src/sentry/filters/localhost.py
+++ b/src/sentry/filters/localhost.py
@@ -25,7 +25,7 @@ class LocalhostFilter(Filter):
             return ''
 
     def get_domain(self, data):
-        return urlparse(self.get_url(data)).netloc.split(':')[0]
+        return urlparse(self.get_url(data)).hostname
 
     def test(self, data):
         return self.get_ip_address(data) in LOCAL_IPS or self.get_domain(data) in LOCAL_DOMAINS

--- a/src/sentry/filters/localhost.py
+++ b/src/sentry/filters/localhost.py
@@ -25,7 +25,7 @@ class LocalhostFilter(Filter):
             return ''
 
     def get_domain(self, data):
-        return urlparse(self.get_url(data)).netloc
+        return urlparse(self.get_url(data)).netloc.split(':')[0]
 
     def test(self, data):
         return self.get_ip_address(data) in LOCAL_IPS or self.get_domain(data) in LOCAL_DOMAINS

--- a/tests/sentry/filters/test_localhost.py
+++ b/tests/sentry/filters/test_localhost.py
@@ -39,6 +39,9 @@ class LocalhostFilterTest(TestCase):
         data = self.get_mock_data(url='http://localhost/something.html')
         assert self.apply_filter(data)
 
+        data = self.get_mock_data(url='http://localhost:9000/')
+        assert self.apply_filter(data)
+
         data = self.get_mock_data(url='https://localhost')
         assert self.apply_filter(data)
 


### PR DESCRIPTION
Fix so it doesn't return False for urls with `localhost:<any_port>`