### PR TITLE
Improve Clojure rollups by collapsing anonymous module names.

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -40,6 +40,9 @@ _java_enhancer_re = re.compile(r'''
 (\$\$[\w_]+?CGLIB\$\$)[a-fA-F0-9]+(_[0-9]+)?
 ''', re.X)
 
+# Clojure anon functions are compiled down to myapp.mymodule$fn__12345
+_clojure_enhancer_re = re.compile(r'''(\$fn__)\d+''', re.X)
+
 
 def max_addr(cur, addr):
     if addr is None:
@@ -175,7 +178,8 @@ def remove_module_outliers(module):
     """Remove things that augment the module but really should not."""
     if module[:35] == 'sun.reflect.GeneratedMethodAccessor':
         return 'sun.reflect.GeneratedMethodAccessor'
-    return _java_enhancer_re.sub(r'\1<auto>', module)
+    module = _java_enhancer_re.sub(r'\1<auto>', module)
+    return _clojure_enhancer_re.sub(r'\1<auto>', module)
 
 
 def slim_frame_data(frames, frame_allowance=settings.SENTRY_MAX_STACKTRACE_FRAMES):

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -228,6 +228,28 @@ class StacktraceTest(TestCase):
             '<function>',
         ])
 
+    def test_get_hash_ignores_ENHANCED_clojure_classes(self):
+        interface = Frame.to_python({
+            'module': 'sentry_clojure_example.core$_main$fn__1539',
+            'function': 'invoke'
+        })
+        result = interface.get_hash()
+        self.assertEquals(result, [
+            'sentry_clojure_example.core$_main$fn__<auto>',
+            'invoke',
+        ])
+
+    def test_get_hash_ignores_extra_ENHANCED_clojure_classes(self):
+        interface = Frame.to_python({
+            'module': 'sentry_clojure_example.core$_main$fn__1539$fn__1540',
+            'function': 'invoke'
+        })
+        result = interface.get_hash()
+        self.assertEquals(result, [
+            'sentry_clojure_example.core$_main$fn__<auto>$fn__<auto>',
+            'invoke',
+        ])
+
     def test_get_hash_ignores_ENHANCED_spring_classes(self):
         interface = Frame.to_python({
             'module': 'invalid.gruml.talkytalkyhub.common.config.'


### PR DESCRIPTION
#5607 

Uh, @mattrobenolt you self-assigned this one, idk if you want to review for me? :)

I tried my damnest to use just one regex, but had no luck. So it's two regexs and each has to be called in turn.

1. We need to substitute a well known group, either by number (`\1`) or name (`foo`)
2. You can't have multiple groups with the same name (`(?P<name>...)`)
3. Number based groups don't work, (`(?:(thing1)|(thing2))`, `\1` is always `thing1`, even if `thing2` is the first match)