### PR TITLE
Update similarity index to use new argument parsing pattern.

### DIFF
--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -45,16 +45,6 @@ local function range(start, stop)
     return result
 end
 
-function table.ifilter(t, f)
-    local result = {}
-    for i, value in ipairs(t) do
-        if f(value) then
-            table.insert(result, value)
-        end
-    end
-    return result
-end
-
 function table.imap(t, f)
     local result = {}
     for i, value in ipairs(t) do
@@ -91,15 +81,6 @@ function table.izip(...)
             table.insert(item, args[j][i])
         end
         table.insert(result, item)
-    end
-    return result
-end
-
-function table.slice(t, start, stop)
-    -- NOTE: ``stop`` is inclusive!
-    local result = {}
-    for i = start or 1, stop or #t do
-        table.insert(result, t[i])
     end
     return result
 end

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -454,6 +454,33 @@ local function fetch_similar(configuration, time_series, index, item_frequencies
     )
 end
 
+
+-- Command Utilities
+
+local function as_search_response(results)
+    -- Sort the results in descending order (most similar first.)
+    table.sort(
+        results,
+        function (left, right)
+            return left[2] > right[2]
+        end
+    )
+
+    return table.imap(
+        results,
+        function (item)
+            return {
+                item[1],
+                string.format(
+                    '%f',  -- converting floats to strings avoids truncation
+                    item[2]
+                ),
+            }
+        end
+    )
+end
+
+
 -- Command Parsing
 
 local commands = {
@@ -536,27 +563,7 @@ local commands = {
                     signature.index,
                     signature.frequencies
                 )
-
-                -- Sort the results in descending order (most similar first.)
-                table.sort(
-                    results,
-                    function (left, right)
-                        return left[2] > right[2]
-                    end
-                )
-
-                return table.imap(
-                    results,
-                    function (item)
-                        return {
-                            item[1],
-                            string.format(
-                                '%f',  -- converting floats to strings avoids truncation
-                                item[2]
-                            ),
-                        }
-                    end
-                )
+                return as_search_response(results)
             end
         )
     end,
@@ -588,27 +595,7 @@ local commands = {
                         item_key
                     )
                 )
-
-                -- Sort the results in descending order (most similar first.)
-                table.sort(
-                    results,
-                    function (left, right)
-                        return left[2] > right[2]
-                    end
-                )
-
-                return table.imap(
-                    results,
-                    function (item)
-                        return {
-                            item[1],
-                            string.format(
-                                '%f',  -- converting floats to strings avoids truncation
-                                item[2]
-                            ),
-                        }
-                    end
-                )
+                return as_search_response(results)
             end
         )
     end,

--- a/src/sentry/similarity/index.py
+++ b/src/sentry/similarity/index.py
@@ -47,7 +47,7 @@ class MinHashIndex(object):
             for i, bucket in enumerate(bands):
                 data[idx][i][bucket] += 1
 
-        arguments = [len(data)]
+        arguments = []
         for idx, bands in data.items():
             arguments.append(idx)
             for buckets in bands:


### PR DESCRIPTION
This also removes some now unused (`table.slice`, `table.ifilter`, etc.) functions.