### PR TITLE
Changing order of build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ class SentrySDistCommand(SDistCommand):
     # part of our source build pipeline.
     if not IS_LIGHT_BUILD:
         sub_commands = SDistCommand.sub_commands + \
-            [('build_assets', None), ('build_integration_docs', None)]
+            [('build_integration_docs', None), ('build_assets', None)]
 
 
 class SentryBuildCommand(BuildCommand):
@@ -164,8 +164,8 @@ class SentryBuildCommand(BuildCommand):
     def run(self):
         BuildCommand.run(self)
         if not IS_LIGHT_BUILD:
-            self.run_command('build_assets')
             self.run_command('build_integration_docs')
+            self.run_command('build_assets')
 
 
 class SentryDevelopCommand(DevelopCommand):
@@ -173,8 +173,8 @@ class SentryDevelopCommand(DevelopCommand):
     def run(self):
         DevelopCommand.run(self)
         if not IS_LIGHT_BUILD:
-            self.run_command('build_assets')
             self.run_command('build_integration_docs')
+            self.run_command('build_assets')
 
 
 cmdclass = {


### PR DESCRIPTION
Switching the order so we can use the `_platform.json` (built by `build_integration_docs`) within the sentry app. Currently, it errors.

To be used in https://github.com/getsentry/sentry/pull/5489