### PR TITLE
monkey: patch HttpRequest repr to not log request variables

### DIFF
--- a/src/sentry/monkey.py
+++ b/src/sentry/monkey.py
@@ -14,3 +14,21 @@ def register_scheme(name):
 
 register_scheme('app')
 register_scheme('chrome-extension')
+
+
+# Intentionally strip all GET/POST/COOKIE values out of repr() for HttpRequest
+# and subclass WSGIRequest. This prevents sensitive information from getting
+# logged. This was yanked out of Django master anyhow.
+# https://code.djangoproject.com/ticket/12098
+def safe_httprequest_repr(self):
+    return '<%s: %s %r>' % (self.__class__.__name__, self.method, self.get_full_path())
+
+
+try:
+    from django.http import HttpRequest
+except ImportError:
+    # This module is potentially imported before Django is installed
+    # during a setup.py run
+    pass
+else:
+    HttpRequest.__repr__ = safe_httprequest_repr


### PR DESCRIPTION
Fixes GH-5933

This is a bit heavy handed, but opted to just completely destroy the HttpRequest.__repr__ instead of doing anything custom within the logger.

The downside is we'll lose this for local. But frankly, I don't think I've ever wanted it locally.

If it tuns out we care, we can just have the new repr check `settings.DEBUG` or something and use old behavior.

The new repr ends up looking like `<WSGIRequest: POST u'/'>`