### PR TITLE
fix: Be consistent about checking the auth pipeline

### DIFF
--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -88,6 +88,9 @@ class AuthOrganizationLoginView(BaseView):
             if request.POST.get('init'):
                 helper.init_pipeline()
 
+            if not helper.pipeline_is_valid():
+                return helper.error('Something unexpected happened during authentication.')
+
             return helper.current_step()
 
         provider = auth_provider.get_provider()

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -188,6 +188,9 @@ class OrganizationAuthSettingsView(OrganizationView):
             if request.POST.get('init'):
                 helper.init_pipeline()
 
+            if not helper.pipeline_is_valid():
+                return helper.error('Something unexpected happened during authentication.')
+
             # render first time setup view
             return helper.current_step()
 


### PR DESCRIPTION
We check the pipeline in the auth_provider_login (SSO endpoint), but we don't check during SSO configuration and the SSO login action (clicking the login button and any associated flow).