### PR TITLE
add message scrubbing to data scrubber

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Version 8.20 (Unreleased)
 -------------------------
 
+- Let data scrubbers also work on issue messages
+
 Version 8.19
 ------------
 

--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -73,6 +73,12 @@ class SensitiveDataFilter(object):
 
     def apply(self, data):
         # TODO(dcramer): move this into each interface
+        if 'sentry.interfaces.Message' in data:
+            self.filter_message(data['sentry.interfaces.Message'])
+
+        if 'message' in data:
+            self.filter_message(data)
+
         if 'sentry.interfaces.Stacktrace' in data:
             self.filter_stacktrace(data['sentry.interfaces.Stacktrace'])
 
@@ -131,6 +137,16 @@ class SensitiveDataFilter(object):
             if field in key and value not in NOT_SCRUBBED_VALUES:
                 return FILTER_MASK
         return value
+
+    def filter_message(self, data):
+        for property in ['message', 'formatted']:
+            if property not in data:
+                continue
+            data[property] = self.sanitize(property, data[property])
+        for property in ['params']:
+            if property not in data:
+                continue
+            data[property] = varmap(self.sanitize, data[property])
 
     def filter_stacktrace(self, data):
         if 'frames' not in data:

--- a/tests/sentry/utils/test_data_scrubber.py
+++ b/tests/sentry/utils/test_data_scrubber.py
@@ -60,6 +60,45 @@ class SensitiveDataFilterTest(TestCase):
         assert 'apiKey' in vars
         assert vars['apiKey'] == FILTER_MASK
 
+    def test_message(self):
+        data = {
+            'message':
+            'something happened when calling https://ab:cd@foobar.com, credit card number %s',
+            'params': ['4111111111111111'],
+            'formatted':
+            'something happened when calling https://ab:cd@foobar.com, credit card number 4111111111111111',
+            'sentry.interfaces.Message': {
+                'message':
+                'something happened when calling https://ab:cd@foobar.com, credit card number %s',
+                'params': ['4111111111111111'],
+                'formatted':
+                'something happened when calling https://ab:cd@foobar.com, credit card number 4111111111111111'
+            }
+        }
+
+        proc = SensitiveDataFilter()
+        proc.apply(data)
+
+        assert 'message' in data
+        assert data[
+            'message'
+        ] == 'something happened when calling https://ab:[Filtered]@foobar.com, credit card number %s'
+        assert 'params' in data
+        assert data['params'] == ['[Filtered]']
+        assert 'formatted' in data
+        assert data['formatted'] == '[Filtered]'
+        assert 'sentry.interfaces.Message' in data
+
+        interface_msg = data['sentry.interfaces.Message']
+        assert 'message' in interface_msg
+        assert interface_msg[
+            'message'
+        ] == 'something happened when calling https://ab:[Filtered]@foobar.com, credit card number %s'
+        assert 'params' in interface_msg
+        assert interface_msg['params'] == ['[Filtered]']
+        assert 'formatted' in interface_msg
+        assert interface_msg['formatted'] == '[Filtered]'
+
     def test_stacktrace(self):
         data = {
             'sentry.interfaces.Stacktrace': {


### PR DESCRIPTION
Our application includes URLs in error messages. These URLs sometimes include http basic auth credentials. Therefore it would be nice to allow the data scrubber to filter out the password in these cases.

In order to approach this generically, I have extended the existing data scrubber analogously to existing implementation.

I grepguessed the fields that probably need to be touched, feel free to point me to documentation if I didn't get it right.

If this is not pythonesque or sentryesque, feel free to criticise accordingly, I'm all ears.