### PR TITLE
perf(similarity): add upper limit on candidate query

### DIFF
--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -83,6 +83,7 @@ def _make_index_backend(cluster=None):
         8,
         60 * 60 * 24 * 30,
         3,
+        5000,
     )
 
 

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -21,13 +21,15 @@ def flatten(value):
 
 
 class RedisMinHashIndexBackend(AbstractIndexBackend):
-    def __init__(self, cluster, namespace, signature_builder, bands, interval, retention):
+    def __init__(self, cluster, namespace, signature_builder,
+                 bands, interval, retention, candidate_set_limit):
         self.cluster = cluster
         self.namespace = namespace
         self.signature_builder = signature_builder
         self.bands = bands
         self.interval = interval
         self.retention = retention
+        self.candidate_set_limit = candidate_set_limit
 
     def _build_signature_arguments(self, features):
         if not features:
@@ -91,6 +93,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
             limit if limit is not None else -1,
         ]
@@ -112,6 +115,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
             limit if limit is not None else -1,
             key,
@@ -136,6 +140,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
             key,
         ]
@@ -157,6 +162,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
             destination,
         ]
@@ -177,6 +183,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
         ]
 
@@ -196,6 +203,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
         ]
 
@@ -232,6 +240,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
         ]
 
@@ -251,6 +260,7 @@ class RedisMinHashIndexBackend(AbstractIndexBackend):
             self.bands,
             self.interval,
             self.retention,
+            self.candidate_set_limit,
             scope,
         ]
 

--- a/tests/sentry/similarity/test_index.py
+++ b/tests/sentry/similarity/test_index.py
@@ -23,6 +23,7 @@ class RedisMinHashIndexBackendTestCase(TestCase):
             16,
             60 * 60,
             12,
+            10,
         )
 
     def test_basic(self):
@@ -102,6 +103,7 @@ class RedisMinHashIndexBackendTestCase(TestCase):
             self.index.bands,
             self.index.interval,
             self.index.retention,
+            self.index.candidate_set_limit,
         ).compare('example', '1', [('index', 0)]) == []
 
     def test_multiple_index(self):


### PR DESCRIPTION
This prevents bad queries from being worse and blocking the request queue.

This, incidentally, should improve performance — `SMEMBERS` is *typically* `O(N)`, but when called from a Redis script, it's implicitly lexicographically sorted to preserve a deterministic order in the script[1], which likely ends up being `O(N log N)` instead. Using `SRANDMEMBER` should remain `O(N)` where `N` is the number of items requested, but it causes the script to be marked as read-only after `SRANDMEMBER` is called if you're not using script effects replication (we try to enable it at the beginning of the script, but don't require it.) This should be OK for us — for now at least — since we only call `SRANDMEMBER` as part of fetching candidates on read-only commands anyway.

1: https://redis.io/commands/eval#scripts-as-pure-functions