### PR TITLE
fix(workflow): fix similarity for null scores

### DIFF
--- a/src/sentry/static/sentry/app/components/similarScoreCard.jsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.jsx
@@ -47,7 +47,7 @@ const SimilarScoreCard = React.createClass({
             <div
               className={classNames(
                 'similar-score-quantity',
-                scoreClassNames[Math.round(score * 5)]
+                score === null ? 'empty' : scoreClassNames[Math.round(score * 5)]
               )}
             />
           </SpreadLayout>

--- a/src/sentry/static/sentry/app/stores/groupingStore.jsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.jsx
@@ -150,7 +150,10 @@ const GroupingStore = Reflux.createStore({
         // Aggregate score by interface
         let aggregate = Object.keys(scoresByInterface)
           .map(interfaceName => [interfaceName, scoresByInterface[interfaceName]])
-          .reduce((acc, [interfaceName, scores]) => {
+          .reduce((acc, [interfaceName, allScores]) => {
+            // `null` scores means feature was not present in both issues, do not
+            // include in aggregate
+            let scores = allScores.filter(([, score]) => score !== null);
             let avg = scores.reduce((sum, [, score]) => sum + score, 0) / scores.length;
             acc[interfaceName] = avg;
             return acc;

--- a/src/sentry/static/sentry/less/similar-scores.less
+++ b/src/sentry/static/sentry/less/similar-scores.less
@@ -1,6 +1,9 @@
 @import './palette.less';
 
 .similar-scores {
+  &.empty {
+    background-color: @gray-lightest;
+  }
   &.low {
     background-color: @orange;
   }

--- a/tests/js/spec/components/__snapshots__/similarScoreCard.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/similarScoreCard.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`SimilarScoreCard renders with score list 1`] = `
   >
     <div />
     <div
-      className="similar-score-quantity low"
+      className="similar-score-quantity empty"
     />
   </SpreadLayout>
   <SpreadLayout

--- a/tests/js/spec/components/similarScoreCard.spec.jsx
+++ b/tests/js/spec/components/similarScoreCard.spec.jsx
@@ -20,7 +20,7 @@ describe('SimilarScoreCard', function() {
     let wrapper = shallow(
       <SimilarScoreCard
         scoreList={[
-          ['exception,message,character-shingles', 0.2],
+          ['exception,message,character-shingles', null],
           ['exception,stacktrace,application-chunks', 0.8],
           ['exception,stacktrace,pairs', 1],
           ['message,message,character-shingles', 0.5]

--- a/tests/js/spec/stores/__snapshots__/groupingStore.spec.jsx.snap
+++ b/tests/js/spec/stores/__snapshots__/groupingStore.spec.jsx.snap
@@ -88,6 +88,44 @@ Object {
         ],
       },
     },
+    Object {
+      "aggregate": Object {
+        "exception": 0.25,
+        "message": 0.7,
+      },
+      "isBelowThreshold": false,
+      "issue": Object {
+        "id": "217",
+      },
+      "score": Object {
+        "exception:message:character-shingles": null,
+        "exception:stacktrace:application-chunks": 0.25,
+        "exception:stacktrace:pairs": 0.25,
+        "message:message:character-shingles": 0.7,
+      },
+      "scoresByInterface": Object {
+        "exception": Array [
+          Array [
+            "exception:message:character-shingles",
+            null,
+          ],
+          Array [
+            "exception:stacktrace:application-chunks",
+            0.25,
+          ],
+          Array [
+            "exception:stacktrace:pairs",
+            0.25,
+          ],
+        ],
+        "message": Array [
+          Array [
+            "message:message:character-shingles",
+            0.7,
+          ],
+        ],
+      },
+    },
   ],
   "similarLinks": undefined,
   "unmergeState": Array [],

--- a/tests/js/spec/stores/groupingStore.spec.jsx
+++ b/tests/js/spec/stores/groupingStore.spec.jsx
@@ -84,6 +84,17 @@ describe('Grouping Store', function() {
             'exception:stacktrace:application-chunks': 0.000235,
             'exception:stacktrace:pairs': 0.001488
           }
+        ],
+        [
+          {
+            id: '217'
+          },
+          {
+            'exception:message:character-shingles': null,
+            'exception:stacktrace:application-chunks': 0.25,
+            'exception:stacktrace:pairs': 0.25,
+            'message:message:character-shingles': 0.7
+          }
         ]
       ]
     });
@@ -124,7 +135,7 @@ describe('Grouping Store', function() {
       let arg = calls[calls.length - 1][0];
 
       expect(arg.filteredSimilarItems.length).toBe(1);
-      expect(arg.similarItems.length).toBe(2);
+      expect(arg.similarItems.length).toBe(3);
       expect(arg).toMatchObject({
         loading: false,
         error: false,
@@ -141,6 +152,12 @@ describe('Grouping Store', function() {
             isBelowThreshold: false,
             issue: {
               id: '275'
+            }
+          },
+          {
+            isBelowThreshold: false,
+            issue: {
+              id: '217'
             }
           }
         ],
@@ -182,6 +199,20 @@ describe('Grouping Store', function() {
           unmergeState: new Map()
         });
       });
+    });
+
+    it('ignores null scores in aggregate', async function() {
+      await GroupingStore.onFetch([
+        {dataKey: 'similar', endpoint: '/issues/groupId/similar/'}
+      ]);
+
+      expect(trigger).toBeCalled();
+      let calls = trigger.mock.calls;
+      let arg = calls[calls.length - 1][0];
+
+      let item = arg.similarItems.find(({issue}) => issue.id === '217');
+      expect(item.aggregate.exception).toBe(0.25);
+      expect(item.aggregate.message).toBe(0.7);
     });
 
     it('fetches list of hashes', function() {


### PR DESCRIPTION
Do not aggregate features with a `null` score.
Show "empty" bar in score tooltip for `null` scores.