### PR TITLE
Correct interval calculation in `RedisQuota`.

### DIFF
--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -145,7 +145,7 @@ class RedisQuota(Quota):
 
         def get_next_period_start(interval, shift):
             """Return the timestamp when the next rate limit period begins for an interval."""
-            return ((timestamp // interval) + 1) * interval - shift
+            return (((timestamp - shift) // interval) + 1) * interval + shift
 
         keys = []
         args = []


### PR DESCRIPTION
This fixes an issue that was introduced with GH-5530 that caused some quotas to be set to expire before the end of the quota window.