### PR TITLE
fix(api): Do not require client_secret for token grants

### DIFF
--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -5,7 +5,6 @@ import six
 
 from django.http import HttpResponse
 from django.utils import timezone
-from django.utils.crypto import constant_time_compare
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View
@@ -46,15 +45,11 @@ class OAuthTokenView(View):
 
         if grant_type == 'authorization_code':
             client_id = request.POST.get('client_id')
-            client_secret = request.POST.get('client_secret')
             redirect_uri = request.POST.get('redirect_uri')
             code = request.POST.get('code')
 
             if not client_id:
                 return self.error(request, 'invalid_client', 'missing client_id')
-
-            if not client_secret:
-                return self.error(request, 'invalid_client', 'missing client_secret')
 
             try:
                 application = ApiApplication.objects.get(
@@ -63,9 +58,6 @@ class OAuthTokenView(View):
                 )
             except ApiApplication.DoesNotExist:
                 return self.error(request, 'invalid_client', 'invalid client_id')
-
-            if not constant_time_compare(client_secret, application.client_secret):
-                return self.error(request, 'invalid_client', 'invalid client_secret')
 
             try:
                 grant = ApiGrant.objects.get(application=application, code=code)
@@ -85,7 +77,6 @@ class OAuthTokenView(View):
             refresh_token = request.POST.get('refresh_token')
             scope = request.POST.get('scope')
             client_id = request.POST.get('client_id')
-            client_secret = request.POST.get('client_secret')
 
             if not refresh_token:
                 return self.error(request, 'invalid_request')
@@ -97,9 +88,6 @@ class OAuthTokenView(View):
             if not client_id:
                 return self.error(request, 'invalid_client', 'missing client_id')
 
-            if not client_secret:
-                return self.error(request, 'invalid_client', 'missing client_secret')
-
             try:
                 application = ApiApplication.objects.get(
                     client_id=client_id,
@@ -107,9 +95,6 @@ class OAuthTokenView(View):
                 )
             except ApiApplication.DoesNotExist:
                 return self.error(request, 'invalid_client', 'invalid client_id')
-
-            if not constant_time_compare(client_secret, application.client_secret):
-                return self.error(request, 'invalid_client', 'invalid client_secret')
 
             try:
                 token = ApiToken.objects.get(

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -65,7 +65,6 @@ class OAuthTokenCodeTest(TestCase):
             self.path, {
                 'grant_type': 'authorization_code',
                 'redirect_uri': self.application.get_default_redirect_uri(),
-                'client_secret': self.application.client_secret,
                 'code': self.grant.code,
             }
         )
@@ -82,38 +81,6 @@ class OAuthTokenCodeTest(TestCase):
                 'redirect_uri': self.application.get_default_redirect_uri(),
                 'code': self.grant.code,
                 'client_id': 'def',
-                'client_secret': self.application.client_secret,
-            }
-        )
-
-        assert resp.status_code == 400
-        assert json.loads(resp.content) == {'error': 'invalid_client'}
-
-    def test_missing_client_secret(self):
-        self.login_as(self.user)
-
-        resp = self.client.post(
-            self.path, {
-                'grant_type': 'authorization_code',
-                'redirect_uri': self.application.get_default_redirect_uri(),
-                'client_id': self.application.client_id,
-                'code': self.grant.code,
-            }
-        )
-
-        assert resp.status_code == 400
-        assert json.loads(resp.content) == {'error': 'invalid_client'}
-
-    def test_invalid_client_secret(self):
-        self.login_as(self.user)
-
-        resp = self.client.post(
-            self.path, {
-                'grant_type': 'authorization_code',
-                'redirect_uri': self.application.get_default_redirect_uri(),
-                'client_id': self.application.client_id,
-                'client_secret': 'abc',
-                'code': self.grant.code,
             }
         )
 
@@ -128,7 +95,6 @@ class OAuthTokenCodeTest(TestCase):
                 'grant_type': 'authorization_code',
                 'redirect_uri': self.application.get_default_redirect_uri(),
                 'client_id': self.application.client_id,
-                'client_secret': self.application.client_secret,
             }
         )
 
@@ -144,7 +110,6 @@ class OAuthTokenCodeTest(TestCase):
                 'redirect_uri': self.application.get_default_redirect_uri(),
                 'code': 'abc',
                 'client_id': self.application.client_id,
-                'client_secret': self.application.client_secret,
             }
         )
 
@@ -160,7 +125,6 @@ class OAuthTokenCodeTest(TestCase):
                 'redirect_uri': self.application.get_default_redirect_uri(),
                 'code': self.grant.code,
                 'client_id': self.application.client_id,
-                'client_secret': self.application.client_secret,
             }
         )
 
@@ -207,7 +171,6 @@ class OAuthTokenRefreshTokenTest(TestCase):
         resp = self.client.post(
             self.path, {
                 'grant_type': 'refresh_token',
-                'client_secret': self.application.client_secret,
                 'refresh_token': self.token.refresh_token,
             }
         )
@@ -222,36 +185,6 @@ class OAuthTokenRefreshTokenTest(TestCase):
             self.path, {
                 'grant_type': 'refresh_token',
                 'client_id': 'abc',
-                'client_secret': self.application.client_secret,
-                'refresh_token': self.token.refresh_token,
-            }
-        )
-
-        assert resp.status_code == 400
-        assert json.loads(resp.content) == {'error': 'invalid_client'}
-
-    def test_missing_client_secret(self):
-        self.login_as(self.user)
-
-        resp = self.client.post(
-            self.path, {
-                'grant_type': 'refresh_token',
-                'client_id': self.application.client_id,
-                'refresh_token': self.token.refresh_token,
-            }
-        )
-
-        assert resp.status_code == 400
-        assert json.loads(resp.content) == {'error': 'invalid_client'}
-
-    def test_invalid_client_secret(self):
-        self.login_as(self.user)
-
-        resp = self.client.post(
-            self.path, {
-                'grant_type': 'refresh_token',
-                'client_id': self.application.client_id,
-                'client_secret': 'abc',
                 'refresh_token': self.token.refresh_token,
             }
         )
@@ -266,7 +199,6 @@ class OAuthTokenRefreshTokenTest(TestCase):
             self.path, {
                 'grant_type': 'refresh_token',
                 'client_id': self.application.client_id,
-                'client_secret': self.application.client_secret,
             }
         )
 
@@ -280,7 +212,6 @@ class OAuthTokenRefreshTokenTest(TestCase):
             self.path, {
                 'grant_type': 'refresh_token',
                 'client_id': self.application.client_id,
-                'client_secret': self.application.client_secret,
                 'refresh_token': 'foo',
             }
         )
@@ -295,7 +226,6 @@ class OAuthTokenRefreshTokenTest(TestCase):
             self.path, {
                 'grant_type': 'refresh_token',
                 'client_id': self.application.client_id,
-                'client_secret': self.application.client_secret,
                 'refresh_token': self.token.refresh_token,
             }
         )


### PR DESCRIPTION
For more details see the OAuth2 specification:

https://tools.ietf.org/html/rfc6749#section-4.1.3