### PR TITLE
deps: Bump requests and urllib3

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -39,7 +39,7 @@ python-openid>=2.2
 PyYAML>=3.11,<3.12
 raven>=5.29.0,<6.0.0
 redis>=2.10.3,<2.10.6
-requests[security]>=2.9.1,<2.13.0
+requests[security]>=2.18.4,<2.19.0
 selenium==3.4.3
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0
@@ -50,7 +50,7 @@ sqlparse>=0.1.16,<0.2.0
 symsynd>=3.0.0,<4.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
-urllib3>=1.14,<1.17
+urllib3>=1.22<1.23
 uwsgi>2.0.0,<2.1.0
 rb>=1.7.0,<2.0.0
 qrcode>=5.2.2,<6.0.0


### PR DESCRIPTION
To pull in the newer Google libraries, which we'll need for analytics
streaming, they depend on newer versions of requests, which depends on
newer version of urllib3.

**Note: this requires a bump in getsentry as well to coordinate.**