### PR TITLE
fix(streamview): Remove absolute positions

### DIFF
--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -91,11 +91,6 @@
     box-shadow: none !important;
   }
 
-  .dropdown-menu {
-    left: -6px;
-    top: 29px;
-  }
-
   .stream-actions-left {
     position: relative;
     padding-left: 54px;


### PR DESCRIPTION
This makes these usable

after: <img width="796" alt="screenshot 2017-09-25 14 07 04" src="https://user-images.githubusercontent.com/5915546/30831180-610051f8-a1fb-11e7-9478-4202f0aa278c.png">
before:
![screenshot 2017-09-25 14 06 52](https://user-images.githubusercontent.com/5915546/30831189-68ae558a-a1fb-11e7-8bb5-06e0f6f47505.png)
