### PR TITLE
Fix unmerge test that wasn't using relative timestamps.

### DIFF
--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -138,7 +138,7 @@ class FeatureSet(object):
             scope,
             key,
             items,
-            timestamp=to_timestamp(event.datetime),
+            timestamp=int(to_timestamp(event.datetime)),
         )
 
     def classify(self, events):
@@ -181,7 +181,7 @@ class FeatureSet(object):
             self.index.classify(
                 scope,
                 items,
-                timestamp=to_timestamp(event.datetime),
+                timestamp=int(to_timestamp(event.datetime)),
             ),
         )
 

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 
 import pytz
+from django.utils import timezone
 
 from sentry.app import tsdb
 from sentry.event_manager import ScoreClause
@@ -152,10 +153,10 @@ class UnmergeTestCase(TestCase):
         }
 
     def test_unmerge(self):
-        now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=pytz.utc)
-
         def shift(i):
             return timedelta(seconds=1 << i)
+
+        now = timezone.now() - shift(16)
 
         project = self.create_project()
         source = self.create_group(project)

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -156,7 +156,7 @@ class UnmergeTestCase(TestCase):
         def shift(i):
             return timedelta(seconds=1 << i)
 
-        now = timezone.now() - shift(16)
+        now = timezone.now().replace(microsecond=0) - shift(16)
 
         project = self.create_project()
         source = self.create_group(project)


### PR DESCRIPTION
This was causing the test to try and read data that had expired.