### PR TITLE
javascript: ignore querystrings when looking up artifacts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Version 8.21 (Unreleased)
 -------------------------
 
+- Ignore querystrings when looking up release artifacts
+
 Version 8.20
 ------------
 - Make BitBucket repositories enabled by default

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -9,6 +9,7 @@ sentry.models.releasefile
 from __future__ import absolute_import
 
 from django.db import models
+from six.moves.urllib.parse import urlsplit, urlunsplit
 
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
 from sentry.utils.hashlib import sha1_text
@@ -59,3 +60,25 @@ class ReleaseFile(Model):
         if dist is not None:
             return sha1_text(name + '\x00\x00' + dist).hexdigest()
         return sha1_text(name).hexdigest()
+
+    @classmethod
+    def normalize(cls, url):
+        """Transforms a full absolute url into 2 or 4 generalized options
+
+        * the original url as input
+        * (optional) original url without querystring
+        * the full url, but stripped of scheme and netloc
+        * (optional) full url without scheme and netloc or querystring
+        """
+        # Always ignore the fragment
+        scheme, netloc, path, query, _ = urlsplit(url)
+        uri_relative = (None, None, path, query, None)
+        uri_without_query = (scheme, netloc, path, None, None)
+        uri_relative_without_query = (None, None, path, None, None)
+        urls = [url]
+        if query:
+            urls.append(urlunsplit(uri_without_query))
+        urls.append('~' + urlunsplit(uri_relative))
+        if query:
+            urls.append('~' + urlunsplit(uri_relative_without_query))
+        return urls

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+from sentry.models import ReleaseFile
+from sentry.testutils import TestCase
+
+
+class ReleaseFileTestCase(TestCase):
+    def test_normalize(self):
+        n = ReleaseFile.normalize
+
+        assert n('http://example.com') == [
+            'http://example.com',
+            '~',
+        ]
+        assert n('http://example.com/foo.js') == [
+            'http://example.com/foo.js',
+            '~/foo.js',
+        ]
+        assert n('http://example.com/foo.js?bar') == [
+            'http://example.com/foo.js?bar',
+            'http://example.com/foo.js',
+            '~/foo.js?bar',
+            '~/foo.js',
+        ]
+        assert n('/foo.js') == [
+            '/foo.js',
+            '~/foo.js',
+        ]
+
+        # This is the current behavior, but seems weird to me.
+        # unclear if we actually experience this case in the real
+        # world, but worth documenting the behavior
+        assert n('foo.js') == [
+            'foo.js',
+            '~foo.js',
+        ]


### PR DESCRIPTION
Replaces #4703

cc @benvinegar 

This refactors the spaghetti code a bit and moves it into `ReleaseFile.normalize()` whose job is to spit out either 2 or 4 options for lookups. It'll only be 4 if there is a querystring.

Then corrects the logic for choosing based on our priority order.