### PR TITLE
test: Verify GroupTagKey, GroupTagValue and TagValue are deleted in c…

### DIFF
--- a/tests/fixtures/cleanup.json
+++ b/tests/fixtures/cleanup.json
@@ -168,5 +168,41 @@
     },
     "model": "sentry.event",
     "pk": 18
+  },
+  {
+    "fields": {
+      "project_id": 1,
+      "group_id": 2,
+      "key": "key",
+      "values_seen": 1
+    },
+    "model": "sentry.grouptagkey",
+    "pk": 19
+  },
+  {
+    "fields": {
+      "project_id": 1,
+      "group_id": 2,
+      "times_seen": 1,
+      "key": "key",
+      "value": "value",
+      "last_seen": "2010-08-31 17:54:24Z",
+      "first_seen": "2010-08-31 17:54:24Z"
+    },
+    "model": "sentry.grouptagvalue",
+    "pk": 20
+  },
+  {
+    "fields": {
+      "project_id": 1,
+      "key": "key",
+      "value": "value",
+      "data": null,
+      "times_seen": 1,
+      "last_seen": "2010-08-31 17:54:24Z",
+      "first_seen": "2010-08-31 17:54:24Z"
+    },
+    "model": "sentry.tagvalue",
+    "pk": 21
   }
 ]

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -2,11 +2,11 @@
 
 from __future__ import absolute_import
 
-from sentry.models import Event, Group, GroupTagValue, TagValue, TagKey
+from sentry.models import Event, Group, GroupTagKey, GroupTagValue, TagValue, TagKey
 from sentry.runner.commands.cleanup import cleanup
 from sentry.testutils import CliTestCase
 
-ALL_MODELS = (Event, Group, GroupTagValue, TagValue, TagKey)
+ALL_MODELS = (Event, Group, GroupTagKey, GroupTagValue, TagValue, TagKey)
 
 
 class SentryCleanupTest(CliTestCase):

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -2,11 +2,11 @@
 
 from __future__ import absolute_import
 
-from sentry.models import Event, Group, GroupTagKey, GroupTagValue, TagValue, TagKey
+from sentry.models import Event, Group, GroupTagKey, GroupTagValue, TagValue
 from sentry.runner.commands.cleanup import cleanup
 from sentry.testutils import CliTestCase
 
-ALL_MODELS = (Event, Group, GroupTagKey, GroupTagValue, TagValue, TagKey)
+ALL_MODELS = (Event, Group, GroupTagKey, GroupTagValue, TagValue)
 
 
 class SentryCleanupTest(CliTestCase):
@@ -23,7 +23,9 @@ class SentryCleanupTest(CliTestCase):
     def test_project(self):
         orig_counts = {}
         for model in ALL_MODELS:
-            orig_counts[model] = model.objects.count()
+            count = model.objects.count()
+            assert count > 0
+            orig_counts[model] = count
 
         rv = self.invoke('--days=1', '--project=2')
         assert rv.exit_code == 0, rv.output


### PR DESCRIPTION
…leanup

We were good here, but the test wasn't verifying these.

Note that I dropped TagKey from the test... cleanup never removed these (even before my refactor https://github.com/getsentry/sentry/commit/e2b3cc3aab11b21367d2f909cdb8bd3ec7e594cf). So if that was an expectation we should fix it.