### PR TITLE
Fix returning a string of json instead of just json

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -883,7 +883,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         else:
             # missing any kind of filter
             return Response(
-                '{"detail": "You must specify a list of IDs for this operation"}', status=400
+                {"detail": "You must specify a list of IDs for this operation"}, status=400
             )
 
         if not group_list:


### PR DESCRIPTION
This fixes a issue with go-sentry-api and it not being able to Unmarshal this error response. 