### PR TITLE
ref(css): Provider better textareas resize experience

### DIFF
--- a/src/sentry/static/sentry/less/forms.less
+++ b/src/sentry/static/sentry/less/forms.less
@@ -72,6 +72,9 @@
 
 textarea.form-control {
   height: 150px;
+  min-height: 150px;
+  min-width: 100%;
+  max-width: 100%;
 }
 
 legend {


### PR DESCRIPTION
Like how github comment resizing works. Locks the x-axis, and ensures it doesn't get too small.