### PR TITLE
Add `expected_extraction_errors` to `FeatureSet`.

### DIFF
--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -8,8 +8,9 @@ from sentry.interfaces.stacktrace import Frame
 from sentry.similarity.encoder import Encoder
 from sentry.similarity.index import MinHashIndex
 from sentry.similarity.features import (
-    FeatureSet,
     ExceptionFeature,
+    FeatureSet,
+    InterfaceDoesNotExist,
     MessageFeature,
     get_application_chunks,
 )
@@ -103,6 +104,9 @@ features = FeatureSet(
             ),
         ),
     },
+    expected_extraction_errors=(
+        InterfaceDoesNotExist,
+    ),
     expected_encoding_errors=(
         FrameEncodingError,
     ),


### PR DESCRIPTION
This doesn't have any real effect with our current logging configuration (warnings aren't logged 😬 ) but seems like a good idea to prevent foot shooting in the future.