### PR TITLE
ref(react): Fix janky loading in org settings

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -1,0 +1,166 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {isEqual} from 'lodash';
+
+import LoadingIndicator from '../components/loadingIndicator';
+import RouteError from './../views/routeError';
+import {Client} from '../api';
+
+class AsyncComponent extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.fetchData = AsyncComponent.errorHandler(this, this.fetchData.bind(this));
+    this.render = AsyncComponent.errorHandler(this, this.render.bind(this));
+
+    this.state = this.getDefaultState();
+  }
+
+  componentWillMount() {
+    this.api = new Client();
+    this.fetchData();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!isEqual(this.props.params, nextProps.params)) {
+      this.remountComponent();
+    }
+  }
+
+  componentWillUnmount() {
+    this.api.clear();
+  }
+
+  // XXX: cant call this getInitialState as React whines
+  getDefaultState() {
+    let endpoints = this.getEndpoints();
+    let state = {
+      // has all data finished requesting?
+      loading: true,
+      // is there an error loading ANY data?
+      error: false,
+      errors: {}
+    };
+    endpoints.forEach(([stateKey, endpoint]) => {
+      state[stateKey] = null;
+    });
+    return state;
+  }
+
+  remountComponent() {
+    this.setState(this.getDefaultState(), this.fetchData);
+  }
+
+  // TODO(dcramer): we'd like to support multiple initial api requests
+  fetchData() {
+    let endpoints = this.getEndpoints();
+    if (!endpoints.length) {
+      this.setState({
+        loading: false,
+        error: false
+      });
+      return;
+    }
+    // TODO(dcramer): this should cancel any existing API requests
+    this.setState({
+      loading: true,
+      error: false,
+      remainingRequests: endpoints.length
+    });
+    endpoints.forEach(([stateKey, endpoint, params]) => {
+      this.api.request(endpoint, {
+        method: 'GET',
+        params,
+        success: (data, _, jqXHR) => {
+          this.setState(prevState => {
+            return {
+              [stateKey]: data,
+              remainingRequests: prevState.remainingRequests - 1,
+              loading: prevState.remainingRequests > 1
+            };
+          });
+        },
+        error: error => {
+          this.setState(prevState => {
+            return {
+              [stateKey]: null,
+              errors: {
+                ...prevState.errors,
+                [stateKey]: error
+              },
+              remainingRequests: prevState.remainingRequests - 1,
+              loading: prevState.remainingRequests > 1,
+              error: true
+            };
+          });
+        }
+      });
+    });
+  }
+
+  // DEPRECATED: use getEndpoints()
+  getEndpointParams() {
+    return {};
+  }
+
+  // DEPRECATED: use getEndpoints()
+  getEndpoint() {
+    return null;
+  }
+
+  /**
+   * Return a list of endpoint queries to make.
+   *
+   * return [
+   *   ['stateKeyName', '/endpoint/', {optional: 'query params'}]
+   * ]
+   */
+  getEndpoints() {
+    let endpoint = this.getEndpoint();
+    if (!endpoint) return [];
+    return [['data', endpoint, this.getEndpointParams()]];
+  }
+
+  renderLoading() {
+    return <LoadingIndicator />;
+  }
+
+  renderError(error) {
+    return <RouteError error={error} component={this} onRetry={this.remountComponent} />;
+  }
+
+  renderComponent() {
+    return this.state.loading
+      ? this.renderLoading()
+      : this.state.error
+          ? this.renderError(new Error('Unable to load all required endpoints'))
+          : this.renderBody();
+  }
+
+  render() {
+    return this.renderComponent();
+  }
+}
+
+AsyncComponent.errorHandler = (component, fn) => {
+  return function(...args) {
+    try {
+      return fn(...args);
+    } catch (err) {
+      /*eslint no-console:0*/
+      setTimeout(() => {
+        throw err;
+      });
+      component.setState({
+        error: err
+      });
+      return null;
+    }
+  };
+};
+
+AsyncComponent.contextTypes = {
+  router: PropTypes.object.isRequired
+};
+
+export default AsyncComponent;

--- a/src/sentry/static/sentry/app/views/asyncView.jsx
+++ b/src/sentry/static/sentry/app/views/asyncView.jsx
@@ -1,171 +1,23 @@
 import DocumentTitle from 'react-document-title';
-import PropTypes from 'prop-types';
 import React from 'react';
-import {isEqual} from 'lodash';
 
-import LoadingIndicator from '../components/loadingIndicator';
-import RouteError from './routeError';
-import {Client} from '../api';
+import AsyncComponent from '../components/asyncComponent';
 
-class AsyncView extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.fetchData = AsyncView.errorHandler(this, this.fetchData.bind(this));
-    this.render = AsyncView.errorHandler(this, this.render.bind(this));
-
-    this.state = this.getDefaultState();
-  }
-
-  componentWillMount() {
-    this.api = new Client();
-    this.fetchData();
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.params, nextProps.params)) {
-      this.remountComponent();
-    }
-  }
-
-  componentWillUnmount() {
-    this.api.clear();
-  }
-
-  // XXX: cant call this getInitialState as React whines
-  getDefaultState() {
-    let endpoints = this.getEndpoints();
-    let state = {
-      // has all data finished requesting?
-      loading: true,
-      // is there an error loading ANY data?
-      error: false,
-      errors: {}
-    };
-    endpoints.forEach(([stateKey, endpoint]) => {
-      state[stateKey] = null;
-    });
-    return state;
-  }
-
-  remountComponent() {
-    this.setState(this.getDefaultState(), this.fetchData);
-  }
-
-  // TODO(dcramer): we'd like to support multiple initial api requests
-  fetchData() {
-    let endpoints = this.getEndpoints();
-    if (!endpoints.length) {
-      this.setState({
-        loading: false,
-        error: false
-      });
-      return;
-    }
-    // TODO(dcramer): this should cancel any existing API requests
-    this.setState({
-      loading: true,
-      error: false,
-      remainingRequests: endpoints.length
-    });
-    endpoints.forEach(([stateKey, endpoint, params]) => {
-      this.api.request(endpoint, {
-        method: 'GET',
-        params,
-        success: (data, _, jqXHR) => {
-          this.setState(prevState => {
-            return {
-              [stateKey]: data,
-              remainingRequests: prevState.remainingRequests - 1,
-              loading: prevState.remainingRequests > 1
-            };
-          });
-        },
-        error: error => {
-          this.setState(prevState => {
-            return {
-              [stateKey]: null,
-              errors: {
-                ...prevState.errors,
-                [stateKey]: error
-              },
-              remainingRequests: prevState.remainingRequests - 1,
-              loading: prevState.remainingRequests > 1,
-              error: true
-            };
-          });
-        }
-      });
-    });
-  }
-
-  // DEPRECATED: use getEndpoints()
-  getEndpointParams() {
-    return {};
-  }
-
-  // DEPRECATED: use getEndpoints()
-  getEndpoint() {
-    return null;
-  }
-
-  /**
-   * Return a list of endpoint queries to make.
-   *
-   * return [
-   *   ['stateKeyName', '/endpoint/', {optional: 'query params'}]
-   * ]
-   */
-  getEndpoints() {
-    let endpoint = this.getEndpoint();
-    if (!endpoint) return [];
-    return [['data', endpoint, this.getEndpointParams()]];
+class AsyncView extends AsyncComponent {
+  constructor(...args) {
+    super(...args);
   }
 
   getTitle() {
     return 'Sentry';
   }
-
-  renderLoading() {
-    return <LoadingIndicator />;
-  }
-
-  renderError(error) {
-    return <RouteError error={error} component={this} onRetry={this.remountComponent} />;
-  }
-
   render() {
     return (
       <DocumentTitle title={this.getTitle()}>
-        {this.state.loading
-          ? this.renderLoading()
-          : this.state.error
-              ? this.renderError(new Error('Unable to load all required endpoints'))
-              : this.renderBody()}
+        {this.renderComponent()}
       </DocumentTitle>
     );
   }
 }
-
-AsyncView.errorHandler = (component, fn) => {
-  return function(...args) {
-    try {
-      return fn(...args);
-    } catch (err) {
-      /*eslint no-console:0*/
-      setTimeout(() => {
-        throw err;
-      });
-      component.setState({
-        error: err
-      });
-      return null;
-    }
-  };
-};
-
-AsyncView.contextTypes = {
-  router: PropTypes.object.isRequired
-};
 
 export default AsyncView;

--- a/src/sentry/static/sentry/app/views/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRepositories.jsx
@@ -1,16 +1,15 @@
+import Modal from 'react-bootstrap/lib/Modal';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Modal from 'react-bootstrap/lib/Modal';
 
-import AsyncView from './asyncView';
 import {FormState} from '../components/forms';
+import {sortArray, parseRepo} from '../utils';
+import {t, tct} from '../locale';
 import DropdownLink from '../components/dropdownLink';
 import IndicatorStore from '../stores/indicatorStore';
 import MenuItem from '../components/menuItem';
-import OrganizationHomeContainer from '../components/organizations/homeContainer';
+import OrganizationSettingsView from './organizationSettingsView';
 import PluginComponentBase from '../components/bases/pluginComponentBase';
-import {t, tct} from '../locale';
-import {sortArray, parseRepo} from '../utils';
 
 const UNKNOWN_ERROR = {
   error_type: 'unknown'
@@ -214,7 +213,7 @@ class AddRepositoryLink extends PluginComponentBase {
   }
 }
 
-class OrganizationRepositories extends AsyncView {
+class OrganizationRepositories extends OrganizationSettingsView {
   getEndpoints() {
     let {orgId} = this.props.params;
     return [
@@ -309,7 +308,7 @@ class OrganizationRepositories extends AsyncView {
     let itemList = this.state.itemList;
 
     return (
-      <OrganizationHomeContainer>
+      <div>
         <div className="pull-right">
           <DropdownLink
             anchorRight
@@ -415,7 +414,7 @@ class OrganizationRepositories extends AsyncView {
                 </a>
               </p>
             </div>}
-      </OrganizationHomeContainer>
+      </div>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationSettings.jsx
+++ b/src/sentry/static/sentry/app/views/organizationSettings.jsx
@@ -351,45 +351,50 @@ const OrganizationSettings = React.createClass({
   },
 
   render() {
-    if (this.state.loading) return <LoadingIndicator />;
-
     let data = this.state.data;
     let orgId = this.props.params.orgId;
-    let access = new Set(data.access);
+    let access = data && new Set(data.access);
 
     return (
       <OrganizationHomeContainer>
-        <h3>{t('Organization Settings')}</h3>
-        <div className="box">
-          <div className="box-content with-padding">
-            <OrganizationSettingsForm
-              initialData={data}
-              orgId={orgId}
-              access={access}
-              onSave={this.onSave}
-            />
-          </div>
-        </div>
+        {this.state.loading && <LoadingIndicator />}
 
-        {access.has('org:admin') &&
-          !data.isDefault &&
-          <div className="box">
-            <div className="box-header">
-              <h3>{t('Remove Organization')}</h3>
+        {!this.state.loading &&
+          <div>
+            <h3>{t('Organization Settings')}</h3>
+            <div className="box">
+              <div className="box-content with-padding">
+                <OrganizationSettingsForm
+                  initialData={data}
+                  orgId={orgId}
+                  access={access}
+                  onSave={this.onSave}
+                />
+              </div>
             </div>
-            <div className="box-content with-padding">
-              <p>
-                {t(
-                  'Removing this organization will delete all data including projects and their associated events.'
-                )}
-              </p>
 
-              <fieldset className="form-actions">
-                <a href={`/organizations/${orgId}/remove/`} className="btn btn-danger">
-                  {t('Remove Organization')}
-                </a>
-              </fieldset>
-            </div>
+            {access.has('org:admin') &&
+              !data.isDefault &&
+              <div className="box">
+                <div className="box-header">
+                  <h3>{t('Remove Organization')}</h3>
+                </div>
+                <div className="box-content with-padding">
+                  <p>
+                    {t(
+                      'Removing this organization will delete all data including projects and their associated events.'
+                    )}
+                  </p>
+
+                  <fieldset className="form-actions">
+                    <a
+                      href={`/organizations/${orgId}/remove/`}
+                      className="btn btn-danger">
+                      {t('Remove Organization')}
+                    </a>
+                  </fieldset>
+                </div>
+              </div>}
           </div>}
       </OrganizationHomeContainer>
     );

--- a/src/sentry/static/sentry/app/views/organizationSettingsView.jsx
+++ b/src/sentry/static/sentry/app/views/organizationSettingsView.jsx
@@ -1,0 +1,19 @@
+import DocumentTitle from 'react-document-title';
+import React from 'react';
+
+import OrganizationHomeContainer from '../components/organizations/homeContainer';
+import AsyncView from './asyncView';
+
+class OrganizationSettingsView extends AsyncView {
+  render() {
+    return (
+      <DocumentTitle title={this.getTitle()}>
+        <OrganizationHomeContainer {...this.props}>
+          {this.renderComponent()}
+        </OrganizationHomeContainer>
+      </DocumentTitle>
+    );
+  }
+}
+
+export default OrganizationSettingsView;

--- a/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -11,7 +11,13 @@ exports[`OrganizationRepositories render() with a provider renders 1`] = `
   <DocumentTitle
     title="Repositories"
   >
-    <HomeContainer>
+    <HomeContainer
+      params={
+        Object {
+          "orgId": "org-slug",
+        }
+      }
+    >
       <div
         className="organization-home"
       >
@@ -490,93 +496,71 @@ exports[`OrganizationRepositories render() with a provider renders 1`] = `
             <div
               className="col-md-10"
             >
-              <div
-                className="pull-right"
-              >
-                <DropdownLink
-                  anchorRight={true}
-                  caret={true}
-                  className="btn btn-primary btn-sm"
-                  disabled={false}
-                  title="Add Repository"
+              <div>
+                <div
+                  className="pull-right"
                 >
-                  <span
-                    className="pull-right anchor-right dropdown"
+                  <DropdownLink
+                    anchorRight={true}
+                    caret={true}
+                    className="btn btn-primary btn-sm"
+                    disabled={false}
+                    title="Add Repository"
                   >
-                    <a
-                      className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-                      data-toggle="dropdown"
+                    <span
+                      className="pull-right anchor-right dropdown"
                     >
-                      Add Repository
-                      <i
-                        className="icon-arrow-down"
-                      />
-                    </a>
-                    <ul
-                      className="dropdown-menu"
-                    >
-                      <MenuItem
-                        noAnchor={true}
+                      <a
+                        className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+                        data-toggle="dropdown"
                       >
-                        <li
-                          className=""
-                          href={null}
-                          role="presentation"
-                          title={null}
+                        Add Repository
+                        <i
+                          className="icon-arrow-down"
+                        />
+                      </a>
+                      <ul
+                        className="dropdown-menu"
+                      >
+                        <MenuItem
+                          noAnchor={true}
                         >
-                          <AddRepositoryLink
-                            onSuccess={[Function]}
-                            orgId="org-slug"
-                            provider={
-                              Object {
-                                "config": Array [
-                                  Object {
-                                    "help": "Enter your repository name, including the owner.",
-                                    "label": "Repository Name",
-                                    "name": "name",
-                                    "placeholder": "e.g. getsentry/sentry",
-                                    "required": true,
-                                    "type": "text",
-                                  },
-                                ],
-                                "id": "github",
-                                "name": "GitHub",
-                              }
-                            }
+                          <li
+                            className=""
+                            href={null}
+                            role="presentation"
+                            title={null}
                           >
-                            <a
-                              onClick={[Function]}
-                            >
-                              GitHub
-                              <Modal
-                                animation={false}
-                                autoFocus={true}
-                                backdrop={true}
-                                bsClass="modal"
-                                dialogComponentClass={[Function]}
-                                enforceFocus={true}
-                                keyboard={true}
-                                manager={
-                                  ModalManager {
-                                    "containers": Array [],
-                                    "data": Array [],
-                                    "handleContainerOverflow": true,
-                                    "hideSiblingNodes": true,
-                                    "modals": Array [],
-                                  }
+                            <AddRepositoryLink
+                              onSuccess={[Function]}
+                              orgId="org-slug"
+                              provider={
+                                Object {
+                                  "config": Array [
+                                    Object {
+                                      "help": "Enter your repository name, including the owner.",
+                                      "label": "Repository Name",
+                                      "name": "name",
+                                      "placeholder": "e.g. getsentry/sentry",
+                                      "required": true,
+                                      "type": "text",
+                                    },
+                                  ],
+                                  "id": "github",
+                                  "name": "GitHub",
                                 }
-                                onHide={[Function]}
-                                renderBackdrop={[Function]}
-                                restoreFocus={true}
-                                show={false}
+                              }
+                            >
+                              <a
+                                onClick={[Function]}
                               >
+                                GitHub
                                 <Modal
+                                  animation={false}
                                   autoFocus={true}
                                   backdrop={true}
-                                  backdropClassName="modal-backdrop"
-                                  backdropTransitionTimeout={150}
-                                  containerClassName="modal-open"
-                                  dialogTransitionTimeout={300}
+                                  bsClass="modal"
+                                  dialogComponentClass={[Function]}
                                   enforceFocus={true}
                                   keyboard={true}
                                   manager={
@@ -588,49 +572,73 @@ exports[`OrganizationRepositories render() with a provider renders 1`] = `
                                       "modals": Array [],
                                     }
                                   }
-                                  onEntering={[Function]}
-                                  onExited={[Function]}
                                   onHide={[Function]}
                                   renderBackdrop={[Function]}
                                   restoreFocus={true}
                                   show={false}
-                                />
-                              </Modal>
-                            </a>
-                          </AddRepositoryLink>
-                        </li>
-                      </MenuItem>
-                    </ul>
-                  </span>
-                </DropdownLink>
-              </div>
-              <h3
-                className="m-b-2"
-              >
-                Repositories
-              </h3>
-              <div
-                className="well blankslate align-center p-x-2 p-y-1"
-              >
-                <div
-                  className="icon icon-lg icon-git-commit"
-                />
-                <h3>
-                  Sentry is better with commit data
-                </h3>
-                <p>
-                  Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
-                </p>
-                <p
-                  className="m-b-1"
+                                >
+                                  <Modal
+                                    autoFocus={true}
+                                    backdrop={true}
+                                    backdropClassName="modal-backdrop"
+                                    backdropTransitionTimeout={150}
+                                    containerClassName="modal-open"
+                                    dialogTransitionTimeout={300}
+                                    enforceFocus={true}
+                                    keyboard={true}
+                                    manager={
+                                      ModalManager {
+                                        "containers": Array [],
+                                        "data": Array [],
+                                        "handleContainerOverflow": true,
+                                        "hideSiblingNodes": true,
+                                        "modals": Array [],
+                                      }
+                                    }
+                                    onEntering={[Function]}
+                                    onExited={[Function]}
+                                    onHide={[Function]}
+                                    renderBackdrop={[Function]}
+                                    restoreFocus={true}
+                                    show={false}
+                                  />
+                                </Modal>
+                              </a>
+                            </AddRepositoryLink>
+                          </li>
+                        </MenuItem>
+                      </ul>
+                    </span>
+                  </DropdownLink>
+                </div>
+                <h3
+                  className="m-b-2"
                 >
-                  <a
-                    className="btn btn-default"
-                    href="https://docs.sentry.io/learn/releases/"
+                  Repositories
+                </h3>
+                <div
+                  className="well blankslate align-center p-x-2 p-y-1"
+                >
+                  <div
+                    className="icon icon-lg icon-git-commit"
+                  />
+                  <h3>
+                    Sentry is better with commit data
+                  </h3>
+                  <p>
+                    Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
+                  </p>
+                  <p
+                    className="m-b-1"
                   >
-                    Learn more
-                  </a>
-                </p>
+                    <a
+                      className="btn btn-default"
+                      href="https://docs.sentry.io/learn/releases/"
+                    >
+                      Learn more
+                    </a>
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -652,7 +660,13 @@ exports[`OrganizationRepositories render() with a provider renders with a reposi
   <DocumentTitle
     title="Repositories"
   >
-    <HomeContainer>
+    <HomeContainer
+      params={
+        Object {
+          "orgId": "org-slug",
+        }
+      }
+    >
       <div
         className="organization-home"
       >
@@ -1131,93 +1145,71 @@ exports[`OrganizationRepositories render() with a provider renders with a reposi
             <div
               className="col-md-10"
             >
-              <div
-                className="pull-right"
-              >
-                <DropdownLink
-                  anchorRight={true}
-                  caret={true}
-                  className="btn btn-primary btn-sm"
-                  disabled={false}
-                  title="Add Repository"
+              <div>
+                <div
+                  className="pull-right"
                 >
-                  <span
-                    className="pull-right anchor-right dropdown"
+                  <DropdownLink
+                    anchorRight={true}
+                    caret={true}
+                    className="btn btn-primary btn-sm"
+                    disabled={false}
+                    title="Add Repository"
                   >
-                    <a
-                      className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-                      data-toggle="dropdown"
+                    <span
+                      className="pull-right anchor-right dropdown"
                     >
-                      Add Repository
-                      <i
-                        className="icon-arrow-down"
-                      />
-                    </a>
-                    <ul
-                      className="dropdown-menu"
-                    >
-                      <MenuItem
-                        noAnchor={true}
+                      <a
+                        className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+                        data-toggle="dropdown"
                       >
-                        <li
-                          className=""
-                          href={null}
-                          role="presentation"
-                          title={null}
+                        Add Repository
+                        <i
+                          className="icon-arrow-down"
+                        />
+                      </a>
+                      <ul
+                        className="dropdown-menu"
+                      >
+                        <MenuItem
+                          noAnchor={true}
                         >
-                          <AddRepositoryLink
-                            onSuccess={[Function]}
-                            orgId="org-slug"
-                            provider={
-                              Object {
-                                "config": Array [
-                                  Object {
-                                    "help": "Enter your repository name, including the owner.",
-                                    "label": "Repository Name",
-                                    "name": "name",
-                                    "placeholder": "e.g. getsentry/sentry",
-                                    "required": true,
-                                    "type": "text",
-                                  },
-                                ],
-                                "id": "github",
-                                "name": "GitHub",
-                              }
-                            }
+                          <li
+                            className=""
+                            href={null}
+                            role="presentation"
+                            title={null}
                           >
-                            <a
-                              onClick={[Function]}
-                            >
-                              GitHub
-                              <Modal
-                                animation={false}
-                                autoFocus={true}
-                                backdrop={true}
-                                bsClass="modal"
-                                dialogComponentClass={[Function]}
-                                enforceFocus={true}
-                                keyboard={true}
-                                manager={
-                                  ModalManager {
-                                    "containers": Array [],
-                                    "data": Array [],
-                                    "handleContainerOverflow": true,
-                                    "hideSiblingNodes": true,
-                                    "modals": Array [],
-                                  }
+                            <AddRepositoryLink
+                              onSuccess={[Function]}
+                              orgId="org-slug"
+                              provider={
+                                Object {
+                                  "config": Array [
+                                    Object {
+                                      "help": "Enter your repository name, including the owner.",
+                                      "label": "Repository Name",
+                                      "name": "name",
+                                      "placeholder": "e.g. getsentry/sentry",
+                                      "required": true,
+                                      "type": "text",
+                                    },
+                                  ],
+                                  "id": "github",
+                                  "name": "GitHub",
                                 }
-                                onHide={[Function]}
-                                renderBackdrop={[Function]}
-                                restoreFocus={true}
-                                show={false}
+                              }
+                            >
+                              <a
+                                onClick={[Function]}
                               >
+                                GitHub
                                 <Modal
+                                  animation={false}
                                   autoFocus={true}
                                   backdrop={true}
-                                  backdropClassName="modal-backdrop"
-                                  backdropTransitionTimeout={150}
-                                  containerClassName="modal-open"
-                                  dialogTransitionTimeout={300}
+                                  bsClass="modal"
+                                  dialogComponentClass={[Function]}
                                   enforceFocus={true}
                                   keyboard={true}
                                   manager={
@@ -1229,93 +1221,117 @@ exports[`OrganizationRepositories render() with a provider renders with a reposi
                                       "modals": Array [],
                                     }
                                   }
-                                  onEntering={[Function]}
-                                  onExited={[Function]}
                                   onHide={[Function]}
                                   renderBackdrop={[Function]}
                                   restoreFocus={true}
                                   show={false}
-                                />
-                              </Modal>
-                            </a>
-                          </AddRepositoryLink>
-                        </li>
-                      </MenuItem>
-                    </ul>
-                  </span>
-                </DropdownLink>
-              </div>
-              <h3
-                className="m-b-2"
-              >
-                Repositories
-              </h3>
-              <div
-                className="m-b-2"
-              >
-                <p>
-                  Connecting a repository allows Sentry to capture commit data via webhooks. This enables features like suggested assignees and resolving issues via commit message. Once you've connected a repository, you can associate commits with releases via the API.
-                   
-                  <span>
-                    <span>
-                      See our 
+                                >
+                                  <Modal
+                                    autoFocus={true}
+                                    backdrop={true}
+                                    backdropClassName="modal-backdrop"
+                                    backdropTransitionTimeout={150}
+                                    containerClassName="modal-open"
+                                    dialogTransitionTimeout={300}
+                                    enforceFocus={true}
+                                    keyboard={true}
+                                    manager={
+                                      ModalManager {
+                                        "containers": Array [],
+                                        "data": Array [],
+                                        "handleContainerOverflow": true,
+                                        "hideSiblingNodes": true,
+                                        "modals": Array [],
+                                      }
+                                    }
+                                    onEntering={[Function]}
+                                    onExited={[Function]}
+                                    onHide={[Function]}
+                                    renderBackdrop={[Function]}
+                                    restoreFocus={true}
+                                    show={false}
+                                  />
+                                </Modal>
+                              </a>
+                            </AddRepositoryLink>
+                          </li>
+                        </MenuItem>
+                      </ul>
                     </span>
-                    <a
-                      href="https://docs.sentry.io/learn/releases/"
-                    >
-                      <span>
-                        documentation
-                      </span>
-                    </a>
-                    <span>
-                       for more details.
-                    </span>
-                  </span>
-                </p>
-              </div>
-              <div
-                className="panel panel-default"
-              >
-                <table
-                  className="table"
+                  </DropdownLink>
+                </div>
+                <h3
+                  className="m-b-2"
                 >
-                  <tbody>
-                    <tr>
-                      <td>
-                        <strong>
-                          repo-name
-                        </strong>
-                        <br />
-                        <small />
-                        <small>
-                           
-                          — 
-                          <a
-                            href="https://github.com/example/repo-name"
-                          >
-                            https://github.com/example/repo-name
-                          </a>
-                        </small>
-                      </td>
-                      <td
-                        style={
-                          Object {
-                            "width": 60,
-                          }
-                        }
+                  Repositories
+                </h3>
+                <div
+                  className="m-b-2"
+                >
+                  <p>
+                    Connecting a repository allows Sentry to capture commit data via webhooks. This enables features like suggested assignees and resolving issues via commit message. Once you've connected a repository, you can associate commits with releases via the API.
+                     
+                    <span>
+                      <span>
+                        See our 
+                      </span>
+                      <a
+                        href="https://docs.sentry.io/learn/releases/"
                       >
-                        <button
-                          className="btn btn-default btn-xs"
-                          onClick={[Function]}
+                        <span>
+                          documentation
+                        </span>
+                      </a>
+                      <span>
+                         for more details.
+                      </span>
+                    </span>
+                  </p>
+                </div>
+                <div
+                  className="panel panel-default"
+                >
+                  <table
+                    className="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td>
+                          <strong>
+                            repo-name
+                          </strong>
+                          <br />
+                          <small />
+                          <small>
+                             
+                            — 
+                            <a
+                              href="https://github.com/example/repo-name"
+                            >
+                              https://github.com/example/repo-name
+                            </a>
+                          </small>
+                        </td>
+                        <td
+                          style={
+                            Object {
+                              "width": 60,
+                            }
+                          }
                         >
-                          <span
-                            className="icon icon-trash"
-                          />
-                        </button>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
+                          <button
+                            className="btn btn-default btn-xs"
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="icon icon-trash"
+                            />
+                          </button>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
             </div>
           </div>
@@ -1330,45 +1346,53 @@ exports[`OrganizationRepositories render() without any providers is loading when
 <DocumentTitle
   title="Repositories"
 >
-  <HomeContainer>
-    <div
-      className="pull-right"
-    >
-      <DropdownLink
-        anchorRight={true}
-        caret={true}
-        className="btn btn-primary btn-sm"
-        disabled={false}
-        title="Add Repository"
-      />
-    </div>
-    <h3
-      className="m-b-2"
-    >
-      Repositories
-    </h3>
-    <div
-      className="well blankslate align-center p-x-2 p-y-1"
-    >
+  <HomeContainer
+    params={
+      Object {
+        "orgId": "org-slug",
+      }
+    }
+  >
+    <div>
       <div
-        className="icon icon-lg icon-git-commit"
-      />
-      <h3>
-        Sentry is better with commit data
-      </h3>
-      <p>
-        Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
-      </p>
-      <p
-        className="m-b-1"
+        className="pull-right"
       >
-        <a
-          className="btn btn-default"
-          href="https://docs.sentry.io/learn/releases/"
+        <DropdownLink
+          anchorRight={true}
+          caret={true}
+          className="btn btn-primary btn-sm"
+          disabled={false}
+          title="Add Repository"
+        />
+      </div>
+      <h3
+        className="m-b-2"
+      >
+        Repositories
+      </h3>
+      <div
+        className="well blankslate align-center p-x-2 p-y-1"
+      >
+        <div
+          className="icon icon-lg icon-git-commit"
+        />
+        <h3>
+          Sentry is better with commit data
+        </h3>
+        <p>
+          Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
+        </p>
+        <p
+          className="m-b-1"
         >
-          Learn more
-        </a>
-      </p>
+          <a
+            className="btn btn-default"
+            href="https://docs.sentry.io/learn/releases/"
+          >
+            Learn more
+          </a>
+        </p>
+      </div>
     </div>
   </HomeContainer>
 </DocumentTitle>
@@ -1385,7 +1409,13 @@ exports[`OrganizationRepositories render() without any providers renders 1`] = `
   <DocumentTitle
     title="Repositories"
   >
-    <HomeContainer>
+    <HomeContainer
+      params={
+        Object {
+          "orgId": "org-slug",
+        }
+      }
+    >
       <div
         className="organization-home"
       >
@@ -1864,61 +1894,63 @@ exports[`OrganizationRepositories render() without any providers renders 1`] = `
             <div
               className="col-md-10"
             >
-              <div
-                className="pull-right"
-              >
-                <DropdownLink
-                  anchorRight={true}
-                  caret={true}
-                  className="btn btn-primary btn-sm"
-                  disabled={false}
-                  title="Add Repository"
+              <div>
+                <div
+                  className="pull-right"
                 >
-                  <span
-                    className="pull-right anchor-right dropdown"
+                  <DropdownLink
+                    anchorRight={true}
+                    caret={true}
+                    className="btn btn-primary btn-sm"
+                    disabled={false}
+                    title="Add Repository"
+                  >
+                    <span
+                      className="pull-right anchor-right dropdown"
+                    >
+                      <a
+                        className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+                        data-toggle="dropdown"
+                      >
+                        Add Repository
+                        <i
+                          className="icon-arrow-down"
+                        />
+                      </a>
+                      <ul
+                        className="dropdown-menu"
+                      />
+                    </span>
+                  </DropdownLink>
+                </div>
+                <h3
+                  className="m-b-2"
+                >
+                  Repositories
+                </h3>
+                <div
+                  className="well blankslate align-center p-x-2 p-y-1"
+                >
+                  <div
+                    className="icon icon-lg icon-git-commit"
+                  />
+                  <h3>
+                    Sentry is better with commit data
+                  </h3>
+                  <p>
+                    Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
+                  </p>
+                  <p
+                    className="m-b-1"
                   >
                     <a
-                      className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-                      data-toggle="dropdown"
+                      className="btn btn-default"
+                      href="https://docs.sentry.io/learn/releases/"
                     >
-                      Add Repository
-                      <i
-                        className="icon-arrow-down"
-                      />
+                      Learn more
                     </a>
-                    <ul
-                      className="dropdown-menu"
-                    />
-                  </span>
-                </DropdownLink>
-              </div>
-              <h3
-                className="m-b-2"
-              >
-                Repositories
-              </h3>
-              <div
-                className="well blankslate align-center p-x-2 p-y-1"
-              >
-                <div
-                  className="icon icon-lg icon-git-commit"
-                />
-                <h3>
-                  Sentry is better with commit data
-                </h3>
-                <p>
-                  Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
-                </p>
-                <p
-                  className="m-b-1"
-                >
-                  <a
-                    className="btn btn-default"
-                    href="https://docs.sentry.io/learn/releases/"
-                  >
-                    Learn more
-                  </a>
-                </p>
+                  </p>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
* Refactor `AsyncView` -> `AsyncView` + `AsyncComponent`
* Create `OrganizationSettingsView` that extends from `AsyncView`
* Change `OrganizationRepositories` to extend from
`OrganizationSettingsView`

Issue: `AsyncView` includes the Org sidebar as part of "body", so when it
is in the loading state, the sidebar is not visible. Switching between
org settings views causes an annoying flicker

`OrganizationSettings` does not use AsyncView, but fix its loadind state
to behave similarly.