### PR TITLE
feat(south): Add flag to skip over running dangerous migrations automatically

### DIFF
--- a/src/south/management/commands/datamigration.py
+++ b/src/south/management/commands/datamigration.py
@@ -126,6 +126,10 @@ from django.db import models
 
 class Migration(DataMigration):
 
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = False
+
     def forwards(self, orm):
         db.commit_transaction()
         try:

--- a/src/south/management/commands/schemamigration.py
+++ b/src/south/management/commands/schemamigration.py
@@ -232,6 +232,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = False
+
     def forwards(self, orm):
 %(forwards)s
 


### PR DESCRIPTION
This allows us to flag certain migrations that we want to coordinate rather than simply plowing out through Freight. Some of our more expensive tables can't be altered without coordinating shutting down workers, and the current process is very error prone and tedious with a fear of a migration in master can take the service down.