### PR TITLE
Change the proguard cache key to be globally unique

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -7,7 +7,7 @@ from sentry.models import ProjectDSymFile, EventError
 from sentry.reprocessing import report_processing_issue
 
 
-FRAME_CACHE_VERSION = 1
+FRAME_CACHE_VERSION = 2
 
 
 class JavaStacktraceProcessor(StacktraceProcessor):
@@ -39,7 +39,7 @@ class JavaStacktraceProcessor(StacktraceProcessor):
             FRAME_CACHE_VERSION,
             processable_frame.frame['module'],
             processable_frame.frame['function'],
-        ))
+        ) + tuple(sorted(self.images)))
 
     def preprocess_step(self, processing_task):
         if not self.available:


### PR DESCRIPTION
This adds the UUIDs for the proguard files into the frame cache.  This
not only ensures that data is not cached across project boundaries
but also makes sure we do not cache frames that were processed before
a proguard file was uploaded.