### PR TITLE
Make build optional for proguard associations

### DIFF
--- a/src/sentry/api/endpoints/dsym_files.py
+++ b/src/sentry/api/endpoints/dsym_files.py
@@ -23,7 +23,7 @@ class AssociateDsymSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=250)
     appId = serializers.CharField(max_length=250)
     version = serializers.CharField(max_length=40)
-    build = serializers.CharField(max_length=40, null=True)
+    build = serializers.CharField(max_length=40, required=False)
 
 
 def upload_from_request(request, project=None):

--- a/src/sentry/api/endpoints/dsym_files.py
+++ b/src/sentry/api/endpoints/dsym_files.py
@@ -131,7 +131,7 @@ class AssociateDSymFilesEndpoint(ProjectEndpoint):
             version_dsym_file, created = VersionDSymFile.objects.get_or_create(
                 dsym_file=dsym_file,
                 version=data['version'],
-                build=data['build'],
+                build=data.get('build'),
                 defaults=dict(dsym_app=dsym_app),
             )
             if created:

--- a/src/sentry/api/endpoints/dsym_files.py
+++ b/src/sentry/api/endpoints/dsym_files.py
@@ -23,7 +23,7 @@ class AssociateDsymSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=250)
     appId = serializers.CharField(max_length=250)
     version = serializers.CharField(max_length=40)
-    build = serializers.CharField(max_length=40)
+    build = serializers.CharField(max_length=40, null=True)
 
 
 def upload_from_request(request, project=None):

--- a/tests/sentry/api/endpoints/test_dsym_files.py
+++ b/tests/sentry/api/endpoints/test_dsym_files.py
@@ -122,6 +122,70 @@ class DSymFilesUploadTest(APITestCase):
         assert vdf.dsym_app.app_id == 'com.example.myapp'
         assert vdf.dsym_file.uuid == PROGUARD_UUID
 
+    def test_associate_proguard_dsym_no_build(self):
+        project = self.create_project(name='foo')
+
+        url = reverse(
+            'sentry-api-0-dsym-files',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'project_slug': project.slug,
+            }
+        )
+
+        self.login_as(user=self.user)
+
+        out = BytesIO()
+        f = zipfile.ZipFile(out, 'w')
+        f.writestr('proguard/%s.txt' % PROGUARD_UUID, PROGUARD_SOURCE)
+        f.close()
+
+        response = self.client.post(
+            url, {
+                'file':
+                SimpleUploadedFile('symbols.zip', out.getvalue(), content_type='application/zip'),
+            },
+            format='multipart'
+        )
+
+        assert response.status_code == 201, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['headers'] == {'Content-Type': 'text/x-proguard+plain'}
+        assert response.data[0]['sha1'] == 'e6d3c5185dac63eddfdc1a5edfffa32d46103b44'
+        assert response.data[0]['uuid'] == PROGUARD_UUID
+        assert response.data[0]['objectName'] == 'proguard-mapping'
+        assert response.data[0]['cpuName'] == 'any'
+        assert response.data[0]['symbolType'] == 'proguard'
+
+        url = reverse(
+            'sentry-api-0-associate-dsym-files',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'project_slug': project.slug,
+            }
+        )
+
+        response = self.client.post(
+            url, {
+                'checksums': ['e6d3c5185dac63eddfdc1a5edfffa32d46103b44'],
+                'platform': 'android',
+                'name': 'MyApp',
+                'appId': 'com.example.myapp',
+                'version': '1.0',
+            },
+            format='json'
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data['associatedDsymFiles'][0]['uuid'] == PROGUARD_UUID
+
+        vdf = VersionDSymFile.objects.get()
+        assert vdf.version == '1.0'
+        assert vdf.build is None
+        assert vdf.dsym_app.app_id == 'com.example.myapp'
+        assert vdf.dsym_file.uuid == PROGUARD_UUID
+
     def test_list_dsyms(self):
         project = self.create_project(name='foo')
 


### PR DESCRIPTION
This makes the built optional for dsym associations through the endpoint
which currently only affects proguard.

This fixes https://github.com/getsentry/sentry-cli/issues/108