### PR TITLE
fix: Bind Project to Event when saving an Event

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -449,6 +449,7 @@ class EventManager(object):
             datetime=date,
             **kwargs
         )
+        event._project_cache = project
 
         # convert this to a dict to ensure we're only storing one value per key
         # as most parts of Sentry dont currently play well with multiple values


### PR DESCRIPTION
This saves a database query later when we check `event.project` when we
already have the value.