### PR TITLE
fix(deletion): Ensure delete_repository is called when deleting orgs

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -268,6 +268,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 kwargs={
                     'object_id': organization.id,
                     'transaction_id': transaction_id,
+                    'actor_id': request.user.id,
                 },
                 countdown=countdown,
             )

--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function
 
+from sentry.signals import pending_delete
+
 from ..base import ModelDeletionTask, ModelRelation
 
 
@@ -10,3 +12,11 @@ class RepositoryDeletionTask(ModelDeletionTask):
         return [
             ModelRelation(Commit, {'repository_id': instance.id}),
         ]
+
+    def delete_instance(self, instance):
+        pending_delete.send(
+            sender=type(instance),
+            instance=instance,
+            actor=self.get_actor(),
+        )
+        return super(RepositoryDeletionTask, self).delete_instance(instance)

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -133,7 +133,7 @@ def revoke_api_tokens(object_id, transaction_id=None, timestamp=None, **kwargs):
     max_retries=MAX_RETRIES
 )
 @retry(exclude=(DeleteAborted, ))
-def delete_organization(object_id, transaction_id=None, **kwargs):
+def delete_organization(object_id, transaction_id=None, actor_id=None, **kwargs):
     from sentry import deletions
     from sentry.models import Organization, OrganizationStatus
 
@@ -158,12 +158,14 @@ def delete_organization(object_id, transaction_id=None, **kwargs):
             'id': object_id,
         },
         transaction_id=transaction_id or uuid4().hex,
+        actor_id=actor_id,
     )
     has_more = task.chunk()
     if has_more:
         delete_organization.apply_async(
             kwargs={'object_id': object_id,
-                    'transaction_id': transaction_id},
+                    'transaction_id': transaction_id,
+                    'actor_id': actor_id},
             countdown=15,
         )
 

--- a/src/sentry/web/frontend/remove_organization.py
+++ b/src/sentry/web/frontend/remove_organization.py
@@ -62,6 +62,7 @@ class RemoveOrganizationView(OrganizationView):
                     kwargs={
                         'object_id': organization.id,
                         'transaction_id': transaction_id,
+                        'actor_id': request.user.id,
                     },
                     countdown=countdown,
                 )

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -321,6 +321,7 @@ class OrganizationDeleteTest(APITestCase):
             kwargs={
                 'object_id': org.id,
                 'transaction_id': 'abc123',
+                'actor_id': user.id,
             },
             countdown=86400,
         )

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -20,6 +20,7 @@ class DeleteOrganizationTest(TestCase):
         repo = Repository.objects.create(
             organization_id=org.id,
             name=org.name,
+            provider='dummy',
         )
         commit_author = CommitAuthor.objects.create(
             organization_id=org.id,

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from datetime import datetime, timedelta
+from mock import patch
 from uuid import uuid4
 
 import pytest
@@ -14,6 +15,7 @@ from sentry.models import (
     OrganizationStatus, Project, ProjectStatus, Release, ReleaseCommit, ReleaseEnvironment,
     Repository, TagKey, TagValue, Team, TeamStatus
 )
+from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
 from sentry.tasks.deletion import (
     delete_api_application, delete_group, delete_organization, delete_project, delete_repository,
     delete_tag_key, delete_team, generic_delete, revoke_api_tokens
@@ -27,6 +29,7 @@ class DeleteOrganizationTest(TestCase):
             name='test',
             status=OrganizationStatus.PENDING_DELETION,
         )
+        user = self.create_user()
         self.create_team(organization=org, name='test1')
         self.create_team(organization=org, name='test2')
         release = Release.objects.create(version='a' * 32, organization_id=org.id)
@@ -59,7 +62,9 @@ class DeleteOrganizationTest(TestCase):
         )
 
         with self.tasks():
-            delete_organization(object_id=org.id)
+            with patch.object(DummyRepositoryProvider, 'delete_repository') as mock_delete_repo:
+                delete_organization(object_id=org.id, actor_id=user.id)
+                mock_delete_repo.assert_called_once()  # NOQA
 
         assert not Organization.objects.filter(id=org.id).exists()
         assert not Environment.objects.filter(id=env.id).exists()

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -33,6 +33,7 @@ class DeleteOrganizationTest(TestCase):
         repo = Repository.objects.create(
             organization_id=org.id,
             name=org.name,
+            provider='dummy',
         )
         commit_author = CommitAuthor.objects.create(
             organization_id=org.id,

--- a/tests/sentry/web/frontend/test_remove_organization.py
+++ b/tests/sentry/web/frontend/test_remove_organization.py
@@ -69,6 +69,7 @@ class RemoveOrganizationTest(TestCase):
             kwargs={
                 'object_id': org.id,
                 'transaction_id': 'abc123',
+                'actor_id': self.user.id,
             },
             countdown=86400,
         )


### PR DESCRIPTION
fixes SENTRY-3B4

we need to make sure the webhook gets deleted


cc @getsentry/workflow 