### PR TITLE
Ensure all usage of `unpack` in digest script have fixed upper bounds.

### DIFF
--- a/src/sentry/scripts/digests/digests.lua
+++ b/src/sentry/scripts/digests/digests.lua
@@ -310,11 +310,13 @@ local function close_digest(configuration, timeline_id, delay_minimum, record_id
 
     for _, chunk_iterator in chunked(1000, ipairs(record_ids)) do
         local record_id_chunk = {}
+        local record_key_chunk = {}
         for i, _, record_id in chunk_iterator do
-            redis.call('DEL', configuration:get_timeline_record_key(timeline_id, record_id))
             record_id_chunk[i] = record_id
+            record_key_chunk[i] = configuration:get_timeline_record_key(timeline_id, record_id)
         end
         redis.call('ZREM', digest_key, unpack(record_id_chunk))
+        redis.call('DEL', unpack(record_key_chunk))
     end
 
     -- If this digest didn't contain any data (no record IDs) and there isn't

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -107,3 +107,14 @@ class RedisBackendTestCase(TestCase):
         # contents were merged back into the digest.
         with backend.digest('timeline', 0) as records:
             assert set(records) == set([record_2])
+
+    def test_large_digest(self):
+        backend = RedisBackend()
+
+        n = 16384
+        t = time.time()
+        for i in xrange(n):
+            backend.add('timeline', Record('record:{}'.format(i), '{}'.format(i), t))
+
+        with backend.digest('timeline', 0) as records:
+            assert len(set(records)) == n

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -111,7 +111,7 @@ class RedisBackendTestCase(TestCase):
     def test_large_digest(self):
         backend = RedisBackend()
 
-        n = 16384
+        n = 8192
         t = time.time()
         for i in xrange(n):
             backend.add('timeline', Record('record:{}'.format(i), '{}'.format(i), t))


### PR DESCRIPTION
This ensures all usage of `unpack` in the digest Lua script have fixed upper bounds to [prevent exceeding the stack limit](https://github.com/antirez/redis/issues/678#issuecomment-15848571).

1. This replaces the existing `unpack`-based argument parser with a cursor-based iterative argument parser.
2. This ensures that all Redis commands that are passed a variable number of arguments with `unpack` are wrapped in a chunk iterator to ensure that they don't exceed a specific number of arguments.

This fixes SENTRY-45E. 