### PR TITLE
Bump Pillow range pin to include latest version (4.2.1).

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -27,7 +27,7 @@ mmh3>=2.3.1,<2.4
 oauth2>=1.5.167
 percy>=0.4.5
 petname>=2.0,<2.1
-Pillow>=3.2.0,<3.3.0
+Pillow>=3.2.0,<=4.2.1
 progressbar2>=3.10,<3.11
 psycopg2>=2.6.0,<2.7.0
 pytest>=3.1.2,<3.2.0


### PR DESCRIPTION
We'd like to consume the `sentry` package via pypi, but it currently conflicts with a `Pillow==4.2.1` pin in our repo. This PR bumps the high end of the `Pillow` requirement in `sentry` to include 4.2.1.

AFAICT, this is a generally safe upgrade - but more detailed release notes are available here for any onlookers more familiar with Sentry's use of Pillow: http://pillow.readthedocs.io/en/4.2.x/releasenotes/index.html