### PR TITLE
Parse full github url when configuring repo for issues integration

### DIFF
--- a/src/sentry/static/sentry/app/plugins/components/settings.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/settings.jsx
@@ -5,6 +5,7 @@ import {Form, FormState} from '../../components/forms';
 import PluginComponentBase from '../../components/bases/pluginComponentBase';
 import LoadingIndicator from '../../components/loadingIndicator';
 import {t, tct} from '../../locale';
+import {parseRepo} from '../../utils';
 
 class PluginSettings extends PluginComponentBase {
   constructor(props, context) {
@@ -42,8 +43,11 @@ class PluginSettings extends PluginComponentBase {
   }
 
   onSubmit() {
+    let repo = this.state.formData.repo;
+    repo = repo && parseRepo(repo);
+    let parsedFormData = {...this.state.formData, repo: repo};
     this.api.request(this.getPluginEndpoint(), {
-      data: this.state.formData,
+      data: parsedFormData,
       method: 'PUT',
       success: this.onSaveSuccess.bind(this, data => {
         let formData = {};


### PR DESCRIPTION
We parse bitbucket and github urls when people are configuring repos for commit data, but this extends that parsing to when users configure their GH repo for issue tracking.

cc @MeredithAnya 