### PR TITLE
perf: Remove huge EventUser query from GroupTagValueSerializer

### DIFF
--- a/tests/sentry/api/serializers/test_grouptagvalue.py
+++ b/tests/sentry/api/serializers/test_grouptagvalue.py
@@ -34,19 +34,3 @@ class GroupTagValueSerializerTest(TestCase):
         assert result['key'] == 'user'
         assert result['value'] == grouptagvalue.value
         assert result['name'] == euser.get_label()
-
-    def test_with_no_tagvalue(self):
-        user = self.create_user()
-        project = self.create_project()
-        grouptagvalue = GroupTagValue.objects.create(
-            project_id=project.id,
-            group_id=self.create_group(project=project).id,
-            key='sentry:user',
-            value='email:foo@example.com',
-        )
-
-        result = serialize(grouptagvalue, user)
-        assert result['id'] == six.text_type(grouptagvalue.id)
-        assert result['key'] == 'user'
-        assert result['value'] == grouptagvalue.value
-        assert result['name'] == grouptagvalue.value


### PR DESCRIPTION
GroupTagValueSerializer used to fetch *all* EventUser records for a
project (which could have been millions -- the reason we're making this
change is because it showed up in the top slowest query logs).

The values were used to build a lookup dict to retrieve the proper
'label'. It turns out the label is simply the raw value without the
prefix. (e.g. Tag Value: "id:10", Label: "10") So instead of doing the
query and building the dict, we just strip the prefix if one exists.

This should be functionally equivalent but without doing the query.