### PR TITLE
perf(similarity): add 50% threshold to api query

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -19,7 +19,15 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
 
         results = filter(
             lambda (group_id, scores): group_id != group.id,
-            features.compare(group, limit=limit)
+            features.compare(
+                group,
+                limit=limit,
+                thresholds={
+                    label: int(features.index.bands * 0.5)
+                    for label in
+                    features.features.keys()
+                },
+            )
         )
 
         serialized_groups = apply_values(


### PR DESCRIPTION
This means that a group must collide in at least half of the bands for at least one feature to be considered as a candidate for inclusion in the search result set.

What this does *not* mean is that the returned group will be at least 50% similar for a specific feature because of the way [searching on aggregated groups works](https://github.com/getsentry/sentry/blob/similarity-api-threshold/src/sentry/scripts/similarity/index.lua#L478-L506). This is much more like an optimization hint to the query planner.