### PR TITLE
fix(ui): time window default to 1w in queue chart

### DIFF
--- a/src/sentry/static/sentry/app/views/adminQueue.jsx
+++ b/src/sentry/static/sentry/app/views/adminQueue.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 
   getInitialState() {
     return {
-      timeWindow: '1h',
+      timeWindow: '1w',
       since: new Date().getTime() / 1000 - 3600 * 24 * 7,
       resolution: '1h',
       loading: true,


### PR DESCRIPTION
@getsentry/ui

**URL**: https://sentry.domain/manage/queue/
**Issue**: When opening the view, chart time range is 1 week, but highlighted button is 1 hour.
**Version**: 8.18.0
**Screenshot**:  

![image](https://user-images.githubusercontent.com/2457529/29657272-6351d2ea-88b7-11e7-8f40-a0af3e29bcf2.png)