### PR TITLE
clean up discarded group list UI

### DIFF
--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -28,5 +28,6 @@ class GroupTombstoneSerializer(Serializer):
             'message': obj.message,
             'culprit': obj.culprit,
             'type': obj.get_event_type(),
+            'metadata': obj.get_event_metadata(),
             'actor': attrs.get('user'),
         }

--- a/src/sentry/models/grouptombstone.py
+++ b/src/sentry/models/grouptombstone.py
@@ -4,6 +4,7 @@ import logging
 
 from django.db import models
 
+from sentry import eventtypes
 from sentry.constants import LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
     BoundedPositiveIntegerField, FlexibleForeignKey, GzippedDictField, Model
@@ -40,3 +41,18 @@ class GroupTombstone(Model):
         See ``sentry.eventtypes``.
         """
         return self.data.get('type', 'default')
+
+    def get_event_metadata(self):
+        """
+        Return the metadata of this issue.
+
+        See ``sentry.eventtypes``.
+        """
+        etype = self.data.get('type')
+        if etype is None:
+            etype = 'default'
+        if 'metadata' not in self.data:
+            data = self.data.copy() if self.data else {}
+            data['message'] = self.message
+            return eventtypes.get(etype)(data).get_metadata()
+        return self.data['metadata']

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -22,8 +22,13 @@ class EventOrGroupHeader extends React.Component {
       groupID: PropTypes.string,
       culprit: PropTypes.string
     }),
+    includeLink: PropTypes.bool,
     hideIcons: PropTypes.bool,
     hideLevel: PropTypes.bool
+  };
+
+  static defaultProps = {
+    includeLink: true
   };
 
   getMessage() {
@@ -40,23 +45,39 @@ class EventOrGroupHeader extends React.Component {
     }
   }
 
-  render() {
-    let {className, hideLevel, hideIcons, orgId, projectId, data} = this.props;
-    let cx = classNames('event-issue-header', className);
+  getTitle() {
+    let {hideLevel, hideIcons, includeLink, orgId, projectId, data} = this.props;
     let {id, level, groupID} = data || {};
     let isEvent = !!data.eventID;
-    let url = `/${orgId}/${projectId}/issues/${isEvent ? groupID : id}/${isEvent ? `events/${data.id}/` : ''}`;
+
+    let props = {};
+    let Wrapper;
+    if (includeLink) {
+      props.to = `/${orgId}/${projectId}/issues/${isEvent ? groupID : id}/${isEvent ? `events/${data.id}/` : ''}`;
+      Wrapper = Link;
+    } else {
+      Wrapper = 'span';
+    }
+
+    return (
+      <Wrapper {...props}>
+        {!hideLevel && level && <span className="error-level truncate">{level}</span>}
+        {!hideIcons && <span className="icon icon-soundoff" />}
+        {!hideIcons && <span className="icon icon-star-solid" />}
+        <EventOrGroupTitle {...this.props} />
+      </Wrapper>
+    );
+  }
+
+  render() {
+    let {className} = this.props;
+    let cx = classNames('event-issue-header', className);
     let message = this.getMessage();
 
     return (
       <div className={cx}>
         <h3 className="truncate">
-          <Link to={url}>
-            {!hideLevel && level && <span className="error-level truncate">{level}</span>}
-            {!hideIcons && <span className="icon icon-soundoff" />}
-            {!hideIcons && <span className="icon icon-star-solid" />}
-            <EventOrGroupTitle {...this.props} />
-          </Link>
+          {this.getTitle()}
         </h3>
         {message &&
           <div className="event-message truncate">

--- a/src/sentry/static/sentry/app/components/groupTombstones.jsx
+++ b/src/sentry/static/sentry/app/components/groupTombstones.jsx
@@ -1,60 +1,71 @@
 import React from 'react';
 
 import AlertActions from '../actions/alertActions';
-
+import Avatar from '../components/avatar';
+import EventOrGroupTitle from '../components/eventOrGroupTitle';
 import LoadingError from '../components/loadingError';
 import LinkWithConfirmation from '../components/linkWithConfirmation';
+import TooltipMixin from '../mixins/tooltip';
 
 import ApiMixin from '../mixins/apiMixin';
 
-import {t, tct} from '../locale';
+import {t} from '../locale';
 
 const GroupTombstoneRow = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired,
-    undiscard: React.PropTypes.func.isRequired
+    undiscard: React.PropTypes.func.isRequired,
+    orgId: React.PropTypes.string.isRequired,
+    projectId: React.PropTypes.string.isRequired
   },
+
+  mixins: [
+    TooltipMixin({
+      selector: '.tip'
+    })
+  ],
+
   render() {
-    let {data, undiscard} = this.props;
+    let {data, undiscard} = this.props, actor = data.actor;
+
     return (
       <li className={`group row level-${data.level} type-${data.type}`}>
-        <div className="col-md-7 col-xs-8 event-details">
-          <div>
+        <div className="col-md-10 event-details issue">
+          <div className="event-issue-header">
             <h3 className="truncate">
               <span className="error-level truncate" title={data.level}>
                 {data.level}
               </span>
-              <span>
-                <span style={{marginRight: 10}}>{data.type}</span>
-                <em>{data.culprit}</em><br />
-              </span>
+              <EventOrGroupTitle data={data} />
             </h3>
             <div className="event-message truncate">
               <span className="message">{data.message}</span>
             </div>
-            <div className="event-extra">
-
-              <LinkWithConfirmation
-                title={t('Undiscard')}
-                className="btn btn-warning btn-xs"
-                message={t(
-                  'Undiscarding this group means that ' +
-                    'incoming events that match this will no longer be discarded. ' +
-                    'New incoming events will count toward your event quota ' +
-                    'and will display on your issues dashboard. ' +
-                    'Are you sure you wish to continue?'
-                )}
-                onConfirm={() => {
-                  undiscard(data.id);
-                }}>
-                <span>{t('Undiscard')}</span>
-              </LinkWithConfirmation>
-              {data.actor &&
-                <span style={{marginLeft: 10}} className="event-message actor">
-                  {tct('discarded by [actor]', {actor: data.actor.name})}
-                </span>}
-            </div>
           </div>
+        </div>
+        <div className="col-md-1 event-actor">
+          {actor &&
+            <span className="tip" title={t('Discarded by %s', actor.name || actor.email)}>
+              <Avatar user={data.actor} />
+            </span>}
+        </div>
+        <div className="col-md-1 event-undiscard">
+          <span className="tip" title={t('Undiscard')}>
+            <LinkWithConfirmation
+              className="group-remove btn btn-default btn-sm"
+              message={t(
+                'Undiscarding this group means that ' +
+                  'incoming events that match this will no longer be discarded. ' +
+                  'New incoming events will count toward your event quota ' +
+                  'and will display on your issues dashboard. ' +
+                  'Are you sure you wish to continue?'
+              )}
+              onConfirm={() => {
+                undiscard(data.id);
+              }}>
+              <span className="icon-trash undiscard" />
+            </LinkWithConfirmation>
+          </span>
         </div>
       </li>
     );
@@ -100,11 +111,11 @@ const GroupTombstones = React.createClass({
   render() {
     if (this.props.tombstoneError) return <LoadingError />;
 
-    let {tombstones} = this.props;
+    let {tombstones, orgId, projectId} = this.props;
     return (
       <div>
         <div className="row" style={{paddingTop: 10}}>
-          <div className="col-sm-8">
+          <div className="col-md-12 discarded-groups">
             <h5>{t('Discarded Groups')}</h5>
             {tombstones.length
               ? <ul className="group-list">
@@ -113,6 +124,8 @@ const GroupTombstones = React.createClass({
                       <GroupTombstoneRow
                         key={data.id}
                         data={data}
+                        orgId={orgId}
+                        projectId={projectId}
                         undiscard={this.undiscard}
                       />
                     );

--- a/src/sentry/static/sentry/app/components/groupTombstones.jsx
+++ b/src/sentry/static/sentry/app/components/groupTombstones.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import _ from 'lodash';
 
 import AlertActions from '../actions/alertActions';
 import Avatar from '../components/avatar';
-import EventOrGroupTitle from '../components/eventOrGroupTitle';
+import EventOrGroupHeader from '../components/eventOrGroupHeader';
 import LoadingError from '../components/loadingError';
 import LinkWithConfirmation from '../components/linkWithConfirmation';
 import TooltipMixin from '../mixins/tooltip';
@@ -31,17 +32,11 @@ const GroupTombstoneRow = React.createClass({
     return (
       <li className={`group row level-${data.level} type-${data.type}`}>
         <div className="col-md-10 event-details issue">
-          <div className="event-issue-header">
-            <h3 className="truncate">
-              <span className="error-level truncate" title={data.level}>
-                {data.level}
-              </span>
-              <EventOrGroupTitle data={data} />
-            </h3>
-            <div className="event-message truncate">
-              <span className="message">{data.message}</span>
-            </div>
-          </div>
+          <EventOrGroupHeader
+            includeLink={false}
+            hideIcons={true}
+            {..._.omit(this.props, 'undiscard')}
+          />
         </div>
         <div className="col-md-1 event-actor">
           {actor &&

--- a/src/sentry/static/sentry/less/discarded-groups.less
+++ b/src/sentry/static/sentry/less/discarded-groups.less
@@ -1,0 +1,50 @@
+/**
+* Discarded Groups
+* ============================================================================
+*/
+
+.discarded-groups {
+
+  .group-list {
+
+    .event-details {
+
+      .error-level {
+        position: absolute;
+        left: -6px;
+        top: 13px;
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: capitalize;
+        text-align: center;
+        color: #fff;
+        padding: 2px 4px;
+        width: 50px;
+        display: block;
+        float: left;
+        border-radius: 2px;
+        margin-right: 5px;
+      }
+
+    }
+
+    .event-actor,
+    .event-undiscard {
+      text-align: center;
+      padding: 12px 0 8px 0;
+    }
+
+    .event-undiscard {
+
+      .btn:hover {
+        color: #fff;
+        background: @red;
+        border-color: @red-dark;
+        text-shadow: 0 1px 0 rgba(0,0,0, .15);
+      }
+
+    }
+
+  }
+
+}

--- a/src/sentry/static/sentry/less/discarded-groups.less
+++ b/src/sentry/static/sentry/less/discarded-groups.less
@@ -7,27 +7,6 @@
 
   .group-list {
 
-    .event-details {
-
-      .error-level {
-        position: absolute;
-        left: -6px;
-        top: 13px;
-        font-size: 10px;
-        font-weight: 600;
-        text-transform: capitalize;
-        text-align: center;
-        color: #fff;
-        padding: 2px 4px;
-        width: 50px;
-        display: block;
-        float: left;
-        border-radius: 2px;
-        margin-right: 5px;
-      }
-
-    }
-
     .event-actor,
     .event-undiscard {
       text-align: center;

--- a/src/sentry/static/sentry/less/sentry.less
+++ b/src/sentry/static/sentry/less/sentry.less
@@ -37,6 +37,7 @@
 @import url("./admin.less");
 @import url("./auth.less");
 @import url("./dashboard.less");
+@import url("./discarded-groups.less");
 @import url("./docs.less");
 @import url("./group-detail.less");
 @import url("./organization.less");

--- a/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
@@ -37,6 +37,7 @@ exports[`EventOrGroupHeader Event hides level tag 1`] = `
           }
         }
         hideLevel={true}
+        includeLink={true}
         orgId="orgId"
         projectId="projectId"
       />
@@ -81,6 +82,7 @@ exports[`EventOrGroupHeader Event renders with \`type = csp\` 1`] = `
             "type": "csp",
           }
         }
+        includeLink={true}
         orgId="orgId"
         projectId="projectId"
       />
@@ -134,6 +136,7 @@ exports[`EventOrGroupHeader Event renders with \`type = default\` 1`] = `
             "type": "default",
           }
         }
+        includeLink={true}
         orgId="orgId"
         projectId="projectId"
       />
@@ -178,6 +181,7 @@ exports[`EventOrGroupHeader Event renders with \`type = error\` 1`] = `
             "type": "error",
           }
         }
+        includeLink={true}
         orgId="orgId"
         projectId="projectId"
       />
@@ -235,6 +239,7 @@ exports[`EventOrGroupHeader Group renders with \`type = csp\` 1`] = `
             "type": "csp",
           }
         }
+        includeLink={true}
         orgId="orgId"
         projectId="projectId"
       />
@@ -292,6 +297,7 @@ exports[`EventOrGroupHeader Group renders with \`type = default\` 1`] = `
             "type": "default",
           }
         }
+        includeLink={true}
         orgId="orgId"
         projectId="projectId"
       />
@@ -349,6 +355,7 @@ exports[`EventOrGroupHeader Group renders with \`type = error\` 1`] = `
             "type": "error",
           }
         }
+        includeLink={true}
         orgId="orgId"
         projectId="projectId"
       />


### PR DESCRIPTION
This is still behind a feature switch and I'll probably do another round of changes, but wanted to get these in.

before:
![screenshot 2017-08-23 17 34 15](https://user-images.githubusercontent.com/5026776/29644221-4d6b6056-8829-11e7-82b3-be2a10dbe61d.png)

after:
![screenshot 2017-08-23 17 30 11](https://user-images.githubusercontent.com/5026776/29644201-1e014664-8829-11e7-9acc-a369e7e26081.png)

#nochanges 