### PR TITLE
Onboarding project polish

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/index.jsx
@@ -41,6 +41,7 @@ const OnboardingWizard = React.createClass({
       name: this.state.projectName,
       setName: n => this.setState({projectName: n})
     };
+
     return React.cloneElement(this.props.children, stepProps);
   },
 

--- a/src/sentry/static/sentry/app/views/onboarding/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/index.jsx
@@ -5,7 +5,7 @@ import {browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
 import ProgressNodes from './progress';
 import ProjectActions from '../../actions/projectActions';
-import {parseLastToken} from './utils';
+import {getPlatformName} from './utils';
 
 import Raven from 'raven-js';
 
@@ -32,9 +32,9 @@ const OnboardingWizard = React.createClass({
       setPlatform: p => {
         if (
           !this.state.projectName ||
-          parseLastToken(this.state.platform) === this.state.projectName
+          getPlatformName(this.state.platform) === this.state.projectName
         ) {
-          this.setState({projectName: parseLastToken(p)});
+          this.setState({projectName: getPlatformName(p)});
         }
         this.setState({platform: p});
       },

--- a/src/sentry/static/sentry/app/views/onboarding/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/index.jsx
@@ -5,6 +5,7 @@ import {browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
 import ProgressNodes from './progress';
 import ProjectActions from '../../actions/projectActions';
+import {parseLastToken} from './utils';
 
 import Raven from 'raven-js';
 
@@ -29,8 +30,11 @@ const OnboardingWizard = React.createClass({
       next: this.next,
       platform: this.state.platform,
       setPlatform: p => {
-        if (!this.state.projectName || this.state.platform === this.state.projectName) {
-          this.setState({projectName: p});
+        if (
+          !this.state.projectName ||
+          parseLastToken(this.state.platform) === this.state.projectName
+        ) {
+          this.setState({projectName: parseLastToken(p)});
         }
         this.setState({platform: p});
       },

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.less
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.less
@@ -249,7 +249,6 @@
 
       &.required{
         border: 1px #e03e2f solid;
-
       }
 
       input {
@@ -266,7 +265,6 @@
         &::placeholder {
           color: @50;
         }
-
       }
 
       .platform-tile {

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.less
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.less
@@ -247,6 +247,11 @@
       width: 300px;
       float: left;
 
+      &.required{
+        border: 1px #e03e2f solid;
+
+      }
+
       input {
         background: none;
         border: 0;
@@ -261,6 +266,7 @@
         &::placeholder {
           color: @50;
         }
+
       }
 
       .platform-tile {

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.less
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.less
@@ -136,10 +136,21 @@
         }
       }
     }
+
     .stuck {
-      padding: 20px;
       position: absolute;
       bottom: 0px;
+      text-align: center;
+      width: 100%;
+      padding: 20px;
+      p,a {
+        margin:0;
+        color: @40;
+      }
+
+       &:hover p,a{
+        color:@30;
+      }
     }
   }
 

--- a/src/sentry/static/sentry/app/views/onboarding/progress.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/progress.jsx
@@ -39,10 +39,10 @@ const ProgressNodes = React.createClass({
           {this.steps.map(this.node)}
         </div>
         <div className="stuck">
-          {/*
-          <p> Stuck?</p>
-          <p> Chat with a real person</p>
-        */}
+          <a href="mailto:support@sentry.io?Subject=Getting%20started">
+            <p> Stuck?</p>
+            <p> Talk to a real person</p>
+          </a>
         </div>
       </div>
     );

--- a/src/sentry/static/sentry/app/views/onboarding/progress.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/progress.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
 import {onboardingSteps, stepDescriptions} from './utils';
+import ConfigStore from '../../stores/configStore';
 
 const ProgressNodes = React.createClass({
   propTypes: {
     params: React.PropTypes.object
+  },
+
+  contextTypes: {
+    organization: React.PropTypes.object
   },
 
   steps: Object.keys(onboardingSteps),
@@ -30,6 +35,9 @@ const ProgressNodes = React.createClass({
   },
 
   render() {
+    let config = ConfigStore.getConfig();
+    let {slug} = this.context.organization;
+
     return (
       <div className="onboarding-sidebar">
         <div className="sentry-flag">
@@ -39,9 +47,14 @@ const ProgressNodes = React.createClass({
           {this.steps.map(this.node)}
         </div>
         <div className="stuck">
-          <a href="mailto:support@sentry.io?Subject=Getting%20started">
+          <a
+            href={
+              !config.isOnPremise
+                ? `/organizations/${slug}/support/`
+                : 'https://forum.sentry.io/'
+            }>
             <p> Stuck?</p>
-            <p> Talk to a real person</p>
+            <p> Ask for help</p>
           </a>
         </div>
       </div>

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -7,11 +7,11 @@ import {t} from '../../../locale';
 
 const Project = React.createClass({
   propTypes: {
-    next: React.PropTypes.func,
-    setPlatform: React.PropTypes.func,
-    platform: React.PropTypes.string,
-    setName: React.PropTypes.func,
-    name: React.PropTypes.string
+    next: React.PropTypes.func.isRequired,
+    setPlatform: React.PropTypes.func.isRequired,
+    platform: React.PropTypes.string.isRequired,
+    setName: React.PropTypes.func.isRequired,
+    name: React.PropTypes.string.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import classnames from 'classnames';
+
 import PlatformPicker from './platformpicker';
 import PlatformiconTile from './platformiconTile';
 import {t} from '../../../locale';
@@ -12,7 +14,20 @@ const Project = React.createClass({
     name: React.PropTypes.string
   },
 
+  getInitialState() {
+    return {projectRequired: false};
+  },
+
+  componentWillReceiveProps(newProps) {
+    this.setWarning(newProps.name);
+  },
+
+  setWarning(value) {
+    this.setState({projectRequired: !value});
+  },
+
   submit() {
+    this.setWarning(this.props.name);
     this.props.next();
   },
 
@@ -23,7 +38,10 @@ const Project = React.createClass({
         <PlatformPicker {...this.props} />
         <div className="project-name client-platform">
           <h4>{t('Give your project a name') + ':'}</h4>
-          <div className="project-name-wrapper">
+          <div
+            className={classnames('project-name-wrapper', {
+              required: this.state.projectRequired
+            })}>
             <PlatformiconTile platform={this.props.platform} />
             <input
               type="text"

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -28,7 +28,7 @@ const Project = React.createClass({
 
   submit() {
     this.setWarning(this.props.name);
-    this.props.next();
+    if (this.props.name) this.props.next();
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/onboarding/utils.js
+++ b/src/sentry/static/sentry/app/views/onboarding/utils.js
@@ -98,4 +98,14 @@ const stepDescriptions = {
   configure: 'Configure your application and send an event'
 };
 
-export {onboardingSteps, stepDescriptions, flattenedPlatforms, categoryLists};
+function parseLastToken(platform) {
+  return platform.split('-').pop();
+}
+
+export {
+  onboardingSteps,
+  stepDescriptions,
+  flattenedPlatforms,
+  categoryLists,
+  parseLastToken
+};

--- a/src/sentry/static/sentry/app/views/onboarding/utils.js
+++ b/src/sentry/static/sentry/app/views/onboarding/utils.js
@@ -98,8 +98,8 @@ const stepDescriptions = {
   configure: 'Configure your application and send an event'
 };
 
-function parseLastToken(platform) {
-  return platform.split('-').pop();
+function getPlatformName(platform) {
+  return flattenedPlatforms.find(({id}) => platform == id).name;
 }
 
 export {
@@ -107,5 +107,5 @@ export {
   stepDescriptions,
   flattenedPlatforms,
   categoryLists,
-  parseLastToken
+  getPlatformName
 };

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -3347,6 +3347,10 @@ ul.tag-list {
     text-shadow: 0 2px 0 rgba(0,0,0, .06);
     background: @gray; // Default BG
   }
+
+  li.go .platformicon {
+    border: 2px solid @gray;
+  }
 }
 
 .client-platform-list, .client-platform {
@@ -3410,16 +3414,9 @@ ul.tag-list {
     &.node-connect .platformicon:before { content: "\e609"; }
     &.node-koa .platformicon:before { content: "\e609"; }
 
-    &.other .platformicon:before {
-      // font-family: Menlo, Monaco, "Courier New", monospace;
-      // content: "\e60A";
-    }
-
     &.objc .platformicon,
     &.cocoa .platformicon, {
       background: @gray;
-      line-height: 54px;
-      font-size: 38px;
     }
 
     &.app-engine .platformicon {
@@ -3431,10 +3428,8 @@ ul.tag-list {
     }
 
     &.go .platformicon {
-      border: 2px solid @gray;
       color: @gray-dark;
       background: #fff;
-      line-height: 52px;
       text-shadow: none;
     }
     &.go-http .platformicon:before { content: "\e606"; }

--- a/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
@@ -1,5 +1,638 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OnboardingWizard render() should fill in project name if its empty when platform is chosen 1`] = `
+<OnboardingWizard
+  location={
+    Object {
+      "query": Object {},
+    }
+  }
+  params={
+    Object {
+      "orgId": "testOrg",
+      "projectId": "",
+    }
+  }
+>
+  <div
+    className="onboarding-container"
+  >
+    <DocumentTitle
+      title="Sentry"
+    />
+    <div
+      className="step-container"
+    >
+      <ProgressNodes
+        params={
+          Object {
+            "orgId": "testOrg",
+            "projectId": "",
+          }
+        }
+      >
+        <div
+          className="onboarding-sidebar"
+        >
+          <div
+            className="sentry-flag"
+          >
+            <span
+              className="icon-sentry-logo-full"
+              href="/"
+            />
+          </div>
+          <div
+            className="progress-nodes"
+          >
+            <div
+              className="node done"
+            >
+              <span
+                className="node done"
+              />
+              Create an organization in Sentry
+            </div>
+            <div
+              className="node active"
+            >
+              <span
+                className="node active"
+              />
+              Tell us about your project
+            </div>
+            <div
+              className="node"
+            >
+              <span
+                className="node"
+              />
+              Configure your application and send an event
+            </div>
+          </div>
+          <div
+            className="stuck"
+          >
+            <a
+              href="/organizations/testOrg/support/"
+            >
+              <p>
+                 Stuck?
+              </p>
+              <p>
+                 Ask for help
+              </p>
+            </a>
+          </div>
+        </div>
+      </ProgressNodes>
+      <div>
+        <bound renderStep>
+          <Project
+            name="another"
+            next={[Function]}
+            platform="csharp"
+            setName={[Function]}
+            setPlatform={[Function]}
+          >
+            <div
+              className="onboarding-info"
+            >
+              <h2>
+                Choose a language or framework
+              </h2>
+              <PlatformPicker
+                name="another"
+                next={[Function]}
+                platform="csharp"
+                setName={[Function]}
+                setPlatform={[Function]}
+              >
+                <div
+                  className="platform-picker"
+                >
+                  <ul
+                    className="nav nav-tabs"
+                  >
+                    <li
+                      style={
+                        Object {
+                          "float": "right",
+                          "marginRight": 0,
+                        }
+                      }
+                    >
+                      <div
+                        className="platform-filter-container"
+                      >
+                        <span
+                          className="icon icon-search"
+                        />
+                        <input
+                          className="platform-filter"
+                          label="Filter"
+                          onChange={[Function]}
+                          placeholder="Filter"
+                          type="text"
+                        />
+                      </div>
+                    </li>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className="active"
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Popular
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Frontend
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Mobile
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Backend
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            All
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                  </ul>
+                  <ul
+                    className="client-platform-list platform-tiles"
+                  >
+                    <PlatformCard
+                      className="selected"
+                      onClick={[Function]}
+                      platform="csharp"
+                    >
+                      <span
+                        className="platform-card selected"
+                      >
+                        <PlatformiconTile
+                          className="selected"
+                          onClick={[Function]}
+                          platform="csharp"
+                        >
+                          <li
+                            className="platform-tile list-unstyled csharp csharp selected"
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-csharp"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          C#
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="java"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="java"
+                        >
+                          <li
+                            className="platform-tile list-unstyled java java "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-java"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Java
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript javascript "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-javascript"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          JavaScript
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript-react"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript-react"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript-react javascript "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-javascript-react"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          React
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="node-express"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="node-express"
+                        >
+                          <li
+                            className="platform-tile list-unstyled node-express node "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-node-express"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Express
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="php-laravel"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php-laravel"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php-laravel php "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-php-laravel"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Laravel
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="php-symfony2"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php-symfony2"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php-symfony2 php "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-php-symfony2"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Symfony2
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="python-django"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python-django"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python-django python "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-python-django"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Django
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="python-flask"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python-flask"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python-flask python "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-python-flask"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Flask
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="python"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python python "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-python"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Python
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      onClick={[Function]}
+                      platform="ruby-rails"
+                    >
+                      <span
+                        className="platform-card"
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="ruby-rails"
+                        >
+                          <li
+                            className="platform-tile list-unstyled ruby-rails ruby "
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="platformicon platformicon-ruby-rails"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Rails
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                  </ul>
+                </div>
+              </PlatformPicker>
+              <div
+                className="project-name client-platform"
+              >
+                <h4>
+                  Give your project a name:
+                </h4>
+                <div
+                  className="project-name-wrapper"
+                >
+                  <PlatformiconTile
+                    platform="csharp"
+                  >
+                    <li
+                      className="platform-tile list-unstyled csharp csharp undefined"
+                    >
+                      <span
+                        className="platformicon platformicon-csharp"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <input
+                    label="Project Name"
+                    name="name"
+                    onChange={[Function]}
+                    placeholder="Project name"
+                    type="text"
+                    value="another"
+                  />
+                </div>
+                <button
+                  className="btn btn-primary pull-right"
+                  onClick={[Function]}
+                >
+                  Continue
+                </button>
+              </div>
+            </div>
+          </Project>
+        </bound renderStep>
+      </div>
+    </div>
+  </div>
+</OnboardingWizard>
+`;
+
 exports[`OnboardingWizard render() should render NotFound if no matching organization 1`] = `
 <div
   className="onboarding-container"

--- a/tests/js/spec/views/onboarding/__snapshots__/progress.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/progress.spec.jsx.snap
@@ -42,7 +42,18 @@ exports[`ProgressNodes render() should render step 0 if no projectId 1`] = `
   </div>
   <div
     className="stuck"
-  />
+  >
+    <a
+      href="mailto:support@sentry.io?Subject=Getting%20started"
+    >
+      <p>
+         Stuck?
+      </p>
+      <p>
+         Talk to a real person
+      </p>
+    </a>
+  </div>
 </div>
 `;
 
@@ -88,6 +99,17 @@ exports[`ProgressNodes render() should render step 1 if has projectId 1`] = `
   </div>
   <div
     className="stuck"
-  />
+  >
+    <a
+      href="mailto:support@sentry.io?Subject=Getting%20started"
+    >
+      <p>
+         Stuck?
+      </p>
+      <p>
+         Talk to a real person
+      </p>
+    </a>
+  </div>
 </div>
 `;

--- a/tests/js/spec/views/onboarding/__snapshots__/progress.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/progress.spec.jsx.snap
@@ -44,13 +44,13 @@ exports[`ProgressNodes render() should render step 0 if no projectId 1`] = `
     className="stuck"
   >
     <a
-      href="mailto:support@sentry.io?Subject=Getting%20started"
+      href="/organizations/testOrg/support/"
     >
       <p>
          Stuck?
       </p>
       <p>
-         Talk to a real person
+         Ask for help
       </p>
     </a>
   </div>
@@ -101,13 +101,13 @@ exports[`ProgressNodes render() should render step 1 if has projectId 1`] = `
     className="stuck"
   >
     <a
-      href="mailto:support@sentry.io?Subject=Getting%20started"
+      href="/organizations/testOrg/support/"
     >
       <p>
          Stuck?
       </p>
       <p>
-         Talk to a real person
+         Ask for help
       </p>
     </a>
   </div>

--- a/tests/js/spec/views/onboarding/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/index.spec.jsx
@@ -66,19 +66,17 @@ describe('OnboardingWizard', function() {
 
       let node = wrapper.find('PlatformCard').first();
       node.props().onClick();
-      node.simulate('click');
       expect(wrapper.state().projectName).toBe('C#');
 
       node = wrapper.find('PlatformCard').last();
       node.props().onClick();
-      node.simulate('click');
       expect(wrapper.state().projectName).toBe('Rails');
 
-      wrapper.setState({projectName: 'another'});
       //but not replace it when project name is something else:
+      wrapper.setState({projectName: 'another'});
+
       node = wrapper.find('PlatformCard').first();
       node.props().onClick();
-      node.simulate('click');
       expect(wrapper.state().projectName).toBe('another');
 
       expect(toJson(wrapper)).toMatchSnapshot();

--- a/tests/js/spec/views/onboarding/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/index.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import {Client} from 'app/api';
 import OnboardingWizard from 'app/views/onboarding/';
+import Project from 'app/views/onboarding/project';
 
 describe('OnboardingWizard', function() {
   beforeEach(function() {
@@ -35,6 +36,51 @@ describe('OnboardingWizard', function() {
       let wrapper = shallow(<OnboardingWizard {...props} />, {
         organization: {id: '1337', slug: 'testOrg'}
       });
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should fill in project name if its empty when platform is chosen', function() {
+      let props = {
+        ...baseProps,
+        children: (
+          <Project
+            next={jest.fn()}
+            platform={''}
+            setName={jest.fn()}
+            name={''}
+            setPlatform={jest.fn()}
+          />
+        )
+      };
+
+      let wrapper = mount(<OnboardingWizard {...props} />, {
+        context: {
+          organization: {id: '1337', slug: 'testOrg'},
+          router: TestStubs.router()
+        },
+        childContextTypes: {
+          router: React.PropTypes.object,
+          organization: React.PropTypes.object
+        }
+      });
+
+      let node = wrapper.find('PlatformCard').first();
+      node.props().onClick();
+      node.simulate('click');
+      expect(wrapper.state().projectName).toBe('C#');
+
+      node = wrapper.find('PlatformCard').last();
+      node.props().onClick();
+      node.simulate('click');
+      expect(wrapper.state().projectName).toBe('Rails');
+
+      wrapper.setState({projectName: 'another'});
+      //but not replace it when project name is something else:
+      node = wrapper.find('PlatformCard').first();
+      node.props().onClick();
+      node.simulate('click');
+      expect(wrapper.state().projectName).toBe('another');
+
       expect(toJson(wrapper)).toMatchSnapshot();
     });
   });

--- a/tests/js/spec/views/onboarding/progress.spec.jsx
+++ b/tests/js/spec/views/onboarding/progress.spec.jsx
@@ -12,8 +12,14 @@ describe('ProgressNodes', function() {
       }
     };
 
+    const baseContext = {
+      context: {
+        organization: {id: '1337', slug: 'testOrg'}
+      }
+    };
+
     it('should render step 0 if no projectId', function() {
-      let wrapper = shallow(<ProgressNodes {...baseProps} />);
+      let wrapper = shallow(<ProgressNodes {...baseProps} />, baseContext);
 
       expect(wrapper.find('.node')).toHaveLength(6);
       expect(wrapper.find('.active')).toHaveLength(2);
@@ -34,7 +40,7 @@ describe('ProgressNodes', function() {
         }
       };
 
-      let wrapper = shallow(<ProgressNodes {...props} />);
+      let wrapper = shallow(<ProgressNodes {...props} />, baseContext);
 
       expect(wrapper.find('.node')).toHaveLength(6);
       expect(wrapper.find('.active')).toHaveLength(2);

--- a/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
@@ -13,11 +13,15 @@ exports[`Project render() should render NotFound if no matching organization 1`]
         "query": Object {},
       }
     }
+    name=""
+    next={[Function]}
     params={
       Object {
         "orgId": "my-cool-org",
       }
     }
+    platform=""
+    setName={[Function]}
     setPlatform={[Function]}
   />
   <div
@@ -29,13 +33,16 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     <div
       className="project-name-wrapper"
     >
-      <PlatformiconTile />
+      <PlatformiconTile
+        platform=""
+      />
       <input
         label="Project Name"
         name="name"
         onChange={[Function]}
         placeholder="Project name"
         type="text"
+        value=""
       />
     </div>
     <button
@@ -46,4 +53,567 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     </button>
   </div>
 </div>
+`;
+
+exports[`Project render() should set required class on empty submit 1`] = `
+<Project
+  location={
+    Object {
+      "query": Object {},
+    }
+  }
+  name="bar"
+  next={[Function]}
+  params={
+    Object {
+      "orgId": "testOrg",
+      "projectId": "",
+    }
+  }
+  platform=""
+  setName={[Function]}
+  setPlatform={[Function]}
+>
+  <div
+    className="onboarding-info"
+  >
+    <h2>
+      Choose a language or framework
+    </h2>
+    <PlatformPicker
+      location={
+        Object {
+          "query": Object {},
+        }
+      }
+      name="bar"
+      next={[Function]}
+      params={
+        Object {
+          "orgId": "testOrg",
+          "projectId": "",
+        }
+      }
+      platform=""
+      setName={[Function]}
+      setPlatform={[Function]}
+    >
+      <div
+        className="platform-picker"
+      >
+        <ul
+          className="nav nav-tabs"
+        >
+          <li
+            style={
+              Object {
+                "float": "right",
+                "marginRight": 0,
+              }
+            }
+          >
+            <div
+              className="platform-filter-container"
+            >
+              <span
+                className="icon icon-search"
+              />
+              <input
+                className="platform-filter"
+                label="Filter"
+                onChange={[Function]}
+                placeholder="Filter"
+                type="text"
+              />
+            </div>
+          </li>
+          <ListLink
+            activeClassName="active"
+            index={false}
+            isActive={[Function]}
+            onClick={[Function]}
+            to=""
+          >
+            <li
+              className="active"
+            >
+              <Link
+                onClick={[Function]}
+                onlyActiveOnIndex={false}
+                style={Object {}}
+                to=""
+              >
+                <a
+                  onClick={[Function]}
+                  style={Object {}}
+                >
+                  Popular
+                </a>
+              </Link>
+            </li>
+          </ListLink>
+          <ListLink
+            activeClassName="active"
+            index={false}
+            isActive={[Function]}
+            onClick={[Function]}
+            to=""
+          >
+            <li
+              className=""
+            >
+              <Link
+                onClick={[Function]}
+                onlyActiveOnIndex={false}
+                style={Object {}}
+                to=""
+              >
+                <a
+                  onClick={[Function]}
+                  style={Object {}}
+                >
+                  Frontend
+                </a>
+              </Link>
+            </li>
+          </ListLink>
+          <ListLink
+            activeClassName="active"
+            index={false}
+            isActive={[Function]}
+            onClick={[Function]}
+            to=""
+          >
+            <li
+              className=""
+            >
+              <Link
+                onClick={[Function]}
+                onlyActiveOnIndex={false}
+                style={Object {}}
+                to=""
+              >
+                <a
+                  onClick={[Function]}
+                  style={Object {}}
+                >
+                  Mobile
+                </a>
+              </Link>
+            </li>
+          </ListLink>
+          <ListLink
+            activeClassName="active"
+            index={false}
+            isActive={[Function]}
+            onClick={[Function]}
+            to=""
+          >
+            <li
+              className=""
+            >
+              <Link
+                onClick={[Function]}
+                onlyActiveOnIndex={false}
+                style={Object {}}
+                to=""
+              >
+                <a
+                  onClick={[Function]}
+                  style={Object {}}
+                >
+                  Backend
+                </a>
+              </Link>
+            </li>
+          </ListLink>
+          <ListLink
+            activeClassName="active"
+            index={false}
+            isActive={[Function]}
+            onClick={[Function]}
+            to=""
+          >
+            <li
+              className=""
+            >
+              <Link
+                onClick={[Function]}
+                onlyActiveOnIndex={false}
+                style={Object {}}
+                to=""
+              >
+                <a
+                  onClick={[Function]}
+                  style={Object {}}
+                >
+                  All
+                </a>
+              </Link>
+            </li>
+          </ListLink>
+        </ul>
+        <ul
+          className="client-platform-list platform-tiles"
+        >
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="csharp"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="csharp"
+              >
+                <li
+                  className="platform-tile list-unstyled csharp csharp "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-csharp"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                C#
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="java"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="java"
+              >
+                <li
+                  className="platform-tile list-unstyled java java "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-java"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Java
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="javascript"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="javascript"
+              >
+                <li
+                  className="platform-tile list-unstyled javascript javascript "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-javascript"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                JavaScript
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="javascript-react"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="javascript-react"
+              >
+                <li
+                  className="platform-tile list-unstyled javascript-react javascript "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-javascript-react"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                React
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="node-express"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="node-express"
+              >
+                <li
+                  className="platform-tile list-unstyled node-express node "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-node-express"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Express
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="php-laravel"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="php-laravel"
+              >
+                <li
+                  className="platform-tile list-unstyled php-laravel php "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-php-laravel"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Laravel
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="php-symfony2"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="php-symfony2"
+              >
+                <li
+                  className="platform-tile list-unstyled php-symfony2 php "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-php-symfony2"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Symfony2
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="python-django"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="python-django"
+              >
+                <li
+                  className="platform-tile list-unstyled python-django python "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-python-django"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Django
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="python-flask"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="python-flask"
+              >
+                <li
+                  className="platform-tile list-unstyled python-flask python "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-python-flask"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Flask
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="python"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="python"
+              >
+                <li
+                  className="platform-tile list-unstyled python python "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-python"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Python
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            onClick={[Function]}
+            platform="ruby-rails"
+          >
+            <span
+              className="platform-card"
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="ruby-rails"
+              >
+                <li
+                  className="platform-tile list-unstyled ruby-rails ruby "
+                  onClick={[Function]}
+                >
+                  <span
+                    className="platformicon platformicon-ruby-rails"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Rails
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+        </ul>
+      </div>
+    </PlatformPicker>
+    <div
+      className="project-name client-platform"
+    >
+      <h4>
+        Give your project a name:
+      </h4>
+      <div
+        className="project-name-wrapper"
+      >
+        <PlatformiconTile
+          platform=""
+        >
+          <li
+            className="platform-tile list-unstyled   undefined"
+          >
+            <span
+              className="platformicon platformicon-"
+            />
+          </li>
+        </PlatformiconTile>
+        <input
+          label="Project Name"
+          name="name"
+          onChange={[Function]}
+          placeholder="Project name"
+          type="text"
+          value="bar"
+        />
+      </div>
+      <button
+        className="btn btn-primary pull-right"
+        onClick={[Function]}
+      >
+        Continue
+      </button>
+    </div>
+  </div>
+</Project>
 `;

--- a/tests/js/spec/views/onboarding/project/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/project/index.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import {Client} from 'app/api';
@@ -17,8 +17,12 @@ describe('Project', function() {
 
   describe('render()', function() {
     const baseProps = {
+      next: jest.fn(),
+      platform: '',
+      setName: jest.fn(),
+      name: '',
+      setPlatform: jest.fn(),
       location: {query: {}},
-      setPlatform: () => {},
       params: {
         projectId: '',
         orgId: 'testOrg'
@@ -36,6 +40,33 @@ describe('Project', function() {
       let wrapper = shallow(<Project {...props} />, {
         organization: {id: '1337', slug: 'testOrg'}
       });
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should set required class on empty submit', function() {
+      let props = {
+        ...baseProps
+      };
+
+      let wrapper = mount(<Project {...props} />, {
+        context: {
+          organization: {id: '1337', slug: 'testOrg'},
+          router: TestStubs.router()
+        },
+        childContextTypes: {
+          router: React.PropTypes.object,
+          organization: React.PropTypes.object
+        }
+      });
+
+      let submit = wrapper.find('button').last();
+      expect(wrapper.state().projectRequired).toBe(false);
+      submit.simulate('click');
+      expect(wrapper.state().projectRequired).toBe(true);
+      wrapper.setProps({name: 'bar'});
+      submit.simulate('click');
+      expect(wrapper.state().projectRequired).toBe(false);
+
       expect(toJson(wrapper)).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
the setPlatform logic is complicated enough it should probably have better testing 

PR does four things: 
- adds           <a href="mailto:support@sentry.io?Subject=Getting%20started"> to on boarding sidebar 

- indicates that project name is missing before submit

- fills in 'flask' instead of 'python-flask' as the project name

- fixes some weird platformicon issues with cocoa and go