### PR TITLE
fix(saml): add a noop refresh_identity method

### DIFF
--- a/src/sentry/auth/providers/saml2.py
+++ b/src/sentry/auth/providers/saml2.py
@@ -266,3 +266,7 @@ class SAML2Provider(Provider):
             if 'idp_x509cert' in data['idp']:
                 parsed_data['x509cert'] = data['idp']['idp_x509cert']
         return parsed_data
+
+    def refresh_identity(self, auth_identity):
+        # Nothing to refresh
+        return


### PR DESCRIPTION
There's nothing to do here since this managed by the IdP, so we noop the
method to avoid raising a NotImplementedError

Fixes SENTRY-4BF

cc @pitbulk