### PR TITLE
Remove unique tag counts display.

### DIFF
--- a/src/sentry/static/sentry/app/views/groupTags.jsx
+++ b/src/sentry/static/sentry/app/views/groupTags.jsx
@@ -102,7 +102,7 @@ const GroupTags = React.createClass({
                     {t('More Details')}
                   </Link>
                 </span>
-                <h5>{tag.name} (<Count value={tag.uniqueValues} />)</h5>
+                <h5>{tag.name}</h5>
               </div>
               <div className="box-content with-padding">
                 <ul className="list-unstyled">

--- a/src/sentry/templates/sentry/projects/manage_tags.html
+++ b/src/sentry/templates/sentry/projects/manage_tags.html
@@ -29,7 +29,6 @@
               <tr data-tagkey="{{ tag.key }}">
                 <td>
                   <h5 style="margin-bottom: 10px;">{{ tag.get_label }} <small>({{ tag.key }})</small></h5>
-                  <small>{{ tag.values_seen|small_count }} unique value(s)</small>
                 </td>
                 <td>
                 {% comment %}


### PR DESCRIPTION
This currently has a few issues:

1.) This value is the number of tags that have been seen across the entire project -- not just the number of tags that have been seen for this issue -- so it's super confusing on the group tag page when all of the other values are scoped to values seen within the group. This reference was removed for the `GroupTagValues` React view with GH-4589, presumably because it was confusing there as well.
2.) It's not recorded correctly on the backend (see GH-5554) and is not a high priority to fix in the near future.