### PR TITLE
feat(react): add alignment props to layout comps

### DIFF
--- a/docs-ui/components/flowLayout.stories.js
+++ b/docs-ui/components/flowLayout.stories.js
@@ -8,9 +8,28 @@ import SpreadLayout from 'sentry-ui/spreadLayout';
 
 storiesOf('ComponentLayouts/FlowLayout', module)
   .add(
-    'default',
+    'row',
     withInfo('Horizontal row with vertical centering')(() => (
       <FlowLayout style={{backgroundColor: '#fff'}}>
+        <div style={{padding: 6, backgroundColor: 'rgba(0, 0, 0, 0.2)'}}>
+          Flow
+        </div>
+        <div style={{padding: 12, backgroundColor: 'rgba(0, 0, 0, 0.1)'}}>
+          Layout
+        </div>
+        <div style={{padding: 24, backgroundColor: 'rgba(0, 0, 0, 0.05)'}}>
+          Flow
+        </div>
+        <div style={{padding: 18, backgroundColor: 'rgba(0, 0, 0, 0.3)'}}>
+          Layout
+        </div>
+      </FlowLayout>
+    ))
+  )
+  .add(
+    'column',
+    withInfo('Vertical column with horizontal centering')(() => (
+      <FlowLayout vertical style={{backgroundColor: '#fff'}}>
         <div style={{padding: 6, backgroundColor: 'rgba(0, 0, 0, 0.2)'}}>
           Flow
         </div>

--- a/docs-ui/components/spreadLayout.stories.js
+++ b/docs-ui/components/spreadLayout.stories.js
@@ -5,16 +5,30 @@ import {withInfo} from '@storybook/addon-info';
 
 import SpreadLayout from 'sentry-ui/spreadLayout';
 
-storiesOf('ComponentLayouts/SpreadLayout', module).add(
-  'default',
-  withInfo('Children elements get spread out (flexbox space-between)')(() => (
-    <SpreadLayout style={{backgroundColor: '#fff'}}>
-      <div style={{padding: 6, backgroundColor: 'rgba(0, 0, 0, 0.2)'}}>
-        Spread
-      </div>
-      <div style={{padding: 12, backgroundColor: 'rgba(0, 0, 0, 0.1)'}}>
-        Layout
-      </div>
-    </SpreadLayout>
-  ))
-);
+storiesOf('ComponentLayouts/SpreadLayout', module)
+  .add(
+    'default',
+    withInfo('Children elements get spread out (flexbox space-between)')(() => (
+      <SpreadLayout style={{backgroundColor: '#fff'}}>
+        <div style={{padding: 6, backgroundColor: 'rgba(0, 0, 0, 0.2)'}}>
+          Spread
+        </div>
+        <div style={{padding: 12, backgroundColor: 'rgba(0, 0, 0, 0.1)'}}>
+          Layout
+        </div>
+      </SpreadLayout>
+    ))
+  )
+  .add(
+    'no center',
+    withInfo('Children elements get spread out (flexbox space-between)')(() => (
+      <SpreadLayout center={false} style={{backgroundColor: '#fff'}}>
+        <div style={{padding: 6, backgroundColor: 'rgba(0, 0, 0, 0.2)'}}>
+          Spread
+        </div>
+        <div style={{padding: 12, backgroundColor: 'rgba(0, 0, 0, 0.1)'}}>
+          Layout
+        </div>
+      </SpreadLayout>
+    ))
+  );

--- a/src/sentry/static/sentry/app/components/flowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/flowLayout.jsx
@@ -9,6 +9,8 @@ const FlowLayout = React.createClass({
   propTypes: {
     /** Centers content via `justify-content` */
     center: PropTypes.bool,
+    /** Changes flex direction to be column */
+    vertical: PropTypes.bool,
     /** Applies "overflow: hidden" to container so that children can be truncated */
     truncate: PropTypes.bool
   },
@@ -20,8 +22,9 @@ const FlowLayout = React.createClass({
   },
 
   render() {
-    let {className, children, truncate, center, ...otherProps} = this.props;
+    let {className, children, truncate, vertical, center, ...otherProps} = this.props;
     let cx = classNames('flow-layout', className, {
+      'is-vertical': vertical,
       'is-center': center,
       'is-truncated': truncate
     });

--- a/src/sentry/static/sentry/app/components/spreadLayout.jsx
+++ b/src/sentry/static/sentry/app/components/spreadLayout.jsx
@@ -6,8 +6,9 @@ import classNames from 'classnames';
 //
 // Intended for children.length == 2
 // "responsive" will change flex-direction to be column on small widths
-const SpreadLayout = ({children, className, responsive, ...props}) => {
+const SpreadLayout = ({children, className, responsive, center, ...props}) => {
   const cx = classNames('spread-layout', className, {
+    center,
     'allow-responsive': responsive
   });
 
@@ -18,9 +19,15 @@ const SpreadLayout = ({children, className, responsive, ...props}) => {
   );
 };
 
+SpreadLayout.defaultProps = {
+  responsive: false,
+  center: true
+};
+
 SpreadLayout.propTypes = {
   children: PropTypes.node,
   style: PropTypes.object,
+  center: PropTypes.bool,
   responsive: PropTypes.bool
 };
 

--- a/src/sentry/static/sentry/less/component-layouts.less
+++ b/src/sentry/static/sentry/less/component-layouts.less
@@ -19,5 +19,8 @@
 .spread-layout {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+
+  &.center {
+    align-items: center;
+  }
 }

--- a/src/sentry/static/sentry/less/components/flowLayout.less
+++ b/src/sentry/static/sentry/less/components/flowLayout.less
@@ -3,6 +3,9 @@
   flex: 1;
   align-items: center;
 
+  &.is-vertical {
+    flex-direction: column;
+  }
 
   &.is-truncated {
     overflow: hidden;

--- a/tests/js/spec/components/__snapshots__/similarScoreCard.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/similarScoreCard.spec.jsx.snap
@@ -7,7 +7,9 @@ exports[`SimilarScoreCard renders with score list 1`] = `
   className="similar-score-card"
 >
   <SpreadLayout
+    center={true}
     className="similar-score-card-row"
+    responsive={false}
   >
     <div />
     <div
@@ -15,7 +17,9 @@ exports[`SimilarScoreCard renders with score list 1`] = `
     />
   </SpreadLayout>
   <SpreadLayout
+    center={true}
     className="similar-score-card-row"
+    responsive={false}
   >
     <div />
     <div
@@ -23,7 +27,9 @@ exports[`SimilarScoreCard renders with score list 1`] = `
     />
   </SpreadLayout>
   <SpreadLayout
+    center={true}
     className="similar-score-card-row"
+    responsive={false}
   >
     <div />
     <div
@@ -31,7 +37,9 @@ exports[`SimilarScoreCard renders with score list 1`] = `
     />
   </SpreadLayout>
   <SpreadLayout
+    center={true}
     className="similar-score-card-row"
+    responsive={false}
   >
     <div />
     <div

--- a/tests/js/spec/components/__snapshots__/splitLayout.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/splitLayout.spec.jsx.snap
@@ -2,7 +2,9 @@
 
 exports[`SplitLayout renders with multiple children 1`] = `
 <SpreadLayout
+  center={true}
   className="split-layout"
+  responsive={false}
 >
   <div
     className="split-layout-child"
@@ -24,7 +26,9 @@ exports[`SplitLayout renders with multiple children 1`] = `
 
 exports[`SplitLayout renders with one child 1`] = `
 <SpreadLayout
+  center={true}
   className="split-layout"
+  responsive={false}
 >
   <div
     className="split-layout-child"
@@ -36,7 +40,9 @@ exports[`SplitLayout renders with one child 1`] = `
 
 exports[`SplitLayout renders with responsive property 1`] = `
 <SpreadLayout
+  center={true}
   className="split-layout allow-responsive"
+  responsive={false}
 >
   <div
     className="split-layout-child"

--- a/tests/js/spec/components/__snapshots__/spreadLayout.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/spreadLayout.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SpreadLayout renders with multiple children 1`] = `
 <div
-  className="spread-layout"
+  className="spread-layout center"
 >
   <div>
     child #1
@@ -15,7 +15,7 @@ exports[`SpreadLayout renders with multiple children 1`] = `
 
 exports[`SpreadLayout renders with one child 1`] = `
 <div
-  className="spread-layout"
+  className="spread-layout center"
 >
   <div>
     child

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -292,14 +292,18 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
               className="toolbar merged-toolbar"
             >
               <SpreadLayout
+                center={true}
                 responsive={true}
               >
                 <div
-                  className="spread-layout allow-responsive"
+                  className="spread-layout center allow-responsive"
                 >
-                  <SpreadLayout>
+                  <SpreadLayout
+                    center={true}
+                    responsive={false}
+                  >
                     <div
-                      className="spread-layout"
+                      className="spread-layout center"
                     >
                       <div
                         className="merged-toolbar-actions"
@@ -375,9 +379,12 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                       </div>
                     </div>
                   </SpreadLayout>
-                  <SpreadLayout>
+                  <SpreadLayout
+                    center={true}
+                    responsive={false}
+                  >
                     <div
-                      className="spread-layout"
+                      className="spread-layout center"
                     >
                       <div>
                         <button
@@ -507,11 +514,12 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
               className="fingerprint-group expanded"
             >
               <SpreadLayout
+                center={true}
                 className="merged-controls"
                 responsive={true}
               >
                 <div
-                  className="spread-layout merged-controls allow-responsive"
+                  className="spread-layout merged-controls center allow-responsive"
                 >
                   <FlowLayout
                     onClick={[Function]}
@@ -1007,11 +1015,12 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
               className="fingerprint-group expanded"
             >
               <SpreadLayout
+                center={true}
                 className="merged-controls"
                 responsive={true}
               >
                 <div
-                  className="spread-layout merged-controls allow-responsive"
+                  className="spread-layout merged-controls center allow-responsive"
                 >
                   <FlowLayout
                     onClick={[Function]}
@@ -1683,14 +1692,18 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
               className="toolbar merged-toolbar"
             >
               <SpreadLayout
+                center={true}
                 responsive={true}
               >
                 <div
-                  className="spread-layout allow-responsive"
+                  className="spread-layout center allow-responsive"
                 >
-                  <SpreadLayout>
+                  <SpreadLayout
+                    center={true}
+                    responsive={false}
+                  >
                     <div
-                      className="spread-layout"
+                      className="spread-layout center"
                     >
                       <div
                         className="merged-toolbar-actions"
@@ -1766,9 +1779,12 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                       </div>
                     </div>
                   </SpreadLayout>
-                  <SpreadLayout>
+                  <SpreadLayout
+                    center={true}
+                    responsive={false}
+                  >
                     <div
-                      className="spread-layout"
+                      className="spread-layout center"
                     >
                       <div>
                         <button
@@ -1898,11 +1914,12 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
               className="fingerprint-group expanded"
             >
               <SpreadLayout
+                center={true}
                 className="merged-controls"
                 responsive={true}
               >
                 <div
-                  className="spread-layout merged-controls allow-responsive"
+                  className="spread-layout merged-controls center allow-responsive"
                 >
                   <FlowLayout
                     onClick={[Function]}
@@ -2398,11 +2415,12 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
               className="fingerprint-group expanded"
             >
               <SpreadLayout
+                center={true}
                 className="merged-controls"
                 responsive={true}
               >
                 <div
-                  className="spread-layout merged-controls allow-responsive"
+                  className="spread-layout merged-controls center allow-responsive"
                 >
                   <FlowLayout
                     onClick={[Function]}

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -284,10 +284,12 @@ exports[`Issues Similar View renders with mocked data 1`] = `
         className="similar-list-container"
       >
         <SpreadLayout
+          center={true}
           className="similar-list-header"
+          responsive={false}
         >
           <div
-            className="spread-layout similar-list-header"
+            className="spread-layout similar-list-header center"
           >
             <h2>
               <span>
@@ -354,10 +356,11 @@ exports[`Issues Similar View renders with mocked data 1`] = `
               className="toolbar similar-toolbar"
             >
               <SpreadLayout
+                center={true}
                 responsive={true}
               >
                 <div
-                  className="spread-layout allow-responsive"
+                  className="spread-layout center allow-responsive"
                 >
                   <FlowLayout
                     style={
@@ -786,10 +789,12 @@ exports[`Issues Similar View renders with mocked data 2`] = `
         className="similar-list-container"
       >
         <SpreadLayout
+          center={true}
           className="similar-list-header"
+          responsive={false}
         >
           <div
-            className="spread-layout similar-list-header"
+            className="spread-layout similar-list-header center"
           >
             <h2>
               <span>
@@ -856,10 +861,11 @@ exports[`Issues Similar View renders with mocked data 2`] = `
               className="toolbar similar-toolbar"
             >
               <SpreadLayout
+                center={true}
                 responsive={true}
               >
                 <div
-                  className="spread-layout allow-responsive"
+                  className="spread-layout center allow-responsive"
                 >
                   <FlowLayout
                     style={


### PR DESCRIPTION
* center by default for <SpreadLayout>
* vertical (flex-direction: column) for <FlowLayout>

View relevant snapshot here: https://percy.io/getsentry/sentry-storybook/builds/341778?snapshot=11993373