### PR TITLE
feat(cloudflare): Expand integration to support webhooks

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -9,7 +9,6 @@ from .endpoints.api_tokens import ApiTokensEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.broadcast_index import BroadcastIndexEndpoint
 from .endpoints.catchall import CatchallEndpoint
-from .endpoints.cloudflare_metadata import CloudflareMetadataEndpoint
 from .endpoints.event_details import EventDetailsEndpoint
 from .endpoints.event_apple_crash_report import EventAppleCrashReportEndpoint
 from .endpoints.group_details import GroupDetailsEndpoint
@@ -151,9 +150,6 @@ urlpatterns = patterns(
 
     # Broadcasts
     url(r'^broadcasts/$', BroadcastIndexEndpoint.as_view(), name='sentry-api-0-broadcast-index'),
-
-    # Cloudflare Integration
-    url(r'^cloudflare/metadata/$', CloudflareMetadataEndpoint.as_view()),
 
     # Users
     url(r'^users/$', UserIndexEndpoint.as_view(), name='sentry-api-0-user-index'),

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -81,7 +81,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         'remote', 'get-cli', 'blog', 'welcome', 'features', 'customers', 'integrations', 'signup',
         'pricing', 'subscribe', 'enterprise', 'about', 'jobs', 'thanks', 'guide', 'privacy',
         'security', 'terms', 'from', 'sponsorship', 'for', 'at', 'platforms', 'branding', 'vs',
-        'answers', '_admin', 'support', 'contact', 'onboarding',
+        'answers', '_admin', 'support', 'contact', 'onboarding', 'ext', 'extension', 'extensions', 'plugins',
     )
 )
 

--- a/src/sentry/integrations/__init__.py
+++ b/src/sentry/integrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/integrations/cloudflare/__init__.py
+++ b/src/sentry/integrations/cloudflare/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/integrations/cloudflare/metadata.py
+++ b/src/sentry/integrations/cloudflare/metadata.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import logging
 import six
 
 from rest_framework.response import Response
@@ -7,11 +8,16 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.api.bases.user import UserPermission
 
+logger = logging.getLogger('sentry.integrations.cloudflare')
+
 
 class CloudflareMetadataEndpoint(Endpoint):
     permission_classes = (UserPermission, )
 
     def get(self, request):
+        logger.info('cloudflare.metadata', extra={
+            'user_id': request.user.id,
+        })
         return Response(
             {
                 'metadata': {

--- a/src/sentry/integrations/cloudflare/urls.py
+++ b/src/sentry/integrations/cloudflare/urls.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, print_function
+
+from django.conf.urls import patterns, url
+
+from .metadata import CloudflareMetadataEndpoint
+from .webhook import CloudflareWebhookEndpoint
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^metadata/$', CloudflareMetadataEndpoint.as_view()),
+    url(r'^webhook/$', CloudflareWebhookEndpoint.as_view()),
+)

--- a/src/sentry/integrations/cloudflare/webhook.py
+++ b/src/sentry/integrations/cloudflare/webhook.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+
+import logging
+
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+
+logger = logging.getLogger('sentry.integrations.cloudflare')
+
+
+class CloudflareWebhookEndpoint(Endpoint):
+    permission_classes = ()
+
+    def post(self, request):
+        event = request.DATA.get('event')
+        logger.info('cloudflare.webhook.{}'.format(event), extra={
+            'user_id': request.user.id if request.user.is_authenticated() else None,
+        })
+        # TODO(dcramer): We still need to implement various hooks for CF
+        return Response({})

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -443,6 +443,10 @@ urlpatterns += patterns(
     url(r'^crossdomain\.xml$', api.crossdomain_xml_index, name='sentry-api-crossdomain-xml-index'),
 
     # plugins
+    # XXX(dcramer): preferably we'd be able to use 'integrations' as the URL
+    # prefix here, but unfortunately sentry.io has that mapped to marketing
+    # assets for the time being
+    url(r'^extensions/cloudflare/', include('sentry.integrations.cloudflare.urls')),
     url(r'^plugins/', include('sentry.plugins.base.urls')),
 
     # Generic API

--- a/tests/sentry/integrations/__init__.py
+++ b/tests/sentry/integrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/integrations/cloudflare/__init__.py
+++ b/tests/sentry/integrations/cloudflare/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/integrations/cloudflare/test_metadata.py
+++ b/tests/sentry/integrations/cloudflare/test_metadata.py
@@ -11,7 +11,7 @@ class CloudflareMetadataTest(APITestCase):
 
         self.login_as(user=user)
 
-        resp = self.client.get('/api/0/cloudflare/metadata/', format='json')
+        resp = self.client.get('/extensions/cloudflare/metadata/', format='json')
 
         assert resp.status_code == 200, resp.content
         assert resp.data['metadata'] == {

--- a/tests/sentry/integrations/cloudflare/test_webhook.py
+++ b/tests/sentry/integrations/cloudflare/test_webhook.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+
+from sentry.testutils import APITestCase
+
+
+class CloudflareWebhookTest(APITestCase):
+    def test_simple(self):
+        resp = self.client.post('/extensions/cloudflare/webhook/', data={
+            'event': 'preview',
+        })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data == {}


### PR DESCRIPTION
Move cloudflare into its own application and URL namespace, and add initial logging and support of webhooks.