### PR TITLE
api: data scrubbers weren't correctly handle case sensitive input

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -147,9 +147,10 @@ CLIENT_RESERVED_ATTRS = (
     'tags', 'platform', 'release', 'dist', 'environment',
 )
 
+# XXX: Must be all lowercase
 DEFAULT_SCRUBBED_FIELDS = (
     'password', 'secret', 'passwd', 'api_key', 'apikey', 'access_token', 'auth', 'credentials',
-    'mysql_pwd', 'stripeToken', 'card[number]',
+    'mysql_pwd', 'stripetoken', 'card[number]',
 )
 
 NOT_SCRUBBED_VALUES = set([

--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -64,13 +64,13 @@ class SensitiveDataFilter(object):
 
     def __init__(self, fields=None, include_defaults=True, exclude_fields=()):
         if fields:
-            fields = tuple(fields)
+            fields = tuple(f.lower() for f in filter(None, fields))
         else:
             fields = ()
         if include_defaults:
             fields += DEFAULT_SCRUBBED_FIELDS
-        self.exclude_fields = set(exclude_fields)
-        self.fields = set(filter(None, fields))
+        self.exclude_fields = {f.lower() for f in exclude_fields}
+        self.fields = set(fields)
 
     def apply(self, data):
         # TODO(dcramer): move this into each interface

--- a/tests/sentry/utils/test_data_scrubber.py
+++ b/tests/sentry/utils/test_data_scrubber.py
@@ -348,6 +348,48 @@ class SensitiveDataFilterTest(TestCase):
         proc.apply(data)
         assert data['extra'] == {'password': '123-45-6789'}
 
+    def test_explicit_fields(self):
+        data = {
+            'extra': {
+                'mystuff': 'xxx',
+            },
+        }
+
+        proc = SensitiveDataFilter(fields=['mystuff'])
+        proc.apply(data)
+        assert data['extra']['mystuff'] == FILTER_MASK
+
+    def test_explicit_fields_case_insensitive(self):
+        data = {
+            'extra': {
+                'myStuff': 'xxx',
+            },
+        }
+
+        proc = SensitiveDataFilter(fields=['myStuff'])
+        proc.apply(data)
+        assert data['extra']['myStuff'] == FILTER_MASK
+
+        data = {
+            'extra': {
+                'MYSTUFF': 'xxx',
+            },
+        }
+
+        proc = SensitiveDataFilter(fields=['myStuff'])
+        proc.apply(data)
+        assert data['extra']['MYSTUFF'] == FILTER_MASK
+
+        data = {
+            'extra': {
+                'mystuff': 'xxx',
+            },
+        }
+
+        proc = SensitiveDataFilter(fields=['myStuff'])
+        proc.apply(data)
+        assert data['extra']['mystuff'] == FILTER_MASK
+
     def test_exclude_fields_on_field_value(self):
         data = {
             'extra': {


### PR DESCRIPTION
From my gathering, keys were always being lowered before comparing, and
this behavior existed from day 1 of data scrubber existing. cbccb466178

At this point, there was no user input to deal with. When user input was
added, keys were never lowered to compare against, so if a user inputs
"fooBar" into the UI for a key to sanitize, this would never match
because we always lowered the key it's comparing against. But an input
of "foobar" would work just fine.