### PR TITLE
fix(workflow): Render total blacklisted project stats until October 11th

### DIFF
--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -461,7 +461,7 @@ const ProjectFilters = React.createClass({
         statOptions.map(stat => {
           let deferred = $.Deferred();
           this.api.request(statEndpoint, {
-            query: Object.assign({stat: stat}, query),
+            query: Object.assign({stat}, query),
             success: deferred.resolve.bind(deferred),
             error: deferred.reject.bind(deferred)
           });
@@ -482,9 +482,9 @@ const ProjectFilters = React.createClass({
           }
 
           this.setState({
-            rawStatsData: rawStatsData,
+            rawStatsData,
             formattedData: this.formatData(rawStatsData),
-            expected: expected,
+            expected,
             loading: expected > 0
           });
         }.bind(this)

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -13,7 +13,7 @@ import ProjectState from '../mixins/projectState';
 import StackedBarChart from '../components/stackedBarChart';
 import Switch from '../components/switch';
 import {FormState, TextareaField} from '../components/forms';
-import {t} from '../locale';
+import {t, tn} from '../locale';
 import {intcomma} from '../utils';
 import marked from '../utils/marked';
 
@@ -664,7 +664,7 @@ const ProjectFilters = React.createClass({
     return ReactDOMServer.renderToStaticMarkup(
       <div style={{width: '175px'}}>
         <div className="time-label"><span>{timeLabel}</span></div>
-        <div>{intcomma(totalY)} {totalY != 1 ? t('total events') : t('total event')}</div>
+        <div>{intcomma(totalY)} {tn('total event', 'total events', totalY)}</div>
         {formattedData.map((dataPoint, i) => {
           return (
             point.y[i] > 0 &&
@@ -674,7 +674,7 @@ const ProjectFilters = React.createClass({
                 {dataPoint.label}{' '}
               </dd>
               <dd style={{textAlign: 'right', position: 'relative'}}>
-                {point.y[i]} {point.y[i] != 1 ? t('events') : t('event')}
+                {point.y[i]} {tn('event', 'events', point.y[i])}
               </dd>
             </dl>
           );


### PR DESCRIPTION

New granular stats was not displaying the data captured before September 11th, so this displays the filtered events stats available before that time, and more granular stats will display September 11th and onward.