### PR TITLE
Allow org owners to transfer projects across orgs

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -38,6 +38,8 @@ class AuditLogEntryEvent(object):
     PROJECT_REMOVE = 32
     PROJECT_SET_PUBLIC = 33
     PROJECT_SET_PRIVATE = 34
+    PROJECT_REQUEST_TRANSFER = 35
+    PROJECT_ACCEPT_TRANSFER = 36
 
     TAGKEY_REMOVE = 40
 
@@ -93,6 +95,8 @@ class AuditLogEntry(Model):
             (AuditLogEntryEvent.PROJECT_REMOVE, 'project.remove'),
             (AuditLogEntryEvent.PROJECT_SET_PUBLIC, 'project.set-public'),
             (AuditLogEntryEvent.PROJECT_SET_PRIVATE, 'project.set-private'),
+            (AuditLogEntryEvent.PROJECT_REQUEST_TRANSFER, 'project.request-transfer'),
+            (AuditLogEntryEvent.PROJECT_ACCEPT_TRANSFER, 'project.accept-transfer'),
             (AuditLogEntryEvent.ORG_ADD, 'org.create'),
             (AuditLogEntryEvent.ORG_EDIT, 'org.edit'),
             (AuditLogEntryEvent.ORG_REMOVE, 'org.remove'),
@@ -197,6 +201,10 @@ class AuditLogEntry(Model):
             return 'edited project %s' % (self.data['slug'], )
         elif self.event == AuditLogEntryEvent.PROJECT_REMOVE:
             return 'removed project %s' % (self.data['slug'], )
+        elif self.event == AuditLogEntryEvent.PROJECT_REQUEST_TRANSFER:
+            return 'requested to transfer project %s' % (self.data['slug'], )
+        elif self.event == AuditLogEntryEvent.PROJECT_ACCEPT_TRANSFER:
+            return 'accepted transfer of project %s' % (self.data['slug'], )
 
         elif self.event == AuditLogEntryEvent.TAGKEY_REMOVE:
             return 'removed tags matching %s = *' % (self.data['key'], )

--- a/src/sentry/templates/sentry/emails/transfer_project.html
+++ b/src/sentry/templates/sentry/emails/transfer_project.html
@@ -1,0 +1,10 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+    <h3>Request for Project Transfer</h3>
+    <p>The <strong>{{ project_name }}</strong> project has been requested to move by:</p>
+    <p><pre>User: {{ requester }}</pre></p>
+    <p><a href="{{ url }}" class="btn">Click Here</a></p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/transfer_project.html
+++ b/src/sentry/templates/sentry/emails/transfer_project.html
@@ -5,6 +5,6 @@
 {% block main %}
     <h3>Request for Project Transfer</h3>
     <p>The <strong>{{ project_name }}</strong> project has been requested to move by:</p>
-    <p><pre>User: {{ requester }}</pre></p>
-    <p><a href="{{ url }}" class="btn">Click Here</a></p>
+    <p><pre>Requested by: {{ requester }}</pre></p>
+    <p><a href="{{ url }}" class="btn">Approve Transfer</a></p>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/transfer_project.html
+++ b/src/sentry/templates/sentry/emails/transfer_project.html
@@ -5,6 +5,7 @@
 {% block main %}
     <h3>Request for Project Transfer</h3>
     <p>A project transfer request has been made:</p>
+    <p><pre>From Organization: <strong>{{ from_org }}</strong></pre></p>
     <p><pre>Project: <strong>{{ project_name }}</strong></pre></p>
     <p><pre>Requested by: {{ requester }}</pre></p>
     <p><pre>Requested at: {{ request_time }}</pre></p>

--- a/src/sentry/templates/sentry/emails/transfer_project.html
+++ b/src/sentry/templates/sentry/emails/transfer_project.html
@@ -4,7 +4,10 @@
 
 {% block main %}
     <h3>Request for Project Transfer</h3>
-    <p>The <strong>{{ project_name }}</strong> project has been requested to move by:</p>
+    <p>A project transfer request has been made:</p>
+    <p><pre>Project: <strong>{{ project_name }}</strong></pre></p>
     <p><pre>Requested by: {{ requester }}</pre></p>
+    <p><pre>Requested at: {{ request_time }}</pre></p>
+    <p>Approving the transfer for <strong>{{ project_name }}</strong> will take you to the finals steps for where you would like <strong>{{ project_name }}</strong> to be transferred to.</p>
     <p><a href="{{ url }}" class="btn">Approve Transfer</a></p>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/transfer_project.txt
+++ b/src/sentry/templates/sentry/emails/transfer_project.txt
@@ -1,5 +1,6 @@
 Request for Project Transfer
 A project transfer request has been made:
+From Organization: {{ from_org }}
 Project: {{ project_name }}
 Requested by: {{ requester }}
 Requested at: {{ request_time }}>

--- a/src/sentry/templates/sentry/emails/transfer_project.txt
+++ b/src/sentry/templates/sentry/emails/transfer_project.txt
@@ -1,3 +1,8 @@
-{{ requester }} has requested the transfer of {{ project_name }} to another organziation
+Request for Project Transfer
+A project transfer request has been made:
+Project: {{ project_name }}
+Requested by: {{ requester }}
+Requested at: {{ request_time }}>
+Approving the transfer for {{ project_name }} will take you to the finals steps for where you would like {{ project_name }} to be transferred to.
 
-Click this: {{url}}
+Approve transfer: {{url}}

--- a/src/sentry/templates/sentry/emails/transfer_project.txt
+++ b/src/sentry/templates/sentry/emails/transfer_project.txt
@@ -1,0 +1,3 @@
+{{ requester }} has requested the transfer of {{ project_name }} to another organziation
+
+Click this: {{url}}

--- a/src/sentry/templates/sentry/projects/accept_project_transfer.html
+++ b/src/sentry/templates/sentry/projects/accept_project_transfer.html
@@ -1,0 +1,29 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Accept Project Transfer" %} | {{ block.super }}{% endblock %}
+
+{% block main %}
+  <div class="page-header">
+    <h2>
+      {% trans "Approve Transfer Project Request" %}
+    </h2>
+  </div>
+  <form action="" method="post">
+    {% csrf_token %}
+    {{ form|as_crispy_errors }}
+    <p>Projects must be transferred to a specific <strong>team</strong> in order to be moved over to another <strong>organization</strong>. You can always change the team later under the <strong>Project Settings</strong>.</p>
+    <p><strong>{% trans "Please select which Team you want to transfer this project to:" %}</strong></p>
+    <div class="box">
+      <div class="box-content with-padding">
+          {{ form.team|as_crispy_field }}
+      </div>
+    </div>
+
+    <fieldset class="form-actions">
+      <button type="submit" class="btn btn-danger">{% trans "Transfer Project" %}</button>
+    </fieldset>
+  </form>
+{% endblock %}

--- a/src/sentry/templates/sentry/projects/accept_project_transfer.html
+++ b/src/sentry/templates/sentry/projects/accept_project_transfer.html
@@ -14,8 +14,8 @@
   <form action="" method="post">
     {% csrf_token %}
     {{ form|as_crispy_errors }}
-    <p>Projects must be transferred to a specific <strong>team</strong> in order to be moved over to another <strong>organization</strong>. You can always change the team later under the <strong>Project Settings</strong>.</p>
-    <p><strong>{% trans "Please select which Team you want to transfer this project to:" %}</strong></p>
+    <p>Projects must be transferred to a specific <strong>Team</strong> in order to be moved over to another <strong>Organization</strong>. You can always change the team later under the <strong>Project Settings</strong>.</p>
+    <p>{% trans "Please select which" %} <strong>{% trans "Team" %}</strong> {% trans "you want for the project" %} <strong>{{ project.name }}</strong>.</p>
     <div class="box">
       <div class="box-content with-padding">
           {{ form.team|as_crispy_field }}

--- a/src/sentry/templates/sentry/projects/manage.html
+++ b/src/sentry/templates/sentry/projects/manage.html
@@ -108,6 +108,25 @@
       </div>
     </div>
 
+    <div class="box">
+      <div class="box-header">
+        <h3>{% trans "Transfer Project" %}</h3>
+      </div>
+      <div class="box-content with-padding">
+        {% if not ACCESS.project_admin %}
+        <p>{% trans "You do not have the required permission to remove this project." %}</p>
+        {% elif project.is_internal_project %}
+        <p>{% trans "This project cannot be removed. It is used internally by the Sentry server." %}</p>
+        {% else %}
+        <p class="clearfix">
+          <a href="{% url 'sentry-transfer-project' project.organization.slug project.slug %}" class="btn btn-danger pull-right">{% trans "Transfer Project" %}</a>
+          Transfer the <strong>{{ project.slug }}</strong> project and all related data. </br>
+          Careful, this action cannot be undone.
+        </p>
+        {% endif %}
+      </div>
+    </div>
+
     <div class="form-actions">
       <button type="submit" class="btn btn-primary btn-lg">{% trans "Save Changes" %}</button>
     </div>
@@ -211,11 +230,14 @@
         </a>
         {% if processing_issues > 0 %}
         <script>
-          ReactDOM.render(React.createElement(Sentry.Badge, {
-            text: '{{ processing_issues|safe }}',
-            isNew: true,
-          }), document.getElementById('processing-badge'));
-        </script>
+        ReactDOM.render(
+  React.createElement(Sentry.Badge, {
+    text: '{{ processing_issues|safe }}',
+    isNew: true
+  }),
+  document.getElementById('processing-badge')
+);
+</script>
         {% endif %}
     </li>
   </ul>

--- a/src/sentry/templates/sentry/projects/transfer.html
+++ b/src/sentry/templates/sentry/projects/transfer.html
@@ -1,0 +1,35 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Remove Project" %} | {{ block.super }}{% endblock %}
+
+{% block main %}
+  <div class="page-header">
+    <h2>
+      {% trans "Transfer Project" %}
+      <small>{{ project.name }}</small>
+    </h2>
+  </div>
+  <form action="" method="post">
+    {% csrf_token %}
+
+    <p><strong>{% trans "Transferring this project is permanent and cannot be undone!" %}</strong></p>
+
+    <p>{% trans "Please enter the Owner of the organziation you would like to transfer this project to." %}</p>
+
+    {{ form|as_crispy_errors }}
+
+    {% for field in form %}
+        {{ field|as_crispy_field }}
+    {% endfor %}
+
+    <p>{% trans "A request will be emailed to the Owner in order to transfer" %} <strong> {{ project.name }} </strong> {%trans "to a new organization." %}</p>
+
+    <fieldset class="form-actions">
+      <button type="submit" class="btn btn-danger">{% trans "Send Transfer Project Request" %}</button>
+      <a href="{% url 'sentry-manage-project' project.organization.slug project.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>
+    </fieldset>
+  </form>
+{% endblock %}

--- a/src/sentry/templates/sentry/projects/transfer.html
+++ b/src/sentry/templates/sentry/projects/transfer.html
@@ -17,7 +17,7 @@
 
     <p><strong>{% trans "Transferring this project is permanent and cannot be undone!" %}</strong></p>
 
-    <p>{% trans "Please enter the Owner of the organziation you would like to transfer this project to." %}</p>
+    <p>{% trans "Please enter the Owner of the organization you would like to transfer this project to." %}</p>
 
     {{ form|as_crispy_errors }}
 

--- a/src/sentry/utils/signing.py
+++ b/src/sentry/utils/signing.py
@@ -1,0 +1,26 @@
+"""
+Generic way to sign and unsign data for use in urls.
+"""
+from __future__ import absolute_import
+
+from base64 import urlsafe_b64encode, urlsafe_b64decode
+from django.core.signing import TimestampSigner
+from sentry.utils.json import dumps, loads
+
+SALT = 'sentry-generic-signing'
+
+
+def sign(**kwargs):
+    return urlsafe_b64encode(
+        TimestampSigner(salt=SALT).sign(dumps(kwargs))
+    ).rstrip('=')
+
+
+def unsign(data, max_age=60 * 60 * 24 * 2):
+    padding = len(data) % 4
+    return loads(
+        TimestampSigner(salt=SALT).unsign(
+            urlsafe_b64decode(data + b'=' * (4 - padding)),
+            max_age=max_age,
+        )
+    )

--- a/src/sentry/web/frontend/accept_project_transfer.py
+++ b/src/sentry/web/frontend/accept_project_transfer.py
@@ -66,7 +66,6 @@ class AcceptProjectTransferView(BaseView):
                 reverse('sentry')
             )
 
-        # from_organization_id = data['from_organization_id']
         project_id = data['project_id']
         user_id = data['user_id']
         transaction_id = data['transaction_id']

--- a/src/sentry/web/frontend/accept_project_transfer.py
+++ b/src/sentry/web/frontend/accept_project_transfer.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from uuid import uuid4
+
 from django import forms
 from sentry.web.frontend.base import BaseView
 from django.core.urlresolvers import reverse
@@ -48,12 +50,15 @@ class AcceptProjectTransferView(BaseView):
             project.organization = new_team.organization
             project.save()
 
+            transaction_id = uuid4().hex
+
             self.create_audit_entry(
                 request=request,
                 organization=project.organization,
                 target_object=project.id,
                 event=AuditLogEntryEvent.PROJECT_ACCEPT_TRANSFER,
                 data=project.get_audit_log_data(),
+                transaction_id=transaction_id,
             )
 
             return HttpResponseRedirect(

--- a/src/sentry/web/frontend/accept_project_transfer.py
+++ b/src/sentry/web/frontend/accept_project_transfer.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from django import forms
+from sentry.web.frontend.base import BaseView
+from sentry.models import OrganizationMember, Organization
+
+
+class AcceptProjectTransferForm(forms.Form):
+    team = forms.ChoiceField(choices=[])
+
+    def __init__(self, request, *args, **kwargs):
+        super(AcceptProjectTransferForm, self).__init__(*args, **kwargs)
+        teams = []
+        for o in OrganizationMember.objects.filter(user__email=request.user):
+            org_name = Organization.objects.get(id=o.organization_id).name
+            for t in o.get_teams():
+                option = " %s - %s" % (t.name, org_name)
+                teams.append([t.id, option])
+
+        self.fields['team'].choices = teams
+        self.fields['team'].widget.choices = self.fields['team'].choices
+
+
+class AcceptProjectTransferView(BaseView):
+        required_scope = 'org:admin'
+        sudo_required = True
+
+        def get_form(self, request):
+            if request.method == 'POST':
+                return AcceptProjectTransferForm(request, initial=request.POST)
+            return AcceptProjectTransferForm(request)
+
+        def handle(self, request, *args, **kwargs):
+            # try:
+            #     project_id = request.GET['project_id']
+            #     to_email = request.GET['to']  # Validate against request.user
+            #     from_user_id = request.GET['from_id']
+            #     from_org_id = request.GET['from_org']
+            # except KeyError:
+            #     raise Http404
+
+            form = self.get_form(request)
+            context = {
+                'form': form,
+            }
+            return self.respond('sentry/projects/accept_project_transfer.html', context)

--- a/src/sentry/web/frontend/accept_project_transfer.py
+++ b/src/sentry/web/frontend/accept_project_transfer.py
@@ -19,10 +19,9 @@ class AcceptProjectTransferForm(forms.Form):
     def __init__(self, request, *args, **kwargs):
         super(AcceptProjectTransferForm, self).__init__(*args, **kwargs)
         teams = []
-        for o in OrganizationMember.objects.filter(user__email=request.user):
-            org_name = Organization.objects.get(id=o.organization_id).name
-            for t in o.get_teams():
-                option = " %s - %s" % (t.name, org_name)
+        for o in Organization.objects.get_for_user(request.user):
+            for t in Team.objects.get_for_user(o, request.user, with_projects=False):
+                option = " %s - %s" % (t.name, o.name)
                 teams.append([t.id, option])
 
         self.fields['team'].choices = teams

--- a/src/sentry/web/frontend/accept_project_transfer.py
+++ b/src/sentry/web/frontend/accept_project_transfer.py
@@ -54,9 +54,6 @@ class AcceptProjectTransferView(BaseView):
             return HttpResponseRedirect(
                 reverse('sentry')
             )
-
-        try:
-            data = unsign(force_str(d))
         except SignatureExpired:
             messages.add_message(
                 request, messages.ERROR,

--- a/src/sentry/web/frontend/accept_project_transfer.py
+++ b/src/sentry/web/frontend/accept_project_transfer.py
@@ -94,9 +94,7 @@ class AcceptProjectTransferView(BaseView):
             # transfer the project
             team_id = form.cleaned_data.get('team')
             new_team = Team.objects.get(id=team_id)
-            project.team = new_team
-            project.organization = new_team.organization
-            project.save()
+            project.transfer_to(new_team)
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/web/frontend/accept_project_transfer.py
+++ b/src/sentry/web/frontend/accept_project_transfer.py
@@ -10,7 +10,7 @@ from django.http import HttpResponseRedirect, Http404
 from django.utils.encoding import force_str
 from django.core.signing import BadSignature, SignatureExpired
 from sentry.utils.signing import unsign
-from sentry.models import AuditLogEntryEvent, OrganizationMember, Organization, Team, Project
+from sentry.models import AuditLogEntryEvent, OrganizationMember, Organization, Team, TeamStatus, Project
 
 
 class AcceptProjectTransferForm(forms.Form):
@@ -20,7 +20,8 @@ class AcceptProjectTransferForm(forms.Form):
         super(AcceptProjectTransferForm, self).__init__(*args, **kwargs)
         teams = []
         for o in Organization.objects.get_for_user(request.user):
-            for t in Team.objects.get_for_user(o, request.user, with_projects=False):
+            # getting ALL the teams for the organization - not scoped to organizationmember
+            for t in Team.objects.filter(organization=o, status=TeamStatus.VISIBLE):
                 option = " %s - %s" % (t.name, o.name)
                 teams.append([t.id, option])
 

--- a/src/sentry/web/frontend/transfer_project.py
+++ b/src/sentry/web/frontend/transfer_project.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from uuid import uuid4
+from six.moves.urllib.parse import urlencode
 
 from django import forms
 from django.contrib import messages
@@ -58,7 +59,7 @@ class TransferProjectView(ProjectView):
                     'project_name': project.name,
                     'request_time': timezone.now(),
                     'url':
-                    'dev.getsentry.net:8000/accept-transfer/?data=' + '%s' % (url_data),
+                    'dev.getsentry.net:8000/accept-transfer/?' + urlencode({'data': url_data}),
                     'requester': request.user
                 }
                 MessageBuilder(

--- a/src/sentry/web/frontend/transfer_project.py
+++ b/src/sentry/web/frontend/transfer_project.py
@@ -45,6 +45,7 @@ class TransferProjectView(ProjectView):
             ).exists():
                 context = {
                     'email': email,
+                    'from_org': organization.name,
                     'project_name': project.name,
                     'request_time': timezone.now(),
                     'url':

--- a/src/sentry/web/frontend/transfer_project.py
+++ b/src/sentry/web/frontend/transfer_project.py
@@ -56,7 +56,7 @@ class TransferProjectView(ProjectView):
                     (options.get('mail.subject-prefix'), ),
                     template='sentry/emails/transfer_project.txt',
                     html_template='sentry/emails/transfer_project.html',
-                    type='org.confirm_delete',
+                    type='org.confirm_project_transfer_request',
                     context=context,
                 ).send_async([email])
 

--- a/src/sentry/web/frontend/transfer_project.py
+++ b/src/sentry/web/frontend/transfer_project.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from uuid import uuid4
+
 from django import forms
 from django.contrib import messages
 from django.core.urlresolvers import reverse
@@ -58,12 +60,15 @@ class TransferProjectView(ProjectView):
                     context=context,
                 ).send_async([email])
 
+                transaction_id = uuid4().hex
+
                 self.create_audit_entry(
                     request=request,
                     organization=project.organization,
                     target_object=project.id,
                     event=AuditLogEntryEvent.PROJECT_REQUEST_TRANSFER,
                     data=project.get_audit_log_data(),
+                    transaction_id=transaction_id,
                 )
 
             messages.add_message(

--- a/src/sentry/web/frontend/transfer_project.py
+++ b/src/sentry/web/frontend/transfer_project.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+from django import forms
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from django.utils.translation import ugettext_lazy as _
+
+from sentry.api import client
+from sentry.web.frontend.base import ProjectView
+
+
+class TransferProjectForm(forms.Form):
+    name = forms.CharField(
+        label=_('Organization Owner'),
+        max_length=200,
+        widget=forms.TextInput(attrs={'placeholder': _('user@company.com')})
+    )
+
+
+class TransferProjectView(ProjectView):
+    required_scope = 'project:admin'
+    sudo_required = True
+
+    def get_form(self, request):
+        if request.method == 'POST':
+            return TransferProjectForm(request.POST)
+        return TransferProjectForm()
+
+    def handle(self, request, organization, team, project):
+        form = self.get_form(request)
+
+        if form.is_valid():
+            client.delete(
+                '/projects/{}/{}/'.format(organization.slug, project.slug),
+                request=request,
+                is_sudo=True
+            )
+
+            messages.add_message(
+                request, messages.SUCCESS,
+                _(u'The project %r was scheduled for deletion.') % (project.name.encode('utf-8'), )
+            )
+
+            return HttpResponseRedirect(
+                reverse('sentry-organization-home', args=[team.organization.slug])
+            )
+
+        context = {
+            'form': form,
+        }
+
+        return self.respond('sentry/projects/transfer.html', context)

--- a/src/sentry/web/frontend/transfer_project.py
+++ b/src/sentry/web/frontend/transfer_project.py
@@ -4,6 +4,7 @@ from django import forms
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import roles, options
@@ -40,7 +41,8 @@ class TransferProjectView(ProjectView):
                 context = {
                     'email': email,
                     'project_name': project.name,
-                    'url': 'https://google.com',
+                    'request_time': timezone.now(),
+                    'url': 'dev.getsentry.net:8000/accept-transfer/?project_id=' + '%s' % (project.id),
                     'requester': request.user
                 }
                 MessageBuilder(

--- a/src/sentry/web/frontend/transfer_project.py
+++ b/src/sentry/web/frontend/transfer_project.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry import roles, options
 from sentry.web.frontend.base import ProjectView
 from sentry.utils.email import MessageBuilder
+from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
 from sentry.models import AuditLogEntryEvent, OrganizationMember, User
 
@@ -65,7 +66,7 @@ class TransferProjectView(ProjectView):
                     'project_name': project.name,
                     'request_time': timezone.now(),
                     'url':
-                    'dev.getsentry.net:8000/accept-transfer/?' + urlencode({'data': url_data}),
+                    absolute_uri('/accept-transfer/') + '?' + urlencode({'data': url_data}),
                     'requester': request.user
                 }
                 MessageBuilder(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -66,6 +66,7 @@ from sentry.web.frontend.remove_account import RemoveAccountView
 from sentry.web.frontend.remove_organization import RemoveOrganizationView
 from sentry.web.frontend.restore_organization import RestoreOrganizationView
 from sentry.web.frontend.remove_project import RemoveProjectView
+from sentry.web.frontend.transfer_project import TransferProjectView
 from sentry.web.frontend.remove_team import RemoveTeamView
 from sentry.web.frontend.sudo import SudoView
 from sentry.web.frontend.unsubscribe_issue_notifications import \
@@ -412,6 +413,11 @@ urlpatterns += patterns(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/settings/remove/$',
         RemoveProjectView.as_view(),
         name='sentry-remove-project'
+    ),
+    url(
+        r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/settings/transfer/$',
+        TransferProjectView.as_view(),
+        name='sentry-transfer-project'
     ),
     url(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/settings/tags/$',

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -67,6 +67,7 @@ from sentry.web.frontend.remove_organization import RemoveOrganizationView
 from sentry.web.frontend.restore_organization import RestoreOrganizationView
 from sentry.web.frontend.remove_project import RemoveProjectView
 from sentry.web.frontend.transfer_project import TransferProjectView
+from sentry.web.frontend.accept_project_transfer import AcceptProjectTransferView
 from sentry.web.frontend.remove_team import RemoveTeamView
 from sentry.web.frontend.sudo import SudoView
 from sentry.web.frontend.unsubscribe_issue_notifications import \
@@ -306,6 +307,9 @@ urlpatterns += patterns(
     url(r'^api/[^0]+/', generic_react_page_view),
     url(r'^out/$', OutView.as_view()),
 
+    url(r'^accept-transfer/$', AcceptProjectTransferView.as_view(),
+        name='sentry-accept-project-transfer'),
+
     # Organizations
     url(r'^(?P<organization_slug>[\w_-]+)/$', react_page_view, name='sentry-organization-home'),
     url(r'^organizations/new/$', generic_react_page_view),
@@ -443,6 +447,8 @@ urlpatterns += patterns(
     # Generic
     url(r'^$', HomeView.as_view(), name='sentry'),
     url(r'^robots\.txt$', api.robots_txt, name='sentry-api-robots-txt'),
+
+
 
     # Force a 404 of favicon.ico.
     # This url is commonly requested by browsers, and without

--- a/tests/sentry/web/frontend/test_accept_project_transfer.py
+++ b/tests/sentry/web/frontend/test_accept_project_transfer.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from uuid import uuid4
+from six.moves.urllib.parse import urlencode
+from django.core.urlresolvers import reverse
+from sentry.utils.signing import sign
+
+from sentry.testutils import TestCase, PermissionTestCase
+
+
+class AcceptTransferProjectPermissionTest(PermissionTestCase):
+    def setUp(self):
+        super(AcceptTransferProjectPermissionTest, self).setUp()
+        self.project = self.create_project(team=self.team)
+        self.path = reverse('sentry-accept-project-transfer')
+
+    def test_team_admin_cannot_load(self):
+        self.assert_team_admin_cannot_access(self.path)
+
+
+class AcceptTransferProjectTest(TestCase):
+    def setUp(self):
+        super(AcceptTransferProjectTest, self).setUp()
+        self.owner = self.create_user(email='example@example.com', is_superuser=False)
+        self.from_organization = self.create_organization(owner=self.owner)
+        self.to_organization = self.create_organization(owner=self.owner)
+        self.team = self.create_team(name='bar', organization=self.to_organization)
+        user = self.create_user('admin@example.com')
+        self.member = self.create_member(
+            organization=self.from_organization,
+            user=user,
+            role='admin',
+            teams=[self.team],
+        )
+        self.project = self.create_project(name='bar', team=self.team)
+        self.path = reverse('sentry-accept-project-transfer')
+
+    def test_requires_authentication(self):
+        self.assertRequiresAuthentication(self.path, 'POST')
+
+    def test_invalid_urldata_errors(self):
+        self.login_as(self.owner)
+
+    def test_renders_template_with_signed_link(self):
+        self.login_as(self.owner)
+        transaction_id = uuid4().hex
+        url_data = sign(
+            actor_id=self.member.id,
+            from_organization_id=self.from_organization.id,
+            project_id=self.project.id,
+            user_id=self.owner.id,
+            transaction_id=transaction_id)
+
+        resp = self.client.get(self.path + '?' + urlencode({'data': url_data}))
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/projects/accept_project_transfer.html')
+        assert resp.context['project'] == self.project

--- a/tests/sentry/web/frontend/test_accept_project_transfer.py
+++ b/tests/sentry/web/frontend/test_accept_project_transfer.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from six.moves.urllib.parse import urlencode
 from django.core.urlresolvers import reverse
 from sentry.utils.signing import sign
+from sentry.models import Project
 
 from sentry.testutils import TestCase, PermissionTestCase
 
@@ -22,9 +23,10 @@ class AcceptTransferProjectTest(TestCase):
     def setUp(self):
         super(AcceptTransferProjectTest, self).setUp()
         self.owner = self.create_user(email='example@example.com', is_superuser=False)
-        self.from_organization = self.create_organization(owner=self.owner)
-        self.to_organization = self.create_organization(owner=self.owner)
+        self.from_organization = self.create_organization(name='love', owner=self.owner)
+        self.to_organization = self.create_organization(name='lust', owner=self.owner)
         self.from_team = self.create_team(name='bar', organization=self.from_organization)
+        self.to_team = self.create_team(name='bub', organization=self.to_organization)
         user = self.create_user('admin@example.com')
         self.member = self.create_member(
             organization=self.from_organization,
@@ -32,26 +34,73 @@ class AcceptTransferProjectTest(TestCase):
             role='admin',
             teams=[self.from_team],
         )
-        self.project = self.create_project(name='bar', team=self.from_team)
+        self.project = self.create_project(name='proj', team=self.from_team)
+        self.transaction_id = uuid4().hex
         self.path = reverse('sentry-accept-project-transfer')
 
     def test_requires_authentication(self):
         self.assertRequiresAuthentication(self.path, 'POST')
 
-    def test_invalid_urldata_errors(self):
+    def test_handle_incorrect_url_data(self):
         self.login_as(self.owner)
+        url_data = sign(
+            actor_id=self.member.id,
+            # This is bad data
+            from_organization_id=9999999,
+            project_id=self.project.id,
+            user_id=self.owner.id,
+            transaction_id=self.transaction_id)
+        resp = self.client.get(self.path + '?' + urlencode({'data': url_data}))
+        assert resp.status_code == 302
+        resp = self.client.get(self.path)
+        assert resp.status_code == 404
 
     def test_renders_template_with_signed_link(self):
         self.login_as(self.owner)
-        transaction_id = uuid4().hex
         url_data = sign(
-            actor_id=self.member.id,
+            actor_id=self.member.user_id,
             from_organization_id=self.from_organization.id,
             project_id=self.project.id,
             user_id=self.owner.id,
-            transaction_id=transaction_id)
+            transaction_id=self.transaction_id)
 
         resp = self.client.get(self.path + '?' + urlencode({'data': url_data}))
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, 'sentry/projects/accept_project_transfer.html')
         assert resp.context['project'] == self.project
+
+    def test_transfers_project_to_correct_organization(self):
+        self.login_as(self.owner)
+        url_data = sign(
+            actor_id=self.member.user_id,
+            from_organization_id=self.from_organization.id,
+            project_id=self.project.id,
+            user_id=self.owner.id,
+            transaction_id=self.transaction_id)
+
+        url = self.path + '?' + urlencode({'data': url_data})
+        resp = self.client.post(url, data={'team': self.to_team.id})
+        assert resp['location'] == 'http://testserver' + \
+            reverse('sentry-organization-home', args=[self.to_team.organization.slug])
+
+        p = Project.objects.get(id=self.project.id)
+        assert p.organization_id == self.to_organization.id
+        assert p.team_id == self.to_team.id
+
+    def test_non_owner_cannot_transfer_project(self):
+        rando_user = self.create_user(email='blipp@bloop.com', is_superuser=False)
+        rando_org = self.create_organization(name='supreme beans')
+
+        self.login_as(rando_user)
+        url_data = sign(
+            actor_id=self.member.user_id,
+            from_organization_id=rando_org.id,
+            project_id=self.project.id,
+            user_id=rando_user.id,
+            transaction_id=self.transaction_id)
+
+        url = self.path + '?' + urlencode({'data': url_data})
+        resp = self.client.post(url, data={'team': self.to_team.id})
+        assert resp.status_code == 302
+        p = Project.objects.get(id=self.project.id)
+        assert p.organization_id == self.from_organization.id

--- a/tests/sentry/web/frontend/test_accept_project_transfer.py
+++ b/tests/sentry/web/frontend/test_accept_project_transfer.py
@@ -104,3 +104,19 @@ class AcceptTransferProjectTest(TestCase):
         assert resp.status_code == 302
         p = Project.objects.get(id=self.project.id)
         assert p.organization_id == self.from_organization.id
+
+    def test_cannot_transfer_project_twice_from_same_org(self):
+        self.login_as(self.owner)
+        url_data = sign(
+            actor_id=self.member.user_id,
+            from_organization_id=self.from_organization.id,
+            project_id=self.project.id,
+            user_id=self.owner.id,
+            transaction_id=self.transaction_id)
+
+        url = self.path + '?' + urlencode({'data': url_data})
+        resp = self.client.post(url, data={'team': self.to_team.id})
+        assert resp['location'] == 'http://testserver' + \
+            reverse('sentry-organization-home', args=[self.to_team.organization.slug])
+        resp = self.client.get(url)
+        assert resp.status_code == 302

--- a/tests/sentry/web/frontend/test_accept_project_transfer.py
+++ b/tests/sentry/web/frontend/test_accept_project_transfer.py
@@ -24,15 +24,15 @@ class AcceptTransferProjectTest(TestCase):
         self.owner = self.create_user(email='example@example.com', is_superuser=False)
         self.from_organization = self.create_organization(owner=self.owner)
         self.to_organization = self.create_organization(owner=self.owner)
-        self.team = self.create_team(name='bar', organization=self.to_organization)
+        self.from_team = self.create_team(name='bar', organization=self.from_organization)
         user = self.create_user('admin@example.com')
         self.member = self.create_member(
             organization=self.from_organization,
             user=user,
             role='admin',
-            teams=[self.team],
+            teams=[self.from_team],
         )
-        self.project = self.create_project(name='bar', team=self.team)
+        self.project = self.create_project(name='bar', team=self.from_team)
         self.path = reverse('sentry-accept-project-transfer')
 
     def test_requires_authentication(self):

--- a/tests/sentry/web/frontend/test_transfer_project.py
+++ b/tests/sentry/web/frontend/test_transfer_project.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import TestCase, PermissionTestCase
+
+
+class TransferProjectPermissionTest(PermissionTestCase):
+    def setUp(self):
+        super(TransferProjectPermissionTest, self).setUp()
+        self.project = self.create_project(team=self.team)
+        self.path = reverse(
+            'sentry-transfer-project', args=[self.organization.slug, self.project.slug]
+        )
+
+    def test_teamless_admin_cannot_load(self):
+        self.assert_teamless_admin_cannot_access(self.path)
+
+    def test_team_admin_can_load(self):
+        self.assert_team_admin_can_access(self.path)
+
+    def test_owner_can_load(self):
+        self.assert_owner_can_access(self.path)
+
+
+class TransferProjectTest(TestCase):
+    def setUp(self):
+        super(TransferProjectTest, self).setUp()
+        self.owner = self.create_user(email='example@example.com', is_superuser=False)
+        organization = self.create_organization(owner=self.owner)
+        self.team = self.create_team(name='bar', organization=organization)
+        self.project = self.create_project(name='bar', team=self.team)
+        self.path = reverse('sentry-transfer-project', args=[organization.slug, self.project.slug])
+
+    def test_requires_authentication(self):
+        self.assertRequiresAuthentication(self.path, 'POST')
+
+    def test_renders_template_with_get(self):
+        self.login_as(self.owner)
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/projects/transfer.html')
+        assert resp.context['team'] == self.team
+        assert resp.context['project'] == self.project
+
+    def test_deletion_flow(self):
+        self.login_as(self.owner)
+        email = self.owner.email
+
+        resp = self.client.post(
+            self.path, format='json', data={
+                'email': email,
+            }
+        )
+        assert resp.status_code == 302
+        assert resp['Location'] == 'http://testserver' + \
+            reverse('sentry-organization-home', args=[self.team.organization.slug])


### PR DESCRIPTION
**Transfer Project Flow:**

With correct permissions user can find the option to transfer project in *Project Settings*
<img width="904" alt="screen shot 2017-06-23 at 3 31 18 pm" src="https://user-images.githubusercontent.com/15368179/27502465-1e77ddc2-5829-11e7-8575-6f93bb1c928d.png">

User must enter a valid email for the owner of the organization they want the project to be transferred to:

<img width="891" alt="screen shot 2017-06-23 at 3 32 32 pm" src="https://user-images.githubusercontent.com/15368179/27502496-4c821d2c-5829-11e7-8107-c59f4c222130.png">

Owner receives the email of the transfer request and gets a link to confirm/accept the project transfer and choose the team:

<img width="897" alt="screen shot 2017-06-23 at 3 35 09 pm" src="https://user-images.githubusercontent.com/15368179/27502545-9526bb96-5829-11e7-822e-20d6538d04f5.png">


Still needed:
* [x] secure accept project transfer url (not ?project_id=<id>)
* [x] audit logs
* probs missing some other things as well