### PR TITLE
Change the `Dangerfile` to use the correct repository.

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -74,7 +74,7 @@ warn("Changes to build requirements") if checkFiles(@S_BUILD_FILES).any?
 securityMatches = checkFilesPattern(@S_SECURITY_FILE_PATTERN, @S_SECURITY_EXCLUDE_FILES) + checkContents(@S_SECURITY_CONTENT_PATTERN, @S_SECURITY_EXCLUDE_FILES)
 if securityMatches.any?
     unless github.pr_labels.include?("Security")
-        github.api.update_issue(github.pr_json["head"]["repo"]["full_name"], github.pr_json["number"], {
+        github.api.update_issue(github.pr_json["base"]["repo"]["full_name"], github.pr_json["number"], {
             :labels => github.pr_labels + ["Security"],
         })
     end


### PR DESCRIPTION
The `Dangerfile` attempts to check the labels of the pull request it is running against on GitHub, however it attempts to update the pull request on the repository of the head branch. This will be incorrect unless the pull request is being made from the `getsentry/sentry` repository. It should instead be updating the PR on the base repository.