### PR TITLE
Reserve /contact

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -82,7 +82,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset((
     'subscribe', 'enterprise', 'about', 'jobs', 'thanks', 'guide',
     'privacy', 'security', 'terms', 'from', 'sponsorship', 'for',
     'at', 'platforms', 'branding', 'vs', 'answers', '_admin',
-    'support',
+    'support', 'contact',
 ))
 
 LOG_LEVELS = {


### PR DESCRIPTION
I'd like to block off `/contact` for future use

cc @mattrobenolt 