### PR TITLE
Correct pagination prev cursor for empty sets

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -115,8 +115,9 @@ class BasePaginator(object):
 
         offset = cursor.offset
         # this effectively gets us the before row, and the current (after) row
-        # every time
-        if cursor.is_prev:
+        # every time. Do not offset if the provided cursor value was empty since
+        # there is nothing to traverse past.
+        if cursor.is_prev and cursor.value:
             offset += 1
         stop = offset + limit + 1
         results = list(queryset[offset:stop])

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -85,10 +85,66 @@ class CursorResult(Sequence):
         )
 
 
-def build_cursor(results, key, limit=100, cursor=None, hits=None, max_hits=None):
-    if cursor is None:
-        cursor = Cursor(0, 0, 0)
+def _build_next_values(cursor, results, key, limit, is_desc):
+    value = cursor.value
+    offset = cursor.offset
+    is_prev = cursor.is_prev
 
+    num_results = len(results)
+
+    if not value and num_results:
+        value = int(key(results[0]))
+
+    # Next cursor for a prev-cursor simply starts from that prev cursors value
+    # without an offset.
+    if is_prev:
+        return (value, 0, True)
+
+    # No results means no more next
+    if not num_results:
+        return (value, offset, False)
+
+    # Are there more results than whats on the current page?
+    has_next = num_results > limit
+
+    # Determine what our next cursor is by ensuring we have a unique offset
+    next_value = int(key(results[-1]))
+
+    # value has not changed, page forward by adjusting the offset
+    if next_value == value:
+        next_offset = offset + limit
+        return (next_value, next_offset, has_next)
+
+    # We have an absolute value to page from. If any of the items in
+    # the current result set come *after* or *before* (depending on the
+    # is_desc flag) we will want to increment the offset to account for
+    # moving past them.
+    #
+    # This is required to account for loss of precision in the key value.
+    next_offset = 0
+    result_iter = reversed(results)
+
+    # If we have more results the last item in the results should be
+    # skipped, as we know we want to start from that item and do not
+    # need to offset from it.
+    if has_next:
+        six.next(result_iter)
+
+    for result in result_iter:
+        result_value = int(key(result))
+
+        is_larger = result_value >= next_value
+        is_smaller = result_value <= next_value
+
+        if (is_desc and is_smaller) or (not is_desc and is_larger):
+            next_offset += 1
+        else:
+            break
+
+    return (next_value, next_offset, has_next)
+
+
+def _build_prev_values(cursor, results, key, limit, is_desc):
     value = cursor.value
     offset = cursor.offset
     is_prev = cursor.is_prev
@@ -97,71 +153,97 @@ def build_cursor(results, key, limit=100, cursor=None, hits=None, max_hits=None)
 
     if is_prev:
         has_prev = num_results > limit
-        num_results = len(results)
-    elif value or offset:
-        # It's likely that there's a previous page if they passed us either offset values
-        has_prev = True
     else:
-        # we don't know
-        has_prev = False
+        # It's likely that there's a previous page if they passed us either
+        # offset values
+        has_prev = value or offset
 
-    # Default cursor if not present
-    if is_prev:
-        next_value = value
-        next_offset = offset
-        has_next = True
-    elif num_results:
-        if not value:
-            value = int(key(results[0]))
+    # If the cursor contains previous results, the first item is the item that
+    # indicates if we have more items later, and is *not* the first item in the
+    # list, that should be used for the value.
+    first_prev_index = 1 if is_prev and has_prev else 0
 
-        # Are there more results than whats on the current page?
-        has_next = num_results > limit
+    # If we're paging back we need to calculate the key from the first result
+    # with for_prev=True to ensure rounding of the key is correct.See
+    # sentry.api.paginator.BasePaginator.get_item_key
+    prev_value = int(key(results[first_prev_index], for_prev=True)) if results else 0
 
-        # Determine what our next cursor is by ensuring we have a unique offset
-        next_value = int(key(results[-1]))
+    # Prev only has an offset if the cursor we were dealing with was a
+    # previous cursor. Otherwise we'd be taking the offset while moving forward.
+    prev_offset = offset if is_prev else 0
 
-        if next_value == value:
-            next_offset = offset + limit
+    if not (is_prev and num_results):
+        return (prev_value, prev_offset, has_prev)
+
+    # Value has not changed, page back by adjusting the offset
+    if prev_value == value:
+        prev_offset = offset + limit
+        return (prev_value, prev_offset, has_prev)
+
+    # Just as in the next cursor builder, we may need to add an offset
+    # if any of the results at the beginning are *before* or *after*
+    # (depending on the is_desc flag).
+    #
+    # This is required to account for loss of precision in the key value.
+    prev_offset = 0
+    result_iter = iter(results)
+
+    # If we know there are more previous results, we need to move past
+    # the item indicating that more items exist.
+    if has_prev:
+        six.next(result_iter)
+
+    # Always move past the first item, this is the prev_value item and will
+    # already be offset in the next query.
+    six.next(result_iter)
+
+    for result in result_iter:
+        result_value = int(key(result, for_prev=True))
+
+        is_larger = result_value >= prev_value
+        is_smaller = result_value <= prev_value
+
+        # Note that the checks are reversed here as a prev query has
+        # it's ordering reversed.
+        if (is_desc and is_larger) or (not is_desc and is_smaller):
+            prev_offset += 1
         else:
-            next_offset = 0
-            result_iter = reversed(results)
-            # skip the last result
-            six.next(result_iter)
-            for result in result_iter:
-                if int(key(result)) == next_value:
-                    next_offset += 1
-                else:
-                    break
-    else:
-        next_value = value
-        next_offset = offset
-        has_next = False
+            break
 
-    # Determine what our pervious cursor is by ensuring we have a unique offset
-    if is_prev and num_results:
-        prev_value = int(key(results[0]))
+    return (prev_value, prev_offset, has_prev)
 
-        if num_results > 2:
-            i = 1
-            while i < num_results and prev_value == int(key(results[i])):
-                i += 1
-            i -= 1
-        else:
-            i = 0
 
-        # if we iterated every result and the offset didn't change, we need
-        # to simply add the current offset to our total results (visible)
-        if prev_value == value:
-            prev_offset = offset + i
-        else:
-            prev_offset = i
-    else:
-        # previous cursor is easy if we're paginating forward
-        prev_value = value
-        prev_offset = offset
+def build_cursor(results, key, limit=100, is_desc=False, cursor=None, hits=None, max_hits=None):
+    if cursor is None:
+        cursor = Cursor(0, 0, 0)
 
-    # Truncate the list to our original result size now that we've determined the next page
-    results = results[:limit]
+    # Compute values for next cursor
+    next_value, next_offset, has_next = _build_next_values(
+        cursor=cursor,
+        results=results,
+        key=key,
+        limit=limit,
+        is_desc=is_desc
+    )
+
+    # Compute values for prev cursor
+    prev_value, prev_offset, has_prev = _build_prev_values(
+        cursor=cursor,
+        results=results,
+        key=key,
+        limit=limit,
+        is_desc=is_desc
+    )
+
+    if cursor.is_prev and has_prev:
+        # A prev cursor with more reults should have the first item chopped off
+        # as this is the item that indicates we have more items before, and
+        # should not be included on this page.
+        results = results[1:]
+    elif not cursor.is_prev:
+        # For next page cursors we cut off the extra item that indicates there
+        # are more items.
+        results = results[:limit]
 
     next_cursor = Cursor(next_value or 0, next_offset, False, has_next)
     prev_cursor = Cursor(prev_value or 0, prev_offset, True, has_prev)

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
 import pytest
-
 from datetime import timedelta
 from django.utils import timezone
 
 from sentry.api.paginator import (Paginator, DateTimePaginator, OffsetPaginator)
 from sentry.models import User
 from sentry.testutils import TestCase
+from sentry.utils.db import is_mysql
 
 
 class PaginatorTest(TestCase):
@@ -109,55 +109,134 @@ class OffsetPaginatorTest(TestCase):
 
 
 class DateTimePaginatorTest(TestCase):
-    @pytest.mark.xfail
-    def test_simple(self):
-        res1 = self.create_user('foo@example.com')
-        res2 = self.create_user('bar@example.com')
-        res3 = self.create_user('baz@example.com')
+    def test_ascending(self):
+        joined = timezone.now()
+
+        # The DateTime pager only has accuracy up to 1000th of a second.
+        # Everythng can't be added within less than 10 microseconds of each
+        # other. This is handled by the pager (see test_rounding_offset), but
+        # this case shouldn't rely on it.
+        res1 = self.create_user('foo@example.com', date_joined=joined)
+        res2 = self.create_user('bar@example.com', date_joined=joined + timedelta(seconds=1))
+        res3 = self.create_user('baz@example.com', date_joined=joined + timedelta(seconds=2))
+        res4 = self.create_user('qux@example.com', date_joined=joined + timedelta(seconds=3))
 
         queryset = User.objects.all()
 
         paginator = DateTimePaginator(queryset, 'date_joined')
+        result1 = paginator.get_result(limit=2, cursor=None)
+        assert len(result1) == 2, result1
+        assert result1[0] == res1
+        assert result1[1] == res2
+        assert result1.next
+        assert not result1.prev
+
+        result2 = paginator.get_result(limit=2, cursor=result1.next)
+        assert len(result2) == 2, result2
+        assert result2[0] == res3
+        assert result2[1] == res4
+        assert not result2.next
+        assert result2.prev
+
+        result3 = paginator.get_result(limit=1, cursor=result2.prev)
+        assert len(result3) == 1, result3
+        assert result3[0] == res2
+        assert result3.next
+        assert result3.prev
+
+        result4 = paginator.get_result(limit=1, cursor=result3.prev)
+        assert len(result4) == 1, result4
+        assert result4[0] == res1
+        assert result4.next
+        assert not result4.prev
+
+    def test_descending(self):
+        joined = timezone.now()
+
+        res1 = self.create_user('foo@example.com', date_joined=joined)
+        res2 = self.create_user('bar@example.com', date_joined=joined + timedelta(seconds=1))
+        res3 = self.create_user('baz@example.com', date_joined=joined + timedelta(seconds=2))
+
+        queryset = User.objects.all()
+
+        paginator = DateTimePaginator(queryset, '-date_joined')
         result1 = paginator.get_result(limit=1, cursor=None)
         assert len(result1) == 1, result1
-        assert result1[0] == res1
+        assert result1[0] == res3
         assert result1.next
         assert not result1.prev
 
         result2 = paginator.get_result(limit=2, cursor=result1.next)
         assert len(result2) == 2, result2
         assert result2[0] == res2
-        assert result2[1] == res3
+        assert result2[1] == res1
         assert not result2.next
         assert result2.prev
 
-        # this is not yet correct
         result3 = paginator.get_result(limit=2, cursor=result2.prev)
-        assert len(result3) == 1, list(result3)
-        assert result3[0] == res1
+        assert len(result3) == 1, result3
+        assert result3[0] == res3
         assert result3.next
         assert not result3.prev
 
-    @pytest.mark.xfail
-    def test_polling_behavior(self):
-        date_joined = timezone.now()
+    def test_prev_descending_with_new(self):
+        joined = timezone.now()
 
-        res1 = self.create_user('foo@example.com', date_joined=date_joined)
-        res2 = self.create_user('bar@example.com', date_joined=date_joined)
+        res1 = self.create_user('foo@example.com', date_joined=joined)
+        res2 = self.create_user('bar@example.com', date_joined=joined + timedelta(seconds=1))
 
         queryset = User.objects.all()
 
         paginator = DateTimePaginator(queryset, '-date_joined')
         result1 = paginator.get_result(limit=10, cursor=None)
         assert len(result1) == 2, result1
-        assert result1[1] == res2
-        assert result1[0] == res1
+        assert result1[0] == res2
+        assert result1[1] == res1
 
-        res3 = self.create_user('baz@example.com', date_joined=date_joined + timedelta(seconds=1))
+        res3 = self.create_user('baz@example.com', date_joined=joined + timedelta(seconds=2))
+        res4 = self.create_user('qux@example.com', date_joined=joined + timedelta(seconds=3))
 
         result2 = paginator.get_result(limit=10, cursor=result1.prev)
-        assert len(result2) == 1, result2
-        assert result2[0] == res3
+        assert len(result2) == 2, result2
+        assert result2[0] == res4
+        assert result2[1] == res3
 
-        result3 = paginator.get_result(limit=10, cursor=result1.next)
+        result3 = paginator.get_result(limit=10, cursor=result2.prev)
         assert len(result3) == 0, result3
+
+        result4 = paginator.get_result(limit=10, cursor=result1.next)
+        assert len(result4) == 0, result4
+
+    @pytest.mark.skipif(is_mysql(), reason='MySQL does not support above second accuracy')
+    def test_roudning_offset(self):
+        joined = timezone.now()
+
+        res1 = self.create_user('foo@example.com', date_joined=joined)
+        res2 = self.create_user('bar@example.com', date_joined=joined + timedelta(microseconds=1))
+        res3 = self.create_user('baz@example.com', date_joined=joined + timedelta(microseconds=2))
+        res4 = self.create_user('qux@example.com', date_joined=joined + timedelta(microseconds=3))
+
+        queryset = User.objects.all()
+
+        paginator = DateTimePaginator(queryset, 'date_joined')
+        result1 = paginator.get_result(limit=3, cursor=None)
+        assert len(result1) == 3, result1
+        assert result1[0] == res1
+        assert result1[1] == res2
+        assert result1[2] == res3
+
+        result2 = paginator.get_result(limit=10, cursor=result1.next)
+        assert len(result2) == 1, result2
+        assert result2[0] == res4
+
+        result3 = paginator.get_result(limit=2, cursor=result2.prev)
+        assert len(result3) == 2, result3
+        assert result3[0] == res2
+        assert result3[1] == res3
+
+        result4 = paginator.get_result(limit=1, cursor=result3.prev)
+        assert len(result4) == 1, result4
+        assert result4[0] == res1
+
+        result5 = paginator.get_result(limit=10, cursor=result4.prev)
+        assert len(result5) == 0, list(result5)

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -52,6 +52,21 @@ class PaginatorTest(TestCase):
         result = paginator.count_hits(1)
         assert result == 1
 
+    def test_prev_emptyset(self):
+        queryset = User.objects.all()
+
+        paginator = self.cls(queryset, 'id')
+        result1 = paginator.get_result(limit=1, cursor=None)
+
+        res1 = self.create_user('foo@example.com')
+
+        result2 = paginator.get_result(limit=1, cursor=result1.prev)
+        assert len(result2) == 1, (result2, list(result2))
+        assert result2[0] == res1
+
+        result3 = paginator.get_result(limit=1, cursor=result2.prev)
+        assert len(result3) == 0, (result3, list(result3))
+
 
 class OffsetPaginatorTest(TestCase):
     # offset paginator does not support dynamic limits on is_prev

--- a/tests/sentry/utils/test_cursors.py
+++ b/tests/sentry/utils/test_cursors.py
@@ -22,8 +22,11 @@ def test_build_cursor():
 
     results = [event1, event2, event3]
 
+    def item_key(key, for_prev=False):
+        return math.floor(key.id)
+
     cursor_kwargs = {
-        'key': lambda x: math.floor(x.id),
+        'key': item_key,
         'limit': 1,
     }
 


### PR DESCRIPTION
Fixes GH-5920

This actually fixes a few different problems in the pagination and cursor logic:

I'd like to merge this with the commits rebased onto master.

@dcramer's test actually exposed a different issue relating to paging in reverse for non-unique date times and non-unique date times that were very close (within more than 1000th of a second).

#### Fixes

 * When using the prev cursor from an empty ResultCursor the paginator will be off by one when paging back. This is because the paginator assumed that given a cursor it had at least one result, and that we would want to start *after* that result. This is fixed by only offseting past the first prev result **only if** we have're starting from a value, since we know that likely exist and will want to move past it.

 * When building a `ResultCursor` from a prev cursor, the offset would not necessarily be correct if the next cursor had one.

 * Due to the way both the `Paginator` and `DateTimePaginator` are implemented, it allows for values that aren't exact and will round up or down the value depending on sort order. This allows the value to fall one one side or the other of a comparison.

   For example If we have the following cursor: `<value=3, offset=0, is_prev=0>`, and we're querying in ascending order with items `[3, 4, 4.5, 4.6, 5, 6, 7]`, using a Paginator with a limit of 3, what will happen is that the first 3 items would be returned `[3, 4, 4.5]` Asking for the next cursor will give you a cursor as `<value=4, offset=0, is_prev=0>`. Of course, 4 and 4.5 are both larger than or equal to 4, so the logic is intended to be implemented such that the next cursor actually looks like `<value=4, offset=2, is_prev>`.

    This was working fine for the most part, however, for *previous* cursors, the logic becomes reversed, so it needs to `ceil` instead of `floor` and comparisons to see if we need to add offsets for items that we've already seen are swapped as well, this is now fixed.

   This meant that the `build_cursor` needed to become aware of the sorting order and the `get_item_key` needed to be told which direction it's traversing in.

 * When constructing a `ResultCursor`, we will have one extra result in the result set, this result tells us if there are more pages in the direction that we're cursing. The extra item must be removed from the result set before returning the result cursor. This was fine for a cursor moving forward, but when we're moving backwards and the cursor has an extra item **at the front**, the item at the end of the result set will be lost, instead of the first item being removed.

In general I've also added more comments around how some of the more complex logic works.