### PR TITLE
feat(api): Accept higher precision timestamp on event ingestion

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -356,7 +356,7 @@ class ClientApiHelper(object):
             raise InvalidTimestamp(
                 'Invalid value for timestamp (too old): %r' % value)
 
-        data['timestamp'] = float(value.strftime('%s'))
+        data['timestamp'] = float(value.strftime('%s.%f'))
 
         return data
 

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -335,7 +335,7 @@ class ClientApiHelper(object):
                 # Python doesn't support long microsecond values
                 # https://github.com/getsentry/sentry/issues/1610
                 ts_bits = value.split('.', 1)
-                value = '%s.%s' % (ts_bits[0], ts_bits[1][:2])
+                value = '%s.%s' % (ts_bits[0], ts_bits[1][:6])
                 fmt = '%Y-%m-%dT%H:%M:%S.%f'
             else:
                 fmt = '%Y-%m-%dT%H:%M:%S'

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -164,7 +164,7 @@ class ProcessDataTimestampTest(BaseAPITest):
             }, current_datetime=d
         )
         self.assertTrue('timestamp' in data)
-        self.assertEquals(data['timestamp'], 1325413845.0)
+        self.assertEquals(data['timestamp'], 1325413845.434)
 
     def test_timestamp_iso_timestamp_with_Z(self):
         d = datetime(2012, 1, 1, 10, 30, 45)
@@ -201,7 +201,17 @@ class ProcessDataTimestampTest(BaseAPITest):
             }, current_datetime=d
         )
         self.assertTrue('timestamp' in data)
-        self.assertEquals(data['timestamp'], 1325413845.0)
+        self.assertEquals(data['timestamp'], 1325413845.341324)
+
+    def test_too_long_microseconds_value(self):
+        d = datetime(2012, 1, 1, 10, 30, 45)
+        data = self.helper._process_data_timestamp(
+            {
+                'timestamp': '2012-01-01T10:30:45.341324999999999Z'
+            }, current_datetime=d
+        )
+        self.assertTrue('timestamp' in data)
+        self.assertEquals(data['timestamp'], 1325413845.341324)
 
 
 class ValidateDataTest(BaseAPITest):


### PR DESCRIPTION
Turns out there were two separate problems here:

* Timestamps were being truncated to 2 decimal places, which is more aggressively than needed since Python can safely handle 6.
* When converting the `datetime` that was parsed back into a float, all decimal was dropped anyways, so no matter what, we only got full second precision.

Specifically adding @dcramer as reviewer since not sure what in here was intentional or not. But this seems safe to do.