### PR TITLE
Implement support for redis clusters

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,8 @@ Version 8.20 (Unreleased)
 - Make BitBucket repositories enabled by default
 - Add raw data toggle for Additional Data
 
+- Add initial support for Redis Cluster.
+
 Schema Changes
 ~~~~~~~~~~~~~~
 - Added index on ``ProjectPlatform(last_seen)`` column

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Version 8.20 (Unreleased)
 - Add raw data toggle for Additional Data
 
 - Add initial support for Redis Cluster.
+- Support a list of hosts in the ``redis.clusters`` configuration along side
+  the traditional dictionary style configuration.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ install_requires = [
     'rb>=1.7.0,<2.0.0',
     'qrcode>=5.2.2,<6.0.0',
     'python-u2flib-server>=4.0.1,<4.1.0',
-    'redis-py-cluster>=1.3.4',
+    'redis-py-cluster>=1.3.4,<1.4.0',
 ]
 
 saml_requires = [

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,7 @@ install_requires = [
     'rb>=1.7.0,<2.0.0',
     'qrcode>=5.2.2,<6.0.0',
     'python-u2flib-server>=4.0.1,<4.1.0',
+    'redis-py-cluster>=1.3.4',
 ]
 
 saml_requires = [

--- a/src/sentry/data/config/config.yml.default
+++ b/src/sentry/data/config/config.yml.default
@@ -38,6 +38,9 @@ system.secret-key: '%(secret_key)s'
 # The ``redis.clusters`` setting is used, unsurprisingly, to configure Redis
 # clusters. These clusters can be then referred to by name when configuring
 # backends such as the cache, digests, or TSDB backend.
+#
+# Clusters that are inteded to be connected to as true Redis Clusters should be
+# marked with the ``is_redis_cluster`` flag.
 redis.clusters:
   default:
     hosts:

--- a/src/sentry/data/config/config.yml.default
+++ b/src/sentry/data/config/config.yml.default
@@ -39,8 +39,17 @@ system.secret-key: '%(secret_key)s'
 # clusters. These clusters can be then referred to by name when configuring
 # backends such as the cache, digests, or TSDB backend.
 #
-# Clusters that are inteded to be connected to as true Redis Clusters should be
-# marked with the ``is_redis_cluster`` flag.
+# Two types of clusters are currently supported:
+#
+#   rb.Cluster
+#   A redis blaster cluster is the traditional cluster used by most services
+#   within sentry. This is the default type cluster type.
+#
+#   rediscluster.StrictRedisCluster
+#   An official Redis Cluster can be configured by marking the named group with
+#   the ``is_redis_cluster: True`` flag. In future versions of Sentry more
+#   services will require this type of cluster.
+#
 redis.clusters:
   default:
     hosts:

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -59,6 +59,12 @@ class _RBCluster(object):
         return not config.get('is_redis_cluster', False)
 
     def factory(self, **config):
+        # rb expects a dict of { host, port } dicts where the key is the host
+        # ID. Coerce the configuration into the correct format if necessary.
+        hosts = config['hosts']
+        hosts = {k: v for k, v in enumerate(hosts)} if isinstance(hosts, list) else hosts
+        config['hosts'] = hosts
+
         return _make_rb_cluster(**config)
 
     def __str__(self):
@@ -70,8 +76,12 @@ class _RedisCluster(object):
         return config.get('is_redis_cluster', False)
 
     def factory(self, **config):
-        nodes = config.get('hosts').values()
-        return rediscluster.StrictRedisCluster(startup_nodes=nodes, decode_responses=True)
+        # StrictRedisCluster expects a list of { host, port } dicts. Coerce the
+        # configuration into the correct format if necessary.
+        hosts = config.get('hosts')
+        hosts = hosts.values() if isinstance(hosts, dict) else hosts
+
+        return rediscluster.StrictRedisCluster(startup_nodes=hosts, decode_responses=True)
 
     def __str__(self):
         return 'Redis Cluster'

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -70,7 +70,7 @@ class _RedisCluster(object):
         return config.get('is_redis_cluster', False)
 
     def factory(self, **config):
-        nodes = map(lambda n: n[1], config.get('hosts').items())
+        nodes = config.get('hosts').values()
         return rediscluster.StrictRedisCluster(startup_nodes=nodes, decode_responses=True)
 
     def __str__(self):

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -89,7 +89,7 @@ class _RedisCluster(object):
         try:
             return rediscluster.StrictRedisCluster(startup_nodes=hosts, decode_responses=True)
         except rediscluster.exceptions.RedisClusterException:
-            logger.warning('Failed to connect to redis cluster', exc_info=True)
+            logger.warning('Failed to connect to Redis Cluster', exc_info=True)
             raise KeyError('Redis Cluster could not be initalized')
 
     def __str__(self):


### PR DESCRIPTION
This adds support for configuring and using true redis clusters.

This adds a new module variable `sentry.utils.redis.redis_clusters` which is an instance of the `ClusterManager` that supports creation and retrieval of `StrictRedisCluster` clients. This deviates from the usage of `ClusterManager` that manages rb `Cluster` objects, thus the separate module variable from `clusters`.

Nothing actually uses this, but will link to the PR for the similarity engine using it here once it's ready.