### PR TITLE
feat(workflow): add similar color spectrum

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -60,6 +60,7 @@ module.exports = {
     })
   ],
   resolve: {
+    extensions: appConfig.resolve.extensions,
     alias: Object.assign({}, appConfig.resolve.alias, {
       'sentry-ui': componentPath
     })

--- a/docs-ui/.eslintrc
+++ b/docs-ui/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "parserOptions": {
-    "sourceType": "module"
-  },
-  "env": {
-    "node": true,
-    "es6": true
-  }
-}

--- a/docs-ui/.eslintrc.js
+++ b/docs-ui/.eslintrc.js
@@ -1,0 +1,19 @@
+var path = require('path');
+
+module.exports = {
+  parserOptions: {
+    sourceType: 'module'
+  },
+  env: {
+    node: true,
+    es6: true
+  },
+  settings: {
+    'import/resolver': {
+      webpack: {
+        config: path.join(__dirname, '../.storybook/webpack.config.js')
+      }
+    },
+    'import/extensions': ['.js', '.jsx']
+  }
+};

--- a/docs-ui/components/similarSpectrum.stories.js
+++ b/docs-ui/components/similarSpectrum.stories.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import SimilarSpectrum from 'sentry-ui/similarSpectrum';
+
+storiesOf('SimilarSpectrum', module).add(
+  'default',
+  withInfo('Description')(() => <SimilarSpectrum />)
+);

--- a/src/sentry/static/sentry/app/components/scoreBar.jsx
+++ b/src/sentry/static/sentry/app/components/scoreBar.jsx
@@ -19,7 +19,7 @@ const ScoreBar = React.createClass({
   getDefaultProps() {
     return {
       palette: [],
-      paletteClassNames: ['red', 'red', 'orange', 'green', 'green']
+      paletteClassNames: ['low', 'low-med', 'med', 'med-high', 'high']
     };
   },
 

--- a/src/sentry/static/sentry/app/components/similarScoreCard.jsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.jsx
@@ -15,7 +15,7 @@ const scoreComponents = {
 };
 
 // classnames that map to colors to css
-const scoreClassNames = ['low', 'low', 'low', 'med', 'high', 'high'];
+const scoreClassNames = ['low', 'low', 'low-med', 'med', 'med-high', 'high'];
 
 const SimilarScoreCard = React.createClass({
   propTypes: {

--- a/src/sentry/static/sentry/app/components/similarSpectrum.jsx
+++ b/src/sentry/static/sentry/app/components/similarSpectrum.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import {t} from '../locale';
+import '../../less/components/similarSpectrum.less';
+
+const SimilarSpectrum = React.createClass({
+  propTypes: {},
+
+  getDefaultProps() {
+    return {};
+  },
+
+  getInitialState() {
+    return {};
+  },
+
+  render() {
+    let {className} = this.props;
+    let cx = classNames('similar-spectrum', className);
+
+    return (
+      <div className={cx}>
+        <span>
+          {t('Similar')}
+        </span>
+        <span className="similar-spectrum-box high" />
+        <span className="similar-spectrum-box med-high" />
+        <span className="similar-spectrum-box med" />
+        <span className="similar-spectrum-box low-med" />
+        <span className="similar-spectrum-box low" />
+        <span>
+          {t('Not Similar')}
+        </span>
+      </div>
+    );
+  }
+});
+
+export default SimilarSpectrum;

--- a/src/sentry/static/sentry/app/views/groupSimilar/similarList.jsx
+++ b/src/sentry/static/sentry/app/views/groupSimilar/similarList.jsx
@@ -6,7 +6,9 @@ import {t} from '../../locale';
 import Pagination from '../../components/pagination';
 import QueryCount from '../../components/queryCount';
 import SimilarItem from './similarItem';
+import SimilarSpectrum from '../../components/similarSpectrum';
 import SimilarToolbar from './similarToolbar';
+import SpreadLayout from '../../components/spreadLayout';
 
 const SimilarItemPropType = PropTypes.shape({
   issue: Group,
@@ -70,10 +72,13 @@ const SimilarList = React.createClass({
 
     return (
       <div className="similar-list-container">
-        <h2>
-          <span>{t('Similar Issues')}</span>
-          <QueryCount count={items.length + filteredItems.length} />
-        </h2>
+        <SpreadLayout className="similar-list-header">
+          <h2>
+            <span>{t('Similar Issues')}</span>
+            <QueryCount count={items.length + filteredItems.length} />
+          </h2>
+          <SimilarSpectrum />
+        </SpreadLayout>
         <SimilarToolbar onMerge={onMerge} />
 
         <div className="similar-list">

--- a/src/sentry/static/sentry/less/components/scoreBar.less
+++ b/src/sentry/static/sentry/less/components/scoreBar.less
@@ -1,6 +1,5 @@
 @import '../palette.less';
 
-
 @thickness: 4px;
 @size: 40px;
 
@@ -17,22 +16,10 @@
 .score-bar-bar {
   border-radius: 3px;
   margin: 2px;
+  .similar-scores;
 
   &.empty {
     background-color: @gray-lightest;
-  }
-
-  // Colors
-  &.red {
-    background-color: @orange;
-  }
-
-  &.orange {
-    background-color: @yellow-orange;
-  }
-
-  &.green {
-    background-color: @green;
   }
 }
 

--- a/src/sentry/static/sentry/less/components/scoreBar.less
+++ b/src/sentry/static/sentry/less/components/scoreBar.less
@@ -1,4 +1,4 @@
-@import '../palette.less';
+@import '../similar-scores.less';
 
 @thickness: 4px;
 @size: 40px;

--- a/src/sentry/static/sentry/less/components/similarSpectrum.less
+++ b/src/sentry/static/sentry/less/components/similarSpectrum.less
@@ -1,0 +1,13 @@
+@import "../similar-scores.less";
+
+.similar-spectrum {
+  display: flex;
+  font-size: 12px;
+}
+
+.similar-spectrum-box {
+  border-radius: 2px;
+  margin: 5px;
+  width: 14px;
+  .similar-scores;
+}

--- a/src/sentry/static/sentry/less/group-similar.less
+++ b/src/sentry/static/sentry/less/group-similar.less
@@ -88,16 +88,7 @@
   height: 16px;
   width: 48px;
   border-radius: 2px;
-
-  &.low {
-    background-color: @orange;
-  }
-  &.med {
-    background-color: @yellow-orange;
-  }
-  &.high {
-    background-color: @green;
-  }
+  .similar-scores;
 }
 
 .similar-items-footer {

--- a/src/sentry/static/sentry/less/group-similar.less
+++ b/src/sentry/static/sentry/less/group-similar.less
@@ -1,5 +1,6 @@
 // For interface for merging/unmerging events/issues
 // Shares CSS with "stream.less" so some defs are in there
+@import './similar-scores.less';
 
 .similar-list-container, .merged-list-container {
   h2 {
@@ -21,6 +22,15 @@
 
   .event-count {
     padding: 0;
+  }
+}
+
+.similar-list-header {
+  margin-top: 20px;
+  margin-bottom: 10px;
+
+  h2 {
+    margin: 0;
   }
 }
 

--- a/src/sentry/static/sentry/less/palette.less
+++ b/src/sentry/static/sentry/less/palette.less
@@ -96,22 +96,3 @@
 @30: lighten(@100, 70%);
 @20: lighten(@100, 80%);
 @10: lighten(@100, 90%);
-
-// mixins for similarity
-.similar-scores {
-  &.low {
-    background-color: @orange;
-  }
-  &.low-med {
-    background-color: mix(@orange, @yellow-orange, 50%);
-  }
-  &.med {
-    background-color: @yellow-orange;
-  }
-  &.med-high {
-    background-color: mix(@yellow-orange, @green, 40%);
-  }
-  &.high {
-    background-color: @green;
-  }
-}

--- a/src/sentry/static/sentry/less/palette.less
+++ b/src/sentry/static/sentry/less/palette.less
@@ -96,3 +96,22 @@
 @30: lighten(@100, 70%);
 @20: lighten(@100, 80%);
 @10: lighten(@100, 90%);
+
+// mixins for similarity
+.similar-scores {
+  &.low {
+    background-color: @orange;
+  }
+  &.low-med {
+    background-color: mix(@orange, @yellow-orange, 50%);
+  }
+  &.med {
+    background-color: @yellow-orange;
+  }
+  &.med-high {
+    background-color: mix(@yellow-orange, @green, 40%);
+  }
+  &.high {
+    background-color: @green;
+  }
+}

--- a/src/sentry/static/sentry/less/similar-scores.less
+++ b/src/sentry/static/sentry/less/similar-scores.less
@@ -1,0 +1,19 @@
+@import './palette.less';
+
+.similar-scores {
+  &.low {
+    background-color: @orange;
+  }
+  &.low-med {
+    background-color: mix(@orange, @yellow-orange, 50%);
+  }
+  &.med {
+    background-color: @yellow-orange;
+  }
+  &.med-high {
+    background-color: mix(@yellow-orange, @green, 40%);
+  }
+  &.high {
+    background-color: @green;
+  }
+}

--- a/tests/js/spec/components/__snapshots__/scoreBar.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/scoreBar.spec.jsx.snap
@@ -91,7 +91,7 @@ exports[`ScoreBar renders 1`] = `
   className="score-bar horizontal"
 >
   <div
-    className="score-bar-bar orange"
+    className="score-bar-bar med"
     style={
       Object {
         "height": 60,
@@ -100,7 +100,7 @@ exports[`ScoreBar renders 1`] = `
     }
   />
   <div
-    className="score-bar-bar orange"
+    className="score-bar-bar med"
     style={
       Object {
         "height": 60,
@@ -109,7 +109,7 @@ exports[`ScoreBar renders 1`] = `
     }
   />
   <div
-    className="score-bar-bar orange"
+    className="score-bar-bar med"
     style={
       Object {
         "height": 60,
@@ -143,7 +143,7 @@ exports[`ScoreBar renders vertically 1`] = `
   className="score-bar vertical"
 >
   <div
-    className="score-bar-bar red"
+    className="score-bar-bar low-med"
     style={
       Object {
         "height": 2,
@@ -152,7 +152,7 @@ exports[`ScoreBar renders vertically 1`] = `
     }
   />
   <div
-    className="score-bar-bar red"
+    className="score-bar-bar low-med"
     style={
       Object {
         "height": 2,
@@ -299,7 +299,7 @@ exports[`ScoreBar renders with score > max score 1`] = `
   className="score-bar horizontal"
 >
   <div
-    className="score-bar-bar green"
+    className="score-bar-bar high"
     style={
       Object {
         "height": 60,
@@ -308,7 +308,7 @@ exports[`ScoreBar renders with score > max score 1`] = `
     }
   />
   <div
-    className="score-bar-bar green"
+    className="score-bar-bar high"
     style={
       Object {
         "height": 60,
@@ -317,7 +317,7 @@ exports[`ScoreBar renders with score > max score 1`] = `
     }
   />
   <div
-    className="score-bar-bar green"
+    className="score-bar-bar high"
     style={
       Object {
         "height": 60,
@@ -326,7 +326,7 @@ exports[`ScoreBar renders with score > max score 1`] = `
     }
   />
   <div
-    className="score-bar-bar green"
+    className="score-bar-bar high"
     style={
       Object {
         "height": 60,
@@ -335,7 +335,7 @@ exports[`ScoreBar renders with score > max score 1`] = `
     }
   />
   <div
-    className="score-bar-bar green"
+    className="score-bar-bar high"
     style={
       Object {
         "height": 60,

--- a/tests/js/spec/components/__snapshots__/similarScoreCard.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/similarScoreCard.spec.jsx.snap
@@ -19,7 +19,7 @@ exports[`SimilarScoreCard renders with score list 1`] = `
   >
     <div />
     <div
-      className="similar-score-quantity high"
+      className="similar-score-quantity med-high"
     />
   </SpreadLayout>
   <SpreadLayout

--- a/tests/js/spec/components/__snapshots__/similarSpectrum.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/similarSpectrum.spec.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SimilarSpectrum renders 1`] = `
+<div
+  className="similar-spectrum"
+>
+  <span>
+    Similar
+  </span>
+  <span
+    className="similar-spectrum-box high"
+  />
+  <span
+    className="similar-spectrum-box med-high"
+  />
+  <span
+    className="similar-spectrum-box med"
+  />
+  <span
+    className="similar-spectrum-box low-med"
+  />
+  <span
+    className="similar-spectrum-box low"
+  />
+  <span>
+    Not Similar
+  </span>
+</div>
+`;

--- a/tests/js/spec/components/similarSpectrum.spec.jsx
+++ b/tests/js/spec/components/similarSpectrum.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import SimilarSpectrum from 'app/components/similarSpectrum';
+
+describe('SimilarSpectrum', function() {
+  beforeEach(function() {
+    this.sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  it('renders', function() {
+    let wrapper = shallow(<SimilarSpectrum />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -283,32 +283,67 @@ exports[`Issues Similar View renders with mocked data 1`] = `
       <div
         className="similar-list-container"
       >
-        <h2>
-          <span>
-            Similar Issues
-          </span>
-          <QueryCount
-            count={4}
-            hideIfEmpty={true}
-            inline={true}
+        <SpreadLayout
+          className="similar-list-header"
+        >
+          <div
+            className="spread-layout similar-list-header"
           >
-            <div
-              className="query-count inline"
-            >
+            <h2>
               <span>
-                (
+                Similar Issues
               </span>
-              <span
-                className="query-count-value"
+              <QueryCount
+                count={4}
+                hideIfEmpty={true}
+                inline={true}
               >
-                4
-              </span>
-              <span>
-                )
-              </span>
-            </div>
-          </QueryCount>
-        </h2>
+                <div
+                  className="query-count inline"
+                >
+                  <span>
+                    (
+                  </span>
+                  <span
+                    className="query-count-value"
+                  >
+                    4
+                  </span>
+                  <span>
+                    )
+                  </span>
+                </div>
+              </QueryCount>
+            </h2>
+            <SimilarSpectrum>
+              <div
+                className="similar-spectrum"
+              >
+                <span>
+                  Similar
+                </span>
+                <span
+                  className="similar-spectrum-box high"
+                />
+                <span
+                  className="similar-spectrum-box med-high"
+                />
+                <span
+                  className="similar-spectrum-box med"
+                />
+                <span
+                  className="similar-spectrum-box low-med"
+                />
+                <span
+                  className="similar-spectrum-box low"
+                />
+                <span>
+                  Not Similar
+                </span>
+              </div>
+            </SimilarSpectrum>
+          </div>
+        </SpreadLayout>
         <SimilarToolbar
           onMerge={[Function]}
         >
@@ -750,32 +785,67 @@ exports[`Issues Similar View renders with mocked data 2`] = `
       <div
         className="similar-list-container"
       >
-        <h2>
-          <span>
-            Similar Issues
-          </span>
-          <QueryCount
-            count={4}
-            hideIfEmpty={true}
-            inline={true}
+        <SpreadLayout
+          className="similar-list-header"
+        >
+          <div
+            className="spread-layout similar-list-header"
           >
-            <div
-              className="query-count inline"
-            >
+            <h2>
               <span>
-                (
+                Similar Issues
               </span>
-              <span
-                className="query-count-value"
+              <QueryCount
+                count={4}
+                hideIfEmpty={true}
+                inline={true}
               >
-                4
-              </span>
-              <span>
-                )
-              </span>
-            </div>
-          </QueryCount>
-        </h2>
+                <div
+                  className="query-count inline"
+                >
+                  <span>
+                    (
+                  </span>
+                  <span
+                    className="query-count-value"
+                  >
+                    4
+                  </span>
+                  <span>
+                    )
+                  </span>
+                </div>
+              </QueryCount>
+            </h2>
+            <SimilarSpectrum>
+              <div
+                className="similar-spectrum"
+              >
+                <span>
+                  Similar
+                </span>
+                <span
+                  className="similar-spectrum-box high"
+                />
+                <span
+                  className="similar-spectrum-box med-high"
+                />
+                <span
+                  className="similar-spectrum-box med"
+                />
+                <span
+                  className="similar-spectrum-box low-med"
+                />
+                <span
+                  className="similar-spectrum-box low"
+                />
+                <span>
+                  Not Similar
+                </span>
+              </div>
+            </SimilarSpectrum>
+          </div>
+        </SpreadLayout>
         <SimilarToolbar
           onMerge={[Function]}
         >


### PR DESCRIPTION
Adds a similar score color spectrum in the similar issues view. Refactors existing components to re-use a LESS mixin for colors.

![image](https://user-images.githubusercontent.com/79684/30081929-d991dae2-923d-11e7-8f4d-01ceccba9c49.png)
