### PR TITLE
Correctly strip prefixes from releases

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 _sha1_re = re.compile(r'^[a-f0-9]{40}$')
-_dotted_path_prefix_re = re.compile(r'^([a-z][a-z0-9-]+)(\.[a-z][a-z0-9-]+)+-')
+_dotted_path_prefix_re = re.compile(r'^([a-zA-Z][a-zA-Z0-9-]+)(\.[a-zA-Z][a-zA-Z0-9-]+)+-')
 BAD_RELEASE_CHARS = '\n\f\t/'
 
 

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -222,7 +222,7 @@ export function formatBytes(bytes) {
 }
 
 export function getShortVersion(version) {
-  let match = version.match(/^(?:[a-z][a-z0-9-]+)(?:\.[a-z][a-z0-9-]+)+-(.*)$/);
+  let match = version.match(/^(?:[a-zA-Z][a-zA-Z0-9-]+)(?:\.[a-zA-Z][a-zA-Z0-9-]+)+-(.*)$/);
   if (match) {
     version = match[1];
   }

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -143,6 +143,17 @@ class MergeReleasesTest(TestCase):
         assert not Release.objects.filter(id=release2.id).exists()
         assert not Release.objects.filter(id=release3.id).exists()
 
+    def test_short_version_dotted_prefix(self):
+        org = self.create_organization()
+
+        release = Release.objects.create(
+            version='foo.bar.Baz-1.0',
+            organization=org
+        )
+
+        assert release.version == 'foo.bar.Baz-1.0'
+        assert release.short_version == '1.0'
+
 
 class SetCommitsTestCase(TestCase):
     def test_simple(self):


### PR DESCRIPTION
This solves the issue that `foo.bar.baz-1.0` was correctly stripped in the UI but `foo.bar.Baz-1.0` was not.