### PR TITLE
ref: Drop old/unused tag key logic

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -115,8 +115,6 @@ LANGUAGES = [(k, LANGUAGE_MAP[k]) for k in get_all_languages() if k in LANGUAGE_
 TAG_LABELS = {
     'exc_type': 'Exception Type',
     'sentry:user': 'User',
-    'sentry:filename': 'File',
-    'sentry:function': 'Function',
     'sentry:release': 'Release',
     'sentry:dist': 'Distribution',
     'os': 'OS',

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -243,7 +243,10 @@ class Release(Model):
 
     @property
     def short_version(self):
-        version = self.version
+        return Release.get_display_version(self.version)
+
+    @staticmethod
+    def get_display_version(version):
         match = _dotted_path_prefix_re.match(version)
         if match is not None:
             version = version[match.end():]

--- a/src/sentry/models/tagvalue.py
+++ b/src/sentry/models/tagvalue.py
@@ -7,7 +7,6 @@ sentry.models.tagvalue
 """
 from __future__ import absolute_import, print_function
 
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
 
@@ -15,7 +14,7 @@ from sentry.constants import MAX_TAG_KEY_LENGTH, MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
     Model, BoundedPositiveIntegerField, GzippedDictField, BaseManager, sane_repr
 )
-from sentry.utils.http import absolute_uri
+from sentry.models import Release
 
 
 class TagValue(Model):
@@ -49,35 +48,6 @@ class TagValue(Model):
 
     def get_label(self):
         # HACK(dcramer): quick and dirty way to hack in better display states
-        if self.key == 'sentry:user':
-            return self.data.get('email') or self.value
-        elif self.key == 'sentry:function':
-            return '%s in %s' % (self.data['function'], self.data['filename'])
-        elif self.key == 'sentry:filename':
-            return self.data['filename']
-        elif self.key == 'sentry:release' and len(self.value) == 40:
-            return self.value[:12]
+        if self.key == 'sentry:release':
+            return Release.get_display_version(self.value)
         return self.value
-
-    def get_absolute_url(self):
-        # HACK(dcramer): quick and dirty way to support code/users
-        if self.key == 'sentry:user':
-            url_name = 'sentry-user-details'
-        elif self.key == 'sentry:filename':
-            url_name = 'sentry-explore-code-details'
-        elif self.key == 'sentry:function':
-            url_name = 'sentry-explore-code-details-by-function'
-        else:
-            url_name = 'sentry-explore-tag-value'
-            return absolute_uri(
-                reverse(
-                    url_name,
-                    args=[self.project.organization.slug,
-                          self.project.slug, self.key, self.id]
-                )
-            )
-
-        return absolute_uri(
-            reverse(url_name, args=[
-                    self.project.organization.slug, self.project.slug, self.id])
-        )

--- a/tests/sentry/api/serializers/test_tagvalue.py
+++ b/tests/sentry/api/serializers/test_tagvalue.py
@@ -43,3 +43,18 @@ class TagValueSerializerTest(TestCase):
         assert result['key'] == 'user'
         assert result['value'] == tagvalue.value
         assert result['name'] == tagvalue.get_label()
+
+    def test_release(self):
+        user = self.create_user()
+        project = self.create_project()
+        tagvalue = TagValue.objects.create(
+            project_id=project.id,
+            key='sentry:release',
+            value='df84bccbb23ca15f2868be1f2a5f7c7a6464fadd',
+        )
+
+        result = serialize(tagvalue, user)
+        assert result['id'] == six.text_type(tagvalue.id)
+        assert result['key'] == 'release'
+        assert result['value'] == tagvalue.value
+        assert result['name'] == tagvalue.get_label()


### PR DESCRIPTION
## Summary
- Adds `userCount` definition to `issue_properties_map` in the attributes reference
- Updates the issue search agent system prompt with user count in capabilities, examples, and basic query classification
- Adds `userCount` to test fixtures for query parser and tools tests

This teaches the AI search agent that `userCount:>N` is the correct syntax for filtering by number of affected users, preventing misinterpretation as `user.id` filters.

Companion sentry PR: https://github.com/getsentry/sentry/pull/114814

## Test plan
- [x] All 139 query parser tests pass
- [x] All 22 issues tools with parser tests pass