### PR TITLE
Add granular filter stats

### DIFF
--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -60,6 +60,22 @@ class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
             stat_model = tsdb.models.project
         elif stat == 'forwarded':
             stat_model = tsdb.models.project_total_forwarded
+        elif stat == 'ip_address':
+            stat_model = tsdb.models.project_total_received_ip_address
+        elif stat == 'release_version':
+            stat_model = tsdb.models.project_total_received_release_version
+        elif stat == 'error_message':
+            stat_model = tsdb.models.project_total_received_error_message
+        elif stat == 'browser_extensions':
+            stat_model = tsdb.models.project_total_received_browser_extensions
+        elif stat == 'legacy_browsers':
+            stat_model = tsdb.models.project_total_received_legacy_browsers
+        elif stat == 'localhost':
+            stat_model = tsdb.models.project_total_received_localhost
+        elif stat == 'web_crawlers':
+            stat_model = tsdb.models.project_total_received_web_crawlers
+        elif stat == 'invalid_csp':
+            stat_model = tsdb.models.project_total_received_invalid_csp
         else:
             raise ValueError('Invalid stat: %s' % stat)
 

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -76,6 +76,8 @@ class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
             stat_model = tsdb.models.project_total_received_web_crawlers
         elif stat == 'invalid_csp':
             stat_model = tsdb.models.project_total_received_invalid_csp
+        elif stat == 'cors':
+            stat_model = tsdb.models.project_total_received_cors
         else:
             raise ValueError('Invalid stat: %s' % stat)
 

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from sentry import tsdb
 from sentry.api.base import DocSection, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.constants import FILTER_STAT_KEYS_TO_VALUES
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -12,7 +13,8 @@ from sentry.utils.apidocs import scenario, attach_scenarios
 def retrieve_event_counts_project(runner):
     runner.request(
         method='GET',
-        path='/projects/%s/%s/stats/' % (runner.org.slug, runner.default_project.slug)
+        path='/projects/%s/%s/stats/' % (runner.org.slug,
+                                         runner.default_project.slug)
     )
 
 
@@ -60,24 +62,8 @@ class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
             stat_model = tsdb.models.project
         elif stat == 'forwarded':
             stat_model = tsdb.models.project_total_forwarded
-        elif stat == 'ip_address':
-            stat_model = tsdb.models.project_total_received_ip_address
-        elif stat == 'release_version':
-            stat_model = tsdb.models.project_total_received_release_version
-        elif stat == 'error_message':
-            stat_model = tsdb.models.project_total_received_error_message
-        elif stat == 'browser_extensions':
-            stat_model = tsdb.models.project_total_received_browser_extensions
-        elif stat == 'legacy_browsers':
-            stat_model = tsdb.models.project_total_received_legacy_browsers
-        elif stat == 'localhost':
-            stat_model = tsdb.models.project_total_received_localhost
-        elif stat == 'web_crawlers':
-            stat_model = tsdb.models.project_total_received_web_crawlers
-        elif stat == 'invalid_csp':
-            stat_model = tsdb.models.project_total_received_invalid_csp
-        elif stat == 'cors':
-            stat_model = tsdb.models.project_total_received_cors
+        elif stat in FILTER_STAT_KEYS_TO_VALUES.keys():
+            stat_model = FILTER_STAT_KEYS_TO_VALUES[stat]
         else:
             raise ValueError('Invalid stat: %s' % stat)
 

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry import tsdb
 from sentry.api.base import DocSection, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.constants import FILTER_STAT_KEYS_TO_VALUES
+from sentry.utils.data_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -62,10 +62,11 @@ class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
             stat_model = tsdb.models.project
         elif stat == 'forwarded':
             stat_model = tsdb.models.project_total_forwarded
-        elif stat in FILTER_STAT_KEYS_TO_VALUES.keys():
-            stat_model = FILTER_STAT_KEYS_TO_VALUES[stat]
         else:
-            raise ValueError('Invalid stat: %s' % stat)
+            try:
+                stat_model = FILTER_STAT_KEYS_TO_VALUES[stat]
+            except KeyError:
+                raise ValueError('Invalid stat: %s' % stat)
 
         data = tsdb.get_range(
             model=stat_model, keys=[project.id], **self._parse_args(request)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -19,7 +19,9 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from operator import attrgetter
 
+from sentry import tsdb
 from sentry.utils.integrationdocs import load_doc
+from sentry.utils.datastructures import BidirectionalMapping
 
 
 def get_all_languages():
@@ -39,7 +41,8 @@ DATA_ROOT = os.path.join(MODULE_ROOT, 'data')
 
 SORT_OPTIONS = OrderedDict(
     (
-        ('priority', _('Priority')), ('date', _('Last Seen')), ('new', _('First Seen')),
+        ('priority', _('Priority')), ('date', _(
+            'Last Seen')), ('new', _('First Seen')),
         ('freq', _('Frequency')),
     )
 )
@@ -109,7 +112,8 @@ DEFAULT_SORT_OPTION = 'date'
 
 # Setup languages for only available locales
 LANGUAGE_MAP = dict(settings.LANGUAGES)
-LANGUAGES = [(k, LANGUAGE_MAP[k]) for k in get_all_languages() if k in LANGUAGE_MAP]
+LANGUAGES = [(k, LANGUAGE_MAP[k])
+             for k in get_all_languages() if k in LANGUAGE_MAP]
 
 # TODO(dcramer): We eventually want to make this user-editable
 TAG_LABELS = {
@@ -139,7 +143,8 @@ SENTRY_RULES = (
 )
 
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH
-HTTP_METHODS = ('GET', 'POST', 'PUT', 'OPTIONS', 'HEAD', 'DELETE', 'TRACE', 'CONNECT', 'PATCH')
+HTTP_METHODS = ('GET', 'POST', 'PUT', 'OPTIONS', 'HEAD',
+                'DELETE', 'TRACE', 'CONNECT', 'PATCH')
 
 CLIENT_RESERVED_ATTRS = (
     'project', 'errors', 'event_id', 'message', 'checksum', 'culprit', 'fingerprint', 'level',
@@ -309,7 +314,8 @@ def get_integration_id_for_event(platform, sdk_name, integrations):
                 return integration_id
 
     # try sdk name, for example "sentry-java" -> "java" or "raven-java:log4j" -> "java-log4j"
-    sdk_name = sdk_name.lower().replace("sentry-", "").replace("raven-", "").replace(":", "-")
+    sdk_name = sdk_name.lower().replace(
+        "sentry-", "").replace("raven-", "").replace(":", "-")
     if sdk_name in INTEGRATION_ID_TO_PLATFORM_DATA:
         return sdk_name
 
@@ -334,3 +340,15 @@ class ObjectStatus(object):
 
 
 StatsPeriod = namedtuple('StatsPeriod', ('segments', 'interval'))
+
+FILTER_STAT_KEYS_TO_VALUES = BidirectionalMapping({
+    'ip-address': tsdb.models.project_total_received_ip_address,
+    'release-version': tsdb.models.project_total_received_release_version,
+    'error-message': tsdb.models.project_total_received_error_message,
+    'browser-extensions': tsdb.models.project_total_received_browser_extensions,
+    'legacy-browsers': tsdb.models.project_total_received_legacy_browsers,
+    'localhost': tsdb.models.project_total_received_localhost,
+    'web-crawlers': tsdb.models.project_total_received_web_crawlers,
+    'invalid-csp': tsdb.models.project_total_received_invalid_csp,
+    'cors': tsdb.models.project_total_received_cors,
+})

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -19,9 +19,7 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from operator import attrgetter
 
-from sentry import tsdb
 from sentry.utils.integrationdocs import load_doc
-from sentry.utils.datastructures import BidirectionalMapping
 
 
 def get_all_languages():
@@ -41,8 +39,7 @@ DATA_ROOT = os.path.join(MODULE_ROOT, 'data')
 
 SORT_OPTIONS = OrderedDict(
     (
-        ('priority', _('Priority')), ('date', _(
-            'Last Seen')), ('new', _('First Seen')),
+        ('priority', _('Priority')), ('date', _('Last Seen')), ('new', _('First Seen')),
         ('freq', _('Frequency')),
     )
 )
@@ -112,8 +109,7 @@ DEFAULT_SORT_OPTION = 'date'
 
 # Setup languages for only available locales
 LANGUAGE_MAP = dict(settings.LANGUAGES)
-LANGUAGES = [(k, LANGUAGE_MAP[k])
-             for k in get_all_languages() if k in LANGUAGE_MAP]
+LANGUAGES = [(k, LANGUAGE_MAP[k]) for k in get_all_languages() if k in LANGUAGE_MAP]
 
 # TODO(dcramer): We eventually want to make this user-editable
 TAG_LABELS = {
@@ -143,8 +139,7 @@ SENTRY_RULES = (
 )
 
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH
-HTTP_METHODS = ('GET', 'POST', 'PUT', 'OPTIONS', 'HEAD',
-                'DELETE', 'TRACE', 'CONNECT', 'PATCH')
+HTTP_METHODS = ('GET', 'POST', 'PUT', 'OPTIONS', 'HEAD', 'DELETE', 'TRACE', 'CONNECT', 'PATCH')
 
 CLIENT_RESERVED_ATTRS = (
     'project', 'errors', 'event_id', 'message', 'checksum', 'culprit', 'fingerprint', 'level',
@@ -314,8 +309,7 @@ def get_integration_id_for_event(platform, sdk_name, integrations):
                 return integration_id
 
     # try sdk name, for example "sentry-java" -> "java" or "raven-java:log4j" -> "java-log4j"
-    sdk_name = sdk_name.lower().replace(
-        "sentry-", "").replace("raven-", "").replace(":", "-")
+    sdk_name = sdk_name.lower().replace("sentry-", "").replace("raven-", "").replace(":", "-")
     if sdk_name in INTEGRATION_ID_TO_PLATFORM_DATA:
         return sdk_name
 
@@ -340,15 +334,3 @@ class ObjectStatus(object):
 
 
 StatsPeriod = namedtuple('StatsPeriod', ('segments', 'interval'))
-
-FILTER_STAT_KEYS_TO_VALUES = BidirectionalMapping({
-    'ip-address': tsdb.models.project_total_received_ip_address,
-    'release-version': tsdb.models.project_total_received_release_version,
-    'error-message': tsdb.models.project_total_received_error_message,
-    'browser-extensions': tsdb.models.project_total_received_browser_extensions,
-    'legacy-browsers': tsdb.models.project_total_received_legacy_browsers,
-    'localhost': tsdb.models.project_total_received_localhost,
-    'web-crawlers': tsdb.models.project_total_received_web_crawlers,
-    'invalid-csp': tsdb.models.project_total_received_invalid_csp,
-    'cors': tsdb.models.project_total_received_cors,
-})

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -397,9 +397,9 @@ class ClientApiHelper(object):
         for filter_cls in filters.all():
             filter_obj = filter_cls(project)
             if filter_obj.is_enabled() and filter_obj.test(data):
-                return (True, 'other_filter')
+                return (True, filter_obj.id)
 
-        return (False, )
+        return (False, None)
 
     def validate_data(self, project, data):
         # TODO(dcramer): move project out of the data packet

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -192,15 +192,18 @@ class ClientApiHelper(object):
         self.log = ClientLogHelper(self.context)
 
     def auth_from_request(self, request):
-        result = {k: request.GET[k] for k in six.iterkeys(request.GET) if k[:7] == 'sentry_'}
+        result = {k: request.GET[k] for k in six.iterkeys(
+            request.GET) if k[:7] == 'sentry_'}
 
         if request.META.get('HTTP_X_SENTRY_AUTH', '')[:7].lower() == 'sentry ':
             if result:
-                raise SuspiciousOperation('Multiple authentication payloads were detected.')
+                raise SuspiciousOperation(
+                    'Multiple authentication payloads were detected.')
             result = parse_auth_header(request.META['HTTP_X_SENTRY_AUTH'])
         elif request.META.get('HTTP_AUTHORIZATION', '')[:7].lower() == 'sentry ':
             if result:
-                raise SuspiciousOperation('Multiple authentication payloads were detected.')
+                raise SuspiciousOperation(
+                    'Multiple authentication payloads were detected.')
             result = parse_auth_header(request.META['HTTP_AUTHORIZATION'])
 
         if not result:
@@ -258,7 +261,8 @@ class ClientApiHelper(object):
             # This error should be caught as it suggests that there's a
             # bug somewhere in the client's code.
             self.log.debug(six.text_type(e), exc_info=True)
-            raise APIError('Bad data decoding request (%s, %s)' % (type(e).__name__, e))
+            raise APIError('Bad data decoding request (%s, %s)' %
+                           (type(e).__name__, e))
 
     def decompress_deflate(self, encoded_data):
         try:
@@ -267,7 +271,8 @@ class ClientApiHelper(object):
             # This error should be caught as it suggests that there's a
             # bug somewhere in the client's code.
             self.log.debug(six.text_type(e), exc_info=True)
-            raise APIError('Bad data decoding request (%s, %s)' % (type(e).__name__, e))
+            raise APIError('Bad data decoding request (%s, %s)' %
+                           (type(e).__name__, e))
 
     def decompress_gzip(self, encoded_data):
         try:
@@ -281,7 +286,8 @@ class ClientApiHelper(object):
             # This error should be caught as it suggests that there's a
             # bug somewhere in the client's code.
             self.log.debug(six.text_type(e), exc_info=True)
-            raise APIError('Bad data decoding request (%s, %s)' % (type(e).__name__, e))
+            raise APIError('Bad data decoding request (%s, %s)' %
+                           (type(e).__name__, e))
 
     def decode_and_decompress_data(self, encoded_data):
         try:
@@ -293,7 +299,8 @@ class ClientApiHelper(object):
             # This error should be caught as it suggests that there's a
             # bug somewhere in the client's code.
             self.log.debug(six.text_type(e), exc_info=True)
-            raise APIError('Bad data decoding request (%s, %s)' % (type(e).__name__, e))
+            raise APIError('Bad data decoding request (%s, %s)' %
+                           (type(e).__name__, e))
 
     def safely_load_json_string(self, json_string):
         try:
@@ -305,7 +312,8 @@ class ClientApiHelper(object):
             # This error should be caught as it suggests that there's a
             # bug somewhere in the client's code.
             self.log.debug(six.text_type(e), exc_info=True)
-            raise APIError('Bad data reconstructing object (%s, %s)' % (type(e).__name__, e))
+            raise APIError('Bad data reconstructing object (%s, %s)' %
+                           (type(e).__name__, e))
         return obj
 
     def _process_data_timestamp(self, data, current_datetime=None):
@@ -317,7 +325,8 @@ class ClientApiHelper(object):
             try:
                 value = datetime.fromtimestamp(float(value))
             except Exception:
-                raise InvalidTimestamp('Invalid value for timestamp: %r' % data['timestamp'])
+                raise InvalidTimestamp(
+                    'Invalid value for timestamp: %r' % data['timestamp'])
         elif not isinstance(value, datetime):
             # all timestamps are in UTC, but the marker is optional
             if value.endswith('Z'):
@@ -333,16 +342,19 @@ class ClientApiHelper(object):
             try:
                 value = datetime.strptime(value, fmt)
             except Exception:
-                raise InvalidTimestamp('Invalid value for timestamp: %r' % data['timestamp'])
+                raise InvalidTimestamp(
+                    'Invalid value for timestamp: %r' % data['timestamp'])
 
         if current_datetime is None:
             current_datetime = datetime.now()
 
         if value > current_datetime + timedelta(minutes=1):
-            raise InvalidTimestamp('Invalid value for timestamp (in future): %r' % value)
+            raise InvalidTimestamp(
+                'Invalid value for timestamp (in future): %r' % value)
 
         if value < current_datetime - timedelta(days=30):
-            raise InvalidTimestamp('Invalid value for timestamp (too old): %r' % value)
+            raise InvalidTimestamp(
+                'Invalid value for timestamp (too old): %r' % value)
 
         data['timestamp'] = float(value.strftime('%s'))
 
@@ -382,17 +394,17 @@ class ClientApiHelper(object):
         so that we can store it in metrics
         """
         if ip_address and not is_valid_ip(project, ip_address):
-            return (True, 'ip_address')
+            return (True, 'ip-address')
 
         release = data.get('release')
         if release and not is_valid_release(project, release):
-            return (True, 'release_version')
+            return (True, 'release-version')
 
         message_interface = data.get('sentry.interfaces.Message', {})
         error_message = message_interface.get('formatted', ''
                                               ) or message_interface.get('message', '')
         if error_message and not is_valid_error_message(project, error_message):
-            return (True, 'error_message')
+            return (True, 'error-message')
 
         for filter_cls in filters.all():
             filter_obj = filter_cls(project)
@@ -418,7 +430,8 @@ class ClientApiHelper(object):
 
         if len(data['event_id']) > 32:
             self.log.debug(
-                'Discarded value for event_id due to length (%d chars)', len(data['event_id'])
+                'Discarded value for event_id due to length (%d chars)', len(
+                    data['event_id'])
             )
             data['errors'].append(
                 {
@@ -479,7 +492,8 @@ class ClientApiHelper(object):
             data['platform'] = 'other'
 
         if data.get('modules') and type(data['modules']) != dict:
-            self.log.debug('Discarded invalid type for modules: %s', type(data['modules']))
+            self.log.debug(
+                'Discarded invalid type for modules: %s', type(data['modules']))
             data['errors'].append(
                 {
                     'type': EventError.INVALID_DATA,
@@ -490,7 +504,8 @@ class ClientApiHelper(object):
             del data['modules']
 
         if data.get('extra') is not None and type(data['extra']) != dict:
-            self.log.debug('Discarded invalid type for extra: %s', type(data['extra']))
+            self.log.debug('Discarded invalid type for extra: %s',
+                           type(data['extra']))
             data['errors'].append(
                 {
                     'type': EventError.INVALID_DATA,
@@ -504,7 +519,8 @@ class ClientApiHelper(object):
             if type(data['tags']) == dict:
                 data['tags'] = list(data['tags'].items())
             elif not isinstance(data['tags'], (list, tuple)):
-                self.log.debug('Discarded invalid type for tags: %s', type(data['tags']))
+                self.log.debug(
+                    'Discarded invalid type for tags: %s', type(data['tags']))
                 data['errors'].append(
                     {
                         'type': EventError.INVALID_DATA,
@@ -535,7 +551,8 @@ class ClientApiHelper(object):
                     try:
                         k = six.text_type(k)
                     except Exception:
-                        self.log.debug('Discarded invalid tag key: %r', type(k))
+                        self.log.debug(
+                            'Discarded invalid tag key: %r', type(k))
                         data['errors'].append(
                             {
                                 'type': EventError.INVALID_DATA,
@@ -549,7 +566,8 @@ class ClientApiHelper(object):
                     try:
                         v = six.text_type(v)
                     except Exception:
-                        self.log.debug('Discarded invalid tag value: %s=%r', k, type(v))
+                        self.log.debug(
+                            'Discarded invalid tag value: %s=%r', k, type(v))
                         data['errors'].append(
                             {
                                 'type': EventError.INVALID_DATA,
@@ -636,7 +654,8 @@ class ClientApiHelper(object):
                 if type(value) in (list, tuple):
                     value = {'values': value}
                 else:
-                    self.log.debug('Invalid parameter for value: %s (%r)', k, type(value))
+                    self.log.debug(
+                        'Invalid parameter for value: %s (%r)', k, type(value))
                     data['errors'].append(
                         {
                             'type': EventError.INVALID_DATA,
@@ -654,7 +673,8 @@ class ClientApiHelper(object):
                     log = self.log.debug
                 else:
                     log = self.log.error
-                log('Discarded invalid value for interface: %s (%r)', k, value, exc_info=True)
+                log('Discarded invalid value for interface: %s (%r)',
+                    k, value, exc_info=True)
                 data['errors'].append(
                     {
                         'type': EventError.INVALID_DATA,
@@ -692,7 +712,8 @@ class ClientApiHelper(object):
                         log = self.log.debug
                     else:
                         log = self.log.error
-                    log('Discarded invalid value for interface: %s (%r)', k, value, exc_info=True)
+                    log('Discarded invalid value for interface: %s (%r)',
+                        k, value, exc_info=True)
                     data['errors'].append(
                         {
                             'type': EventError.INVALID_DATA,
@@ -715,7 +736,8 @@ class ClientApiHelper(object):
                         'value': level,
                     }
                 )
-                data['level'] = LOG_LEVELS_MAP.get(DEFAULT_LOG_LEVEL, DEFAULT_LOG_LEVEL)
+                data['level'] = LOG_LEVELS_MAP.get(
+                    DEFAULT_LOG_LEVEL, DEFAULT_LOG_LEVEL)
 
         if data.get('release'):
             data['release'] = six.text_type(data['release'])
@@ -813,7 +835,8 @@ class ClientApiHelper(object):
             got_ip = True
 
         if not got_ip and set_if_missing:
-            data.setdefault('sentry.interfaces.User', {})['ip_address'] = ip_address
+            data.setdefault('sentry.interfaces.User', {})[
+                'ip_address'] = ip_address
 
     def insert_data_to_database(self, data, from_reprocessing=False):
         # we might be passed LazyData
@@ -823,7 +846,8 @@ class ClientApiHelper(object):
         default_cache.set(cache_key, data, timeout=3600)
         task = from_reprocessing and \
             preprocess_event_from_reprocessing or preprocess_event
-        task.delay(cache_key=cache_key, start_time=time(), event_id=data['event_id'])
+        task.delay(cache_key=cache_key, start_time=time(),
+                   event_id=data['event_id'])
 
 
 class CspApiHelper(ClientApiHelper):

--- a/src/sentry/filters/browser_extensions.py
+++ b/src/sentry/filters/browser_extensions.py
@@ -4,6 +4,8 @@ from .base import Filter
 
 import re
 
+from sentry.utils.data_filters import FilterStatKeys
+
 EXTENSION_EXC_VALUES = re.compile(
     '|'.join(
         (
@@ -71,7 +73,7 @@ EXTENSION_EXC_SOURCES = re.compile(
 
 
 class BrowserExtensionsFilter(Filter):
-    id = 'browser-extensions'
+    id = FilterStatKeys.BROWSER_EXTENSION
     name = 'Filter out errors known to be caused by browser extensions'
     description = 'Certain browser extensions will inject inline scripts and are known to cause errors.'
 

--- a/src/sentry/filters/legacy_browsers.py
+++ b/src/sentry/filters/legacy_browsers.py
@@ -6,6 +6,8 @@ from ua_parser.user_agent_parser import Parse
 from rest_framework import serializers
 from sentry.models import ProjectOption
 from sentry.api.fields import MultipleChoiceField
+from sentry.utils.data_filters import FilterStatKeys
+
 """
 For default (legacy) filter
 """
@@ -28,7 +30,7 @@ class LegacyBrowserFilterSerializer(serializers.Serializer):
 
 
 class LegacyBrowsersFilter(Filter):
-    id = 'legacy-browsers'
+    id = FilterStatKeys.LEGACY_BROWSER
     name = 'Filter out known errors from legacy browsers'
     description = 'Older browsers often give less accurate information, and while they may report valid issues, the context to understand them is incorrect or missing.'
     default = False

--- a/src/sentry/filters/localhost.py
+++ b/src/sentry/filters/localhost.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import
 
 from .base import Filter
 from six.moves.urllib.parse import urlparse
+from sentry.utils.data_filters import FilterStatKeys
 
 LOCAL_IPS = frozenset(['127.0.0.1', '::1'])
 LOCAL_DOMAINS = frozenset(['127.0.0.1', 'localhost'])
 
 
 class LocalhostFilter(Filter):
-    id = 'localhost'
+    id = FilterStatKeys.LOCALHOST
     name = 'Filter out errors coming from localhost'
     description = 'This applies to to both IPv4 (``127.0.0.1``) and IPv6 (``::1``) addresses.'
 

--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import re
 
 from .base import Filter
+from sentry.utils.data_filters import FilterStatKeys
 
 # not all of these agents are guaranteed to execute JavaScript, but to avoid
 # overhead of identifying which ones do, and which ones will over time we simply
@@ -41,7 +42,7 @@ CRAWLERS = re.compile(
 
 
 class WebCrawlersFilter(Filter):
-    id = 'web-crawlers'
+    id = FilterStatKeys.WEB_CRAWLER
     name = 'Filter out known web crawlers'
     description = 'Some crawlers may execute pages in incompatible ways which then cause errors that are unlikely to be seen by a normal user.'
     default = True

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -398,14 +398,14 @@ const ProjectFilters = React.createClass({
   },
 
   STAT_OPTS: {
-    ip_address: 'IP Address',
-    release_version: 'Release',
-    error_message: 'Error Message',
-    browser_extensions: 'Browser Extension',
-    legacy_browsers: 'Legacy Browser',
+    'ip-address': 'IP Address',
+    'release-version': 'Release',
+    'error-message': 'Error Message',
+    'browser-extensions': 'Browser Extension',
+    'legacy-browsers': 'Legacy Browser',
     localhost: 'Localhost',
-    web_crawlers: 'Web Crawler',
-    invalid_csp: 'Invalid CSP',
+    'web-crawlers': 'Web Crawler',
+    'invalid-csp': 'Invalid CSP',
     cors: 'CORS'
   },
 

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -435,7 +435,7 @@ const ProjectFilters = React.createClass({
   },
 
   getFilterStats() {
-    let stat_options = Object.keys(this.getStatOpts());
+    let statOptions = Object.keys(this.getStatOpts());
     let {orgId, projectId} = this.props.params;
     let statEndpoint = `/projects/${orgId}/${projectId}/stats/`;
     let query = {
@@ -446,7 +446,8 @@ const ProjectFilters = React.createClass({
     $.when
       .apply(
         $,
-        stat_options.map(stat => {
+        // parallelize requests for each statistic
+        statOptions.map(stat => {
           let deferred = $.Deferred();
           this.api.request(statEndpoint, {
             query: Object.assign({stat: stat}, query),
@@ -457,15 +458,15 @@ const ProjectFilters = React.createClass({
         })
       )
       .done(
-        function() {
+        function(/* statOption1, statOption2, ... statOptionN */) {
           let rawStatsData = {};
           let expected = this.state.expected - 1;
           // when there is a single request made, this is inexplicably called without being wrapped in an array
-          if(stat_options.length===1){
-            rawStatsData[stat_options[0]] = arguments[0];
+          if(statOptions.length===1){
+            rawStatsData[statOptions[0]] = arguments[0];
           } else {
-            for (let i = 0; i < stat_options.length; i++) {
-              rawStatsData[stat_options[i]] = arguments[i][0];
+            for (let i = 0; i < statOptions.length; i++) {
+              rawStatsData[statOptions[i]] = arguments[i][0];
             }
           }
 
@@ -652,7 +653,7 @@ const ProjectFilters = React.createClass({
     return ReactDOMServer.renderToStaticMarkup(
       <div style={{width: '150px'}}>
         <div className="time-label"><span>{timeLabel}</span></div>
-        <div>{intcomma(totalY)} {t('total event')}{totalY !== 1 ? 's' : ''}</div>
+        <div>{intcomma(totalY)} {totalY > 1 ? t('total events') : t('total event')}</div>
         {formattedData.map((dataPoint, i) => {
           return (
             point.y[i] > 0 &&

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -402,7 +402,8 @@ const ProjectFilters = React.createClass({
     'legacy_browsers',
     'localhost',
     'web_crawlers',
-    'invalid_csp'
+    'invalid_csp',
+    'cors'
   ],
 
   formatData(rawData) {

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -231,8 +231,13 @@ const ProjectFiltersSettingsForm = React.createClass({
 
   getInitialState() {
     let formData = {};
+    let features = this.getProjectFeatures()
     for (let key of Object.keys(this.props.initialData)) {
       if (key.lastIndexOf('filters:') === 0) {
+        // the project details endpoint can partially succeed and still return a 400
+        // if the org does not have the additional-data-filters feature enabled,
+        // so this prevents the form from sending an empty string by default
+        if(!features.has('additional-data-filters') && key === 'filters:error_messages' || key === 'filters:releases') continue;
         formData[key] = this.props.initialData[key];
       }
     }
@@ -254,7 +259,6 @@ const ProjectFiltersSettingsForm = React.createClass({
 
   onSubmit(e) {
     e.preventDefault();
-
     if (this.state.state === FormState.SAVING) {
       return;
     }

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -374,7 +374,6 @@ const ProjectFilters = React.createClass({
       filterList: [],
       querySince: since,
       queryUntil: until,
-      stats: null,
       rawStatsData: null,
       formattedData: null,
       projectOptions: {},

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -25,7 +25,7 @@
         }
 
         &.release_version {
-          background: @orange-light;
+          background: @purple-light;
         }
 
         &.error_message {
@@ -37,11 +37,11 @@
         }
 
         &.legacy_browsers {
-          background: @red;
+          background: @gray-light;
         }
 
         &.localhost {
-          background: @orange;
+          background: @blue;
         }
 
         &.web_crawlers {
@@ -49,7 +49,7 @@
         }
 
         &.invalid_csp {
-          background: @blue;
+          background: @blue-light;
         }
       }
     }

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -7,6 +7,53 @@
   padding-top: 20px;
 }
 
+/**
+* Inbound Data Filters
+* ============================================================================
+*/
+
+.filtered-stats-barchart {
+    height: 100px;
+
+    a {
+      > span {
+        left: 2px;
+        right: 2px;
+
+        &.ip_address {
+          background: @red-light;
+        }
+
+        &.release_version {
+          background: @orange-light;
+        }
+
+        &.error_message {
+          background: @purple;
+        }
+
+        &.browser_extensions {
+          background: @gray;
+        }
+
+        &.legacy_browsers {
+          background: @red;
+        }
+
+        &.localhost {
+          background: @orange;
+        }
+
+        &.web_crawlers {
+          background: @red;
+        }
+
+        &.invalid_csp {
+          background: @blue;
+        }
+      }
+    }
+  }
 
 /**
 * Rules

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -51,9 +51,65 @@
         &.invalid_csp {
           background: @blue-light;
         }
+
+        &.cors {
+          background: @green-dark;
+        }
       }
     }
   }
+
+.legend {
+  padding: 3px 0;
+  position: relative;
+  line-height: 10px;
+
+  dt {
+    margin: 0;
+    position: absolute;
+    left: 0;
+    width: 8px;
+    margin-right: 5px;
+
+    span {
+      &.ip_address {
+        background: @red-light;
+      }
+
+      &.release_version {
+        background: @purple-light;
+      }
+
+      &.error_message {
+        background: @purple;
+      }
+
+      &.browser_extensions {
+        background: @gray;
+      }
+
+      &.legacy_browsers {
+        background: @gray-light;
+      }
+
+      &.localhost {
+        background: @blue;
+      }
+
+      &.web_crawlers {
+        background: @red;
+      }
+
+      &.invalid_csp {
+        background: @blue-light;
+      }
+
+      &.cors {
+        background: @green-dark;
+      }
+    }
+  }
+}
 
 /**
 * Rules

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -20,23 +20,23 @@
         left: 2px;
         right: 2px;
 
-        &.ip_address {
+        &.ip-address {
           background: @red-light;
         }
 
-        &.release_version {
+        &.release-version {
           background: @purple-light;
         }
 
-        &.error_message {
+        &.error-message {
           background: @purple;
         }
 
-        &.browser_extensions {
+        &.browser-extensions {
           background: @gray;
         }
 
-        &.legacy_browsers {
+        &.legacy-browsers {
           background: @gray-light;
         }
 
@@ -44,16 +44,16 @@
           background: @blue;
         }
 
-        &.web_crawlers {
+        &.web-crawlers {
           background: @red;
         }
 
-        &.invalid_csp {
+        &.invalid-csp {
           background: @blue-light;
         }
 
         &.cors {
-          background: @green-dark;
+          background: @orange;
         }
       }
     }
@@ -72,23 +72,23 @@
     margin-right: 5px;
 
     span {
-      &.ip_address {
+      &.ip-address {
         background: @red-light;
       }
 
-      &.release_version {
+      &.release-version {
         background: @purple-light;
       }
 
-      &.error_message {
+      &.error-message {
         background: @purple;
       }
 
-      &.browser_extensions {
+      &.browser-extensions {
         background: @gray;
       }
 
-      &.legacy_browsers {
+      &.legacy-browsers {
         background: @gray-light;
       }
 
@@ -96,16 +96,16 @@
         background: @blue;
       }
 
-      &.web_crawlers {
+      &.web-crawlers {
         background: @red;
       }
 
-      &.invalid_csp {
+      &.invalid-csp {
         background: @blue-light;
       }
 
       &.cors {
-        background: @green-dark;
+        background: @orange;
       }
     }
   }

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -83,13 +83,21 @@ class TSDBModel(Enum):
     # the number of events blocked due to being blacklisted
     key_total_blacklisted = 502
 
+    # the number of events filtered by ip
     project_total_received_ip_address = 601
+    # the number of events filtered by release
     project_total_received_release_version = 602
+    # the number of events filtered by error message
     project_total_received_error_message = 603
+    # the number of events filtered by browser extension
     project_total_received_browser_extensions = 604
+    # the number of events filtered by legacy browser
     project_total_received_legacy_browsers = 605
+    # the number of events filtered by localhost
     project_total_received_localhost = 606
+    # the number of events filtered by web crawlers
     project_total_received_web_crawlers = 607
+    # the number of events filtered by invalid csp
     project_total_received_invalid_csp = 608
 
 

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -83,6 +83,15 @@ class TSDBModel(Enum):
     # the number of events blocked due to being blacklisted
     key_total_blacklisted = 502
 
+    project_total_received_ip_address = 601
+    project_total_received_release_version = 602
+    project_total_received_error_message = 603
+    project_total_received_browser_extensions = 604
+    project_total_received_legacy_browsers = 605
+    project_total_received_localhost = 606
+    project_total_received_web_crawlers = 607
+    project_total_received_invalid_csp = 608
+
 
 class BaseTSDB(Service):
     __all__ = (

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -99,6 +99,8 @@ class TSDBModel(Enum):
     project_total_received_web_crawlers = 607
     # the number of events filtered by invalid csp
     project_total_received_invalid_csp = 608
+    # the number of events filtered by invalid origin
+    project_total_received_cors = 609
 
 
 class BaseTSDB(Service):

--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -13,6 +13,32 @@ import six
 
 from django.utils.encoding import force_text
 
+from sentry import tsdb
+
+
+class FilterStatKeys(object):
+    IP_ADDRESS = 'ip-address'
+    RELEASE_VERSION = 'release-version'
+    ERROR_MESSAGE = 'error-message'
+    BROWSER_EXTENSION = 'browser-extensions'
+    LEGACY_BROWSER = 'legacy-browsers'
+    LOCALHOST = 'localhost'
+    WEB_CRAWLER = 'web-crawlers'
+    INVALID_CSP = 'invalid-csp'
+    CORS = 'cors'
+
+FILTER_STAT_KEYS_TO_VALUES = {
+    FilterStatKeys.IP_ADDRESS: tsdb.models.project_total_received_ip_address,
+    FilterStatKeys.RELEASE_VERSION: tsdb.models.project_total_received_release_version,
+    FilterStatKeys.ERROR_MESSAGE: tsdb.models.project_total_received_error_message,
+    FilterStatKeys.BROWSER_EXTENSION: tsdb.models.project_total_received_browser_extensions,
+    FilterStatKeys.LEGACY_BROWSER: tsdb.models.project_total_received_legacy_browsers,
+    FilterStatKeys.LOCALHOST: tsdb.models.project_total_received_localhost,
+    FilterStatKeys.WEB_CRAWLER: tsdb.models.project_total_received_web_crawlers,
+    FilterStatKeys.INVALID_CSP: tsdb.models.project_total_received_invalid_csp,
+    FilterStatKeys.CORS: tsdb.models.project_total_received_cors,
+}
+
 
 class FilterTypes(object):
     ERROR_MESSAGES = 'error_messages'

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -344,6 +344,23 @@ class StoreView(APIView):
                     (tsdb.models.key_total_blacklisted, key.id),
                 ]
             )
+            if should_filter[1] == 'ip_address':
+                tsdb.incr(tsdb.models.project_total_received_ip_address, project.id)
+            elif should_filter[1] == 'release_version':
+                tsdb.incr(tsdb.models.project_total_received_release_version, project.id)
+            elif should_filter[1] == 'error_message':
+                tsdb.incr(tsdb.models.project_total_received_error_message, project.id)
+            elif should_filter[1] == 'browser-extensions':
+                tsdb.incr(tsdb.models.project_total_received_browser_extensions, project.id)
+            elif should_filter[1] == 'legacy-browsers':
+                tsdb.incr(tsdb.models.project_total_received_legacy_browsers, project.id)
+            elif should_filter[1] == 'localhost':
+                tsdb.incr(tsdb.models.project_total_received_localhost, project.id)
+            elif should_filter[1] == 'web-crawlers':
+                tsdb.incr(tsdb.models.project_total_received_web_crawlers, project.id)
+            elif should_filter[1] == 'invalid_csp':
+                tsdb.incr(tsdb.models.project_total_received_invalid_csp, project.id)
+
             metrics.incr('events.blacklisted', tags={'reason': should_filter[1]})
             event_filtered.send_robust(
                 ip=remote_addr,

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -175,6 +175,7 @@ class APIView(BaseView):
             if not project:
                 raise APIError('Client must be upgraded for CORS support')
             if not is_valid_origin(origin, project):
+                tsdb.incr(tsdb.models.project_total_received_cors, project.id or None)
                 raise APIForbidden('Invalid origin: %s' % (origin, ))
 
         # XXX: It seems that the OPTIONS call does not always include custom headers
@@ -216,6 +217,7 @@ class APIView(BaseView):
                         )
 
                     if not is_valid_origin(origin, project):
+                        tsdb.incr(tsdb.models.project_total_received_cors, project.id or None)
                         raise APIForbidden('Missing required Origin or Referer header')
 
             response = super(APIView, self).dispatch(
@@ -538,6 +540,7 @@ class CspReportView(StoreView):
             raise APIForbidden('Invalid document-uri')
 
         if not is_valid_origin(origin, project):
+            tsdb.incr(tsdb.models.project_total_received_cors, project.id or None)
             raise APIForbidden('Invalid document-uri')
 
         # Attach on collected meta data. This data obviously isn't a part

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -18,11 +18,13 @@ from functools import wraps
 from raven.contrib.django.models import client as Raven
 
 from sentry import quotas, tsdb
+from sentry.constants import FILTER_STAT_KEYS_TO_VALUES
 from sentry.coreapi import (
     APIError, APIForbidden, APIRateLimited, ClientApiHelper, CspApiHelper, LazyData
 )
 from sentry.models import Project, OrganizationOption, Organization
-from sentry.signals import (event_accepted, event_dropped, event_filtered, event_received)
+from sentry.signals import (
+    event_accepted, event_dropped, event_filtered, event_received)
 from sentry.quotas.base import RateLimit
 from sentry.utils import json, metrics
 from sentry.utils.data_scrubber import SensitiveDataFilter
@@ -127,24 +129,30 @@ class APIView(BaseView):
             else:
                 content = ''
             logger.exception(e)
-            response = HttpResponse(content, content_type='text/plain', status=500)
+            response = HttpResponse(
+                content, content_type='text/plain', status=500)
 
         # TODO(dcramer): it'd be nice if we had an incr_multi method so
         # tsdb could optimize this
         metrics.incr('client-api.all-versions.requests')
-        metrics.incr('client-api.all-versions.responses.%s' % (response.status_code, ))
+        metrics.incr('client-api.all-versions.responses.%s' %
+                     (response.status_code, ))
         metrics.incr(
-            'client-api.all-versions.responses.%sxx' % (six.text_type(response.status_code)[0], )
+            'client-api.all-versions.responses.%sxx' % (
+                six.text_type(response.status_code)[0], )
         )
 
         if helper.context.version:
-            metrics.incr('client-api.v%s.requests' % (helper.context.version, ))
+            metrics.incr('client-api.v%s.requests' %
+                         (helper.context.version, ))
             metrics.incr(
-                'client-api.v%s.responses.%s' % (helper.context.version, response.status_code)
+                'client-api.v%s.responses.%s' % (
+                    helper.context.version, response.status_code)
             )
             metrics.incr(
                 'client-api.v%s.responses.%sxx' %
-                (helper.context.version, six.text_type(response.status_code)[0])
+                (helper.context.version, six.text_type(
+                    response.status_code)[0])
             )
 
         if response.status_code != 200 and origin:
@@ -175,7 +183,9 @@ class APIView(BaseView):
             if not project:
                 raise APIError('Client must be upgraded for CORS support')
             if not is_valid_origin(origin, project):
-                tsdb.incr(tsdb.models.project_total_received_cors, project.id or None)
+                if project:
+                    tsdb.incr(tsdb.models.project_total_received_cors,
+                              project.id)
                 raise APIForbidden('Invalid origin: %s' % (origin, ))
 
         # XXX: It seems that the OPTIONS call does not always include custom headers
@@ -200,7 +210,8 @@ class APIView(BaseView):
             # this just allows us to comfortably assure that `project.organization` is safe.
             # This also allows us to pull the object from cache, instead of being
             # implicitly fetched from database.
-            project.organization = Organization.objects.get_from_cache(id=project.organization_id)
+            project.organization = Organization.objects.get_from_cache(
+                id=project.organization_id)
 
             if auth.version != '2.0':
                 if not auth.secret_key:
@@ -217,8 +228,11 @@ class APIView(BaseView):
                         )
 
                     if not is_valid_origin(origin, project):
-                        tsdb.incr(tsdb.models.project_total_received_cors, project.id or None)
-                        raise APIForbidden('Missing required Origin or Referer header')
+                        if project:
+                            tsdb.incr(
+                                tsdb.models.project_total_received_cors, project.id)
+                        raise APIForbidden(
+                            'Missing required Origin or Referer header')
 
             response = super(APIView, self).dispatch(
                 request=request, project=project, auth=auth, helper=helper, key=key, **kwargs
@@ -334,36 +348,29 @@ class StoreView(APIView):
             sender=type(self),
         )
 
-        should_filter = helper.should_filter(project, data, ip_address=remote_addr)
+        should_filter = helper.should_filter(
+            project, data, ip_address=remote_addr)
         if should_filter[0]:
             tsdb.incr_multi(
                 [
                     (tsdb.models.project_total_received, project.id),
                     (tsdb.models.project_total_blacklisted, project.id),
-                    (tsdb.models.organization_total_received, project.organization_id),
-                    (tsdb.models.organization_total_blacklisted, project.organization_id),
+                    (tsdb.models.organization_total_received,
+                     project.organization_id),
+                    (tsdb.models.organization_total_blacklisted,
+                     project.organization_id),
                     (tsdb.models.key_total_received, key.id),
                     (tsdb.models.key_total_blacklisted, key.id),
                 ]
             )
-            if should_filter[1] == 'ip_address':
-                tsdb.incr(tsdb.models.project_total_received_ip_address, project.id)
-            elif should_filter[1] == 'release_version':
-                tsdb.incr(tsdb.models.project_total_received_release_version, project.id)
-            elif should_filter[1] == 'error_message':
-                tsdb.incr(tsdb.models.project_total_received_error_message, project.id)
-            elif should_filter[1] == 'browser-extensions':
-                tsdb.incr(tsdb.models.project_total_received_browser_extensions, project.id)
-            elif should_filter[1] == 'legacy-browsers':
-                tsdb.incr(tsdb.models.project_total_received_legacy_browsers, project.id)
-            elif should_filter[1] == 'localhost':
-                tsdb.incr(tsdb.models.project_total_received_localhost, project.id)
-            elif should_filter[1] == 'web-crawlers':
-                tsdb.incr(tsdb.models.project_total_received_web_crawlers, project.id)
-            elif should_filter[1] == 'invalid_csp':
-                tsdb.incr(tsdb.models.project_total_received_invalid_csp, project.id)
+            try:
+                tsdb.incr(
+                    FILTER_STAT_KEYS_TO_VALUES[should_filter[1]], project.id)
+            except KeyError:
+                pass
 
-            metrics.incr('events.blacklisted', tags={'reason': should_filter[1]})
+            metrics.incr('events.blacklisted', tags={
+                         'reason': should_filter[1]})
             event_filtered.send_robust(
                 ip=remote_addr,
                 project=project,
@@ -382,13 +389,16 @@ class StoreView(APIView):
         # it cannot cascade
         if rate_limit is None or rate_limit.is_limited:
             if rate_limit is None:
-                helper.log.debug('Dropped event due to error with rate limiter')
+                helper.log.debug(
+                    'Dropped event due to error with rate limiter')
             tsdb.incr_multi(
                 [
                     (tsdb.models.project_total_received, project.id),
                     (tsdb.models.project_total_rejected, project.id),
-                    (tsdb.models.organization_total_received, project.organization_id),
-                    (tsdb.models.organization_total_rejected, project.organization_id),
+                    (tsdb.models.organization_total_received,
+                     project.organization_id),
+                    (tsdb.models.organization_total_rejected,
+                     project.organization_id),
                     (tsdb.models.key_total_received, key.id),
                     (tsdb.models.key_total_rejected, key.id),
                 ]
@@ -411,17 +421,20 @@ class StoreView(APIView):
             tsdb.incr_multi(
                 [
                     (tsdb.models.project_total_received, project.id),
-                    (tsdb.models.organization_total_received, project.organization_id),
+                    (tsdb.models.organization_total_received,
+                     project.organization_id),
                     (tsdb.models.key_total_received, key.id),
                 ]
             )
 
-        org_options = OrganizationOption.objects.get_all_values(project.organization_id)
+        org_options = OrganizationOption.objects.get_all_values(
+            project.organization_id)
 
         if org_options.get('sentry:require_scrub_ip_address', False):
             scrub_ip_address = True
         else:
-            scrub_ip_address = project.get_option('sentry:scrub_ip_address', False)
+            scrub_ip_address = project.get_option(
+                'sentry:scrub_ip_address', False)
 
         event_id = data['event_id']
 
@@ -430,7 +443,8 @@ class StoreView(APIView):
         cache_key = 'ev:%s:%s' % (project.id, event_id, )
 
         if cache.get(cache_key) is not None:
-            raise APIForbidden('An event with the same ID already exists (%s)' % (event_id, ))
+            raise APIForbidden(
+                'An event with the same ID already exists (%s)' % (event_id, ))
 
         if org_options.get('sentry:require_scrub_data', False):
             scrub_data = True
@@ -454,7 +468,8 @@ class StoreView(APIView):
             if org_options.get('sentry:require_scrub_defaults', False):
                 scrub_defaults = True
             else:
-                scrub_defaults = project.get_option('sentry:scrub_defaults', True)
+                scrub_defaults = project.get_option(
+                    'sentry:scrub_defaults', True)
 
             inst = SensitiveDataFilter(
                 fields=sensitive_fields,
@@ -540,7 +555,9 @@ class CspReportView(StoreView):
             raise APIForbidden('Invalid document-uri')
 
         if not is_valid_origin(origin, project):
-            tsdb.incr(tsdb.models.project_total_received_cors, project.id or None)
+            if project:
+                tsdb.incr(tsdb.models.project_total_received_cors,
+                          project.id)
             raise APIForbidden('Invalid document-uri')
 
         # Attach on collected meta data. This data obviously isn't a part
@@ -580,7 +597,8 @@ def crossdomain_xml(request, project_id):
         return HttpResponse(status=404)
 
     origin_list = get_origins(project)
-    response = render_to_response('sentry/crossdomain.xml', {'origin_list': origin_list})
+    response = render_to_response(
+        'sentry/crossdomain.xml', {'origin_list': origin_list})
     response['Content-Type'] = 'application/xml'
 
     return response

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -352,18 +352,23 @@ class StoreView(APIView):
             project, data, ip_address=remote_addr)
         if should_filter[0]:
             filter_reason = should_filter[1]
+            increment_list = [
+                (tsdb.models.project_total_received, project.id),
+                (tsdb.models.project_total_blacklisted, project.id),
+                (tsdb.models.organization_total_received,
+                 project.organization_id),
+                (tsdb.models.organization_total_blacklisted,
+                 project.organization_id),
+                (tsdb.models.key_total_received, key.id),
+                (tsdb.models.key_total_blacklisted, key.id),
+            ]
+            try:
+                increment_list.append((FILTER_STAT_KEYS_TO_VALUES[filter_reason], project.id))
+            except KeyError:
+                pass
+
             tsdb.incr_multi(
-                [
-                    (tsdb.models.project_total_received, project.id),
-                    (tsdb.models.project_total_blacklisted, project.id),
-                    (tsdb.models.organization_total_received,
-                     project.organization_id),
-                    (tsdb.models.organization_total_blacklisted,
-                     project.organization_id),
-                    (tsdb.models.key_total_received, key.id),
-                    (tsdb.models.key_total_blacklisted, key.id),
-                    (FILTER_STAT_KEYS_TO_VALUES[filter_reason], project.id),
-                ]
+                increment_list
             )
 
             metrics.incr('events.blacklisted', tags={

--- a/tests/sentry/api/endpoints/test_project_stats.py
+++ b/tests/sentry/api/endpoints/test_project_stats.py
@@ -37,53 +37,54 @@ class ProjectStatsTest(APITestCase):
         project1 = self.create_project(name='foo')
 
         STAT_OPTS = {
-            'ip_address': 1,
-            'release_version': 2,
-            'error_message': 3,
-            'browser_extensions': 4,
-            'legacy_browsers': 5,
+            'ip-address': 1,
+            'release-version': 2,
+            'error-message': 3,
+            'browser-extensions': 4,
+            'legacy-browsers': 5,
             'localhost': 6,
-            'web_crawlers': 7,
-            'invalid_csp': 8,
+            'web-crawlers': 7,
+            'invalid-csp': 8,
         }
 
         tsdb.incr(
             tsdb.models.project_total_received_ip_address,
             project1.id,
-            count=STAT_OPTS['ip_address']
+            count=STAT_OPTS['ip-address']
         )
         tsdb.incr(
             tsdb.models.project_total_received_release_version,
             project1.id,
-            count=STAT_OPTS['release_version']
+            count=STAT_OPTS['release-version']
         )
         tsdb.incr(
             tsdb.models.project_total_received_error_message,
             project1.id,
-            count=STAT_OPTS['error_message']
+            count=STAT_OPTS['error-message']
         )
         tsdb.incr(
             tsdb.models.project_total_received_browser_extensions,
             project1.id,
-            count=STAT_OPTS['browser_extensions']
+            count=STAT_OPTS['browser-extensions']
         )
         tsdb.incr(
             tsdb.models.project_total_received_legacy_browsers,
             project1.id,
-            count=STAT_OPTS['legacy_browsers']
+            count=STAT_OPTS['legacy-browsers']
         )
         tsdb.incr(
-            tsdb.models.project_total_received_localhost, project1.id, count=STAT_OPTS['localhost']
+            tsdb.models.project_total_received_localhost, project1.id, count=STAT_OPTS[
+                'localhost']
         )
         tsdb.incr(
             tsdb.models.project_total_received_web_crawlers,
             project1.id,
-            count=STAT_OPTS['web_crawlers']
+            count=STAT_OPTS['web-crawlers']
         )
         tsdb.incr(
             tsdb.models.project_total_received_invalid_csp,
             project1.id,
-            count=STAT_OPTS['invalid_csp']
+            count=STAT_OPTS['invalid-csp']
         )
 
         url = reverse(

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -533,7 +533,7 @@ class StoreViewTest(TestCase):
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database', Mock())
     @mock.patch('sentry.coreapi.ClientApiHelper.should_filter')
     def test_filtered_signal(self, mock_should_filter):
-        mock_should_filter.return_value = 'ip_address'
+        mock_should_filter.return_value = (True, 'ip-address')
 
         mock_event_filtered = Mock()
 


### PR DESCRIPTION
Track filtered events with more granularity and display them in the inbound filters chart. 

![image](https://user-images.githubusercontent.com/9269824/29785577-f9f58f98-8bdc-11e7-89bf-14bcc1393519.png)

Looking for feedback on whether this is the correct implementation of capturing and returning the data.

Also recommendations on what colors to use for the chart.

Seems like we don't necessarily need to feature gate the UI since the graph will only display the filtered events and the other feature gate should prevent people from filtering events from releases and error messages at all.