### PR TITLE
ui: various fixes for form context

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/form.jsx
+++ b/src/sentry/static/sentry/app/components/forms/form.jsx
@@ -24,7 +24,7 @@ export default class Form extends React.Component {
   };
 
   static childContextTypes = {
-    form: React.PropTypes.object
+    form: React.PropTypes.object.isRequired
   };
 
   constructor(props) {

--- a/src/sentry/static/sentry/app/components/forms/formField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/formField.jsx
@@ -29,32 +29,37 @@ export default class FormField extends React.Component {
     form: React.PropTypes.object
   };
 
-  static childContextTypes = {
-    form: React.PropTypes.object
-  };
-
-  constructor(props) {
+  constructor(props, context) {
     super(props);
 
     this.state = {
-      value: this.getValue(props)
+      value: this.getValue(props, context)
     };
   }
 
-  getValue(props) {
-    let form = (this.context || {}).form;
+  componentWillReceiveProps(nextProps, nextContext) {
+    if (
+      this.props.value !== nextProps.value ||
+      (!defined(this.context.form) && defined(nextContext.form))
+    ) {
+      this.setState({value: this.getValue(nextProps, nextContext)});
+    }
+  }
+
+  getValue(props, context) {
+    let form = (context || this.context || {}).form;
     props = props || this.props;
     if (defined(props.value)) {
       return props.value;
     }
-    if (form) {
-      return idx(form, _ => _.data[props.name]);
+    if (form && form.data.hasOwnProperty(props.name)) {
+      return form.data[props.name];
     }
     return props.defaultValue || '';
   }
 
-  getError(props) {
-    let form = (this.context || {}).form;
+  getError(props, context) {
+    let form = (context || this.context || {}).form;
     props = props || this.props;
     if (defined(props.error)) {
       return props.error;

--- a/tests/js/spec/components/forms/__snapshots__/textField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/textField.spec.jsx.snap
@@ -14,7 +14,7 @@ exports[`TextField render() renders with form context 1`] = `
       onChange={[Function]}
       required={false}
       type="text"
-      value=""
+      value="fieldValue"
     />
   </div>
 </div>


### PR DESCRIPTION
``context`` isnt bound when the constructor is called, and it also turns out React passes context and nextContext to lifecycle methods, which is how you'd correctly access it.

https://facebook.github.io/react/docs/context.html#referencing-context-in-lifecycle-methods