### PR TITLE
perf(tasks): Add 1min gossip interval and a comment about the kwarg name.

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -195,9 +195,9 @@ def worker(**options):
 
     from sentry.celery import app
     worker = app.Worker(
-        # without_gossip=True,
-        # without_mingle=True,
-        # without_heartbeat=True,
+        # This gets passed all the way down to the Gossip bootstrap step here:
+        # https://github.com/celery/celery/blob/v3.1.18/celery/worker/consumer.py#L668
+        interval=60,
         pool_cls='processes',
         **options
     )


### PR DESCRIPTION
From my search through what I could, the [commented link](https://github.com/celery/celery/blob/v3.1.18/celery/worker/consumer.py#L668) is the only place where a bare `interval` is used.