### PR TITLE
build(travis): use node 8.9.1 and yarn 1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ env:
     - PIP_DISABLE_PIP_VERSION_CHECK=on
     - SENTRY_LIGHT_BUILD=1
     - SENTRY_SKIP_BACKEND_VALIDATION=1
-    - TRAVIS_NODE_VERSION=4
+    - TRAVIS_NODE_VERSION=8.9.1
     - CXX=g++-4.8
     - SOUTH_TESTS_MIGRATE=1
 install:
   - nvm install $TRAVIS_NODE_VERSION
-  - npm install -g yarn@0.27.5
+  - npm install -g yarn@1.3.2
   - make travis-install-$TEST_SUITE
 before_script:
   - pip freeze

--- a/docs/installation/python/index.rst
+++ b/docs/installation/python/index.rst
@@ -21,7 +21,7 @@ Some basic prerequisites which you'll need in order to run Sentry:
 
 If you're building from source you'll also need:
 
-* Node.js 4.0 or newer.
+* Node.js 8.0 or newer.
 
 Setting up an Environment
 -------------------------


### PR DESCRIPTION
This seems to decrease jest run times by > 50%