### PR TITLE
add plugin slug to urls

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -12,7 +12,7 @@ from six.moves.urllib.parse import (
     urlparse,
     urlencode,
     urlunparse,
-    parse_qsl,
+    parse_qs,
 )
 
 from django import forms
@@ -171,11 +171,11 @@ class NotificationPlugin(Plugin):
 
     def add_notification_referrer_param(self, url):
         parsed_url = urlparse(url)
-        query = dict(parse_qsl(parsed_url.query))
+        query = parse_qs(parsed_url.query)
         query['referrer'] = self.slug
 
         url_list = list(parsed_url)
-        url_list[4] = urlencode(query)
+        url_list[4] = urlencode(query, doseq=True)
         return urlunparse(url_list)
 
 

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -8,6 +8,12 @@ sentry.plugins.bases.notify
 from __future__ import absolute_import, print_function
 
 import logging
+from six.moves.urllib.parse import (
+    urlparse,
+    urlencode,
+    urlunparse,
+    parse_qsl,
+)
 
 from django import forms
 
@@ -44,6 +50,7 @@ class BaseNotificationUserOptionsForm(forms.Form):
 
 
 class NotificationPlugin(Plugin):
+    slug = ''
     description = (
         'Notify project members when a new event is seen for the first time, or when an '
         'already resolved event has changed back to unresolved.'
@@ -161,6 +168,15 @@ class NotificationPlugin(Plugin):
 
     def get_notification_doc_html(self, **kwargs):
         return ""
+
+    def add_notification_referrer_param(self, url):
+        parsed_url = urlparse(url)
+        query = dict(parse_qsl(parsed_url.query))
+        query['referrer'] = self.slug
+
+        url_list = list(parsed_url)
+        url_list[4] = urlencode(query)
+        return urlunparse(url_list)
 
 
 # Backwards-compatibility

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -170,13 +170,16 @@ class NotificationPlugin(Plugin):
         return ""
 
     def add_notification_referrer_param(self, url):
-        parsed_url = urlparse(url)
-        query = parse_qs(parsed_url.query)
-        query['referrer'] = self.slug
+        if self.slug:
+            parsed_url = urlparse(url)
+            query = parse_qs(parsed_url.query)
+            query['referrer'] = self.slug
 
-        url_list = list(parsed_url)
-        url_list[4] = urlencode(query, doseq=True)
-        return urlunparse(url_list)
+            url_list = list(parsed_url)
+            url_list[4] = urlencode(query, doseq=True)
+            return urlunparse(url_list)
+
+        return url
 
 
 # Backwards-compatibility

--- a/tests/sentry/plugins/bases/notify/__init__.py
+++ b/tests/sentry/plugins/bases/notify/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from sentry.plugins import NotificationPlugin
+from sentry.testutils import TestCase
+
+
+class NotifyPlugin(TestCase):
+    def test_add_notification_referrer_param(self):
+        n = NotificationPlugin()
+        n.slug = 'slack'
+        url = 'https://sentry.io/'
+        assert n.add_notification_referrer_param(url) == url + '?referrer=' + n.slug

--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -10,3 +10,11 @@ class NotifyPlugin(TestCase):
         n.slug = 'slack'
         url = 'https://sentry.io/'
         assert n.add_notification_referrer_param(url) == url + '?referrer=' + n.slug
+
+        url = 'https://sentry.io/?referrer=notslack'
+        assert n.add_notification_referrer_param(url) == 'https://sentry.io/?referrer=slack'
+
+        url = 'https://sentry.io/?utm_source=google'
+        assert n.add_notification_referrer_param(
+            url
+        ) == 'https://sentry.io/?referrer=slack&utm_source=google'

--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -18,3 +18,7 @@ class NotifyPlugin(TestCase):
         assert n.add_notification_referrer_param(
             url
         ) == 'https://sentry.io/?referrer=slack&utm_source=google'
+
+        n.slug = ''
+        url = 'https://sentry.io/'
+        assert n.add_notification_referrer_param(url) == 'https://sentry.io/'


### PR DESCRIPTION
Adding helper function for adding a param like `?referrer=slack` for notification plugins, so we can track active usage of plugins.