### PR TITLE
deps: pin responses to <0.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ tests_require = [
     'pytest-timeout>=0.5.0,<0.6.0',
     'pytest-xdist>=1.11.0,<1.12.0',
     'python-coveralls',
-    'responses',
+    'responses<0.6.2',  # 0.6.2 has a bug that causes our tests to fail.
 ]
 
 install_requires = [


### PR DESCRIPTION
I'm not sure what exactly is wrong, but responses got bumped to 0.6.2 and some of our tests on master are failing now because it seems they're not being stubbed correctly. Or at least some change in behavior.