### PR TITLE
fix(workflow): bulk actions modal + text

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/actionLink.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actionLink.jsx
@@ -19,7 +19,7 @@ const ActionLink = React.createClass({
     onlyIfBulk: PropTypes.bool,
     selectAllActive: PropTypes.bool.isRequired, // "select all" checkbox
     tooltip: PropTypes.string,
-    extraDescription: PropTypes.string
+    extraDescription: PropTypes.node
   },
 
   mixins: [


### PR DESCRIPTION
* fix bug in Resolve/Ignore modals where "all" state never occurs
* update text to say that "all" really means the 1,000 most recent

Fixes #5840 

![image](https://user-images.githubusercontent.com/79684/29986772-be76d16c-8f19-11e7-8f8f-cc28a738d2ef.png)
![image](https://user-images.githubusercontent.com/79684/29986974-bd573b86-8f1a-11e7-9e49-1391f3b5a9c8.png)
![image](https://user-images.githubusercontent.com/79684/29986982-c8dd63b8-8f1a-11e7-9903-862874be5bdb.png)
![image](https://user-images.githubusercontent.com/79684/29986966-b6194c24-8f1a-11e7-9edb-7976030bb5fe.png)

