### PR TITLE
Include last_active in User serializer

### DIFF
--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -72,6 +72,7 @@ class UserSerializer(Serializer):
             'dateJoined': obj.date_joined,
             'lastLogin': obj.last_login,
             'has2fa': attrs['has2fa'],
+            'lastActive': obj.last_active,
         }
 
         if obj == user:


### PR DESCRIPTION
Surfacing User.last_active - useful in general but immediate need is for use in adding last active to getsentry _admin