### PR TITLE
fix(http-interface): Allow empty request interface data

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -29,15 +29,17 @@ export function getCurlCommand(data) {
     result += ' \\\n -H "' + header[0] + ': ' + escapeQuotes(header[1] + '') + '"';
   }
 
-  switch (data.inferredContentType) {
-    case 'application/json':
-      result += ' \\\n --data "' + escapeQuotes(JSON.stringify(data.data)) + '"';
-      break;
-    case 'application/x-www-form-urlencoded':
-      result += ' \\\n --data "' + escapeQuotes(jQuery.param(data.data)) + '"';
-      break;
-    default:
-      result += ' \\\n --data "' + escapeQuotes(data.data) + '"';
+  if (data.data !== null && data.data !== undefined) {
+    switch (data.inferredContentType) {
+      case 'application/json':
+        result += ' \\\n --data "' + escapeQuotes(JSON.stringify(data.data)) + '"';
+        break;
+      case 'application/x-www-form-urlencoded':
+        result += ' \\\n --data "' + escapeQuotes(jQuery.param(data.data)) + '"';
+        break;
+      default:
+        result += ' \\\n --data "' + escapeQuotes(data.data) + '"';
+    }
   }
 
   result += ' \\\n "' + data.url;

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -29,7 +29,7 @@ export function getCurlCommand(data) {
     result += ' \\\n -H "' + header[0] + ': ' + escapeQuotes(header[1] + '') + '"';
   }
 
-  if (data.data !== null && data.data !== undefined) {
+  if (defined(data.data)) {
     switch (data.inferredContentType) {
       case 'application/json':
         result += ' \\\n --data "' + escapeQuotes(JSON.stringify(data.data)) + '"';

--- a/tests/js/spec/components/events/interfaces/utils.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/utils.spec.jsx
@@ -61,6 +61,20 @@ describe('components/interfaces/utils', function() {
           ' --data "{\\"hello\\": \\"world\\"}" \\\n' +
           ' "http://example.com/foo?foo=bar"'
       );
+
+      // Do not add data if data is empty
+      expect(
+        getCurlCommand({
+          url: 'http://example.com/foo',
+          headers: [],
+          env: {
+            ENV: 'prod'
+          },
+          fragment: '',
+          query: 'foo=bar',
+          method: 'GET'
+        })
+      ).toEqual('curl \\\n "http://example.com/foo?foo=bar"');
     });
   });
 


### PR DESCRIPTION
Fixes [JAVASCRIPT-2DQ](https://sentry.io/sentry/javascript/issues/355551765/)