### PR TITLE
Change per-project limit wording to refer to hourly limit, not quota

### DIFF
--- a/src/sentry/locale/it/LC_MESSAGES/django.po
+++ b/src/sentry/locale/it/LC_MESSAGES/django.po
@@ -3781,7 +3781,7 @@ msgstr ""
 
 #: static/sentry/app/views/organizationRateLimits/index.jsx:85
 msgid ""
-"The maximum percentage of your quota an individual project can consume."
+"The maximum percentage of your hourly account limit an individual project can consume."
 msgstr ""
 
 #: static/sentry/app/views/organizationRateLimits/index.jsx:91

--- a/src/sentry/locale/it/LC_MESSAGES/django.po
+++ b/src/sentry/locale/it/LC_MESSAGES/django.po
@@ -3781,7 +3781,7 @@ msgstr ""
 
 #: static/sentry/app/views/organizationRateLimits/index.jsx:85
 msgid ""
-"The maximum percentage of your hourly account limit an individual project can consume."
+"The maximum percentage of your account limit an individual project can consume."
 msgstr ""
 
 #: static/sentry/app/views/organizationRateLimits/index.jsx:91

--- a/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
@@ -177,7 +177,7 @@ const RateLimitEditor = React.createClass({
 
         <div className="help-block">
           {t(
-            'The maximum percentage of your hourly account limit an individual project can consume.'
+            'The maximum percentage of your account limit an individual project can consume.'
           )}
         </div>
 

--- a/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRateLimits/index.jsx
@@ -177,7 +177,7 @@ const RateLimitEditor = React.createClass({
 
         <div className="help-block">
           {t(
-            'The maximum percentage of your account quota an individual project can consume.'
+            'The maximum percentage of your hourly account limit an individual project can consume.'
           )}
         </div>
 


### PR DESCRIPTION
The wording here is confusing people that think it refers to their monthly quota. 

![](http://screens.jess.la/2017-09-13-140326-0maeu7bex9.png)

Proposing it gets changed to:
>The maximum percentage of your account limit an individual project can consume.