### PR TITLE
ref(saml): Refactor to use provider helper flow

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -719,5 +719,8 @@ class AuthHelper(object):
         self.request.session['auth']['state'][key] = value
         self.request.session.modified = True
 
-    def fetch_state(self, key):
+    def fetch_state(self, key=None):
+        if key is None:
+            return self.request.session['auth']['state']
+
         return self.request.session['auth']['state'].get(key)

--- a/src/sentry/auth/providers/saml2.py
+++ b/src/sentry/auth/providers/saml2.py
@@ -20,6 +20,7 @@ from sentry.auth.view import ConfigureView
 from sentry.models import (AuthProvider, Organization, OrganizationStatus, User, UserEmail)
 from sentry.utils.http import absolute_uri
 from sentry.utils.auth import login, get_login_redirect, get_login_url
+from sentry.web.frontend.base import BaseView
 
 try:
     from onelogin.saml2.auth import OneLogin_Saml2_Auth, OneLogin_Saml2_Settings
@@ -311,7 +312,7 @@ class SAML2ACSView(AuthView):
         return None
 
 
-class SAML2SLSView(AuthView):
+class SAML2SLSView(BaseView):
     def dispatch(self, request, organization_slug):
         provider = get_provider(organization_slug)
         if provider is None:
@@ -333,7 +334,7 @@ class SAML2SLSView(AuthView):
         return self.redirect(redirect_to)
 
 
-class SAML2MetadataView(AuthView):
+class SAML2MetadataView(BaseView):
     def dispatch(self, request, organization_slug):
         provider = get_provider(organization_slug)
         if provider is None:

--- a/src/sentry/auth/providers/saml2.py
+++ b/src/sentry/auth/providers/saml2.py
@@ -1,23 +1,20 @@
 from __future__ import absolute_import, print_function
 
-from django import forms
-from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.contrib import messages
 from django.contrib.auth import logout
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseServerError
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
+from six import iteritems
 from six.moves.urllib.parse import urlparse
-from six import add_metaclass
 
 from sentry import options
 from sentry.auth import Provider, AuthView
-from sentry.auth.view import ConfigureView
-from sentry.models import (AuthProvider, Organization, OrganizationStatus, User, UserEmail)
+from sentry.models import (AuthProvider, Organization, OrganizationStatus)
+from sentry.utils.auth import get_login_url
 from sentry.utils.http import absolute_uri
-from sentry.utils.auth import login, get_login_redirect, get_login_url
 from sentry.web.frontend.base import BaseView
 
 try:
@@ -33,52 +30,9 @@ except ImportError:
     def OneLogin_Saml2_Settings(*args, **kwargs):
         raise NotImplementedError('Missing SAML libraries')
 
-    class NoopGetter(type):
-        def __getattr__(self, key):
-            return None
-
-    @add_metaclass(NoopGetter)
-    class OneLogin_Saml2_Constants(object):
-        pass
-
-
-NAMEID_FORMAT_CHOICES = (
-    (OneLogin_Saml2_Constants.NAMEID_UNSPECIFIED, 'unspecified'),
-    (OneLogin_Saml2_Constants.NAMEID_EMAIL_ADDRESS, 'emailAddress'),
-    (OneLogin_Saml2_Constants.NAMEID_TRANSIENT, 'transient'),
-    (OneLogin_Saml2_Constants.NAMEID_PERSISTENT, 'persistent'),
-    (OneLogin_Saml2_Constants.NAMEID_ENTITY, 'entity'),
-    (OneLogin_Saml2_Constants.NAMEID_ENCRYPTED, 'encrypted'),
-    (OneLogin_Saml2_Constants.NAMEID_KERBEROS, 'kerberos'),
-    (OneLogin_Saml2_Constants.NAMEID_X509_SUBJECT_NAME, 'x509subjecname'),
-    (OneLogin_Saml2_Constants.NAMEID_WINDOWS_DOMAIN_QUALIFIED_NAME, 'windowsdomainqualifiedname')
-)
-
-AUTHNCONTEXT_CHOICES = (
-    (OneLogin_Saml2_Constants.AC_UNSPECIFIED, OneLogin_Saml2_Constants.AC_UNSPECIFIED),
-    (OneLogin_Saml2_Constants.AC_PASSWORD, OneLogin_Saml2_Constants.AC_PASSWORD),
-    (OneLogin_Saml2_Constants.AC_PASSWORD_PROTECTED, OneLogin_Saml2_Constants.AC_PASSWORD_PROTECTED),
-    (OneLogin_Saml2_Constants.AC_X509, OneLogin_Saml2_Constants.AC_X509),
-    (OneLogin_Saml2_Constants.AC_SMARTCARD, OneLogin_Saml2_Constants.AC_SMARTCARD),
-    (OneLogin_Saml2_Constants.AC_KERBEROS, OneLogin_Saml2_Constants.AC_KERBEROS)
-)
-
-SIGNATURE_ALGORITHM_CHOICES = (
-    (OneLogin_Saml2_Constants.RSA_SHA256, 'RSA_SHA256'),
-    (OneLogin_Saml2_Constants.RSA_SHA384, 'RSA_SHA384'),
-    (OneLogin_Saml2_Constants.RSA_SHA512, 'RSA_SHA512'),
-    (OneLogin_Saml2_Constants.RSA_SHA1, 'RSA_SHA1'),
-    (OneLogin_Saml2_Constants.DSA_SHA1, 'DSA_SHA1')
-)
-
-DIGEST_ALGORITHM_CHOICES = (
-    (OneLogin_Saml2_Constants.SHA256, 'SHA256'),
-    (OneLogin_Saml2_Constants.SHA384, 'SHA384'),
-    (OneLogin_Saml2_Constants.SHA512, 'SHA512'),
-    (OneLogin_Saml2_Constants.SHA1, 'SHA1')
-)
 
 ERR_NO_SAML_SSO = _('The organization does not exist or does not have SAML SSO enabled.')
+ERR_SAML_FAILED = _('SAML SSO failed, {reason}')
 
 
 def get_provider(organization_slug):
@@ -101,213 +55,46 @@ def get_provider(organization_slug):
     return provider
 
 
-class OptionsForm(forms.Form):
-    options_jit = forms.BooleanField(
-        label="Just-in-time Provisioning",
-        required=False,
-        help_text=_('Enable/disable Auto-provisioning. If user not exists, '
-                    'Sentry will create a new user account with the data '
-                    'provided by the IdP when they first login.')
-    )
-
-    def clean(self):
-        super(OptionsForm, self).clean()
-
-        invalid_jit = (
-            self.data.get('options_jit', None) and
-            not (
-                self.data.get('attribute_mapping_email', None) and
-                self.data.get('attribute_mapping_displayname', None)
-            )
-        )
-
-        if invalid_jit:
-            del self.cleaned_data["options_jit"]
-            self._errors["options_jit"] = [
-                _("JIT enabled but required attribute mapping not provided")
-            ]
-
-        return self.cleaned_data
-
-
-class AttributeMappingForm(forms.Form):
-    attribute_mapping_email = forms.CharField(label='Email', required=False)
-    attribute_mapping_displayname = forms.CharField(label='Display Name', required=False)
-
-
-class SAML2ConfigureView(ConfigureView):
-    saml_form_cls = None
-    advanced_form_cls = None
-
-    def dispatch(self, request, organization, auth_provider):
-        if self.saml_form_cls is None or self.advanced_form_cls is None:
-            raise NotImplementedError('Custom forms must be defined by the extended class')
-
-        if request.method == 'POST':
-            data = request.POST
-            saml_form = self.saml_form_cls(data)
-            options_form = OptionsForm(data)
-            attr_mapping_form = AttributeMappingForm(data)
-            advanced_form = self.advanced_form_cls(data)
-
-            valid_forms = 0
-            if saml_form.is_valid():
-                idp_data = SAML2Provider.extract_idp_data_from_form(saml_form)
-                auth_provider.config['idp'] = idp_data
-                valid_forms += 1
-            if options_form.is_valid():
-                options_data = SAML2Provider.extract_options_data_from_form(options_form)
-                auth_provider.config['options'] = options_data
-                valid_forms += 1
-            if attr_mapping_form.is_valid():
-                attribute_mapping_data = SAML2Provider.extract_attribute_mapping_from_form(
-                    attr_mapping_form
-                )
-                auth_provider.config['attribute_mapping'] = attribute_mapping_data
-                valid_forms += 1
-            if advanced_form.is_valid():
-                advanced_settings_data = SAML2Provider.extract_advanced_settings_from_form(
-                    advanced_form
-                )
-                auth_provider.config['advanced_settings'] = advanced_settings_data
-                valid_forms += 1
-
-            if valid_forms == 4:
-                auth_provider.save()
-        else:
-            idp_data = auth_provider.config.get('idp', None)
-            saml_form = self.saml_form_cls(initial=idp_data)
-
-            options_data = auth_provider.config.get('options', None)
-            options_form = OptionsForm(initial=options_data)
-
-            attr_mapping_data = auth_provider.config.get('attribute_mapping', None)
-            attr_mapping_form = AttributeMappingForm(initial=attr_mapping_data)
-
-            advanced_data = auth_provider.config.get('advanced_settings', None)
-            advanced_form = self.advanced_form_cls(initial=advanced_data)
-
-        return self.display_configure_view(
-            organization,
-            saml_form,
-            options_form,
-            attr_mapping_form,
-            advanced_form
-        )
-
-    def display_configure_view(self, organization, saml_form, options_form,
-                               attr_mapping_form, advanced_form):
-        raise NotImplementedError('Display Configure View not implemented!')
-
-
 class SAML2LoginView(AuthView):
     def dispatch(self, request, helper):
-        provider = helper.provider
-        if provider is None:
-            messages.add_message(request, messages.ERROR, ERR_NO_SAML_SSO)
-            return HttpResponseRedirect(request.path)
+        if 'SAMLResponse' in request.POST:
+            return helper.next_step()
 
-        saml_config = provider.build_saml_config(helper.organization.slug)
-        auth = provider.build_auth(request, saml_config)
+        provider = helper.provider
+
+        # If we're authenticating during the setup piepline the provider will
+        # not have been configured yet, build the config first from the state
+        if not provider.config:
+            provider.config = provider.build_config(helper.fetch_state())
+
+        saml_config = build_saml_config(provider.config, helper.organization.slug)
+        auth = build_auth(request, saml_config)
+
         return self.redirect(auth.login())
 
 
 class SAML2ACSView(AuthView):
     @method_decorator(csrf_exempt)
-    def dispatch(self, request, organization_slug):
-        if request.method != 'POST':
-            return HttpResponseNotAllowed(['POST'])
+    def dispatch(self, request, helper):
+        provider = helper.provider
 
-        provider = get_provider(organization_slug)
-        if provider is None:
-            messages.add_message(request, messages.ERROR, ERR_NO_SAML_SSO)
-            return HttpResponseRedirect('/')
+        # If we're authenticating during the setup piepline the provider will
+        # not have been configured yet, build the config first from the state
+        if not provider.config:
+            provider.config = provider.build_config(helper.fetch_state())
 
-        organization = Organization.objects.get(slug=organization_slug)
-        saml_config = provider.build_saml_config(organization_slug)
+        saml_config = build_saml_config(provider.config, helper.organization.slug)
 
-        auth = provider.build_auth(request, saml_config)
+        auth = build_auth(request, saml_config)
         auth.process_response()
 
         # SSO response verification failed
-        errors = auth.get_errors()
-        if errors:
-            message = _('SAML SSO failed: {reason}').format(reason=auth.get_last_error_reason())
-            messages.add_message(request, messages.ERROR, message)
+        if auth.get_errors():
+            return helper.error(ERR_SAML_FAILED.format(reason=auth.get_last_error_reason()))
 
-            return HttpResponseRedirect(get_login_url())
+        helper.bind_state('auth_attributes', auth.get_attributes())
 
-        attributes = auth.get_attributes()
-        nameid = auth.get_nameid()
-
-        email = self.retrieve_email(attributes, nameid, provider.config)
-        user_emails = list(
-            UserEmail.objects.filter(email__iexact=email, is_verified=True).order_by('id')
-        )
-
-        users = []
-        if user_emails:
-            users = User.objects.filter(
-                id__in=set((ue.user_id for ue in user_emails)),
-                is_active=True,
-                sentry_orgmember_set__organization_id=organization.id
-            )
-            users = list(users[0:2])
-
-        if not users:
-            options_jit = provider.config.get('options', {}).get('options_jit', False)
-
-            if not options_jit:
-                message = "The user with a verified email %s does not exist" % email
-                return HttpResponseServerError(message)
-            else:
-                return HttpResponseServerError("Just-in-Time provisioning not implemented yet")
-
-        if len(users) > 1:
-            return HttpResponseServerError(
-                "Found several accounts related with %s on this organization" % email)
-
-        user = users[0]
-        user.backend = settings.AUTHENTICATION_BACKENDS[0]
-
-        login_resp = login(
-            request,
-            user,
-            after_2fa=request.build_absolute_uri(),
-            organization_id=organization.id
-        )
-
-        if login_resp:
-            request.session['saml'] = {
-                'nameid': nameid,
-                'nameid_format': auth.get_nameid_format(),
-                'session_index': auth.get_session_index()
-            }
-
-        return HttpResponseRedirect(get_login_redirect(request))
-
-    def retrieve_email(self, attributes, nameid, config):
-        possible_email = None
-        if nameid and '@' in nameid:
-            possible_email = nameid
-
-        email_key = config.get('attribute_mapping', {}).get('attribute_mapping_email', None)
-
-        if attributes and email_key in attributes:
-            return attributes[email_key][0]
-
-        if possible_email:
-            return possible_email
-
-        raise Exception('Cannot retrieve email from attributes')
-
-    def retrieve_displayname(self, attributes, config):
-        name_key = config.get('attribute_mapping', {}).get('attribute_mapping_displayname', None)
-
-        if attributes and name_key in attributes:
-            return attributes[name_key][0]
-
-        return None
+        return helper.next_step()
 
 
 class SAML2SLSView(BaseView):
@@ -315,10 +102,10 @@ class SAML2SLSView(BaseView):
         provider = get_provider(organization_slug)
         if provider is None:
             messages.add_message(request, messages.ERROR, ERR_NO_SAML_SSO)
-            return HttpResponseRedirect('/')
+            return self.redirect('/')
 
-        saml_config = provider.build_saml_config(organization_slug)
-        auth = provider.build_auth(request, saml_config)
+        saml_config = build_saml_config(provider.config, organization_slug)
+        auth = build_auth(request, saml_config)
 
         # No need to logout an anonymous user.
         should_logout = request.user.is_authenticated()
@@ -344,9 +131,9 @@ class SAML2MetadataView(BaseView):
         provider = get_provider(organization_slug)
         if provider is None:
             messages.add_message(request, messages.ERROR, ERR_NO_SAML_SSO)
-            return HttpResponseRedirect('/')
+            return self.redirect('/')
 
-        saml_config = provider.build_saml_config(organization_slug)
+        saml_config = build_saml_config(provider.config, organization_slug)
         saml_settings = OneLogin_Saml2_Settings(settings=saml_config, sp_validation_only=True)
         metadata = saml_settings.get_sp_metadata()
         errors = saml_settings.validate_metadata(metadata)
@@ -358,196 +145,187 @@ class SAML2MetadataView(BaseView):
         return HttpResponse(content=metadata, content_type='text/xml')
 
 
+class Attributes(object):
+    IDENTIFIER = 'identifier'
+    USER_EMAIL = 'user_email'
+    FIRST_NAME = 'first_name'
+    LAST_NAME = 'last_name'
+
+
 class SAML2Provider(Provider):
+    """
+    Base SAML2 Authentication provider. SAML style authentication plugins
+    should implement this.
+
+    - The provider must implement the `get_configure_view`.
+
+    - The provider must implement the `get_saml_setup_pipeline`. The
+      AuthView(s) passed in this method MUST bind the `idp` configuration
+      object. The dict should match the shape:
+
+      >>> state.get('idp')
+      {
+        'entityId': # Identity Provider entity ID. Usually a URL
+        'x509cert': # Identity Provider x509 public certificate
+        'sso_url:   # Identity Provider Single Sign-On URL
+        'slo_url':  # identity Provider Single Sign-Out URL
+      }
+
+      The provider may also bind the `advanced` configuration. This dict
+      provides advanced SAML configurations. The dict should match the shape:
+
+      HINT: You *probably* don't need this.
+
+      >>> state.get('advanced')
+      {
+        'authn_request_signed':     # Sign the authentication request?
+        'logout_request_signed':    # Sign the logout request?
+        'logout_response_signed':   # Sign the logout response?
+        'metadata_signed':          # Sign the metadata?
+        'want_message_signed':      # Expect signed message
+        'want_assertion_signed':    # Expect signed assertions
+        'want_assertion_encrypted': # Expect encrypted assertions
+        'signature_algorithm':      # Algorithm used to sign / verify requests / responses
+        'digest_algorithm':         # Algorithm used to generate / verify digests
+        'x509cert':                 # Public Service Provider key
+        'private_key':              # Private Key used for signing / encryption
+      }
+
+    - The provider must EITHER specify an attribute mapping by implementing the
+      `attribute_mapping` method OR bind the `attribute_mapping` key to the
+      state during setup. The attribute mapping should map the `Attributes`
+      constants to the Identity Provider attribute keys.
+    """
+
     def get_auth_pipeline(self):
-        return [SAML2LoginView()]
+        return [SAML2LoginView(), SAML2ACSView()]
+
+    def get_setup_pipeline(self):
+        return self.get_saml_setup_pipeline() + self.get_auth_pipeline()
+
+    def get_saml_setup_pipeline(self):
+        """
+        Return a list of AuthViews to setup the SAML provider.
+
+        The setup AuthView(s) must bind the `idp` parameter into the helper
+        state.
+        """
+        raise NotImplementedError
+
+    def attribute_mapping(self):
+        """
+        Returns the default Attribute Key -> IdP attribute key mapping.
+
+        This value will be merged into the configuration by self.build_config,
+        however, should a attribute_mapping exist in the helper state at
+        configuration build time, these may be overriden.
+        """
+        return {}
 
     def build_config(self, state):
-        data = {}
+        config = state
 
-        if 'idp' in state.keys():
-            data['idp'] = state['idp']
+        # Default attriute mapping if none bound
+        if 'attribute_mapping' not in config:
+            config['attribute_mapping'] = self.attribute_mapping()
 
-        if 'contact' in state.keys():
-            data['contact'] = state['contact']
-
-        return data
+        return config
 
     def build_identity(self, state):
-        # return None   # TODO  If I return None, then a loop after execute the config
-        # happens from organizations/<org>/auth/ to /auth/login/  /<org>/
-        identity = {}
-        if state and 'contact' in state:
-            identity['id'] = state['contact']
-            identity['email'] = state['contact']
-        return identity
+        raw_attributes = state['auth_attributes']
+        attributes = {}
 
-    def build_saml_config(self, org_slug):
-        metadata_url = absolute_uri(
-            reverse('sentry-auth-organization-saml-metadata', args=[org_slug])
-        )
-        acs_url = absolute_uri(reverse('sentry-auth-organization-saml-acs', args=[org_slug]))
-        sls_url = absolute_uri(reverse('sentry-auth-organization-saml-sls', args=[org_slug]))
+        # map configured provider attributes
+        for key, provider_key in iteritems(self.config['attribute_mapping']):
+            attributes[key] = raw_attributes[provider_key][0]
 
-        saml_config = {}
-        saml_config['strict'] = True
-        saml_config['idp'] = self.extract_parsed_data_from_idp_data(self.config)
-        saml_config['sp'] = {
-            "entityId": metadata_url,
-            "assertionConsumerService": {
-                "url": acs_url,
-                "binding": OneLogin_Saml2_Constants.BINDING_HTTP_POST
-            },
-            "singleLogoutService": {
-                "url": sls_url,
-                "binding": OneLogin_Saml2_Constants.BINDING_HTTP_REDIRECT
-            }
-        }
+        name = (attributes[k] for k in (Attributes.FIRST_NAME, Attributes.LAST_NAME))
+        name = ' '.join(filter(None, name))
 
-        saml_config['security'] = self.extract_parsed_data_from_advanced_data(self.config)
-
-        sp_entity_id = saml_config['security'].get('spEntityId', None)
-        if sp_entity_id:
-            saml_config['sp']['entityId'] = sp_entity_id
-            del saml_config['security']['spEntityId']
-
-        sp_x509cert = saml_config['security'].get('spx509cert', None)
-        if sp_x509cert:
-            saml_config['sp']['x509cert'] = sp_x509cert
-            del saml_config['security']['spx509cert']
-
-        sp_private_key = saml_config['security'].get('spPrivateKey', None)
-        if sp_private_key:
-            saml_config['sp']['privateKey'] = sp_private_key
-            del saml_config['security']['spPrivateKey']
-
-        return saml_config
-
-    def prepare_saml_request(self, request):
-        url = urlparse(options.get('system.url-prefix'))
         return {
-            'https': 'on' if url.scheme == 'https' else 'off',
-            'http_host': url.hostname,
-            'script_name': request.META['PATH_INFO'],
-            'server_port': url.port,
-            'get_data': request.GET.copy(),
-            'post_data': request.POST.copy()
+            'id': attributes[Attributes.IDENTIFIER],
+            'email': attributes[Attributes.USER_EMAIL],
+            'name': name,
         }
-
-    def build_auth(self, request, config):
-        req = self.prepare_saml_request(request)
-        return OneLogin_Saml2_Auth(req, config)
 
     def refresh_identity(self, auth_identity):
         # Nothing to refresh
         return
 
-    @staticmethod
-    def extract_idp_data_from_parsed_data(data):
-        idp_data = {}
-        if 'entityId' in data['idp']:
-            idp_data['idp_entityid'] = data['idp']['entityId']
-        if 'singleSignOnService' in data['idp'] and 'url' in data['idp']['singleSignOnService']:
-            idp_data['idp_sso_url'] = data['idp']['singleSignOnService']['url']
-        if 'singleLogoutService' in data['idp'] and 'url' in data['idp']['singleLogoutService']:
-            idp_data['idp_slo_url'] = data['idp']['singleLogoutService']['url']
-        if 'x509cert' in data['idp']:
-            idp_data['idp_x509cert'] = data['idp']['x509cert']
-        return idp_data
 
-    @staticmethod
-    def extract_idp_data_from_form(form):
-        d = form.cleaned_data
+def build_saml_config(provider_config, org):
+    """
+    Construct the SAML configuration dict to be passed into the OneLogin SAML
+    library.
 
-        return {
-            'idp_entityid': d.get('idp_entityid', None),
-            'idp_sso_url': d.get('idp_sso_url', None),
-            'idp_x509cert': d.get('idp_x509cert', None),
-            'idp_slo_url': d.get('idp_slo_url', None)
-        }
+    For more details about the structure of this object see the
+    SAML2Provider.build_config method.
+    """
+    avd = provider_config.get('advanced', {})
 
-    @staticmethod
-    def extract_options_data_from_form(form):
-        d = form.cleaned_data
+    security_config = {
+        'authnRequestsSigned': avd.get('authn_request_signed', False),
+        'logoutRequestSigned': avd.get('logout_request_signed', False),
+        'logoutResponseSigned': avd.get('logout_response_signed', False),
+        'signMetadata': avd.get('metadata_signed', False),
+        'wantMessagesSigned': avd.get('want_message_signed', False),
+        'wantAssertionsSigned': avd.get('want_assertion_signed', False),
+        'wantAssertionsEncrypted': avd.get('want_assertion_encrypted', False),
+        'signatureAlgorithm': avd.get('signature_algorithm', OneLogin_Saml2_Constants.RSA_SHA256),
+        'digestAlgorithm': avd.get('digest_algorithm', OneLogin_Saml2_Constants.SHA256),
+        'wantNameId': False,
+    }
 
-        return {
-            'options_jit': d.get('options_jit', False),
-        }
+    idp = provider_config['idp']
 
-    @staticmethod
-    def extract_attribute_mapping_from_form(form):
-        d = form.cleaned_data
+    # TODO(epurkhiser): This is also available in the helper and should probably come from there.
+    acs_url = absolute_uri(reverse('sentry-auth-sso'))
+    sls_url = absolute_uri(reverse('sentry-auth-organization-saml-sls', args=[org]))
+    metadata_url = absolute_uri(reverse('sentry-auth-organization-saml-metadata', args=[org]))
 
-        return {
-            'attribute_mapping_email': d.get('attribute_mapping_email', None),
-            'attribute_mapping_displayname': d.get('attribute_mapping_displayname', None)
-        }
+    saml_config = {
+        'strict': True,
+        'idp': {
+            'entityId': idp['entity_id'],
+            'x509cert': idp['x509cert'],
+            'singleSignOnService': {'url': idp['sso_url']},
+            'singleLogoutService': {'url': idp['slo_url']},
+        },
+        'sp': {
+            "entityId": metadata_url,
+            "assertionConsumerService": {
+                "url": acs_url,
+                "binding": OneLogin_Saml2_Constants.BINDING_HTTP_POST,
+            },
+            "singleLogoutService": {
+                "url": sls_url,
+                "binding": OneLogin_Saml2_Constants.BINDING_HTTP_REDIRECT,
+            },
+        },
+        'security': security_config,
+    }
 
-    @staticmethod
-    def extract_advanced_settings_from_form(form):
-        d = form.cleaned_data
+    if avd.get('x509cert') is not None:
+        saml_config['sp']['x509cert'] = avd['x509cert']
 
-        return {
-            'advanced_spentityid': d.get('advanced_spentityid', None),
-            'advanced_nameidformat': d.get('advanced_nameidformat', OneLogin_Saml2_Constants.NAMEID_UNSPECIFIED),
-            'advanced_requestedauthncontext': d.get('advanced_requestedauthncontext', False),
-            'advanced_authn_request_signed': d.get('advanced_authn_request_signed', False),
-            'advanced_logout_request_signed': d.get('advanced_logout_request_signed', False),
-            'advanced_logout_response_signed': d.get('advanced_logout_response_signed', False),
-            'advanced_metadata_signed': d.get('advanced_metadata_signed', False),
-            'advanced_want_message_signed': d.get('advanced_want_message_signed', False),
-            'advanced_want_assertion_signed': d.get('advanced_want_assertion_signed', False),
-            'advanced_want_assertion_encrypted': d.get('advanced_want_assertion_encrypted', False),
-            'advanced_signaturealgorithm': d.get('advanced_signaturealgorithm', OneLogin_Saml2_Constants.RSA_SHA256),
-            'advanced_digestalgorithm': d.get('advanced_digestalgorithm', OneLogin_Saml2_Constants.SHA256),
-            'advanced_sp_x509cert': d.get('advanced_sp_x509cert', None),
-            'advanced_sp_privatekey': d.get('advanced_sp_privatekey', None),
-        }
+    if avd.get('private_key') is not None:
+        saml_config['sp']['privateKey'] = avd['private_key']
 
-    @staticmethod
-    def extract_parsed_data_from_idp_data(data):
-        if 'idp' not in data:
-            return {}
+    return saml_config
 
-        parsed_data = {}
 
-        if 'idp_entityid' in data['idp']:
-            parsed_data['entityId'] = data['idp']['idp_entityid']
-        if 'idp_sso_url' in data['idp']:
-            parsed_data['singleSignOnService'] = {'url': data['idp']['idp_sso_url']}
-        if 'idp_slo_url' in data['idp']:
-            parsed_data['singleLogoutService'] = {'url': data['idp']['idp_slo_url']}
-        if 'idp_x509cert' in data['idp']:
-            parsed_data['x509cert'] = data['idp']['idp_x509cert']
+def build_auth(request, saml_config):
+    """
+    Construct a OneLogin_Saml2_Auth object for the current request.
+    """
+    url = urlparse(options.get('system.url-prefix'))
+    saml_request = {
+        'https': 'on' if url.scheme == 'https' else 'off',
+        'http_host': url.hostname,
+        'script_name': request.META['PATH_INFO'],
+        'server_port': url.port,
+        'get_data': request.GET.copy(),
+        'post_data': request.POST.copy()
+    }
 
-        return parsed_data
-
-    @staticmethod
-    def extract_parsed_data_from_advanced_data(data):
-        if 'advanced_settings' not in data:
-            return {}
-
-        d = data['advanced_settings']
-
-        parsed_data = {
-            'spEntityId': d.get('advanced_spentityid', None),
-            'NameIDFormat': d.get('advanced_nameidformat', OneLogin_Saml2_Constants.NAMEID_UNSPECIFIED),
-            'requestedAuthnContext': d.get('advanced_requestedauthncontext', False),
-            'authnRequestsSigned': d.get('advanced_authn_request_signed', False),
-            'logoutRequestSigned': d.get('advanced_logout_request_signed', False),
-            'logoutResponseSigned': d.get('advanced_logout_response_signed', False),
-            'signMetadata': d.get('advanced_metadata_signed', False),
-            'wantMessagesSigned': d.get('advanced_want_message_signed', False),
-            'wantAssertionsSigned': d.get('advanced_want_assertion_signed', False),
-            'wantAssertionsEncrypted': d.get('advanced_want_assertion_encrypted', False),
-            'signatureAlgorithm': d.get('advanced_signaturealgorithm', OneLogin_Saml2_Constants.RSA_SHA256),
-            'digestAlgorithm': d.get('advanced_digestalgorithm', OneLogin_Saml2_Constants.SHA256),
-            'wantNameId': False,
-        }
-
-        if d.get('advanced_sp_x509cert', None):
-            parsed_data['spx509cert'] = d['advanced_sp_x509cert']
-        if d.get('advanced_sp_privatekey', None):
-            parsed_data['spPrivateKey'] = d['advanced_sp_privatekey']
-
-        return parsed_data
+    return OneLogin_Saml2_Auth(saml_request, saml_config)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -37,7 +37,7 @@ from sentry.web.frontend.mailgun_inbound_webhook import \
     MailgunInboundWebhookView
 from sentry.web.frontend.oauth_authorize import OAuthAuthorizeView
 from sentry.web.frontend.oauth_token import OAuthTokenView
-from sentry.auth.providers.saml2 import SAML2ACSView, SAML2SLSView, SAML2MetadataView
+from sentry.auth.providers.saml2 import SAML2SLSView, SAML2MetadataView
 from sentry.web.frontend.organization_api_key_settings import \
     OrganizationApiKeySettingsView
 from sentry.web.frontend.organization_api_keys import OrganizationApiKeysView
@@ -142,8 +142,6 @@ urlpatterns += patterns(
     url(r'^oauth/token/$', OAuthTokenView.as_view()),
 
     # SAML
-    url(r'^saml/acs/(?P<organization_slug>[^/]+)/$', SAML2ACSView.as_view(),
-        name='sentry-auth-organization-saml-acs'),
     url(r'^saml/sls/(?P<organization_slug>[^/]+)/$', SAML2SLSView.as_view(),
         name='sentry-auth-organization-saml-sls'),
     url(r'^saml/metadata/(?P<organization_slug>[^/]+)/$', SAML2MetadataView.as_view(),


### PR DESCRIPTION
This is a large refactoring of the SAML2 authentication provider to use the AuthHelper, which reduces a *lot* of boiler plate code and helps to provide a really solid separation of concerns.

 * The AuthHelper handles the authentication and setup of authentication as a 'piepline'. It does this by keeping state in the session.  Previously the authentication callback (the Assertion Consumer Service) completely ran out-of-band to the helper. The result of this was that the helper would never finish the pipeline. This refactor puts the ACS endpoint into the pipeline, as a consequence of this things become simpler:

   - The ACS endpoint no longer needs to do *any* type of authentication for the user, other than verifying the SAML assertion.

   - The ACS endpoint simply binds the SAML attributes from the response into the helpers state, build_identity takes care of the rest of the work for providing needed details to authenticate the user.

     Finally the helper handles the *entire* authentication flow which includes:

     + Linking the users account to the identity
     + Creating a new account for the user should they not have one (this
       also correctly uses the first and last name attributes now).

 * As part of this refactoring, We've made a clean abstraction between the SAML provider plugins (okta, onelogin, auth0) and the base saml2 provider.

   - The provider is now *documented* with the expected state during the setup pipeline.

   - Configuration forms have been moved out of the saml2 authentication module and into the plugins module themselves.

   - Provider static methods have been removed in favor of just making them module level functions.

   - Various 'extract' static methods are now simply baked into the caller, as they added very little value in terms of abstract by separation.

I'll have a follow up PR for the saml2 plugin that implements some of the forms here. I'd like to fix those up over there, since some of them were implemented in places they don't need to be (onelogin had the totally custom forms).