### PR TITLE
Introduce purple badge for emails that include sample events

### DIFF
--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -442,6 +442,7 @@
   .level-warning { background-color: #ECD744; }
   .level-error { background-color: #ec5e44; }
   .level-fatal { background-color: #e03e2f; }
+  .level-sample { background-color: #6C5FC7; }
   .event .count .span {
     position: absolute;
     left: 0;


### PR DESCRIPTION
<img width="746" alt="screen shot 2017-08-04 at 2 41 57 pm" src="https://user-images.githubusercontent.com/30713/28988110-2c3e6ef6-7923-11e7-8ff8-bef5b97c97c5.png">

@getsentry/growth 