### PR TITLE
api: logger name is a TagValue, not TagKey

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -29,7 +29,7 @@ from sentry.constants import (
 from sentry.interfaces.base import get_interface
 from sentry.models import (
     Activity, Environment, Event, EventMapping, EventUser, Group, GroupHash, GroupRelease,
-    GroupResolution, GroupStatus, Project, Release, ReleaseEnvironment, ReleaseProject, TagKey,
+    GroupResolution, GroupStatus, Project, Release, ReleaseEnvironment, ReleaseProject, TagValue,
     UserReport
 )
 from sentry.plugins import plugins
@@ -249,7 +249,7 @@ class EventManager(object):
             data['logger'] = DEFAULT_LOGGER_NAME
         else:
             logger = trim(data['logger'].strip(), 64)
-            if TagKey.is_valid_key(logger):
+            if TagValue.is_valid_value(logger):
                 data['logger'] = logger
             else:
                 data['logger'] = DEFAULT_LOGGER_NAME


### PR DESCRIPTION
The validation for key names is much more strict than values. And
loggers ultimately are TagValues, so use the validation there.

@dcramer any reason this would have been more strict intentionally? A user reported wanting to use a space in the logger name and we silently discarded it. Not sure I see any technical reason to be extra restrictive over logger names.