### PR TITLE
fix(workflow): fix assignee selector loading 

### DIFF
--- a/src/sentry/static/sentry/app/components/flowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/flowLayout.jsx
@@ -7,6 +7,8 @@ import '../../less/components/flowLayout.less';
 // Takes up remaining space of a flexbox container (i.e. "flex: 1")
 const FlowLayout = React.createClass({
   propTypes: {
+    /** Centers content via `justify-content` */
+    center: PropTypes.bool,
     /** Applies "overflow: hidden" to container so that children can be truncated */
     truncate: PropTypes.bool
   },
@@ -18,8 +20,9 @@ const FlowLayout = React.createClass({
   },
 
   render() {
-    let {className, children, truncate, ...otherProps} = this.props;
+    let {className, children, truncate, center, ...otherProps} = this.props;
     let cx = classNames('flow-layout', className, {
+      'is-center': center,
       'is-truncated': truncate
     });
 

--- a/src/sentry/static/sentry/app/stores/memberListStore.jsx
+++ b/src/sentry/static/sentry/app/stores/memberListStore.jsx
@@ -5,15 +5,19 @@ const MemberListStore = Reflux.createStore({
 
   init() {
     this.items = [];
+    this.loaded = false;
   },
 
   // TODO(dcramer): this should actually come from an action of some sorts
   loadInitialData(items) {
     this.items = items;
+    this.loaded = true;
     this.trigger(this.items, 'initial');
   },
 
   getById(id) {
+    if (!this.items) return null;
+
     id = '' + id;
     for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].id === id) {
@@ -24,6 +28,8 @@ const MemberListStore = Reflux.createStore({
   },
 
   getByEmail(email) {
+    if (!this.items) return null;
+
     email = email.toLowerCase();
     for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].email.toLowerCase() === email) {

--- a/src/sentry/static/sentry/less/components/flowLayout.less
+++ b/src/sentry/static/sentry/less/components/flowLayout.less
@@ -7,4 +7,8 @@
   &.is-truncated {
     overflow: hidden;
   }
+
+  &.is-center {
+    justify-content: center;
+  }
 }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1768,6 +1768,10 @@ ul.faces {
 .assignee-selector {
   height: 24px;
 
+  .loading {
+    display: inline-block;
+  }
+
   .btn-group {
     height: 24px;
 

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1897,6 +1897,10 @@ ul.faces {
       opacity: .3;
     }
   }
+
+  .list-loading-container {
+    padding: 15px 0 10px 0;
+  }
 }
 
 /**


### PR DESCRIPTION
fix(workflow): fix assignee selector loading
* problem was due to `shouldComponentUpdate`
* now displays a loader if member list request does not finish before selector is first opened
* still does NOT update assignee selector if `MemberListStore` loads new members
* cleaned up deprecated react string refs

Fixes GH-4434

