### PR TITLE
Add raw toggle for additional data section

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Version 8.20 (Unreleased)
 -------------------------
+- Add raw data toggle for Additional Data
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/static/sentry/app/components/events/eventDataSection.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from '../../proptypes';
+import {t} from '../../locale';
 
 const GroupEventDataSection = React.createClass({
   propTypes: {
@@ -7,12 +8,15 @@ const GroupEventDataSection = React.createClass({
     event: PropTypes.Event.isRequired,
     title: React.PropTypes.any,
     type: React.PropTypes.string.isRequired,
-    wrapTitle: React.PropTypes.bool
+    wrapTitle: React.PropTypes.bool,
+    toggleRaw: React.PropTypes.func,
+    raw: React.PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      wrapTitle: true
+      wrapTitle: true,
+      raw: false
     };
   },
 
@@ -45,8 +49,27 @@ const GroupEventDataSection = React.createClass({
               <em className="icon-anchor" />
             </a>
             {this.props.wrapTitle
-              ? <h3>{this.props.title}</h3>
-              : <div>{this.props.title}</div>}
+              ? <h3>
+                  {this.props.title}
+                </h3>
+              : <div>
+                  {this.props.title}
+                </div>}
+            {this.props.type === 'extra' &&
+              <div className="btn-group pull-right">
+                <a
+                  className={
+                    (!this.props.raw ? 'active' : '') + ' btn btn-default btn-sm'
+                  }
+                  onClick={() => this.props.toggleRaw(false)}>
+                  {t('Formatted')}
+                </a>
+                <a
+                  className={(this.props.raw ? 'active' : '') + ' btn btn-default btn-sm'}
+                  onClick={() => this.props.toggleRaw(true)}>
+                  {t('Raw')}
+                </a>
+              </div>}
           </div>}
         <div className="box-content with-padding">
           {this.props.children}

--- a/src/sentry/static/sentry/app/components/events/extraData.jsx
+++ b/src/sentry/static/sentry/app/components/events/extraData.jsx
@@ -25,7 +25,7 @@ const EventExtraData = React.createClass({
 
   toggleRaw(shouldBeRaw) {
     this.setState({
-      raw: !this.state.raw
+      raw: shouldBeRaw
     });
   },
 
@@ -45,32 +45,18 @@ const EventExtraData = React.createClass({
     );
   },
 
-  renderPretty() {
-    let extraDataArray = objectToArray(this.props.event.context);
-    return <KeyValueList data={extraDataArray} isContextData={true} />;
-  },
-
   render() {
+    let extraDataArray = objectToArray(this.props.event.context);
     return (
-      <div>
+      <div className="extra-data">
         <EventDataSection
           group={this.props.group}
           event={this.props.event}
           type="extra"
-          title={t('Additional Data')}>
-          <div className="btn-group">
-            <a
-              className={(!this.state.raw ? 'active' : '') + ' btn btn-default btn-sm'}
-              onClick={this.toggleRaw}>
-              {t('Formatted')}
-            </a>
-            <a
-              className={(this.state.raw ? 'active' : '') + ' btn btn-default btn-sm'}
-              onClick={this.toggleRaw}>
-              {t('Raw')}
-            </a>
-          </div>
-          {this.state.raw ? this.renderRaw() : this.renderPretty()}
+          title={t('Additional Data')}
+          toggleRaw={this.toggleRaw}
+          raw={this.state.raw}>
+          <KeyValueList data={extraDataArray} isContextData={true} raw={this.state.raw} />
         </EventDataSection>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/extraData.jsx
+++ b/src/sentry/static/sentry/app/components/events/extraData.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import PropTypes from '../../proptypes';
 import {objectToArray} from '../../utils';
+import ContextData from '../contextData';
 import EventDataSection from './eventDataSection';
 import KeyValueList from './interfaces/keyValueList';
 import {t} from '../../locale';
@@ -12,21 +13,66 @@ const EventExtraData = React.createClass({
     event: PropTypes.Event.isRequired
   },
 
+  getInitialState() {
+    return {
+      raw: false
+    };
+  },
+
   shouldComponentUpdate(nextProps, nextState) {
-    return this.props.event.id !== nextProps.event.id;
+    return this.props.event.id !== nextProps.event.id || this.state.raw !== nextState.raw;
+  },
+
+  toggleRaw(shouldBeRaw) {
+    this.setState({
+      raw: !this.state.raw
+    });
+  },
+
+  renderRaw() {
+    let extraRawData = JSON.stringify(this.props.event.context);
+    // extraRawData = [extraRawData];
+    return (
+      <table className="table key-value">
+        <tbody>
+          <tr>
+            <td className="value">
+              <ContextData data={extraRawData} />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  },
+
+  renderPretty() {
+    let extraDataArray = objectToArray(this.props.event.context);
+    return <KeyValueList data={extraDataArray} isContextData={true} />;
   },
 
   render() {
-    let extraDataArray = objectToArray(this.props.event.context);
-
     return (
-      <EventDataSection
-        group={this.props.group}
-        event={this.props.event}
-        type="extra"
-        title={t('Additional Data')}>
-        <KeyValueList data={extraDataArray} isContextData={true} />
-      </EventDataSection>
+      <div>
+        <EventDataSection
+          group={this.props.group}
+          event={this.props.event}
+          type="extra"
+          title={t('Additional Data')}>
+          <div className="btn-group">
+            <a
+              className={(!this.state.raw ? 'active' : '') + ' btn btn-default btn-sm'}
+              onClick={this.toggleRaw}>
+              {t('Formatted')}
+            </a>
+            <a
+              className={(this.state.raw ? 'active' : '') + ' btn btn-default btn-sm'}
+              onClick={this.toggleRaw}>
+              {t('Raw')}
+            </a>
+          </div>
+          {this.state.raw ? this.renderRaw() : this.renderPretty()}
+        </EventDataSection>
+      </div>
     );
   }
 });

--- a/src/sentry/static/sentry/app/components/events/extraData.jsx
+++ b/src/sentry/static/sentry/app/components/events/extraData.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import PropTypes from '../../proptypes';
 import {objectToArray} from '../../utils';
-import ContextData from '../contextData';
 import EventDataSection from './eventDataSection';
 import KeyValueList from './interfaces/keyValueList';
 import {t} from '../../locale';

--- a/src/sentry/static/sentry/app/components/events/extraData.jsx
+++ b/src/sentry/static/sentry/app/components/events/extraData.jsx
@@ -29,22 +29,6 @@ const EventExtraData = React.createClass({
     });
   },
 
-  renderRaw() {
-    let extraRawData = JSON.stringify(this.props.event.context);
-    // extraRawData = [extraRawData];
-    return (
-      <table className="table key-value">
-        <tbody>
-          <tr>
-            <td className="value">
-              <ContextData data={extraRawData} />
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    );
-  },
-
   render() {
     let extraDataArray = objectToArray(this.props.event.context);
     return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
@@ -9,13 +9,15 @@ const KeyValueList = React.createClass({
     data: React.PropTypes.any.isRequired,
     isContextData: React.PropTypes.bool,
     isSorted: React.PropTypes.bool,
-    onClick: React.PropTypes.func
+    onClick: React.PropTypes.func,
+    raw: React.PropTypes.bool
   },
 
   getDefaultProps() {
     return {
       isContextData: false,
-      isSorted: true
+      isSorted: true,
+      raw: false
     };
   },
 
@@ -31,7 +33,7 @@ const KeyValueList = React.createClass({
     }
 
     data = this.props.isSorted ? _.sortBy(data, [(key, value) => key]) : data;
-
+    let raw = this.props.raw;
     const props = this.props.onClick ? {onClick: this.props.onClick} : {};
     return (
       <table className="table key-value" {...props}>
@@ -40,16 +42,24 @@ const KeyValueList = React.createClass({
             if (this.props.isContextData) {
               return [
                 <tr key={key}>
-                  <td className="key">{key}</td>
-                  <td className="value"><ContextData data={value} /></td>
+                  <td className="key">
+                    {key}
+                  </td>
+                  <td className="value">
+                    <ContextData data={!raw ? value : JSON.stringify(value)} />
+                  </td>
                 </tr>
               ];
             } else {
               return [
                 <tr key={key}>
-                  <td className="key">{key}</td>
+                  <td className="key">
+                    {key}
+                  </td>
                   <td className="value">
-                    <pre>{deviceNameMapper('' + value || ' ')}</pre>
+                    <pre>
+                      {deviceNameMapper('' + value || ' ')}
+                    </pre>
                   </td>
                 </tr>
               ];

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1168,6 +1168,22 @@
   }
 }
 
+.extra-data
+  .box
+    .box-header {
+      margin-bottom: 20px;
+
+      h3 {
+        position: absolute;
+      }
+      .btn-group {
+        position:relative;
+        .btn {
+          margin: 0;
+        }
+      }
+    }
+
 /**
 * Traceback
 * ============================================================================

--- a/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventDataSection renders formatted 1`] = `
+<div
+  className=" box"
+>
+  <div
+    className="box-header"
+    id="extra"
+  >
+    <a
+      className="permalink"
+      href="#extra"
+    >
+      <em
+        className="icon-anchor"
+      />
+    </a>
+    <h3>
+      Additional Data
+    </h3>
+    <div
+      className="btn-group pull-right"
+    >
+      <a
+        className="active btn btn-default btn-sm"
+        onClick={[Function]}
+      >
+        Formatted
+      </a>
+      <a
+        className=" btn btn-default btn-sm"
+        onClick={[Function]}
+      >
+        Raw
+      </a>
+    </div>
+  </div>
+  <div
+    className="box-content with-padding"
+  />
+</div>
+`;
+
+exports[`EventDataSection renders raw 1`] = `
+<div
+  className=" box"
+>
+  <div
+    className="box-header"
+    id="extra"
+  >
+    <a
+      className="permalink"
+      href="#extra"
+    >
+      <em
+        className="icon-anchor"
+      />
+    </a>
+    <h3>
+      Additional Data
+    </h3>
+    <div
+      className="btn-group pull-right"
+    >
+      <a
+        className=" btn btn-default btn-sm"
+        onClick={[Function]}
+      >
+        Formatted
+      </a>
+      <a
+        className="active btn btn-default btn-sm"
+        onClick={[Function]}
+      >
+        Raw
+      </a>
+    </div>
+  </div>
+  <div
+    className="box-content with-padding"
+  />
+</div>
+`;
+
+exports[`KeyValueList renders formatted 1`] = `
+<table
+  className="table key-value"
+>
+  <tbody>
+    <tr>
+      <td
+        className="key"
+      >
+        andthis
+      </td>
+      <td
+        className="value"
+      >
+        <ContextData
+          data={0}
+        />
+      </td>
+    </tr>
+    <tr>
+      <td
+        className="key"
+      >
+        plussomeotherstuff
+      </td>
+      <td
+        className="value"
+      >
+        <ContextData
+          data="here"
+        />
+      </td>
+    </tr>
+    <tr>
+      <td
+        className="key"
+      >
+        somestuff
+      </td>
+      <td
+        className="value"
+      >
+        <ContextData
+          data={
+            Object {
+              "andsomeotherstuff": "here",
+            }
+          }
+        />
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`KeyValueList renders raw 1`] = `
+<table
+  className="table key-value"
+>
+  <tbody>
+    <tr>
+      <td
+        className="key"
+      >
+        andthis
+      </td>
+      <td
+        className="value"
+      >
+        <ContextData
+          data="0"
+        />
+      </td>
+    </tr>
+    <tr>
+      <td
+        className="key"
+      >
+        plussomeotherstuff
+      </td>
+      <td
+        className="value"
+      >
+        <ContextData
+          data="\\"here\\""
+        />
+      </td>
+    </tr>
+    <tr>
+      <td
+        className="key"
+      >
+        somestuff
+      </td>
+      <td
+        className="value"
+      >
+        <ContextData
+          data="{\\"andsomeotherstuff\\":\\"here\\"}"
+        />
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/tests/js/spec/components/toggleRawEventData.spec.jsx
+++ b/tests/js/spec/components/toggleRawEventData.spec.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import EventDataSection from 'app/components/events/eventDataSection';
+import KeyValueList from 'app/components/events/interfaces/keyValueList';
+import {objectToArray} from 'app/utils';
+
+const data = {
+  metadata: {
+    title: 'metadata title',
+    type: 'metadata type',
+    directive: 'metadata directive',
+    uri: 'metadata uri',
+    value: 'metadata value',
+    message: 'metadata message'
+  },
+  culprit: 'culprit'
+};
+
+describe('EventDataSection', function() {
+  const groupData = {
+    ...data,
+    level: 'error',
+    id: 'id'
+  };
+  const eventData = {
+    ...data,
+    id: 'id',
+    eventID: 'eventID',
+    groupID: 'groupID',
+    culprit: undefined
+  };
+  it('renders formatted', function() {
+    let component = shallow(
+      <EventDataSection
+        group={groupData}
+        event={eventData}
+        type="extra"
+        title="Additional Data"
+        raw={false}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders raw', function() {
+    let component = shallow(
+      <EventDataSection
+        group={groupData}
+        event={eventData}
+        type="extra"
+        title="Additional Data"
+        raw={true}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+});
+
+describe('KeyValueList', function() {
+  const context = {
+    somestuff: {andsomeotherstuff: 'here'},
+    plussomeotherstuff: 'here',
+    andthis: 0
+  };
+  const extraDataArray = objectToArray(context);
+
+  it('renders formatted', function() {
+    let component = shallow(
+      <KeyValueList data={extraDataArray} isContextData={true} raw={false} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders raw', function() {
+    let component = shallow(
+      <KeyValueList data={extraDataArray} isContextData={true} raw={true} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Allow toggle so that additional data can be accessed in its raw format. Fixes #5689

What it looks like (updated):
![toggle_raw](https://user-images.githubusercontent.com/9269824/29282825-19f6ba7e-80d9-11e7-827e-48490cd39998.gif)

