### PR TITLE
adding email query to org member api

### DIFF
--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from sentry.api.bases.organization import (OrganizationEndpoint, OrganizationPermission)
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import OrganizationMember, User
+from sentry.models import OrganizationMember
 from sentry.search.utils import tokenize_query
 
 
@@ -34,7 +34,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             for key, value in six.iteritems(tokens):
                 if key == 'email':
                     queryset = queryset.filter(
-                        user_id__in=User.objects.filter(email__in=value).values('id')
+                        Q(user__email__in=value) | Q(user__emails__email__in=value)
                     )
 
         return self.paginate(

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -370,6 +370,17 @@ class Fixtures(object):
 
         return user
 
+    def create_useremail(self, user, email, **kwargs):
+        if not email:
+            email = uuid4().hex + '@example.com'
+
+        kwargs.setdefault('is_verified', True)
+
+        useremail = UserEmail(user=user, email=email, **kwargs)
+        useremail.save()
+
+        return useremail
+
     def create_event(self, event_id=None, **kwargs):
         if event_id is None:
             event_id = uuid4().hex

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -16,14 +16,14 @@ class OrganizationMemberListTest(APITestCase):
 
         self.login_as(user=self.user_1)
 
-    def test_simple(self):
-        url = reverse(
+        self.url = reverse(
             'sentry-api-0-organization-member-index', kwargs={
                 'organization_slug': self.org.slug,
             }
         )
 
-        response = self.client.get(url)
+    def test_simple(self):
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert len(response.data) == 2
@@ -31,13 +31,15 @@ class OrganizationMemberListTest(APITestCase):
         assert response.data[1]['email'] == self.user_1.email
 
     def test_email_query(self):
-        url = reverse(
-            'sentry-api-0-organization-member-index', kwargs={
-                'organization_slug': self.org.slug,
-            }
-        )
+        response = self.client.get(self.url + "?query=email:foo@localhost")
 
-        response = self.client.get(url + "?query=email:foo@localhost")
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]['email'] == self.user_1.email
+
+    def test_user_email_email_query(self):
+        self.create_useremail(self.user_1, 'baz@localhost')
+        response = self.client.get(self.url + "?query=email:baz@localhost")
 
         assert response.status_code == 200
         assert len(response.data) == 1

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -6,19 +6,20 @@ from sentry.testutils import APITestCase
 
 
 class OrganizationMemberListTest(APITestCase):
-    def test_simple(self):
-        user_1 = self.create_user('foo@localhost', username='foo')
-        user_2 = self.create_user('bar@localhost', username='bar')
+    def setUp(self):
+        self.user_1 = self.create_user('foo@localhost', username='foo')
+        self.user_2 = self.create_user('bar@localhost', username='bar')
         self.create_user('baz@localhost', username='baz')
 
-        org = self.create_organization(owner=user_1)
-        org.member_set.create(user=user_2)
+        self.org = self.create_organization(owner=self.user_1)
+        self.org.member_set.create(user=self.user_2)
 
-        self.login_as(user=user_1)
+        self.login_as(user=self.user_1)
 
+    def test_simple(self):
         url = reverse(
             'sentry-api-0-organization-member-index', kwargs={
-                'organization_slug': org.slug,
+                'organization_slug': self.org.slug,
             }
         )
 
@@ -26,5 +27,18 @@ class OrganizationMemberListTest(APITestCase):
 
         assert response.status_code == 200
         assert len(response.data) == 2
-        assert response.data[0]['email'] == user_2.email
-        assert response.data[1]['email'] == user_1.email
+        assert response.data[0]['email'] == self.user_2.email
+        assert response.data[1]['email'] == self.user_1.email
+
+    def test_email_query(self):
+        url = reverse(
+            'sentry-api-0-organization-member-index', kwargs={
+                'organization_slug': self.org.slug,
+            }
+        )
+
+        response = self.client.get(url + "?query=email:foo@localhost")
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]['email'] == self.user_1.email


### PR DESCRIPTION
Working with @mikellykels on Zendesk Widget data. She needs to ability to get the role for a specific email address for a specific organization.

Adding support for `?query=email:eric@sentry.io` to the `/api/0/organization/<org_slug>/members/` endpoint.