### PR TITLE
fix(releases): Return 404 when project does not exist in release hook

### DIFF
--- a/src/sentry/web/frontend/release_webhook.py
+++ b/src/sentry/web/frontend/release_webhook.py
@@ -80,7 +80,12 @@ class ReleaseWebhookView(View):
         )
 
     def post(self, request, plugin_id, project_id, signature):
-        project = Project.objects.get_from_cache(id=project_id)
+        try:
+            project = Project.objects.get_from_cache(id=project_id)
+        except Project.DoesNotExist:
+            logger.warn(
+                'Invalid project for release hook project_id=%s', project_id)
+            return HttpResponse(status=404)
 
         logger.info('Incoming webhook for project_id=%s, plugin_id=%s', project_id, plugin_id)
 

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -62,6 +62,18 @@ class ReleaseWebhookTest(TestCase):
         resp = self.client.post(path)
         assert resp.status_code == 403
 
+    def test_invalid_project(self):
+        path = reverse(
+            'sentry-release-hook',
+            kwargs={
+                'project_id': 1000000,
+                'plugin_id': 'dummy',
+                'signature': self.signature,
+            }
+        )
+        resp = self.client.post(path)
+        assert resp.status_code == 404
+
     @patch('sentry.plugins.plugins.get')
     def test_valid_signature(self, mock_plugin_get):
         MockPlugin = mock_plugin_get.return_value


### PR DESCRIPTION
fixes SENTRY-107