### PR TITLE
standalone proptypes module + update react + run codemod [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
     "node-libs-browser": "0.5.3",
     "platformicons": "0.1.1",
     "po-catalog-loader": "^1.2.0",
+    "prop-types": "^15.5.10",
     "query-string": "2.4.2",
     "raven-js": "3.16.1",
-    "react": "15.3.2",
+    "react": "15.6.1",
     "react-addons-css-transition-group": "15.3.2",
     "react-addons-pure-render-mixin": "15.3.2",
     "react-addons-test-utils": "15.3.2",
@@ -54,7 +55,7 @@
     "react-bootstrap": "^0.29.5",
     "react-code-input": "1.0.8",
     "react-document-title": "1.0.4",
-    "react-dom": "15.3.2",
+    "react-dom": "^15.3.2",
     "react-icon-base": "^2.0.4",
     "react-lazy-load": "3.0.10",
     "react-mentions": "^1.0.0",
@@ -83,7 +84,9 @@
     "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=375,1280"
   },
   "jest": {
-    "snapshotSerializers": ["enzyme-to-json/serializer"],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ],
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/tests/js/helpers/importStyleMock.js",
       "integration-docs-platforms": "<rootDir>/tests/fixtures/_platforms.json"

--- a/src/sentry/static/sentry/app/components/actionOverlay.jsx
+++ b/src/sentry/static/sentry/app/components/actionOverlay.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import OrganizationState from '../mixins/organizationState';
 import {t} from '../locale';
@@ -6,12 +7,12 @@ import LoadingIndicator from '../components/loadingIndicator';
 
 const ActionOverlay = React.createClass({
   propTypes: {
-    actionId: React.PropTypes.string.isRequired,
-    isLoading: React.PropTypes.bool
+    actionId: PropTypes.string.isRequired,
+    isLoading: PropTypes.bool
   },
 
   contextTypes: {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   },
 
   mixins: [OrganizationState],

--- a/src/sentry/static/sentry/app/components/activity/feed.jsx
+++ b/src/sentry/static/sentry/app/components/activity/feed.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -10,10 +11,10 @@ import {logException} from '../../utils/logging';
 
 const ActivityFeed = React.createClass({
   propTypes: {
-    endpoint: React.PropTypes.string,
-    query: React.PropTypes.object,
-    renderEmpty: React.PropTypes.func,
-    pagination: React.PropTypes.bool
+    endpoint: PropTypes.string,
+    query: PropTypes.object,
+    renderEmpty: PropTypes.func,
+    pagination: PropTypes.bool
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/activity/item.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item.jsx
@@ -1,4 +1,5 @@
 import marked from 'marked';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {CommitLink} from '../../views/releases/releaseCommits';
@@ -14,10 +15,10 @@ import {t, tn, tct} from '../../locale';
 
 const ActivityItem = React.createClass({
   propTypes: {
-    clipHeight: React.PropTypes.number,
-    defaultClipped: React.PropTypes.bool,
-    item: React.PropTypes.object.isRequired,
-    orgId: React.PropTypes.string.isRequired
+    clipHeight: PropTypes.number,
+    defaultClipped: PropTypes.bool,
+    item: PropTypes.object.isRequired,
+    orgId: PropTypes.string.isRequired
   },
 
   getDefaultProps() {
@@ -55,9 +56,9 @@ const ActivityItem = React.createClass({
     let issue = item.issue;
 
     let issueLink = issue
-      ? (<IssueLink orgId={orgId} projectId={project.slug} issue={issue}>
+      ? <IssueLink orgId={orgId} projectId={project.slug} issue={issue}>
           {issue.shortId}
-        </IssueLink>)
+        </IssueLink>
       : null;
 
     switch (item.type) {

--- a/src/sentry/static/sentry/app/components/activity/note.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import TimeSince from '../../components/timeSince';
@@ -8,10 +9,10 @@ import marked from '../../utils/marked';
 
 const Note = React.createClass({
   propTypes: {
-    author: React.PropTypes.object.isRequired,
-    item: React.PropTypes.object.isRequired,
-    onEdit: React.PropTypes.func.isRequired,
-    onDelete: React.PropTypes.func.isRequired
+    author: PropTypes.object.isRequired,
+    item: PropTypes.object.isRequired,
+    onEdit: PropTypes.func.isRequired,
+    onDelete: PropTypes.func.isRequired
   },
 
   canEdit() {

--- a/src/sentry/static/sentry/app/components/activity/noteContainer.jsx
+++ b/src/sentry/static/sentry/app/components/activity/noteContainer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Note from './note';
@@ -5,12 +6,12 @@ import NoteInput from './noteInput';
 
 const NoteContainer = React.createClass({
   propTypes: {
-    group: React.PropTypes.object.isRequired,
-    item: React.PropTypes.object.isRequired,
-    author: React.PropTypes.object.isRequired,
-    onDelete: React.PropTypes.func.isRequired,
-    sessionUser: React.PropTypes.object.isRequired,
-    memberList: React.PropTypes.array.isRequired
+    group: PropTypes.object.isRequired,
+    item: PropTypes.object.isRequired,
+    author: PropTypes.object.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    sessionUser: PropTypes.object.isRequired,
+    memberList: PropTypes.array.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/activity/noteInput.jsx
+++ b/src/sentry/static/sentry/app/components/activity/noteInput.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import marked from 'marked';
 
@@ -20,11 +21,11 @@ function makeDefaultErrorJson() {
 
 const NoteInput = React.createClass({
   propTypes: {
-    item: React.PropTypes.object,
-    group: React.PropTypes.object.isRequired,
-    onFinish: React.PropTypes.func,
-    memberList: React.PropTypes.array.isRequired,
-    sessionUser: React.PropTypes.object.isRequired
+    item: PropTypes.object,
+    group: PropTypes.object.isRequired,
+    onFinish: PropTypes.func,
+    memberList: PropTypes.array.isRequired,
+    sessionUser: PropTypes.object.isRequired
   },
 
   mixins: [PureRenderMixin, ApiMixin],

--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import AlertActions from '../actions/alertActions';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -5,11 +6,11 @@ import {t} from '../locale';
 
 const AlertMessage = React.createClass({
   propTypes: {
-    alert: React.PropTypes.shape({
-      id: React.PropTypes.string,
-      message: React.PropTypes.string.isRequired,
-      type: React.PropTypes.oneOf(['success', 'error', 'warning']),
-      url: React.PropTypes.string
+    alert: PropTypes.shape({
+      id: PropTypes.string,
+      message: PropTypes.string.isRequired,
+      type: PropTypes.oneOf(['success', 'error', 'warning']),
+      url: PropTypes.string
     })
   },
 

--- a/src/sentry/static/sentry/app/components/alerts/toastIndicator.jsx
+++ b/src/sentry/static/sentry/app/components/alerts/toastIndicator.jsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function ToastIndicator({type, children}) {
@@ -11,7 +12,7 @@ function ToastIndicator({type, children}) {
 }
 
 ToastIndicator.propTypes = {
-  type: React.PropTypes.string.isRequired
+  type: PropTypes.string.isRequired
 };
 
 export default ToastIndicator;

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
@@ -17,7 +18,7 @@ import {t} from '../locale';
 
 const AssigneeSelector = React.createClass({
   propTypes: {
-    id: React.PropTypes.string.isRequired
+    id: PropTypes.string.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/avatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
 import MD5 from 'crypto-js/md5';
@@ -6,11 +7,11 @@ import UserLetterAvatar from '../components/userLetterAvatar';
 
 const Avatar = React.createClass({
   propTypes: {
-    user: React.PropTypes.object,
-    size: React.PropTypes.number,
-    default: React.PropTypes.string,
-    title: React.PropTypes.string,
-    gravatar: React.PropTypes.bool
+    user: PropTypes.object,
+    size: PropTypes.number,
+    default: PropTypes.string,
+    title: PropTypes.string,
+    gravatar: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/avatarCropper.jsx
+++ b/src/sentry/static/sentry/app/components/avatarCropper.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AlertActions from '../actions/alertActions';
@@ -5,9 +6,9 @@ import {t} from '../locale';
 
 const AvatarCropper = React.createClass({
   propTypes: {
-    user: React.PropTypes.object.isRequired,
-    updateDataUrlState: React.PropTypes.func.isRequired,
-    savedDataUrl: React.PropTypes.string
+    user: PropTypes.object.isRequired,
+    updateDataUrlState: PropTypes.func.isRequired,
+    savedDataUrl: PropTypes.string
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/avatarRadio.jsx
+++ b/src/sentry/static/sentry/app/components/avatarRadio.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {t} from '../locale';
 
 const AvatarRadio = React.createClass({
   propTypes: {
-    user: React.PropTypes.object.isRequired,
-    updateUser: React.PropTypes.func.isRequired
+    user: PropTypes.object.isRequired,
+    updateUser: PropTypes.func.isRequired
   },
 
   OPTIONS: {

--- a/src/sentry/static/sentry/app/components/avatarSettings.jsx
+++ b/src/sentry/static/sentry/app/components/avatarSettings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AlertActions from '../actions/alertActions';
@@ -10,7 +11,7 @@ import {t} from '../locale';
 
 const AvatarSettings = React.createClass({
   propTypes: {
-    userId: React.PropTypes.number
+    userId: PropTypes.number
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/badge.jsx
+++ b/src/sentry/static/sentry/app/components/badge.jsx
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Badge = React.createClass({
   propTypes: {
-    text: React.PropTypes.string,
-    isNew: React.PropTypes.bool
+    text: PropTypes.string,
+    isNew: PropTypes.bool
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/barChart.jsx
@@ -1,24 +1,25 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import StackedBarChart from '../components/stackedBarChart';
 
 const BarChart = React.createClass({
   propTypes: {
-    points: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        x: React.PropTypes.number.isRequired,
-        y: React.PropTypes.number.isRequired,
-        label: React.PropTypes.string
+    points: PropTypes.arrayOf(
+      PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+        label: PropTypes.string
       })
     ),
-    interval: React.PropTypes.string,
-    height: React.PropTypes.number,
-    width: React.PropTypes.number,
-    placement: React.PropTypes.string,
-    label: React.PropTypes.string,
-    markers: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        x: React.PropTypes.number.isRequired,
-        label: React.PropTypes.string
+    interval: PropTypes.string,
+    height: PropTypes.number,
+    width: PropTypes.number,
+    placement: PropTypes.string,
+    label: PropTypes.string,
+    markers: PropTypes.arrayOf(
+      PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        label: PropTypes.string
       })
     )
   },

--- a/src/sentry/static/sentry/app/components/broadcastModal.jsx
+++ b/src/sentry/static/sentry/app/components/broadcastModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import IconCloseLg from '../icons/icon-close-lg';
 import ConfigStore from '../stores/configStore';
@@ -49,12 +50,12 @@ const ReleaseAnnouncement = ({close}) => {
 };
 
 ReleaseAnnouncement.propTypes = {
-  close: React.PropTypes.func.isRequired
+  close: PropTypes.func.isRequired
 };
 
 const BroadcastModal = React.createClass({
   propTypes: {
-    closeBroadcast: React.PropTypes.func.isRequired
+    closeBroadcast: PropTypes.func.isRequired
   },
   mixins: [ApiMixin],
 

--- a/src/sentry/static/sentry/app/components/clippedBox.jsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.jsx
@@ -1,14 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {t} from '../locale';
 
 const ClippedBox = React.createClass({
   propTypes: {
-    title: React.PropTypes.string,
-    defaultClipped: React.PropTypes.bool,
-    clipHeight: React.PropTypes.number,
-    btnClassName: React.PropTypes.string,
-    btnText: React.PropTypes.string
+    title: PropTypes.string,
+    defaultClipped: PropTypes.bool,
+    clipHeight: PropTypes.number,
+    btnClassName: PropTypes.string,
+    btnText: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
+++ b/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import LoadingIndicator from '../components/loadingIndicator';
@@ -11,8 +12,8 @@ import {t} from '../locale';
 
 const CommitBar = React.createClass({
   propTypes: {
-    totalCommits: React.PropTypes.number.isRequired,
-    authorCommits: React.PropTypes.number.isRequired
+    totalCommits: PropTypes.number.isRequired,
+    authorCommits: PropTypes.number.isRequired
   },
 
   render() {
@@ -25,9 +26,9 @@ const CommitBar = React.createClass({
 
 const CommitAuthorStats = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    version: React.PropTypes.string.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    version: PropTypes.string.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 
@@ -12,9 +13,9 @@ import {t} from '../locale';
 
 const CompactIssueHeader = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    data: PropTypes.object.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired
   },
 
   getTitle() {
@@ -94,11 +95,11 @@ const CompactIssueHeader = React.createClass({
 
 const CompactIssue = React.createClass({
   propTypes: {
-    data: React.PropTypes.object,
-    id: React.PropTypes.string,
-    orgId: React.PropTypes.string,
-    statsPeriod: React.PropTypes.string,
-    showActions: React.PropTypes.bool
+    data: PropTypes.object,
+    id: PropTypes.string,
+    orgId: PropTypes.string,
+    statsPeriod: PropTypes.string,
+    showActions: PropTypes.bool
   },
 
   mixins: [ApiMixin, Reflux.listenTo(GroupStore, 'onGroupChange')],

--- a/src/sentry/static/sentry/app/components/confirms/numberConfirm.jsx
+++ b/src/sentry/static/sentry/app/components/confirms/numberConfirm.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactCodeInput from 'react-code-input';
 import Modal from 'react-bootstrap/lib/Modal';
@@ -5,9 +6,9 @@ import {t} from '../../locale';
 
 const NumberConfirm = React.createClass({
   propTypes: {
-    digits: React.PropTypes.number.isRequired,
-    show: React.PropTypes.bool,
-    onFinished: React.PropTypes.func
+    digits: PropTypes.number.isRequired,
+    show: PropTypes.bool,
+    onFinished: PropTypes.func
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import jQuery from 'jquery';
 import {isUrl} from '../utils';
@@ -70,7 +71,7 @@ function analyzeStringForRepr(value) {
 
 const ContextData = React.createClass({
   propTypes: {
-    data: React.PropTypes.any
+    data: PropTypes.any
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/count.jsx
+++ b/src/sentry/static/sentry/app/components/count.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export default React.createClass({
   propTypes: {
-    value: React.PropTypes.any.isRequired
+    value: PropTypes.any.isRequired
   },
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/sentry/static/sentry/app/components/customIgnoreCountModal.jsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreCountModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import {Select2Field} from './forms';
@@ -5,14 +6,14 @@ import {t} from '../locale';
 
 export default React.createClass({
   propTypes: {
-    onSelected: React.PropTypes.func,
-    onCanceled: React.PropTypes.func,
-    show: React.PropTypes.bool,
-    label: React.PropTypes.string.isRequired,
-    countLabel: React.PropTypes.string.isRequired,
-    countName: React.PropTypes.string.isRequired,
-    windowName: React.PropTypes.string.isRequired,
-    windowChoices: React.PropTypes.array.isRequired
+    onSelected: PropTypes.func,
+    onCanceled: PropTypes.func,
+    show: PropTypes.bool,
+    label: PropTypes.string.isRequired,
+    countLabel: PropTypes.string.isRequired,
+    countName: PropTypes.string.isRequired,
+    windowName: PropTypes.string.isRequired,
+    windowChoices: PropTypes.array.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import {t} from '../locale';
@@ -5,10 +6,10 @@ import {sprintf} from 'sprintf-js';
 
 export default React.createClass({
   propTypes: {
-    onSelected: React.PropTypes.func,
-    onCanceled: React.PropTypes.func,
-    show: React.PropTypes.bool,
-    label: React.PropTypes.string
+    onSelected: PropTypes.func,
+    onCanceled: PropTypes.func,
+    show: PropTypes.bool,
+    label: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/customResolutionModal.jsx
+++ b/src/sentry/static/sentry/app/components/customResolutionModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import jQuery from 'jquery';
@@ -12,11 +13,11 @@ import {t} from '../locale';
 
 export default React.createClass({
   propTypes: {
-    onSelected: React.PropTypes.func.isRequired,
-    onCanceled: React.PropTypes.func.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    show: React.PropTypes.bool
+    onSelected: PropTypes.func.isRequired,
+    onCanceled: PropTypes.func.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    show: PropTypes.bool
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/dateTime.jsx
+++ b/src/sentry/static/sentry/app/components/dateTime.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 import ConfigStore from '../stores/configStore.jsx';
@@ -5,8 +6,8 @@ import _ from 'lodash';
 
 const DateTime = React.createClass({
   propTypes: {
-    date: React.PropTypes.any.isRequired,
-    seconds: React.PropTypes.bool
+    date: PropTypes.any.isRequired,
+    seconds: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -6,13 +7,13 @@ require('bootstrap/js/dropdown');
 
 const DropdownLink = React.createClass({
   propTypes: {
-    title: React.PropTypes.node,
-    caret: React.PropTypes.bool,
-    disabled: React.PropTypes.bool,
-    onOpen: React.PropTypes.func,
-    onClose: React.PropTypes.func,
-    topLevelClasses: React.PropTypes.string,
-    menuClasses: React.PropTypes.string
+    title: PropTypes.node,
+    caret: PropTypes.bool,
+    disabled: PropTypes.bool,
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
+    topLevelClasses: PropTypes.string,
+    menuClasses: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/duration.jsx
+++ b/src/sentry/static/sentry/app/components/duration.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Duration = React.createClass({
   propTypes: {
-    seconds: React.PropTypes.number.isRequired
+    seconds: PropTypes.number.isRequired
   },
 
   getDuration() {

--- a/src/sentry/static/sentry/app/components/errors/detailedError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/detailedError.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classNames from 'classnames';
 
 import {t} from '../../locale';

--- a/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/groupEventDetailsLoadingError.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import {t} from '../../locale';
 import DetailedError from './detailedError';

--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Link} from 'react-router';
 
 import ProjectState from '../mixins/projectState';

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Link} from 'react-router';
 
 import {Metadata} from '../proptypes';

--- a/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Metadata} from '../proptypes';
 
 const EventOrGroupTitle = React.createClass({

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -1,7 +1,8 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Avatar from '../../components/avatar';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import {t} from '../../locale';
 import {objectIsEmpty, deviceNameMapper} from '../../utils';
 
@@ -15,7 +16,7 @@ const generateClassName = function(name) {
 
 const NoSummary = React.createClass({
   propTypes: {
-    title: React.PropTypes.string.isRequired
+    title: PropTypes.string.isRequired
   },
 
   render() {
@@ -30,8 +31,8 @@ const NoSummary = React.createClass({
 
 const GenericSummary = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired,
-    unknownTitle: React.PropTypes.string.isRequired
+    data: PropTypes.object.isRequired,
+    unknownTitle: PropTypes.string.isRequired
   },
 
   render() {
@@ -55,7 +56,7 @@ const GenericSummary = React.createClass({
 
 const UserSummary = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
   },
 
   render() {
@@ -94,7 +95,7 @@ const UserSummary = React.createClass({
 
 const DeviceSummary = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
   },
 
   render() {
@@ -119,8 +120,8 @@ const DeviceSummary = React.createClass({
 
 const EventContextSummary = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import GroupEventDataSection from './eventDataSection';
@@ -31,11 +32,11 @@ function getSourcePlugin(pluginContexts, contextType) {
 
 const ContextChunk = React.createClass({
   propTypes: {
-    event: React.PropTypes.object.isRequired,
-    group: React.PropTypes.object.isRequired,
-    type: React.PropTypes.string.isRequired,
-    alias: React.PropTypes.string.isRequired,
-    value: React.PropTypes.object.isRequired
+    event: PropTypes.object.isRequired,
+    group: PropTypes.object.isRequired,
+    type: PropTypes.string.isRequired,
+    alias: PropTypes.string.isRequired,
+    value: PropTypes.object.isRequired
   },
 
   getInitialState() {
@@ -127,8 +128,8 @@ const ContextChunk = React.createClass({
 
 const ContextsInterface = React.createClass({
   propTypes: {
-    event: React.PropTypes.object.isRequired,
-    group: React.PropTypes.object.isRequired
+    event: PropTypes.object.isRequired,
+    group: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts/app.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ContextBlock from './contextBlock';
 
 const AppContextType = React.createClass({
   propTypes: {
-    alias: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    alias: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts/contextBlock.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/contextBlock.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -6,9 +7,9 @@ import {defined} from '../../../utils';
 
 const ContextBlock = React.createClass({
   propTypes: {
-    alias: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    knownData: React.PropTypes.array
+    alias: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    knownData: PropTypes.array
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts/default.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/default.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ContextBlock from './contextBlock';
 
 const DefaultContextType = React.createClass({
   propTypes: {
-    alias: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    alias: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ContextBlock from './contextBlock';
@@ -5,8 +6,8 @@ import {defined, formatBytes} from '../../../utils';
 
 const DeviceContextType = React.createClass({
   propTypes: {
-    alias: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    alias: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   formatMemory(memory_size, free_memory, usable_memory) {

--- a/src/sentry/static/sentry/app/components/events/contexts/os.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/os.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ContextBlock from './contextBlock';
@@ -5,8 +6,8 @@ import {defined} from '../../../utils';
 
 const OsContextType = React.createClass({
   propTypes: {
-    alias: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    alias: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts/runtime.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/runtime.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ContextBlock from './contextBlock';
 
 const RuntimeContextType = React.createClass({
   propTypes: {
-    alias: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    alias: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -1,4 +1,6 @@
 /*eslint react/jsx-key:0*/
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import _ from 'lodash';
 
@@ -7,7 +9,7 @@ import KeyValueList from '../interfaces/keyValueList';
 
 const UserContextType = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/errorItem.jsx
+++ b/src/sentry/static/sentry/app/components/events/errorItem.jsx
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {t} from '../../locale';
 
 const EventErrorItem = React.createClass({
   propTypes: {
-    error: React.PropTypes.object.isRequired
+    error: PropTypes.object.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import EventDataSection from './eventDataSection';
 import EventErrorItem from './errorItem';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import {t, tn} from '../../locale';
 
 const EventErrors = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/eventDataSection.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.jsx
@@ -1,13 +1,14 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 
 const GroupEventDataSection = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    title: React.PropTypes.any,
-    type: React.PropTypes.string.isRequired,
-    wrapTitle: React.PropTypes.bool
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    title: PropTypes.any,
+    type: PropTypes.string.isRequired,
+    wrapTitle: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {logException} from '../../utils/logging';
@@ -11,7 +12,7 @@ import EventTags from './eventTags';
 import EventSdk from './sdk';
 import EventDevice from './device';
 import EventUserReport from './userReport';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import utils from '../../utils';
 import {t} from '../../locale';
 
@@ -39,13 +40,13 @@ export const INTERFACES = {
 
 const EventEntries = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    project: React.PropTypes.object.isRequired,
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    orgId: PropTypes.string.isRequired,
+    project: PropTypes.object.isRequired,
     // TODO(dcramer): ideally isShare would be replaced with simple permission
     // checks
-    isShare: React.PropTypes.bool
+    isShare: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/events/eventRow.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventRow.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Router from 'react-router';
 import EventStore from '../../stores/eventStore';
@@ -6,9 +7,9 @@ import TimeSince from '../timeSince';
 
 const EventRow = React.createClass({
   propTypes: {
-    id: React.PropTypes.string.isRequired,
-    orgSlug: React.PropTypes.string.isRequired,
-    projectSlug: React.PropTypes.string.isRequired
+    id: PropTypes.string.isRequired,
+    orgSlug: PropTypes.string.isRequired,
+    projectSlug: PropTypes.string.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import _ from 'lodash';
 
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 
 import EventDataSection from './eventDataSection';
 import {isUrl, deviceNameMapper} from '../../utils';
@@ -12,10 +13,10 @@ import Pill from '../pill';
 
 const EventTags = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/extraData.jsx
+++ b/src/sentry/static/sentry/app/components/events/extraData.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import {objectToArray} from '../../utils';
 import EventDataSection from './eventDataSection';
 import KeyValueList from './interfaces/keyValueList';
@@ -8,8 +8,8 @@ import {t} from '../../locale';
 
 const EventExtraData = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired
   },
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import Breadcrumb from './breadcrumbs/breadcrumb';
 import {t} from '../../../locale';
 
@@ -27,22 +28,22 @@ function moduleToCategory(module) {
 }
 
 Collapsed.propTypes = {
-  onClick: React.PropTypes.func.isRequired,
-  count: React.PropTypes.number.isRequired
+  onClick: PropTypes.func.isRequired,
+  count: PropTypes.number.isRequired
 };
 
 const BreadcrumbsInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    isShare: React.PropTypes.bool
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    isShare: PropTypes.bool
   },
 
   contextTypes: {
-    organization: PropTypes.Organization,
-    project: PropTypes.Project
+    organization: CustomPropTypes.Organization,
+    project: CustomPropTypes.Project
   },
 
   statics: {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 
@@ -12,7 +13,7 @@ const CUSTOM_RENDERERS = {
 
 const Breadcrumb = React.createClass({
   propTypes: {
-    crumb: React.PropTypes.object.isRequired
+    crumb: PropTypes.object.isRequired
   },
 
   getClassName() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Category = React.createClass({
   propTypes: {
-    value: React.PropTypes.string,
-    title: React.PropTypes.string,
-    hideIfEmpty: React.PropTypes.bool
+    value: PropTypes.string,
+    title: PropTypes.string,
+    hideIfEmpty: PropTypes.bool
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/crumbTable.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/crumbTable.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -5,10 +6,10 @@ import Category from './category';
 
 const CrumbTable = React.createClass({
   propTypes: {
-    crumb: React.PropTypes.object,
-    title: React.PropTypes.string,
-    kvData: React.PropTypes.object,
-    summary: React.PropTypes.object
+    crumb: PropTypes.object,
+    title: PropTypes.string,
+    kvData: PropTypes.object,
+    summary: PropTypes.object
   },
 
   renderData() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/defaultRenderer.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/defaultRenderer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import CrumbTable from './crumbTable';
@@ -5,8 +6,8 @@ import SummaryLine from './summaryLine';
 
 const DefaultRenderer = React.createClass({
   propTypes: {
-    crumb: React.PropTypes.object.isRequired,
-    kvData: React.PropTypes.object
+    crumb: PropTypes.object.isRequired,
+    kvData: PropTypes.object
   },
 
   getTitle() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/errorRenderer.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/errorRenderer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import CrumbTable from './crumbTable';
@@ -5,7 +6,7 @@ import SummaryLine from './summaryLine';
 
 const ErrorRenderer = React.createClass({
   propTypes: {
-    crumb: React.PropTypes.object.isRequired
+    crumb: PropTypes.object.isRequired
   },
 
   renderUrl(url) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/httpRenderer.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/httpRenderer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import CrumbTable from './crumbTable';
@@ -5,7 +6,7 @@ import SummaryLine from './summaryLine';
 
 const HttpRenderer = React.createClass({
   propTypes: {
-    crumb: React.PropTypes.object.isRequired
+    crumb: PropTypes.object.isRequired
   },
 
   renderUrl(url) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/summaryLine.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/summaryLine.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function isOverflowing(el) {
@@ -7,7 +8,7 @@ function isOverflowing(el) {
 
 const SummaryLine = React.createClass({
   propTypes: {
-    crumb: React.PropTypes.object.isRequired
+    crumb: PropTypes.object.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/contextLine.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/contextLine.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {defined} from '../../../utils';
 
@@ -22,8 +23,8 @@ const ContextLine = function(props) {
 };
 
 ContextLine.propTypes = {
-  line: React.PropTypes.array.isRequired,
-  isActive: React.PropTypes.bool
+  line: PropTypes.array.isRequired,
+  isActive: PropTypes.bool
 };
 
 export default ContextLine;

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashContent.jsx
@@ -1,5 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import rawStacktraceContent from './rawStacktraceContent';
 import StacktraceContent from './stacktraceContent';
 import ExceptionContent from './exceptionContent';
@@ -7,13 +8,13 @@ import RawExceptionContent from './rawExceptionContent';
 
 const CrashContent = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    stackView: React.PropTypes.string.isRequired,
-    stackType: React.PropTypes.string,
-    newestFirst: React.PropTypes.bool.isRequired,
-    exception: React.PropTypes.object,
-    stacktrace: React.PropTypes.object
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    stackView: PropTypes.string.isRequired,
+    stackType: PropTypes.string,
+    newestFirst: PropTypes.bool.isRequired,
+    exception: PropTypes.object,
+    stacktrace: PropTypes.object
   },
 
   renderException() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -1,21 +1,22 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import TooltipMixin from '../../../mixins/tooltip';
 import {t} from '../../../locale';
 
 const CrashHeader = React.createClass({
   propTypes: {
-    title: React.PropTypes.string,
-    beforeTitle: React.PropTypes.any,
-    group: PropTypes.Group.isRequired,
-    platform: React.PropTypes.string,
-    thread: React.PropTypes.object,
-    exception: React.PropTypes.object,
-    stacktrace: React.PropTypes.object,
-    stackView: React.PropTypes.string.isRequired,
-    newestFirst: React.PropTypes.bool.isRequired,
-    stackType: React.PropTypes.string, // 'original', 'minified', or falsy (none)
-    onChange: React.PropTypes.func
+    title: PropTypes.string,
+    beforeTitle: PropTypes.any,
+    group: CustomPropTypes.Group.isRequired,
+    platform: PropTypes.string,
+    thread: PropTypes.object,
+    exception: PropTypes.object,
+    stacktrace: PropTypes.object,
+    stackView: PropTypes.string.isRequired,
+    newestFirst: PropTypes.bool.isRequired,
+    stackType: PropTypes.string, // 'original', 'minified', or falsy (none)
+    onChange: PropTypes.func
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
@@ -1,5 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 
 import GroupEventDataSection from '../eventDataSection';
 import CSPContent from './cspContent';
@@ -21,10 +22,10 @@ function getView(view, data) {
 
 const CSPInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/cspContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspContent.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {objectToArray} from '../../../utils';
@@ -5,7 +6,7 @@ import KeyValueList from './keyValueList';
 
 const CSPContent = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/cspHelp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspHelp.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {t} from '../../../locale';
 
@@ -128,7 +129,7 @@ function getLink(key) {
 
 const CSPHelp = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -1,5 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import EventDataSection from '../eventDataSection';
 import ClippedBox from '../../clippedBox';
 import KeyValueList from './keyValueList';
@@ -7,9 +8,9 @@ import {t} from '../../../locale';
 
 const DebugMetaInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    data: React.PropTypes.object.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   getImageDetail(img, evt) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exception.jsx
@@ -1,16 +1,17 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import {isStacktraceNewestFirst} from './stacktrace';
 import CrashHeader from './crashHeader';
 import CrashContent from './crashContent';
 
 const ExceptionInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {defined} from '../../../utils';
 
@@ -6,11 +7,11 @@ import ExceptionMechanism from './exceptionMechanism';
 
 const ExceptionContent = React.createClass({
   propTypes: {
-    type: React.PropTypes.oneOf(['original', 'minified']),
-    values: React.PropTypes.array.isRequired,
-    view: React.PropTypes.string.isRequired,
-    platform: React.PropTypes.string,
-    newestFirst: React.PropTypes.bool
+    type: PropTypes.oneOf(['original', 'minified']),
+    values: PropTypes.array.isRequired,
+    view: PropTypes.string.isRequired,
+    platform: PropTypes.string,
+    newestFirst: PropTypes.bool
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Pills from '../../pills';
 import Pill from '../../pill';
 
 const ExceptionMechanism = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired,
-    platform: React.PropTypes.string
+    data: PropTypes.object.isRequired,
+    platform: PropTypes.string
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 import classNames from 'classnames';
@@ -21,14 +22,14 @@ export function trimPackage(pkg) {
 
 const Frame = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired,
-    nextFrame: React.PropTypes.object,
-    prevFrame: React.PropTypes.object,
-    platform: React.PropTypes.string,
-    isExpanded: React.PropTypes.bool,
-    emptySourceNotation: React.PropTypes.bool,
-    isOnlyFrame: React.PropTypes.bool,
-    timesRepeated: React.PropTypes.number
+    data: PropTypes.object.isRequired,
+    nextFrame: PropTypes.object,
+    prevFrame: PropTypes.object,
+    platform: PropTypes.string,
+    isExpanded: PropTypes.bool,
+    emptySourceNotation: PropTypes.bool,
+    isOnlyFrame: PropTypes.bool,
+    timesRepeated: PropTypes.number
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameVariables.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameVariables.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {objectToArray} from '../../../utils';
@@ -5,7 +6,7 @@ import KeyValueList from './keyValueList';
 
 const FrameVariables = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
   },
 
   // make sure that clicking on the variables does not actually do

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -6,10 +7,10 @@ import {deviceNameMapper} from '../../../utils';
 
 const KeyValueList = React.createClass({
   propTypes: {
-    data: React.PropTypes.any.isRequired,
-    isContextData: React.PropTypes.bool,
-    isSorted: React.PropTypes.bool,
-    onClick: React.PropTypes.func
+    data: PropTypes.any.isRequired,
+    isContextData: PropTypes.bool,
+    isSorted: PropTypes.bool,
+    onClick: PropTypes.func
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
@@ -1,16 +1,17 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import EventDataSection from '../eventDataSection';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import utils from '../../../utils';
 import {t} from '../../../locale';
 
 const MessageInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import rawStacktraceContent from './rawStacktraceContent';
 import ApiMixin from '../../../mixins/apiMixin';
@@ -7,10 +8,10 @@ import ClippedBox from '../../clippedBox';
 
 const RawExceptionContent = React.createClass({
   propTypes: {
-    type: React.PropTypes.oneOf(['original', 'minified']),
-    platform: React.PropTypes.string,
-    eventId: React.PropTypes.string,
-    values: React.PropTypes.array.isRequired
+    type: PropTypes.oneOf(['original', 'minified']),
+    platform: PropTypes.string,
+    eventId: PropTypes.string,
+    values: PropTypes.array.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import RichHttpContent from './richHttpContent';
 import {getCurlCommand} from './utils';
 import {isUrl} from '../../../utils';
@@ -10,16 +11,16 @@ import Truncate from '../../../components/truncate';
 
 const RequestInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    isShare: React.PropTypes.bool
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    isShare: PropTypes.bool
   },
 
   contextTypes: {
-    organization: PropTypes.Organization,
-    project: PropTypes.Project
+    organization: CustomPropTypes.Organization,
+    project: CustomPropTypes.Project
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
@@ -5,12 +5,13 @@ import KeyValueList from './keyValueList';
 import ContextData from '../../contextData';
 
 import {objectIsEmpty} from '../../../utils';
+import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import {t} from '../../../locale';
 
 const RichHttpContent = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
   },
 
   /**

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -1,7 +1,8 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ConfigStore from '../../../stores/configStore';
 import GroupEventDataSection from '../eventDataSection';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import {t} from '../../../locale';
 import CrashHeader from './crashHeader';
 import CrashContent from './crashContent';
@@ -23,11 +24,11 @@ export function isStacktraceNewestFirst() {
 
 const StacktraceInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    platform: React.PropTypes.string
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    platform: PropTypes.string
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 //import GroupEventDataSection from "../eventDataSection";
 import Frame from './frame';
@@ -6,11 +7,11 @@ import OrganizationState from '../../../mixins/organizationState';
 
 const StacktraceContent = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired,
-    includeSystemFrames: React.PropTypes.bool,
-    expandFirstFrame: React.PropTypes.bool,
-    platform: React.PropTypes.string,
-    newestFirst: React.PropTypes.bool
+    data: PropTypes.object.isRequired,
+    includeSystemFrames: PropTypes.bool,
+    expandFirstFrame: PropTypes.bool,
+    platform: PropTypes.string,
+    newestFirst: PropTypes.bool
   },
   mixins: [OrganizationState],
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/template.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/template.jsx
@@ -1,15 +1,16 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import Frame from './frame';
 import {t} from '../../../locale';
 
 const TemplateInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import GroupEventDataSection from '../eventDataSection';
-import PropTypes from '../../../proptypes';
+import CustomPropTypes from '../../../proptypes';
 import {isStacktraceNewestFirst} from './stacktrace';
 import {defined} from '../../../utils';
 import DropdownLink from '../../dropdownLink';
@@ -123,14 +124,14 @@ function findBestThread(threads) {
 
 const Thread = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    data: React.PropTypes.object.isRequired,
-    stackView: React.PropTypes.string,
-    stackType: React.PropTypes.string,
-    newestFirst: React.PropTypes.bool,
-    exception: React.PropTypes.object,
-    stacktrace: React.PropTypes.object
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    data: PropTypes.object.isRequired,
+    stackView: PropTypes.string,
+    stackType: PropTypes.string,
+    newestFirst: PropTypes.bool,
+    exception: PropTypes.object,
+    stacktrace: PropTypes.object
   },
 
   renderMissingStacktrace() {
@@ -193,11 +194,11 @@ const Thread = React.createClass({
 
 const ThreadsInterface = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired,
-    type: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    platform: React.PropTypes.string
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    platform: PropTypes.string
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/events/userReport.jsx
+++ b/src/sentry/static/sentry/app/components/events/userReport.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Avatar from '../../components/avatar';
 import TimeSince from '../../components/timeSince';
@@ -5,7 +6,7 @@ import utils from '../../utils';
 
 const EventUserReport = React.createClass({
   propTypes: {
-    event: React.PropTypes.object.isRequired
+    event: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Avatar from '../components/avatar';
 import IconFileGeneric from '../icons/icon-file-generic';
@@ -7,9 +8,9 @@ import ApiMixin from '../mixins/apiMixin';
 
 const FileChange = React.createClass({
   propTypes: {
-    filename: React.PropTypes.string.isRequired,
-    authors: React.PropTypes.array.isRequired,
-    types: React.PropTypes.object.isRequired
+    filename: PropTypes.string.isRequired,
+    authors: PropTypes.array.isRequired,
+    types: PropTypes.object.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/fileSize.jsx
+++ b/src/sentry/static/sentry/app/components/fileSize.jsx
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {formatBytes} from '../utils';
 
 const FileSize = React.createClass({
   propTypes: {
-    bytes: React.PropTypes.number.isRequired
+    bytes: PropTypes.number.isRequired
   },
 
   render: function() {

--- a/src/sentry/static/sentry/app/components/forms/apiForm.jsx
+++ b/src/sentry/static/sentry/app/components/forms/apiForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 
 import {Client} from '../../api';
 import IndicatorStore from '../../stores/indicatorStore';
@@ -9,9 +9,9 @@ import {t} from '../../locale';
 export default class ApiForm extends Form {
   static propTypes = {
     ...Form.propTypes,
-    onSubmit: React.PropTypes.func,
-    apiMethod: React.PropTypes.string.isRequired,
-    apiEndpoint: React.PropTypes.string.isRequired
+    onSubmit: PropTypes.func,
+    apiMethod: PropTypes.string.isRequired,
+    apiEndpoint: PropTypes.string.isRequired
   };
 
   constructor(props, context) {

--- a/src/sentry/static/sentry/app/components/forms/form.jsx
+++ b/src/sentry/static/sentry/app/components/forms/form.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -6,17 +7,17 @@ import {t} from '../../locale';
 
 export default class Form extends React.Component {
   static propTypes = {
-    cancelLabel: React.PropTypes.string,
-    onCancel: React.PropTypes.func,
-    onSubmit: React.PropTypes.func.isRequired,
-    onSubmitSuccess: React.PropTypes.func,
-    onSubmitError: React.PropTypes.func,
-    submitDisabled: React.PropTypes.bool,
-    submitLabel: React.PropTypes.string,
-    footerClass: React.PropTypes.string,
-    extraButton: React.PropTypes.element,
-    initialData: React.PropTypes.object,
-    requireChanges: React.PropTypes.bool
+    cancelLabel: PropTypes.string,
+    onCancel: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    onSubmitSuccess: PropTypes.func,
+    onSubmitError: PropTypes.func,
+    submitDisabled: PropTypes.bool,
+    submitLabel: PropTypes.string,
+    footerClass: PropTypes.string,
+    extraButton: PropTypes.element,
+    initialData: PropTypes.object,
+    requireChanges: PropTypes.bool
   };
 
   static defaultProps = {
@@ -29,7 +30,7 @@ export default class Form extends React.Component {
   };
 
   static childContextTypes = {
-    form: React.PropTypes.object.isRequired
+    form: PropTypes.object.isRequired
   };
 
   constructor(props, context) {

--- a/src/sentry/static/sentry/app/components/forms/formField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/formField.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import idx from 'idx';
 
@@ -5,19 +6,19 @@ import {defined} from '../../utils';
 
 export default class FormField extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
 
-    label: React.PropTypes.string,
-    defaultValue: React.PropTypes.any,
-    disabled: React.PropTypes.bool,
-    disabledReason: React.PropTypes.string,
-    help: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
-    required: React.PropTypes.bool,
+    label: PropTypes.string,
+    defaultValue: PropTypes.any,
+    disabled: PropTypes.bool,
+    disabledReason: PropTypes.string,
+    help: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    required: PropTypes.bool,
 
     // the following should only be used without form context
-    onChange: React.PropTypes.func,
-    error: React.PropTypes.string,
-    value: React.PropTypes.any
+    onChange: PropTypes.func,
+    error: PropTypes.string,
+    value: PropTypes.any
   };
 
   static defaultProps = {
@@ -26,7 +27,7 @@ export default class FormField extends React.Component {
   };
 
   static contextTypes = {
-    form: React.PropTypes.object
+    form: PropTypes.object
   };
 
   constructor(props, context) {

--- a/src/sentry/static/sentry/app/components/forms/genericField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/genericField.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {defined} from '../../utils';
@@ -66,11 +67,11 @@ class GenericField extends React.Component {
 }
 
 GenericField.propTypes = {
-  config: React.PropTypes.object.isRequired,
-  formData: React.PropTypes.object,
-  formErrors: React.PropTypes.object,
-  formState: React.PropTypes.string.isRequired,
-  onChange: React.PropTypes.func
+  config: PropTypes.object.isRequired,
+  formData: PropTypes.object,
+  formErrors: PropTypes.object,
+  formState: PropTypes.string.isRequired,
+  onChange: PropTypes.func
 };
 
 export default GenericField;

--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FormField from './formField';
@@ -6,7 +7,7 @@ import FormField from './formField';
 export default class InputField extends FormField {
   static propTypes = {
     ...FormField.propTypes,
-    placeholder: React.PropTypes.string
+    placeholder: PropTypes.string
   };
 
   // XXX(dcramer): this comes from TooltipMixin

--- a/src/sentry/static/sentry/app/components/forms/multipleCheckboxField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/multipleCheckboxField.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FormField from './formField';
@@ -6,7 +7,7 @@ import FormField from './formField';
 export default class MultipleCheckboxField extends FormField {
   static propTypes = {
     ...FormField.propTypes,
-    choices: React.PropTypes.array.isRequired
+    choices: PropTypes.array.isRequired
   };
 
   // XXX(dcramer): this comes from TooltipMixin

--- a/src/sentry/static/sentry/app/components/forms/numberField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/numberField.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 import InputField from './inputField';
 
 export default class NumberField extends InputField {
   static propTypes = {
     ...InputField.propTypes,
-    min: React.PropTypes.number,
-    max: React.PropTypes.number
+    min: PropTypes.number,
+    max: PropTypes.number
   };
 
   coerceValue(value) {

--- a/src/sentry/static/sentry/app/components/forms/passwordField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import InputField from './inputField';
 import FormState from './state';
@@ -7,8 +8,8 @@ import FormState from './state';
 export default class PasswordField extends InputField {
   static propTypes = {
     ...InputField.propTypes,
-    hasSavedValue: React.PropTypes.bool,
-    prefix: React.PropTypes.string
+    hasSavedValue: PropTypes.bool,
+    prefix: PropTypes.string
   };
 
   static defaultProps = {

--- a/src/sentry/static/sentry/app/components/forms/rangeField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/rangeField.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 import jQuery from 'jquery';
 import ReactDOM from 'react-dom';
 
@@ -12,11 +12,11 @@ export default class RangeField extends InputField {
 
   static propTypes = {
     ...InputField.propTypes,
-    min: React.PropTypes.number,
-    max: React.PropTypes.number,
-    step: React.PropTypes.number,
-    snap: React.PropTypes.bool,
-    allowedValues: React.PropTypes.arrayOf(React.PropTypes.number)
+    min: PropTypes.number,
+    max: PropTypes.number,
+    step: PropTypes.number,
+    snap: PropTypes.bool,
+    allowedValues: PropTypes.arrayOf(PropTypes.number)
   };
 
   static defaultProps = {

--- a/src/sentry/static/sentry/app/components/forms/select2Field.jsx
+++ b/src/sentry/static/sentry/app/components/forms/select2Field.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import InputField from './inputField';
@@ -62,11 +63,11 @@ class Select2Field extends InputField {
 
 Select2Field.propTypes = Object.assign(
   {
-    choices: React.PropTypes.array.isRequired,
-    allowClear: React.PropTypes.bool,
-    allowEmpty: React.PropTypes.bool,
-    multiple: React.PropTypes.bool,
-    escapeMarkup: React.PropTypes.bool
+    choices: PropTypes.array.isRequired,
+    allowClear: PropTypes.bool,
+    allowEmpty: PropTypes.bool,
+    multiple: PropTypes.bool,
+    escapeMarkup: PropTypes.bool
   },
   InputField.propTypes
 );

--- a/src/sentry/static/sentry/app/components/forms/select2FieldAutocomplete.jsx
+++ b/src/sentry/static/sentry/app/components/forms/select2FieldAutocomplete.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Select2Field from './select2Field';
 
@@ -66,14 +67,14 @@ Select2FieldAutocomplete.defaultProps = Object.assign(
 );
 
 Select2FieldAutocomplete.propTypes = Object.assign({}, Select2Field.propTypes, {
-  ajaxDelay: React.PropTypes.number,
-  minimumInputLength: React.PropTypes.number,
-  formatResult: React.PropTypes.func,
-  formatSelection: React.PropTypes.func,
-  onResults: React.PropTypes.func,
-  onQuery: React.PropTypes.func,
-  url: React.PropTypes.string.isRequired,
-  id: React.PropTypes.any
+  ajaxDelay: PropTypes.number,
+  minimumInputLength: PropTypes.number,
+  formatResult: PropTypes.func,
+  formatSelection: PropTypes.func,
+  onResults: PropTypes.func,
+  onQuery: PropTypes.func,
+  url: PropTypes.string.isRequired,
+  id: PropTypes.any
 });
 
 delete Select2FieldAutocomplete.propTypes.choices;

--- a/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import ApiMixin from '../../mixins/apiMixin';
@@ -10,7 +11,7 @@ import {toTitleCase} from '../../utils';
 
 const IssuePluginActions = React.createClass({
   propTypes: {
-    plugin: React.PropTypes.object.isRequired
+    plugin: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin, GroupState],

--- a/src/sentry/static/sentry/app/components/group/participants.jsx
+++ b/src/sentry/static/sentry/app/components/group/participants.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Avatar from '../avatar';
@@ -6,7 +7,7 @@ import {userDisplayName} from '../../utils/formatters';
 
 const GroupParticipants = React.createClass({
   propTypes: {
-    participants: React.PropTypes.array.isRequired
+    participants: PropTypes.array.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/group/releaseChart.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseChart.jsx
@@ -1,23 +1,24 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import StackedBarChart from '../stackedBarChart';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import {t} from '../../locale';
 import {defined, escape, intcomma} from '../../utils';
 
 const GroupReleaseChart = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    release: React.PropTypes.shape({
-      version: React.PropTypes.string.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    release: PropTypes.shape({
+      version: PropTypes.string.isRequired
     }),
-    releaseStats: React.PropTypes.object,
-    statsPeriod: React.PropTypes.string.isRequired,
-    environment: React.PropTypes.string,
-    environmentStats: React.PropTypes.object,
-    firstSeen: React.PropTypes.string,
-    lastSeen: React.PropTypes.string,
-    title: React.PropTypes.string
+    releaseStats: PropTypes.object,
+    statsPeriod: PropTypes.string.isRequired,
+    environment: PropTypes.string,
+    environmentStats: PropTypes.object,
+    firstSeen: PropTypes.string,
+    lastSeen: PropTypes.string,
+    title: PropTypes.string
   },
 
   getInitialState(props) {

--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {browserHistory} from 'react-router';
 
@@ -27,8 +28,8 @@ const PRODUCTION_ENV_NAMES = new Set([
 // changes
 const GroupReleaseStats = React.createClass({
   propTypes: {
-    defaultEnvironment: React.PropTypes.string,
-    group: React.PropTypes.object
+    defaultEnvironment: PropTypes.string,
+    group: PropTypes.object
   },
 
   mixins: [ApiMixin, GroupState],

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DateTime from '../../components/dateTime';
 import TimeSince from '../../components/timeSince';
@@ -10,19 +11,19 @@ import {t} from '../../locale';
 
 const SeenInfo = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    date: React.PropTypes.any,
-    dateGlobal: React.PropTypes.any,
-    release: React.PropTypes.shape({
-      version: React.PropTypes.string.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    date: PropTypes.any,
+    dateGlobal: PropTypes.any,
+    release: PropTypes.shape({
+      version: PropTypes.string.isRequired
     }),
-    environment: React.PropTypes.string,
-    hasRelease: React.PropTypes.bool.isRequired
+    environment: PropTypes.string,
+    hasRelease: PropTypes.bool.isRequired
   },
 
   contextTypes: {
-    organization: React.PropTypes.object
+    organization: PropTypes.object
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -12,12 +13,12 @@ import {t, tct} from '../../locale';
 
 const GroupSidebar = React.createClass({
   propTypes: {
-    group: React.PropTypes.object,
-    event: React.PropTypes.object
+    group: PropTypes.object,
+    event: PropTypes.object
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [ApiMixin, GroupState],

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import moment from 'moment';
@@ -10,7 +11,7 @@ import {t} from '../../locale';
 
 const SuggestedOwners = React.createClass({
   propTypes: {
-    event: React.PropTypes.object
+    event: PropTypes.object
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -1,18 +1,19 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import TooltipMixin from '../../mixins/tooltip';
 import {escape, percent, deviceNameMapper} from '../../utils';
 import {t} from '../../locale';
 
 const TagDistributionMeter = React.createClass({
   propTypes: {
-    group: PropTypes.Group.isRequired,
-    tag: React.PropTypes.string.isRequired,
-    name: React.PropTypes.string,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    group: CustomPropTypes.Group.isRequired,
+    tag: PropTypes.string.isRequired,
+    name: PropTypes.string,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import jQuery from 'jquery';
@@ -14,15 +15,15 @@ import {t} from '../locale';
 
 const GroupList = React.createClass({
   propTypes: {
-    query: React.PropTypes.string.isRequired,
-    canSelectGroups: React.PropTypes.bool,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    bulkActions: React.PropTypes.bool.isRequired
+    query: PropTypes.string.isRequired,
+    canSelectGroups: PropTypes.bool,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    bulkActions: PropTypes.bool.isRequired
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [ProjectState, Reflux.listenTo(GroupStore, 'onGroupChange'), ApiMixin],

--- a/src/sentry/static/sentry/app/components/groupTombstones.jsx
+++ b/src/sentry/static/sentry/app/components/groupTombstones.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AlertActions from '../actions/alertActions';
@@ -11,8 +12,8 @@ import {t, tct} from '../locale';
 
 const GroupTombstoneRow = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired,
-    undiscard: React.PropTypes.func.isRequired
+    data: PropTypes.object.isRequired,
+    undiscard: PropTypes.func.isRequired
   },
   render() {
     let {data, undiscard} = this.props;
@@ -63,11 +64,11 @@ const GroupTombstoneRow = React.createClass({
 
 const GroupTombstones = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    tombstones: React.PropTypes.array.isRequired,
-    tombstoneError: React.PropTypes.bool.isRequired,
-    fetchData: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    tombstones: PropTypes.array.isRequired,
+    tombstoneError: PropTypes.bool.isRequired,
+    fetchData: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/inactivePlugins.jsx
+++ b/src/sentry/static/sentry/app/components/inactivePlugins.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {t} from '../locale';
 
 export default React.createClass({
   propTypes: {
-    plugins: React.PropTypes.array.isRequired,
-    onEnablePlugin: React.PropTypes.func.isRequired
+    plugins: PropTypes.array.isRequired,
+    onEnablePlugin: PropTypes.func.isRequired
   },
 
   enablePlugin(plugin) {

--- a/src/sentry/static/sentry/app/components/internalStatChart.jsx
+++ b/src/sentry/static/sentry/app/components/internalStatChart.jsx
@@ -1,4 +1,6 @@
 /*eslint getsentry/jsx-needs-il8n:0*/
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import _ from 'lodash';
 
@@ -9,11 +11,11 @@ import LoadingIndicator from '../components/loadingIndicator';
 
 export default React.createClass({
   propTypes: {
-    since: React.PropTypes.number.isRequired,
-    resolution: React.PropTypes.string.isRequired,
-    stat: React.PropTypes.string.isRequired,
-    label: React.PropTypes.string,
-    height: React.PropTypes.number
+    since: PropTypes.number.isRequired,
+    resolution: PropTypes.string.isRequired,
+    stat: PropTypes.string.isRequired,
+    label: PropTypes.string,
+    height: PropTypes.number
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/issueLink.jsx
+++ b/src/sentry/static/sentry/app/components/issueLink.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -8,10 +9,10 @@ import TimeSince from './timeSince';
 
 export default React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    issue: React.PropTypes.object.isRequired,
-    card: React.PropTypes.bool
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    issue: PropTypes.object.isRequired,
+    card: PropTypes.bool
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/issueList.jsx
+++ b/src/sentry/static/sentry/app/components/issueList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -9,12 +10,12 @@ import {t} from '../locale';
 
 const IssueList = React.createClass({
   propTypes: {
-    endpoint: React.PropTypes.string.isRequired,
-    query: React.PropTypes.object,
-    pagination: React.PropTypes.bool,
-    renderEmpty: React.PropTypes.func,
-    statsPeriod: React.PropTypes.string,
-    showActions: React.PropTypes.bool
+    endpoint: PropTypes.string.isRequired,
+    query: PropTypes.object,
+    pagination: PropTypes.bool,
+    renderEmpty: PropTypes.func,
+    statsPeriod: PropTypes.string,
+    showActions: PropTypes.bool
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/issues/snoozeAction.jsx
+++ b/src/sentry/static/sentry/app/components/issues/snoozeAction.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import {t} from '../../locale';
@@ -11,9 +12,9 @@ const Snooze = {
 
 const SnoozeAction = React.createClass({
   propTypes: {
-    disabled: React.PropTypes.bool,
-    onSnooze: React.PropTypes.func.isRequired,
-    tooltip: React.PropTypes.string
+    disabled: PropTypes.bool,
+    onSnooze: PropTypes.func.isRequired,
+    tooltip: PropTypes.string
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/lastCommit.jsx
+++ b/src/sentry/static/sentry/app/components/lastCommit.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Avatar from './avatar';
@@ -7,8 +8,8 @@ import {t} from '../locale';
 
 const LastCommit = React.createClass({
   propTypes: {
-    commit: React.PropTypes.object.isRequired,
-    headerClass: React.PropTypes.string
+    commit: PropTypes.object.isRequired,
+    headerClass: PropTypes.string
   },
 
   renderMessage(message) {

--- a/src/sentry/static/sentry/app/components/latestDeployOrReleaseTime.jsx
+++ b/src/sentry/static/sentry/app/components/latestDeployOrReleaseTime.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ApiMixin from '../mixins/apiMixin';
 import TooltipMixin from '../mixins/tooltip';
@@ -6,8 +7,8 @@ import {t} from '../locale';
 
 const LatestDeployOrReleaseTime = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    release: React.PropTypes.object.isRequired
+    orgId: PropTypes.string.isRequired,
+    release: PropTypes.object.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/letterAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/letterAvatar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -7,8 +8,8 @@ import React from 'react';
 
 const LetterAvatar = React.createClass({
   propTypes: {
-    identifier: React.PropTypes.string.isRequired,
-    displayName: React.PropTypes.string.isRequired
+    identifier: PropTypes.string.isRequired,
+    displayName: PropTypes.string.isRequired
   },
 
   COLORS: [

--- a/src/sentry/static/sentry/app/components/link.jsx
+++ b/src/sentry/static/sentry/app/components/link.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link as RouterLink} from 'react-router';
 import _ from 'lodash';
@@ -8,11 +9,11 @@ import _ from 'lodash';
  */
 const Link = React.createClass({
   propTypes: {
-    to: React.PropTypes.string.isRequired
+    to: PropTypes.string.isRequired
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
+++ b/src/sentry/static/sentry/app/components/linkWithConfirmation.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -5,10 +6,10 @@ import {t} from '../locale';
 
 const LinkWithConfirmation = React.createClass({
   propTypes: {
-    disabled: React.PropTypes.bool,
-    message: React.PropTypes.string.isRequired,
-    title: React.PropTypes.string.isRequired,
-    onConfirm: React.PropTypes.func.isRequired
+    disabled: PropTypes.bool,
+    message: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    onConfirm: PropTypes.func.isRequired
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/listLink.jsx
+++ b/src/sentry/static/sentry/app/components/listLink.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 import {Link} from 'react-router';
@@ -7,20 +8,20 @@ const ListLink = React.createClass({
   displayName: 'ListLink',
 
   propTypes: {
-    activeClassName: React.PropTypes.string.isRequired,
-    to: React.PropTypes.string.isRequired,
-    query: React.PropTypes.object,
-    onClick: React.PropTypes.func,
-    index: React.PropTypes.bool,
+    activeClassName: PropTypes.string.isRequired,
+    to: PropTypes.string.isRequired,
+    query: PropTypes.object,
+    onClick: PropTypes.func,
+    index: PropTypes.bool,
 
     // If supplied by parent component, decides whether link element
     // is "active" or not ... overriding default behavior of strict
     // route matching
-    isActive: React.PropTypes.func
+    isActive: PropTypes.func
   },
 
   contextTypes: {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/loadingError.jsx
+++ b/src/sentry/static/sentry/app/components/loadingError.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {t} from '../locale';
 
 const LoadingError = React.createClass({
   propTypes: {
-    onRetry: React.PropTypes.func,
-    message: React.PropTypes.string
+    onRetry: PropTypes.func,
+    message: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/loadingIndicator.jsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -18,8 +19,8 @@ function LoadingIndicator(props) {
 }
 
 LoadingIndicator.propTypes = {
-  mini: React.PropTypes.bool,
-  triangle: React.PropTypes.bool
+  mini: PropTypes.bool,
+  triangle: PropTypes.bool
 };
 
 export default LoadingIndicator;

--- a/src/sentry/static/sentry/app/components/menuItem.jsx
+++ b/src/sentry/static/sentry/app/components/menuItem.jsx
@@ -1,23 +1,24 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import classNames from 'classnames';
 
 const MenuItem = React.createClass({
   propTypes: {
-    header: React.PropTypes.bool,
-    divider: React.PropTypes.bool,
-    title: React.PropTypes.string,
-    onSelect: React.PropTypes.func,
-    eventKey: React.PropTypes.any,
-    isActive: React.PropTypes.bool,
-    noAnchor: React.PropTypes.bool,
+    header: PropTypes.bool,
+    divider: PropTypes.bool,
+    title: PropTypes.string,
+    onSelect: PropTypes.func,
+    eventKey: PropTypes.any,
+    isActive: PropTypes.bool,
+    noAnchor: PropTypes.bool,
     // basic link
-    href: React.PropTypes.string,
+    href: PropTypes.string,
     // router link
-    to: React.PropTypes.string,
-    query: React.PropTypes.object,
-    linkClassName: React.PropTypes.string,
-    onClick: React.PropTypes.func
+    to: PropTypes.string,
+    query: PropTypes.object,
+    linkClassName: PropTypes.string,
+    onClick: PropTypes.func
   },
 
   handleClick(e) {

--- a/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AlertActions from '../actions/alertActions';
@@ -6,8 +7,8 @@ import {t} from '../locale';
 
 const MissingProjectMembership = React.createClass({
   propTypes: {
-    organization: React.PropTypes.object.isRequired,
-    team: React.PropTypes.object.isRequired
+    organization: PropTypes.object.isRequired,
+    team: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/mutedBox.jsx
+++ b/src/sentry/static/sentry/app/components/mutedBox.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -7,7 +8,7 @@ import {t} from '../locale';
 
 export default React.createClass({
   propTypes: {
-    statusDetails: React.PropTypes.object.isRequired
+    statusDetails: PropTypes.object.isRequired
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -8,9 +9,9 @@ import {t} from '../locale';
 
 const OrganizationIssueList = React.createClass({
   propTypes: {
-    title: React.PropTypes.string,
-    endpoint: React.PropTypes.string.isRequired,
-    pageSize: React.PropTypes.number
+    title: PropTypes.string,
+    endpoint: PropTypes.string.isRequired,
+    pageSize: PropTypes.number
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ListLink from '../listLink';
 import OrganizationState from '../../mixins/organizationState';
@@ -6,7 +7,7 @@ import {t} from '../../locale';
 
 const HomeSidebar = React.createClass({
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [OrganizationState],

--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import utils from '../utils';
 import {browserHistory} from 'react-router';
@@ -5,13 +6,13 @@ import {t} from '../locale';
 
 export default React.createClass({
   propTypes: {
-    pageLinks: React.PropTypes.string,
-    to: React.PropTypes.string,
-    onCursor: React.PropTypes.func
+    pageLinks: PropTypes.string,
+    to: PropTypes.string,
+    onCursor: PropTypes.func
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/pill.jsx
+++ b/src/sentry/static/sentry/app/components/pill.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Pill = React.createClass({
   propTypes: {
-    className: React.PropTypes.string,
-    name: React.PropTypes.string,
-    value: React.PropTypes.any
+    className: PropTypes.string,
+    name: PropTypes.string,
+    value: PropTypes.any
   },
 
   renderValue() {

--- a/src/sentry/static/sentry/app/components/pluginConfig.jsx
+++ b/src/sentry/static/sentry/app/components/pluginConfig.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -9,10 +10,10 @@ import {t} from '../locale';
 
 const PluginConfig = React.createClass({
   propTypes: {
-    organization: React.PropTypes.object.isRequired,
-    project: React.PropTypes.object.isRequired,
-    data: React.PropTypes.object.isRequired,
-    onDisablePlugin: React.PropTypes.func
+    organization: PropTypes.object.isRequired,
+    project: PropTypes.object.isRequired,
+    data: PropTypes.object.isRequired,
+    onDisablePlugin: PropTypes.func
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/pluginList.jsx
+++ b/src/sentry/static/sentry/app/components/pluginList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -8,11 +9,11 @@ import {t} from '../locale';
 
 export default React.createClass({
   propTypes: {
-    organization: React.PropTypes.object.isRequired,
-    project: React.PropTypes.object.isRequired,
-    pluginList: React.PropTypes.array.isRequired,
-    onDisablePlugin: React.PropTypes.func.isRequired,
-    onEnablePlugin: React.PropTypes.func.isRequired
+    organization: PropTypes.object.isRequired,
+    project: PropTypes.object.isRequired,
+    pluginList: PropTypes.array.isRequired,
+    onDisablePlugin: PropTypes.func.isRequired,
+    onEnablePlugin: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/projectHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -8,9 +9,9 @@ import {t} from '../../locale';
 
 const ProjectHeader = React.createClass({
   propTypes: {
-    project: React.PropTypes.object.isRequired,
-    organization: React.PropTypes.object.isRequired,
-    activeSection: React.PropTypes.string
+    project: PropTypes.object.isRequired,
+    organization: PropTypes.object.isRequired,
+    activeSection: PropTypes.string
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {browserHistory} from 'react-router';
@@ -18,12 +19,12 @@ const ProjectSelector = React.createClass({
   propTypes: {
     // Accepts a project id (slug) and not a project *object* because ProjectSelector
     // is created from Django templates, and only organization is serialized
-    projectId: React.PropTypes.string,
-    organization: React.PropTypes.object.isRequired
+    projectId: PropTypes.string,
+    organization: PropTypes.object.isRequired
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/projectLabel.jsx
+++ b/src/sentry/static/sentry/app/components/projectLabel.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 const ProjectLabel = React.createClass({
   propTypes: {
-    project: React.PropTypes.object,
-    organization: React.PropTypes.object
+    project: PropTypes.object,
+    organization: PropTypes.object
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/projects/bookmarkToggle.jsx
+++ b/src/sentry/static/sentry/app/components/projects/bookmarkToggle.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -6,8 +7,8 @@ import {update as projectUpdate} from '../../actionCreators/projects';
 
 const BookmarkToggle = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    project: React.PropTypes.object.isRequired
+    orgId: PropTypes.string.isRequired,
+    project: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/queryCount.jsx
+++ b/src/sentry/static/sentry/app/components/queryCount.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classNames from 'classnames';
 
 /**

--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import {Sparklines, SparklinesLine} from 'react-sparklines';
@@ -11,9 +12,9 @@ import {t, tn} from '../locale';
 
 const ReleaseProjectStatSparkline = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string,
-    project: React.PropTypes.object,
-    version: React.PropTypes.string
+    orgId: PropTypes.string,
+    project: PropTypes.object,
+    version: PropTypes.string
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Avatar from './avatar';
 import TooltipMixin from '../mixins/tooltip';
@@ -5,7 +6,7 @@ import {t} from '../locale';
 
 const ReleaseStats = React.createClass({
   propTypes: {
-    release: React.PropTypes.object
+    release: PropTypes.object
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import FileChange from './fileChange';
 import {t, tn} from '../locale';
@@ -14,14 +15,14 @@ function Collapsed(props) {
 }
 
 Collapsed.propTypes = {
-  onClick: React.PropTypes.func.isRequired,
-  count: React.PropTypes.number.isRequired
+  onClick: PropTypes.func.isRequired,
+  count: PropTypes.number.isRequired
 };
 
 const RepositoryFileSummary = React.createClass({
   propTypes: {
-    fileChangeSummary: React.PropTypes.object,
-    repository: React.PropTypes.string
+    fileChangeSummary: PropTypes.object,
+    repository: PropTypes.string
   },
 
   statics: {

--- a/src/sentry/static/sentry/app/components/resolutionBox.jsx
+++ b/src/sentry/static/sentry/app/components/resolutionBox.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -7,7 +8,7 @@ import {t, tct} from '../locale';
 
 export default React.createClass({
   propTypes: {
-    statusDetails: React.PropTypes.object.isRequired
+    statusDetails: PropTypes.object.isRequired
   },
 
   mixins: [PureRenderMixin],
@@ -15,10 +16,10 @@ export default React.createClass({
   renderReason() {
     let {params, statusDetails} = this.props;
     let actor = statusDetails.actor
-      ? (<strong>
+      ? <strong>
           <Avatar user={statusDetails.actor} size={20} className="avatar" />
           <span style={{marginLeft: 5}}>{statusDetails.actor.name}</span>
-        </strong>)
+        </strong>
       : null;
 
     if (statusDetails.inNextRelease && statusDetails.actor) {

--- a/src/sentry/static/sentry/app/components/resultGrid.jsx
+++ b/src/sentry/static/sentry/app/components/resultGrid.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
 import {browserHistory} from 'react-router';
@@ -9,11 +10,11 @@ import Pagination from './pagination';
 
 const Filter = React.createClass({
   propTypes: {
-    name: React.PropTypes.string.isRequired,
-    queryKey: React.PropTypes.string.isRequired,
-    options: React.PropTypes.array.isRequired,
-    path: React.PropTypes.string.isRequired,
-    value: React.PropTypes.any
+    name: PropTypes.string.isRequired,
+    queryKey: PropTypes.string.isRequired,
+    options: PropTypes.array.isRequired,
+    path: PropTypes.string.isRequired,
+    value: PropTypes.any
   },
 
   getCurrentLabel() {
@@ -77,10 +78,10 @@ const Filter = React.createClass({
 
 const SortBy = React.createClass({
   propTypes: {
-    options: React.PropTypes.array.isRequired,
-    path: React.PropTypes.string.isRequired,
-    location: React.PropTypes.string.isRequired,
-    value: React.PropTypes.any
+    options: PropTypes.array.isRequired,
+    path: PropTypes.string.isRequired,
+    location: PropTypes.string.isRequired,
+    value: PropTypes.any
   },
 
   getCurrentSortLabel() {
@@ -127,20 +128,20 @@ const SortBy = React.createClass({
 
 const ResultGrid = React.createClass({
   propTypes: {
-    columns: React.PropTypes.array,
-    columnsForRow: React.PropTypes.func,
-    defaultSort: React.PropTypes.string,
-    defaultParams: React.PropTypes.object,
-    endpoint: React.PropTypes.string,
-    filters: React.PropTypes.object,
-    hasPagination: React.PropTypes.bool,
-    hasSearch: React.PropTypes.bool,
-    keyForRow: React.PropTypes.func,
-    location: React.PropTypes.string,
-    method: React.PropTypes.string,
-    options: React.PropTypes.array,
-    path: React.PropTypes.string,
-    sortOptions: React.PropTypes.array
+    columns: PropTypes.array,
+    columnsForRow: PropTypes.func,
+    defaultSort: PropTypes.string,
+    defaultParams: PropTypes.object,
+    endpoint: PropTypes.string,
+    filters: PropTypes.object,
+    hasPagination: PropTypes.bool,
+    hasSearch: PropTypes.bool,
+    keyForRow: PropTypes.func,
+    location: PropTypes.string,
+    method: PropTypes.string,
+    options: PropTypes.array,
+    path: PropTypes.string,
+    sortOptions: PropTypes.array
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/searchBar.jsx
+++ b/src/sentry/static/sentry/app/components/searchBar.jsx
@@ -1,14 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 const SearchBar = React.createClass({
   propTypes: {
-    query: React.PropTypes.string,
-    defaultQuery: React.PropTypes.string,
-    onSearch: React.PropTypes.func,
-    onQueryChange: React.PropTypes.func,
-    placeholder: React.PropTypes.string
+    query: PropTypes.string,
+    defaultQuery: PropTypes.string,
+    onSearch: PropTypes.func,
+    onQueryChange: PropTypes.func,
+    placeholder: PropTypes.string
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -1,14 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import jQuery from 'jquery';
 
 const SelectInput = React.createClass({
   propTypes: {
-    disabled: React.PropTypes.bool,
-    multiple: React.PropTypes.bool,
-    required: React.PropTypes.bool,
-    placeholder: React.PropTypes.string,
-    value: React.PropTypes.string,
-    onChange: React.PropTypes.func
+    disabled: PropTypes.bool,
+    multiple: PropTypes.bool,
+    required: PropTypes.bool,
+    placeholder: PropTypes.string,
+    value: PropTypes.string,
+    onChange: PropTypes.func
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/shortId.jsx
+++ b/src/sentry/static/sentry/app/components/shortId.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ProjectState from '../mixins/projectState';
@@ -6,8 +7,8 @@ import AutoSelectText from './autoSelectText';
 
 const ShortId = React.createClass({
   propTypes: {
-    shortId: React.PropTypes.string,
-    project: React.PropTypes.object
+    shortId: PropTypes.string,
+    project: PropTypes.object
   },
 
   mixins: [PureRenderMixin, ProjectState],

--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -12,10 +13,10 @@ const POLLER_DELAY = 60000;
 
 const Broadcasts = React.createClass({
   propTypes: {
-    showPanel: React.PropTypes.bool,
-    currentPanel: React.PropTypes.string,
-    hidePanel: React.PropTypes.func,
-    onShowPanel: React.PropTypes.func.isRequired
+    showPanel: PropTypes.bool,
+    currentPanel: PropTypes.string,
+    hidePanel: PropTypes.func,
+    onShowPanel: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/components/sidebar/incidents.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/incidents.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 
@@ -8,10 +9,10 @@ import {t} from '../../locale';
 
 const Incidents = React.createClass({
   propTypes: {
-    showPanel: React.PropTypes.bool,
-    currentPanel: React.PropTypes.string,
-    hidePanel: React.PropTypes.func,
-    onShowPanel: React.PropTypes.func.isRequired
+    showPanel: PropTypes.bool,
+    currentPanel: PropTypes.string,
+    hidePanel: PropTypes.func,
+    onShowPanel: PropTypes.func.isRequired
   },
 
   mixins: [Reflux.listenTo(IncidentStore, 'onIncidentChange')],

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
 
@@ -19,11 +20,11 @@ import {t} from '../../locale';
 
 const OnboardingStatus = React.createClass({
   propTypes: {
-    org: React.PropTypes.object.isRequired,
-    currentPanel: React.PropTypes.string,
-    onShowPanel: React.PropTypes.func,
-    showPanel: React.PropTypes.bool,
-    hidePanel: React.PropTypes.func
+    org: PropTypes.object.isRequired,
+    currentPanel: PropTypes.string,
+    onShowPanel: PropTypes.func,
+    showPanel: PropTypes.bool,
+    hidePanel: PropTypes.func
   },
 
   render() {
@@ -72,7 +73,7 @@ function getFirstRequiredAdminAction(org) {
 
 const Sidebar = React.createClass({
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [ApiMixin, OrganizationState],

--- a/src/sentry/static/sentry/app/components/sidebar/organizationSelector.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/organizationSelector.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -12,15 +13,15 @@ import {t} from '../../locale';
 
 const OrganizationSelector = React.createClass({
   propTypes: {
-    organization: React.PropTypes.object,
-    showPanel: React.PropTypes.bool,
-    togglePanel: React.PropTypes.func,
-    hidePanel: React.PropTypes.func,
-    currentPanel: React.PropTypes.string
+    organization: PropTypes.object,
+    showPanel: PropTypes.bool,
+    togglePanel: PropTypes.func,
+    hidePanel: PropTypes.func,
+    currentPanel: PropTypes.string
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [AppState],

--- a/src/sentry/static/sentry/app/components/sidebar/userNav.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/userNav.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ConfigStore from '../../stores/configStore';
 import DropdownLink from '../dropdownLink';
@@ -7,7 +8,7 @@ import {t} from '../../locale';
 
 const UserNav = React.createClass({
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/sentry/static/sentry/app/components/sidebarPanel.jsx
+++ b/src/sentry/static/sentry/app/components/sidebarPanel.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import SidebarPanelItem from './sidebarPanelItem';
 
 const SidebarPanel = React.createClass({
   propTypes: {
-    title: React.PropTypes.string,
-    items: React.PropTypes.array,
-    hidePanel: React.PropTypes.func
+    title: PropTypes.string,
+    items: PropTypes.array,
+    hidePanel: PropTypes.func
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/sidebarPanelItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebarPanelItem.jsx
@@ -1,12 +1,13 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const SidebarPanelItem = React.createClass({
   propTypes: {
-    title: React.PropTypes.string,
-    image: React.PropTypes.string,
-    message: React.PropTypes.any,
-    link: React.PropTypes.string,
-    hasSeen: React.PropTypes.bool
+    title: PropTypes.string,
+    image: PropTypes.string,
+    message: PropTypes.any,
+    link: PropTypes.string,
+    hasSeen: PropTypes.bool
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/splitLayout.jsx
+++ b/src/sentry/static/sentry/app/components/splitLayout.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classNames from 'classnames';
 import SpreadLayout from './spreadLayout';
 

--- a/src/sentry/static/sentry/app/components/spreadLayout.jsx
+++ b/src/sentry/static/sentry/app/components/spreadLayout.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classNames from 'classnames';
 
 // Flexbox container whose children will have `justify-content: space-between`

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import TooltipMixin from '../mixins/tooltip';
 import Count from './count';
@@ -8,37 +9,37 @@ import ConfigStore from '../stores/configStore.jsx';
 const StackedBarChart = React.createClass({
   propTypes: {
     // TODO(dcramer): DEPRECATED, use series instead
-    points: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        x: React.PropTypes.number.isRequired,
-        y: React.PropTypes.array.isRequired,
-        label: React.PropTypes.string
+    points: PropTypes.arrayOf(
+      PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        y: PropTypes.array.isRequired,
+        label: PropTypes.string
       })
     ),
-    series: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        data: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            x: React.PropTypes.number.isRequired,
-            y: React.PropTypes.number
+    series: PropTypes.arrayOf(
+      PropTypes.shape({
+        data: PropTypes.arrayOf(
+          PropTypes.shape({
+            x: PropTypes.number.isRequired,
+            y: PropTypes.number
           })
         ),
-        label: React.PropTypes.string
+        label: PropTypes.string
       })
     ),
-    interval: React.PropTypes.string,
-    height: React.PropTypes.number,
-    width: React.PropTypes.number,
-    placement: React.PropTypes.string,
-    label: React.PropTypes.string,
-    markers: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        x: React.PropTypes.number.isRequired,
-        label: React.PropTypes.string
+    interval: PropTypes.string,
+    height: PropTypes.number,
+    width: PropTypes.number,
+    placement: PropTypes.string,
+    label: PropTypes.string,
+    markers: PropTypes.arrayOf(
+      PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        label: PropTypes.string
       })
     ),
-    tooltip: React.PropTypes.func,
-    barClasses: React.PropTypes.array
+    tooltip: PropTypes.func,
+    barClasses: PropTypes.array
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 
@@ -16,11 +17,11 @@ import {valueIsEqual} from '../../utils';
 
 const StreamGroup = React.createClass({
   propTypes: {
-    id: React.PropTypes.string.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    statsPeriod: React.PropTypes.string.isRequired,
-    canSelect: React.PropTypes.bool
+    id: PropTypes.string.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    statsPeriod: PropTypes.string.isRequired,
+    canSelect: PropTypes.bool
   },
 
   mixins: [Reflux.listenTo(GroupStore, 'onGroupChange'), ProjectState],

--- a/src/sentry/static/sentry/app/components/stream/groupChart.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.jsx
@@ -1,11 +1,12 @@
 import LazyLoad from 'react-lazy-load';
+import PropTypes from 'prop-types';
 import React from 'react';
 import BarChart from '../barChart';
 
 const GroupChart = React.createClass({
   propTypes: {
-    statsPeriod: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired
+    statsPeriod: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired
   },
 
   shouldComponentUpdate(nextProps) {

--- a/src/sentry/static/sentry/app/components/stream/groupCheckBox.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupCheckBox.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 
@@ -6,7 +7,7 @@ import Checkbox from '../checkbox';
 
 const GroupCheckBox = React.createClass({
   propTypes: {
-    id: React.PropTypes.string.isRequired
+    id: PropTypes.string.isRequired
   },
 
   mixins: [Reflux.listenTo(SelectedGroupStore, 'onSelectedGroupChange')],

--- a/src/sentry/static/sentry/app/components/strictClick.jsx
+++ b/src/sentry/static/sentry/app/components/strictClick.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -9,7 +10,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
  */
 const StrictClick = React.createClass({
   propTypes: {
-    onClick: React.PropTypes.func
+    onClick: PropTypes.func
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/switch.jsx
+++ b/src/sentry/static/sentry/app/components/switch.jsx
@@ -1,12 +1,13 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Switch = React.createClass({
   propTypes: {
-    size: React.PropTypes.string,
-    isActive: React.PropTypes.bool,
-    isLoading: React.PropTypes.bool,
-    isDisabled: React.PropTypes.bool,
-    toggle: React.PropTypes.func.isRequired
+    size: PropTypes.string,
+    isActive: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isDisabled: PropTypes.bool,
+    toggle: PropTypes.func.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/timeSince.jsx
+++ b/src/sentry/static/sentry/app/components/timeSince.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -7,8 +8,8 @@ import _ from 'lodash';
 
 const TimeSince = React.createClass({
   propTypes: {
-    date: React.PropTypes.any.isRequired,
-    suffix: React.PropTypes.string
+    date: PropTypes.any.isRequired,
+    suffix: PropTypes.string
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/components/todos.jsx
+++ b/src/sentry/static/sentry/app/components/todos.jsx
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {t, tct} from '../locale';
 
@@ -7,8 +8,8 @@ import OrganizationState from '../mixins/organizationState';
 
 const TodoItem = React.createClass({
   propTypes: {
-    task: React.PropTypes.object,
-    onSkip: React.PropTypes.func.isRequired
+    task: PropTypes.object,
+    onSkip: PropTypes.func.isRequired
   },
 
   mixins: [OrganizationState],
@@ -114,9 +115,9 @@ const TodoItem = React.createClass({
 
 const Confirmation = React.createClass({
   propTypes: {
-    task: React.PropTypes.number,
-    onSkip: React.PropTypes.func.isRequired,
-    dismiss: React.PropTypes.func.isRequired
+    task: PropTypes.number,
+    onSkip: PropTypes.func.isRequired,
+    dismiss: PropTypes.func.isRequired
   },
 
   skip: function(e) {

--- a/src/sentry/static/sentry/app/components/truncate.jsx
+++ b/src/sentry/static/sentry/app/components/truncate.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Truncate = React.createClass({
   propTypes: {
-    value: React.PropTypes.string.isRequired,
-    leftTrim: React.PropTypes.bool,
-    maxLength: React.PropTypes.number
+    value: PropTypes.string.isRequired,
+    leftTrim: PropTypes.bool,
+    maxLength: PropTypes.number
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/u2fenrollment.jsx
+++ b/src/sentry/static/sentry/app/components/u2fenrollment.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import U2fInterface from './u2finterface';
@@ -5,7 +6,7 @@ import {t} from '../locale';
 
 const U2fEnrollment = React.createClass({
   propTypes: {
-    enrollmentData: React.PropTypes.object
+    enrollmentData: PropTypes.object
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/u2finterface.jsx
+++ b/src/sentry/static/sentry/app/components/u2finterface.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import u2f from 'u2f-api';
 import ConfigStore from '../stores/configStore';
@@ -6,10 +7,10 @@ import {t, tct} from '../locale';
 
 const U2fInterface = React.createClass({
   propTypes: {
-    challengeData: React.PropTypes.object.isRequired,
-    flowMode: React.PropTypes.string.isRequired,
-    onTap: React.PropTypes.func,
-    silentIfUnsupported: React.PropTypes.bool
+    challengeData: PropTypes.object.isRequired,
+    flowMode: PropTypes.string.isRequired,
+    onTap: PropTypes.func,
+    silentIfUnsupported: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/u2fsign.jsx
+++ b/src/sentry/static/sentry/app/components/u2fsign.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import U2fInterface from './u2finterface';
@@ -5,8 +6,8 @@ import {t} from '../locale';
 
 const U2fSign = React.createClass({
   propTypes: {
-    challengeData: React.PropTypes.object,
-    displayMode: React.PropTypes.string
+    challengeData: PropTypes.object,
+    displayMode: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/userInfo.jsx
+++ b/src/sentry/static/sentry/app/components/userInfo.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function getUserDisplayName(name) {
@@ -10,7 +11,7 @@ function getUserDisplayName(name) {
 
 const UserInfo = React.createClass({
   propTypes: {
-    user: React.PropTypes.any.isRequired
+    user: PropTypes.any.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/userLetterAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/userLetterAvatar.jsx
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import LetterAvatar from './letterAvatar';
 
 const UserLetterAvatar = React.createClass({
   propTypes: {
-    user: React.PropTypes.object.isRequired
+    user: PropTypes.object.isRequired
   },
 
   getIdentifier() {

--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -5,10 +6,10 @@ import {getShortVersion} from '../utils';
 
 const Version = React.createClass({
   propTypes: {
-    anchor: React.PropTypes.bool,
-    version: React.PropTypes.string.isRequired,
-    orgId: React.PropTypes.string,
-    projectId: React.PropTypes.string
+    anchor: PropTypes.bool,
+    version: PropTypes.string.isRequired,
+    orgId: PropTypes.string,
+    projectId: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -15,9 +16,9 @@ import ApiMixin from '../mixins/apiMixin';
 
 const VersionHoverCard = React.createClass({
   propTypes: {
-    version: React.PropTypes.string.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    version: PropTypes.string.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/mixins/projectState.jsx
+++ b/src/sentry/static/sentry/app/mixins/projectState.jsx
@@ -1,11 +1,11 @@
-import PropTypes from '../proptypes';
+import CustomPropTypes from '../proptypes';
 import TeamState from './teamState';
 
 let ProjectState = {
   mixins: [TeamState],
 
   contextTypes: {
-    project: PropTypes.Project
+    project: CustomPropTypes.Project
   },
 
   getProjectFeatures() {

--- a/src/sentry/static/sentry/app/plugins/baseContext.jsx
+++ b/src/sentry/static/sentry/app/plugins/baseContext.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ContextBlock from '../components/events/contexts/contextBlock';
@@ -11,8 +12,8 @@ class BaseContext extends React.Component {
 BaseContext.displayName = 'BaseContext';
 
 BaseContext.propTypes = {
-  alias: React.PropTypes.string.isRequired,
-  data: React.PropTypes.object.isRequired
+  alias: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired
 };
 
 BaseContext.getTitle = function(value) {

--- a/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {Form, FormState} from '../../components/forms';
@@ -354,9 +355,9 @@ class IssueActions extends PluginComponentBase {
 }
 
 IssueActions.propTypes = {
-  plugin: React.PropTypes.object.isRequired,
-  actionType: React.PropTypes.oneOf(['unlink', 'link', 'create']).isRequired,
-  onSuccess: React.PropTypes.func
+  plugin: PropTypes.object.isRequired,
+  actionType: PropTypes.oneOf(['unlink', 'link', 'create']).isRequired,
+  onSuccess: PropTypes.func
 };
 
 export default IssueActions;

--- a/src/sentry/static/sentry/app/plugins/components/settings.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/settings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -164,9 +165,9 @@ class PluginSettings extends PluginComponentBase {
 }
 
 PluginSettings.propTypes = {
-  organization: React.PropTypes.object.isRequired,
-  project: React.PropTypes.object.isRequired,
-  plugin: React.PropTypes.object.isRequired
+  organization: PropTypes.object.isRequired,
+  project: PropTypes.object.isRequired,
+  plugin: PropTypes.object.isRequired
 };
 
 export default PluginSettings;

--- a/src/sentry/static/sentry/app/proptypes.jsx
+++ b/src/sentry/static/sentry/app/proptypes.jsx
@@ -1,107 +1,107 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 
-const Metadata = React.PropTypes.shape({
-  value: React.PropTypes.string,
-  message: React.PropTypes.string,
-  directive: React.PropTypes.string,
-  type: React.PropTypes.string,
-  title: React.PropTypes.string,
-  uri: React.PropTypes.string
+const Metadata = PropTypes.shape({
+  value: PropTypes.string,
+  message: PropTypes.string,
+  directive: PropTypes.string,
+  type: PropTypes.string,
+  title: PropTypes.string,
+  uri: PropTypes.string
 });
 
-const User = React.PropTypes.shape({
-  id: React.PropTypes.string.isRequired
+const User = PropTypes.shape({
+  id: PropTypes.string.isRequired
 });
 
-const Group = React.PropTypes.shape({
-  id: React.PropTypes.string.isRequired,
-  annotations: React.PropTypes.array,
+const Group = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  annotations: PropTypes.array,
   assignedTo: User,
-  count: React.PropTypes.string,
-  culprit: React.PropTypes.string,
-  firstSeen: React.PropTypes.string,
-  hasSeen: React.PropTypes.bool,
-  isBookmarked: React.PropTypes.bool,
-  isPublic: React.PropTypes.bool,
-  isSubscribed: React.PropTypes.bool,
-  lastSeen: React.PropTypes.string,
-  level: React.PropTypes.string,
-  logger: React.PropTypes.string,
+  count: PropTypes.string,
+  culprit: PropTypes.string,
+  firstSeen: PropTypes.string,
+  hasSeen: PropTypes.bool,
+  isBookmarked: PropTypes.bool,
+  isPublic: PropTypes.bool,
+  isSubscribed: PropTypes.bool,
+  lastSeen: PropTypes.string,
+  level: PropTypes.string,
+  logger: PropTypes.string,
   metadata: Metadata,
-  numComments: React.PropTypes.number,
-  permalink: React.PropTypes.string,
-  project: React.PropTypes.shape({
-    name: React.PropTypes.string,
-    slug: React.PropTypes.string
+  numComments: PropTypes.number,
+  permalink: PropTypes.string,
+  project: PropTypes.shape({
+    name: PropTypes.string,
+    slug: PropTypes.string
   }),
-  shareId: React.PropTypes.string,
-  shortId: React.PropTypes.string,
-  status: React.PropTypes.string,
-  statusDetails: React.PropTypes.object,
-  title: React.PropTypes.string,
-  type: React.PropTypes.oneOf(['error', 'csp', 'default']),
-  userCount: React.PropTypes.number
+  shareId: PropTypes.string,
+  shortId: PropTypes.string,
+  status: PropTypes.string,
+  statusDetails: PropTypes.object,
+  title: PropTypes.string,
+  type: PropTypes.oneOf(['error', 'csp', 'default']),
+  userCount: PropTypes.number
 });
 
-const Event = React.PropTypes.shape({
-  id: React.PropTypes.string.isRequired,
-  context: React.PropTypes.object,
-  contexts: React.PropTypes.object,
-  dateCreated: React.PropTypes.string,
-  dateReceived: React.PropTypes.string,
-  entries: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      data: React.PropTypes.object,
-      type: React.PropTypes.string
+const Event = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  context: PropTypes.object,
+  contexts: PropTypes.object,
+  dateCreated: PropTypes.string,
+  dateReceived: PropTypes.string,
+  entries: PropTypes.arrayOf(
+    PropTypes.shape({
+      data: PropTypes.object,
+      type: PropTypes.string
     })
   ),
-  errors: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      data: React.PropTypes.object,
-      message: React.PropTypes.string,
-      type: React.PropTypes.string
+  errors: PropTypes.arrayOf(
+    PropTypes.shape({
+      data: PropTypes.object,
+      message: PropTypes.string,
+      type: PropTypes.string
     })
   ),
-  eventID: React.PropTypes.string,
-  fingerprints: React.PropTypes.arrayOf(React.PropTypes.string),
-  groupID: React.PropTypes.string,
-  message: React.PropTypes.string,
+  eventID: PropTypes.string,
+  fingerprints: PropTypes.arrayOf(PropTypes.string),
+  groupID: PropTypes.string,
+  message: PropTypes.string,
   metadata: Metadata,
-  packages: React.PropTypes.object,
-  platform: React.PropTypes.string,
-  sdk: React.PropTypes.object,
-  size: React.PropTypes.number,
-  tags: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      key: React.PropTypes.string,
-      value: React.PropTypes.string
+  packages: PropTypes.object,
+  platform: PropTypes.string,
+  sdk: PropTypes.object,
+  size: PropTypes.number,
+  tags: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      value: PropTypes.string
     })
   ),
-  type: React.PropTypes.oneOf(['error', 'csp', 'default']),
-  user: React.PropTypes.object
+  type: PropTypes.oneOf(['error', 'csp', 'default']),
+  user: PropTypes.object
 });
 
-let PropTypes = {
-  AnyModel: React.PropTypes.shape({
-    id: React.PropTypes.string.isRequired
+let CustomPropTypes = {
+  AnyModel: PropTypes.shape({
+    id: PropTypes.string.isRequired
   }),
   Group,
   Event,
-  Organization: React.PropTypes.shape({
-    id: React.PropTypes.string.isRequired
+  Organization: PropTypes.shape({
+    id: PropTypes.string.isRequired
   }),
-  Project: React.PropTypes.shape({
-    id: React.PropTypes.string.isRequired
+  Project: PropTypes.shape({
+    id: PropTypes.string.isRequired
   }),
-  TagKey: React.PropTypes.shape({
-    key: React.PropTypes.string.isRequired
+  TagKey: PropTypes.shape({
+    key: PropTypes.string.isRequired
   }),
-  Team: React.PropTypes.shape({
-    id: React.PropTypes.string.isRequired
+  Team: PropTypes.shape({
+    id: PropTypes.string.isRequired
   }),
   User
 };
 
 export {Group, Event, Metadata};
 
-export default PropTypes;
+export default CustomPropTypes;

--- a/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
+++ b/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AsyncView from './asyncView';
@@ -7,8 +8,8 @@ import {t} from '../locale';
 
 const AuthorizationRow = React.createClass({
   propTypes: {
-    authorization: React.PropTypes.object.isRequired,
-    onRevoke: React.PropTypes.func.isRequired
+    authorization: PropTypes.object.isRequired,
+    onRevoke: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/apiChart.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -7,8 +8,8 @@ import LoadingIndicator from '../../components/loadingIndicator';
 
 export default React.createClass({
   propTypes: {
-    since: React.PropTypes.number.isRequired,
-    resolution: React.PropTypes.string.isRequired
+    since: PropTypes.number.isRequired,
+    resolution: PropTypes.string.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/adminOverview/eventChart.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -7,8 +8,8 @@ import LoadingIndicator from '../../components/loadingIndicator';
 
 export default React.createClass({
   propTypes: {
-    since: React.PropTypes.number.isRequired,
-    resolution: React.PropTypes.string.isRequired
+    since: PropTypes.number.isRequired,
+    resolution: PropTypes.string.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/apiApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/apiApplicationDetails.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 
@@ -12,7 +13,7 @@ import {t} from '../locale';
 
 const ApiApplicationDetails = React.createClass({
   contextTypes: {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/apiApplications.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 import {Link} from 'react-router';
@@ -10,8 +11,8 @@ import {t} from '../locale';
 
 const ApiApplicationRow = React.createClass({
   propTypes: {
-    app: React.PropTypes.object.isRequired,
-    onRemove: React.PropTypes.func.isRequired
+    app: PropTypes.object.isRequired,
+    onRemove: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],
@@ -83,7 +84,7 @@ const ApiApplicationRow = React.createClass({
 
 const ApiApplications = React.createClass({
   contextTypes: {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/apiTokens.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 import {Link} from 'react-router';
@@ -12,8 +13,8 @@ import {t, tct} from '../locale';
 
 const ApiTokenRow = React.createClass({
   propTypes: {
-    token: React.PropTypes.object.isRequired,
-    onRemove: React.PropTypes.func.isRequired
+    token: PropTypes.object.isRequired,
+    onRemove: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
 import Cookies from 'js-cookie';
@@ -25,7 +26,7 @@ function getAlertTypeForProblem(problem) {
 
 const App = React.createClass({
   childContextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/asyncView.jsx
+++ b/src/sentry/static/sentry/app/views/asyncView.jsx
@@ -1,4 +1,5 @@
 import DocumentTitle from 'react-document-title';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {isEqual} from 'lodash';
 
@@ -164,7 +165,7 @@ AsyncView.errorHandler = (component, fn) => {
 };
 
 AsyncView.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 export default AsyncView;

--- a/src/sentry/static/sentry/app/views/groupActivity/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupActivity/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -21,7 +22,7 @@ import {t, tct, tn} from '../../locale';
 const GroupActivity = React.createClass({
   // TODO(dcramer): only re-render on group/activity change
   propTypes: {
-    group: React.PropTypes.object
+    group: PropTypes.object
   },
 
   mixins: [GroupState, ApiMixin],

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import {browserHistory} from 'react-router';
@@ -7,7 +8,7 @@ import GroupHeader from './groupDetails/header';
 import GroupStore from '../stores/groupStore';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
-import PropTypes from '../proptypes';
+import CustomPropTypes from '../proptypes';
 import {t} from '../locale';
 
 let ERROR_TYPES = {
@@ -16,13 +17,13 @@ let ERROR_TYPES = {
 
 const GroupDetails = React.createClass({
   propTypes: {
-    setProjectNavSection: React.PropTypes.func,
-    memberList: React.PropTypes.array
+    setProjectNavSection: PropTypes.func,
+    memberList: PropTypes.array
   },
 
   childContextTypes: {
-    group: PropTypes.Group,
-    location: React.PropTypes.object
+    group: CustomPropTypes.Group,
+    location: PropTypes.object
   },
 
   mixins: [ApiMixin, Reflux.listenTo(GroupStore, 'onGroupChange')],

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
@@ -18,12 +19,12 @@ import {getShortVersion} from '../../utils';
 
 const ResolveActions = React.createClass({
   propTypes: {
-    group: React.PropTypes.object.isRequired,
-    hasRelease: React.PropTypes.bool.isRequired,
-    latestRelease: React.PropTypes.object,
-    onUpdate: React.PropTypes.func.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired
+    group: PropTypes.object.isRequired,
+    hasRelease: PropTypes.bool.isRequired,
+    latestRelease: PropTypes.object,
+    onUpdate: PropTypes.func.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired
   },
 
   getInitialState() {
@@ -154,8 +155,8 @@ const ResolveActions = React.createClass({
 
 const IgnoreActions = React.createClass({
   propTypes: {
-    group: React.PropTypes.object.isRequired,
-    onUpdate: React.PropTypes.func.isRequired
+    group: PropTypes.object.isRequired,
+    onUpdate: PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -360,9 +361,9 @@ const IgnoreActions = React.createClass({
 
 const DeleteActions = React.createClass({
   propTypes: {
-    project: React.PropTypes.object.isRequired,
-    onDelete: React.PropTypes.func.isRequired,
-    onDiscard: React.PropTypes.func.isRequired
+    project: PropTypes.object.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    onDiscard: PropTypes.func.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -1,9 +1,10 @@
 import {Link} from 'react-router';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ConfigStore from '../../stores/configStore';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import DateTime from '../../components/dateTime';
 import FileSize from '../../components/fileSize';
 import TooltipMixin from '../../mixins/tooltip';
@@ -32,10 +33,10 @@ let formatDateDelta = (reference, observed) => {
 
 let GroupEventToolbar = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    group: PropTypes.Group.isRequired,
-    event: PropTypes.Event.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    group: CustomPropTypes.Group.isRequired,
+    event: CustomPropTypes.Event.isRequired
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/groupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/header.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link, browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
@@ -16,11 +17,11 @@ import {t} from '../../locale';
 
 const GroupHeader = React.createClass({
   propTypes: {
-    group: React.PropTypes.object.isRequired
+    group: PropTypes.object.isRequired
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/groupGrouping/groupGroupingView.jsx
+++ b/src/sentry/static/sentry/app/views/groupGrouping/groupGroupingView.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Reflux from 'reflux';
 
 import {t} from '../../locale';

--- a/src/sentry/static/sentry/app/views/groupGrouping/mergedItem.jsx
+++ b/src/sentry/static/sentry/app/views/groupGrouping/mergedItem.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Reflux from 'reflux';
 import classNames from 'classnames';
 

--- a/src/sentry/static/sentry/app/views/groupGrouping/mergedList.jsx
+++ b/src/sentry/static/sentry/app/views/groupGrouping/mergedList.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import {t} from '../../locale';
 import {Event} from '../../proptypes';

--- a/src/sentry/static/sentry/app/views/groupGrouping/mergedToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupGrouping/mergedToolbar.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Reflux from 'reflux';
 
 import {t} from '../../locale';

--- a/src/sentry/static/sentry/app/views/groupGrouping/similarItem.jsx
+++ b/src/sentry/static/sentry/app/views/groupGrouping/similarItem.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Reflux from 'reflux';
 import classNames from 'classnames';
 

--- a/src/sentry/static/sentry/app/views/groupGrouping/similarList.jsx
+++ b/src/sentry/static/sentry/app/views/groupGrouping/similarList.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import {t} from '../../locale';
 import {Group} from '../../proptypes';

--- a/src/sentry/static/sentry/app/views/groupGrouping/similarToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupGrouping/similarToolbar.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Reflux from 'reflux';
 
 import {t} from '../../locale';

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 import _ from 'lodash';
@@ -11,9 +12,9 @@ import {getOption, getOptionField, getForm} from '../options';
 
 const InstallWizardSettings = React.createClass({
   propTypes: {
-    options: React.PropTypes.object.isRequired,
-    formDisabled: React.PropTypes.bool,
-    onSubmit: React.PropTypes.func.isRequired
+    options: PropTypes.object.isRequired,
+    formDisabled: PropTypes.bool,
+    onSubmit: PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -105,7 +106,7 @@ const InstallWizardSettings = React.createClass({
 
 const InstallWizard = React.createClass({
   propTypes: {
-    onConfigured: React.PropTypes.func.isRequired
+    onConfigured: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/onboarding/configure/waiting.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/configure/waiting.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {t} from '../../../locale';
 
 const Waiting = React.createClass({
   propTypes: {
-    skip: React.PropTypes.func,
-    hasEvent: React.PropTypes.bool.isRequired
+    skip: PropTypes.func,
+    hasEvent: PropTypes.bool.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/onboarding/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/index.jsx
@@ -7,11 +7,13 @@ import ProgressNodes from './progress';
 import ProjectActions from '../../actions/projectActions';
 import {getPlatformName} from './utils';
 
+import PropTypes from 'prop-types';
+
 import Raven from 'raven-js';
 
 const OnboardingWizard = React.createClass({
   contextTypes: {
-    organization: React.PropTypes.object
+    organization: PropTypes.object
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/onboarding/progress.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/progress.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import {onboardingSteps, stepDescriptions} from './utils';
@@ -5,11 +6,11 @@ import ConfigStore from '../../stores/configStore';
 
 const ProgressNodes = React.createClass({
   propTypes: {
-    params: React.PropTypes.object
+    params: PropTypes.object
   },
 
   contextTypes: {
-    organization: React.PropTypes.object
+    organization: PropTypes.object
   },
 
   steps: Object.keys(onboardingSteps),

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
@@ -7,11 +8,11 @@ import {t} from '../../../locale';
 
 const Project = React.createClass({
   propTypes: {
-    next: React.PropTypes.func,
-    setPlatform: React.PropTypes.func,
-    platform: React.PropTypes.string,
-    setName: React.PropTypes.func,
-    name: React.PropTypes.string
+    next: PropTypes.func,
+    setPlatform: PropTypes.func,
+    platform: PropTypes.string,
+    setName: PropTypes.func,
+    name: PropTypes.string
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/onboarding/project/platformCard.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/platformCard.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {flattenedPlatforms} from '../utils';
@@ -6,8 +7,8 @@ import classnames from 'classnames';
 
 const PlatformCard = React.createClass({
   propTypes: {
-    platform: React.PropTypes.string,
-    onClick: React.PropTypes.func
+    platform: PropTypes.string,
+    onClick: PropTypes.func
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/onboarding/project/platformiconTile.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/platformiconTile.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const PlatformiconTile = React.createClass({
   propTypes: {
-    platform: React.PropTypes.string,
-    onClick: React.PropTypes.func,
-    className: React.PropTypes.string
+    platform: PropTypes.string,
+    onClick: PropTypes.func,
+    className: PropTypes.string
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/onboarding/project/platformpicker.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/platformpicker.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ListLink from '../../../components/listLink';
 import classnames from 'classnames';
@@ -10,9 +11,9 @@ const categoryList = Object.keys(categoryLists).concat('All');
 
 const PlatformPicker = React.createClass({
   propTypes: {
-    setPlatform: React.PropTypes.func.isRequired,
-    platform: React.PropTypes.string,
-    showOther: React.PropTypes.bool
+    setPlatform: PropTypes.func.isRequired,
+    platform: PropTypes.string,
+    showOther: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import {Link} from 'react-router';
@@ -20,8 +21,8 @@ import {sortArray} from '../utils';
 
 const AssignedIssues = React.createClass({
   propTypes: {
-    statsPeriod: React.PropTypes.string,
-    pageSize: React.PropTypes.number
+    statsPeriod: PropTypes.string,
+    pageSize: PropTypes.number
   },
 
   getEndpoint() {
@@ -74,8 +75,8 @@ const AssignedIssues = React.createClass({
 
 const NewIssues = React.createClass({
   propTypes: {
-    statsPeriod: React.PropTypes.string,
-    pageSize: React.PropTypes.number
+    statsPeriod: PropTypes.string,
+    pageSize: PropTypes.number
   },
 
   getEndpoint() {
@@ -136,13 +137,13 @@ function ProjectSparkline(props) {
   );
 }
 ProjectSparkline.propTypes = {
-  data: React.PropTypes.array.isRequired
+  data: PropTypes.array.isRequired
 };
 
 const ProjectList = React.createClass({
   propTypes: {
-    teams: React.PropTypes.array,
-    maxProjects: React.PropTypes.number
+    teams: PropTypes.array,
+    maxProjects: PropTypes.number
   },
 
   mixins: [OrganizationState],

--- a/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -9,8 +10,8 @@ import {t} from '../../locale';
 
 const AccountLimit = React.createClass({
   propTypes: {
-    value: React.PropTypes.number,
-    onChange: React.PropTypes.func.isRequired
+    value: PropTypes.number,
+    onChange: PropTypes.func.isRequired
   },
 
   getRateLimitValues() {
@@ -51,7 +52,7 @@ const AccountLimit = React.createClass({
 
 const RateLimitEditor = React.createClass({
   propTypes: {
-    organization: React.PropTypes.object.isRequired
+    organization: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRepositories.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 
@@ -197,7 +198,7 @@ class AddRepositoryLink extends PluginComponentBase {
 }
 
 AddRepositoryLink.propTypes = {
-  provider: React.PropTypes.object.isRequired
+  provider: PropTypes.object.isRequired
 };
 
 const OrganizationRepositories = React.createClass({

--- a/src/sentry/static/sentry/app/views/organizationSettings.jsx
+++ b/src/sentry/static/sentry/app/views/organizationSettings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -17,10 +18,10 @@ import {extractMultilineFields} from '../utils';
 
 const OrganizationSettingsForm = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    access: React.PropTypes.object.isRequired,
-    initialData: React.PropTypes.object.isRequired,
-    onSave: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    access: PropTypes.object.isRequired,
+    initialData: PropTypes.object.isRequired,
+    onSave: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import Count from '../../components/count';
@@ -16,10 +17,10 @@ let getPercent = (item, total) => {
 
 const ProjectTable = React.createClass({
   propTypes: {
-    projectMap: React.PropTypes.object.isRequired,
-    projectTotals: React.PropTypes.array.isRequired,
-    orgTotal: React.PropTypes.object.isRequired,
-    organization: React.PropTypes.object.isRequired
+    projectMap: PropTypes.object.isRequired,
+    projectTotals: PropTypes.array.isRequired,
+    orgTotal: PropTypes.object.isRequired,
+    organization: PropTypes.object.isRequired
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsList.jsx
@@ -1,17 +1,18 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 
 import AllTeamsRow from './allTeamsRow';
 import {tct} from '../../locale';
 
 const AllTeamsList = React.createClass({
   propTypes: {
-    access: React.PropTypes.object,
-    organization: PropTypes.Organization,
-    teamList: React.PropTypes.arrayOf(PropTypes.Team),
-    openMembership: React.PropTypes.bool
+    access: PropTypes.object,
+    organization: CustomPropTypes.Organization,
+    teamList: PropTypes.arrayOf(PropTypes.Team),
+    openMembership: PropTypes.bool
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -9,10 +10,10 @@ import {t} from '../../locale';
 
 const AllTeamsRow = React.createClass({
   propTypes: {
-    access: React.PropTypes.object.isRequired,
-    organization: React.PropTypes.object.isRequired,
-    team: React.PropTypes.object.isRequired,
-    openMembership: React.PropTypes.bool.isRequired
+    access: PropTypes.object.isRequired,
+    organization: PropTypes.object.isRequired,
+    team: PropTypes.object.isRequired,
+    openMembership: PropTypes.bool.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import LazyLoad from 'react-lazy-load';
@@ -6,18 +7,18 @@ import ApiMixin from '../../mixins/apiMixin';
 import {update as projectUpdate} from '../../actionCreators/projects';
 import BarChart from '../../components/barChart';
 import ProjectLabel from '../../components/projectLabel';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import TooltipMixin from '../../mixins/tooltip';
 import {sortArray} from '../../utils';
 import {t, tct} from '../../locale';
 
 const ExpandedTeamList = React.createClass({
   propTypes: {
-    access: React.PropTypes.object.isRequired,
-    organization: PropTypes.Organization.isRequired,
-    teamList: React.PropTypes.arrayOf(PropTypes.Team).isRequired,
-    projectStats: React.PropTypes.object,
-    hasTeams: React.PropTypes.bool
+    access: PropTypes.object.isRequired,
+    organization: CustomPropTypes.Organization.isRequired,
+    teamList: PropTypes.arrayOf(CustomPropTypes.Team).isRequired,
+    projectStats: PropTypes.object,
+    hasTeams: PropTypes.bool
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/organizationStatOverview.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import classNames from 'classnames';
@@ -10,11 +11,11 @@ import {t} from '../../locale';
 
 const OrganizationStatOverview = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string
+    orgId: PropTypes.string
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   mixins: [ApiMixin, OrganizationState],

--- a/src/sentry/static/sentry/app/views/projectAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertRules.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -10,10 +11,10 @@ import {t} from '../locale';
 
 const RuleRow = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    onDelete: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    onDelete: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AsyncView from './asyncView';
@@ -8,10 +9,10 @@ import {t, tct} from '../locale';
 
 class DigestSettings extends React.Component {
   static propTypes = {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    initialData: React.PropTypes.object.isRequired,
-    onSave: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    initialData: PropTypes.object.isRequired,
+    onSave: PropTypes.func.isRequired
   };
 
   render() {
@@ -72,10 +73,10 @@ class DigestSettings extends React.Component {
 
 class GeneralSettings extends React.Component {
   static propTypes = {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    initialData: React.PropTypes.object,
-    onSave: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    initialData: PropTypes.object,
+    onSave: PropTypes.func.isRequired
   };
 
   render() {
@@ -114,8 +115,8 @@ export default class ProjectAlertSettings extends AsyncView {
     // these are not declared as required of issues with cloned elements
     // not initially defining them (though they are bound before) ever
     // rendered
-    organization: React.PropTypes.object,
-    project: React.PropTypes.object
+    organization: PropTypes.object,
+    project: PropTypes.object
   };
 
   getEndpoints() {

--- a/src/sentry/static/sentry/app/views/projectCspSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectCspSettings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -8,9 +9,9 @@ import {t} from '../locale';
 
 const ProjectCspSettingsForm = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    initialData: React.PropTypes.object.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    initialData: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],
@@ -123,7 +124,7 @@ const ProjectCspSettingsForm = React.createClass({
 
 const ProjectCspSettings = React.createClass({
   propTypes: {
-    setProjectNavSection: React.PropTypes.func
+    setProjectNavSection: PropTypes.func
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -14,8 +15,8 @@ const PERIODS = new Set([PERIOD_HOUR, PERIOD_DAY, PERIOD_WEEK]);
 
 const ProjectDashboard = React.createClass({
   propTypes: {
-    defaultStatsPeriod: React.PropTypes.string,
-    setProjectNavSection: React.PropTypes.func
+    defaultStatsPeriod: PropTypes.string,
+    setProjectNavSection: PropTypes.func
   },
 
   mixins: [ProjectState],

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 import ApiMixin from '../../mixins/apiMixin';
@@ -8,8 +9,8 @@ import ProjectState from '../../mixins/projectState';
 
 const ProjectChart = React.createClass({
   propTypes: {
-    dateSince: React.PropTypes.number.isRequired,
-    resolution: React.PropTypes.string.isRequired
+    dateSince: PropTypes.number.isRequired,
+    resolution: PropTypes.string.isRequired
   },
 
   mixins: [ApiMixin, ProjectState],

--- a/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ApiMixin from '../../mixins/apiMixin';
 import LoadingError from '../../components/loadingError';
@@ -8,8 +9,8 @@ import EventNode from './eventNode';
 
 const EventList = React.createClass({
   propTypes: {
-    title: React.PropTypes.string.isRequired,
-    endpoint: React.PropTypes.string.isRequired
+    title: PropTypes.string.isRequired,
+    endpoint: PropTypes.string.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/index.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link, browserHistory} from 'react-router';
 import ApiMixin from '../../mixins/apiMixin';
@@ -12,8 +13,8 @@ import {t} from '../../locale';
 
 const ProjectEvents = React.createClass({
   propTypes: {
-    defaultQuery: React.PropTypes.string,
-    setProjectNavSection: React.PropTypes.func
+    defaultQuery: PropTypes.string,
+    setProjectNavSection: PropTypes.func
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -26,17 +27,17 @@ const FilterSwitch = function(props) {
 };
 
 FilterSwitch.propTypes = {
-  data: React.PropTypes.object.isRequired,
-  onToggle: React.PropTypes.func.isRequired,
-  size: React.PropTypes.string.isRequired
+  data: PropTypes.object.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  size: PropTypes.string.isRequired
 };
 
 const FilterRow = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    onToggle: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    onToggle: PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -112,10 +113,10 @@ const LEGACY_BROWSER_KEYS = Object.keys(LEGACY_BROWSER_SUBFILTERS);
 
 const LegacyBrowserFilterRow = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    onToggle: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    onToggle: PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -218,9 +219,9 @@ const LegacyBrowserFilterRow = React.createClass({
 
 const ProjectFiltersSettingsForm = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    initialData: React.PropTypes.object.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    initialData: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin, ProjectState],

--- a/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ProjectContext from '../projects/projectContext';
@@ -6,8 +7,8 @@ import ProjectSelector from '../../components/projectHeader/projectSelector';
 
 const GettingStartedBody = React.createClass({
   contextTypes: {
-    project: React.PropTypes.object,
-    organization: React.PropTypes.object
+    project: PropTypes.object,
+    organization: PropTypes.object
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/languageNav.jsx
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const LanguageNav = React.createClass({
   propTypes: {
-    name: React.PropTypes.string.isRequired,
-    active: React.PropTypes.bool
+    name: PropTypes.string.isRequired,
+    active: PropTypes.bool
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {browserHistory} from 'react-router';
 
@@ -8,7 +9,7 @@ import {t, tct} from '../../locale';
 
 const ProjectInstallOverview = React.createClass({
   propTypes: {
-    platformData: React.PropTypes.object
+    platformData: PropTypes.object
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -10,8 +11,8 @@ import {t, tct} from '../../locale';
 
 const ProjectInstallPlatform = React.createClass({
   propTypes: {
-    platformData: React.PropTypes.object.isRequired,
-    linkPath: React.PropTypes.func
+    platformData: PropTypes.object.isRequired,
+    linkPath: PropTypes.func
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectIssueTracking.jsx
+++ b/src/sentry/static/sentry/app/views/projectIssueTracking.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import PluginConfig from '../components/pluginConfig';
 
 const ProjectIssueTracking = React.createClass({
   propTypes: {
-    organization: React.PropTypes.object.isRequired,
-    project: React.PropTypes.object.isRequired,
-    dataList: React.PropTypes.array.isRequired
+    organization: PropTypes.object.isRequired,
+    project: PropTypes.object.isRequired,
+    dataList: PropTypes.array.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectKeyDetails.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 import {isEqual} from 'lodash';
@@ -126,14 +127,14 @@ const KeyStats = React.createClass({
 
 const KeySettings = React.createClass({
   propTypes: {
-    organization: React.PropTypes.object.isRequired,
-    project: React.PropTypes.object.isRequired,
-    access: React.PropTypes.object.isRequired,
-    data: React.PropTypes.object.isRequired,
-    initialData: React.PropTypes.object,
-    onRemove: React.PropTypes.func.isRequired,
-    onSave: React.PropTypes.func.isRequired,
-    rateLimitsEnabled: React.PropTypes.bool
+    organization: PropTypes.object.isRequired,
+    project: PropTypes.object.isRequired,
+    access: PropTypes.object.isRequired,
+    data: PropTypes.object.isRequired,
+    initialData: PropTypes.object,
+    onRemove: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    rateLimitsEnabled: PropTypes.bool
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectKeys.jsx
+++ b/src/sentry/static/sentry/app/views/projectKeys.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 import {Link} from 'react-router';
@@ -14,12 +15,12 @@ import Pagination from '../components/pagination';
 
 const KeyRow = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    access: React.PropTypes.object.isRequired,
-    onToggle: React.PropTypes.func.isRequired,
-    onRemove: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    access: PropTypes.object.isRequired,
+    onToggle: PropTypes.func.isRequired,
+    onRemove: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectReleaseTracking.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleaseTracking.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -10,8 +11,8 @@ import LoadingIndicator from '../components/loadingIndicator';
 
 const ProjectReleaseTracking = React.createClass({
   propTypes: {
-    organization: React.PropTypes.object,
-    project: React.PropTypes.object
+    organization: PropTypes.object,
+    project: PropTypes.object
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {browserHistory} from 'react-router';
 
@@ -13,8 +14,8 @@ import ReleaseList from './releaseList';
 
 const ProjectReleases = React.createClass({
   propTypes: {
-    defaultQuery: React.PropTypes.string,
-    setProjectNavSection: React.PropTypes.func
+    defaultQuery: PropTypes.string,
+    setProjectNavSection: PropTypes.func
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReleaseStats from '../../components/releaseStats';
 import Count from '../../components/count';
@@ -7,9 +8,9 @@ import LatestDeployOrReleaseTime from '../../components/latestDeployOrReleaseTim
 
 const ReleaseList = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    releaseList: React.PropTypes.array.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    releaseList: PropTypes.array.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
+++ b/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -9,13 +10,13 @@ import OrganizationState from '../mixins/organizationState';
 
 const SavedSearchRow = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object.isRequired,
-    access: React.PropTypes.object.isRequired,
-    onDefault: React.PropTypes.func.isRequired,
-    onUserDefault: React.PropTypes.func.isRequired,
-    onRemove: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    access: PropTypes.object.isRequired,
+    onDefault: PropTypes.func.isRequired,
+    onUserDefault: PropTypes.func.isRequired,
+    onRemove: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import OrganizationState from '../../mixins/organizationState';
 import ApiMixin from '../../mixins/apiMixin';
@@ -9,12 +10,12 @@ import {t} from '../../locale';
 
 const ProjectSettings = React.createClass({
   propTypes: {
-    setProjectNavSection: React.PropTypes.func
+    setProjectNavSection: PropTypes.func
   },
 
   contextTypes: {
-    location: React.PropTypes.object,
-    organization: React.PropTypes.object
+    location: PropTypes.object,
+    organization: PropTypes.object
   },
 
   mixins: [ApiMixin, OrganizationState],

--- a/src/sentry/static/sentry/app/views/projectUserReportSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectUserReportSettings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -8,9 +9,9 @@ import {t} from '../locale';
 
 const ProjectFeedbackSettingsForm = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    initialData: React.PropTypes.object.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    initialData: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],
@@ -109,7 +110,7 @@ const ProjectFeedbackSettingsForm = React.createClass({
 
 const ProjectUserReportSettings = React.createClass({
   propTypes: {
-    setProjectNavSection: React.PropTypes.func
+    setProjectNavSection: PropTypes.func
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projectUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/projectUserReports.jsx
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {browserHistory, Link} from 'react-router';
 import ApiMixin from '../mixins/apiMixin';
@@ -14,9 +15,9 @@ import {t} from '../locale';
 
 const ProjectUserReports = React.createClass({
   propTypes: {
-    defaultQuery: React.PropTypes.string,
-    defaultStatus: React.PropTypes.string,
-    setProjectNavSection: React.PropTypes.func
+    defaultQuery: PropTypes.string,
+    defaultStatus: PropTypes.string,
+    setProjectNavSection: PropTypes.func
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import DocumentTitle from 'react-document-title';
@@ -9,7 +10,7 @@ import LoadingError from '../../components/loadingError';
 import LoadingIndicator from '../../components/loadingIndicator';
 import MissingProjectMembership from '../../components/missingProjectMembership';
 import OrganizationState from '../../mixins/organizationState';
-import PropTypes from '../../proptypes';
+import CustomPropTypes from '../../proptypes';
 import TeamStore from '../../stores/teamStore';
 import ProjectStore from '../../stores/projectStore';
 import {t} from '../../locale';
@@ -29,13 +30,13 @@ const ERROR_TYPES = {
  */
 const ProjectContext = React.createClass({
   propTypes: {
-    projectId: React.PropTypes.string,
-    orgId: React.PropTypes.string
+    projectId: PropTypes.string,
+    orgId: PropTypes.string
   },
 
   childContextTypes: {
-    project: PropTypes.Project,
-    team: PropTypes.Team
+    project: CustomPropTypes.Project,
+    team: CustomPropTypes.Team
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseAllEvents.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import GroupList from '../components/groupList';
@@ -5,7 +6,7 @@ import {t} from '../locale';
 
 const ReleaseAllEvents = React.createClass({
   contextTypes: {
-    release: React.PropTypes.object
+    release: PropTypes.object
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ApiMixin from '../mixins/apiMixin';
@@ -14,7 +15,7 @@ import {t} from '../locale';
 
 const ReleaseArtifacts = React.createClass({
   contextTypes: {
-    release: React.PropTypes.object
+    release: PropTypes.object
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ApiMixin from '../mixins/apiMixin';
 import Count from '../components/count';
@@ -13,15 +14,15 @@ import {t} from '../locale';
 
 const ReleaseDetails = React.createClass({
   propTypes: {
-    setProjectNavSection: React.PropTypes.func
+    setProjectNavSection: PropTypes.func
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   childContextTypes: {
-    release: React.PropTypes.object
+    release: PropTypes.object
   },
 
   mixins: [ApiMixin, ProjectState],

--- a/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releaseNewEvents.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import GroupList from '../components/groupList';
@@ -5,7 +6,7 @@ import {t} from '../locale';
 
 const ReleaseNewEvents = React.createClass({
   contextTypes: {
-    release: React.PropTypes.object
+    release: PropTypes.object
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseCommits.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import LoadingIndicator from '../../components/loadingIndicator';
@@ -15,9 +16,9 @@ import {t} from '../../locale';
 
 const CommitLink = React.createClass({
   propTypes: {
-    commitId: React.PropTypes.string,
-    repository: React.PropTypes.object,
-    inline: React.PropTypes.bool
+    commitId: PropTypes.string,
+    repository: PropTypes.object,
+    inline: PropTypes.bool
   },
 
   getCommitUrl() {
@@ -39,8 +40,7 @@ const CommitLink = React.createClass({
       ? <a
           className={this.props.inline ? 'inline-commit' : 'btn btn-default btn-sm'}
           href={commitUrl}
-          target="_blank"
-        >
+          target="_blank">
           {this.props.repository.provider.id == 'github' &&
             <IconGithub size="16" style={{verticalAlign: 'text-top'}} />}
           {this.props.repository.provider.id == 'bitbucket' &&
@@ -55,11 +55,11 @@ const CommitLink = React.createClass({
 
 const ReleaseCommit = React.createClass({
   propTypes: {
-    commitId: React.PropTypes.string,
-    commitMessage: React.PropTypes.string,
-    commitDateCreated: React.PropTypes.string,
-    author: React.PropTypes.object,
-    repository: React.PropTypes.object
+    commitId: PropTypes.string,
+    commitMessage: PropTypes.string,
+    commitDateCreated: PropTypes.string,
+    author: PropTypes.object,
+    repository: PropTypes.object
   },
 
   renderMessage(message) {
@@ -223,16 +223,14 @@ const ReleaseCommits = React.createClass({
                           style={{marginLeft: 3, marginRight: -3}}
                         />
                       </h5>
-                    }
-                  >
+                    }>
                     <MenuItem
                       key="all"
                       noAnchor={true}
                       onClick={() => {
                         this.setActiveRepo(null);
                       }}
-                      isActive={this.state.activeRepo === null}
-                    >
+                      isActive={this.state.activeRepo === null}>
                       <a>All Repositories</a>
                     </MenuItem>
                     {Object.keys(commitsByRepository).map(repository => {
@@ -243,8 +241,7 @@ const ReleaseCommits = React.createClass({
                           onClick={() => {
                             this.setActiveRepo(repository);
                           }}
-                          isActive={this.state.activeRepo === repository}
-                        >
+                          isActive={this.state.activeRepo === repository}>
                           <a>{repository}</a>
                         </MenuItem>
                       );

--- a/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/releaseOverview.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import LoadingIndicator from '../../components/loadingIndicator';
@@ -16,7 +17,7 @@ import {t} from '../../locale';
 
 const ReleaseOverview = React.createClass({
   contextTypes: {
-    release: React.PropTypes.object
+    release: PropTypes.object
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -1,12 +1,13 @@
 import $ from 'jquery';
+import PropTypes from 'prop-types';
 import Raven from 'raven-js';
 import React from 'react';
 
 const RouteError = React.createClass({
   propTypes: {
-    error: React.PropTypes.object.isRequired,
+    error: PropTypes.object.isRequired,
     // not used yet, but future proofing
-    onRetry: React.PropTypes.func
+    onRetry: PropTypes.func
   },
 
   componentWillMount() {

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
@@ -10,11 +11,11 @@ import RuleNodeList from './ruleNodeList';
 
 const RuleEditor = React.createClass({
   propTypes: {
-    actions: React.PropTypes.array.isRequired,
-    conditions: React.PropTypes.array.isRequired,
-    rule: React.PropTypes.object.isRequired,
-    project: React.PropTypes.object.isRequired,
-    organization: React.PropTypes.object.isRequired
+    actions: PropTypes.array.isRequired,
+    conditions: PropTypes.array.isRequired,
+    rule: PropTypes.object.isRequired,
+    project: PropTypes.object.isRequired,
+    organization: PropTypes.object.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNode.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNode.jsx
@@ -1,14 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
 
 const RuleNode = React.createClass({
   propTypes: {
-    data: React.PropTypes.object.isRequired,
-    node: React.PropTypes.shape({
-      html: React.PropTypes.string.isRequired
+    data: PropTypes.object.isRequired,
+    node: PropTypes.shape({
+      html: PropTypes.string.isRequired
     }).isRequired,
-    onDelete: React.PropTypes.func.isRequired
+    onDelete: PropTypes.func.isRequired
   },
 
   componentDidMount() {

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import SelectInput from '../../components/selectInput';
@@ -5,8 +6,8 @@ import RuleNode from './ruleNode';
 
 const RuleNodeList = React.createClass({
   propTypes: {
-    initialItems: React.PropTypes.array,
-    nodes: React.PropTypes.array.isRequired
+    initialItems: PropTypes.array,
+    nodes: PropTypes.array.isRequired
   },
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/sharedGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/sharedGroupHeader.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const SharedGroupHeader = React.createClass({
   propTypes: {
-    group: React.PropTypes.object.isRequired
+    group: PropTypes.object.isRequired
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import {browserHistory} from 'react-router';
@@ -27,11 +28,11 @@ import {t, tn, tct} from '../locale';
 
 const Stream = React.createClass({
   propTypes: {
-    defaultSort: React.PropTypes.string,
-    defaultStatsPeriod: React.PropTypes.string,
-    defaultQuery: React.PropTypes.string,
-    maxItems: React.PropTypes.number,
-    setProjectNavSection: React.PropTypes.func
+    defaultSort: PropTypes.string,
+    defaultStatsPeriod: PropTypes.string,
+    defaultQuery: PropTypes.string,
+    maxItems: PropTypes.number,
+    setProjectNavSection: PropTypes.func
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/stream/actionLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actionLink.jsx
@@ -1,5 +1,6 @@
 import Modal from 'react-bootstrap/lib/Modal';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import PropTypes from 'prop-types';
 import React from 'react';
 import SelectedGroupStore from '../../stores/selectedGroupStore';
 import TooltipMixin from '../../mixins/tooltip';
@@ -9,15 +10,15 @@ import _ from 'lodash';
 // TODO(mitsuhiko): very unclear how to translate this
 const ActionLink = React.createClass({
   propTypes: {
-    confirmationQuestion: React.PropTypes.any,
-    buttonTitle: React.PropTypes.string,
-    confirmLabel: React.PropTypes.any,
-    disabled: React.PropTypes.bool,
-    onAction: React.PropTypes.func.isRequired,
-    onlyIfBulk: React.PropTypes.bool,
-    selectAllActive: React.PropTypes.bool.isRequired, // "select all" checkbox
-    tooltip: React.PropTypes.string,
-    extraDescription: React.PropTypes.string
+    confirmationQuestion: PropTypes.any,
+    buttonTitle: PropTypes.string,
+    confirmLabel: PropTypes.any,
+    disabled: PropTypes.bool,
+    onAction: PropTypes.func.isRequired,
+    onlyIfBulk: PropTypes.bool,
+    selectAllActive: PropTypes.bool.isRequired, // "select all" checkbox
+    tooltip: PropTypes.string,
+    extraDescription: PropTypes.string
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import ApiMixin from '../../mixins/apiMixin';
@@ -19,11 +20,11 @@ import Checkbox from '../../components/checkbox';
 
 const IgnoreActions = React.createClass({
   propTypes: {
-    anySelected: React.PropTypes.bool.isRequired,
-    allInQuerySelected: React.PropTypes.bool.isRequired,
-    pageSelected: React.PropTypes.bool.isRequired,
-    onUpdate: React.PropTypes.func.isRequired,
-    query: React.PropTypes.string
+    anySelected: PropTypes.bool.isRequired,
+    allInQuerySelected: PropTypes.bool.isRequired,
+    pageSelected: PropTypes.bool.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    query: PropTypes.string
   },
 
   getInitialState() {
@@ -249,15 +250,15 @@ const IgnoreActions = React.createClass({
 
 const ResolveActions = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    hasRelease: React.PropTypes.bool.isRequired,
-    latestRelease: React.PropTypes.object,
-    anySelected: React.PropTypes.bool.isRequired,
-    allInQuerySelected: React.PropTypes.bool.isRequired,
-    pageSelected: React.PropTypes.bool.isRequired,
-    onUpdate: React.PropTypes.func.isRequired,
-    query: React.PropTypes.string
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    hasRelease: PropTypes.bool.isRequired,
+    latestRelease: PropTypes.object,
+    anySelected: PropTypes.bool.isRequired,
+    allInQuerySelected: PropTypes.bool.isRequired,
+    pageSelected: PropTypes.bool.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    query: PropTypes.string
   },
 
   getInitialState() {
@@ -368,17 +369,17 @@ const ResolveActions = React.createClass({
 
 const StreamActions = React.createClass({
   propTypes: {
-    allResultsVisible: React.PropTypes.bool,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    groupIds: React.PropTypes.instanceOf(Array).isRequired,
-    onRealtimeChange: React.PropTypes.func.isRequired,
-    onSelectStatsPeriod: React.PropTypes.func.isRequired,
-    realtimeActive: React.PropTypes.bool.isRequired,
-    statsPeriod: React.PropTypes.string.isRequired,
-    query: React.PropTypes.string.isRequired,
-    hasReleases: React.PropTypes.bool,
-    latestRelease: React.PropTypes.object
+    allResultsVisible: PropTypes.bool,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    groupIds: PropTypes.instanceOf(Array).isRequired,
+    onRealtimeChange: PropTypes.func.isRequired,
+    onSelectStatsPeriod: PropTypes.func.isRequired,
+    realtimeActive: PropTypes.bool.isRequired,
+    statsPeriod: PropTypes.string.isRequired,
+    query: PropTypes.string.isRequired,
+    hasReleases: PropTypes.bool,
+    latestRelease: PropTypes.object
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import SavedSearchSelector from './savedSearchSelector';
@@ -7,30 +8,30 @@ import {t} from '../../locale';
 
 const StreamFilters = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    access: React.PropTypes.object.isRequired,
-    tags: React.PropTypes.object.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    access: PropTypes.object.isRequired,
+    tags: PropTypes.object.isRequired,
 
-    searchId: React.PropTypes.string,
-    savedSearchList: React.PropTypes.array.isRequired,
+    searchId: PropTypes.string,
+    savedSearchList: PropTypes.array.isRequired,
 
-    defaultQuery: React.PropTypes.string,
-    sort: React.PropTypes.string,
-    filter: React.PropTypes.string,
-    query: React.PropTypes.string,
-    isSearchDisabled: React.PropTypes.bool,
-    queryCount: React.PropTypes.number,
-    queryMaxCount: React.PropTypes.number,
+    defaultQuery: PropTypes.string,
+    sort: PropTypes.string,
+    filter: PropTypes.string,
+    query: PropTypes.string,
+    isSearchDisabled: PropTypes.bool,
+    queryCount: PropTypes.number,
+    queryMaxCount: PropTypes.number,
 
-    onSortChange: React.PropTypes.func,
-    onSearch: React.PropTypes.func,
-    onSidebarToggle: React.PropTypes.func,
-    onSavedSearchCreate: React.PropTypes.func.isRequired
+    onSortChange: PropTypes.func,
+    onSearch: PropTypes.func,
+    onSidebarToggle: PropTypes.func,
+    onSavedSearchCreate: PropTypes.func.isRequired
   },
 
   contextTypes: {
-    location: React.PropTypes.object
+    location: PropTypes.object
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import {Link} from 'react-router';
@@ -12,16 +13,16 @@ import {BooleanField, FormState, TextField} from '../../components/forms';
 
 const SaveSearchButton = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    access: React.PropTypes.object.isRequired,
-    query: React.PropTypes.string.isRequired,
-    disabled: React.PropTypes.bool,
-    style: React.PropTypes.object,
-    tooltip: React.PropTypes.string,
-    buttonTitle: React.PropTypes.string,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    access: PropTypes.object.isRequired,
+    query: PropTypes.string.isRequired,
+    disabled: PropTypes.bool,
+    style: PropTypes.object,
+    tooltip: PropTypes.string,
+    buttonTitle: PropTypes.string,
 
-    onSave: React.PropTypes.func.isRequired
+    onSave: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],
@@ -182,14 +183,14 @@ const SaveSearchButton = React.createClass({
 
 const SavedSearchSelector = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    searchId: React.PropTypes.string,
-    access: React.PropTypes.object.isRequired,
-    savedSearchList: React.PropTypes.array.isRequired,
-    queryCount: React.PropTypes.number,
-    queryMaxCount: React.PropTypes.number,
-    onSavedSearchCreate: React.PropTypes.func.isRequired
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    searchId: PropTypes.string,
+    access: PropTypes.object.isRequired,
+    savedSearchList: PropTypes.array.isRequired,
+    queryCount: PropTypes.number,
+    queryMaxCount: PropTypes.number,
+    onSavedSearchCreate: PropTypes.func.isRequired
   },
 
   mixins: [ApiMixin],

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
@@ -16,17 +17,17 @@ import SearchDropdown from './searchDropdown';
 
 const SearchBar = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
 
-    defaultQuery: React.PropTypes.string,
-    query: React.PropTypes.string,
-    defaultSearchItems: React.PropTypes.array.isRequired,
-    disabled: React.PropTypes.bool,
-    placeholder: React.PropTypes.string,
+    defaultQuery: PropTypes.string,
+    query: PropTypes.string,
+    defaultSearchItems: PropTypes.array.isRequired,
+    disabled: PropTypes.bool,
+    placeholder: PropTypes.string,
 
-    onQueryChange: React.PropTypes.func,
-    onSearch: React.PropTypes.func
+    onQueryChange: PropTypes.func,
+    onSearch: PropTypes.func
   },
 
   mixins: [

--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -7,10 +8,10 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 const SearchDropdown = React.createClass({
   propTypes: {
-    items: React.PropTypes.array.isRequired,
-    searchSubstring: React.PropTypes.string,
-    onClick: React.PropTypes.func.isRequired,
-    loading: React.PropTypes.bool
+    items: PropTypes.array.isRequired,
+    searchSubstring: PropTypes.string,
+    onClick: PropTypes.func.isRequired,
+    loading: PropTypes.bool
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/views/stream/sidebar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sidebar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 import StreamTagFilter from './tagFilter';
@@ -9,14 +10,14 @@ let TEXT_FILTER_DEBOUNCE_IN_MS = 300;
 
 const StreamSidebar = React.createClass({
   propTypes: {
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
 
-    tags: React.PropTypes.object.isRequired,
-    query: React.PropTypes.string,
-    onQueryChange: React.PropTypes.func.isRequired,
-    defaultQuery: React.PropTypes.string,
-    loading: React.PropTypes.bool
+    tags: PropTypes.object.isRequired,
+    query: PropTypes.string,
+    onQueryChange: PropTypes.func.isRequired,
+    defaultQuery: PropTypes.string,
+    loading: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -1,4 +1,5 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import PropTypes from 'prop-types';
 import React from 'react';
 import DropdownLink from '../../components/dropdownLink';
 import MenuItem from '../../components/menuItem';
@@ -6,8 +7,8 @@ import {t} from '../../locale';
 
 const SortOptions = React.createClass({
   propTypes: {
-    sort: React.PropTypes.string,
-    onSelect: React.PropTypes.func
+    sort: PropTypes.string,
+    onSelect: PropTypes.func
   },
 
   mixins: [PureRenderMixin],

--- a/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
+++ b/src/sentry/static/sentry/app/views/stream/tagFilter.jsx
@@ -1,14 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import _ from 'lodash';
 
 const StreamTagFilter = React.createClass({
   propTypes: {
-    tag: React.PropTypes.object.isRequired,
-    orgId: React.PropTypes.string.isRequired,
-    projectId: React.PropTypes.string.isRequired,
-    value: React.PropTypes.string,
-    onSelect: React.PropTypes.func
+    tag: PropTypes.object.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    onSelect: PropTypes.func
   },
 
   statics: {

--- a/src/sentry/static/sentry/app/views/teamSettings.jsx
+++ b/src/sentry/static/sentry/app/views/teamSettings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AsyncView from './asyncView';
@@ -7,8 +8,8 @@ import {t} from '../locale';
 export default class TeamSettings extends AsyncView {
   static propTypes = {
     ...AsyncView.propTypes,
-    team: React.PropTypes.object.isRequired,
-    onTeamChange: React.PropTypes.func.isRequired
+    team: PropTypes.object.isRequired,
+    onTeamChange: PropTypes.func.isRequired
   };
 
   getTitle() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,8 +131,8 @@
     webpack-hot-middleware "^2.18.0"
 
 "@storybook/ui@^3.2.0":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.2.3.tgz#9579c191a1695d3d5aaabcef93a7a5456d8f19af"
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.2.4.tgz#a52b10a5f9daaf22570af457ec7c79210b0abcc3"
   dependencies:
     "@storybook/react-fuzzy" "^0.4.0"
     babel-runtime "^6.23.0"
@@ -142,6 +142,7 @@
     global "^4.3.2"
     json-stringify-safe "^5.0.1"
     keycode "^2.1.8"
+    lodash.debounce "4.0.8"
     lodash.pick "^4.4.0"
     lodash.sortby "^4.7.0"
     mantra-core "^1.7.0"
@@ -201,7 +202,7 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.0.1:
+acorn@^5.0.0, acorn@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
 
@@ -287,11 +288,11 @@ ansi-styles@^3.0.0, ansi-styles@^3.1.0:
     color-convert "^1.9.0"
 
 anymatch@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
   dependencies:
-    arrify "^1.0.0"
     micromatch "^2.1.5"
+    normalize-path "^2.0.0"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -472,7 +473,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@6.22.0, babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
+babel-code-frame@6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -480,7 +481,15 @@ babel-code-frame@6.22.0, babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, bab
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@6.21.0:
+babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.20.0, babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
+babel-core@6.21.0, babel-core@^6.0.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.21.0.tgz#75525480c21c803f826ef3867d22c19f080a3724"
   dependencies:
@@ -504,29 +513,29 @@ babel-core@6.21.0:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
+babel-core@^6.25.0, babel-core@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
-    babel-code-frame "^6.22.0"
-    babel-generator "^6.25.0"
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
     babel-helpers "^6.24.1"
     babel-messages "^6.23.0"
-    babel-register "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.25.0"
-    babel-traverse "^6.25.0"
-    babel-types "^6.25.0"
-    babylon "^6.17.2"
-    convert-source-map "^1.1.0"
-    debug "^2.1.1"
-    json5 "^0.5.0"
-    lodash "^4.2.0"
-    minimatch "^3.0.2"
-    path-is-absolute "^1.0.0"
-    private "^0.1.6"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.0"
+    debug "^2.6.8"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.7"
     slash "^1.0.0"
-    source-map "^0.5.0"
+    source-map "^0.5.6"
 
 babel-eslint@7.1.1:
   version "7.1.1"
@@ -538,17 +547,17 @@ babel-eslint@7.1.1:
     babylon "^6.13.0"
     lodash.pickby "^4.6.0"
 
-babel-generator@^6.18.0, babel-generator@^6.21.0, babel-generator@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
+babel-generator@^6.18.0, babel-generator@^6.21.0, babel-generator@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
   dependencies:
     babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.25.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
     detect-indent "^4.0.0"
     jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
+    lodash "^4.17.4"
+    source-map "^0.5.6"
     trim-right "^1.0.1"
 
 babel-gettext-extractor@^3.0.0:
@@ -575,12 +584,12 @@ babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
     babel-types "^6.24.1"
 
 babel-helper-builder-react-jsx@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz#0ad7917e33c8d751e646daca4e77cc19377d2cbc"
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
   dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    esutils "^2.0.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    esutils "^2.0.2"
 
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
@@ -592,13 +601,13 @@ babel-helper-call-delegate@^6.24.1:
     babel-types "^6.24.1"
 
 babel-helper-define-map@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz#7a9747f258d8947d32d515f6aa1c7bd02204a080"
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f"
   dependencies:
     babel-helper-function-name "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    lodash "^4.2.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
 babel-helper-explode-assignable-expression@^6.24.1:
   version "6.24.1"
@@ -649,12 +658,12 @@ babel-helper-optimise-call-expression@^6.24.1:
     babel-types "^6.24.1"
 
 babel-helper-regex@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz#d36e22fab1008d79d88648e32116868128456ce8"
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72"
   dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    lodash "^4.2.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
 babel-helper-remap-async-to-generator@^6.24.1:
   version "6.24.1"
@@ -748,8 +757,8 @@ babel-plugin-lodash@^3.2.11:
     lodash "^4.17.2"
 
 babel-plugin-react-docgen@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.6.0.tgz#9be36121b094da7a1a3ba7911a9e8ea4b0f44da0"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.7.0.tgz#87e72d3d54b182a30706b740bb4d116f59aadc80"
   dependencies:
     babel-types "^6.24.1"
     lodash "4.x.x"
@@ -881,14 +890,14 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz#76c295dc3a4741b1665adfd3167215dcff32a576"
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
   dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    lodash "^4.2.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
 babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
   version "6.24.1"
@@ -953,13 +962,13 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
     babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz#d3e310b40ef664a36622200097c6d440298f2bfe"
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
   dependencies:
     babel-plugin-transform-strict-mode "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-types "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
 
 babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
   version "6.24.1"
@@ -1065,12 +1074,19 @@ babel-plugin-transform-function-bind@^6.22.0:
     babel-plugin-syntax-function-bind "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@6.23.0, babel-plugin-transform-object-rest-spread@^6.20.2, babel-plugin-transform-object-rest-spread@^6.22.0:
+babel-plugin-transform-object-rest-spread@6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.20.2, babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-react-constant-elements@6.23.0:
   version "6.23.0"
@@ -1106,11 +1122,17 @@ babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@6.24.1, babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
+babel-plugin-transform-regenerator@6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
   dependencies:
     regenerator-transform "0.9.11"
+
+babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  dependencies:
+    regenerator-transform "^0.10.0"
 
 babel-plugin-transform-runtime@6.23.0:
   version "6.23.0"
@@ -1231,8 +1253,8 @@ babel-preset-latest@^6.16.0:
     babel-preset-es2017 "^6.24.1"
 
 babel-preset-react-app@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-3.0.1.tgz#8b744cbe47fd57c868e6f913552ceae26ae31860"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-3.0.2.tgz#d062fca5dce68ed9c2615f2fecbc08861720f8e5"
   dependencies:
     babel-plugin-dynamic-import-node "1.0.2"
     babel-plugin-syntax-dynamic-import "6.18.0"
@@ -1293,24 +1315,24 @@ babel-preset-stage-3@^6.24.1:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@^6.18.0, babel-register@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.1.tgz#7e10e13a2f71065bdfad5a1787ba45bca6ded75f"
+babel-register@^6.18.0, babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   dependencies:
-    babel-core "^6.24.1"
-    babel-runtime "^6.22.0"
-    core-js "^2.4.0"
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
     home-or-tmp "^2.0.0"
-    lodash "^4.2.0"
+    lodash "^4.17.4"
     mkdirp "^0.5.1"
-    source-map-support "^0.4.2"
+    source-map-support "^0.4.15"
 
-babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.5.0, babel-runtime@^6.9.2:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.5.0, babel-runtime@^6.9.2:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
+    regenerator-runtime "^0.11.0"
 
 babel-runtime@^5.8.38:
   version "5.8.38"
@@ -1319,49 +1341,49 @@ babel-runtime@^5.8.38:
     core-js "^1.0.0"
 
 babel-standalone@^6.24.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.25.0.tgz#759ef04574402b6d1a1b5efa62d18c9a47e4abeb"
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.26.0.tgz#15fb3d35f2c456695815ebf1ed96fe7f015b6886"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.3.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.25.0"
-    babel-types "^6.25.0"
-    babylon "^6.17.2"
-    lodash "^4.2.0"
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
 
-babel-traverse@^6.15.0, babel-traverse@^6.18.0, babel-traverse@^6.21.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
+babel-traverse@^6.15.0, babel-traverse@^6.18.0, babel-traverse@^6.21.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
-    babel-code-frame "^6.22.0"
+    babel-code-frame "^6.26.0"
     babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.25.0"
-    babylon "^6.17.2"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
 
-babel-types@^6.15.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.21.0, babel-types@^6.24.1, babel-types@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
+babel-types@^6.15.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.21.0, babel-types@^6.24.1, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
-    babel-runtime "^6.22.0"
+    babel-runtime "^6.26.0"
     esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
 
 babylon@7.0.0-beta.8:
   version "7.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.17.2, babylon@^6.17.4:
-  version "6.17.4"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.17.4, babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 babylon@~5.8.3:
   version "5.8.38"
@@ -1394,8 +1416,8 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
 binary-extensions@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.9.0.tgz#66506c16ce6f4d6928a5b3cd6a33ca41e941e37b"
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
 
 block-stream@*:
   version "0.0.9"
@@ -1408,8 +1430,8 @@ bluebird@^3.5.0:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.7"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
 body-parser@~1.14.0:
   version "1.14.2"
@@ -1532,11 +1554,11 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     electron-to-chromium "^1.2.7"
 
 browserslist@^2.1.2, browserslist@^2.1.5:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.2.2.tgz#e9b4618b8a01c193f9786beea09f6fd10dbe31c3"
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.3.3.tgz#2b0cabc4d28489f682598605858a0782f14b154c"
   dependencies:
-    caniuse-lite "^1.0.30000704"
-    electron-to-chromium "^1.3.16"
+    caniuse-lite "^1.0.30000715"
+    electron-to-chromium "^1.3.18"
 
 bser@1.0.2:
   version "1.0.2"
@@ -1622,12 +1644,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000706"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000706.tgz#e2b5f0460573cbcc88a0985f5cced08f1617c6f5"
+  version "1.0.30000715"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000715.tgz#0b9b5c795950dfbaf301a8806bafe87f126da8ca"
 
-caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000704:
-  version "1.0.30000709"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000709.tgz#e027c7a0dfd5ada58f931a1080fc71965375559b"
+caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000715:
+  version "1.0.30000715"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz#c327f5e6d907ebcec62cde598c3bf0dd793fb9a0"
 
 case-sensitive-paths-webpack-plugin@^2.0.0:
   version "2.1.1"
@@ -1670,9 +1692,9 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+chalk@^2.0.1, chalk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -1917,7 +1939,7 @@ content-type@~1.0.1, content-type@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
 
-convert-source-map@^1.1.0:
+convert-source-map@^1.1.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
@@ -1933,11 +1955,11 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
 
-core-util-is@~1.0.0:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
@@ -1980,7 +2002,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2:
+create-react-class@^15.5.2, create-react-class@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
   dependencies:
@@ -2161,13 +2183,7 @@ debug@0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
-debug@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
-  dependencies:
-    ms "2.0.0"
-
-debug@^2.1.1, debug@^2.2.0, debug@^2.6.3:
+debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -2244,9 +2260,9 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.0, depd@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
+depd@1.1.1, depd@~1.1.0, depd@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -2351,9 +2367,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.16:
-  version "1.3.16"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz#d0e026735754770901ae301a21664cba45d92f7d"
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.18:
+  version "1.3.18"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz#3dcc99da3e6b665f6abbc71c28ad51a2cd731a9c"
 
 element-class@^0.2.0:
   version "0.2.2"
@@ -2438,13 +2454,14 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.0.tgz#3b00385e85729932beffa9163bbea1234e932914"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.0"
+    has "^1.0.1"
     is-callable "^1.1.3"
-    is-regex "^1.0.3"
+    is-regex "^1.0.4"
 
 es-to-primitive@^1.1.1:
   version "1.1.1"
@@ -2455,8 +2472,8 @@ es-to-primitive@^1.1.1:
     is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.24"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.24.tgz#a55877c9924bc0c8d9bd3c2cbe17495ac1709b14"
+  version "0.10.27"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.27.tgz#bf926b058c62b1cb5de1a887930673b6aa6d9a66"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
@@ -2605,10 +2622,10 @@ eslint@3.19.0:
     user-home "^2.0.0"
 
 espree@^3.4.0:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
   dependencies:
-    acorn "^5.0.1"
+    acorn "^5.1.1"
     acorn-jsx "^3.0.0"
 
 esprima@^2.6.0, esprima@^2.7.1:
@@ -2640,7 +2657,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-esutils@2.0.2, esutils@^2.0.0, esutils@^2.0.2:
+esutils@2.0.2, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -2716,8 +2733,8 @@ expand-range@^1.8.1:
     fill-range "^2.1.0"
 
 express@^4.15.3:
-  version "4.15.3"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
+  version "4.15.4"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.15.4.tgz#032e2253489cf8fce02666beca3d11ed7a2daed1"
   dependencies:
     accepts "~1.3.3"
     array-flatten "1.1.1"
@@ -2725,23 +2742,23 @@ express@^4.15.3:
     content-type "~1.0.2"
     cookie "0.3.1"
     cookie-signature "1.0.6"
-    debug "2.6.7"
-    depd "~1.1.0"
+    debug "2.6.8"
+    depd "~1.1.1"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     etag "~1.8.0"
-    finalhandler "~1.0.3"
+    finalhandler "~1.0.4"
     fresh "0.5.0"
     merge-descriptors "1.0.1"
     methods "~1.1.2"
     on-finished "~2.3.0"
     parseurl "~1.3.1"
     path-to-regexp "0.1.7"
-    proxy-addr "~1.1.4"
-    qs "6.4.0"
+    proxy-addr "~1.1.5"
+    qs "6.5.0"
     range-parser "~1.2.0"
-    send "0.15.3"
-    serve-static "1.12.3"
+    send "0.15.4"
+    serve-static "1.12.4"
     setprototypeof "1.0.3"
     statuses "~1.3.1"
     type-is "~1.6.15"
@@ -2775,9 +2792,9 @@ extract-zip@~1.5.0:
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
-extsprintf@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+extsprintf@1.3.0, extsprintf@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -2822,8 +2839,8 @@ fbjs@0.1.0-alpha.10:
     whatwg-fetch "^0.9.0"
 
 fbjs@^0.8.12, fbjs@^0.8.4, fbjs@^0.8.9:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -2886,11 +2903,11 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-finalhandler@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
+finalhandler@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.4.tgz#18574f2e7c4b98b8ae3b230c21f201f31bdb3fb7"
   dependencies:
-    debug "2.6.7"
+    debug "2.6.8"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
@@ -3091,8 +3108,8 @@ gettext-parser@^1.1.2:
     safe-buffer "^5.1.1"
 
 glamor@^2.20.25:
-  version "2.20.39"
-  resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.39.tgz#f2496b5bd252c4337eadae8c6233ce4ea2a81596"
+  version "2.20.40"
+  resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.40.tgz#f606660357b7cf18dface731ad1a2cfa93817f05"
   dependencies:
     fbjs "^0.8.12"
     inline-style-prefixer "^3.0.6"
@@ -3152,7 +3169,7 @@ global@^4.3.2:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^9.0.0, globals@^9.14.0:
+globals@^9.14.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -3360,11 +3377,11 @@ http-errors@~1.3.1:
     inherits "~2.0.1"
     statuses "1"
 
-http-errors@~1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.1.tgz#5f8b8ed98aca545656bf572997387f904a722257"
+http-errors@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
   dependencies:
-    depd "1.1.0"
+    depd "1.1.1"
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
@@ -3659,7 +3676,7 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
-is-regex@^1.0.3:
+is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
@@ -4016,13 +4033,13 @@ js-cookie@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.0.4.tgz#5f43d1872118aaf5e7a16029b70976eb7315c6a5"
 
-js-tokens@^3.0.0:
+js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -4115,13 +4132,13 @@ jsonpointer@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
 jsprim@^1.2.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
   dependencies:
     assert-plus "1.0.0"
-    extsprintf "1.0.2"
+    extsprintf "1.3.0"
     json-schema "0.2.3"
-    verror "1.3.6"
+    verror "1.10.0"
 
 jssha@^2.1.0:
   version "2.3.1"
@@ -4304,7 +4321,7 @@ lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
-lodash.debounce@^4.0.0:
+lodash.debounce@4.0.8, lodash.debounce@^4.0.0:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
@@ -4646,8 +4663,8 @@ node-dir@^0.1.10:
     minimatch "^3.0.2"
 
 node-fetch@^1.0.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.2.tgz#c54e9aac57e432875233525f3c891c4159ffefd7"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -4760,7 +4777,7 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -5008,7 +5025,7 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
-path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
@@ -5047,8 +5064,8 @@ pbkdf2-compat@2.0.1:
   resolved "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288"
 
 pbkdf2@^3.0.3:
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.13.tgz#c37d295531e786b1da3e3eadc840426accb0ae25"
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -5061,8 +5078,8 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
 percy-client@^2.1.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-2.1.3.tgz#63835b55046917428e29ae7fa4e445ba31ecc957"
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-2.1.4.tgz#b32ef81718da7360c886f098fc733610f23d2256"
   dependencies:
     base64-js "^1.1.2"
     jssha "^2.1.0"
@@ -5405,12 +5422,12 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.1, postcss@^6.0.2, postcss@^6.0.6:
-  version "6.0.8"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.8.tgz#89067a9ce8b11f8a84cbc5117efc30419a0857b3"
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.9.tgz#54819766784a51c65b1ec4d54c2f93765438c35a"
   dependencies:
-    chalk "^2.0.1"
+    chalk "^2.1.0"
     source-map "^0.5.6"
-    supports-color "^4.2.0"
+    supports-color "^4.2.1"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -5445,7 +5462,7 @@ pretty-format@^19.0.0:
   dependencies:
     ansi-styles "^3.0.0"
 
-private@^0.1.6, private@~0.1.5:
+private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
@@ -5498,7 +5515,7 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7,
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-proxy-addr@~1.1.4:
+proxy-addr@~1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
   dependencies:
@@ -5539,17 +5556,13 @@ qs@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.0.tgz#a9f31142af468cb72b25b30136ba2456834916be"
 
-qs@6.4.0, qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+qs@6.5.0, qs@^6.4.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
 
 qs@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-4.0.0.tgz#c31d9b74ec27df75e543a86c78728ed8d4623607"
-
-qs@^6.4.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
 
 qs@~5.1.0:
   version "5.1.0"
@@ -5558,6 +5571,10 @@ qs@~5.1.0:
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 query-string@2.4.2:
   version "2.4.2"
@@ -5707,9 +5724,14 @@ react-dom-factories@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.1.tgz#c50692ac5ff1adb39d86dfe6dbe3485dacf58455"
 
-react-dom@15.3.2:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
+react-dom@^15.3.2:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
 
 react-html-attributes@^1.3.0:
   version "1.4.1"
@@ -5734,8 +5756,8 @@ react-icons@^2.2.5:
     react-icon-base "2.0.7"
 
 react-inspector@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.1.3.tgz#61fc4c6b6b29b5262af3aad781a12138cd181a32"
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.1.4.tgz#2123fab74f68ae3136fbd02392fadb764326d04d"
   dependencies:
     babel-runtime "^6.23.0"
     is-dom "^1.0.9"
@@ -5839,8 +5861,8 @@ react-sparklines@1.6.0:
     react-addons-shallow-compare "^15.0.2"
 
 react-split-pane@^0.1.65:
-  version "0.1.65"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.65.tgz#37c0b5ea5c960827e7f3621d0a114b0f8c9c8918"
+  version "0.1.66"
+  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.66.tgz#369085dd07ec1237bda123e73813dcc7dc6502c1"
   dependencies:
     inline-style-prefixer "^3.0.6"
     prop-types "^15.5.10"
@@ -5883,7 +5905,17 @@ react-treebeard@^2.0.3:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@15.3.2, react@^15.3.2:
+react@15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
+react@^15.3.2:
   version "15.3.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
   dependencies:
@@ -6030,9 +6062,21 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
+
+regenerator-transform@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.0.tgz#f9ab3eac9cc2de38431d996a6a8abf1c50f2e459"
   dependencies:
     babel-runtime "^6.18.0"
     babel-types "^6.19.0"
@@ -6072,8 +6116,8 @@ regjsparser@^0.1.4:
     jsesc "~0.5.0"
 
 remove-trailing-separator@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -6190,8 +6234,8 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6, resolve@^1.2.0:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
 
@@ -6277,18 +6321,18 @@ select2@3.5.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
-send@0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.15.3.tgz#5013f9f99023df50d1bd9892c19e3defd1d53309"
+send@0.15.4:
+  version "0.15.4"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.15.4.tgz#985faa3e284b0273c793364a35c6737bd93905b9"
   dependencies:
-    debug "2.6.7"
-    depd "~1.1.0"
+    debug "2.6.8"
+    depd "~1.1.1"
     destroy "~1.0.4"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     etag "~1.8.0"
     fresh "0.5.0"
-    http-errors "~1.6.1"
+    http-errors "~1.6.2"
     mime "1.3.4"
     ms "2.0.0"
     on-finished "~2.3.0"
@@ -6305,14 +6349,14 @@ serve-favicon@^2.4.3:
     parseurl "~1.3.1"
     safe-buffer "5.0.1"
 
-serve-static@1.12.3:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.3.tgz#9f4ba19e2f3030c547f8af99107838ec38d5b1e2"
+serve-static@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.4.tgz#9b6aa98eeb7253c4eedc4c1f6fdbca609901a961"
   dependencies:
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     parseurl "~1.3.1"
-    send "0.15.3"
+    send "0.15.4"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -6398,8 +6442,8 @@ slide@^1.1.5:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
 slugify@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.1.0.tgz#7e5b0938d52b5efab1878247ef0f6a4f05db7ee0"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.2.1.tgz#2118f4b0fbcfd79d7b2c451c22b724e5c1991330"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -6421,7 +6465,7 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
-source-map-support@^0.4.2:
+source-map-support@^0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
   dependencies:
@@ -6630,7 +6674,7 @@ supports-color@^3.1.0, supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0, supports-color@^4.2.0, supports-color@^4.2.1:
+supports-color@^4.0.0, supports-color@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
   dependencies:
@@ -6672,8 +6716,8 @@ table@^3.7.8:
     string-width "^2.0.0"
 
 tapable@^0.2.7, tapable@~0.2.5:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.7.tgz#e46c0daacbb2b8a98b9b0cea0f4052105817ed5c"
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
 
 tar-pack@^3.4.0:
   version "3.4.0"
@@ -6733,8 +6777,8 @@ timers-browserify@^1.0.1:
     process "~0.11.0"
 
 timers-browserify@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
     setimmediate "^1.0.4"
 
@@ -6757,7 +6801,7 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
-to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
@@ -6965,11 +7009,13 @@ vendors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.1.tgz#37ad73c8ee417fb3d580e785312307d274847f22"
 
-verror@1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
   dependencies:
-    extsprintf "1.0.2"
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -7018,8 +7064,8 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
 
 webidl-conversions@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
 webpack-dev-middleware@1.9.0:
   version "1.9.0"
@@ -7095,8 +7141,8 @@ webpack@2.2.0:
     yargs "^6.0.0"
 
 "webpack@^2.5.1 || ^3.0.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.4.1.tgz#4c3f4f3fb318155a4db0cb6a36ff05c5697418f4"
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.5.tgz#3226f09fc8b3e435ff781e7af34f82b68b26996c"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
@@ -7189,8 +7235,8 @@ wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
 worker-farm@^1.3.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.4.1.tgz#a438bc993a7a7d133bcb6547c95eca7cff4897d8"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.0.tgz#adfdf0cd40581465ed0a1f648f9735722afd5c8d"
   dependencies:
     errno "^0.1.4"
     xtend "^4.0.1"


### PR DESCRIPTION
Why: react 16 has major internal changes to the way it renders, and this will change stack traces in a way that it's important for us to experience firsthand. In order to get ready for react 16, we need to update some things including proptypes and createClass. This is a step in that process. 


this mostly works, with the exception of some complications of the way we use refs in certain components.
https://facebook.github.io/react/warnings/refs-must-have-owner.html

(and warnings about createClass being deprecated, but this is solvable with another codemod)


```
Test Suites: 6 failed, 69 passed, 75 total
Tests:       21 failed, 321 passed, 342 total
Snapshots:   89 passed, 89 total
```


note: this codemod is much more localized than the prettier ones and I don't think it will cause much in the way of merge conflicts