### PR TITLE
nodestore: support bulk cleanup through Riak TTLs

### DIFF
--- a/src/sentry/nodestore/riak/backend.py
+++ b/src/sentry/nodestore/riak/backend.py
@@ -46,7 +46,8 @@ class RiakNodeStorage(NodeStorage):
         max_retries=3,
         multiget_pool_size=5,
         tcp_keepalive=True,
-        protocol=None
+        protocol=None,
+        automatic_expiry=False
     ):
         # protocol being defined is useless, but is needed for backwards
         # compatability and leveraged as an opportunity to yell at the user
@@ -63,6 +64,7 @@ class RiakNodeStorage(NodeStorage):
             cooldown=cooldown,
             tcp_keepalive=tcp_keepalive,
         )
+        self.automatic_expiry = automatic_expiry
 
     def set(self, id, data):
         self.conn.put(self.bucket, id, json_dumps(data), returnbody='false')
@@ -95,6 +97,5 @@ class RiakNodeStorage(NodeStorage):
         return results
 
     def cleanup(self, cutoff_timestamp):
-        # TODO(dcramer): we should either index timestamps or have this run
-        # a map/reduce (probably the latter)
-        raise NotImplementedError
+        if not self.automatic_expiry:
+            raise NotImplementedError

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -192,6 +192,8 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
         (models.Group, 'last_seen', 'last_seen'),
     )
 
+    skip_nodestore = False
+
     if not silent:
         click.echo('Removing expired values for LostPasswordHash')
 
@@ -235,6 +237,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
         cutoff = timezone.now() - timedelta(days=days)
         try:
             nodestore.cleanup(cutoff)
+            skip_nodestore = True
         except NotImplementedError:
             click.echo(
                 "NodeStore backend does not support cleanup operation", err=True)
@@ -264,6 +267,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
                 days=days,
                 project_id=project_id,
                 order_by=order_by,
+                skip_nodestore=skip_nodestore,
             ).execute(chunk_size=chunk_size)
 
     for model, dtfield, order_by in DELETES:


### PR DESCRIPTION
Optimize cleanup to explicitly skip deleting node objects when managed
by a larger/bulk cleanup. This makes the assumption that if
`Nodestore.cleanup()` completes successfully, we can safely skip
deleting on a per-object level.