### PR TITLE
Revert "New function name logic for javascript"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,6 @@ Version 8.20 (Unreleased)
 -------------------------
 - Make BitBucket repositories enabled by default
 - Add raw data toggle for Additional Data
-- Improved function name resolving for JavaScript sourcemaps
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ install_requires = [
     'honcho>=0.7.0,<0.8.0',
     'kombu==3.0.35',
     'ipaddress>=1.0.16,<1.1.0',
-    'libsourcemap>=0.8.1,<0.9.0',
+    'libsourcemap>=0.7.2,<0.8.0',
     'loremipsum>=1.0.5,<1.1.0',
     'lxml>=3.4.1',
     'mock>=0.8.0,<1.1',

--- a/src/sentry/lang/javascript/cache.py
+++ b/src/sentry/lang/javascript/cache.py
@@ -20,7 +20,7 @@ class SourceCache(object):
             url = self._aliases[url]
         return url
 
-    def get(self, url, raw=False):
+    def get(self, url):
         url = self._get_canonical_url(url)
         try:
             parsed, rv = self._cache[url]
@@ -30,10 +30,7 @@ class SourceCache(object):
         # We have already gotten this file and we've
         # decoded the response, so just return
         if parsed:
-            parsed, raw_body = rv
-            if raw:
-                return raw_body
-            return parsed
+            return rv
 
         # Otherwise, we have a 2-tuple that needs to be applied
         body, encoding = rv
@@ -43,11 +40,10 @@ class SourceCache(object):
         if callable(body):
             body = body()
 
-        raw_body = body
         body = body.decode(codec_lookup(encoding, 'utf-8').name, 'replace').split(u'\n')
 
         # Set back a marker to indicate we've parsed this url
-        self._cache[url] = (True, (body, raw_body))
+        self._cache[url] = (True, body)
         return body
 
     def get_errors(self, url):

--- a/tests/sentry/lang/javascript/test_example.py
+++ b/tests/sentry/lang/javascript/test_example.py
@@ -67,14 +67,13 @@ class ExampleTestCase(TestCase):
 
         assert len(frame_list) == 4
 
-        import pprint
-        pprint.pprint(frame_list)
-
         assert frame_list[0].function == 'produceStack'
         assert frame_list[0].lineno == 6
         assert frame_list[0].filename == 'index.html'
 
-        assert frame_list[1].function == 'test'
+        # This function name is obviously wrong but the current logic we
+        # have does not permit better data here
+        assert frame_list[1].function == 'i'
         assert frame_list[1].lineno == 20
         assert frame_list[1].filename == 'test.js'
 
@@ -82,6 +81,8 @@ class ExampleTestCase(TestCase):
         assert frame_list[2].lineno == 15
         assert frame_list[2].filename == 'test.js'
 
-        assert frame_list[3].function == 'onFailure'
+        # This function name is obviously wrong but the current logic we
+        # have does not permit better data here
+        assert frame_list[3].function == 'cb'
         assert frame_list[3].lineno == 5
         assert frame_list[3].filename == 'test.js'

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -883,7 +883,7 @@ class JavascriptIntegrationTest(TestCase):
 
         # ... but line, column numbers are still correctly mapped
         assert frame.lineno == 3
-        assert frame.colno == 9
+        assert frame.colno == 8
 
     @responses.activate
     def test_failed_sourcemap_expansion(self):


### PR DESCRIPTION
Reverts getsentry/sentry#5977

Not entirely sure what is happening here but an error was reported here: https://sentry.io/sentry/sentry/issues/336137828/