### PR TITLE
Fix some alerts flagged by lgtm.com.

### DIFF
--- a/src/debug_toolbar/panels/sql/panel.py
+++ b/src/debug_toolbar/panels/sql/panel.py
@@ -81,10 +81,7 @@ class SQLPanel(Panel):
             return None
 
         if cur_status != last_status:
-            if cur_status:
-                self._transaction_ids[alias] = uuid.uuid4().hex
-            else:
-                self._transaction_ids[alias] = None
+            self._transaction_ids[alias] = uuid.uuid4().hex
 
         return self._transaction_ids[alias]
 

--- a/src/sentry/api/serializers/models/deploy.py
+++ b/src/sentry/api/serializers/models/deploy.py
@@ -27,7 +27,6 @@ class DeploySerializer(Serializer):
     def serialize(self, obj, attrs, user, *args, **kwargs):
         return {
             'id': six.text_type(obj.id),
-            'environment': attrs.get('environment'),
             'dateStarted': obj.date_started,
             'dateFinished': obj.date_finished,
             'name': obj.name,

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -24,7 +24,6 @@ class BulkDeleteQuery(object):
             where.append("{} < '{}'::timestamptz".format(
                 quote_name(self.dtfield),
                 (timezone.now() - timedelta(days=self.days)).isoformat(),
-                self.days,
             ))
         if self.project_id:
             where.append("project_id = {}".format(self.project_id))

--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -80,7 +80,7 @@ if settings.SENTRY_USE_BIG_INTS:
             elif 'sqlite' in engine:
                 return 'integer'
             else:
-                raise NotImplemented
+                raise NotImplementedError()
 
         def get_related_db_type(self, connection):
             return BoundedBigIntegerField().db_type(connection)

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -265,7 +265,7 @@ class BaseManager(Manager):
                 logger.error('Cache response returned invalid value %r', retval)
                 return self.get(**kwargs)
 
-            if key == pk_name and int(value) != retval.pk:
+            if int(value) != retval.pk:
                 if settings.DEBUG:
                     raise ValueError('Unexpected value returned from cache')
                 logger.error('Cache response returned invalid value %r', retval)

--- a/src/sentry/filters/__init__.py
+++ b/src/sentry/filters/__init__.py
@@ -6,7 +6,7 @@ __all__ = [
 ]
 
 from .base import Filter  # NOQA
-from .manager import FilterManager  # NOQA
+from .manager import FilterManager, FilterNotRegistered  # NOQA
 
 from .localhost import LocalhostFilter
 from .browser_extensions import BrowserExtensionsFilter

--- a/src/sentry/south_migrations/0014_auto__add_project__add_projectmember__add_unique_projectmember_project.py
+++ b/src/sentry/south_migrations/0014_auto__add_project__add_projectmember__add_unique_projectmember_project.py
@@ -45,20 +45,6 @@ class Migration(SchemaMigration):
 
 
     models = {
-        'sentry.user': {
-            'Meta': {'object_name': 'User', 'db_table': "'auth_user'"},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
-        },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
             'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -83,12 +83,12 @@ def recover(request):
         'accounts:recover:{}'.format(extra['ip_address']),
         limit=5, window=60,  # 5 per minute should be enough for anyone
     ):
+        logger.warning('recover.rate-limited', extra=extra)
         return HttpResponse(
             'You have made too many password recovery attempts. Please try again later.',
             content_type='text/plain',
             status=429,
         )
-        logger.warning('recover.rate-limited', extra=extra)
 
     form = RecoverPasswordForm(request.POST or None)
     extra['user_recovered'] = form.data.get('user')

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -92,7 +92,6 @@ class OrganizationMixin(object):
                 active_organization = organizations[0]
             except IndexError:
                 logger.info('User is not a member of any organizations')
-                pass
 
         if active_organization and self._is_org_member(request.user, active_organization):
             if active_organization.slug != request.session.get('activeorg'):

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -265,7 +265,6 @@ def alert(request):
             'event': event,
             'link': 'http://example.com/link',
             'interfaces': interface_list,
-            'tags': event.get_tags(),
             'project_label': project.name,
             'tags': [
                 ('logger', 'javascript'),

--- a/src/social_auth/backends/bitbucket.py
+++ b/src/social_auth/backends/bitbucket.py
@@ -102,7 +102,6 @@ class BitbucketAuth(ConsumerBasedOAuth):
             return user_details
         except ValueError:
             return None
-        return None
 
 
 # Backend definition


### PR DESCRIPTION
This pull request fixes some small problems identified by lgtm. You can find [more details here](https://lgtm.com/projects/g/getsentry/sentry/alerts/).

The first commit fixes some places where a key in a dictionary was defined multiple times. This change should be completely behavior preserving.

The second commit fixes a place where [`NotImplemented`](https://docs.python.org/2/library/constants.html#NotImplemented) is raised, but because this is not an exception a type error is raised instead. I believe it was intended [`NotImplementedError`](https://docs.python.org/2/library/exceptions.html#exceptions.NotImplementedError) be raised.

The third commit imports `FilterNotRegistered` into the `__init__` file, because it is explicitly exported by `__all__`. This currently causes an attribute error when doing `from sentry.filters import *`.

The forth commit removes an unused argument to a formatting call, which should also be behavior preserving.

The fifth commit removes an unneeded pass statement.

The sixth fixes some unreachable code. In `panel.py`, `cur_status` is always true, because there is an if statement that returns if it is false. In `accounts.py`, an attempt is made to log a message, but the function is returned from just before the log statement so nothing gets logged. In `bitbucket.py` the `return None` is not needed because either the end of the try statement will be reached and the function will be returned from or the except statement will return.

The seventh removes a condition in an if statement that is always true (there is a previous if statement that returns from the function if `key != pk_name`).