### PR TITLE
feat(plugins): Expand issue tracking storage

### DIFF
--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -36,7 +36,13 @@ class IssueGroupActionEndpoint(PluginGroupEndpoint):
 
 class IssueTrackingPlugin2(Plugin):
     auth_provider = None
+
     allowed_actions = ('create', 'link', 'unlink')
+
+    # we default this to None to support legacy integrations, but newer style
+    # should explicitly call out what is stored
+    issue_fields = None
+    # issue_fields = frozenset(['id', 'title', 'url'])
 
     def configure(self, project, request):
         return react_plugin_config(self, project, request)
@@ -139,31 +145,28 @@ class IssueTrackingPlugin2(Plugin):
     def get_link_existing_issue_fields(self, request, group, event, **kwargs):
         return []
 
-    def get_issue_url(self, group, issue_id, **kwargs):
+    def get_issue_url(self, group, issue, **kwargs):
         """
-        Given an issue_id (string) return an absolute URL to the issue's details
+        Given an issue context (issue_id string or issue dict) return an absolute URL to the issue's details
         page.
         """
         raise NotImplementedError
 
-    # TODO: should this return more than just title?
-    def get_issue_title_by_id(self, request, group, issue_id):
+    def get_issue_label(self, group, issue, **kwargs):
         """
-        Given an issue_id return the issue's title.
-        """
-        raise NotImplementedError
-
-    def get_issue_label(self, group, issue_id, **kwargs):
-        """
-        Given an issue_id (string) return a string representing the issue.
+        Given an issue context (issue_id string or issue dict) return a string representing the issue.
 
         e.g. GitHub represents issues as GH-XXX
         """
-        return '#%s' % issue_id
+        if isinstance(issue, dict):
+            return '#{}'.format(issue['id'])
+        return '#{}'.format(issue)
 
     def create_issue(self, request, group, form_data, **kwargs):
         """
         Creates the issue on the remote service and returns an issue ID.
+
+        Returns ``{'id': '1', 'title': issue_title}``
         """
         raise NotImplementedError
 
@@ -191,6 +194,39 @@ class IssueTrackingPlugin2(Plugin):
                     errors[field['name']] = u'%s is a required field.' % field['label']
         return errors
 
+    def get_issue_field_map(self):
+        # XXX(dcramer): legacy support
+        conf_key = self.get_conf_key()
+        if self.issue_fields is None:
+            return {
+                'id': '{}:tid'.format(conf_key)
+            }
+        return {
+            key: '{}:issue_{}'.format(
+                conf_key,
+                key,
+            )
+            for key in self.issue_fields
+        }
+
+    def build_issue(self, group):
+        issue_field_map = self.get_issue_field_map()
+        issue = {}
+        for key, meta_name in six.iteritems(issue_field_map):
+            issue[key] = GroupMeta.objects.get_value(group, meta_name, None)
+        if not any(issue.values()):
+            return None
+        return issue
+
+    def has_linked_issue(self, group):
+        return bool(self.build_issue(group))
+
+    def unlink_issue(self, request, group, issue, **kwargs):
+        issue_field_map = self.get_issue_field_map()
+        for meta_name in six.itervalues(issue_field_map):
+            GroupMeta.objects.unset_value(group, meta_name)
+        return self.redirect(group.get_absolute_url())
+
     def view_create(self, request, group, **kwargs):
         auth_errors = self.check_config_and_auth(request, group)
         if auth_errors:
@@ -215,20 +251,29 @@ class IssueTrackingPlugin2(Plugin):
             return Response({'error_type': 'validation', 'errors': errors}, status=400)
 
         try:
-            issue_id = self.create_issue(
+            issue = self.create_issue(
                 group=group,
                 form_data=request.DATA,
                 request=request,
             )
         except Exception as e:
             return self.handle_api_error(e)
-        GroupMeta.objects.set_value(group, '%s:tid' % self.get_conf_key(), issue_id)
+
+        if not isinstance(issue, dict):
+            issue = {'id': issue}
+
+        issue_field_map = self.get_issue_field_map()
+        for key, meta_name in six.iteritems(issue_field_map):
+            if key in issue:
+                GroupMeta.objects.set_value(group, meta_name, issue[key])
+            else:
+                GroupMeta.objects.unset_value(group, meta_name)
 
         issue_information = {
             'title': request.DATA['title'],
             'provider': self.get_title(),
-            'location': self.get_issue_url(group, issue_id),
-            'label': self.get_issue_label(group=group, issue_id=issue_id),
+            'location': self.get_issue_url(group, issue),
+            'label': self.get_issue_label(group, issue),
         }
         Activity.objects.create(
             project=group.project,
@@ -239,26 +284,25 @@ class IssueTrackingPlugin2(Plugin):
         )
 
         issue_tracker_used.send(
-            plugin=self, project=group.project, user=request.user, sender=IssueTrackingPlugin2
+            plugin=self, project=group.project, user=request.user,
+            sender=type(self)
         )
-        return Response({'issue_url': self.get_issue_url(group=group, issue_id=issue_id)})
-
-    def view_unlink(self, request, group, **kwargs):
-        auth_errors = self.check_config_and_auth(request, group)
-        if auth_errors:
-            return Response(auth_errors, status=400)
-        if GroupMeta.objects.get_value(group, '%s:tid' % self.get_conf_key(), None):
-            if 'unlink' in self.allowed_actions:
-                GroupMeta.objects.unset_value(group, '%s:tid' % self.get_conf_key())
-                return Response({'message': 'Successfully unlinked issue.'})
-        return Response({'message': 'No issues to unlink.'}, status=400)
+        return Response({'issue_url': self.get_issue_url(group, issue)})
 
     def view_link(self, request, group, **kwargs):
         auth_errors = self.check_config_and_auth(request, group)
         if auth_errors:
             return Response(auth_errors, status=400)
+
         event = group.get_latest_event()
+        if event is None:
+            return Response({
+                'message': 'Unable to create issues: there are '
+                           'no events associated with this group',
+            }, status=400)
+
         Event.objects.bind_nodes([event], 'data')
+
         try:
             fields = self.get_link_existing_issue_fields(request, group, event, **kwargs)
         except Exception as e:
@@ -270,30 +314,26 @@ class IssueTrackingPlugin2(Plugin):
             return Response({'error_type': 'validation', 'errors': errors}, status=400)
 
         try:
-            issue_id = int(request.DATA['issue_id'])
-        except ValueError:
-            issue_id = request.DATA['issue_id']
-
-        try:
             issue = self.link_issue(
                 group=group,
                 form_data=request.DATA,
                 request=request,
             )
-            if issue is None:
-                issue = {
-                    'title': self.get_issue_title_by_id(request, group, issue_id),
-                }
         except Exception as e:
             return self.handle_api_error(e)
 
-        GroupMeta.objects.set_value(group, '%s:tid' % self.get_conf_key(), issue_id)
+        issue_field_map = self.get_issue_field_map()
+        for key, meta_name in six.iteritems(issue_field_map):
+            if key in issue:
+                GroupMeta.objects.set_value(group, meta_name, issue[key])
+            else:
+                GroupMeta.objects.unset_value(group, meta_name)
 
         issue_information = {
             'title': issue['title'],
             'provider': self.get_title(),
-            'location': self.get_issue_url(group, issue_id),
-            'label': self.get_issue_label(group=group, issue_id=issue_id),
+            'location': self.get_issue_url(group, issue),
+            'label': self.get_issue_label(group, issue),
         }
         Activity.objects.create(
             project=group.project,
@@ -303,6 +343,37 @@ class IssueTrackingPlugin2(Plugin):
             data=issue_information,
         )
         return Response({'message': 'Successfully linked issue.'})
+
+    def view_unlink(self, request, group, **kwargs):
+        auth_errors = self.check_config_and_auth(request, group)
+        if auth_errors:
+            return Response(auth_errors, status=400)
+        issue = self.build_issue(group)
+        if issue and 'unlink' in self.allowed_actions:
+            self.unlink_issue(request, group, issue)
+            return Response({'message': 'Successfully unlinked issue.'})
+        return Response({'message': 'No issues to unlink.'}, status=400)
+
+    def plugin_issues(self, request, group, plugin_issues, **kwargs):
+        if not self.is_configured(request=request, project=group.project):
+            return plugin_issues
+
+        item = {
+            'slug': self.slug,
+            'allowed_actions': self.allowed_actions,
+            'title': self.get_title()
+        }
+        issue = self.build_issue(group)
+        if issue:
+            item['issue'] = {
+                'issue_id': issue.get('id'),
+                'url': self.get_issue_url(group, issue),
+                'label': self.get_issue_label(group, issue),
+            }
+
+        item.update(PluginSerializer(group.project).serialize(self, None, request.user))
+        plugin_issues.append(item)
+        return plugin_issues
 
     def get_config(self, *args, **kwargs):
         # TODO(dcramer): update existing plugins to just use get_config
@@ -333,30 +404,6 @@ class IssueTrackingPlugin2(Plugin):
                 'auth_url': reverse('socialauth_associate', args=[self.auth_provider])
             }
 
-    def plugin_issues(self, request, group, plugin_issues, **kwargs):
-        if not self.is_configured(request=request, project=group.project):
-            return plugin_issues
-        prefix = self.get_conf_key()
-        issue_id = GroupMeta.objects.get_value(group, '%s:tid' % prefix, None)
-        item = {
-            'slug': self.slug,
-            'allowed_actions': self.allowed_actions,
-            # TODO(dcramer): remove in Sentry 8.22+
-            'title': self.get_title(),
-            'name': self.get_title(),
-            'shortName': self.get_short_title(),
-        }
-        if issue_id:
-            item['issue'] = {
-                'issue_id': issue_id,
-                'url': self.get_issue_url(group=group, issue_id=issue_id),
-                'label': self.get_issue_label(group=group, issue_id=issue_id),
-            }
-
-        item.update(PluginSerializer(group.project).serialize(self, None, request.user))
-        plugin_issues.append(item)
-        return plugin_issues
-
     # TODO: should we get rid of this (move it to react?)
     def tags(self, request, group, tag_list, **kwargs):
         if not self.is_configured(request=request, project=group.project):
@@ -370,8 +417,8 @@ class IssueTrackingPlugin2(Plugin):
         tag_list.append(
             format_html(
                 '<a href="{}">{}</a>',
-                self.get_issue_url(group=group, issue_id=issue_id),
-                self.get_issue_label(group=group, issue_id=issue_id),
+                self.get_issue_url(group, issue_id),
+                self.get_issue_label(group, issue_id),
             )
         )
 

--- a/tests/sentry/plugins/bases/issue/tests.py
+++ b/tests/sentry/plugins/bases/issue/tests.py
@@ -2,13 +2,12 @@
 
 from __future__ import absolute_import
 
-import json
 import mock
 
 from social_auth.models import UserSocialAuth
 
-from sentry.models import User, GroupMeta
-from sentry.plugins import IssueTrackingPlugin, IssueTrackingPlugin2, plugins
+from sentry.models import User
+from sentry.plugins import IssueTrackingPlugin
 from sentry.testutils import TestCase
 
 
@@ -36,113 +35,3 @@ class GetAuthForUserTest(TestCase):
         p = IssueTrackingPlugin()
         p.auth_provider = 'test'
         self.assertEquals(p.get_auth_for_user(user), auth)
-
-
-class GetAuthForUserTestIssue2(TestCase):
-    def _get_mock_user(self):
-        user = mock.Mock(spec=User())
-        user.id = 1
-        user.is_authenticated.return_value = False
-        return user
-
-    def test_requires_auth_provider(self):
-        user = self._get_mock_user()
-        p = IssueTrackingPlugin2()
-        self.assertRaises(AssertionError, p.get_auth_for_user, user)
-
-    def test_returns_none_on_missing_identity(self):
-        user = self._get_mock_user()
-        p = IssueTrackingPlugin2()
-        p.auth_provider = 'test'
-        self.assertEquals(p.get_auth_for_user(user), None)
-
-    def test_returns_identity(self):
-        user = User.objects.create(username='test', email='test@example.com')
-        auth = UserSocialAuth.objects.create(provider='test', user=user)
-        p = IssueTrackingPlugin2()
-        p.auth_provider = 'test'
-        self.assertEquals(p.get_auth_for_user(user), auth)
-
-
-class IssuePlugin2GroupAction(TestCase):
-    def setUp(self):
-        super(IssuePlugin2GroupAction, self).setUp()
-        self.project = self.create_project()
-        self.group = self.create_group(project=self.project)
-        self.plugin_instance = plugins.get(slug='issuetrackingplugin2')
-        self.event = self.create_event(
-            event_id='a',
-            group=self.group,
-        )
-
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
-    def test_get_create(self, *args):
-        self.login_as(user=self.user)
-        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % self.group.id
-        response = self.client.get(url, format='json')
-        content = json.loads(response.content)
-        field_names = [field['name'] for field in content]
-        assert response.status_code == 200
-        assert 'title' in field_names
-        assert 'description' in field_names
-
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.create_issue')
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
-    def test_post_create_invalid(self, *args):
-        self.login_as(user=self.user)
-        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % self.group.id
-        response = self.client.post(url, data={'title': '', 'description': ''}, format='json')
-        content = json.loads(response.content)
-        assert response.status_code == 400
-        assert content['error_type'] == 'validation'
-
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.create_issue', return_value=1)
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.get_issue_url', return_value='')
-    def test_post_create_valid(self, *args):
-        self.login_as(user=self.user)
-        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % self.group.id
-        response = self.client.post(
-            url, data={'title': 'test',
-                       'description': 'test'}, format='json'
-        )
-        content = json.loads(response.content)
-        assert response.status_code == 200
-        assert 'issue_url' in content
-
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
-    def test_get_link(self, *args):
-        self.login_as(user=self.user)
-        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/link/' % self.group.id
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200
-
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
-    def test_get_unlink_invalid(self, *args):
-        self.login_as(user=self.user)
-        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/unlink/' % self.group.id
-        response = self.client.get(url, format='json')
-        assert response.status_code == 400
-
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
-    def test_get_unlink_valid(self, *args):
-        self.login_as(user=self.user)
-        id_ = '%s:tid' % self.plugin_instance.get_conf_key()
-        GroupMeta.objects.set_value(self.group, id_, 4)
-        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/unlink/' % self.group.id
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200
-        GroupMeta.objects.populate_cache([self.group])
-        assert GroupMeta.objects.get_value(self.group, id_, None) is None
-
-    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
-    def test_no_group_events(self, *args):
-        self.login_as(user=self.user)
-        group = self.create_group(project=self.project)
-        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % group.id
-        response = self.client.get(url, format='json')
-        assert response.status_code == 400
-        assert response.data == {
-            'message': 'Unable to create issues: there are '
-                       'no events associated with this group',
-        }

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import json
+import mock
+
+from social_auth.models import UserSocialAuth
+
+from sentry.models import GroupMeta, User
+from sentry.plugins import IssueTrackingPlugin2, plugins
+from sentry.testutils import TestCase
+
+
+class TestPluginWithFields(IssueTrackingPlugin2):
+    slug = 'test-plugin-with-fields'
+    conf_key = slug
+    issue_fields = frozenset(['id', 'title', 'url'])
+
+
+class TestPluginWithoutFields(IssueTrackingPlugin2):
+    slug = 'test-plugin-without-fields'
+    conf_key = slug
+    issue_fields = None
+
+
+class IssueTrackingPlugin2Test(TestCase):
+    def test_issue_label_as_dict(self):
+        plugin = TestPluginWithFields()
+        result = plugin.get_issue_label(mock.Mock(), {'id': '1'})
+        assert result == '#1'
+
+    def test_issue_label_legacy(self):
+        plugin = TestPluginWithoutFields()
+        result = plugin.get_issue_label(mock.Mock(), '1')
+        assert result == '#1'
+
+    def test_issue_field_map_with_fields(self):
+        plugin = TestPluginWithFields()
+        result = plugin.get_issue_field_map()
+        assert result == {
+            'id': 'test-plugin-with-fields:issue_id',
+            'title': 'test-plugin-with-fields:issue_title',
+            'url': 'test-plugin-with-fields:issue_url',
+        }
+
+    def test_issue_field_map_without_fields(self):
+        plugin = TestPluginWithoutFields()
+        result = plugin.get_issue_field_map()
+        assert result == {'id': 'test-plugin-without-fields:tid'}
+
+
+class GetAuthForUserTest(TestCase):
+    def _get_mock_user(self):
+        user = mock.Mock(spec=User())
+        user.id = 1
+        user.is_authenticated.return_value = False
+        return user
+
+    def test_requires_auth_provider(self):
+        user = self._get_mock_user()
+        p = IssueTrackingPlugin2()
+        self.assertRaises(AssertionError, p.get_auth_for_user, user)
+
+    def test_returns_none_on_missing_identity(self):
+        user = self._get_mock_user()
+        p = IssueTrackingPlugin2()
+        p.auth_provider = 'test'
+        self.assertEquals(p.get_auth_for_user(user), None)
+
+    def test_returns_identity(self):
+        user = User.objects.create(username='test', email='test@example.com')
+        auth = UserSocialAuth.objects.create(provider='test', user=user)
+        p = IssueTrackingPlugin2()
+        p.auth_provider = 'test'
+        self.assertEquals(p.get_auth_for_user(user), auth)
+
+
+class IssuePlugin2GroupActionTest(TestCase):
+    def setUp(self):
+        super(IssuePlugin2GroupActionTest, self).setUp()
+        self.project = self.create_project()
+        self.group = self.create_group(project=self.project)
+        self.plugin_instance = plugins.get(slug='issuetrackingplugin2')
+        self.event = self.create_event(
+            event_id='a',
+            group=self.group,
+        )
+
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
+    def test_get_create(self, *args):
+        self.login_as(user=self.user)
+        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % self.group.id
+        response = self.client.get(url, format='json')
+        content = json.loads(response.content)
+        field_names = [field['name'] for field in content]
+        assert response.status_code == 200
+        assert 'title' in field_names
+        assert 'description' in field_names
+
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.create_issue')
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
+    def test_post_create_invalid(self, *args):
+        self.login_as(user=self.user)
+        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % self.group.id
+        response = self.client.post(url, data={'title': '', 'description': ''}, format='json')
+        content = json.loads(response.content)
+        assert response.status_code == 400
+        assert content['error_type'] == 'validation'
+
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.create_issue', return_value=1)
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.get_issue_url', return_value='')
+    def test_post_create_valid(self, *args):
+        self.login_as(user=self.user)
+        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % self.group.id
+        response = self.client.post(
+            url, data={'title': 'test',
+                       'description': 'test'}, format='json'
+        )
+        content = json.loads(response.content)
+        assert response.status_code == 200
+        assert 'issue_url' in content
+
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
+    def test_get_link(self, *args):
+        self.login_as(user=self.user)
+        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/link/' % self.group.id
+        response = self.client.get(url, format='json')
+        assert response.status_code == 200
+
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
+    def test_get_unlink_invalid(self, *args):
+        self.login_as(user=self.user)
+        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/unlink/' % self.group.id
+        response = self.client.get(url, format='json')
+        assert response.status_code == 400
+
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
+    def test_get_unlink_valid(self, *args):
+        self.login_as(user=self.user)
+        id_ = '%s:tid' % self.plugin_instance.get_conf_key()
+        GroupMeta.objects.set_value(self.group, id_, 4)
+        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/unlink/' % self.group.id
+        response = self.client.get(url, format='json')
+        assert response.status_code == 200
+        GroupMeta.objects.populate_cache([self.group])
+        assert GroupMeta.objects.get_value(self.group, id_, None) is None
+
+    @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
+    def test_no_group_events(self, *args):
+        self.login_as(user=self.user)
+        group = self.create_group(project=self.project)
+        url = '/api/0/issues/%s/plugins/issuetrackingplugin2/create/' % group.id
+        response = self.client.get(url, format='json')
+        assert response.status_code == 400
+        assert response.data == {
+            'message': 'Unable to create issues: there are '
+                       'no events associated with this group',
+        }


### PR DESCRIPTION
Add capability to store arbitrary metadata when linking or creating issues.

This is based on code present in sentry-plugins, but abstracted to handle legacy cases better.