### PR TITLE
ref: Drop GroupTagValue sorts on times_seen

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -4,7 +4,7 @@ from sentry import tagstore
 from sentry.api.base import DocSection
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.paginator import DateTimePaginator, OffsetPaginator, Paginator
+from sentry.api.paginator import DateTimePaginator, Paginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.tagvalue import UserTagValueSerializer
 from sentry.models import GroupTagValue, Group
@@ -55,9 +55,6 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         elif sort == 'age':
             order_by = '-first_seen'
             paginator_cls = DateTimePaginator
-        elif sort == 'freq':
-            order_by = '-times_seen'
-            paginator_cls = OffsetPaginator
         else:
             order_by = '-id'
             paginator_cls = Paginator

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -324,23 +324,6 @@ class Group(Model):
                 self._oldest_event = None
         return self._oldest_event
 
-    def get_unique_tags(self, tag, since=None, order_by='-times_seen'):
-        # TODO(dcramer): this has zero test coverage and is a critical path
-        from sentry.models import GroupTagValue
-
-        queryset = GroupTagValue.objects.filter(
-            group=self,
-            key=tag,
-        )
-        if since:
-            queryset = queryset.filter(last_seen__gte=since)
-        return queryset.values_list(
-            'value',
-            'times_seen',
-            'first_seen',
-            'last_seen',
-        ).order_by(order_by)
-
     def get_tags(self):
         from sentry.models import GroupTagKey
         if not hasattr(self, '_tag_cache'):


### PR DESCRIPTION
@dcramer tagging you because this technically removes functionality, see description below though.

Could use any @getsentry/platform review(s) though, too.

---

In preperation for "Tags 2.0" this removes some unused sorts on columns
we hope to move into Redis (or elsewhere).

GroupTagKeyValuesEndpoint 'freq' sort seems completely unused in the
codebase. The only 'freq' sort that is used is against Groups
themselves.

get_unique_tags wasn't called anywhere.

---

Details:

`freq` search in the codebase only showing Group (stream) searches. My hunch is that 'freq' was added to the `GroupTagKeyValuesEndpoint` endpoint because the column was there and it was easy to add:

```
rg "['\"]freq['\"]"

src/sentry/constants.py
43:        ('freq', _('Frequency')),

src/sentry/search/django/constants.py
15:    'freq': 'sentry_groupedmessage.times_seen',

src/sentry/search/django/backend.py
299:        elif sort_by == 'freq':

tests/js/spec/views/stream.spec.jsx
318:        location: {query: {sort: 'freq'}, search: 'sort=freq'},
334:        sort: 'freq',
349:        location: {query: {sort: 'freq'}, search: 'sort=freq'},
365:        sort: 'freq',
384:        location: {query: {sort: 'freq'}, search: 'sort=freq'},
400:        sort: 'freq',

tests/sentry/search/django/tests.py
135:        results = self.backend.query(self.project1, sort_by='freq')

src/sentry/static/sentry/app/views/stream/sortOptions.jsx
52:      case 'freq':
73:        {this.getMenuItem('freq')}
```

The only reference to `group.get_unique_tags` (which defaulted to sorting by `-times_seen`) is in a docstring here: https://github.com/getsentry/sentry/blob/04d8cf5987353b7018e6682077b68a7dc236a003/src/sntry/plugins/base/v1.py#L445

I actually don't even see a place where `is_regression` is overridden, and its body is empty. It seems like dead code too, but we probably want to leave it in the V1 plugin API.
