### PR TITLE
feat(api): Allow to change team of a project via API

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Version 8.21 (Unreleased)
 
 - Ignore querystrings when looking up release artifacts
 - Add Visual Studio authentication provider for plugins.
+- Add "team" parameter to the project details API.
 
 Version 8.20
 ------------


### PR DESCRIPTION
This pull request introduces a new parameter to the project details API for changing team of a project.

cc @getsentry/api