### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import print_function
 import sys
 import os
 
@@ -242,4 +243,4 @@ if os.environ.get('SENTRY_FEDERATED_DOCS') != '1':
         import sentryext
         sentryext.activate()
     except ImportError:
-        print 'ERROR: could not import sentryext.  You need to check out the _sentryext submodule.'
+        print('ERROR: could not import sentryext.  You need to check out the _sentryext submodule.')

--- a/examples/oauth2_consumer_webserver/app.py
+++ b/examples/oauth2_consumer_webserver/app.py
@@ -53,7 +53,7 @@ def index():
     req = Request('{}/api/0/organizations/'.format(BASE_URL), None, headers)
     try:
         res = urlopen(req)
-    except URLError, e:
+    except URLError as e:
         if e.code == 401:
             # Unauthorized - bad token
             session.pop('access_token', None)

--- a/src/debug_toolbar/panels/signals.py
+++ b/src/debug_toolbar/panels/signals.py
@@ -83,7 +83,7 @@ class SignalsPanel(Panel):
                     receiver_class_name = getattr(receiver.__self__, '__class__', type).__name__
                     text = "%s.%s" % (receiver_class_name, receiver_name)
                 elif getattr(receiver, 'im_class', None) is not None:  # Python 2 only
-                    receiver_class_name = receiver.im_class.__name__
+                    receiver_class_name = receiver.__self__.__class__.__name__
                     text = "%s.%s" % (receiver_class_name, receiver_name)
                 else:
                     text = "%s" % receiver_name

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -14,6 +14,7 @@ from django.db.models import Q
 
 from itertools import izip
 from collections import defaultdict
+from functools import reduce
 
 
 def tokenize_path(path):

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -15,6 +15,7 @@ from sentry.search.utils import parse_query
 from sentry.utils.apidocs import scenario, attach_scenarios
 from rest_framework.response import Response
 from sentry.search.utils import InvalidQuery
+from functools import reduce
 
 
 @scenario('ListAvailableSamples')

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -18,7 +18,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
             limit = int(limit) + 1  # the target group will always be included
 
         results = filter(
-            lambda (group_id, scores): group_id != group.id,
+            lambda group_id_scores2: group_id_scores2[0] != group.id,
             features.compare(group, limit=limit)
         )
 
@@ -32,9 +32,9 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         # unexpected behavior, but still possible.)
         return Response(
             filter(
-                lambda (group_id, scores): group_id is not None,
+                lambda group_id_scores1: group_id_scores1[0] is not None,
                 map(
-                    lambda (group_id, scores): (serialized_groups.get(group_id), scores, ),
+                    lambda group_id_scores: (serialized_groups.get(group_id_scores[0]), group_id_scores[1], ),
                     results,
                 ),
             ),

--- a/src/sentry/api/endpoints/organization_user_issues.py
+++ b/src/sentry/api/endpoints/organization_user_issues.py
@@ -9,6 +9,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import TagBasedStreamGroupSerializer
 from sentry.models import (EventUser, Group, GroupTagValue, Project)
+from functools import reduce
 
 
 class OrganizationUserIssuesEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/serializers/models/grouptagvalue.py
+++ b/src/sentry/api/serializers/models/grouptagvalue.py
@@ -8,6 +8,7 @@ from six.moves import reduce
 
 from sentry.api.serializers import Serializer, register
 from sentry.models import EventUser, GroupTagValue, TagKey, TagValue
+from functools import reduce
 
 
 def parse_user_tag(value):

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -17,6 +17,7 @@ from django.db.models.signals import post_save
 from six.moves import reduce
 
 from .utils import ExpressionNode, resolve_expression_node
+from functools import reduce
 
 __all__ = ('update', 'create_or_update')
 

--- a/src/sentry/debug/panels/route.py
+++ b/src/sentry/debug/panels/route.py
@@ -36,7 +36,7 @@ class RoutePanel(Panel):
         if hasattr(func, 'im_class'):
             return '{}.{}.{}'.format(
                 func.__module__,
-                func.im_class.__name__,
+                func.__self__.__class__.__name__,
                 func.__name__,
             )
         return '{}.{}'.format(func.__module__, func.__name__)

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -228,10 +228,10 @@ class RedisBackend(Backend):
                     raise
 
             records = map(
-                lambda (key, value, timestamp): Record(
-                    key,
-                    self.codec.decode(value) if value is not None else None,
-                    float(timestamp),
+                lambda key_value_timestamp: Record(
+                    key_value_timestamp[0],
+                    self.codec.decode(key_value_timestamp[1]) if key_value_timestamp[1] is not None else None,
+                    float(key_value_timestamp[2]),
                 ),
                 response,
             )

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -21,6 +21,7 @@ from sentry.models import (
     Rule,
 )
 from sentry.utils.dates import to_timestamp
+from functools import reduce
 
 logger = logging.getLogger('sentry.digests')
 

--- a/src/sentry/management/commands/merge_users.py
+++ b/src/sentry/management/commands/merge_users.py
@@ -9,6 +9,7 @@ from django.db.models import Q
 from six.moves import input, reduce
 
 from sentry.models import Organization, OrganizationMember, User
+from functools import reduce
 
 
 class Command(BaseCommand):

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -197,16 +197,16 @@ class AuthenticatorInterface(object):
         """If the interface has an activation method that needs to be
         called this returns `True`.
         """
-        return self.activate.im_func is not \
-            AuthenticatorInterface.activate.im_func
+        return self.activate.__func__ is not \
+            AuthenticatorInterface.activate.__func__
 
     @property
     def can_validate_otp(self):
         """If the interface is able to validate OTP codes then this returns
         `True`.
         """
-        return self.validate_otp.im_func is not \
-            AuthenticatorInterface.validate_otp.im_func
+        return self.validate_otp.__func__ is not \
+            AuthenticatorInterface.validate_otp.__func__
 
     @property
     def config(self):

--- a/src/sentry/models/eventuser.py
+++ b/src/sentry/models/eventuser.py
@@ -8,6 +8,7 @@ from six.moves import reduce
 from sentry.db.models import BoundedPositiveIntegerField, Model, sane_repr
 from sentry.utils.hashlib import md5_text
 from sentry.constants import MAX_EMAIL_FIELD_LENGTH
+from functools import reduce
 
 KEYWORD_MAP = {
     'id': 'ident',

--- a/src/sentry/nodestore/riak/client.py
+++ b/src/sentry/nodestore/riak/client.py
@@ -67,10 +67,11 @@ class SimpleThreadedWorkerPool(object):
 
         self.__started = True
 
-    def submit(self, (func, arg, kwargs, cb)):
+    def submit(self, xxx_todo_changeme):
         """\
         Submit a task to the worker pool.
         """
+        (func, arg, kwargs, cb) = xxx_todo_changeme
         if not self.__started:
             self.__start()
 

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -29,7 +29,7 @@ class EventFrequencyForm(forms.Form):
         choices=[
             (key, label)
             for key, (label, duration
-                      ) in sorted(intervals.items(), key=lambda (key, (label, duration)): duration)
+                      ) in sorted(intervals.items(), key=lambda key_label_duration: key_label_duration[1][1])
         ]
     )
     value = forms.IntegerField(

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -16,9 +16,9 @@ def get_application_chunks(exception):
     application code "chunks": blocks of contiguously called application code.
     """
     return map(
-        lambda (in_app, frames): list(frames),
+        lambda in_app_frames2: list(in_app_frames2[1]),
         itertools.ifilter(
-            lambda (in_app, frames): in_app,
+            lambda in_app_frames: in_app_frames[0],
             itertools.groupby(
                 exception.stacktrace.frames,
                 key=lambda frame: frame.in_app,
@@ -180,9 +180,9 @@ class FeatureSet(object):
                         labels.append(label)
 
         return map(
-            lambda (key, scores): (
-                int(key),
-                dict(zip(labels, scores)),
+            lambda key_scores: (
+                int(key_scores[0]),
+                dict(zip(labels, key_scores[1])),
             ),
             self.index.classify(
                 scope,
@@ -201,9 +201,9 @@ class FeatureSet(object):
         items = [(self.aliases[label], thresholds.get(label, 0), ) for label in features]
 
         return map(
-            lambda (key, scores): (
-                int(key),
-                dict(zip(features, scores)),
+            lambda key_scores1: (
+                int(key_scores1[0]),
+                dict(zip(features, key_scores1[1])),
             ),
             self.index.compare(
                 self.__get_scope(group.project),

--- a/src/sentry/south_migrations/0213_migrate_file_blobs.py
+++ b/src/sentry/south_migrations/0213_migrate_file_blobs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 import six
 
 from collections import defaultdict

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -18,6 +18,8 @@ from sentry.models import (
 from sentry.similarity import features
 from sentry.tasks.base import instrumented_task
 
+from six.moves import reduce
+
 
 def cache(function):
     results = {}

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -431,7 +431,7 @@ class PluginTestCase(TestCase):
 
         # Old plugins, plugin is a class, new plugins, it's an instance
         # New plugins don't need to be registered
-        if isinstance(self.plugin, (type, types.ClassType)):
+        if isinstance(self.plugin, type):
             plugins.register(self.plugin)
             self.addCleanup(plugins.unregister, self.plugin)
 

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -18,7 +18,7 @@ def shingle(n, iterator):
     """
     return itertools.izip(
         *map(
-            lambda (i, iterator): advance(i, iterator),
+            lambda i_iterator: advance(i_iterator[0], i_iterator[1]),
             enumerate(itertools.tee(iterator, n)),
         )
     )

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -29,7 +29,7 @@ def safe_execute(func, *args, **kwargs):
             result = func(*args, **kwargs)
     except Exception as e:
         if hasattr(func, 'im_class'):
-            cls = func.im_class
+            cls = func.__self__.__class__
         else:
             cls = func.__class__
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -34,6 +34,9 @@ from sentry.utils.samples import load_data
 from sentry.web.decorators import login_required
 from sentry.web.helpers import render_to_response, render_to_string
 
+from six.moves import xrange
+
+
 logger = logging.getLogger(__name__)
 
 loremipsum = Generator()

--- a/src/south/migration/__init__.py
+++ b/src/south/migration/__init__.py
@@ -112,7 +112,7 @@ def get_dependencies(target, migrations):
         # When migrating backwards we want to remove up to and
         # including the next migration up in this app (not the next
         # one, that includes other apps)
-        migration_before_here = target.next()
+        migration_before_here = next(target)
         if migration_before_here:
             backwards = migration_before_here.backwards_plan
     return forwards, backwards
@@ -206,7 +206,7 @@ def migrate_app(migrations, target_name=None, merge=False, fake=False, db_dry_ru
             target_name = 'zero'
     elif target_name == 'current+1':
         try:
-            first_unapplied_migration = get_unapplied_migrations(migrations, applied).next()
+            first_unapplied_migration = next(get_unapplied_migrations(migrations, applied))
             target_name = first_unapplied_migration.name()
         except StopIteration:
             target_name = None

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -8,6 +8,8 @@ from sentry.digests.backends.base import InvalidState
 from sentry.digests.backends.redis import RedisBackend
 from sentry.testutils import TestCase
 
+from six.moves import xrange
+
 
 class RedisBackendTestCase(TestCase):
     def test_basic(self):

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -18,6 +18,7 @@ from sentry.digests.notifications import (
 )
 from sentry.models import Rule
 from sentry.testutils import TestCase
+from functools import reduce
 
 
 class RewriteRecordTestCase(TestCase):

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -10,6 +10,8 @@ from sentry.testutils import TestCase
 from sentry.models import GroupSnooze, GroupTagKey
 from sentry.tsdb import backend as tsdb
 
+from six.moves import xrange
+
 
 class GroupSnoozeTest(TestCase):
     sequence = itertools.count()  # generates unique values, class scope doesn't matter

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import mock
 import six
 import time
+from six.moves import xrange
 
 from exam import fixture, patcher
 

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -15,8 +15,6 @@ from sentry.rules.conditions.event_frequency import (
 from sentry.testutils.cases import RuleTestCase
 
 
-
-
 class FrequencyConditionMixin(object):
     def increment(self, event, count, timestamp=None):
         raise NotImplementedError

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -6,12 +6,15 @@ from datetime import datetime, timedelta
 
 import mock
 import six
+from six.moves import xrange
 
 from sentry.tsdb import backend as tsdb
 from sentry.rules.conditions.event_frequency import (
     EventFrequencyCondition, EventUniqueUserFrequencyCondition
 )
 from sentry.testutils.cases import RuleTestCase
+
+
 
 
 class FrequencyConditionMixin(object):

--- a/tests/sentry/similarity/test_signatures.py
+++ b/tests/sentry/similarity/test_signatures.py
@@ -22,7 +22,7 @@ class MinHashSignatureBuilderTestCase(TestCase):
 
         results = Counter(
             map(
-                lambda (l, r): l == r,
+                lambda l_r: l_r[0] == l_r[1],
                 zip(
                     get_signature(a),
                     get_signature(b),

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -19,6 +19,8 @@ from sentry.tasks.reports import (
 from sentry.testutils.cases import TestCase
 from sentry.utils.dates import to_datetime, to_timestamp
 
+from six.moves import xrange
+
 
 @pytest.yield_fixture(scope="module")
 def interval():

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -26,6 +26,9 @@ from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
 from sentry.utils import redis
 
+from six.moves import xrange
+
+
 # Use the default redis client as a cluster client in the similarity index
 index = _make_index_backend(redis.clusters.get('default').get_local_client(0))
 

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -9,6 +9,8 @@ from sentry.testutils import TestCase
 from sentry.tsdb.base import BaseTSDB, ONE_MINUTE, ONE_HOUR, ONE_DAY
 from sentry.utils.dates import to_timestamp
 
+from six.moves import xrange
+
 
 class BaseTSDBTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/test_iterators.py
+++ b/tests/sentry/utils/test_iterators.py
@@ -4,6 +4,8 @@ import pytest
 
 from sentry.utils.iterators import advance, chunked, shingle
 
+from six.moves import xrange
+
 
 def test_chunked():
     assert list(chunked(range(5), 5)) == [

--- a/tests/sentry/web/frontend/test_project_plugins.py
+++ b/tests/sentry/web/frontend/test_project_plugins.py
@@ -39,8 +39,8 @@ class ManageProjectPluginsTest(TestCase):
                 key__in=[
                     'auto_tag:_operating_systems:enabled', 'auto_tag:_urls:enabled',
                     'mail:enabled',
-                ],
-            ),
+                ]
+            )
         )
         assert opts.get('auto_tag:_operating_systems:enabled') is True
         assert opts.get('auto_tag:_urls:enabled') is True


### PR DESCRIPTION
A more automated approach than #5921  

Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There would _definitely_ be much more work required to complete the port to Python 3 but this is a minimal, safe first step.

1. Run: `futurize --stage1 -w **/*.py`

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py` # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`

2. Make some of the manual changes in #5921 to fix a few Python 3 syntax errors