### PR TITLE
Migrate similarity feature to use redis clusters

### DIFF
--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -220,8 +220,10 @@ end
 -- Key Generation
 
 local function get_key_prefix(configuration, index)
+    -- NB: The brackets around the scope allow redis cluster to shard keys
+    -- using the value within the brackets, this is known as a redis hash tag.
     return string.format(
-        '%s:%s:%s',
+        '%s:{%s}:%s',
         configuration.namespace,
         configuration.scope,
         index

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -60,18 +60,18 @@ def get_frame_attributes(frame):
     return attributes
 
 
-def _make_index():
-    try:
-        cluster = redis.redis_clusters.get(
-            getattr(
+def _make_index(cluster=None):
+    if not cluster:
+        try:
+            cluster_id = getattr(
                 settings,
                 'SENTRY_SIMILARITY_INDEX_REDIS_CLUSTER',
                 'similarity',
             )
-        )
-    except KeyError:
-        logger.info('No redis cluster provided for similarity, using NOOP index.')
-        return NoopIndex()
+            cluster = redis.redis_clusters.get(cluster_id)
+        except KeyError:
+            logger.info('No redis cluster provided for similarity, using NOOP index.')
+            return NoopIndex()
 
     return MinHashIndex(
         cluster,

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -72,7 +72,7 @@ def _make_index(cluster=None):
             cluster = redis.redis_clusters.get(cluster_id)
         except KeyError:
             index = DummyIndex()
-            logger.info('No redis cluster provided for similarity, using {}.'.format(index))
+            logger.info('No redis cluster provided for similarity, using {!r}.'.format(index))
             return index
 
     return MinHashIndex(

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -71,8 +71,9 @@ def _make_index(cluster=None):
         try:
             cluster = redis.redis_clusters.get(cluster_id)
         except KeyError:
-            logger.info('No redis cluster provided for similarity, using NOOP index.')
-            return DummyIndex()
+            index = DummyIndex()
+            logger.info('No redis cluster provided for similarity, using {}.'.format(index))
+            return index
 
     return MinHashIndex(
         cluster,

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -62,12 +62,13 @@ def get_frame_attributes(frame):
 
 def _make_index(cluster=None):
     if not cluster:
+        cluster_id = getattr(
+            settings,
+            'SENTRY_SIMILARITY_INDEX_REDIS_CLUSTER',
+            'similarity',
+        )
+
         try:
-            cluster_id = getattr(
-                settings,
-                'SENTRY_SIMILARITY_INDEX_REDIS_CLUSTER',
-                'similarity',
-            )
             cluster = redis.redis_clusters.get(cluster_id)
         except KeyError:
             logger.info('No redis cluster provided for similarity, using NOOP index.')

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -7,7 +7,7 @@ from django.conf import settings
 
 from sentry.interfaces.stacktrace import Frame
 from sentry.similarity.encoder import Encoder
-from sentry.similarity.index import MinHashIndex, NoopIndex
+from sentry.similarity.index import MinHashIndex, DummyIndex
 from sentry.similarity.features import (
     ExceptionFeature,
     FeatureSet,
@@ -71,7 +71,7 @@ def _make_index(cluster=None):
             cluster = redis.redis_clusters.get(cluster_id)
         except KeyError:
             logger.info('No redis cluster provided for similarity, using NOOP index.')
-            return NoopIndex()
+            return DummyIndex()
 
     return MinHashIndex(
         cluster,

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 
 import itertools
+import logging
 
 from django.conf import settings
 
 from sentry.interfaces.stacktrace import Frame
 from sentry.similarity.encoder import Encoder
-from sentry.similarity.index import MinHashIndex
+from sentry.similarity.index import MinHashIndex, NoopIndex
 from sentry.similarity.features import (
     ExceptionFeature,
     FeatureSet,
@@ -18,6 +19,8 @@ from sentry.similarity.signatures import MinHashSignatureBuilder
 from sentry.utils import redis
 from sentry.utils.datastructures import BidirectionalMapping
 from sentry.utils.iterators import shingle
+
+logger = logging.getLogger(__name__)
 
 
 def text_shingle(n, value):
@@ -57,21 +60,31 @@ def get_frame_attributes(frame):
     return attributes
 
 
-features = FeatureSet(
-    MinHashIndex(
-        redis.clusters.get(
+def _make_index():
+    try:
+        cluster = redis.redis_clusters.get(
             getattr(
                 settings,
                 'SENTRY_SIMILARITY_INDEX_REDIS_CLUSTER',
-                'default',
-            ),
-        ),
+                'similarity',
+            )
+        )
+    except KeyError:
+        logger.info('No redis cluster provided for similarity, using NOOP index.')
+        return NoopIndex()
+
+    return MinHashIndex(
+        cluster,
         'sim:1',
         MinHashSignatureBuilder(16, 0xFFFF),
         8,
         60 * 60 * 24 * 30,
         3,
-    ),
+    )
+
+
+features = FeatureSet(
+    _make_index(),
     Encoder({
         Frame: get_frame_attributes,
     }),

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -265,8 +265,8 @@ class FeatureSet(object):
             [(self.aliases[label], key) for label in self.features.keys()],
         )
 
-    def flush(self, project=None):
+    def flush(self, project):
         return self.index.flush(
-            '*' if project is None else self.__get_scope(project),
+            self.__get_scope(project),
             self.aliases.values(),
         )

--- a/src/sentry/similarity/index.py
+++ b/src/sentry/similarity/index.py
@@ -273,5 +273,5 @@ class DummyIndex(object):
     def export(self, scope, items, timestamp=None):
         return {}
 
-    def _import(self, scope, items, timestamp=None):
+    def import_(self, scope, items, timestamp=None):
         return {}

--- a/src/sentry/similarity/index.py
+++ b/src/sentry/similarity/index.py
@@ -263,7 +263,9 @@ class DummyIndex(object):
         return False
 
     def scan(self, scope, indices, batch=1000, timestamp=None):
-        return []
+        # empty generator
+        return
+        yield
 
     def flush(self, scope, indices, batch=1000, timestamp=None):
         pass

--- a/src/sentry/similarity/index.py
+++ b/src/sentry/similarity/index.py
@@ -246,7 +246,7 @@ class MinHashIndex(object):
         return self.__index(scope, arguments)
 
 
-class NoopIndex(object):
+class DummyIndex(object):
     def classify(self, scope, items, timestamp=None):
         return []
 

--- a/src/sentry/similarity/index.py
+++ b/src/sentry/similarity/index.py
@@ -272,3 +272,6 @@ class DummyIndex(object):
 
     def export(self, scope, items, timestamp=None):
         return {}
+
+    def _import(self, scope, items, timestamp=None):
+        return {}

--- a/src/sentry/similarity/index.py
+++ b/src/sentry/similarity/index.py
@@ -254,7 +254,7 @@ class DummyIndex(object):
         return []
 
     def record(self, scope, key, items, timestamp=None):
-        return False
+        return {}
 
     def merge(self, scope, destination, items, timestamp=None):
         return False
@@ -263,10 +263,10 @@ class DummyIndex(object):
         return False
 
     def scan(self, scope, indices, batch=1000, timestamp=None):
-        pass
+        return []
 
     def flush(self, scope, indices, batch=1000, timestamp=None):
         pass
 
     def export(self, scope, items, timestamp=None):
-        return False
+        return {}

--- a/tests/sentry/similarity/test_index.py
+++ b/tests/sentry/similarity/test_index.py
@@ -17,7 +17,7 @@ class MinHashIndexTestCase(TestCase):
     @fixture
     def index(self):
         return MinHashIndex(
-            redis.clusters.get('default'),
+            redis.clusters.get('default').get_local_client(0),
             'sim',
             signature_builder,
             16,

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -1,12 +1,19 @@
 from __future__ import absolute_import
 
 from collections import defaultdict
+from mock import patch
 
 from sentry.tasks.merge import merge_group, rehash_group_events
 from sentry.models import Event, Group, GroupMeta, GroupRedirect, GroupTagKey, GroupTagValue
+from sentry.similarity import _make_index
 from sentry.testutils import TestCase
+from sentry.utils import redis
+
+# Use the default redis client as a cluster client in the similarity index
+index = _make_index(redis.clusters.get('default').get_local_client(0))
 
 
+@patch('sentry.similarity.features.index', new=index)
 class MergeGroupTest(TestCase):
     def test_merge_with_event_integrity(self):
         project1 = self.create_project()

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 
 import pytz
 from django.utils import timezone
+from mock import patch
 
 from sentry.app import tsdb
 from sentry.event_manager import ScoreClause
@@ -16,15 +17,20 @@ from sentry.models import (
     Activity, Environment, EnvironmentProject, Event, EventMapping, Group, GroupHash, GroupRelease,
     GroupTagKey, GroupTagValue, Release, UserReport
 )
-from sentry.similarity import features
+from sentry.similarity import features, _make_index
 from sentry.tasks.unmerge import (
     get_caches, get_event_user_from_interface, get_fingerprint, get_group_backfill_attributes,
     get_group_creation_attributes, unmerge
 )
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
+from sentry.utils import redis
+
+# Use the default redis client as a cluster client in the similarity index
+index = _make_index(redis.clusters.get('default').get_local_client(0))
 
 
+@patch('sentry.similarity.features.index', new=index)
 class UnmergeTestCase(TestCase):
     def test_get_group_creation_attributes(self):
         now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=pytz.utc)


### PR DESCRIPTION
This switches the similarity engine over to use the redis cluster (as implemented in #5883).

This will gracefully degrade to a `NoopIndex` for similarity if no redis cluster is available, however, in current getsentry production the similarity engine is enabled for early adoptor orgs already using the redisblaster cluster, so we cannot merge this for production until we setup a redis cluster.

/cc @getsentry/platform 