### PR TITLE
Add UnicodeDecoder into logging setup

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -196,8 +196,9 @@ def configure_structlog():
         'processors': [
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.format_exc_info,
             structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
         ]
     }
 


### PR DESCRIPTION
Fix UnicodeDecodeError reported in #6029 when logged content contains byte string values outside ASCII character range.

The recommended structlog configuration contains the UnicodeDecoder processor in the standard logging configuration whereas the filter is missing in the default Sentry configuration.

http://structlog.readthedocs.io/en/stable/standard-library.html#suggested-configurations

**EDIT: This configuration seems to break due to some reason; the following PR https://github.com/getsentry/sentry/pull/6037 seems to run tests OK.**