### PR TITLE
Disable travis secret filtering because it's buggy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+filter_secrets: false
 sudo: false
 language: python
 rvm:


### PR DESCRIPTION
This temporarily disables the secret filtering on travis because their filtering code has problems with lots of output from out dist build step. They are investigating it.