### PR TITLE
Add discard pending processing issues button

### DIFF
--- a/src/sentry/api/endpoints/project_processingissues.py
+++ b/src/sentry/api/endpoints/project_processingissues.py
@@ -12,6 +12,15 @@ from sentry.models import ApiToken
 from sentry.utils.http import absolute_uri
 
 
+class ProjectProcessingIssuesDiscardEndpoint(ProjectEndpoint):
+    def delete(self, request, project):
+        """
+        This dicards all open processing issues
+        """
+        ProcessingIssue.objects.discard_all_processing_issue(project=project)
+        return Response(status=200)
+
+
 class ProjectProcessingIssuesFixEndpoint(ProjectEndpoint):
     def get(self, request, project):
         token = None

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -93,7 +93,7 @@ from .endpoints.project_tags import ProjectTagsEndpoint
 from .endpoints.project_tagkey_details import ProjectTagKeyDetailsEndpoint
 from .endpoints.project_tagkey_values import ProjectTagKeyValuesEndpoint
 from .endpoints.project_processingissues import ProjectProcessingIssuesEndpoint, \
-    ProjectProcessingIssuesFixEndpoint
+    ProjectProcessingIssuesFixEndpoint, ProjectProcessingIssuesDiscardEndpoint
 from .endpoints.project_reprocessing import ProjectReprocessingEndpoint
 from .endpoints.project_user_details import ProjectUserDetailsEndpoint
 from .endpoints.project_user_reports import ProjectUserReportsEndpoint
@@ -591,6 +591,11 @@ urlpatterns = patterns(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/reprocessing/$',
         ProjectReprocessingEndpoint.as_view(),
         name='sentry-api-0-project-reprocessing'
+    ),
+    url(
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/processingissues/discard$',
+        ProjectProcessingIssuesDiscardEndpoint.as_view(),
+        name='sentry-api-0-project-discard-processing-issues'
     ),
 
     # Load plugin project urls

--- a/src/sentry/models/processingissue.py
+++ b/src/sentry/models/processingissue.py
@@ -49,6 +49,16 @@ class ProcessingIssueManager(BaseManager):
         )
         q.delete()
 
+    def discard_all_processing_issue(self, project):
+        """
+        Resolves all processing issues.
+        """
+        self.resolve_all_processing_issue(project)
+        from sentry.models import RawEvent, ReprocessingReport
+        RawEvent.objects.filter(project_id=project.id).delete()
+        ReprocessingReport.objects \
+            .filter(project_id=project.id).delete()
+
     def find_resolved(self, project_id, limit=100):
         """Returns a list of raw events that generally match the given
         processing issue and no longer have any issues remaining.  Returns

--- a/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
@@ -342,7 +342,7 @@ const ProjectProcessingIssues = React.createClass({
       <div>
         {fixLinkBlock}
         <h3>
-          {t('Pending issues')}
+          {t('Pending Issues')}
           <a
             className="btn btn-default btn-sm pull-right"
             onClick={() => {

--- a/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
@@ -341,6 +341,16 @@ const ProjectProcessingIssues = React.createClass({
     return (
       <div>
         {fixLinkBlock}
+        <h3>
+          {t('Pending issues')}
+          <a
+            className="btn btn-default btn-sm pull-right"
+            onClick={() => {
+              this.discardEvents();
+            }}>
+            {t('Discard all')}
+          </a>
+        </h3>
         <div className="panel panel-default">
           <div className="panel-heading panel-heading-bold hidden-xs">
             <div className="row">
@@ -379,18 +389,6 @@ const ProjectProcessingIssues = React.createClass({
                 </div>
               );
             })}
-            <div className="list-group-item">
-              {t(
-                `In case you want to discard all events with pending processing issues: `
-              )}
-              <a
-                className="btn btn-sm btn-danger"
-                onClick={() => {
-                  this.discardEvents();
-                }}>
-                Discard all pending Events
-              </a>
-            </div>
           </div>
         </div>
       </div>

--- a/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
@@ -22,7 +22,7 @@ const MESSAGES = {
   native_simulator_frame: t('Encountered an unprocessable simulator frame.'),
   native_unknown_image: t('An binary image is referenced that is unknown.'),
   proguard_missing_mapping: t('A proguard mapping file was missing.'),
-  proguard_missing_lineno: t('A proguard mapping file does not contain line info.'),
+  proguard_missing_lineno: t('A proguard mapping file does not contain line info.')
 };
 
 const HELP_LINKS = {
@@ -130,12 +130,40 @@ const ProjectProcessingIssues = React.createClass({
     });
   },
 
+  discardEvents() {
+    let {orgId, projectId} = this.props.params;
+    this.setState({
+      expected: this.state.expected + 1
+    });
+    this.api.request(`/projects/${orgId}/${projectId}/processingissues/discard`, {
+      method: 'DELETE',
+      success: (data, _, jqXHR) => {
+        let expected = this.state.expected - 1;
+        this.setState({
+          expected: expected,
+          error: false,
+          loading: expected > 0
+        });
+        // we reload to get rid of the badge in the sidebar
+        window.location.reload();
+      },
+      error: () => {
+        let expected = this.state.expected - 1;
+        this.setState({
+          expected: expected,
+          error: true,
+          loading: expected > 0
+        });
+      }
+    });
+  },
+
   deleteProcessingIssues() {
     let {orgId, projectId} = this.props.params;
     this.setState({
       expected: this.state.expected + 1
     });
-    this.api.request(`/projects/${orgId}/${projectId}/processingissues/?detailed=1`, {
+    this.api.request(`/projects/${orgId}/${projectId}/processingissues/`, {
       method: 'DELETE',
       success: (data, _, jqXHR) => {
         let expected = this.state.expected - 1;
@@ -163,7 +191,11 @@ const ProjectProcessingIssues = React.createClass({
 
     if (this.state.loading) body = this.renderLoading();
     else if (this.state.error) body = <LoadingError onRetry={this.fetchData} />;
-    else if (this.state.processingIssues.hasIssues) body = this.renderResults();
+    else if (
+      this.state.processingIssues.hasIssues ||
+      this.state.processingIssues.resolveableIssues
+    )
+      body = this.renderResults();
     else body = this.renderEmpty();
 
     return body;
@@ -181,7 +213,9 @@ const ProjectProcessingIssues = React.createClass({
     return (
       <div className="box empty-stream">
         <span className="icon icon-exclamation" />
-        <p>{t('Good news! There are no processing issues.')}</p>
+        <p>
+          {t('Good news! There are no processing issues.')}
+        </p>
       </div>
     );
   },
@@ -201,10 +235,11 @@ const ProjectProcessingIssues = React.createClass({
     let helpLink = HELP_LINKS[item.type];
     return (
       <div className="processing-issue">
-        <span className="description">{description}</span>
-        {' '}
+        <span className="description">{description}</span>{' '}
         {helpLink &&
-          <a href={helpLink} className="help-link"><span className="icon-question" /></a>}
+          <a href={helpLink} className="help-link">
+            <span className="icon-question" />
+          </a>}
       </div>
     );
   },
@@ -216,10 +251,18 @@ const ProjectProcessingIssues = React.createClass({
 
     if (item.data._scope === 'native') {
       if (item.data.image_uuid) {
-        dsymUUID = <code className="uuid">{item.data.image_uuid}</code>;
+        dsymUUID = (
+          <code className="uuid">
+            {item.data.image_uuid}
+          </code>
+        );
       }
       if (item.data.image_path) {
-        dsymName = <em>{this.getImageName(item.data.image_path)}</em>;
+        dsymName = (
+          <em>
+            {this.getImageName(item.data.image_path)}
+          </em>
+        );
       }
       if (item.data.image_arch) {
         dsymArch = item.data.image_arch;
@@ -228,9 +271,18 @@ const ProjectProcessingIssues = React.createClass({
 
     return (
       <span>
-        {dsymUUID && <span> {dsymUUID}</span>}
-        {dsymArch && <span> {dsymArch}</span>}
-        {dsymName && <span> (for {dsymName})</span>}
+        {dsymUUID &&
+          <span>
+            {' '}{dsymUUID}
+          </span>}
+        {dsymArch &&
+          <span>
+            {' '}{dsymArch}
+          </span>}
+        {dsymName &&
+          <span>
+            {' '}(for {dsymName})
+          </span>}
       </span>
     );
   },
@@ -265,7 +317,9 @@ const ProjectProcessingIssues = React.createClass({
       fixLinkBlock = (
         <div className="panel panel-info">
           <div className="panel-heading">
-            <h3>{t('Having trouble uploading debug symbols? We can help!')}</h3>
+            <h3>
+              {t('Having trouble uploading debug symbols? We can help!')}
+            </h3>
           </div>
           <div className="panel-body">
             <div className="form-group" style={{marginBottom: 0}}>
@@ -325,6 +379,18 @@ const ProjectProcessingIssues = React.createClass({
                 </div>
               );
             })}
+            <div className="list-group-item">
+              {t(
+                `In case you want to discard all events with pending processing issues: `
+              )}
+              <a
+                className="btn btn-sm btn-danger"
+                onClick={() => {
+                  this.discardEvents();
+                }}>
+                Discard all pending Events
+              </a>
+            </div>
           </div>
         </div>
       </div>
@@ -340,7 +406,9 @@ const ProjectProcessingIssues = React.createClass({
     return (
       <div className="box">
         <div className="box-header">
-          <h3>{t('Settings')}</h3>
+          <h3>
+            {t('Settings')}
+          </h3>
         </div>
         <div className="box-content with-padding">
           <div className="row">
@@ -374,7 +442,9 @@ const ProjectProcessingIssues = React.createClass({
           {!access.has('project:write') &&
             <div className="row">
               <div className="col-md-12" style={{marginBottom: 20}}>
-                <strong>{t('Note: ')}</strong>
+                <strong>
+                  {t('Note: ')}
+                </strong>
                 {t('An admin can turn processing on or off')}
               </div>
             </div>}
@@ -421,7 +491,9 @@ const ProjectProcessingIssues = React.createClass({
   render() {
     return (
       <div>
-        <h1>{t('Processing Issues')}</h1>
+        <h1>
+          {t('Processing Issues')}
+        </h1>
         <p>
           {t(
             `


### PR DESCRIPTION
This adds functionality to discard pending events for reprocessing.
Under some circumstances it can occur that events will be forever stuck in reprocessing, we are still trying to figure out the conditions.
This PR adds a button so all pending issues with their events can be deleted.

![sentry___internal](https://user-images.githubusercontent.com/363802/29589290-9b04c464-8749-11e7-97d9-bb13d3435ef9.png)

@ckj Probably need some feedback on UI