### PR TITLE
api: don't silently discard fields on project details

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 import logging
 from uuid import uuid4
 
@@ -180,6 +181,16 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             return Response(serializer.errors, status=400)
 
         result = serializer.object
+
+        if not has_project_write:
+            for key in six.iterkeys(ProjectAdminSerializer.base_fields):
+                if request.DATA.get(key) and not result.get(key):
+                    return Response(
+                        {
+                            'detail': ['You do not have permission to perform this action.']
+                        },
+                        status=403
+                    )
 
         changed = False
         if result.get('slug'):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -107,14 +107,44 @@ class ProjectUpdateTest(APITestCase):
         )
         response = self.client.put(
             url, data={
-                'slug': 'zzz',
                 'isBookmarked': 'true',
             }
         )
         assert response.status_code == 200
-        assert response.data['slug'] != 'zzz'
 
         assert ProjectBookmark.objects.filter(
+            user=user,
+            project_id=project.id,
+        ).exists()
+
+    def test_member_changes_permission_denied(self):
+        project = self.create_project()
+        user = self.create_user('bar@example.com')
+        self.create_member(
+            user=user,
+            organization=project.organization,
+            teams=[project.team],
+            role='member',
+        )
+        self.login_as(user=user)
+        url = reverse(
+            'sentry-api-0-project-details',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'project_slug': project.slug,
+            }
+        )
+        response = self.client.put(
+            url, data={
+                'slug': 'zzz',
+                'isBookmarked': 'true',
+            }
+        )
+        assert response.status_code == 403
+
+        assert Project.objects.get(id=project.id).slug != 'zzz'
+
+        assert not ProjectBookmark.objects.filter(
             user=user,
             project_id=project.id,
         ).exists()


### PR DESCRIPTION
The project details endpoint is weird in that it has two different
behaviors based on permissions of the key making the request. This
difference in behavior causes fields to be silently discarded since
serializers by default ignore extraneous keys.

This adds an explicit check that the user is not trying to send keys
from the project:write version of the serializer so we can message the
problem instead of being ignored silently.