### PR TITLE
Implement RetryingStrictRedisCluster

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -86,6 +86,9 @@ class RetryingStrictRedisCluster(StrictRedisCluster):
     """
     retry_exceptions = (ConnectionError, BusyLoadingError)
 
+    # We should really only need to retry once to correct the clients view of
+    # the cluster, give it a low retry timeout in the case of being hard down
+    # to avoid connection thrashing.
     @timed_retry(timeout=1, exceptions=retry_exceptions)
     def execute_command(self, *args, **kwargs):
         try:

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -8,10 +8,12 @@ import six
 from threading import Lock
 
 import rb
-import rediscluster
 from pkg_resources import resource_string
 from redis.client import Script
 from redis.connection import ConnectionPool
+from redis.exceptions import ConnectionError, BusyLoadingError
+from rediscluster.exceptions import RedisClusterException
+from rediscluster import StrictRedisCluster
 
 from sentry import options
 from sentry.exceptions import InvalidConfiguration
@@ -74,6 +76,23 @@ class _RBCluster(object):
         return 'Redis Blaster Cluster'
 
 
+class RetryingStrictRedisCluster(StrictRedisCluster):
+    def execute_command(self, *args, **kwargs):
+        """
+        Execute a command with cluster reinitialization retry logic. Should a
+        cluster respond with a ConnectionError or BusyLoadingError the cluster
+        nodes list will be reinitialized.
+        """
+        for i in range(3):
+            try:
+                return super(self.__class__, self).execute_command(*args, **kwargs)
+            except (ConnectionError, BusyLoadingError) as e:
+                self.connection_pool.nodes.reset()
+
+        # Error occurred too many times
+        raise e
+
+
 class _RedisCluster(object):
     def supports(self, config):
         return config.get('is_redis_cluster', False)
@@ -87,8 +106,8 @@ class _RedisCluster(object):
         # Redis cluster does not wait to attempt to connect, we don't want the
         # application to fail to boot because of this, raise a KeyError
         try:
-            return rediscluster.StrictRedisCluster(startup_nodes=hosts, decode_responses=True)
-        except rediscluster.exceptions.RedisClusterException:
+            return RetryingStrictRedisCluster(startup_nodes=hosts, decode_responses=True)
+        except RedisClusterException:
             logger.warning('Failed to connect to Redis Cluster', exc_info=True)
             raise KeyError('Redis Cluster could not be initalized')
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -86,7 +86,7 @@ class RetryingStrictRedisCluster(StrictRedisCluster):
     """
     retry_exceptions = (ConnectionError, BusyLoadingError)
 
-    @timed_retry(timeout=4, exceptions=retry_exceptions)
+    @timed_retry(timeout=1, exceptions=retry_exceptions)
     def execute_command(self, *args, **kwargs):
         try:
             return super(self.__class__, self).execute_command(*args, **kwargs)

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 import random
 import time
+import functools
 
 from django.utils.encoding import force_bytes
 
@@ -73,3 +74,18 @@ class TimedRetryPolicy(RetryPolicy):
                         delay,
                     )
                     self.clock.sleep(delay)
+
+
+def timed_retry(*args, **kwargs):
+    """
+    TimedRetryPolicy decorator function.
+    """
+    retrier = TimedRetryPolicy(*args, **kwargs)
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def execute_with_retry(*args, **kwargs):
+            return retrier(functools.partial(fn, *args, **kwargs))
+
+        return execute_with_retry
+    return decorator

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -78,7 +78,8 @@ class TimedRetryPolicy(RetryPolicy):
 
 def timed_retry(*args, **kwargs):
     """
-    TimedRetryPolicy decorator function.
+    A decorator that may be used to wrap a function to be retried using the
+    TimedRetryPolicy.
     """
     retrier = TimedRetryPolicy(*args, **kwargs)
 


### PR DESCRIPTION
This is with the intention of better handling failover errors.

As investigated by @JTCunning, during failover of a redis cluster node, the client will continue to try and communicate with the node that has failed over *after* it has come back and is in the process of becoming the slave, thus the `BusyLoadingError`.

Fixes [SENTRY-4J9](https://sentry.io/sentry/sentry/issues/347696693/), [SENTRY-4HY](https://sentry.io/sentry/sentry/issues/348763347/)

Builds off of GH-6111.