### PR TITLE
handle null stacktrace in event commiter endpoint fixes SENTRY-3N1

### DIFF
--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -41,7 +41,7 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
         except KeyError:
             try:
                 frames = data['sentry.interfaces.Exception']['values'][0]['stacktrace']['frames']
-            except KeyError:
+            except (KeyError, TypeError):
                 return []  # can't find stacktrace information
 
         return frames

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -76,12 +76,12 @@ class EventCommittersTest(APITestCase):
 
         release = self.create_release(
             project,
-            self.user
+            self.user,
         )
 
         group = self.create_group(
             project=project,
-            first_release=release
+            first_release=release,
         )
 
         event = self.create_event(

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from datetime import datetime
 from django.core.urlresolvers import reverse
 
+from sentry.models import Event
 from sentry.testutils import APITestCase
 
 
@@ -67,3 +68,57 @@ class EventCommittersTest(APITestCase):
         response = self.client.get(url, format='json')
         assert response.status_code == 404, response.content
         assert response.data['detail'] == "No Commits found for Release"
+
+    def test_null_stacktrace(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        release = self.create_release(
+            project,
+            self.user
+        )
+
+        group = self.create_group(
+            project=project,
+            first_release=release
+        )
+
+        event = self.create_event(
+            event_id='a',
+            group=group,
+            datetime=datetime(2016, 8, 13, 3, 8, 25),
+            tags={'sentry:release': release.version}
+        )
+
+        event = Event.objects.create(
+            project_id=project.id,
+            group_id=group.id,
+            event_id='abcd',
+            message='hello 123456',
+            data={
+                'environment': 'production',
+                'type': 'default',
+                'sentry.interfaces.Exception': {
+                    'values': [{
+                        'type': 'ValueError',
+                        'value': 'My exception value',
+                        'module': '__builtins__',
+                        'stacktrace': None,
+                    }]
+                },
+                'tags': [
+                    ['environment', 'production'],
+                    ['sentry:release', release.version],
+                ],
+            },
+        )
+
+        url = reverse('sentry-api-0-event-file-committers', kwargs={
+            'event_id': event.id,
+            'project_slug': event.project.slug,
+            'organization_slug': event.project.organization.slug,
+        })
+
+        response = self.client.get(url, format='json')
+        assert response.status_code == 200, response.content


### PR DESCRIPTION
https://sentry.io/sentry/sentry/issues/293528173/

#nochanges 