### PR TITLE
feat(saml): Support IdP initiated SSO

### DIFF
--- a/src/sentry/auth/providers/saml2.py
+++ b/src/sentry/auth/providers/saml2.py
@@ -96,9 +96,8 @@ class SAML2AcceptACSView(BaseView):
 
         # AuthOranizationLogin will init the login flow *only if* the ``init``
         # parameter is set.
-        request.POST._mutable = True
+        request.POST = request.POST.copy()
         request.POST['init'] = True
-        request.POST._mutable = False
 
         org_login = AuthOrganizationLoginView()
         return org_login.handle(request, organization_slug)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -37,7 +37,7 @@ from sentry.web.frontend.mailgun_inbound_webhook import \
     MailgunInboundWebhookView
 from sentry.web.frontend.oauth_authorize import OAuthAuthorizeView
 from sentry.web.frontend.oauth_token import OAuthTokenView
-from sentry.auth.providers.saml2 import SAML2SLSView, SAML2MetadataView
+from sentry.auth.providers.saml2 import SAML2AcceptACSView, SAML2SLSView, SAML2MetadataView
 from sentry.web.frontend.organization_api_key_settings import \
     OrganizationApiKeySettingsView
 from sentry.web.frontend.organization_api_keys import OrganizationApiKeysView
@@ -144,6 +144,8 @@ urlpatterns += patterns(
     url(r'^oauth/token/$', OAuthTokenView.as_view()),
 
     # SAML
+    url(r'^saml/acs/(?P<organization_slug>[^/]+)/$', SAML2AcceptACSView.as_view(),
+        name='sentry-auth-organization-saml-acs'),
     url(r'^saml/sls/(?P<organization_slug>[^/]+)/$', SAML2SLSView.as_view(),
         name='sentry-auth-organization-saml-sls'),
     url(r'^saml/metadata/(?P<organization_slug>[^/]+)/$', SAML2MetadataView.as_view(),

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -75,8 +75,8 @@ class AuthSAML2Test(AuthProviderTestCase):
         return reverse('sentry-auth-organization', args=['saml2-org'])
 
     @fixture
-    def sso_path(self):
-        return reverse('sentry-auth-sso')
+    def acs_path(self):
+        return reverse('sentry-auth-organization-saml-acs', args=['saml2-org'])
 
     def test_redirects_to_idp(self):
         resp = self.client.post(self.login_path, {'init': True})
@@ -88,7 +88,7 @@ class AuthSAML2Test(AuthProviderTestCase):
         assert redirect.path == '/sso_url'
         assert 'SAMLRequest' in query
 
-    def test_auth_from_idp(self):
+    def accept_auth(self):
         # Start auth process
         self.client.post(self.login_path, {'init': True})
 
@@ -99,10 +99,18 @@ class AuthSAML2Test(AuthProviderTestCase):
         is_valid = 'onelogin.saml2.response.OneLogin_Saml2_Response.is_valid'
 
         with mock.patch(is_valid, return_value=True):
-            resp = self.client.post(self.sso_path, {'SAMLResponse': saml_response})
+            resp = self.client.post(self.acs_path, {'SAMLResponse': saml_response})
 
         assert resp.status_code == 200
         assert resp.context['existing_user'] == self.user
+
+    def test_auth_sp_initiated(self):
+        # Start auth process from SP side
+        self.client.post(self.login_path, {'init': True})
+        self.accept_auth()
+
+    def test_auth_idp_initiated(self):
+        self.accept_auth()
 
     def test_saml_metadata(self):
         path = reverse('sentry-auth-organization-saml-metadata', args=['saml2-org'])

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -89,9 +89,6 @@ class AuthSAML2Test(AuthProviderTestCase):
         assert 'SAMLRequest' in query
 
     def accept_auth(self):
-        # Start auth process
-        self.client.post(self.login_path, {'init': True})
-
         saml_response = self.load_fixture('saml2_auth_response.xml')
         saml_response = base64.b64encode(saml_response)
 


### PR DESCRIPTION
In order to support IdP initiated SSO, the ACS endpoint must be aware of the organization the user is authenticating to. Becuase the generic /auth/sso endpoint expects the user to already have initiated the login flow through the org login page, this endpoint cannot work for a IdP initiated sign in.

This adds a SAML specific SSO endpoint that will proxy to either the SSO org login init action or the in-progress auth-sslo action.