### PR TITLE
tell users when they're using the wrong releases endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -107,6 +107,15 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
         """
         serializer = ReleaseSerializer(data=request.DATA)
 
+        if 'refs' in request.DATA:
+            return Response({
+                'refs': [
+                    'Invalid parameter. If you are trying to set '
+                    'commits for a release, see '
+                    'https://docs.sentry.io/api/releases/post-organization-releases/'
+                ]
+            }, status=400)
+
         if serializer.is_valid():
             result = serializer.object
 

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -286,3 +286,23 @@ class ProjectReleaseCreateTest(APITestCase):
         assert len(rc_list) == 2
         for rc in rc_list:
             assert rc.organization_id
+
+    def test_fails_with_refs(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project(name='foo')
+
+        url = reverse('sentry-api-0-project-releases', kwargs={
+            'organization_slug': project.organization.slug,
+            'project_slug': project.slug,
+        })
+
+        response = self.client.post(url, data={
+            'version': '1.2.1',
+            'refs': [{
+                'repository': 'getsentry/sentry',
+                'commit': 'a' * 40,
+            }],
+        })
+
+        assert response.status_code == 400


### PR DESCRIPTION
is this a good idea? i'm not really sure, but enough support requests have come in where people are just using the wrong endpoint where it seems like we should do something