### PR TITLE
feat(analytics): Add Google PubSub backend

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -15,6 +15,8 @@ email-reply-parser>=0.2.0,<0.3.0
 enum34>=0.9.18,<1.2.0
 exam>=0.5.1
 google-cloud-pubsub>=0.28.3,<0.29
+# See https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4001
+grpcio==1.4.0
 # broken on python3
 hiredis>=0.1.0,<0.2.0
 honcho>=0.7.0,<0.8.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -14,6 +14,7 @@ djangorestframework>=2.4.8,<2.5.0
 email-reply-parser>=0.2.0,<0.3.0
 enum34>=0.9.18,<1.2.0
 exam>=0.5.1
+google-cloud-pubsub>=0.28.3,<0.29
 # broken on python3
 hiredis>=0.1.0,<0.2.0
 honcho>=0.7.0,<0.8.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -14,9 +14,6 @@ djangorestframework>=2.4.8,<2.5.0
 email-reply-parser>=0.2.0,<0.3.0
 enum34>=0.9.18,<1.2.0
 exam>=0.5.1
-google-cloud-pubsub>=0.28.3,<0.29
-# See https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4001
-grpcio==1.4.0
 # broken on python3
 hiredis>=0.1.0,<0.2.0
 honcho>=0.7.0,<0.8.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,1 +1,4 @@
+google-cloud-pubsub>=0.28.3,<0.29
+# See https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4001
+grpcio==1.4.0
 python3-saml>=1.2.6,<1.3

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 __all__ = ('Attribute', 'Event', 'Map')
 
 import six
+from uuid import uuid1
 
 from collections import Mapping
 from django.utils import timezone
@@ -68,13 +69,15 @@ class Map(Attribute):
 
 
 class Event(object):
-    __slots__ = ['attributes', 'data', 'datetime', 'type']
+    __slots__ = ['guid', 'attributes', 'data', 'datetime', 'type']
 
     type = None
 
     attributes = ()
 
     def __init__(self, type=None, datetime=None, **items):
+        self.guid = uuid1().hex
+
         self.datetime = datetime or timezone.now()
         if type is not None:
             self.type = type
@@ -101,6 +104,7 @@ class Event(object):
     def serialize(self):
         return dict(
             {
+                'guid': self.guid,
                 'timestamp': int(self.datetime.strftime('%s')),
                 'type': self.type,
             }, **self.data

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -101,7 +101,7 @@ class Event(object):
     def serialize(self):
         return dict(
             {
-                'timestamp': int(self.datetime.isoformat('%s')),
+                'timestamp': int(self.datetime.strftime('%s')),
                 'type': self.type,
             }, **self.data
         )

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -4,6 +4,7 @@ __all__ = ('Attribute', 'Event', 'Map')
 
 import six
 from uuid import uuid1
+from base64 import b64encode
 
 from collections import Mapping
 from django.utils import timezone
@@ -78,7 +79,7 @@ class Event(object):
     attributes = ()
 
     def __init__(self, type=None, datetime=None, **items):
-        self.guid = uuid1().hex
+        self.guid = uuid1()
 
         self.datetime = datetime or timezone.now()
         if type is not None:
@@ -104,13 +105,12 @@ class Event(object):
         self.data = data
 
     def serialize(self):
-        return dict(
-            {
-                'guid': self.guid,
-                'timestamp': int(to_timestamp(self.datetime) * 1000000),
-                'type': self.type,
-            }, **self.data
-        )
+        return {
+            'guid': b64encode(self.guid.bytes),
+            'timestamp': to_timestamp(self.datetime),
+            'type': self.type,
+            'data': self.data,
+        }
 
     @classmethod
     def from_instance(cls, instance, **kwargs):

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -8,6 +8,8 @@ from uuid import uuid1
 from collections import Mapping
 from django.utils import timezone
 
+from sentry.utils.dates import to_timestamp
+
 
 class Attribute(object):
     def __init__(self, name, type=six.text_type, required=True):
@@ -105,7 +107,7 @@ class Event(object):
         return dict(
             {
                 'guid': self.guid,
-                'timestamp': int(self.datetime.strftime('%s')),
+                'timestamp': int(to_timestamp(self.datetime) * 1000000),
                 'type': self.type,
             }, **self.data
         )

--- a/src/sentry/analytics/pubsub.py
+++ b/src/sentry/analytics/pubsub.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+__all__ = ('PubSubAnalytics',)
+
+from sentry.utils.json import dumps
+from google.cloud import pubsub_v1
+
+from .base import Analytics
+
+
+class PubSubAnalytics(Analytics):
+    def __init__(self, project, topic, batch_max_bytes=1024 * 100, batch_max_latency=1):
+        settings = pubsub_v1.types.BatchSettings(
+            max_bytes=batch_max_bytes,
+            max_latency=batch_max_latency,
+        )
+        self.publisher = pubsub_v1.PublisherClient(settings)
+        self.topic = self.publisher.topic_path(project, topic)
+
+    def record_event(self, event):
+        self.publisher.publish(
+            self.topic,
+            data=dumps(event.serialize()),
+        )

--- a/src/sentry/analytics/pubsub.py
+++ b/src/sentry/analytics/pubsub.py
@@ -9,10 +9,12 @@ from .base import Analytics
 
 
 class PubSubAnalytics(Analytics):
-    def __init__(self, project, topic, batch_max_bytes=1024 * 100, batch_max_latency=1):
+    def __init__(self, project, topic, batch_max_bytes=1024 * 1024 *
+                 5, batch_max_latency=0.05, batch_max_messages=1000):
         settings = pubsub_v1.types.BatchSettings(
             max_bytes=batch_max_bytes,
             max_latency=batch_max_latency,
+            max_messages=batch_max_messages,
         )
         self.publisher = pubsub_v1.PublisherClient(settings)
         self.topic = self.publisher.topic_path(project, topic)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -833,6 +833,7 @@ SENTRY_FILESTORE_ALIASES = {
 
 SENTRY_ANALYTICS_ALIASES = {
     'noop': 'sentry.analytics.Analytics',
+    'pubsub': 'sentry.analytics.PubSubAnalytics',
 }
 
 # set of backends that do not support needing SMTP mail.* settings

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -833,7 +833,7 @@ SENTRY_FILESTORE_ALIASES = {
 
 SENTRY_ANALYTICS_ALIASES = {
     'noop': 'sentry.analytics.Analytics',
-    'pubsub': 'sentry.analytics.PubSubAnalytics',
+    'pubsub': 'sentry.analytics.pubsub.PubSubAnalytics',
 }
 
 # set of backends that do not support needing SMTP mail.* settings

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+from datetime import datetime
 import pytest
+import pytz
 
 from sentry.analytics import Attribute, Event, Map
 from sentry.testutils import TestCase
@@ -21,13 +23,27 @@ class DummyType(object):
 
 class EventTest(TestCase):
     def test_simple(self):
-        result = ExampleEvent(id='1', map={'key': 'value'}, optional=False)
+        result = ExampleEvent(
+            id='1',
+            map={'key': 'value'},
+            optional=False,
+            datetime=datetime(2001, 4, 18, tzinfo=pytz.utc)
+        )
         assert result.data == {
             'id': 1,
             'map': {
                 'key': 'value',
             },
             'optional': False,
+        }
+        assert result.serialize() == {
+            'id': 1,
+            'map': {
+                'key': 'value',
+            },
+            'optional': False,
+            'type': 'example',
+            'timestamp': 987552000,
         }
 
     def test_optional_is_optional(self):

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from datetime import datetime
+from mock import patch
 import pytest
 import pytz
 
@@ -22,7 +23,13 @@ class DummyType(object):
 
 
 class EventTest(TestCase):
-    def test_simple(self):
+    @patch('sentry.analytics.event.uuid1')
+    def test_simple(self, mock_uuid1):
+        class uuid(object):
+            hex = 'abc123'
+
+        mock_uuid1.return_value = uuid
+
         result = ExampleEvent(
             id='1',
             map={'key': 'value'},
@@ -44,6 +51,7 @@ class EventTest(TestCase):
             'optional': False,
             'type': 'example',
             'timestamp': 987552000,
+            'guid': 'abc123',
         }
 
     def test_optional_is_optional(self):

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -26,7 +26,7 @@ class EventTest(TestCase):
     @patch('sentry.analytics.event.uuid1')
     def test_simple(self, mock_uuid1):
         class uuid(object):
-            hex = 'abc123'
+            bytes = b'\x00\x01\x02'
 
         mock_uuid1.return_value = uuid
 
@@ -44,14 +44,16 @@ class EventTest(TestCase):
             'optional': False,
         }
         assert result.serialize() == {
-            'id': 1,
-            'map': {
-                'key': 'value',
+            'data': {
+                'id': 1,
+                'map': {
+                    'key': 'value',
+                },
+                'optional': False,
             },
-            'optional': False,
             'type': 'example',
             'timestamp': 987552000,
-            'guid': 'abc123',
+            'guid': 'AAEC',
         }
 
     def test_optional_is_optional(self):


### PR DESCRIPTION
Replaces #5420

Decided that the best way moving forward was to simply write into PubSub instead of directly into BigQuery. PubSub provides being able to natively send batches asynchronously instead of BigQuery streaming inserts being done synchronously.

Having events flow into PubSub also gives us significantly more flexibility like being able to attach multiple subscribers to the data to do different things with it. Like, archiving into Google Storage for long term, and writing in BQ. Or reprocessing old/raw data.

cc @ehfeng 