### PR TITLE
build(eslint): remove eslint cli conf arg

### DIFF
--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -116,7 +116,6 @@ def py_lint(file_list, parseable=False):
 
 def js_lint(file_list=None, parseable=False, format=False):
 
-    project_root = get_project_root()
     eslint_path = get_node_modules_bin('eslint')
 
     if not os.path.exists(eslint_path):
@@ -124,12 +123,11 @@ def js_lint(file_list=None, parseable=False, format=False):
         echo('!! Skipping JavaScript linting because eslint is not installed.')
         return False
 
-    eslint_config = os.path.join(project_root, '.eslintrc')
     js_file_list = get_js_files(file_list)
 
     has_errors = False
     if js_file_list:
-        cmd = [eslint_path, '--config', eslint_config, '--ext', '.jsx']
+        cmd = [eslint_path, '--ext', '.js,.jsx']
         if format:
             cmd.append('--fix')
         if parseable:


### PR DESCRIPTION
In precommit hook, when calling eslint, remove the `--config` arg so
that we can have maintain eslint behavior with nested eslint config
files. This is required to be able to lint child directories using an
extended config. (i.e. in `docs-ui`)

~~TODO: check getsentry compat before merging.~~
This breaks `getsentry` because it relies on `--config`. Let's refactor our eslint rules into a package.