### PR TITLE
fix(workflow): broadcasts w/ failed api req

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -56,7 +56,7 @@ const Broadcasts = React.createClass({
       method: 'GET',
       success: data => {
         this.setState({
-          broadcasts: data,
+          broadcasts: data || [],
           loading: false
         });
         this.poller = window.setTimeout(this.fetchData, POLLER_DELAY);


### PR DESCRIPTION
Simple fix for when the `/broadcasts/` api fails.

Fixes JAVASCRIPT-2AD