### PR TITLE
Use jest w/ --runInBand on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ test-js:
 	@echo "--> Building static assets"
 	@${NPM_ROOT}/.bin/webpack
 	@echo "--> Running JavaScript tests"
-	@npm run test
+	@npm run test-ci
 	@echo ""
 
 test-python:

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "proxyURL": "http://localhost:8000",
   "scripts": {
     "test": "NODE_ENV=test node_modules/.bin/jest tests/js/spec",
+    "test-ci": "NODE_ENV=test node_modules/.bin/jest tests/js/spec --runInBand",
     "test-watch": "NODE_ENV=test node_modules/.bin/jest tests/js/spec --watch",
     "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .jsx"
   },


### PR DESCRIPTION
Should address the really slow test execution times we're seeing on Travis:

```
 PASS  tests/js/spec/utils/stream.spec.jsx (13.617s)
 PASS  tests/js/spec/utils/logging.spec.jsx (12.874s)
 PASS  tests/js/spec/stores/groupStore.spec.jsx (281.09s)
 PASS  tests/js/spec/utils/streamManager.spec.js (280.377s)
 PASS  tests/js/spec/stores/selectedGroupStore.spec.js (281.445s)
 PASS  tests/js/spec/api.spec.jsx (281.191s)
 PASS  tests/js/spec/utils/utils.spec.jsx (281.68s)
 PASS  tests/js/spec/components/userLetterAvatar.spec.jsx (281.33s)
 PASS  tests/js/spec/components/letterAvatar.spec.jsx (281.531s)
```