### PR TITLE
ref(tsdb): Clean up counter data type key generation for Redis.

### DIFF
--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -10,7 +10,7 @@ from datetime import (
 from sentry.testutils import TestCase
 from sentry.tsdb.base import TSDBModel, ONE_MINUTE, ONE_HOUR, ONE_DAY
 from sentry.tsdb.redis import RedisTSDB, CountMinScript
-from sentry.utils.dates import to_timestamp
+from sentry.utils.dates import to_datetime, to_timestamp
 
 
 class RedisTSDBTest(TestCase):
@@ -35,11 +35,11 @@ class RedisTSDBTest(TestCase):
             client.flushdb()
 
     def test_make_counter_key(self):
-        result = self.db.make_counter_key(TSDBModel.project, 1368889980, 1)
-        assert result == 'ts:1:1368889980:1'
+        result = self.db.make_counter_key(TSDBModel.project, 1, to_datetime(1368889980), 1)
+        assert result == ('ts:1:1368889980:1', 1)
 
-        result = self.db.make_counter_key(TSDBModel.project, 1368889980, 'foo')
-        assert result == 'ts:1:1368889980:33'
+        result = self.db.make_counter_key(TSDBModel.project, 1, to_datetime(1368889980), 'foo')
+        assert result == ('ts:1:1368889980:46', self.db.get_model_key('foo'))
 
     def test_get_model_key(self):
         result = self.db.get_model_key(1)


### PR DESCRIPTION
This makes the method signature to `make_counter_key` more similar to the signature of `make_key` for consistency, and changes the return type of `make_counter_key` to return the a tuple of `(hash key, hash field)` for additional clarity about how these are structured internally.