### PR TITLE
fix(auth): Allow the helper to move the SSO pipelines along

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -133,7 +133,7 @@ class AuthHelper(object):
             'ap': self.auth_provider.id if self.auth_provider else None,
             'p': self.provider.key,
             'org': self.organization.id,
-            'idx': -1,
+            'idx': 0,
             'sig': self.signature,
             'flow': self.flow,
             'state': {},

--- a/src/sentry/templates/sentry/organization-auth-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-settings.html
@@ -19,6 +19,7 @@
       {% if provider_list %}
         <form method="POST">
           {% csrf_token %}
+          <input type="hidden" name="init_setup" value="1" />
           <ul class="simple-list list-unstyled">
             {% for provider_key, provider_name in provider_list %}
               <li>

--- a/src/sentry/templates/sentry/organization-auth-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-settings.html
@@ -19,7 +19,7 @@
       {% if provider_list %}
         <form method="POST">
           {% csrf_token %}
-          <input type="hidden" name="init_setup" value="1" />
+          <input type="hidden" name="init" value="1" />
           <ul class="simple-list list-unstyled">
             {% for provider_key, provider_name in provider_list %}
               <li>

--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -49,6 +49,7 @@
   {% if provider_name %}
     <form class="form-stacked" action="" method="post" autocomplete="off">
       {% csrf_token %}
+      <input type="hidden" name="init_login" value="1" />
 
       <div class="align-center">
         <p>Sign in with your {{ provider_name }} account to continue.</p>

--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -49,7 +49,7 @@
   {% if provider_name %}
     <form class="form-stacked" action="" method="post" autocomplete="off">
       {% csrf_token %}
-      <input type="hidden" name="init_login" value="1" />
+      <input type="hidden" name="init" value="1" />
 
       <div class="align-center">
         <p>Sign in with your {{ provider_name }} account to continue.</p>

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -85,7 +85,7 @@ class AuthOrganizationLoginView(BaseView):
                 flow=AuthHelper.FLOW_LOGIN,
             )
 
-            if request.POST.get('init_login'):
+            if request.POST.get('init'):
                 helper.init_pipeline()
 
             return helper.current_step()

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -84,8 +84,11 @@ class AuthOrganizationLoginView(BaseView):
                 auth_provider=auth_provider,
                 flow=AuthHelper.FLOW_LOGIN,
             )
-            helper.init_pipeline()
-            return helper.next_step()
+
+            if request.POST.get('init_login'):
+                helper.init_pipeline()
+
+            return helper.current_step()
 
         provider = auth_provider.get_provider()
 

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -185,7 +185,7 @@ class OrganizationAuthSettingsView(OrganizationView):
                 flow=AuthHelper.FLOW_SETUP_PROVIDER,
             )
 
-            if request.POST.get('init_setup'):
+            if request.POST.get('init'):
                 helper.init_pipeline()
 
             # render first time setup view

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -148,16 +148,6 @@ class OrganizationAuthSettingsView(OrganizationView):
 
         return self.respond('sentry/organization-auth-provider-settings.html', context)
 
-    def handle_provider_setup(self, request, organization, provider_key):
-        helper = AuthHelper(
-            request=request,
-            organization=organization,
-            provider_key=provider_key,
-            flow=AuthHelper.FLOW_SETUP_PROVIDER,
-        )
-        helper.init_pipeline()
-        return helper.next_step()
-
     @transaction.atomic
     def handle(self, request, organization):
         if not features.has('organizations:sso', organization, actor=request.user):
@@ -188,8 +178,18 @@ class OrganizationAuthSettingsView(OrganizationView):
             if not manager.exists(provider_key):
                 raise ValueError('Provider not found: {}'.format(provider_key))
 
+            helper = AuthHelper(
+                request=request,
+                organization=organization,
+                provider_key=provider_key,
+                flow=AuthHelper.FLOW_SETUP_PROVIDER,
+            )
+
+            if request.POST.get('init_setup'):
+                helper.init_pipeline()
+
             # render first time setup view
-            return self.handle_provider_setup(request, organization, provider_key)
+            return helper.current_step()
 
         provider_list = []
 

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -45,7 +45,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -91,7 +91,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         self.login_as(user)
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -137,7 +137,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -159,7 +159,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -204,7 +204,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -260,7 +260,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -315,7 +315,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -374,7 +374,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -440,7 +440,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -509,7 +509,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -563,7 +563,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')
@@ -614,7 +614,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, {'init': True})
 
         assert resp.status_code == 200
         assert self.provider.TEMPLATE in resp.content.decode('utf-8')

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -54,7 +54,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         self.login_as(self.user)
 
         with self.feature('organizations:sso'):
-            resp = self.client.post(path, {'provider': 'dummy'})
+            resp = self.client.post(path, {'provider': 'dummy', 'init': True})
 
         assert resp.status_code == 200
         assert resp.content.decode('utf-8') == self.provider.TEMPLATE
@@ -68,7 +68,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         self.login_as(user)
 
         with self.feature('organizations:sso'):
-            resp = self.client.post(base_path, {'provider': 'dummy'})
+            resp = self.client.post(base_path, {'provider': 'dummy', 'init': True})
 
             assert resp.status_code == 200
             assert self.provider.TEMPLATE in resp.content.decode('utf-8')


### PR DESCRIPTION
Authentication (setup) pipelines should only be initialized when they are *first* started, NOT every action through the pipeline.

This worked fine for providers that only had a two step callback style pipeline, as the callback would usually be to the sso route, even for setups