### PR TITLE
Fixes for the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CPUS ?= $(shell sysctl -n hw.ncpu || echo 1)
+CPUS ?= $(shell sysctl -n hw.ncpu 2> /dev/null || echo 1)
 MAKEFLAGS += --jobs=$(CPUS)
 NPM_ROOT = ./node_modules
 STATIC_DIR = src/sentry/static/sentry

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ MAKEFLAGS += --jobs=$(CPUS)
 NPM_ROOT = ./node_modules
 STATIC_DIR = src/sentry/static/sentry
 
-develop: setup-git update-submodules install-python install-yarn
-	@echo ""
+develop-only: update-submodules install-python install-yarn
 
-develop-only: develop
+develop: setup-git develop-only
+	@echo ""
 
 install-yarn:
 	@echo "--> Installing Node dependencies"


### PR DESCRIPTION
This makes the makefile not spit out errors on linux and restores
the `develop-only` command to work for doc builds