### PR TITLE
fix: Skip similarity feature deletion during cleanup

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -38,7 +38,8 @@ class GroupDeletionTask(ModelDeletionTask):
     def delete_instance(self, instance):
         from sentry.similarity import features
 
-        features.delete(instance)
+        if not self.skip_models or features not in self.skip_models:
+            features.delete(instance)
 
         return super(GroupDeletionTask, self).delete_instance(instance)
 

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -14,7 +14,6 @@ import click
 from django.utils import timezone
 
 from sentry.runner.decorators import configuration, log_options
-from sentry import similarity
 
 
 def get_project(value):
@@ -77,6 +76,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
     from sentry.db.deletion import BulkDeleteQuery
     from sentry import deletions
     from sentry import models
+    from sentry import similarity
 
     if timed:
         import time

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -14,6 +14,7 @@ import click
 from django.utils import timezone
 
 from sentry.runner.decorators import configuration, log_options
+from sentry import similarity
 
 
 def get_project(value):
@@ -199,12 +200,15 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
                 query=query,
                 order_by=order_by,
                 skip_models=[
+                    # Handled by other parts of cleanup
                     models.Event,
                     models.EventMapping,
                     models.EventTag,
                     models.GroupEmailThread,
                     models.GroupRuleStatus,
                     models.GroupTagValue,
+                    # Handled by TTL
+                    similarity.features,
                 ],
                 transaction_id=uuid4().hex,
             )


### PR DESCRIPTION
Not sure how gross it is to call `similarity.features` a "model."

But I think it's better than adding another special `kwarg` to deletions just for this. I could rename the argument if it helps...? 😬 