### PR TITLE
Makefile: Fix typo when setting LDFLAGS from env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifneq "$(wildcard /usr/local/opt/libxmlsec1/lib)" ""
 	LDFLAGS += -L/usr/local/opt/libxmlsec1/lib
 endif
 ifneq "$(wildcard /usr/local/opt/openssl/lib)" ""
-	LDFLAGS +=- L/usr/local/opt/openssl/lib
+	LDFLAGS += -L/usr/local/opt/openssl/lib
 endif
 
 PIP = LDFLAGS="$(LDFLAGS)" pip


### PR DESCRIPTION
There was a typo in recent commit getsentry/sentry@39d80d80107dd6710208f4d0906a8920408479e2