### PR TITLE
Truncate timelines during digestion to prevent excessive resource consumption.

### DIFF
--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -209,7 +209,14 @@ class RedisBackend(Backend):
         with self._get_timeline_lock(key, duration=30).acquire():
             try:
                 response = script(
-                    connection, [key], ['DIGEST_OPEN', self.namespace, self.ttl, timestamp, key]
+                    connection, [key], [
+                        'DIGEST_OPEN',
+                        self.namespace,
+                        self.ttl,
+                        timestamp,
+                        key,
+                        self.capacity if self.capacity else -1,
+                    ]
                 )
             except ResponseError as e:
                 if 'err(invalid_state):' in e.message:

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -112,8 +112,8 @@ class RedisBackendTestCase(TestCase):
         # Only the new records should exist -- the older one should have been
         # trimmed to avoid the digest growing beyond the timeline capacity.
         with backend.digest('timeline', 0) as records:
-            assert set(record.key
-                       for record in records) == set('record:{}'.format(i) for i in xrange(10, 20))
+            expected_keys = set('record:{}'.format(i) for i in xrange(10, 20))
+            assert set(record.key for record in records) == expected_keys
 
     def test_delete(self):
         backend = RedisBackend()


### PR DESCRIPTION
Without this, the digest can grow by the capacity during each invocation of `DIGEST_OPEN` if the digest is unable to be successfully closed.