### PR TITLE
fix(ci): Require responses 0.6.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,4 +11,4 @@ pytest-cov>=2.5.1,<2.6.0
 pytest-timeout>=0.5.0,<0.6.0
 pytest-xdist>=1.18.0,<1.19.0
 # responses 0.6.2 has a bug that causes our tests to fail.
-responses<0.6.2
+responses==0.6.1


### PR DESCRIPTION
We require some newer functionality, so e.g. 0.3.0 no longer works.