### PR TITLE
make sure github apps won't be shown in repo dropdown, correct api param on frontend

### DIFF
--- a/src/sentry/api/endpoints/organization_config_repositories.py
+++ b/src/sentry/api/endpoints/organization_config_repositories.py
@@ -7,19 +7,22 @@ from sentry.plugins import bindings
 
 
 class OrganizationConfigRepositoriesEndpoint(OrganizationEndpoint):
+
     def get(self, request, organization):
         provider_bindings = bindings.get('repository.provider')
 
         providers = []
         for provider_id in provider_bindings:
             provider = provider_bindings.get(provider_id)(id=provider_id)
-            providers.append(
-                {
-                    'id': provider_id,
-                    'name': provider.name,
-                    'config': provider.get_config(),
-                }
-            )
+            # TODO(jess): figure out better way to exclude this
+            if provider_id != 'github_apps':
+                providers.append(
+                    {
+                        'id': provider_id,
+                        'name': provider.name,
+                        'config': provider.get_config(),
+                    }
+                )
 
         return Response({
             'providers': providers,

--- a/src/sentry/static/sentry/app/views/organizationIntegrations.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations.jsx
@@ -45,7 +45,7 @@ const OrganizationIntegrations = React.createClass({
     this.api.request(`/organizations/${this.props.params.orgId}/integrations/`, {
       method: 'POST',
       data: {
-        providerId,
+        provider: providerId,
         defaultAuthId: auth.defaultAuthId,
         integrationId: auth.integrationId
       },


### PR DESCRIPTION
- this prevents github apps from being shown as a repo provider (that would only happen once https://github.com/getsentry/sentry-plugins/pull/188 is merged)
- fixes incorrect `providerId` param 