### PR TITLE
feat(tsdb): Add support for environment filtering

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -289,7 +289,7 @@ class BaseTSDB(Service):
         raise NotImplementedError
 
     def get_sums(self, model, keys, start, end, rollup=None, environment_id=None):
-        range_set = self.get_range(model, keys, start, end, rollup)
+        range_set = self.get_range(model, keys, start, end, rollup, environment_id)
         sum_set = dict(
             (key, sum(p for _, p in points)) for (key, points) in six.iteritems(range_set)
         )

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -246,7 +246,7 @@ class BaseTSDB(Service):
             rollup,
         )
 
-    def incr(self, model, key, timestamp=None, count=1, environment=None):
+    def incr(self, model, key, timestamp=None, count=1, environment_id=None):
         """
         Increment project ID=1:
 
@@ -254,28 +254,28 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def incr_multi(self, items, timestamp=None, count=1, environment=None):
+    def incr_multi(self, items, timestamp=None, count=1, environment_id=None):
         """
         Increment project ID=1 and group ID=5:
 
         >>> incr_multi([(TimeSeriesModel.project, 1), (TimeSeriesModel.group, 5)])
         """
         for model, key in items:
-            self.incr(model, key, timestamp, count, environment=environment)
+            self.incr(model, key, timestamp, count, environment_id=environment_id)
 
-    def merge(self, model, destination, sources, timestamp=None, environments=None):
+    def merge(self, model, destination, sources, timestamp=None, environment_ids=None):
         """
         Transfer all counters from the source keys to the destination key.
         """
         raise NotImplementedError
 
-    def delete(self, models, keys, start=None, end=None, timestamp=None, environments=None):
+    def delete(self, models, keys, start=None, end=None, timestamp=None, environment_ids=None):
         """
         Delete all counters.
         """
         raise NotImplementedError
 
-    def get_range(self, model, keys, start, end, rollup=None, environment=None):
+    def get_range(self, model, keys, start, end, rollup=None, environment_id=None):
         """
         To get a range of data for group ID=[1, 2, 3]:
 
@@ -288,7 +288,7 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_sums(self, model, keys, start, end, rollup=None, environment=None):
+    def get_sums(self, model, keys, start, end, rollup=None, environment_id=None):
         range_set = self.get_range(model, keys, start, end, rollup)
         sum_set = dict(
             (key, sum(p for _, p in points)) for (key, points) in six.iteritems(range_set)
@@ -314,42 +314,43 @@ class BaseTSDB(Service):
                     last_new_ts = new_ts
         return result
 
-    def record(self, model, key, values, timestamp=None, environment=None):
+    def record(self, model, key, values, timestamp=None, environment_id=None):
         """
         Record occurences of items in a single distinct counter.
         """
         raise NotImplementedError
 
-    def record_multi(self, items, timestamp=None, environment=None):
+    def record_multi(self, items, timestamp=None, environment_id=None):
         """
         Record occurences of items in multiple distinct counters.
         """
         for model, key, values in items:
-            self.record(model, key, values, timestamp, environment=environment)
+            self.record(model, key, values, timestamp, environment_id=environment_id)
 
     def get_distinct_counts_series(self, model, keys, start, end=None,
-                                   rollup=None, environment=None):
+                                   rollup=None, environment_id=None):
         """
         Fetch counts of distinct items for each rollup interval within the range.
         """
         raise NotImplementedError
 
     def get_distinct_counts_totals(self, model, keys, start, end=None,
-                                   rollup=None, environment=None):
+                                   rollup=None, environment_id=None):
         """
         Count distinct items during a time range.
         """
         raise NotImplementedError
 
     def get_distinct_counts_union(self, model, keys, start, end=None,
-                                  rollup=None, environment=None):
+                                  rollup=None, environment_id=None):
         """
         Count the total number of distinct items across multiple counters
         during a time range.
         """
         raise NotImplementedError
 
-    def merge_distinct_counts(self, model, destination, sources, timestamp=None, environments=None):
+    def merge_distinct_counts(self, model, destination, sources,
+                              timestamp=None, environment_ids=None):
         """
         Transfer all distinct counters from the source keys to the
         destination key.
@@ -357,13 +358,13 @@ class BaseTSDB(Service):
         raise NotImplementedError
 
     def delete_distinct_counts(self, models, keys, start=None, end=None,
-                               timestamp=None, environments=None):
+                               timestamp=None, environment_ids=None):
         """
         Delete all distinct counters.
         """
         raise NotImplementedError
 
-    def record_frequency_multi(self, requests, timestamp=None, environment=None):
+    def record_frequency_multi(self, requests, timestamp=None, environment_id=None):
         """
         Record items in a frequency table.
 
@@ -373,7 +374,7 @@ class BaseTSDB(Service):
         raise NotImplementedError
 
     def get_most_frequent(self, model, keys, start, end=None,
-                          rollup=None, limit=None, environment=None):
+                          rollup=None, limit=None, environment_id=None):
         """
         Retrieve the most frequently seen items in a frequency table.
 
@@ -386,7 +387,7 @@ class BaseTSDB(Service):
         raise NotImplementedError
 
     def get_most_frequent_series(self, model, keys, start, end=None,
-                                 rollup=None, limit=None, environment=None):
+                                 rollup=None, limit=None, environment_id=None):
         """
         Retrieve the most frequently seen items in a frequency table for each
         interval in a series. (This is in contrast with ``get_most_frequent``,
@@ -400,7 +401,7 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment=None):
+    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment_id=None):
         """
         Retrieve the frequency of known items in a table over time.
 
@@ -414,7 +415,7 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment=None):
+    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment_id=None):
         """
         Retrieve the total frequency of known items in a table over time.
 
@@ -428,7 +429,7 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def merge_frequencies(self, model, destination, sources, timestamp=None, environments=None):
+    def merge_frequencies(self, model, destination, sources, timestamp=None, environment_ids=None):
         """
         Transfer all frequency tables from the source keys to the destination
         key.
@@ -436,7 +437,7 @@ class BaseTSDB(Service):
         raise NotImplementedError
 
     def delete_frequencies(self, models, keys, start=None, end=None,
-                           timestamp=None, environments=None):
+                           timestamp=None, environment_ids=None):
         """
         Delete all frequency tables.
         """

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -246,7 +246,7 @@ class BaseTSDB(Service):
             rollup,
         )
 
-    def incr(self, model, key, timestamp=None, count=1):
+    def incr(self, model, key, timestamp=None, count=1, environment=None):
         """
         Increment project ID=1:
 
@@ -254,28 +254,28 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def incr_multi(self, items, timestamp=None, count=1):
+    def incr_multi(self, items, timestamp=None, count=1, environment=None):
         """
         Increment project ID=1 and group ID=5:
 
         >>> incr_multi([(TimeSeriesModel.project, 1), (TimeSeriesModel.group, 5)])
         """
         for model, key in items:
-            self.incr(model, key, timestamp, count)
+            self.incr(model, key, timestamp, count, environment=environment)
 
-    def merge(self, model, destination, sources, timestamp=None):
+    def merge(self, model, destination, sources, timestamp=None, environments=None):
         """
         Transfer all counters from the source keys to the destination key.
         """
         raise NotImplementedError
 
-    def delete(self, models, keys, start=None, end=None, timestamp=None):
+    def delete(self, models, keys, start=None, end=None, timestamp=None, environments=None):
         """
         Delete all counters.
         """
         raise NotImplementedError
 
-    def get_range(self, model, keys, start, end, rollup=None):
+    def get_range(self, model, keys, start, end, rollup=None, environment=None):
         """
         To get a range of data for group ID=[1, 2, 3]:
 
@@ -288,7 +288,7 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_sums(self, model, keys, start, end, rollup=None):
+    def get_sums(self, model, keys, start, end, rollup=None, environment=None):
         range_set = self.get_range(model, keys, start, end, rollup)
         sum_set = dict(
             (key, sum(p for _, p in points)) for (key, points) in six.iteritems(range_set)
@@ -314,52 +314,56 @@ class BaseTSDB(Service):
                     last_new_ts = new_ts
         return result
 
-    def record(self, model, key, values, timestamp=None):
+    def record(self, model, key, values, timestamp=None, environment=None):
         """
         Record occurences of items in a single distinct counter.
         """
         raise NotImplementedError
 
-    def record_multi(self, items, timestamp=None):
+    def record_multi(self, items, timestamp=None, environment=None):
         """
         Record occurences of items in multiple distinct counters.
         """
         for model, key, values in items:
-            self.record(model, key, values, timestamp)
+            self.record(model, key, values, timestamp, environment=environment)
 
-    def get_distinct_counts_series(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_series(self, model, keys, start, end=None,
+                                   rollup=None, environment=None):
         """
         Fetch counts of distinct items for each rollup interval within the range.
         """
         raise NotImplementedError
 
-    def get_distinct_counts_totals(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_totals(self, model, keys, start, end=None,
+                                   rollup=None, environment=None):
         """
         Count distinct items during a time range.
         """
         raise NotImplementedError
 
-    def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_union(self, model, keys, start, end=None,
+                                  rollup=None, environment=None):
         """
         Count the total number of distinct items across multiple counters
         during a time range.
         """
         raise NotImplementedError
 
-    def merge_distinct_counts(self, model, destination, sources, timestamp=None):
+    def merge_distinct_counts(self, model, destination, sources, timestamp=None, environments=None):
         """
         Transfer all distinct counters from the source keys to the
         destination key.
         """
         raise NotImplementedError
 
-    def delete_distinct_counts(self, models, keys, start=None, end=None, timestamp=None):
+    def delete_distinct_counts(self, models, keys, start=None, end=None,
+                               timestamp=None, environments=None):
         """
         Delete all distinct counters.
         """
         raise NotImplementedError
 
-    def record_frequency_multi(self, requests, timestamp=None):
+    def record_frequency_multi(self, requests, timestamp=None, environment=None):
         """
         Record items in a frequency table.
 
@@ -368,7 +372,8 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_most_frequent(self, model, keys, start, end=None, rollup=None, limit=None):
+    def get_most_frequent(self, model, keys, start, end=None,
+                          rollup=None, limit=None, environment=None):
         """
         Retrieve the most frequently seen items in a frequency table.
 
@@ -380,7 +385,8 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_most_frequent_series(self, model, keys, start, end=None, rollup=None, limit=None):
+    def get_most_frequent_series(self, model, keys, start, end=None,
+                                 rollup=None, limit=None, environment=None):
         """
         Retrieve the most frequently seen items in a frequency table for each
         interval in a series. (This is in contrast with ``get_most_frequent``,
@@ -394,7 +400,7 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_frequency_series(self, model, items, start, end=None, rollup=None):
+    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment=None):
         """
         Retrieve the frequency of known items in a table over time.
 
@@ -408,7 +414,7 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def get_frequency_totals(self, model, items, start, end=None, rollup=None):
+    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment=None):
         """
         Retrieve the total frequency of known items in a table over time.
 
@@ -422,14 +428,15 @@ class BaseTSDB(Service):
         """
         raise NotImplementedError
 
-    def merge_frequencies(self, model, destination, sources, timestamp=None):
+    def merge_frequencies(self, model, destination, sources, timestamp=None, environments=None):
         """
         Transfer all frequency tables from the source keys to the destination
         key.
         """
         raise NotImplementedError
 
-    def delete_frequencies(self, models, keys, start=None, end=None, timestamp=None):
+    def delete_frequencies(self, models, keys, start=None, end=None,
+                           timestamp=None, environments=None):
         """
         Delete all frequency tables.
         """

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -15,55 +15,56 @@ class DummyTSDB(BaseTSDB):
     A no-op time-series storage.
     """
 
-    def incr(self, model, key, timestamp=None, count=1, environment=None):
+    def incr(self, model, key, timestamp=None, count=1, environment_id=None):
         pass
 
-    def merge(self, model, destination, sources, timestamp=None, environments=None):
+    def merge(self, model, destination, sources, timestamp=None, environment_ids=None):
         pass
 
-    def delete(self, models, keys, start=None, end=None, timestamp=None, environments=None):
+    def delete(self, models, keys, start=None, end=None, timestamp=None, environment_ids=None):
         pass
 
-    def get_range(self, model, keys, start, end, rollup=None, environment=None):
+    def get_range(self, model, keys, start, end, rollup=None, environment_id=None):
         _, series = self.get_optimal_rollup_series(start, end, rollup)
         return {k: [(ts, 0) for ts in series] for k in keys}
 
-    def record(self, model, key, values, timestamp=None, environment=None):
+    def record(self, model, key, values, timestamp=None, environment_id=None):
         pass
 
     def get_distinct_counts_series(self, model, keys, start, end=None,
-                                   rollup=None, environment=None):
+                                   rollup=None, environment_id=None):
         _, series = self.get_optimal_rollup_series(start, end, rollup)
         return {k: [(ts, 0) for ts in series] for k in keys}
 
     def get_distinct_counts_totals(self, model, keys, start, end=None,
-                                   rollup=None, environment=None):
+                                   rollup=None, environment_id=None):
         return {k: 0 for k in keys}
 
     def get_distinct_counts_union(self, model, keys, start, end=None,
-                                  rollup=None, environment=None):
+                                  rollup=None, environment_id=None):
         return 0
 
-    def merge_distinct_counts(self, model, destination, sources, timestamp=None, environments=None):
+    def merge_distinct_counts(self, model, destination, sources,
+                              timestamp=None, environment_ids=None):
         pass
 
     def delete_distinct_counts(self, models, keys, start=None, end=None,
-                               timestamp=None, environments=None):
+                               timestamp=None, environment_ids=None):
         pass
 
-    def record_frequency_multi(self, requests, timestamp=None, environment=None):
+    def record_frequency_multi(self, requests, timestamp=None, environment_id=None):
         pass
 
     def get_most_frequent(self, model, keys, start, end=None,
-                          rollup=None, limit=None, environment=None):
+                          rollup=None, limit=None, environment_id=None):
         return {key: [] for key in keys}
 
     def get_most_frequent_series(self, model, keys, start, end=None,
-                                 rollup=None, limit=None, environment=None):
+                                 rollup=None, limit=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
         return {key: [(timestamp, {}) for timestamp in series] for key in keys}
 
-    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment=None):
+    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
@@ -74,15 +75,15 @@ class DummyTSDB(BaseTSDB):
 
         return results
 
-    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment=None):
+    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment_id=None):
         results = {}
         for key, members in items.items():
             results[key] = {member: 0.0 for member in members}
         return results
 
-    def merge_frequencies(self, model, destination, sources, timestamp=None, environments=None):
+    def merge_frequencies(self, model, destination, sources, timestamp=None, environment_ids=None):
         pass
 
     def delete_frequencies(self, models, keys, start=None, end=None,
-                           timestamp=None, environments=None):
+                           timestamp=None, environment_ids=None):
         pass

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -15,49 +15,55 @@ class DummyTSDB(BaseTSDB):
     A no-op time-series storage.
     """
 
-    def incr(self, model, key, timestamp=None, count=1):
+    def incr(self, model, key, timestamp=None, count=1, environment=None):
         pass
 
-    def merge(self, model, destination, sources, timestamp=None):
+    def merge(self, model, destination, sources, timestamp=None, environments=None):
         pass
 
-    def delete(self, models, keys, start=None, end=None, timestamp=None):
+    def delete(self, models, keys, start=None, end=None, timestamp=None, environments=None):
         pass
 
-    def get_range(self, model, keys, start, end, rollup=None):
+    def get_range(self, model, keys, start, end, rollup=None, environment=None):
         _, series = self.get_optimal_rollup_series(start, end, rollup)
         return {k: [(ts, 0) for ts in series] for k in keys}
 
-    def record(self, model, key, values, timestamp=None):
+    def record(self, model, key, values, timestamp=None, environment=None):
         pass
 
-    def get_distinct_counts_series(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_series(self, model, keys, start, end=None,
+                                   rollup=None, environment=None):
         _, series = self.get_optimal_rollup_series(start, end, rollup)
         return {k: [(ts, 0) for ts in series] for k in keys}
 
-    def get_distinct_counts_totals(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_totals(self, model, keys, start, end=None,
+                                   rollup=None, environment=None):
         return {k: 0 for k in keys}
 
-    def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_union(self, model, keys, start, end=None,
+                                  rollup=None, environment=None):
         return 0
 
-    def merge_distinct_counts(self, model, destination, sources, timestamp=None):
+    def merge_distinct_counts(self, model, destination, sources, timestamp=None, environments=None):
         pass
 
-    def delete_distinct_counts(self, models, keys, start=None, end=None, timestamp=None):
+    def delete_distinct_counts(self, models, keys, start=None, end=None,
+                               timestamp=None, environments=None):
         pass
 
-    def record_frequency_multi(self, requests, timestamp=None):
+    def record_frequency_multi(self, requests, timestamp=None, environment=None):
         pass
 
-    def get_most_frequent(self, model, keys, start, end=None, rollup=None, limit=None):
+    def get_most_frequent(self, model, keys, start, end=None,
+                          rollup=None, limit=None, environment=None):
         return {key: [] for key in keys}
 
-    def get_most_frequent_series(self, model, keys, start, end=None, rollup=None, limit=None):
+    def get_most_frequent_series(self, model, keys, start, end=None,
+                                 rollup=None, limit=None, environment=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
         return {key: [(timestamp, {}) for timestamp in series] for key in keys}
 
-    def get_frequency_series(self, model, items, start, end=None, rollup=None):
+    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
@@ -68,14 +74,15 @@ class DummyTSDB(BaseTSDB):
 
         return results
 
-    def get_frequency_totals(self, model, items, start, end=None, rollup=None):
+    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment=None):
         results = {}
         for key, members in items.items():
             results[key] = {member: 0.0 for member in members}
         return results
 
-    def merge_frequencies(self, model, destination, sources, timestamp=None):
+    def merge_frequencies(self, model, destination, sources, timestamp=None, environments=None):
         pass
 
-    def delete_frequencies(self, models, keys, start=None, end=None, timestamp=None):
+    def delete_frequencies(self, models, keys, start=None, end=None,
+                           timestamp=None, environments=None):
         pass

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -27,7 +27,10 @@ class InMemoryTSDB(BaseTSDB):
         super(InMemoryTSDB, self).__init__(*args, **kwargs)
         self.flush()
 
-    def incr(self, model, key, timestamp=None, count=1):
+    def incr(self, model, key, timestamp=None, count=1, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         if timestamp is None:
             timestamp = timezone.now()
 
@@ -35,13 +38,19 @@ class InMemoryTSDB(BaseTSDB):
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
             self.data[model][key][norm_epoch] += count
 
-    def merge(self, model, destination, sources, timestamp=None):
+    def merge(self, model, destination, sources, timestamp=None, environments=None):
+        if environments is not None:
+            raise NotImplementedError
+
         destination = self.data[model][destination]
         for source in sources:
             for bucket, count in self.data[model].pop(source, {}).items():
                 destination[bucket] += count
 
-    def delete(self, models, keys, start=None, end=None, timestamp=None):
+    def delete(self, models, keys, start=None, end=None, timestamp=None, environments=None):
+        if environments is not None:
+            raise NotImplementedError
+
         rollups = self.get_active_series(start, end, timestamp)
 
         for rollup, series in rollups.items():
@@ -54,7 +63,10 @@ class InMemoryTSDB(BaseTSDB):
                             0,
                         )
 
-    def get_range(self, model, keys, start, end, rollup=None):
+    def get_range(self, model, keys, start, end, rollup=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = []
@@ -73,7 +85,10 @@ class InMemoryTSDB(BaseTSDB):
             results_by_key[key] = sorted(points.items())
         return dict(results_by_key)
 
-    def record(self, model, key, values, timestamp=None):
+    def record(self, model, key, values, timestamp=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         if timestamp is None:
             timestamp = timezone.now()
 
@@ -81,7 +96,11 @@ class InMemoryTSDB(BaseTSDB):
             r = self.normalize_to_rollup(timestamp, rollup)
             self.sets[model][key][r].update(values)
 
-    def get_distinct_counts_series(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_series(self, model, keys, start, end=None,
+                                   rollup=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
@@ -94,7 +113,11 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
-    def get_distinct_counts_totals(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_totals(self, model, keys, start, end=None,
+                                   rollup=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
@@ -108,7 +131,11 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
-    def get_distinct_counts_union(self, model, keys, start, end=None, rollup=None):
+    def get_distinct_counts_union(self, model, keys, start, end=None,
+                                  rollup=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         values = set()
@@ -120,13 +147,20 @@ class InMemoryTSDB(BaseTSDB):
 
         return len(values)
 
-    def merge_distinct_counts(self, model, destination, sources, timestamp=None):
+    def merge_distinct_counts(self, model, destination, sources, timestamp=None, environments=None):
+        if environments is not None:
+            raise NotImplementedError
+
         destination = self.sets[model][destination]
         for source in sources:
             for bucket, values in self.sets[model].pop(source, {}).items():
                 destination[bucket].update(values)
 
-    def delete_distinct_counts(self, models, keys, start=None, end=None, timestamp=None):
+    def delete_distinct_counts(self, models, keys, start=None, end=None,
+                               timestamp=None, environments=None):
+        if environments is not None:
+            raise NotImplementedError
+
         rollups = self.get_active_series(start, end, timestamp)
 
         for rollup, series in rollups.items():
@@ -167,7 +201,10 @@ class InMemoryTSDB(BaseTSDB):
             ),
         )
 
-    def record_frequency_multi(self, requests, timestamp=None):
+    def record_frequency_multi(self, requests, timestamp=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         if timestamp is None:
             timestamp = timezone.now()
 
@@ -178,7 +215,11 @@ class InMemoryTSDB(BaseTSDB):
                 for rollup in self.rollups:
                     source[self.normalize_to_rollup(timestamp, rollup)].update(items)
 
-    def get_most_frequent(self, model, keys, start, end=None, rollup=None, limit=None):
+    def get_most_frequent(self, model, keys, start, end=None,
+                          rollup=None, limit=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
@@ -193,7 +234,11 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
-    def get_most_frequent_series(self, model, keys, start, end=None, rollup=None, limit=None):
+    def get_most_frequent_series(self, model, keys, start, end=None,
+                                 rollup=None, limit=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
@@ -206,7 +251,10 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
-    def get_frequency_series(self, model, items, start, end=None, rollup=None):
+    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
@@ -219,7 +267,10 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
-    def get_frequency_totals(self, model, items, start, end=None, rollup=None):
+    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment=None):
+        if environment is not None:
+            raise NotImplementedError
+
         results = {}
 
         for key, series in six.iteritems(
@@ -232,13 +283,20 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
-    def merge_frequencies(self, model, destination, sources, timestamp=None):
+    def merge_frequencies(self, model, destination, sources, timestamp=None, environments=None):
+        if environments is not None:
+            raise NotImplementedError
+
         destination = self.frequencies[model][destination]
         for source in sources:
             for bucket, counter in self.data[model].pop(source, {}).items():
                 destination[bucket].update(counter)
 
-    def delete_frequencies(self, models, keys, start=None, end=None, timestamp=None):
+    def delete_frequencies(self, models, keys, start=None, end=None,
+                           timestamp=None, environments=None):
+        if environments is not None:
+            raise NotImplementedError
+
         rollups = self.get_active_series(start, end, timestamp)
 
         for rollup, series in rollups.items():

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -27,43 +27,47 @@ class InMemoryTSDB(BaseTSDB):
         super(InMemoryTSDB, self).__init__(*args, **kwargs)
         self.flush()
 
-    def incr(self, model, key, timestamp=None, count=1, environment=None):
-        environments = set([environment, None])
+    def incr(self, model, key, timestamp=None, count=1, environment_id=None):
+        environment_ids = set([environment_id, None])
 
         if timestamp is None:
             timestamp = timezone.now()
 
         for rollup, max_values in six.iteritems(self.rollups):
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
-            for environment in environments:
-                self.data[model][(key, environment)][norm_epoch] += count
+            for environment_id in environment_ids:
+                self.data[model][(key, environment_id)][norm_epoch] += count
 
-    def merge(self, model, destination, sources, timestamp=None, environments=None):
-        environments = (set(environments) if environments is not None else set()).union([None])
+    def merge(self, model, destination, sources, timestamp=None, environment_ids=None):
+        environment_ids = (
+            set(environment_ids) if environment_ids is not None else set()).union(
+            [None])
 
-        for environment in environments:
-            destination = self.data[model][(destination, environment)]
+        for environment_id in environment_ids:
+            destination = self.data[model][(destination, environment_id)]
             for source in sources:
-                for bucket, count in self.data[model].pop((source, environment), {}).items():
+                for bucket, count in self.data[model].pop((source, environment_id), {}).items():
                     destination[bucket] += count
 
-    def delete(self, models, keys, start=None, end=None, timestamp=None, environments=None):
-        environments = (set(environments) if environments is not None else set()).union([None])
+    def delete(self, models, keys, start=None, end=None, timestamp=None, environment_ids=None):
+        environment_ids = (
+            set(environment_ids) if environment_ids is not None else set()).union(
+            [None])
 
         rollups = self.get_active_series(start, end, timestamp)
 
         for rollup, series in rollups.items():
             for model in models:
                 for key in keys:
-                    for environment in environments:
-                        data = self.data[model][(key, environment)]
+                    for environment_id in environment_ids:
+                        data = self.data[model][(key, environment_id)]
                         for timestamp in series:
                             data.pop(
                                 self.normalize_to_rollup(timestamp, rollup),
                                 0,
                             )
 
-    def get_range(self, model, keys, start, end, rollup=None, environment=None):
+    def get_range(self, model, keys, start, end, rollup=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = []
@@ -71,7 +75,7 @@ class InMemoryTSDB(BaseTSDB):
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
 
             for key in keys:
-                value = self.data[model][(key, environment)][norm_epoch]
+                value = self.data[model][(key, environment_id)][norm_epoch]
                 results.append((to_timestamp(timestamp), key, value))
 
         results_by_key = defaultdict(dict)
@@ -82,24 +86,24 @@ class InMemoryTSDB(BaseTSDB):
             results_by_key[key] = sorted(points.items())
         return dict(results_by_key)
 
-    def record(self, model, key, values, timestamp=None, environment=None):
-        environments = set([environment, None])
+    def record(self, model, key, values, timestamp=None, environment_id=None):
+        environment_ids = set([environment_id, None])
 
         if timestamp is None:
             timestamp = timezone.now()
 
         for rollup, max_values in six.iteritems(self.rollups):
             r = self.normalize_to_rollup(timestamp, rollup)
-            for environment in environments:
-                self.sets[model][(key, environment)][r].update(values)
+            for environment_id in environment_ids:
+                self.sets[model][(key, environment_id)][r].update(values)
 
     def get_distinct_counts_series(self, model, keys, start, end=None,
-                                   rollup=None, environment=None):
+                                   rollup=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
         for key in keys:
-            source = self.sets[model][(key, environment)]
+            source = self.sets[model][(key, environment_id)]
             counts = results[key] = []
             for timestamp in series:
                 r = self.normalize_ts_to_rollup(timestamp, rollup)
@@ -108,12 +112,12 @@ class InMemoryTSDB(BaseTSDB):
         return results
 
     def get_distinct_counts_totals(self, model, keys, start, end=None,
-                                   rollup=None, environment=None):
+                                   rollup=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
         for key in keys:
-            source = self.sets[model][(key, environment)]
+            source = self.sets[model][(key, environment_id)]
             values = set()
             for timestamp in series:
                 r = self.normalize_ts_to_rollup(timestamp, rollup)
@@ -123,38 +127,43 @@ class InMemoryTSDB(BaseTSDB):
         return results
 
     def get_distinct_counts_union(self, model, keys, start, end=None,
-                                  rollup=None, environment=None):
+                                  rollup=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         values = set()
         for key in keys:
-            source = self.sets[model][(key, environment)]
+            source = self.sets[model][(key, environment_id)]
             for timestamp in series:
                 r = self.normalize_ts_to_rollup(timestamp, rollup)
                 values.update(source[r])
 
         return len(values)
 
-    def merge_distinct_counts(self, model, destination, sources, timestamp=None, environments=None):
-        environments = (set(environments) if environments is not None else set()).union([None])
+    def merge_distinct_counts(self, model, destination, sources,
+                              timestamp=None, environment_ids=None):
+        environment_ids = (
+            set(environment_ids) if environment_ids is not None else set()).union(
+            [None])
 
-        for environment in environments:
-            destination = self.sets[model][(destination, environment)]
+        for environment_id in environment_ids:
+            destination = self.sets[model][(destination, environment_id)]
             for source in sources:
-                for bucket, values in self.sets[model].pop((source, environment), {}).items():
+                for bucket, values in self.sets[model].pop((source, environment_id), {}).items():
                     destination[bucket].update(values)
 
     def delete_distinct_counts(self, models, keys, start=None, end=None,
-                               timestamp=None, environments=None):
-        environments = (set(environments) if environments is not None else set()).union([None])
+                               timestamp=None, environment_ids=None):
+        environment_ids = (
+            set(environment_ids) if environment_ids is not None else set()).union(
+            [None])
 
         rollups = self.get_active_series(start, end, timestamp)
 
         for rollup, series in rollups.items():
             for model in models:
                 for key in keys:
-                    for environment in environments:
-                        data = self.data[model][(key, environment)]
+                    for environment_id in environment_ids:
+                        data = self.data[model][(key, environment_id)]
                         for timestamp in series:
                             data.pop(
                                 self.normalize_to_rollup(timestamp, rollup),
@@ -189,8 +198,8 @@ class InMemoryTSDB(BaseTSDB):
             ),
         )
 
-    def record_frequency_multi(self, requests, timestamp=None, environment=None):
-        environments = set([environment, None])
+    def record_frequency_multi(self, requests, timestamp=None, environment_id=None):
+        environment_ids = set([environment_id, None])
 
         if timestamp is None:
             timestamp = timezone.now()
@@ -198,19 +207,19 @@ class InMemoryTSDB(BaseTSDB):
         for model, request in requests:
             for key, items in request.items():
                 items = {k: float(v) for k, v in items.items()}
-                for environment in environments:
-                    source = self.frequencies[model][(key, environment)]
+                for environment_id in environment_ids:
+                    source = self.frequencies[model][(key, environment_id)]
                     for rollup in self.rollups:
                         source[self.normalize_to_rollup(timestamp, rollup)].update(items)
 
     def get_most_frequent(self, model, keys, start, end=None,
-                          rollup=None, limit=None, environment=None):
+                          rollup=None, limit=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
         for key in keys:
             result = results[key] = Counter()
-            source = self.frequencies[model][(key, environment)]
+            source = self.frequencies[model][(key, environment_id)]
             for timestamp in series:
                 result.update(source[self.normalize_ts_to_rollup(timestamp, rollup)])
 
@@ -220,37 +229,37 @@ class InMemoryTSDB(BaseTSDB):
         return results
 
     def get_most_frequent_series(self, model, keys, start, end=None,
-                                 rollup=None, limit=None, environment=None):
+                                 rollup=None, limit=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
         for key in keys:
             result = results[key] = []
-            source = self.frequencies[model][(key, environment)]
+            source = self.frequencies[model][(key, environment_id)]
             for timestamp in series:
                 data = source[self.normalize_ts_to_rollup(timestamp, rollup)]
                 result.append((timestamp, dict(data.most_common(limit))))
 
         return results
 
-    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment=None):
+    def get_frequency_series(self, model, items, start, end=None, rollup=None, environment_id=None):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = {}
         for key, members in items.items():
             result = results[key] = []
-            source = self.frequencies[model][(key, environment)]
+            source = self.frequencies[model][(key, environment_id)]
             for timestamp in series:
                 scores = source[self.normalize_ts_to_rollup(timestamp, rollup)]
                 result.append((timestamp, {k: scores.get(k, 0.0) for k in members}, ))
 
         return results
 
-    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment=None):
+    def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment_id=None):
         results = {}
 
         for key, series in six.iteritems(
-            self.get_frequency_series(model, items, start, end, rollup, environment)
+            self.get_frequency_series(model, items, start, end, rollup, environment_id)
         ):
             result = results[key] = {}
             for timestamp, scores in series:
@@ -259,26 +268,30 @@ class InMemoryTSDB(BaseTSDB):
 
         return results
 
-    def merge_frequencies(self, model, destination, sources, timestamp=None, environments=None):
-        environments = (set(environments) if environments is not None else set()).union([None])
+    def merge_frequencies(self, model, destination, sources, timestamp=None, environment_ids=None):
+        environment_ids = (
+            set(environment_ids) if environment_ids is not None else set()).union(
+            [None])
 
-        for environment in environments:
-            destination = self.frequencies[model][(destination, environment)]
+        for environment_id in environment_ids:
+            destination = self.frequencies[model][(destination, environment_id)]
             for source in sources:
-                for bucket, counter in self.data[model].pop((source, environment), {}).items():
+                for bucket, counter in self.data[model].pop((source, environment_id), {}).items():
                     destination[bucket].update(counter)
 
     def delete_frequencies(self, models, keys, start=None, end=None,
-                           timestamp=None, environments=None):
-        environments = (set(environments) if environments is not None else set()).union([None])
+                           timestamp=None, environment_ids=None):
+        environment_ids = (
+            set(environment_ids) if environment_ids is not None else set()).union(
+            [None])
 
         rollups = self.get_active_series(start, end, timestamp)
 
         for rollup, series in rollups.items():
             for model in models:
                 for key in keys:
-                    for environment in environments:
-                        data = self.frequencies[model][(key, environment)]
+                    for environment_id in environment_ids:
+                        data = self.frequencies[model][(key, environment_id)]
                         for timestamp in series:
                             data.pop(
                                 self.normalize_to_rollup(timestamp, rollup),

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -40,12 +40,12 @@ class InMemoryTSDB(BaseTSDB):
 
     def merge(self, model, destination, sources, timestamp=None, environments=None):
         environments = (set(environments) if environments is not None else set()).union([None])
-        raise NotImplementedError
 
-        destination = self.data[model][destination]
-        for source in sources:
-            for bucket, count in self.data[model].pop(source, {}).items():
-                destination[bucket] += count
+        for environment in environments:
+            destination = self.data[model][(destination, environment)]
+            for source in sources:
+                for bucket, count in self.data[model].pop((source, environment), {}).items():
+                    destination[bucket] += count
 
     def delete(self, models, keys, start=None, end=None, timestamp=None, environments=None):
         environments = (set(environments) if environments is not None else set()).union([None])
@@ -137,12 +137,12 @@ class InMemoryTSDB(BaseTSDB):
 
     def merge_distinct_counts(self, model, destination, sources, timestamp=None, environments=None):
         environments = (set(environments) if environments is not None else set()).union([None])
-        raise NotImplementedError
 
-        destination = self.sets[model][destination]
-        for source in sources:
-            for bucket, values in self.sets[model].pop(source, {}).items():
-                destination[bucket].update(values)
+        for environment in environments:
+            destination = self.sets[model][(destination, environment)]
+            for source in sources:
+                for bucket, values in self.sets[model].pop((source, environment), {}).items():
+                    destination[bucket].update(values)
 
     def delete_distinct_counts(self, models, keys, start=None, end=None,
                                timestamp=None, environments=None):
@@ -261,12 +261,12 @@ class InMemoryTSDB(BaseTSDB):
 
     def merge_frequencies(self, model, destination, sources, timestamp=None, environments=None):
         environments = (set(environments) if environments is not None else set()).union([None])
-        raise NotImplementedError
 
-        destination = self.frequencies[model][destination]
-        for source in sources:
-            for bucket, counter in self.data[model].pop(source, {}).items():
-                destination[bucket].update(counter)
+        for environment in environments:
+            destination = self.frequencies[model][(destination, environment)]
+            for source in sources:
+                for bucket, counter in self.data[model].pop((source, environment), {}).items():
+                    destination[bucket].update(counter)
 
     def delete_frequencies(self, models, keys, start=None, end=None,
                            timestamp=None, environments=None):

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -762,13 +762,16 @@ class RedisTSDB(BaseTSDB):
             for source in sources:
                 for rollup, series in rollups:
                     for timestamp in series:
+                        keys = []
                         for environment_id in environment_ids:
-                            keys = self.make_frequency_table_keys(
-                                model,
-                                rollup,
-                                to_timestamp(timestamp),
-                                source,
-                                environment_id,
+                            keys.extend(
+                                self.make_frequency_table_keys(
+                                    model,
+                                    rollup,
+                                    to_timestamp(timestamp),
+                                    source,
+                                    environment_id,
+                                )
                             )
                         arguments = ['EXPORT'] + list(self.DEFAULT_SKETCH_PARAMETERS)
                         exports[source].extend(

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -156,9 +156,6 @@ class RedisTSDB(BaseTSDB):
         return key
 
     def incr(self, model, key, timestamp=None, count=1, environment=None):
-        if environment is not None:
-            raise NotImplementedError
-
         self.incr_multi([(model, key)], timestamp, count, environment)
 
     def incr_multi(self, items, timestamp=None, count=1, environment=None):
@@ -286,9 +283,6 @@ class RedisTSDB(BaseTSDB):
                             )
 
     def record(self, model, key, values, timestamp=None, environment=None):
-        if environment is not None:
-            raise NotImplementedError
-
         self.record_multi(((model, key, values), ), timestamp, environment)
 
     def record_multi(self, items, timestamp=None, environment=None):

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -134,7 +134,7 @@ class RedisTSDBTest(TestCase):
             2: 0,
         }
 
-        self.db.merge(TSDBModel.project, 1, [2], now, environment_ids=[1, 2, 3])
+        self.db.merge(TSDBModel.project, 1, [2], now, environment_ids=[0, 1, 2])
 
         results = self.db.get_range(TSDBModel.project, [1], dts[0], dts[-1])
         assert results == {
@@ -173,7 +173,7 @@ class RedisTSDBTest(TestCase):
             2: 0,
         }
 
-        self.db.delete([TSDBModel.project], [1, 2], dts[0], dts[-1], environment_ids=[1, 2, 3])
+        self.db.delete([TSDBModel.project], [1, 2], dts[0], dts[-1], environment_ids=[0, 1, 2])
 
         results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
         assert results == {
@@ -297,7 +297,7 @@ class RedisTSDBTest(TestCase):
         assert self.db.get_distinct_counts_union(
             model, [1, 2], dts[0], dts[-1], rollup=3600, environment_id=0) == 0
 
-        self.db.merge_distinct_counts(model, 1, [2], dts[0], environment_ids=[1, 2])
+        self.db.merge_distinct_counts(model, 1, [2], dts[0], environment_ids=[0, 1])
 
         assert self.db.get_distinct_counts_series(
             model, [1], dts[0], dts[-1], rollup=3600
@@ -349,7 +349,7 @@ class RedisTSDBTest(TestCase):
         assert self.db.get_distinct_counts_union(model, [1, 2], dts[0], dts[-1], rollup=3600) == 3
         assert self.db.get_distinct_counts_union(model, [2], dts[0], dts[-1], rollup=3600) == 0
 
-        self.db.delete_distinct_counts([model], [1, 2], dts[0], dts[-1], environment_ids=[1, 2])
+        self.db.delete_distinct_counts([model], [1, 2], dts[0], dts[-1], environment_ids=[0, 1])
 
         results = self.db.get_distinct_counts_totals(model, [1, 2], dts[0], dts[-1])
         assert results == {
@@ -639,7 +639,7 @@ class RedisTSDBTest(TestCase):
             'organization:1',
             ['organization:2'],
             now,
-            environment_ids=[1],
+            environment_ids=[0, 1],
         )
 
         assert self.db.get_frequency_totals(
@@ -700,7 +700,7 @@ class RedisTSDBTest(TestCase):
             ['organization:1', 'organization:2'],
             now - timedelta(hours=1),
             now,
-            environment_ids=[1],
+            environment_ids=[0, 1],
         )
 
         assert self.db.get_most_frequent(

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -35,11 +35,18 @@ class RedisTSDBTest(TestCase):
             client.flushdb()
 
     def test_make_counter_key(self):
-        result = self.db.make_counter_key(TSDBModel.project, 1, to_datetime(1368889980), 1)
+        result = self.db.make_counter_key(TSDBModel.project, 1, to_datetime(1368889980), 1, None)
         assert result == ('ts:1:1368889980:1', 1)
 
-        result = self.db.make_counter_key(TSDBModel.project, 1, to_datetime(1368889980), 'foo')
+        result = self.db.make_counter_key(
+            TSDBModel.project, 1, to_datetime(1368889980), 'foo', None)
         assert result == ('ts:1:1368889980:46', self.db.get_model_key('foo'))
+
+        result = self.db.make_counter_key(TSDBModel.project, 1, to_datetime(1368889980), 1, 1)
+        assert result == ('ts:1:1368889980:1', '1?e=1')
+
+        result = self.db.make_counter_key(TSDBModel.project, 1, to_datetime(1368889980), 'foo', 1)
+        assert result == ('ts:1:1368889980:46', self.db.get_model_key('foo') + '?e=1')
 
     def test_get_model_key(self):
         result = self.db.get_model_key(1)

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -639,6 +639,7 @@ class RedisTSDBTest(TestCase):
             'organization:1',
             ['organization:2'],
             now,
+            environment_ids=[1],
         )
 
         assert self.db.get_frequency_totals(
@@ -671,7 +672,7 @@ class RedisTSDBTest(TestCase):
             model,
             {
                 'organization:1': ("project:1", "project:2", "project:3", "project:4", "project:5"),
-                'organization:2': ("project:1", ),
+                'organization:2': ("project:1", "project:2", "project:3", "project:4", "project:5"),
             },
             now - timedelta(hours=1),
             now,
@@ -683,10 +684,14 @@ class RedisTSDBTest(TestCase):
                 "project:2": 1.0,
                 "project:3": 2.0,
                 "project:4": 3.0,
-                "project:5": 0.0,
+                "project:5": 0.5,
             },
             'organization:2': {
                 "project:1": 0.0,
+                "project:2": 0.0,
+                "project:3": 0.0,
+                "project:4": 0.0,
+                "project:5": 0.0,
             },
         }
 


### PR DESCRIPTION
# Basic Overview

This adds an optional `environment` keyword argument to all TSDB APIs. The `InMemoryTSDB` implementation likely provides the clearest overview of what the changes here actually do, but this can be summarized with two main points:

- Reads go to the "no environment" series if no series is provided, and to the specific series for that environment (if one is provided.)
- Writes go to *both* the "no environment" series, as well as the series for specific environment if one is provided. Merges and deletes are applied to the series for each provided environment, as well as the "no environment" series (it doesn't need to be explicitly passed.)

This change does implement the read and write paths for supporting tag filters, but they are unused (other than in tests) as it stands today: these additional code paths will only be active once the `environment_id{,s}` arguments are provided.

# Implementation Notes

These notes primarily relate to the changes with `RedisTSDB`, since that is the de facto canonical implementation of this backend.

## Advantages

- This is the simplest approach that I can think of that makes the minimal possible changes.
- This doesn't change any existing keys or placement criteria for data that was already written without an environment (and is also backwards compatible if we need to revert it.)

## Disadvantages

- For operations that are intended to apply to all environments (e.g. merge, delete in some cases), all of the environments have to be explicitly provided to the call. This increases the potential for race conditions.
- This implementation is reasonably specific to only filtering on environments. I have mixed feelings about this — it'd be nice if this was more abstract so that we could filter on more dimensions than environments if we wanted, but after I thought a bit about it, making this support multiple filters introduces a lot of complexity and storage overhead and I'm not really sure it's worth the complexity cost and effort to do so.
- Some fields (e.g. releases by environment which is stored as a frequency table) don't make sense to have an environment as part of the key, but there's no way to restrict this to keep people from doing something weird by accident.
- This still depends on `rb` without a migration path towards Redis Cluster (and actively makes it more difficult to migrate in the future due to adding new data.) This doesn't have any effect on changing retention periods.
- These APIs are getting pretty unruly. I intended to add it as a keyword argument before the `timestamp` and `rollup` argument(s), since I thought that made a more readable API, but then I remembered that'd break any non-keyword argument usage of other trailing arguments. (On another note, I finally understand where [fluent interfaces](https://en.wikipedia.org/wiki/Fluent_interface) make sense!)
- The environments are intended to be passed in as their primary key (integer) ID, but nothing enforces this.