### PR TITLE
api: fix cocoa sample event

### DIFF
--- a/src/sentry/data/samples/cocoa.json
+++ b/src/sentry/data/samples/cocoa.json
@@ -218,7 +218,6 @@
       }
     ]
   },
-  "timestamp": "2017-08-04T07:57:12Z",
   "release": "io.sentry.sentry-ios-cocoapods-1.0",
   "dist": "1",
   "tags": {"a": "b"},


### PR DESCRIPTION
Sample events skip some phases of the pipeline, so this value isn't
coerced into the right value. We also want it to use `now()` as the
value so we don't generate events in the past for samples.

Fixes SENTRY-43Q