### PR TITLE
fix(release-tracking): Drop token regenerate button down

### DIFF
--- a/src/sentry/static/sentry/app/views/projectReleaseTracking.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleaseTracking.jsx
@@ -207,6 +207,8 @@ const ProjectReleaseTracking = React.createClass({
                 <code style={{display: 'inlineBlock'}} className="auto-select">
                   {this.state.token}
                 </code>
+              </p>
+              <p>
                 <button
                   type="submit"
                   className="btn btn-sm btn-danger"


### PR DESCRIPTION
![localhost_8000_sentry-4v_python_settings_release-tracking_ 2](https://user-images.githubusercontent.com/1421724/30620995-8f97b17a-9d5d-11e7-9834-67400ee4b28d.png)
↓
![localhost_8000_sentry-4v_python_settings_release-tracking_ 1](https://user-images.githubusercontent.com/1421724/30621032-c7d65f46-9d5d-11e7-97c2-ad77d638e0fb.png)
