### PR TITLE
Support missing project/event_id in reprocessing

### DIFF
--- a/src/sentry/models/rawevent.py
+++ b/src/sentry/models/rawevent.py
@@ -35,4 +35,15 @@ class RawEvent(Model):
         db_table = 'sentry_rawevent'
         unique_together = (('project', 'event_id'),)
 
+    def get_data(self):
+        rv = dict(self.data.data)
+        # Under some rare circumstances the project or event_id might not
+        # be correct in the data.  We have seen this in the past, most
+        # likely where processing failed so late that something pulled
+        # the data from it.  This will then fail in insert_data_to_database
+        # when reprocessing triggers.
+        rv['project'] = self.project_id
+        rv['event_id'] = self.event_id
+        return rv
+
     __repr__ = sane_repr('project_id')

--- a/src/sentry/tasks/reprocessing.py
+++ b/src/sentry/tasks/reprocessing.py
@@ -31,7 +31,7 @@ def reprocess_events(project_id, **kwargs):
             if raw_events:
                 helper = ClientApiHelper()
                 for raw_event in raw_events:
-                    helper.insert_data_to_database(raw_event.data.data,
+                    helper.insert_data_to_database(raw_event.get_data(),
                                                    from_reprocessing=True)
                     create_reprocessing_report(project_id=project_id,
                         event_id=raw_event.event_id)


### PR DESCRIPTION
I'm not entirely sure why it happens (and cannot reproduce) but this should
fix it nonetheless.

This fixes SENTRY-3FY