### PR TITLE
Remove IntegrityError exception logging

### DIFF
--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -178,7 +178,9 @@ class FeatureAdoptionManager(BaseManager):
         except IntegrityError as e:
             # This can occur if redis somehow loses the set of complete features and
             # we attempt to insert duplicate (org_id, feature_id) rows
-            logger.exception(e)
+            # This also will happen if we get parallel processes running `bulk_record` and
+            # `get_all_cache` returns in the second process before the first process
+            # can `bulk_set_cache`.
             return False
         finally:
             return self.bulk_set_cache(organization_id, *incomplete_feature_ids)

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -175,7 +175,7 @@ class FeatureAdoptionManager(BaseManager):
                 self.bulk_create(features)
                 return True
 
-        except IntegrityError as e:
+        except IntegrityError:
             # This can occur if redis somehow loses the set of complete features and
             # we attempt to insert duplicate (org_id, feature_id) rows
             # This also will happen if we get parallel processes running `bulk_record` and


### PR DESCRIPTION
Unnecessary exception logging for the FeatureAdoption `bulk_record` method.

Fixes #5709