### PR TITLE
ref: Simplify GroupTagValueSerializer logic

### DIFF
--- a/src/sentry/api/serializers/models/grouptagvalue.py
+++ b/src/sentry/api/serializers/models/grouptagvalue.py
@@ -1,57 +1,17 @@
 from __future__ import absolute_import
 
-import operator
 import six
 
-from django.db.models import Q
-from six.moves import reduce
-
 from sentry.api.serializers import Serializer, register
-from sentry.models import GroupTagValue, TagKey, TagValue
-
-
-def parse_user_tag(value):
-    lookup, value = value.split(':', 1)
-    if lookup == 'id':
-        lookup = 'ident'
-    elif lookup == 'ip':
-        lookup = 'ip_address'
-    elif lookup not in ('email', 'ip_address', 'username'):
-        raise ValueError('{} is not a valid user attribute'.format(lookup))
-    return {lookup: value}
+from sentry.models import GroupTagValue, Release, TagKey
 
 
 @register(GroupTagValue)
 class GroupTagValueSerializer(Serializer):
     def get_attrs(self, item_list, user):
-        project_id = item_list[0].project_id
-
-        user_lookups = []
-        for item in item_list:
-            if item.key != 'sentry:user':
-                continue
-            if ':' not in item.value:
-                continue
-            try:
-                user_lookups.append(Q(**parse_user_tag(item.value)))
-            except ValueError:
-                continue
-
-        tag_labels = {}
-        other_lookups = [Q(key=i.key, value=i.value) for i in item_list if i.key != 'sentry:user']
-        if other_lookups:
-            tag_labels.update(
-                {
-                    (t.key, t.value): t.get_label()
-                    for t in TagValue.objects.filter(
-                        reduce(operator.or_, other_lookups),
-                        project_id=project_id,
-                    )
-                }
-            )
-
         result = {}
         for item in item_list:
+            label = item.value
             if item.key == 'sentry:user':
                 if item.value.startswith('id:'):
                     label = item.value[len('id:'):]
@@ -61,16 +21,13 @@ class GroupTagValueSerializer(Serializer):
                     label = item.value[len('username:'):]
                 elif item.value.startswith('ip:'):
                     label = item.value[len('ip:'):]
-                else:
-                    label = item.value
-            else:
-                try:
-                    label = tag_labels[(item.key, item.value)]
-                except KeyError:
-                    label = item.value
+            elif item.key == 'sentry:release':
+                label = Release.get_display_version(item.value)
+
             result[item] = {
                 'name': label,
             }
+
         return result
 
     def serialize(self, obj, attrs, user):


### PR DESCRIPTION
First, there was dead code related to user_lookups that I forgot to
remove before.

Second, the only label we support for TagValues are for
'sentry:release', so that query can be removed and the logic can be
greatly simplified.

In the future I will move the label-ification block into the tagstore
abstraction so it won't be in such a weird spot.