### PR TITLE
feat(auth): Support raising IdentityNotValid in provider.build_identity

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.app import locks
+from sentry.auth.exceptions import IdentityNotValid
 from sentry.models import (
     AuditLogEntry, AuditLogEntryEvent, AuthIdentity, AuthProvider, Organization, OrganizationMember,
     OrganizationMemberTeam, User, UserEmail
@@ -36,6 +37,8 @@ OK_SETUP_SSO = _(
 ERR_UID_MISMATCH = _('There was an error encountered during authentication.')
 
 ERR_NOT_AUTHED = _('You must be authenticated to link accounts.')
+
+ERR_INVALID_IDENTITY = _('The provider did not return a valid user identity.')
 
 
 class AuthHelper(object):
@@ -170,7 +173,11 @@ class AuthHelper(object):
     def finish_pipeline(self):
         session = self.request.session['auth']
         state = session['state']
-        identity = self.provider.build_identity(state)
+
+        try:
+            identity = self.provider.build_identity(state)
+        except IdentityNotValid:
+            return self.error(ERR_INVALID_IDENTITY)
 
         if session['flow'] == self.FLOW_LOGIN:
             # create identity and authenticate the user

--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -60,6 +60,9 @@ class Provider(object):
         >>> }
 
         The ``email`` and ``id`` keys are required, ``name`` is optional.
+
+        If the identity can not be constructed an ``IdentityNotValid`` error
+        should be raised.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Useful in cases where the user has misconfigured their Identity Provider and an Identity cannot be created.