### PR TITLE
feat(store): Add ability to generate hashes from unprocessed data

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -7,6 +7,7 @@ sentry.event_manager
 """
 from __future__ import absolute_import, print_function
 
+import functools
 import logging
 import math
 import six
@@ -101,9 +102,9 @@ def get_grouping_behavior(event):
     return ('fingerprint', get_hashes_from_fingerprint_with_reason(event, fingerprint))
 
 
-def get_hashes_from_fingerprint(event, fingerprint):
+def _get_hashes_from_fingerprint(get_hash_inputs, fingerprint):
     if any(d in fingerprint for d in DEFAULT_FINGERPRINT_VALUES):
-        default_hashes = get_hashes_for_event(event)
+        default_hashes = get_hash_inputs()
         hash_count = len(default_hashes)
     else:
         hash_count = 1
@@ -118,6 +119,13 @@ def get_hashes_from_fingerprint(event, fingerprint):
                 result.append(bit)
         hashes.append(result)
     return hashes
+
+
+def get_hashes_from_fingerprint(event, fingerprint):
+    return _get_hashes_from_fingerprint(
+        functools.partial(get_hashes_for_event, event),
+        fingerprint,
+    )
 
 
 def get_hashes_from_fingerprint_with_reason(event, fingerprint):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -44,6 +44,9 @@ from sentry.utils.validators import validate_ip
 from sentry.stacktraces import normalize_in_app
 
 
+DEFAULT_FINGERPRINT_VALUES = frozenset(['{{ default }}', '{{default}}'])
+
+
 def count_limit(count):
     # TODO: could we do something like num_to_store = max(math.sqrt(100*count)+59, 200) ?
     # ~ 150 * ((log(n) - 1.5) ^ 2 - 0.25)
@@ -99,8 +102,7 @@ def get_grouping_behavior(event):
 
 
 def get_hashes_from_fingerprint(event, fingerprint):
-    default_values = set(['{{ default }}', '{{default}}'])
-    if any(d in fingerprint for d in default_values):
+    if any(d in fingerprint for d in DEFAULT_FINGERPRINT_VALUES):
         default_hashes = get_hashes_for_event(event)
         hash_count = len(default_hashes)
     else:
@@ -110,7 +112,7 @@ def get_hashes_from_fingerprint(event, fingerprint):
     for idx in range(hash_count):
         result = []
         for bit in fingerprint:
-            if bit in default_values:
+            if bit in DEFAULT_FINGERPRINT_VALUES:
                 result.extend(default_hashes[idx])
             else:
                 result.append(bit)
@@ -119,8 +121,7 @@ def get_hashes_from_fingerprint(event, fingerprint):
 
 
 def get_hashes_from_fingerprint_with_reason(event, fingerprint):
-    default_values = set(['{{ default }}', '{{default}}'])
-    if any(d in fingerprint for d in default_values):
+    if any(d in fingerprint for d in DEFAULT_FINGERPRINT_VALUES):
         default_hashes = get_hashes_for_event_with_reason(event)
         hash_count = len(default_hashes[1])
     else:
@@ -129,7 +130,7 @@ def get_hashes_from_fingerprint_with_reason(event, fingerprint):
     hashes = OrderedDict((bit, []) for bit in fingerprint)
     for idx in range(hash_count):
         for bit in fingerprint:
-            if bit in default_values:
+            if bit in DEFAULT_FINGERPRINT_VALUES:
                 hashes[bit].append(default_hashes)
             else:
                 hashes[bit] = bit

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -91,7 +91,8 @@ def get_hashes_for_event_with_reason(event):
         if not result:
             continue
         return (interface.get_path(), result)
-    return ('message', [event.message])
+
+    return ('no_interfaces', [''])
 
 
 def get_grouping_behavior(event):

--- a/src/sentry/filters/preprocess_hashes.py
+++ b/src/sentry/filters/preprocess_hashes.py
@@ -1,6 +1,14 @@
 from __future__ import absolute_import
 
+import functools
+import six
+
 from django.core.cache import cache, get_cache, InvalidCacheBackendError
+
+from sentry.interfaces.base import get_interfaces
+from sentry.interfaces.exception import Exception as ExceptionInterface, SingleException
+from sentry.interfaces.stacktrace import Frame, Stacktrace
+from sentry.event_manager import _get_hashes_from_fingerprint, md5_from_hash
 
 
 try:
@@ -9,5 +17,56 @@ except InvalidCacheBackendError:
     hash_cache = cache
 
 
+class UnableToGenerateHash(Exception):
+    pass
+
+
 def get_raw_cache_key(project_id, event_id):
     return 'e:raw:{1}:{0}'.format(project_id, event_id)
+
+
+def get_preprocess_hash_inputs(event):
+    return get_preprocess_hash_inputs_with_reason(event)[1]
+
+
+def get_preprocess_hash_inputs_with_reason(data):
+    interfaces = get_interfaces(data)
+    platform = data['platform']
+    for interface in six.itervalues(interfaces):
+        kwargs = {'is_processed_data': False}
+        if isinstance(interface, SingleException):
+            kwargs['platform'] = platform
+        elif isinstance(interface, (ExceptionInterface, Stacktrace, Frame)):
+            # normalize_in_app hasn't run on the data, so
+            # `in_app` isn't necessarily accurate
+            kwargs.update({
+                'platform': platform,
+                'system_frames': True,
+            })
+        result = interface.get_hash(**kwargs)
+        if result:
+            return (interface.get_path(), [result])
+
+    raise UnableToGenerateHash
+
+
+def get_preprocess_hashes_from_fingerprint(data, fingerprint):
+    return _get_hashes_from_fingerprint(
+        functools.partial(get_preprocess_hash_inputs, data),
+        fingerprint,
+    )
+
+
+def get_preprocess_hashes(data):
+    fingerprint = data.get('fingerprint')
+
+    if fingerprint:
+        hashes = [
+            md5_from_hash(h) for h in get_preprocess_hashes_from_fingerprint(data, fingerprint)
+        ]
+    elif data.get('checksum'):
+        hashes = [data['checksum']]
+    else:
+        hashes = [md5_from_hash(h) for h in get_preprocess_hash_inputs(data)]
+
+    return hashes

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -118,7 +118,10 @@ class Interface(object):
     def get_alias(self):
         return self.get_slug()
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
+        # is_processed_data will be false when used for
+        # hashing to check whether an event should be
+        # discarded or not
         return []
 
     def compute_hashes(self, platform):

--- a/src/sentry/interfaces/csp.py
+++ b/src/sentry/interfaces/csp.py
@@ -94,7 +94,7 @@ class Csp(Interface):
 
         return cls(**kwargs)
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
         directive = self.effective_directive
         uri = self._normalized_blocked_uri
 

--- a/src/sentry/interfaces/device.py
+++ b/src/sentry/interfaces/device.py
@@ -57,5 +57,5 @@ class Device(Interface):
     def get_path(self):
         return 'device'
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
         return []

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -140,10 +140,13 @@ class SingleException(Interface):
     def get_path(self):
         return 'sentry.interfaces.Exception'
 
-    def get_hash(self, platform=None):
+    def get_hash(self, platform=None, is_processed_data=True):
         output = None
         if self.stacktrace:
-            output = self.stacktrace.get_hash(platform=platform)
+            output = self.stacktrace.get_hash(
+                platform=platform,
+                is_processed_data=is_processed_data,
+            )
             if output and self.type:
                 output.append(self.type)
         if not output:
@@ -246,7 +249,7 @@ class Exception(Interface):
 
         return [system_hash, app_hash]
 
-    def get_hash(self, platform=None, system_frames=True):
+    def get_hash(self, platform=None, system_frames=True, is_processed_data=True):
         # optimize around the fact that some exceptions might have stacktraces
         # while others may not and we ALWAYS want stacktraces over values
         output = []
@@ -256,6 +259,7 @@ class Exception(Interface):
             stack_hash = value.stacktrace.get_hash(
                 platform=platform,
                 system_frames=system_frames,
+                is_processed_data=is_processed_data,
             )
             if stack_hash:
                 output.extend(stack_hash)
@@ -263,7 +267,9 @@ class Exception(Interface):
 
         if not output:
             for value in self.values:
-                output.extend(value.get_hash(platform=platform))
+                output.extend(
+                    value.get_hash(platform=platform, is_processed_data=is_processed_data)
+                )
 
         return output
 

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -93,7 +93,7 @@ class Message(Interface):
     def get_path(self):
         return 'sentry.interfaces.Message'
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
         return [self.message]
 
     def to_string(self, event, is_public=False, **kwargs):

--- a/src/sentry/interfaces/query.py
+++ b/src/sentry/interfaces/query.py
@@ -35,7 +35,7 @@ class Query(Interface):
         }
         return cls(**kwargs)
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
         return [self.query]
 
     def get_path(self):

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -370,7 +370,7 @@ class Frame(Interface):
 
         return cls(**kwargs)
 
-    def get_hash(self, platform=None):
+    def get_hash(self, platform=None, is_processed_data=True):
         """
         The hash of the frame varies depending on the data available.
 
@@ -413,10 +413,11 @@ class Frame(Interface):
         # XXX: hack around what appear to be non-useful lines of context
         if can_use_context:
             output.append(self.context_line)
-        elif not output:
+        elif not output and is_processed_data:
             # If we were unable to achieve any context at this point
             # (likely due to a bad JavaScript error) we should just
-            # bail on recording this frame
+            # bail on recording this frame unless we're working with
+            # unprocessed data
             return output
         elif self.symbol:
             output.append(self.symbol)
@@ -427,6 +428,8 @@ class Frame(Interface):
                 output.append(remove_function_outliers(self.function))
         elif self.lineno is not None:
             output.append(self.lineno)
+            if not is_processed_data and self.colno is not None:
+                output.append(self.colno)
         return output
 
     def get_api_context(self, is_public=False, pad_addr=None):
@@ -734,7 +737,7 @@ class Stacktrace(Interface):
 
         return [system_hash, app_hash]
 
-    def get_hash(self, platform=None, system_frames=True):
+    def get_hash(self, platform=None, system_frames=True, is_processed_data=True):
         frames = self.frames
 
         # TODO(dcramer): this should apply only to platform=javascript
@@ -759,7 +762,7 @@ class Stacktrace(Interface):
 
         output = []
         for frame in frames:
-            output.extend(frame.get_hash(platform))
+            output.extend(frame.get_hash(platform, is_processed_data=is_processed_data))
         return output
 
     def to_string(self, event, is_public=False, **kwargs):

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -66,7 +66,7 @@ class Template(Interface):
     def get_path(self):
         return 'sentry.interfaces.Template'
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
         return [self.filename, self.context_line]
 
     def to_string(self, event, is_public=False, **kwargs):

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -78,16 +78,16 @@ class Threads(Interface):
     def get_path(self):
         return 'threads'
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
         if len(self.values) != 1:
             return []
         stacktrace = self.values[0].get('stacktrace')
         if not stacktrace:
             return []
-        system_hash = stacktrace.get_hash(system_frames=True)
+        system_hash = stacktrace.get_hash(system_frames=True, is_processed_data=is_processed_data)
         if not system_hash:
             return []
-        app_hash = stacktrace.get_hash(system_frames=False)
+        app_hash = stacktrace.get_hash(system_frames=False, is_processed_data=is_processed_data)
         if system_hash == app_hash or not app_hash:
             return [system_hash]
 

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -106,7 +106,7 @@ class User(Interface):
     def get_path(self):
         return 'sentry.interfaces.User'
 
-    def get_hash(self):
+    def get_hash(self, is_processed_data=True):
         return []
 
     def get_display_name(self):

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -20,9 +20,8 @@ from sentry import eventtypes
 from sentry.db.models import (
     BaseManager, BoundedBigIntegerField, BoundedIntegerField, Model, NodeField, sane_repr
 )
-from sentry.interfaces.base import get_interface
+from sentry.interfaces.base import get_interfaces
 from sentry.utils.cache import memoize
-from sentry.utils.safe import safe_execute
 from sentry.utils.strings import truncatechars
 
 
@@ -161,22 +160,7 @@ class Event(Model):
         return None
 
     def get_interfaces(self):
-        result = []
-        for key, data in six.iteritems(self.data):
-            try:
-                cls = get_interface(key)
-            except ValueError:
-                continue
-
-            value = safe_execute(cls.to_python, data, _with_transaction=False)
-            if not value:
-                continue
-
-            result.append((key, value))
-
-        return OrderedDict(
-            (k, v) for k, v in sorted(result, key=lambda x: x[1].get_score(), reverse=True)
-        )
+        return get_interfaces(self.data)
 
     @memoize
     def interfaces(self):

--- a/tests/sentry/filters/test_preprocess_hashes.py
+++ b/tests/sentry/filters/test_preprocess_hashes.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, print_function
+
+import logging
+
+from sentry.event_manager import EventManager
+from sentry.filters.preprocess_hashes import (
+    get_preprocess_hash_inputs, get_preprocess_hashes, UnableToGenerateHash
+)
+from sentry.testutils import TestCase
+
+
+class PreProcessingHashTest(TestCase):
+    def make_event_data(self, **kwargs):
+        data = kwargs.pop('data', {})
+        result = {
+            'event_id': 'a' * 32,
+            'message': 'foo',
+            'timestamp': 1403007314.570599,
+            'level': logging.ERROR,
+            'logger': 'default',
+            'platform': 'python',
+            'tags': [],
+        }
+        result.update(kwargs)
+        result.update(data)
+        manager = EventManager(result)
+        manager.normalize()
+        return manager.data
+
+    def test_similar_message_prefix_doesnt_match(self):
+        manager = EventManager(self.make_event_data(message='foo bar'))
+        manager.normalize()
+        event_data1 = manager.data
+        hashes1 = get_preprocess_hashes(event_data1)
+
+        manager = EventManager(self.make_event_data(message='foo baz'))
+        manager.normalize()
+        event_data2 = manager.data
+        hashes2 = get_preprocess_hashes(event_data2)
+
+        assert hashes1 != hashes2
+
+    def test_no_message(self):
+        event_data = self.make_event_data()
+        event_data.pop('sentry.interfaces.Message')
+
+        with self.assertRaises(UnableToGenerateHash):
+            get_preprocess_hashes(event_data)
+
+    def test_matches_with_fingerprint(self):
+        event_data1 = self.make_event_data(
+            message='foo',
+            event_id='a' * 32,
+            fingerprint=['a' * 32],
+        )
+
+        event_data2 = self.make_event_data(
+            message='foo bar',
+            event_id='b' * 32,
+            fingerprint=['a' * 32],
+        )
+        hashes1 = get_preprocess_hashes(event_data1)
+        hashes2 = get_preprocess_hashes(event_data2)
+        assert hashes1 == hashes2
+
+    def test_differentiates_with_fingerprint(self):
+        event_data1 = self.make_event_data(
+            message='foo',
+            event_id='a' * 32,
+            fingerprint=['{{ default }}', 'a' * 32],
+        )
+
+        event_data2 = self.make_event_data(
+            message='foo bar',
+            event_id='b' * 32,
+            fingerprint=['a' * 32],
+        )
+        hashes1 = get_preprocess_hashes(event_data1)
+        hashes2 = get_preprocess_hashes(event_data2)
+        assert hashes1 != hashes2
+
+    def test_stacktrace_wins_over_template(self):
+        event_data = self.make_event_data(
+            data={
+                'sentry.interfaces.Stacktrace': {
+                    'frames': [{
+                        'lineno': 1,
+                        'filename': 'foo.py',
+                    }],
+                },
+                'sentry.interfaces.Template': {
+                    'abs_path': '/real/file/name.html',
+                    'filename': 'file/name.html',
+                    'pre_context': ['line1', 'line2'],
+                    'context_line': 'line3',
+                    'lineno': 3,
+                    'post_context': ['line4', 'line5'],
+                }
+            },
+            platform='python',
+            message='Foo bar',
+        )
+        hashes = get_preprocess_hash_inputs(event_data)
+        assert len(hashes) == 1
+        assert hashes == [['foo.py', 1]]
+
+    def test_default_value(self):
+        data = {
+            'sentry.interfaces.Stacktrace': {
+                'frames': [
+                    {
+                        'lineno': 1,
+                        'filename': 'foo.py',
+                    }, {
+                        'lineno': 1,
+                        'filename': 'foo.py',
+                        'in_app': True,
+                    }
+                ],
+            },
+            'sentry.interfaces.Http': {
+                'url': 'http://example.com'
+            },
+        }
+        event_data1 = self.make_event_data(
+            data=data,
+            fingerprint=["{{default}}"],
+            platform='python',
+            message='Foo bar',
+        )
+
+        event_data2 = self.make_event_data(
+            data=data,
+            platform='python',
+            message='Foo bar',
+        )
+        fp_checksums = get_preprocess_hashes(event_data1)
+        def_checksums = get_preprocess_hashes(event_data2)
+        assert def_checksums == fp_checksums
+
+    def test_custom_values(self):
+        data = {
+            'sentry.interfaces.Stacktrace': {
+                'frames': [
+                    {
+                        'lineno': 1,
+                        'filename': 'foo.py',
+                    }, {
+                        'lineno': 1,
+                        'filename': 'foo.py',
+                        'in_app': True,
+                    }
+                ],
+            },
+            'sentry.interfaces.Http': {
+                'url': 'http://example.com'
+            },
+        }
+        event_data1 = self.make_event_data(
+            data=data,
+            platform='python',
+            message='Foo bar',
+        )
+        event_data2 = self.make_event_data(
+            data=data,
+            platform='python',
+            message='Foo bar',
+            fingerprint=["{{default}}", "custom"],
+        )
+        fp_checksums = get_preprocess_hashes(event_data1)
+        def_checksums = get_preprocess_hashes(event_data2)
+        assert len(fp_checksums) == len(def_checksums)
+        assert def_checksums != fp_checksums
+
+    def test_exception_with_stacktrace(self):
+        data = {
+            'exception': {
+                'values': [
+                    {
+                        'stacktrace': {
+                            'frames': [
+                                {
+                                    'abs_path':
+                                    u'http://localhost:8000/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/vendor.js',
+                                    'colno':
+                                    22,
+                                    'filename':
+                                    u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/vendor.js',
+                                    'function':
+                                    u'Object.receiveComponent',
+                                    'in_app':
+                                    True,
+                                    'lineno':
+                                    17866
+                                }, {
+                                    'abs_path':
+                                    u'http://localhost:8000/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/vendor.js',
+                                    'colno':
+                                    10,
+                                    'filename':
+                                    u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/vendor.js',
+                                    'function':
+                                    u'ReactCompositeComponentWrapper.receiveComponent',
+                                    'in_app':
+                                    True,
+                                    'lineno':
+                                    74002
+                                }, {
+                                    'abs_path':
+                                    u'http://localhost:8000/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/app.js',
+                                    'colno':
+                                    9,
+                                    'filename':
+                                    u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/app.js',
+                                    'function':
+                                    u'Constructor.render',
+                                    'in_app':
+                                    True,
+                                    'lineno':
+                                    47628
+                                }
+                            ],
+                            'frames_omitted':
+                            None,
+                            'registers':
+                            None
+                        },
+                        'thread_id': None,
+                        'type': u'TypeError',
+                        'value': u"Cannot set property 'b' of null"
+                    }
+                ]
+            }
+        }
+
+        event_data = self.make_event_data(
+            data=data,
+            platform='javascript',
+        )
+
+        assert get_preprocess_hash_inputs(event_data) == [[
+            u'Object.receiveComponent',
+            u'ReactCompositeComponentWrapper.receiveComponent',
+            u'Constructor.render',
+            u'TypeError'
+        ]]


### PR DESCRIPTION
- refactors `Interface.get_hash` to take an `is_processed_data` kwarg
- refactors `get_interfaces` and `get_hashes_from_fingerprint` so that they can be used in generating preprocess hashes
- updates `Frame.get_hash` to account for minified hash generation

This is related to https://github.com/getsentry/sentry/pull/5987, which I'm closing since this seemed like a better way to avoid duplicated code.