### PR TITLE
fix: Remove unneeded .nav-header from groupListHeader

### DIFF
--- a/src/sentry/static/sentry/app/components/groupListHeader.jsx
+++ b/src/sentry/static/sentry/app/components/groupListHeader.jsx
@@ -8,10 +8,10 @@ const GroupListHeader = React.createClass({
     return (
       <div className="group-header">
         <Toolbar className="stream-actions row">
-          <ToolbarHeader className="stream-actions-left col-md-7 col-sm-8 col-xs-8 nav-header">
+          <ToolbarHeader className="stream-actions-left col-md-7 col-sm-8 col-xs-8">
             {t('Event')}
           </ToolbarHeader>
-          <ToolbarHeader className="hidden-sm hidden-xs stream-actions-graph col-md-2 col-md-offset-1 align-right nav-header">
+          <ToolbarHeader className="hidden-sm hidden-xs stream-actions-graph col-md-2 col-md-offset-1 align-right">
             {t('Last 24 hours')}
           </ToolbarHeader>
           <ToolbarHeader className="stream-actions-count align-right col-md-1 col-sm-2 col-xs-2">


### PR DESCRIPTION
This class wasn't adding anything that wasn't already set aside from a bottom-margin that was breaking an items that flex below it.

![image](https://user-images.githubusercontent.com/1421724/29989965-97c72d52-8f2b-11e7-804d-d5ea393638f0.png)
