### PR TITLE
Fix function names in javascript stacktraces

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -553,7 +553,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 # zero-indexed value from tokens.
                 assert frame['lineno'] > 0, "line numbers are 1-indexed"
                 token = sourcemap_view.lookup_token(
-                    frame['lineno'] - 1, frame['colno'])
+                    frame['lineno'] - 1, frame['colno'] - 1)
             except Exception:
                 token = None
                 all_errors.append({

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -187,7 +187,7 @@ class JavascriptIntegrationTest(TestCase):
                                 'abs_path': 'http://example.com/test.min.js',
                                 'filename': 'test.js',
                                 'lineno': 1,
-                                'colno': 0,
+                                'colno': 1,
                             },
                         ],
                     },


### PR DESCRIPTION
I've noticed weird function names for stracktraces in javascript. So @mitsuhiko and myself investigated the issue.

We found out that we should substract `1` not only from the line number but also from the column. Since lineno and col start at `1` and in libsourcemap we start to count at `0`, we have to substract both by one to get the correct function name again.

I know this is a major change, since this means all the groups will change (tested it). Probably we will have to discuss how we gonna tackle this problem.

Here are two screenshots indicating the change:
_Current status:_ 
<img width="1016" alt="wrong" src="https://user-images.githubusercontent.com/363802/27735452-e51ed5e0-5d9f-11e7-8ed9-ee0bbcb2d7d3.png">

_Fix:_
<img width="1017" alt="right" src="https://user-images.githubusercontent.com/363802/27735456-e9c85cd8-5d9f-11e7-8be9-0838d9c9c882.png">
