### PR TITLE
Add UnicodeDecoder into logging setup (alternative)

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -196,8 +196,8 @@ def configure_structlog():
         'processors': [
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
+            structlog.processors.StackInfoRenderer(),
             structlog.processors.UnicodeDecoder(),
         ]
     }

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -196,8 +196,9 @@ def configure_structlog():
         'processors': [
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.format_exc_info,
             structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
         ]
     }
 


### PR DESCRIPTION
Try alternative structlog processor ordering
compared to PR #6036 which fails tests.

Fixes #6029.