### PR TITLE
Bump docs to force the doc-hook to bump the sentry module

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,10 +2,10 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
-BUILDDIR      = ./_build
+SPHINXOPTS  =
+SPHINXBUILD = sphinx-build
+PAPER       =
+BUILDDIR    = ./_build
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4


### PR DESCRIPTION
Builds are currently failing for sentry-docs. This is due to the sentry-doc-hook selecting a merge commit with a `/docs` change that is ancestrally older than the recent fix by @mitsuhiko for building docs.

### Timeline / Investigation

1. sentry-docs began failing after a change to the Makefile causing the Makefile `git-hooks` target to be execute in the sentry-docs doc-modules/sentry submodule.

2. This was fixed in https://github.com/getsentry/sentry/commit/b716b9e96a1245bb6290b45454c602d431ecd5eb and the subsequently the module was bumped https://github.com/getsentry/sentry-docs/commit/fd3dbb4ccf060d42d22697caf29d0d84252094d9 (note the commit message is slightly incorrect here, this is for bumping the `sentry` module).

3. Documentation builds working until https://github.com/getsentry/sentry/pull/4931 is merged in.

   The merge of this branch triggers the doc-hook and the sentry module in sentry-docs is bumped to 91b45b1da1f1fbc021203844b6adb91cb9cbe23e here: https://github.com/getsentry/sentry-docs/commit/20d0f777f373d7386f5c8795b374d36a0194d8a2

   Looking closer at this merge commit we can see ancestrally it occurs before @mitsuhiko's fix to the makefile, thus builds start failing again.

   Why does this happen?

   The sentry-doc-hook is unfortunately closed source currently, however the way it decides when to update a submodule commit is based on the JSON received from GitHub when a change happens to master. it will look through commits and their files changed, if any commit changes an item in `/docs` it will consider that commit to be the new module commit. Because the merge commit mentioned earlier merged master into the feature branch it looked as though this commit actually changed docs (as there was a doc change in master).

   For those with permissions, you can [see this logic here](https://github.com/getsentry/sentry-doc-hook/blob/master/dochook.py#L118-L123).

   We'll likely have to address the doc-hook script to *not* consider merge commits.

4. This commit makes a small stylistic change to the `docs/Makefile` and should cause the docs-hook to trigger and bump to this commit, which has @mitsuhiko's fix.