### PR TITLE
ref: Extract GroupTagValue interactions out to TagStorage abstraction

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -9,7 +9,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import (GroupTagValue, Group)
+from sentry.models import Group
 from sentry.utils.apidocs import scenario
 
 
@@ -50,9 +50,8 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         except tagstore.GroupTagKeyNotFound:
             raise ResourceDoesNotExist
 
-        total_values = GroupTagValue.get_value_count(group.id, lookup_key)
-
-        top_values = GroupTagValue.get_top_values(group.id, lookup_key, limit=9)
+        total_values = tagstore.get_group_tag_value_count(group.id, lookup_key)
+        top_values = tagstore.get_top_group_tag_values(group.id, lookup_key, limit=9)
 
         data = {
             'id': six.text_type(tag_key.id),

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -7,7 +7,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import DateTimePaginator, Paginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.tagvalue import UserTagValueSerializer
-from sentry.models import GroupTagValue, Group
+from sentry.models import Group
 from sentry.utils.apidocs import scenario
 
 
@@ -43,10 +43,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
-        queryset = GroupTagValue.objects.filter(
-            group_id=group.id,
-            key=lookup_key,
-        )
+        queryset = tagstore.get_group_tag_value_qs(group.id, lookup_key)
 
         sort = request.GET.get('sort')
         if sort == 'date':

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -2,13 +2,12 @@ from __future__ import absolute_import
 
 import six
 
+from collections import defaultdict
 from rest_framework.response import Response
 
-from collections import defaultdict
 from sentry import tagstore
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import GroupTagValue
 
 
 class GroupTagsEndpoint(GroupEndpoint):
@@ -21,8 +20,8 @@ class GroupTagsEndpoint(GroupEndpoint):
         data = []
         all_top_values = []
         for tag_key in tag_keys:
-            total_values = GroupTagValue.get_value_count(group.id, tag_key.key)
-            top_values = GroupTagValue.get_top_values(group.id, tag_key.key, limit=10)
+            total_values = tagstore.get_group_tag_value_count(group.id, tag_key.key)
+            top_values = tagstore.get_top_group_tag_values(group.id, tag_key.key, limit=10)
 
             all_top_values.extend(top_values)
 

--- a/src/sentry/api/endpoints/organization_user_issues_search.py
+++ b/src/sentry/api/endpoints/organization_user_issues_search.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+from sentry import tagstore
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
-from sentry.models import (EventUser, Group, GroupTagValue, OrganizationMemberTeam, Project)
+from sentry.models import (EventUser, Group, OrganizationMemberTeam, Project)
 
 
 class OrganizationUserIssuesSearchEndpoint(OrganizationEndpoint):
@@ -35,13 +36,7 @@ class OrganizationUserIssuesSearchEndpoint(OrganizationEndpoint):
 
         project_ids = list(set([e.project_id for e in event_users]))
 
-        group_ids = list(
-            GroupTagValue.objects.filter(
-                key='sentry:user',
-                value__in=[eu.tag_value for eu in event_users],
-                project_id__in=project_ids,
-            ).order_by('-last_seen').values_list('group_id', flat=True)[:limit]
-        )
+        group_ids = tagstore.get_group_ids_for_users(project_ids, event_users, limit=limit)
 
         groups = Group.objects.filter(
             id__in=group_ids,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -21,7 +21,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import buffer, eventtypes, tagstore
+from sentry import eventtypes, tagstore
 from sentry.constants import (
     DEFAULT_LOGGER_NAME, EVENT_ORDERING_KEY, LOG_LEVELS, MAX_CULPRIT_LENGTH
 )
@@ -120,8 +120,6 @@ class GroupManager(BaseManager):
             )
 
     def add_tags(self, group, tags):
-        from sentry.models import GroupTagValue
-
         project_id = group.project_id
         date = group.last_seen
 
@@ -131,23 +129,15 @@ class GroupManager(BaseManager):
             else:
                 key, value, data = tag_item
 
-            tagstore.incr_times_seen(project_id, key, value, {
+            tagstore.incr_tag_value_times_seen(project_id, key, value, {
                 'last_seen': date,
                 'data': data,
             })
 
-            buffer.incr(
-                GroupTagValue, {
-                    'times_seen': 1,
-                }, {
-                    'group_id': group.id,
-                    'key': key,
-                    'value': value,
-                }, {
-                    'project_id': project_id,
-                    'last_seen': date,
-                }
-            )
+            tagstore.incr_group_tag_value_times_seen(group.id, key, value, {
+                'project_id': project_id,
+                'last_seen': date,
+            })
 
 
 class Group(Model):
@@ -351,31 +341,13 @@ class Group(Model):
         return self._tag_cache
 
     def get_first_release(self):
-        from sentry.models import GroupTagValue
         if self.first_release_id is None:
-            try:
-                first_release = GroupTagValue.objects.filter(
-                    group_id=self.id,
-                    key__in=('sentry:release', 'release'),
-                ).order_by('first_seen')[0]
-            except IndexError:
-                return None
-            else:
-                return first_release.value
+            return tagstore.get_first_release(self.id)
 
         return self.first_release.version
 
     def get_last_release(self):
-        from sentry.models import GroupTagValue
-        try:
-            last_release = GroupTagValue.objects.filter(
-                group_id=self.id,
-                key__in=('sentry:release', 'release'),
-            ).order_by('-last_seen')[0]
-        except IndexError:
-            return None
-
-        return last_release.value
+        return tagstore.get_last_release(self.id)
 
     def get_event_type(self):
         """

--- a/src/sentry/models/grouptagvalue.py
+++ b/src/sentry/models/grouptagvalue.py
@@ -7,15 +7,12 @@ sentry.models.grouptagvalue
 """
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.db import connections, models, router
-from django.db.models import Sum
+from django.db import models
 from django.utils import timezone
 
 from sentry.constants import MAX_TAG_KEY_LENGTH, MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
     Model, BoundedPositiveIntegerField, BaseManager, sane_repr)
-from sentry.utils import db
 
 
 class GroupTagValue(Model):
@@ -48,68 +45,4 @@ class GroupTagValue(Model):
     def save(self, *args, **kwargs):
         if not self.first_seen:
             self.first_seen = self.last_seen
-        super(GroupTag, self).save(*args, **kwargs)
-
-    @classmethod
-    def get_value_count(cls, group_id, key):
-        if db.is_postgres():
-            # This doesnt guarantee percentage is accurate, but it does ensure
-            # that the query has a maximum cost
-            using = router.db_for_read(cls)
-            cursor = connections[using].cursor()
-            cursor.execute(
-                """
-                SELECT SUM(t)
-                FROM (
-                    SELECT times_seen as t
-                    FROM sentry_messagefiltervalue
-                    WHERE group_id = %s
-                    AND key = %s
-                    ORDER BY last_seen DESC
-                    LIMIT 10000
-                ) as a
-            """, [group_id, key]
-            )
-            return cursor.fetchone()[0] or 0
-
-        cutoff = timezone.now() - timedelta(days=7)
-        return cls.objects.filter(
-            group_id=group_id,
-            key=key,
-            last_seen__gte=cutoff,
-        ).aggregate(t=Sum('times_seen'))['t']
-
-    @classmethod
-    def get_top_values(cls, group_id, key, limit=3):
-        if db.is_postgres():
-            # This doesnt guarantee percentage is accurate, but it does ensure
-            # that the query has a maximum cost
-            return list(
-                cls.objects.raw(
-                    """
-                SELECT *
-                FROM (
-                    SELECT *
-                    FROM sentry_messagefiltervalue
-                    WHERE group_id = %%s
-                    AND key = %%s
-                    ORDER BY last_seen DESC
-                    LIMIT 10000
-                ) as a
-                ORDER BY times_seen DESC
-                LIMIT %d
-            """ % limit, [group_id, key]
-                )
-            )
-
-        cutoff = timezone.now() - timedelta(days=7)
-        return list(
-            cls.objects.filter(
-                group_id=group_id,
-                key=key,
-                last_seen__gte=cutoff,
-            ).order_by('-times_seen')[:limit]
-        )
-
-
-GroupTag = GroupTagValue
+        super(GroupTagValue, self).save(*args, **kwargs)

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -145,7 +145,7 @@ class Project(Model):
         return absolute_uri('/{}/{}/'.format(self.organization.slug, self.slug))
 
     def merge_to(self, project):
-        from sentry.models import (Group, GroupTagValue, Event)
+        from sentry.models import (Group, Event)
 
         if not isinstance(project, Project):
             project = Project.objects.get_from_cache(pk=project)
@@ -157,17 +157,17 @@ class Project(Model):
                 )
             except Group.DoesNotExist:
                 group.update(project=project)
-                GroupTagValue.objects.filter(
-                    project_id=self.id,
+                tagstore.update_project_for_group(
                     group_id=group.id,
-                ).update(project_id=project.id)
+                    old_project_id=self.id,
+                    new_project_id=project.id)
             else:
                 Event.objects.filter(
                     group_id=group.id,
                 ).update(group_id=other.id)
 
-                for obj in GroupTagValue.objects.filter(group=group):
-                    obj2, created = GroupTagValue.objects.get_or_create(
+                for obj in tagstore.get_group_tag_values(group_id=group.id):
+                    obj2, created = tagstore.get_or_create_group_tag_value(
                         project_id=project.id,
                         group_id=group.id,
                         key=obj.key,

--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -10,10 +10,10 @@ from django.db.models.signals import post_syncdb, post_save
 from functools import wraps
 from pkg_resources import parse_version as Version
 
-from sentry import buffer, options, tagstore
+from sentry import options, tagstore
 from sentry.models import (
     Organization, OrganizationMember, Project, User, Team, ProjectKey, TagValue,
-    GroupTagValue, GroupTagKey
+    GroupTagValue
 )
 from sentry.signals import buffer_incr_complete
 from sentry.utils import db
@@ -149,7 +149,7 @@ def record_project_tag_count(filters, created, **kwargs):
     if not project_id:
         project_id = filters['project'].id
 
-    tagstore.incr_values_seen(project_id, filters['key'])
+    tagstore.incr_tag_key_values_seen(project_id, filters['key'])
 
 
 @buffer_incr_complete.connect(sender=GroupTagValue, weak=False)
@@ -163,15 +163,7 @@ def record_group_tag_count(filters, created, extra, **kwargs):
 
     group_id = filters['group_id']
 
-    buffer.incr(
-        GroupTagKey, {
-            'values_seen': 1,
-        }, {
-            'project_id': project_id,
-            'group_id': group_id,
-            'key': filters['key'],
-        }
-    )
+    tagstore.incr_group_tag_key_values_seen(project_id, group_id, filters['key'])
 
 
 # Anything that relies on default objects that may not exist with default

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -42,6 +42,8 @@ class TagStorage(Service):
         'get_or_create_tag_value',
         'create_group_tag_key',
         'get_or_create_group_tag_key',
+        'create_group_tag_value',
+        'get_or_create_group_tag_value',
 
         'get_tag_key',
         'get_tag_keys',
@@ -49,17 +51,30 @@ class TagStorage(Service):
         'get_tag_values',
         'get_group_tag_key',
         'get_group_tag_keys',
-
-        'get_group_event_ids',
-        'get_tag_value_qs',
+        'get_group_tag_value',
+        'get_group_tag_values',
 
         'delete_tag_key',
         'delete_group_tag_key',
         'delete_all_group_tag_keys',
+        'delete_all_group_tag_values',
 
         'get_values_seen',
-        'incr_values_seen',
-        'incr_times_seen',
+        'get_group_event_ids',
+        'get_tag_value_qs',
+        'get_group_tag_value_qs',
+        'get_group_tag_value_count',
+        'get_top_group_tag_values',
+        'get_first_release',
+        'get_last_release',
+        'incr_tag_key_values_seen',
+        'incr_tag_value_times_seen',
+        'incr_group_tag_key_values_seen',
+        'incr_group_tag_value_times_seen',
+        'update_project_for_group',
+        'get_group_ids_for_users',
+        'get_group_tag_values_for_users',
+        'get_tags_for_search_filter',
     )
 
     def is_valid_key(self, key):
@@ -119,6 +134,18 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
+    def create_group_tag_value(self, project_id, group_id, key, value, **kwargs):
+        """
+        >>> create_group_tag_value(1, 2, "key1", "value1")
+        """
+        raise NotImplementedError
+
+    def get_or_create_group_tag_value(self, project_id, group_id, key, value, **kwargs):
+        """
+        >>> get_or_create_group_tag_value(1, 2, "key1", "value1")
+        """
+        raise NotImplementedError
+
     def get_tag_key(self, project_id, key, status=TagKeyStatus.VISIBLE):
         """
         >>> get_tag_key(1, "key1")
@@ -158,6 +185,19 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
+    def get_group_tag_value(self, group_id, key, value):
+        """
+        >>> get_group_tag_value(1, "key1", "value1")
+        """
+        raise NotImplementedError
+
+    def get_group_tag_values(self, group_ids, keys=None, values=None):
+        """
+        >>> get_group_tag_values([1, 2], ["key1", "key2"], ["value1", "value2"])
+        >>> get_group_tag_values(1, ["key1", "key2"], ["value1", "value2"])
+        """
+        raise NotImplementedError
+
     def delete_tag_key(self, project_id, key):
         """
         >>> delete_tag_key(1, "key1")
@@ -176,15 +216,33 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def incr_values_seen(self, project_id, key, count=1):
+    def delete_all_group_tag_values(self, group_id):
         """
-        >>> incr_values_seen(1, "key1")
+        >>> delete_all_group_tag_values(1)
         """
         raise NotImplementedError
 
-    def incr_times_seen(self, project_id, key, value, extra=None, count=1):
+    def incr_tag_key_values_seen(self, project_id, key, count=1):
         """
-        >>> incr_times_seen(1, "key1", "value1")
+        >>> incr_tag_key_values_seen(1, "key1")
+        """
+        raise NotImplementedError
+
+    def incr_tag_value_times_seen(self, project_id, key, value, extra=None, count=1):
+        """
+        >>> incr_tag_value_times_seen(1, "key1", "value1")
+        """
+        raise NotImplementedError
+
+    def incr_group_tag_key_values_seen(self, project_id, group_id, key, count=1):
+        """
+        >>> incr_group_tag_key_values_seen(1, 2, "key1")
+        """
+        raise NotImplementedError
+
+    def incr_group_tag_value_times_seen(self, group_id, key, value, extra=None, count=1):
+        """
+        >>> incr_group_tag_value_times_seen(1, "key1", "value1")
         """
         raise NotImplementedError
 
@@ -200,8 +258,62 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
+    def get_group_tag_value_qs(self, group_id, key):
+        """
+        >>> get_group_tag_value_qs(1, 'environment')
+        """
+        raise NotImplementedError
+
     def get_values_seen(self, group_ids, key):
         """
-        get_values_seen([1, 2], 'key1')
+        >>> get_values_seen([1, 2], 'key1')
+        """
+        raise NotImplementedError
+
+    def get_group_tag_value_count(self, group_id, key):
+        """
+        >>> get_group_tag_value_count(1, 'key1')
+        """
+        raise NotImplementedError
+
+    def get_top_group_tag_values(self, group_id, key, limit=3):
+        """
+        >>> get_top_group_tag_values(1, 'key1')
+        """
+        raise NotImplementedError
+
+    def get_first_release(self, group_id):
+        """
+        >>> get_first_release(1)
+        """
+        raise NotImplementedError
+
+    def get_last_release(self, group_id):
+        """
+        >>> get_last_release(1)
+        """
+        raise NotImplementedError
+
+    def update_project_for_group(self, group_id, old_project_id, new_project_id):
+        """
+        >>> update_project_for_group(1, 2, 3)
+        """
+        raise NotImplementedError
+
+    def get_group_ids_for_users(self, project_ids, event_users, limit=100):
+        """
+        >>> get_group_ids_for_users([1,2], [EventUser(1), EventUser(2)])
+        """
+        raise NotImplementedError
+
+    def get_group_tag_values_for_users(self, event_users, limit=100):
+        """
+        >>> get_group_tag_values_for_users([EventUser(1), EventUser(2)])
+        """
+        raise NotImplementedError
+
+    def get_tags_for_search_filter(self, project_id, tags):
+        """
+        >>> get_tags_for_search_filter(1, [('key1', 'value1'), ('key2', 'value2')])
         """
         raise NotImplementedError

--- a/src/sentry/tagstore/exceptions.py
+++ b/src/sentry/tagstore/exceptions.py
@@ -19,3 +19,7 @@ class TagValueNotFound(Exception):
 
 class GroupTagKeyNotFound(Exception):
     pass
+
+
+class GroupTagValueNotFound(Exception):
+    pass

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -434,11 +434,11 @@ class LegacyTagStorage(TagStorage):
         ).update(project_id=new_project_id)
 
     def get_group_ids_for_users(self, project_ids, event_users, limit=100):
-        return GroupTagValue.objects.filter(
+        return list(GroupTagValue.objects.filter(
             key='sentry:user',
             value__in=[eu.tag_value for eu in event_users],
             project_id__in=project_ids,
-        ).order_by('-last_seen').values_list('group_id', flat=True)[:limit]
+        ).order_by('-last_seen').values_list('group_id', flat=True)[:limit])
 
     def get_group_tag_values_for_users(self, event_users, limit=100):
         tag_filters = [Q(value=eu.tag_value, project_id=eu.project_id) for eu in event_users]

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -155,7 +155,7 @@ class LegacyTagStorage(TagStorage):
             qs = GroupTagKey.objects.filter(group_id__in=group_ids)
 
         if keys is not None:
-            if isinstance(keys, six.text_type):
+            if isinstance(keys, six.string_types):
                 qs = qs.filter(key=keys)
             else:
                 qs = qs.filter(key__in=keys)
@@ -184,13 +184,13 @@ class LegacyTagStorage(TagStorage):
             qs = GroupTagValue.objects.filter(group_id__in=group_ids)
 
         if keys is not None:
-            if isinstance(keys, six.text_type):
+            if isinstance(keys, six.string_types):
                 qs = qs.filter(key=keys)
             else:
                 qs = qs.filter(key__in=keys)
 
         if values is not None:
-            if isinstance(values, six.text_type):
+            if isinstance(values, six.string_types):
                 qs = qs.filter(value=values)
             else:
                 qs = qs.filter(value__in=values)

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -11,14 +11,18 @@ from __future__ import absolute_import
 import six
 
 from collections import defaultdict, Iterable
-from django.db.models import Q
+from datetime import timedelta
+from django.db import connections, router
+from django.db.models import Q, Sum
+from django.utils import timezone
 from operator import or_
 from six.moves import reduce
 
 from sentry import buffer
 from sentry.tagstore import TagKeyStatus
-from sentry.models import GroupTagKey, TagKey, TagValue, EventTag
+from sentry.models import EventTag, GroupTagKey, GroupTagValue, TagKey, TagValue
 from sentry.tagstore.base import TagStorage
+from sentry.utils import db
 from sentry.utils.cache import cache
 from sentry.tasks.deletion import delete_tag_key
 
@@ -28,14 +32,14 @@ class LegacyTagStorage(TagStorage):
         return TagKey.objects.create(project_id=project_id, key=key, **kwargs)
 
     def get_or_create_tag_key(self, project_id, key, **kwargs):
-        return TagKey.objects.get_or_create(project_id=project_id, key=key, defaults=kwargs)
+        return TagKey.objects.get_or_create(project_id=project_id, key=key, **kwargs)
 
     def create_tag_value(self, project_id, key, value, **kwargs):
         return TagValue.objects.create(project_id=project_id, key=key, value=value, **kwargs)
 
     def get_or_create_tag_value(self, project_id, key, value, **kwargs):
         return TagValue.objects.get_or_create(
-            project_id=project_id, key=key, value=value, defaults=kwargs)
+            project_id=project_id, key=key, value=value, **kwargs)
 
     def create_group_tag_key(self, project_id, group_id, key, **kwargs):
         return GroupTagKey.objects.create(project_id=project_id, group_id=group_id,
@@ -43,7 +47,15 @@ class LegacyTagStorage(TagStorage):
 
     def get_or_create_group_tag_key(self, project_id, group_id, key, **kwargs):
         return GroupTagKey.objects.get_or_create(project_id=project_id, group_id=group_id,
-                                                 key=key, defaults=kwargs)
+                                                 key=key, **kwargs)
+
+    def create_group_tag_value(self, project_id, group_id, key, value, **kwargs):
+        return GroupTagValue.objects.create(
+            project_id=project_id, group_id=group_id, key=key, value=value, **kwargs)
+
+    def get_or_create_group_tag_value(self, project_id, group_id, key, value, **kwargs):
+        return GroupTagValue.objects.get_or_create(
+            project_id=project_id, group_id=group_id, key=key, value=value, **kwargs)
 
     def get_tag_key(self, project_id, key, status=TagKeyStatus.VISIBLE):
         from sentry.tagstore.exceptions import TagKeyNotFound
@@ -153,6 +165,38 @@ class LegacyTagStorage(TagStorage):
 
         return list(qs)
 
+    def get_group_tag_value(self, group_id, key, value):
+        from sentry.tagstore.exceptions import GroupTagValueNotFound
+
+        try:
+            return GroupTagValue.objects.get(
+                group_id=group_id,
+                key=key,
+                value=value,
+            )
+        except GroupTagValue.DoesNotExist:
+            raise GroupTagValueNotFound
+
+    def get_group_tag_values(self, group_ids, keys=None, values=None):
+        if isinstance(group_ids, six.integer_types):
+            qs = GroupTagValue.objects.filter(group_id=group_ids)
+        else:
+            qs = GroupTagValue.objects.filter(group_id__in=group_ids)
+
+        if keys is not None:
+            if isinstance(keys, six.text_type):
+                qs = qs.filter(key=keys)
+            else:
+                qs = qs.filter(key__in=keys)
+
+        if values is not None:
+            if isinstance(values, six.text_type):
+                qs = qs.filter(value=values)
+            else:
+                qs = qs.filter(value__in=values)
+
+        return list(qs)
+
     def delete_tag_key(self, project_id, key):
         tagkey = self.get_tag_key(project_id, key, status=None)
 
@@ -177,7 +221,12 @@ class LegacyTagStorage(TagStorage):
             group_id=group_id,
         ).delete()
 
-    def incr_values_seen(self, project_id, key, count=1):
+    def delete_all_group_tag_values(self, group_id):
+        GroupTagValue.objects.filter(
+            group_id=group_id,
+        ).delete()
+
+    def incr_tag_key_values_seen(self, project_id, key, count=1):
         buffer.incr(TagKey, {
             'values_seen': count,
         }, {
@@ -185,7 +234,7 @@ class LegacyTagStorage(TagStorage):
             'key': key,
         })
 
-    def incr_times_seen(self, project_id, key, value, extra=None, count=1):
+    def incr_tag_value_times_seen(self, project_id, key, value, extra=None, count=1):
         buffer.incr(TagValue, {
             'times_seen': count,
         }, {
@@ -193,6 +242,26 @@ class LegacyTagStorage(TagStorage):
             'key': key,
             'value': value,
         }, extra)
+
+    def incr_group_tag_key_values_seen(self, project_id, group_id, key, count=1):
+        buffer.incr(GroupTagKey, {
+            'values_seen': count,
+        }, {
+            'project_id': project_id,
+            'group_id': group_id,
+            'key': key,
+        })
+
+    def incr_group_tag_value_times_seen(self, group_id, key, value, extra=None, count=1):
+        buffer.incr(
+            GroupTagValue, {
+                'times_seen': count,
+            }, {
+                'group_id': group_id,
+                'key': key,
+                'value': value,
+            }, extra
+        )
 
     def get_group_event_ids(self, project_id, group_id, tags):
         tagkeys = dict(
@@ -261,6 +330,12 @@ class LegacyTagStorage(TagStorage):
 
         return queryset
 
+    def get_group_tag_value_qs(self, group_id, key):
+        return GroupTagValue.objects.filter(
+            group_id=group_id,
+            key=key,
+        )
+
     def get_values_seen(self, group_ids, key):
         if isinstance(group_ids, six.integer_types):
             qs = GroupTagKey.objects.filter(group_id=group_ids)
@@ -270,3 +345,148 @@ class LegacyTagStorage(TagStorage):
         return defaultdict(int, qs.filter(
             key=key,
         ).values_list('group_id', 'values_seen'))
+
+    def get_group_tag_value_count(self, group_id, key):
+        if db.is_postgres():
+            # This doesnt guarantee percentage is accurate, but it does ensure
+            # that the query has a maximum cost
+            using = router.db_for_read(GroupTagValue)
+            cursor = connections[using].cursor()
+            cursor.execute(
+                """
+                SELECT SUM(t)
+                FROM (
+                    SELECT times_seen as t
+                    FROM sentry_messagefiltervalue
+                    WHERE group_id = %s
+                    AND key = %s
+                    ORDER BY last_seen DESC
+                    LIMIT 10000
+                ) as a
+            """, [group_id, key]
+            )
+            return cursor.fetchone()[0] or 0
+
+        cutoff = timezone.now() - timedelta(days=7)
+        return GroupTagValue.objects.filter(
+            group_id=group_id,
+            key=key,
+            last_seen__gte=cutoff,
+        ).aggregate(t=Sum('times_seen'))['t']
+
+    def get_top_group_tag_values(self, group_id, key, limit=3):
+        if db.is_postgres():
+            # This doesnt guarantee percentage is accurate, but it does ensure
+            # that the query has a maximum cost
+            return list(
+                GroupTagValue.objects.raw(
+                    """
+                SELECT *
+                FROM (
+                    SELECT *
+                    FROM sentry_messagefiltervalue
+                    WHERE group_id = %%s
+                    AND key = %%s
+                    ORDER BY last_seen DESC
+                    LIMIT 10000
+                ) as a
+                ORDER BY times_seen DESC
+                LIMIT %d
+            """ % limit, [group_id, key]
+                )
+            )
+
+        cutoff = timezone.now() - timedelta(days=7)
+        return list(
+            GroupTagValue.objects.filter(
+                group_id=group_id,
+                key=key,
+                last_seen__gte=cutoff,
+            ).order_by('-times_seen')[:limit]
+        )
+
+    def get_first_release(self, group_id):
+        try:
+            first_release = GroupTagValue.objects.filter(
+                group_id=group_id,
+                key__in=('sentry:release', 'release'),
+            ).order_by('first_seen')[0]
+        except IndexError:
+            return None
+        else:
+            return first_release.value
+
+    def get_last_release(self, group_id):
+        try:
+            last_release = GroupTagValue.objects.filter(
+                group_id=group_id,
+                key__in=('sentry:release', 'release'),
+            ).order_by('-last_seen')[0]
+        except IndexError:
+            return None
+
+        return last_release.value
+
+    def update_project_for_group(self, group_id, old_project_id, new_project_id):
+        GroupTagValue.objects.filter(
+            project_id=old_project_id,
+            group_id=group_id,
+        ).update(project_id=new_project_id)
+
+    def get_group_ids_for_users(self, project_ids, event_users, limit=100):
+        return GroupTagValue.objects.filter(
+            key='sentry:user',
+            value__in=[eu.tag_value for eu in event_users],
+            project_id__in=project_ids,
+        ).order_by('-last_seen').values_list('group_id', flat=True)[:limit]
+
+    def get_group_tag_values_for_users(self, event_users, limit=100):
+        tag_filters = [Q(value=eu.tag_value, project_id=eu.project_id) for eu in event_users]
+        return list(GroupTagValue.objects.filter(
+            reduce(or_, tag_filters),
+            key='sentry:user',
+        ).order_by('-last_seen')[:limit])
+
+    def get_tags_for_search_filter(self, project_id, tags):
+        from sentry.search.base import ANY, EMPTY
+        # Django doesnt support union, so we limit results and try to find
+        # reasonable matches
+
+        # ANY matches should come last since they're the least specific and
+        # will provide the largest range of matches
+        tag_lookups = sorted(six.iteritems(tags), key=lambda x: x != ANY)
+
+        # get initial matches to start the filter
+        matches = None
+
+        # for each remaining tag, find matches contained in our
+        # existing set, pruning it down each iteration
+        for k, v in tag_lookups:
+            if v is EMPTY:
+                return None
+
+            elif v != ANY:
+                base_qs = GroupTagValue.objects.filter(
+                    key=k,
+                    value=v,
+                    project_id=project_id,
+                )
+
+            else:
+                base_qs = GroupTagValue.objects.filter(
+                    key=k,
+                    project_id=project_id,
+                ).distinct()
+
+            if matches:
+                base_qs = base_qs.filter(group_id__in=matches)
+            else:
+                # restrict matches to only the most recently seen issues
+                base_qs = base_qs.order_by('-last_seen')
+
+            matches = list(base_qs.values_list('group_id', flat=True)[:1000])
+
+            if not matches:
+                return None
+
+        return matches

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -239,10 +239,7 @@ def migrate_events(caches, project, source_id, destination_id, fingerprints, eve
 
 def truncate_denormalizations(group):
     tagstore.delete_all_group_tag_keys(group.id)
-
-    GroupTagValue.objects.filter(
-        group_id=group.id,
-    ).delete()
+    tagstore.delete_all_group_tag_values(group.id)
 
     GroupRelease.objects.filter(
         group_id=group.id,
@@ -297,7 +294,7 @@ def repair_tag_data(caches, project, events):
             # ingestion logic (but actually represent a more accurate value.)
             # See GH-5289 for more details.
             for value, (times_seen, first_seen, last_seen) in values.items():
-                instance, created = GroupTagValue.objects.get_or_create(
+                instance, created = tagstore.get_or_create_group_tag_value(
                     project_id=project.id,
                     group_id=group_id,
                     key=key,

--- a/src/sentry/web/frontend/group_tag_export.py
+++ b/src/sentry/web/frontend/group_tag_export.py
@@ -4,7 +4,7 @@ from django.http import Http404
 
 from sentry import tagstore
 from sentry.models import (
-    EventUser, GroupTagValue, Group, get_group_with_redirect
+    EventUser, Group, get_group_with_redirect
 )
 from sentry.web.frontend.base import ProjectView
 from sentry.web.frontend.mixins.csv import CsvMixin
@@ -85,10 +85,7 @@ class GroupTagExportView(ProjectView, CsvMixin):
             callbacks = []
 
         queryset = RangeQuerySetWrapper(
-            GroupTagValue.objects.filter(
-                group_id=group.id,
-                key=lookup_key,
-            ),
+            tagstore.get_group_tag_value_qs(group.id, lookup_key),
             callbacks=callbacks,
         )
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -20,7 +20,7 @@ from gzip import GzipFile
 from raven import Client
 from six import StringIO
 
-from sentry.models import (Group, GroupTagValue, Event)
+from sentry.models import (Group, Event)
 from sentry.testutils import TestCase, TransactionTestCase
 from sentry.testutils.helpers import get_auth_header
 from sentry.utils.settings import (validate_settings, ConfigurationError, import_string)
@@ -176,12 +176,7 @@ class SentryRemoteTest(TestCase):
         assert tagstore.get_tag_key(self.project.id, 'foo') is not None
         assert tagstore.get_tag_value(self.project.id, 'foo', 'bar') is not None
         assert tagstore.get_group_tag_key(instance.group_id, 'foo') is not None
-        assert GroupTagValue.objects.filter(
-            key='foo',
-            value='bar',
-            group_id=instance.group_id,
-            project_id=self.project.id,
-        ).exists()
+        assert tagstore.get_group_tag_value(instance.group_id, 'foo', 'bar') is not None
 
     def test_timestamp(self):
         timestamp = timezone.now().replace(

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -5,9 +5,10 @@ import six
 from datetime import timedelta
 from django.utils import timezone
 
+from sentry import tagstore
 from sentry.models import (
     Activity, Group, GroupHash, GroupAssignee, GroupBookmark, GroupResolution, GroupSeen,
-    GroupSnooze, GroupSubscription, GroupStatus, GroupTagValue, GroupTombstone, Release
+    GroupSnooze, GroupSubscription, GroupStatus, GroupTombstone, Release
 )
 from sentry.testutils import APITestCase
 
@@ -34,7 +35,7 @@ class GroupDetailsTest(APITestCase):
             version='1.0',
         )
         release.add_project(group.project)
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             group_id=group.id,
             project_id=group.project_id,
             key='sentry:release',

--- a/tests/sentry/api/endpoints/test_group_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_details.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import six
 
 from sentry import tagstore
-from sentry.models import GroupTagValue
 from sentry.testutils import APITestCase
 
 
@@ -32,7 +31,7 @@ class GroupTagDetailsTest(APITestCase):
             key=key,
             values_seen=1,
         )
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             project_id=group.project_id,
             group_id=group.id,
             key=key,

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry import tagstore
-from sentry.models import EventUser, GroupTagValue
+from sentry.models import EventUser
 from sentry.testutils import APITestCase
 
 
@@ -17,7 +17,7 @@ class GroupTagKeyValuesTest(APITestCase):
             key=key,
             value=value,
         )
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             project_id=project.id,
             group_id=group.id,
             key=key,
@@ -54,7 +54,7 @@ class GroupTagKeyValuesTest(APITestCase):
             key='sentry:user',
             value=euser.tag_value,
         )
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             project_id=project.id,
             group_id=group.id,
             key='sentry:user',

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from sentry import tagstore
-from sentry.models import GroupTagValue
 from sentry.testutils import APITestCase
 
 
@@ -26,7 +25,7 @@ class GroupTagsTest(APITestCase):
                 group_id=group.id,
                 key=key,
             )
-            GroupTagValue.objects.create(
+            tagstore.create_group_tag_value(
                 project_id=group.project_id,
                 group_id=group.id,
                 key=key,

--- a/tests/sentry/api/endpoints/test_organization_user_issues.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
-from sentry.models import EventUser, GroupTagValue, OrganizationMemberTeam
+from sentry import tagstore
+from sentry.models import EventUser, OrganizationMemberTeam
 from sentry.testutils import APITestCase
 
 
@@ -32,19 +33,19 @@ class OrganizationUserIssuesTest(APITestCase):
         self.euser2 = EventUser.objects.create(email='bar@example.com', project_id=self.project1.id)
         self.euser3 = EventUser.objects.create(email='foo@example.com', project_id=self.project2.id)
 
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key='sentry:user',
             value=self.euser1.tag_value,
             group_id=self.group1.id,
             project_id=self.project1.id
         )
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key='sentry:user',
             value=self.euser2.tag_value,
             group_id=self.group1.id,
             project_id=self.project1.id
         )
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key='sentry:user',
             value=self.euser3.tag_value,
             group_id=self.group2.id,

--- a/tests/sentry/api/endpoints/test_organization_user_issues_search.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues_search.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
-from sentry.models import EventUser, GroupTagValue, OrganizationMemberTeam
+from sentry import tagstore
+from sentry.models import EventUser, OrganizationMemberTeam
 from sentry.testutils import APITestCase
 
 
@@ -29,19 +30,19 @@ class OrganizationUserIssuesSearchTest(APITestCase):
         EventUser.objects.create(email='bar@example.com', project_id=self.project1.id)
         EventUser.objects.create(email='foo@example.com', project_id=self.project2.id)
 
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key='sentry:user',
             value='email:foo@example.com',
             group_id=group1.id,
             project_id=self.project1.id
         )
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key='sentry:user',
             value='email:bar@example.com',
             group_id=group1.id,
             project_id=self.project1.id
         )
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key='sentry:user',
             value='email:foo@example.com',
             group_id=group2.id,

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -12,7 +12,7 @@ from mock import patch
 from sentry import tagstore
 from sentry.models import (
     Activity, EventMapping, Group, GroupAssignee, GroupBookmark, GroupHash, GroupResolution,
-    GroupSeen, GroupSnooze, GroupStatus, GroupSubscription, GroupTagValue,
+    GroupSeen, GroupSnooze, GroupStatus, GroupSubscription,
     GroupTombstone, Release, UserOption
 )
 from sentry.models.event import Event
@@ -247,11 +247,11 @@ class GroupListTest(APITestCase):
         release.add_project(project2)
         group = self.create_group(checksum='a' * 32, project=project)
         group2 = self.create_group(checksum='b' * 32, project=project2)
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             project_id=project.id, group_id=group.id, key='sentry:release', value=release.version
         )
 
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             project_id=project2.id, group_id=group2.id, key='sentry:release', value=release.version
         )
 

--- a/tests/sentry/api/serializers/test_grouptagvalue.py
+++ b/tests/sentry/api/serializers/test_grouptagvalue.py
@@ -6,7 +6,7 @@ import six
 
 from sentry import tagstore
 from sentry.api.serializers import serialize
-from sentry.models import EventUser, GroupTagValue
+from sentry.models import EventUser
 from sentry.testutils import TestCase
 
 
@@ -23,7 +23,7 @@ class GroupTagValueSerializerTest(TestCase):
             key='sentry:user',
             value=euser.tag_value,
         )
-        grouptagvalue = GroupTagValue.objects.create(
+        grouptagvalue = tagstore.create_group_tag_value(
             project_id=project.id,
             group_id=self.create_group(project=project).id,
             key=tagvalue.key,

--- a/tests/sentry/deletions/test_tagkey.py
+++ b/tests/sentry/deletions/test_tagkey.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
 from sentry import tagstore
-from sentry.models import (
-    EventTag, GroupTagValue, ScheduledDeletion
-)
+from sentry.models import EventTag, ScheduledDeletion
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TestCase
 
@@ -18,7 +16,7 @@ class DeleteTagKeyTest(TestCase):
         tk = tagstore.create_tag_key(key=key, project_id=project.id)
         tagstore.create_tag_value(key=key, value=value, project_id=project.id)
         tagstore.create_group_tag_key(key=key, group_id=group.id, project_id=project.id)
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key=key, value=value, group_id=group.id, project_id=project.id
         )
         EventTag.objects.create(
@@ -33,7 +31,7 @@ class DeleteTagKeyTest(TestCase):
         group2 = self.create_group(project=project2)
         tk2 = tagstore.create_tag_key(project2.id, key)
         tagstore.create_group_tag_key(key=key, group_id=group2.id, project_id=project2.id)
-        gtv2 = GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key=key, value=value, group_id=group2.id, project_id=project2.id
         )
         EventTag.objects.create(
@@ -50,7 +48,11 @@ class DeleteTagKeyTest(TestCase):
         with self.tasks():
             run_deletion(deletion.id)
 
-        assert not GroupTagValue.objects.filter(key=tk.key, project_id=project.id).exists()
+        try:
+            tagstore.get_group_tag_value(group.id, key, value)
+            assert False  # verify exception thrown
+        except tagstore.GroupTagValueNotFound:
+            pass
         try:
             tagstore.get_group_tag_key(group.id, key)
             assert False  # verify exception thrown
@@ -70,5 +72,5 @@ class DeleteTagKeyTest(TestCase):
 
         assert tagstore.get_tag_key(project2.id, key) is not None
         assert tagstore.get_group_tag_key(group2.id, key) is not None
-        assert GroupTagValue.objects.filter(id=gtv2.id).exists()
+        assert tagstore.get_group_tag_value(group2.id, key, value) is not None
         assert EventTag.objects.filter(key_id=tk2.id).exists()

--- a/tests/sentry/manager/tests.py
+++ b/tests/sentry/manager/tests.py
@@ -2,7 +2,8 @@
 
 from __future__ import absolute_import
 
-from sentry.models import Group, GroupTagValue, Team, User
+from sentry import tagstore
+from sentry.models import Group, Team, User
 from sentry.testutils import TestCase
 
 
@@ -20,7 +21,7 @@ class SentryManagerTest(TestCase):
         with self.tasks():
             Group.objects.add_tags(group, tags=(('foo', 'bar'), ('foo', 'baz'), ('biz', 'boz')))
 
-        results = list(GroupTagValue.objects.filter(group_id=group.id, key='foo').order_by('id'))
+        results = sorted(tagstore.get_group_tag_values(group.id, 'foo'), key=lambda x: x.id)
         assert len(results) == 2
         res = results[0]
         self.assertEquals(res.value, 'bar')
@@ -29,7 +30,7 @@ class SentryManagerTest(TestCase):
         self.assertEquals(res.value, 'baz')
         self.assertEquals(res.times_seen, 1)
 
-        results = list(GroupTagValue.objects.filter(group_id=group.id, key='biz').order_by('id'))
+        results = sorted(tagstore.get_group_tag_values(group.id, 'biz'), key=lambda x: x.id)
         assert len(results) == 1
         res = results[0]
         self.assertEquals(res.value, 'boz')

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -8,8 +8,9 @@ import pytest
 from django.db.models import ProtectedError
 from django.utils import timezone
 
+from sentry import tagstore
 from sentry.models import (
-    Group, GroupRedirect, GroupSnooze, GroupStatus, Release, get_group_with_redirect, GroupTagValue
+    Group, GroupRedirect, GroupSnooze, GroupStatus, Release, get_group_with_redirect
 )
 from sentry.testutils import TestCase
 
@@ -178,7 +179,7 @@ class GroupTest(TestCase):
             first_release=release,
         )
 
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             project_id=project.id, group_id=group.id, key='sentry:release', value=release.version
         )
 
@@ -198,7 +199,7 @@ class GroupTest(TestCase):
             project=project,
         )
 
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             project_id=project.id, group_id=group.id, key='sentry:release', value=release.version
         )
 

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -4,8 +4,9 @@ from __future__ import absolute_import
 
 from datetime import datetime, timedelta
 
+from sentry import tagstore
 from sentry.models import (
-    GroupAssignee, GroupBookmark, GroupStatus, GroupSubscription, GroupTagValue
+    GroupAssignee, GroupBookmark, GroupStatus, GroupSubscription
 )
 from sentry.search.base import ANY
 from sentry.search.django.backend import DjangoSearchBackend
@@ -71,14 +72,14 @@ class DjangoSearchBackendTest(TestCase):
         )
 
         for key, value in self.event1.data['tags']:
-            GroupTagValue.objects.create(
+            tagstore.create_group_tag_value(
                 project_id=self.group1.project_id,
                 group_id=self.group1.id,
                 key=key,
                 value=value,
             )
         for key, value in self.event2.data['tags']:
-            GroupTagValue.objects.create(
+            tagstore.create_group_tag_value(
                 project_id=self.group2.project_id,
                 group_id=self.group2.id,
                 key=key,

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -12,9 +12,8 @@ from sentry.exceptions import DeleteAborted
 from sentry.models import (
     ApiApplication, ApiApplicationStatus, ApiGrant, ApiToken, Commit, CommitAuthor, Environment,
     EnvironmentProject, Event, EventMapping, EventTag, Group, GroupAssignee, GroupHash, GroupMeta,
-    GroupRedirect, GroupResolution, GroupStatus, GroupTagValue, Organization,
-    OrganizationStatus, Project, ProjectStatus, Release, ReleaseCommit, ReleaseEnvironment,
-    Repository, Team, TeamStatus
+    GroupRedirect, GroupResolution, GroupStatus, Organization, OrganizationStatus, Project,
+    ProjectStatus, Release, ReleaseCommit, ReleaseEnvironment, Repository, Team, TeamStatus
 )
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
 from sentry.tasks.deletion import (
@@ -193,7 +192,7 @@ class DeleteTagKeyTest(TestCase):
         tk = tagstore.create_tag_key(key=key, project_id=project.id)
         tagstore.create_tag_value(key=key, value=value, project_id=project.id)
         tagstore.create_group_tag_key(key=key, group_id=group.id, project_id=project.id)
-        GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key=key, value=value, group_id=group.id, project_id=project.id
         )
         EventTag.objects.create(
@@ -208,7 +207,7 @@ class DeleteTagKeyTest(TestCase):
         group2 = self.create_group(project=project2)
         tk2 = tagstore.create_tag_key(key=key, project_id=project2.id)
         tagstore.create_group_tag_key(key=key, group_id=group2.id, project_id=project2.id)
-        gtv2 = GroupTagValue.objects.create(
+        tagstore.create_group_tag_value(
             key=key, value=value, group_id=group2.id, project_id=project2.id
         )
         EventTag.objects.create(
@@ -222,7 +221,11 @@ class DeleteTagKeyTest(TestCase):
         with self.tasks():
             delete_tag_key(object_id=tk.id)
 
-            assert not GroupTagValue.objects.filter(key=tk.key, project_id=project.id).exists()
+            try:
+                tagstore.get_group_tag_value(group.id, key, value)
+                assert False  # verify exception thrown
+            except tagstore.GroupTagValueNotFound:
+                pass
             try:
                 tagstore.get_group_tag_key(group.id, key)
                 assert False  # verify exception thrown
@@ -242,7 +245,7 @@ class DeleteTagKeyTest(TestCase):
 
         assert tagstore.get_tag_key(project2.id, key) is not None
         assert tagstore.get_group_tag_key(group2.id, key) is not None
-        assert GroupTagValue.objects.filter(id=gtv2.id).exists()
+        assert tagstore.get_group_tag_value(group2.id, key, value) is not None
         assert EventTag.objects.filter(key_id=tk2.id).exists()
 
 

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -5,7 +5,7 @@ from mock import patch
 
 from sentry import tagstore
 from sentry.tasks.merge import merge_group, rehash_group_events
-from sentry.models import Event, Group, GroupMeta, GroupRedirect, GroupTagValue
+from sentry.models import Event, Group, GroupMeta, GroupRedirect
 from sentry.similarity import _make_index_backend
 from sentry.testutils import TestCase
 from sentry.utils import redis
@@ -107,31 +107,27 @@ class MergeGroupTest(TestCase):
                 values_seen=values_seen,
             )
 
-        GroupTagValue.objects.bulk_create(
-            [
-                GroupTagValue(
-                    project_id=project.id,
-                    group_id=group.id,
-                    key=key,
-                    value=value,
-                    times_seen=times_seen,
-                ) for ((group, key, value), times_seen) in input_group_tag_values.items()
-            ]
-        )
+        for ((group, key, value), times_seen) in input_group_tag_values.items():
+            tagstore.create_group_tag_value(
+                project_id=project.id,
+                group_id=group.id,
+                key=key,
+                value=value,
+                times_seen=times_seen,
+            )
 
         with self.tasks():
             merge_group(other.id, target.id)
 
         assert not Group.objects.filter(id=other.id).exists()
         assert len(tagstore.get_group_tag_keys(other.id)) == 0
-        assert not GroupTagValue.objects.filter(group_id=other.id).exists()
+        assert len(tagstore.get_group_tag_values(other.id)) == 0
 
         for key, values_seen in output_group_tag_keys.items():
             assert tagstore.get_group_tag_key(target.id, key).values_seen == values_seen
 
         for (key, value), times_seen in output_group_tag_values.items():
-            assert GroupTagValue.objects.get(
-                project_id=project.id,
+            assert tagstore.get_group_tag_value(
                 group_id=target.id,
                 key=key,
                 value=value,

--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry import tagstore
-from sentry.models import GroupTagValue
 from sentry.testutils import TestCase
 
 
@@ -23,7 +22,7 @@ class GroupTagExportTest(TestCase):
             key=key,
             value=value,
         )
-        group_tag_value = GroupTagValue.objects.create(
+        group_tag_value = tagstore.create_group_tag_value(
             project_id=project.id,
             group_id=group.id,
             key=key,


### PR DESCRIPTION
`GroupTagValue` has the most unique queries, so this adds a number of one-off 'special methods' to the `tagstore`. I was able to reduce some, but my plan for now is still move stuff in and then take a more holistic look at refactor/changes as I go forward.

Last one left after this is `EventTag`