### PR TITLE
feat(plugins): Add support for short names

### DIFF
--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -30,29 +30,21 @@ class PluginSerializer(Serializer):
         if hasattr(obj, 'get_custom_contexts'):
             contexts.extend(x.type for x in obj.get_custom_contexts() or ())
         d = {
-            'id':
-            obj.slug,
-            'name':
-            six.text_type(obj.get_title()),
-            'type':
-            obj.get_plugin_type(),
-            'canDisable':
-            obj.can_disable,
-            'isTestable':
-            hasattr(obj, 'is_testable') and obj.is_testable(),
-            'metadata':
-            obj.get_metadata(),
-            'contexts':
-            contexts,
-            'status':
-            obj.get_status(),
+            'id': obj.slug,
+            'name': six.text_type(obj.get_title()),
+            'shortName': six.text_type(obj.get_short_title()),
+            'type': obj.get_plugin_type(),
+            'canDisable': obj.can_disable,
+            'isTestable': hasattr(obj, 'is_testable') and obj.is_testable(),
+            'metadata': obj.get_metadata(),
+            'contexts': contexts,
+            'status': obj.get_status(),
             'assets': [
                 {
                     'url': absolute_uri(get_asset_url(obj.asset_key or obj.slug, asset)),
                 } for asset in obj.get_assets()
             ],
-            'doc':
-            doc,
+            'doc': doc,
         }
         if self.project:
             d['enabled'] = obj.is_enabled(self.project)

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -280,6 +280,8 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin, PluginStatusMixin):
         """
         return self.title
 
+    get_short_title = get_title
+
     def get_description(self):
         """
         Returns the description for this plugin. This is shown on the plugin configuration

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -269,6 +269,8 @@ class IPlugin2(local, PluginConfigMixin, PluginStatusMixin):
         """
         return self.title
 
+    get_short_title = get_title
+
     def get_description(self):
         """
         Returns the description for this plugin. This is shown on the plugin configuration

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -344,7 +344,10 @@ class IssueTrackingPlugin2(Plugin):
         item = {
             'slug': self.slug,
             'allowed_actions': self.allowed_actions,
-            'title': self.get_title()
+            # TODO(dcramer): remove in Sentry 8.22+
+            'title': self.get_title(),
+            'name': self.get_title(),
+            'shortName': self.get_short_title(),
         }
         if issue_id:
             item['issue'] = {

--- a/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
@@ -80,14 +80,19 @@ const IssuePluginActions = React.createClass({
 
     let button;
     if (allowedActions.length === 1) {
+      // # TODO(dcramer): remove plugin.title check in Sentry 8.22+
       button = (
         <button
           className={'btn btn-default btn-sm btn-plugin-' + plugin.slug}
           onClick={this.openModal.bind(this, allowedActions[0])}>
-          {toTitleCase(allowedActions[0]) + ' ' + plugin.title + ' Issue'}
+          {toTitleCase(allowedActions[0]) +
+            ' ' +
+            (plugin.shortName || plugin.name || plugin.title) +
+            ' Issue'}
         </button>
       );
     } else {
+      // # TODO(dcramer): remove plugin.title check in Sentry 8.22+
       button = (
         <div className={'btn-group btn-plugin-' + plugin.slug}>
           <DropdownLink
@@ -95,7 +100,7 @@ const IssuePluginActions = React.createClass({
             className="btn btn-default btn-sm"
             title={
               <span>
-                {plugin.title}
+                {plugin.shortName || plugin.name || plugin.title}
                 <span
                   className="icon-arrow-down"
                   style={{marginLeft: 3, marginRight: -3}}
@@ -116,6 +121,7 @@ const IssuePluginActions = React.createClass({
       );
     }
 
+    // # TODO(dcramer): remove plugin.title check in Sentry 8.22+
     return (
       <span>
         {button}
@@ -126,7 +132,7 @@ const IssuePluginActions = React.createClass({
           backdrop="static"
           enforceFocus={false}>
           <Modal.Header closeButton>
-            <Modal.Title>{plugin.title + ' Issue'}</Modal.Title>
+            <Modal.Title>{`${plugin.name || plugin.title} Issue`}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
             {!this.state.pluginLoading &&

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -108,10 +108,11 @@ const GroupSidebar = React.createClass({
     let issues = [];
     (this.props.group.pluginIssues || []).forEach(plugin => {
       let issue = plugin.issue;
+      // # TODO(dcramer): remove plugin.title check in Sentry 8.22+
       if (issue) {
         issues.push(
           <dl key={plugin.slug}>
-            <dt>{plugin.title + ': '}</dt>
+            <dt>{`${plugin.shortName || plugin.name || plugin.title}: `}</dt>
             <dd><a href={issue.url}>{issue.label}</a></dd>
           </dl>
         );

--- a/src/sentry/static/sentry/app/components/inactivePlugins.jsx
+++ b/src/sentry/static/sentry/app/components/inactivePlugins.jsx
@@ -30,7 +30,7 @@ export default React.createClass({
                     onClick={this.enablePlugin.bind(this, plugin)}
                     className={`ref-plugin-enable-${plugin.id}`}>
                     <div className={'icon-integration icon-' + plugin.id} />
-                    {plugin.name}
+                    {plugin.shortName || plugin.name}
                   </button>
                 </li>
               );


### PR DESCRIPTION
This will let us support, for example, 'Visual Studio Team Services' with 'VSTS'.