### PR TITLE
Fix long release version number in cocoa images

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -23,7 +23,6 @@ const DebugMetaInterface = React.createClass({
     if (name == 'dyld_sim') return null; // this is only for simulator builds
 
     let version = null;
-
     if (
       Number.isInteger(img.major_version) &&
       Number.isInteger(img.minor_version) &&
@@ -31,7 +30,7 @@ const DebugMetaInterface = React.createClass({
     ) {
       if (img.major_version == 0 && img.minor_version == 0 && img.revision_version == 0) {
         // we show the version
-        version = (evt.release && evt.release.version) || 'unknown';
+        version = (evt.release && evt.release.shortVersion) || 'unknown';
       } else
         version = `${img.major_version}.${img.minor_version}.${img.revision_version}`;
     } else version = img.uuid;


### PR DESCRIPTION
This fixes the too long version numbers in the loaded images section for iOS events:

Before: 
<img width="842" alt="screenshot 2017-08-14 11 10 48" src="https://user-images.githubusercontent.com/363802/29265591-e4b9a458-80e1-11e7-82e6-258b90850f25.png">

After: 
<img width="843" alt="screenshot 2017-08-14 11 11 25" src="https://user-images.githubusercontent.com/363802/29265595-e8a11088-80e1-11e7-9e3b-988f18ab10c0.png">

