### PR TITLE
workflow: fix various behavior with GroupSnooze

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item.jsx
@@ -125,7 +125,7 @@ const ActivityItem = React.createClass({
             {
               author: author,
               count: data.ignoreCount,
-              interval: <Duration seconds={data.ignoreWindow * 3600} />,
+              duration: <Duration seconds={data.ignoreWindow * 3600} />,
               issue: issueLink
             }
           );
@@ -141,7 +141,7 @@ const ActivityItem = React.createClass({
             {
               author: author,
               count: data.ignoreUserCount,
-              interval: <Duration seconds={data.ignoreUserWindow * 3600} />,
+              duration: <Duration seconds={data.ignoreUserWindow * 3600} />,
               issue: issueLink
             }
           );

--- a/src/sentry/static/sentry/app/views/groupActivity/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/index.jsx
@@ -73,7 +73,7 @@ const GroupActivity = React.createClass({
             {
               author: author,
               count: data.ignoreCount,
-              interval: <Duration seconds={data.ignoreWindow * 3600} />
+              duration: <Duration seconds={data.ignoreWindow * 3600} />
             }
           );
         } else if (data.ignoreCount) {
@@ -87,7 +87,7 @@ const GroupActivity = React.createClass({
             {
               author: author,
               count: data.ignoreUserCount,
-              interval: <Duration seconds={data.ignoreUserWindow * 3600} />
+              duration: <Duration seconds={data.ignoreUserWindow * 3600} />
             }
           );
         } else if (data.ignoreUserCount) {

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -129,13 +129,15 @@ class GroupSnoozeTest(TestCase):
         snooze = GroupSnooze.objects.create(
             group=self.group,
             count=100,
-            window=60,
+            window=24 * 60,
         )
-        tsdb.incr(
-            tsdb.models.group,
-            self.group.id,
-            count=100,
-        )
+        for n in range(6):
+            tsdb.incr(
+                tsdb.models.group,
+                self.group.id,
+                count=20,
+                timestamp=mock_now() - timedelta(minutes=n),
+            )
         assert not snooze.is_valid(test_rates=True)
 
     @mock.patch('django.utils.timezone.now')


### PR DESCRIPTION
- activity entry was showing wrong value for duration
- upon clearing of GroupSnooze, status was not reflected (fixes GH-5742)