### PR TITLE
Sort status check problems by severity and message.

### DIFF
--- a/src/sentry/api/endpoints/system_health.py
+++ b/src/sentry/api/endpoints/system_health.py
@@ -4,7 +4,7 @@ import itertools
 
 from rest_framework.response import Response
 
-from sentry import status_checks, sort_by_severity
+from sentry import sort_by_severity, status_checks
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils.hashlib import md5_text

--- a/src/sentry/api/endpoints/system_health.py
+++ b/src/sentry/api/endpoints/system_health.py
@@ -4,7 +4,8 @@ import itertools
 
 from rest_framework.response import Response
 
-from sentry import sort_by_severity, status_checks
+from sentry import status_checks
+from sentry.status_checks import sort_by_severity
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils.hashlib import md5_text

--- a/src/sentry/api/endpoints/system_health.py
+++ b/src/sentry/api/endpoints/system_health.py
@@ -4,7 +4,7 @@ import itertools
 
 from rest_framework.response import Response
 
-from sentry import status_checks
+from sentry import status_checks, sort_by_severity
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils.hashlib import md5_text
@@ -23,8 +23,8 @@ class SystemHealthEndpoint(Endpoint):
                     'severity': problem.severity,
                     'url': problem.url,
                 }
-                for problem in sorted(itertools.chain.from_iterable(results.values()),
-                                      reverse=True)
+                for problem in
+                sort_by_severity(itertools.chain.from_iterable(results.values()))
             ],
             'healthy': {type(check).__name__: not problems for check, problems in results.items()},
         })

--- a/src/sentry/status_checks/__init__.py
+++ b/src/sentry/status_checks/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
-__all__ = ('check_all', 'Problem', 'StatusCheck')
+__all__ = ('check_all', 'sort_by_severity', 'Problem', 'StatusCheck')
 
 from sentry.utils.warnings import seen_warnings
 
-from .base import Problem, StatusCheck  # NOQA
+from .base import Problem, StatusCheck, sort_by_severity  # NOQA
 from .celery_alive import CeleryAliveCheck
 from .celery_app_version import CeleryAppVersionCheck
 from .warnings import WarningStatusCheck

--- a/src/sentry/status_checks/base.py
+++ b/src/sentry/status_checks/base.py
@@ -2,13 +2,23 @@ from __future__ import absolute_import
 
 import six
 
-from functools import total_ordering
-
 from sentry.utils.compat import implements_to_string
 
 
+def sort_by_severity(problems):
+    """\
+    Sort an iterable of ``Problem``s by their severity, from most severe to least severe.
+    """
+    return sorted(
+        problems,
+        key=lambda i: (
+            -Problem.SEVERITY_LEVELS[i.severity],
+            i.message,
+        ),
+    )
+
+
 @implements_to_string
-@total_ordering
 class Problem(object):
 
     # Used for issues that may render the system inoperable or have effects on
@@ -34,12 +44,6 @@ class Problem(object):
         self.message = six.text_type(message)
         self.severity = severity
         self.url = url
-
-    def __eq__(self, other):
-        return self.SEVERITY_LEVELS[self.severity] == self.SEVERITY_LEVELS[other.severity]
-
-    def __lt__(self, other):
-        return self.SEVERITY_LEVELS[self.severity] < self.SEVERITY_LEVELS[other.severity]
 
     def __str__(self):
         return self.message

--- a/src/sentry/templatetags/sentry_status.py
+++ b/src/sentry/templatetags/sentry_status.py
@@ -4,7 +4,9 @@ import itertools
 
 from django import template
 
-from sentry import sort_by_severity, status_checks
+from sentry import status_checks
+from sentry.status_checks import sort_by_severity
+
 
 register = template.Library()
 

--- a/src/sentry/templatetags/sentry_status.py
+++ b/src/sentry/templatetags/sentry_status.py
@@ -4,15 +4,16 @@ import itertools
 
 from django import template
 
-from sentry import status_checks
+from sentry import status_checks, sort_by_severity
 
 register = template.Library()
 
 
 @register.inclusion_tag('sentry/partial/system-status.html', takes_context=True)
 def show_system_status(context):
-    problems = list(itertools.chain.from_iterable(status_checks.check_all().values()))
-
+    problems = itertools.chain.from_iterable(
+        status_checks.check_all().values(),
+    )
     return {
-        'problems': problems,
+        'problems': sort_by_severity(problems),
     }

--- a/src/sentry/templatetags/sentry_status.py
+++ b/src/sentry/templatetags/sentry_status.py
@@ -4,7 +4,7 @@ import itertools
 
 from django import template
 
-from sentry import status_checks, sort_by_severity
+from sentry import sort_by_severity, status_checks
 
 register = template.Library()
 


### PR DESCRIPTION
This was previously sorting by severity only for the API endpoint and not at all for the server rendered pages. Now, this sorts by priority descending (most severe problems first) and message ascending.

This fixes what GH-5663 was intended to fix.