### PR TITLE
Remove box class from releases panel children

### DIFF
--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -133,11 +133,7 @@ const ProjectReleases = React.createClass({
   },
 
   renderLoading() {
-    return (
-      <div className="box">
-        <LoadingIndicator />
-      </div>
-    );
+    return <LoadingIndicator />;
   },
 
   renderNoQueryResults() {
@@ -151,7 +147,7 @@ const ProjectReleases = React.createClass({
 
   renderEmpty() {
     return (
-      <div className="box empty-stream">
+      <div className="empty-stream">
         <span className="icon icon-exclamation" />
         <p>{t("There don't seem to be any releases yet.")}</p>
         <p>

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -1222,6 +1222,12 @@
   }
 }
 
+.panel {
+  .alert-box, .empty-stream {
+    border: 0;
+  }
+}
+
 
 /**
 * Responsive small screen


### PR DESCRIPTION
Both the loading indicator and empty-stream indicators were wrapped with a box, which added borders and margin which are unnecessary as the panel already includes these.

Before:
![image](https://user-images.githubusercontent.com/1421724/29844753-422dd890-8cc5-11e7-825a-88bd935f7643.png)


After:
![image](https://user-images.githubusercontent.com/1421724/29844706-1172bdba-8cc5-11e7-9c9b-1f45919fbb64.png)

The loading indicator had a similar look.