### PR TITLE
Turn off automatic redirect if first event sent

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
@@ -51,18 +51,25 @@ const Configure = React.createClass({
       success: data => {
         let {isFirst, hasSent} = this.state;
 
-        // this indicates that a real event has been sent to the project (the first one is the sample event)
-        let sentEvent = data.length > 1;
+        // this indicates that a real event has been sent to the project
+        var sentEvent = function() {
+          if (data.length == 1) {
+            let firstError = data[0];
+            return !firstError.message.includes('This is an example');
+          } else {
+            return data.length > 1;
+          }
+        };
 
         if (isFirst) {
           // record sentEvent value of first poll to avoid redirecting when someone has already sent an event
           this.setState({
             isFirst: false,
-            hasSent: sentEvent
+            hasSent: sentEvent()
           });
         } else {
           // if sentEvent changes from false to true then redirect
-          if (!hasSent && sentEvent) {
+          if (!hasSent && sentEvent()) {
             this.redirectUrl();
           }
         }

--- a/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
@@ -52,7 +52,7 @@ const Configure = React.createClass({
         let {isFirst, hasSent} = this.state;
 
         // this indicates that a real event has been sent to the project
-        var sentEvent = function() {
+        let sentEvent = function() {
           if (data.length == 1) {
             let firstError = data[0];
             return !firstError.message.includes('This is an example');

--- a/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
@@ -7,8 +7,17 @@ import ProjectContext from '../../projects/projectContext';
 import ProjectDocsContext from '../../projectInstall/docsContext';
 import ProjectInstallPlatform from '../../projectInstall/platform';
 
+import Raven from 'raven-js';
+
 const Configure = React.createClass({
   mixins: [ApiMixin],
+
+  getInitialState() {
+    return {
+      isFirst: true,
+      hasSent: false
+    };
+  },
 
   componentWillMount() {
     let {platform} = this.props.params;
@@ -16,9 +25,8 @@ const Configure = React.createClass({
     if (!platform || platform === 'other') {
       this.redirectToNeutralDocs();
     }
-  },
 
-  componentDidMount() {
+    this.fetchEventData();
     this.timer = setInterval(() => {
       this.fetchEventData();
     }, 2000);
@@ -41,13 +49,29 @@ const Configure = React.createClass({
     this.api.request(`/projects/${orgId}/${projectId}/events/`, {
       method: 'GET',
       success: data => {
+        let {isFirst, hasSent} = this.state;
+
         // this indicates that a real event has been sent to the project (the first one is the sample event)
-        if (data.length > 1) {
-          this.redirectUrl();
+        let sentEvent = data.length > 1;
+
+        if (isFirst) {
+          // record sentEvent value of first poll to avoid redirecting when someone has already sent an event
+          this.setState({
+            isFirst: false,
+            hasSent: sentEvent
+          });
+        } else {
+          // if sentEvent changes from false to true then redirect
+          if (!hasSent && sentEvent) {
+            this.redirectUrl();
+          }
         }
       },
-      error: () => {
-        this.setState({hasError: true});
+
+      error: err => {
+        Raven.captureMessage('Polling for events in onboarding configure failed', {
+          extra: err
+        });
       }
     });
   },
@@ -82,7 +106,7 @@ const Configure = React.createClass({
               />
             </ProjectDocsContext>
           </ProjectContext>
-          <Waiting skip={this.submit} />
+          <Waiting skip={this.submit} hasEvent={this.state.hasSent} />
         </div>
       </div>
     );

--- a/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
@@ -55,22 +55,6 @@ const Configure = React.createClass({
     }
   },
 
-  checkPollEventData(data) {
-    let {isFirstTimePolling} = this.state;
-
-    if (isFirstTimePolling) {
-      // record sentEvent value of first poll to avoid redirecting when someone has already sent an event
-      this.setState({
-        isFirstTimePolling: false,
-        hasSentRealEvent: this.sentRealEvent(data)
-      });
-    } else {
-      this.setState({
-        hasSentRealEvent: this.sentRealEvent(data)
-      });
-    }
-  },
-
   redirectUrl() {
     let {orgId, projectId} = this.props.params;
 
@@ -84,7 +68,10 @@ const Configure = React.createClass({
     this.api.request(`/projects/${orgId}/${projectId}/events/`, {
       method: 'GET',
       success: data => {
-        this.checkPollEventData(data);
+        this.setState({
+          isFirstTimePolling: false,
+          hasSentRealEvent: this.sentRealEvent(data)
+        });
       },
 
       error: err => {

--- a/src/sentry/static/sentry/app/views/onboarding/configure/waiting.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/configure/waiting.jsx
@@ -3,7 +3,8 @@ import {t} from '../../../locale';
 
 const Waiting = React.createClass({
   propTypes: {
-    skip: React.PropTypes.func
+    skip: React.PropTypes.func,
+    hasEvent: React.PropTypes.bool.isRequired
   },
 
   render() {
@@ -15,7 +16,9 @@ const Waiting = React.createClass({
           </div>
         </div>
         <div className="wrap waiting-text">
-          <h3 className="animated-ellipsis">{t('Waiting to receive an error')}</h3>
+          {!this.props.hasEvent
+            ? <h3 className="animated-ellipsis">{t('Waiting to receive an error')}</h3>
+            : <h3>{t("You've successfully sent an error")}</h3>}
           <div className="robot">
             <span className="eye" />
           </div>

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -42,6 +42,7 @@ exports[`Configure should render correctly render() should redirect to if no mat
       </ProjectDocsContext>
     </ProjectContext>
     <Waiting
+      hasEvent={false}
       skip={[Function]}
     />
   </div>
@@ -101,6 +102,7 @@ exports[`Configure should render correctly render() should render platform docs 
         </DocumentTitle>
       </ProjectContext>
       <Waiting
+        hasEvent={false}
         skip={[Function]}
       >
         <div
@@ -181,6 +183,7 @@ exports[`Configure should render correctly render() shouldn't redirect for a fou
       </ProjectDocsContext>
     </ProjectContext>
     <Waiting
+      hasEvent={false}
       skip={[Function]}
     />
   </div>

--- a/tests/js/spec/views/onboarding/configure/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/configure/index.spec.jsx
@@ -106,7 +106,7 @@ describe('Configure should render correctly', function() {
         childContextTypes: {organization: PropTypes.Organization}
       });
       expect(wrapper).toMatchSnapshot();
-      expect(this.stubbedApiRequest.callCount).toEqual(4);
+      expect(this.stubbedApiRequest.callCount).toEqual(5);
     });
   });
 });


### PR DESCRIPTION
The config page includes a function that continuously checks whether the user has sent their first event. If they have, it redirects them out of the page. The goal of this PR is to only redirect if they just sent their FE and not if they are revisiting the page.

Parallel PR that has users manually [trigger a sample event](https://github.com/getsentry/sentry/pull/5808) means this PR needs tweaking.