### PR TITLE
fix(api): Remove case insensitive email searches from EventUser

### DIFF
--- a/src/sentry/api/endpoints/organization_user_issues_search.py
+++ b/src/sentry/api/endpoints/organization_user_issues_search.py
@@ -29,7 +29,7 @@ class OrganizationUserIssuesSearchEndpoint(OrganizationEndpoint):
         )
 
         event_users = EventUser.objects.filter(
-            email__iexact=email,
+            email=email,
             project_id__in=project_ids,
         )[:1000]
 

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -150,7 +150,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint):
             try:
                 return EventUser.objects.filter(
                     project=report.project_id,
-                    email__iexact=report.email,
+                    email=report.email,
                 )[0]
             except IndexError:
                 return None

--- a/src/sentry/models/eventuser.py
+++ b/src/sentry/models/eventuser.py
@@ -109,7 +109,7 @@ class EventUser(Model):
 
         filters = []
         if self.email:
-            filters.append(models.Q(email__iexact=self.email))
+            filters.append(models.Q(email=self.email))
         if self.ip_address:
             filters.append(models.Q(ip_address=self.ip_address))
         if not filters:


### PR DESCRIPTION
We don't have a proper functional index on these, and we had an incident
where we were hitting a bunch of queries that took multiple minutes
causing some brief downtime.

The alternative is to add another functional index for this as well.

To do this, I'd prefer if we just maintained one index, and made all
lookup on this field case insensitive to not need to maintain both. But
as it stands, event attempting to add this index is causing performance
issues since the table is so massive, so trying to punt on adding a new
index unless absolutely necessary.