### PR TITLE
fix(form-css): Use new-style 'required' markers globally

### DIFF
--- a/src/sentry/static/sentry/less/forms.less
+++ b/src/sentry/static/sentry/less/forms.less
@@ -33,13 +33,20 @@
   }
 }
 
+.control-label.requiredField,
 .form-stacked .required .controls label {
   &:after {
     margin-left: 10px;
+    vertical-align: bottom;
     content: '[required]';
     font-size: 12px;
     color: #999;
     text-transform: uppercase;
+  }
+
+  // Hide the crispy-forms required asterisk
+  .asteriskField {
+    display: none;
   }
 }
 

--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -66,9 +66,9 @@
 
         <input type="hidden" name="op" value="sso" />
 
-        <div class="control-group">
+        <div class="control-group required">
           <div class="controls">
-            <label style="display: block">{% trans "Organization ID" %}*</label>
+            <label class="control-label">{% trans "Organization ID" %}</label>
             <input type="text" class="form-control" name="organization" placeholder="acme" required>
             <p class="help-block">Enter your organization's ID and we'll get things started.</p>
             <p class="help-block">Your ID is the reference used when Sentry generates URLs.<br />e.g. <code>{{ server_hostname }}/<strong>acme</strong>/</code></p>


### PR DESCRIPTION
This makes the 'required' field markers more consistent between the newstyle react forms and 
oldstyle serverside crispy forms.

Some examples:

Login form:
![localhost_8000_auth_login_ 1](https://user-images.githubusercontent.com/1421724/30666794-5302a2a8-9e0a-11e7-9a0a-92a1d365a0f1.png)
![localhost_8000_auth_login_](https://user-images.githubusercontent.com/1421724/30666792-52cb8ad4-9e0a-11e7-9e64-902483545cb6.png)
![localhost_8000_sentry-4v_python_settings_ 1](https://user-images.githubusercontent.com/1421724/30666836-7025b91a-9e0a-11e7-9f34-191001f2192d.png)

Also corrects a minor vertical positioning error.