### PR TITLE
Add test suite that requires network.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=network DB=postgres
       services:
+        - memcached
+        - redis-server
         - postgresql
     - python: 2.7
       env: TEST_SUITE=mysql DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,10 @@ matrix:
         - redis-server
         - postgresql
     - python: 2.7
+      env: TEST_SUITE=network DB=postgres
+      services:
+        - postgresql
+    - python: 2.7
       env: TEST_SUITE=mysql DB=mysql
       services:
         - memcached

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ travis-lint-sqlite: lint-python
 travis-lint-postgres: lint-python
 travis-lint-mysql: lint-python
 travis-lint-acceptance: travis-noop
+travis-lint-network: lint-python
 travis-lint-js: lint-js
 travis-lint-cli: travis-noop
 travis-lint-dist: travis-noop

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ travis-install-mysql: travis-install-python
 	pip install mysqlclient
 	echo 'create database sentry;' | mysql -uroot
 travis-install-acceptance: install-yarn travis-install-postgres
+travis-install-network: travis-install-postgres
 travis-install-js:
 	$(MAKE) travis-upgrade-pip
 	$(MAKE) install-python install-yarn

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ test-python:
 
 test-network:
 	@echo "--> Building platform assets"
- 	sentry init
+	sentry init
 	@echo "from sentry.utils.integrationdocs import sync_docs; sync_docs()" | sentry exec
 	@echo "--> Running network tests"
 	py.test tests/network

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,14 @@ test-python:
 	py.test tests/integration tests/sentry || exit 1
 	@echo ""
 
+test-network:
+	@echo "--> Building platform assets"
+ 	sentry init
+	@echo "from sentry.utils.integrationdocs import sync_docs; sync_docs()" | sentry exec
+	@echo "--> Running network tests"
+	py.test tests/network
+	@echo ""
+
 test-acceptance:
 	@echo "--> Building static assets"
 	@${NPM_ROOT}/.bin/webpack
@@ -217,6 +225,7 @@ travis-test-sqlite: test-python-coverage
 travis-test-postgres: test-python-coverage
 travis-test-mysql: test-python-coverage
 travis-test-acceptance: test-acceptance
+travis-test-network: test-network
 travis-test-js: test-js
 travis-test-cli: test-cli
 travis-test-dist:

--- a/tests/network/test_thing.py
+++ b/tests/network/test_thing.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+from sentry.constants import INTEGRATION_ID_TO_PLATFORM_DATA
+from sentry.testutils import TestCase
+
+
+class ThingTest(TestCase):
+    def test_thing(self):
+        assert len(INTEGRATION_ID_TO_PLATFORM_DATA) > 0


### PR DESCRIPTION
@dcramer and @mattrobenolt we discussed testing the code that requires `_platform.json` a few weeks ago.

I solved my issues by mocking, but as @ehfeng and @MaxBittker have started using the platform data more, they say they need to do more complex tests that expect a lot of the platform data to be there, and they don't want to mock the entire dataset.

So this adds a `network` test suite that requires networking (it syncs the docs). This OK with you guys?