### PR TITLE
fix(analytics): Don't record every User save for user.created

### DIFF
--- a/src/sentry/receivers/analytics.py
+++ b/src/sentry/receivers/analytics.py
@@ -7,8 +7,9 @@ from sentry.models import User
 
 
 def capture_signal(type):
-    def wrapped(instance, **kwargs):
-        analytics.record(type, instance)
+    def wrapped(instance, created, **kwargs):
+        if created:
+            analytics.record(type, instance)
 
     return wrapped
 


### PR DESCRIPTION
We record this on every User.save, which also happens very frequently because of us bumping `last_active` in middleware. https://github.com/getsentry/sentry/blob/master/src/sentry/middleware/user.py#L37