### PR TITLE
fix: Normalize .stream-action-left top padding

### DIFF
--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -100,7 +100,7 @@
 
   .stream-actions-left {
     position: relative;
-    padding: 8px 0 8px 54px;
+    padding: 10px 0 8px 54px;
 
     .checkbox {
       position: absolute;


### PR DESCRIPTION
The padding-top specificed here is diffrent from other similar defintions:

https://github.com/getsentry/sentry/blob/9a713edd3bcc232926ef66ac631c1872dc03ce23/src/sentry/static/sentry/less/stream.less#L55-L60

This fixes the alignment.

Before:
![image](https://user-images.githubusercontent.com/1421724/29990163-e538b762-8f2c-11e7-9930-12edb1953d32.png)

After:
![image](https://user-images.githubusercontent.com/1421724/29990173-0062f408-8f2d-11e7-971e-a79bc6ce265e.png)
