### PR TITLE
feat(u2f): Catch u2f errors in flow

### DIFF
--- a/src/sentry/static/sentry/app/components/u2finterface.jsx
+++ b/src/sentry/static/sentry/app/components/u2finterface.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import u2f from 'u2f-api';
-import ConfigStore from '../stores/configStore';
 import Raven from 'raven-js';
+import ConfigStore from '../stores/configStore';
 
 import {t, tct} from '../locale';
 


### PR DESCRIPTION
This changes two things:

1. if we get an error without metadata (which happens on prod for firefox)
   we don't fail.
2. we log the u2f errors we get in sentry so that we can see what is happening.

This is unlikely to solve the issue with firefox not being able to sign in in
prod but it should help us find out what is wrong.  I verified and firefox works
fine for me locally.