### PR TITLE
extend project platform retention to 90 days

### DIFF
--- a/src/sentry/tasks/collect_project_platforms.py
+++ b/src/sentry/tasks/collect_project_platforms.py
@@ -39,5 +39,5 @@ def collect_project_platforms(**kwargs):
 
     # remove (likely) unused platform associations
     ProjectPlatform.objects.filter(
-        last_seen__lte=now - timedelta(days=30),
+        last_seen__lte=now - timedelta(days=90),
     ).delete()


### PR DESCRIPTION
The table doesn't seem to be very large today and extending it to 90 days would give us valuable historical context (roughly when a churned customer uninstalled us from a given project).

Ideally, we'd make this unlimited, but 90 days should cover the vast majority of the business needs.