### PR TITLE
Fix #5703: Improve error message when events fail to load

### DIFF
--- a/src/sentry/static/sentry/app/components/errors/detailedError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/detailedError.jsx
@@ -1,10 +1,12 @@
 import React, {PropTypes} from 'react';
+import classNames from 'classnames';
 
 import {t} from '../../locale';
 import IconCircleExclamation from '../../icons/icon-circle-exclamation';
 
 const DetailedError = React.createClass({
   propTypes: {
+    className: PropTypes.string,
     /* Retry callback */
     onRetry: PropTypes.func,
     /* Error heading */
@@ -22,12 +24,13 @@ const DetailedError = React.createClass({
   },
 
   render() {
-    const {heading, message, onRetry, hideSupportLinks} = this.props;
+    const {className, heading, message, onRetry, hideSupportLinks} = this.props;
+    const cx = classNames('detailed-error', className);
 
     const showFooter = !!onRetry || !hideSupportLinks;
 
     return (
-      <div className="detailed-error">
+      <div className={cx}>
         <div className="detailed-error-icon">
           <IconCircleExclamation />
         </div>

--- a/src/sentry/static/sentry/app/components/errors/detailedError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/detailedError.jsx
@@ -1,0 +1,69 @@
+import React, {PropTypes} from 'react';
+
+import {t} from '../../locale';
+import IconCircleExclamation from '../../icons/icon-circle-exclamation';
+
+const DetailedError = React.createClass({
+  propTypes: {
+    /* Retry callback */
+    onRetry: PropTypes.func,
+    /* Error heading */
+    heading: PropTypes.string.isRequired,
+    /* Detailed error explanation */
+    message: PropTypes.node,
+    /* Hide support links in footer of error message */
+    hideSupportLinks: PropTypes.bool
+  },
+
+  getDefaultProps() {
+    return {
+      hideSupportLinks: false
+    };
+  },
+
+  render() {
+    const {heading, message, onRetry, hideSupportLinks} = this.props;
+
+    const showFooter = !!onRetry || !hideSupportLinks;
+
+    return (
+      <div className="detailed-error">
+        <div className="detailed-error-icon">
+          <IconCircleExclamation />
+        </div>
+        <div className="detailed-error-content">
+          <h4>
+            {heading}
+          </h4>
+
+          <div className="detailed-error-content-body">
+            {message}
+          </div>
+
+          {showFooter &&
+            <div className="detailed-error-content-footer">
+              <div>
+                {onRetry &&
+                  <a onClick={onRetry} className="btn btn-default">
+                    {t('Retry')}
+                  </a>}
+              </div>
+
+              {!hideSupportLinks &&
+                <div className="detailed-error-support-links">
+                  <a href="https://status.sentry.io/">
+                    Service status
+                  </a>
+
+                  <a href="https://sentry.io/support/">
+                    Contact support
+                  </a>
+                </div>}
+            </div>}
+        </div>
+      </div>
+    );
+  }
+});
+
+export default DetailedError;

--- a/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
@@ -13,10 +13,10 @@ const GroupEventDetailsLoadingError = ({onRetry}) => {
   return (
     <DetailedError
       onRetry={onRetry}
-      heading="Sorry, the events for this issue could not be found."
+      heading={t('Sorry, the events for this issue could not be found.')}
       message={
         <div>
-          <p>This could be due to a handful of reasons:</p>
+          <p>{t('This could be due to a handful of reasons:')}</p>
           <ol className="detailed-error-list">
             {reasons.map((reason, i) => (
               <li key={i}>

--- a/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
@@ -1,0 +1,37 @@
+import React, {PropTypes} from 'react';
+
+import {t} from '../../locale';
+import DetailedError from './detailedError';
+
+const GroupEventDetailsLoadingError = ({onRetry}) => {
+  const reasons = [
+    t('The events are still processing and are on their way'),
+    t('The events have been deleted'),
+    t('There is an internal systems error or active issue')
+  ];
+
+  return (
+    <DetailedError
+      onRetry={onRetry}
+      heading="Sorry, the events for this issue could not be found."
+      message={
+        <div>
+          <p>This could be due to a handful of reasons:</p>
+          <ol className="detailed-error-list">
+            {reasons.map((reason, i) => (
+              <li key={i}>
+                {reason}
+              </li>
+            ))}
+          </ol>
+        </div>
+      }
+    />
+  );
+};
+
+GroupEventDetailsLoadingError.propTypes = {
+  onRetry: PropTypes.func
+};
+
+export default GroupEventDetailsLoadingError;

--- a/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
@@ -12,6 +12,7 @@ const GroupEventDetailsLoadingError = ({onRetry}) => {
 
   return (
     <DetailedError
+      className="group-event-details-error"
       onRetry={onRetry}
       heading={t('Sorry, the events for this issue could not be found.')}
       message={

--- a/src/sentry/static/sentry/app/icons/icon-circle-exclamation.js
+++ b/src/sentry/static/sentry/app/icons/icon-circle-exclamation.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Icon from 'react-icon-base';
+
+function IconCircleExclamation(props) {
+  return (
+    <Icon viewBox="0 0 15 15" {...props}>
+      <g stroke="currentColor" fill="none" strokeLinejoin="round" strokeLinecap="round">
+        <circle cx="7.5" cy="7.5" r="7" />
+        <path d="M7.5,3.5 L7.5,8.5" />
+        <path d="M7.5,10.5 L7.5,11.5" />
+      </g>
+    </Icon>
+  );
+}
+
+export default IconCircleExclamation;

--- a/src/sentry/static/sentry/app/views/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupEventDetails.jsx
@@ -5,7 +5,8 @@ import GroupEventToolbar from './groupDetails/eventToolbar';
 import GroupSidebar from '../components/group/sidebar';
 import GroupState from '../mixins/groupState';
 import MutedBox from '../components/mutedBox';
-import LoadingError from '../components/loadingError';
+import GroupEventDetailsLoadingError
+  from '../components/errors/groupEventDetailsLoadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import ResolutionBox from '../components/resolutionBox';
 
@@ -94,7 +95,7 @@ const GroupEventDetails = React.createClass({
             {this.state.loading
               ? <LoadingIndicator />
               : this.state.error
-                  ? <LoadingError onRetry={this.fetchData} />
+                  ? <GroupEventDetailsLoadingError onRetry={this.fetchData} />
                   : <EventEntries
                       group={group}
                       event={evt}

--- a/src/sentry/static/sentry/less/errors.less
+++ b/src/sentry/static/sentry/less/errors.less
@@ -1,0 +1,38 @@
+.detailed-error {
+  display: flex;
+  justify-content: center;
+  padding: 18px;
+}
+
+.detailed-error-icon {
+  color: @red;
+  font-size: 2.4em;
+  padding: 0 18px;
+  opacity: 0.3;
+}
+
+.detailed-error-content-footer {
+  margin-top: 18px;
+  border-top: 1px solid @trim;
+  padding-top: 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.detailed-error-support-links {
+  font-size: 0.9em;
+  a {
+    margin: 12px;
+  }
+}
+
+.detailed-error-list {
+  li {
+    margin-bottom: 6px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/sentry/static/sentry/less/errors.less
+++ b/src/sentry/static/sentry/less/errors.less
@@ -2,6 +2,9 @@
   display: flex;
   justify-content: center;
   padding: 18px;
+  &.group-event-details-error {
+    padding-top: 48px;
+  }
 }
 
 .detailed-error-icon {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -2732,6 +2732,10 @@ ul.crumbs {
       border: 0;
       margin-bottom: 20px;
     }
+
+    .detailed-error {
+      border-top: 1px solid @trim;
+    }
   }
 
   // Context callout

--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -30,6 +30,7 @@
 @import url("./type.less");
 @import url("./browser-icons.less");
 @import url("./dropdowns.less");
+@import url("./errors.less");
 
 // Page specific
 

--- a/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetailedError can hide support links 1`] = `
+<div
+  className="detailed-error"
+>
+  <div
+    className="detailed-error-icon"
+  >
+    <IconCircleExclamation />
+  </div>
+  <div
+    className="detailed-error-content"
+  >
+    <h4>
+      Error heading
+    </h4>
+    <div
+      className="detailed-error-content-body"
+    >
+      <div>
+        Message
+      </div>
+    </div>
+    <div
+      className="detailed-error-content-footer"
+    >
+      <div>
+        <a
+          className="btn btn-default"
+          onClick={[Function]}
+        >
+          Retry
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailedError hides footer when no "Retry" and no support links 1`] = `
+<div
+  className="detailed-error"
+>
+  <div
+    className="detailed-error-icon"
+  >
+    <IconCircleExclamation />
+  </div>
+  <div
+    className="detailed-error-content"
+  >
+    <h4>
+      Error heading
+    </h4>
+    <div
+      className="detailed-error-content-body"
+    >
+      <div>
+        Message
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailedError renders 1`] = `
+<div
+  className="detailed-error"
+>
+  <div
+    className="detailed-error-icon"
+  >
+    <IconCircleExclamation />
+  </div>
+  <div
+    className="detailed-error-content"
+  >
+    <h4>
+      Error heading
+    </h4>
+    <div
+      className="detailed-error-content-body"
+    >
+      <div>
+        Message
+      </div>
+    </div>
+    <div
+      className="detailed-error-content-footer"
+    >
+      <div />
+      <div
+        className="detailed-error-support-links"
+      >
+        <a
+          href="https://status.sentry.io/"
+        >
+          Service status
+        </a>
+        <a
+          href="https://sentry.io/support/"
+        >
+          Contact support
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailedError renders with "Retry" button 1`] = `
+<div
+  className="detailed-error"
+>
+  <div
+    className="detailed-error-icon"
+  >
+    <IconCircleExclamation />
+  </div>
+  <div
+    className="detailed-error-content"
+  >
+    <h4>
+      Error heading
+    </h4>
+    <div
+      className="detailed-error-content-body"
+    >
+      <div>
+        Message
+      </div>
+    </div>
+    <div
+      className="detailed-error-content-footer"
+    >
+      <div>
+        <a
+          className="btn btn-default"
+          onClick={[Function]}
+        >
+          Retry
+        </a>
+      </div>
+      <div
+        className="detailed-error-support-links"
+      >
+        <a
+          href="https://status.sentry.io/"
+        >
+          Service status
+        </a>
+        <a
+          href="https://sentry.io/support/"
+        >
+          Contact support
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/js/spec/components/detailedError.spec.jsx
+++ b/tests/js/spec/components/detailedError.spec.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import DetailedError from 'app/components/errors/detailedError';
+
+describe('DetailedError', function() {
+  it('renders', function() {
+    let wrapper = shallow(
+      <DetailedError heading="Error heading" message={<div>Message</div>} />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('renders with "Retry" button', function() {
+    let wrapper = shallow(
+      <DetailedError
+        onRetry={() => {}}
+        heading="Error heading"
+        message={<div>Message</div>}
+      />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('can hide support links', function() {
+    let wrapper = shallow(
+      <DetailedError
+        hideSupportLinks
+        onRetry={() => {}}
+        heading="Error heading"
+        message={<div>Message</div>}
+      />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('hides footer when no "Retry" and no support links', function() {
+    let wrapper = shallow(
+      <DetailedError
+        hideSupportLinks
+        heading="Error heading"
+        message={<div>Message</div>}
+      />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
In `<GroupEventDetails>`, swapped out `<LoadingError>` with a new `<DetailedError>`.

![image](https://user-images.githubusercontent.com/79684/28142867-b56afaaa-6717-11e7-8427-acb7ed3e5288.png)

Fixes #5703