### PR TITLE
fix(workflow): install wizard "mail.use-tls" opt

### DIFF
--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -168,6 +168,15 @@ const InstallWizard = React.createClass({
       _.pickBy(options, option => !option.field.disabled),
       option => option.value
     );
+
+    // keys to cast as boolean, otherwise will throw server error
+    // see https://github.com/getsentry/sentry/issues/5699
+    ['mail.use-tls'].forEach(key => {
+      if (typeof data[key] !== 'undefined') {
+        data[key] = !!data[key];
+      }
+    });
+
     this.api.request('/internal/options/', {
       method: 'PUT',
       data: data,


### PR DESCRIPTION
It's possible that an old value of `mail.use-tls` is an integer, and if
the user does not modify the form then it will never be cast as a
boolean. Let's just force the `mail.use-tls` option to be boolean on submit.

Fixes #5699