### PR TITLE
feat(s3): Added prefetch support for files (S3)

### DIFF
--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -9,9 +9,12 @@ sentry.models.file
 from __future__ import absolute_import
 
 import six
+import shutil
+import tempfile
 
 from hashlib import sha1
 from uuid import uuid4
+from concurrent.futures import ThreadPoolExecutor
 
 from django.conf import settings
 from django.core.files.base import File as FileObj
@@ -160,15 +163,15 @@ class File(Model):
         app_label = 'sentry'
         db_table = 'sentry_file'
 
-    def getfile(self, *args, **kwargs):
-        return FileObj(
-            ChunkedFileBlobIndexWrapper(
-                FileBlobIndex.objects.filter(
-                    file=self,
-                ).select_related('blob').order_by('offset'),
-                mode=kwargs.get('mode'),
-            ), self.name
+    def getfile(self, mode=None, prefetch=False):
+        cfbiw = ChunkedFileBlobIndexWrapper(
+            FileBlobIndex.objects.filter(
+                file=self,
+            ).select_related('blob').order_by('offset'),
+            mode=mode,
+            prefetch=prefetch
         )
+        return FileObj(cfbiw, self.name)
 
     def putfile(self, fileobj, blob_size=DEFAULT_BLOB_SIZE, commit=True):
         """
@@ -219,11 +222,16 @@ class FileBlobIndex(Model):
 
 
 class ChunkedFileBlobIndexWrapper(object):
-    def __init__(self, indexes, mode=None):
+    def __init__(self, indexes, mode=None, prefetch=False):
         # eager load from database incase its a queryset
         self._indexes = list(indexes)
         self._curfile = None
         self._curidx = None
+        if prefetch:
+            self.prefetched = True
+            self._prefetch()
+        else:
+            self.prefetched = False
         self.mode = mode
         self.open()
 
@@ -234,12 +242,19 @@ class ChunkedFileBlobIndexWrapper(object):
         self.close()
 
     def _nextidx(self):
+        if self.prefetched:
+            self._
+        old_file = self._curfile
         try:
-            self._curidx = six.next(self._idxiter)
-            self._curfile = self._curidx.blob.getfile()
-        except StopIteration:
-            self._curidx = None
-            self._curfile = None
+            try:
+                self._curidx = six.next(self._idxiter)
+                self._curfile = self._curidx.blob.getfile()
+            except StopIteration:
+                self._curidx = None
+                self._curfile = None
+        finally:
+            if old_file is not None:
+                old_file.close()
 
     @property
     def size(self):
@@ -248,6 +263,23 @@ class ChunkedFileBlobIndexWrapper(object):
     def open(self):
         self.closed = False
         self.seek(0)
+
+    def _prefetch(self):
+        f = tempfile.NamedTemporaryFile()
+        fpath = f.name
+
+        def fetch_file(offset, getfile):
+            with open(fpath, 'r+') as f:
+                f.seek(offset)
+                with getfile() as sf:
+                    shutil.copyfileobj(sf, f)
+                f.flush()
+
+        with ThreadPoolExecutor(max_workers=4) as exe:
+            for idx in self._indexes:
+                exe.submit(fetch_file, idx.offset, idx.blob.getfile)
+
+        self._curfile = f
 
     def close(self):
         if self._curfile:
@@ -259,6 +291,10 @@ class ChunkedFileBlobIndexWrapper(object):
     def seek(self, pos):
         if self.closed:
             raise ValueError('I/O operation on closed file')
+
+        if self.prefetched:
+            return self._curfile.seek(pos)
+
         if pos < 0:
             raise IOError('Invalid argument')
         for n, idx in enumerate(self._indexes[::-1]):
@@ -269,12 +305,13 @@ class ChunkedFileBlobIndexWrapper(object):
                 break
         else:
             raise ValueError('Cannot seek to pos')
-        rel_pos = min(pos - self._curidx.offset, self._curidx.blob.size)
-        self._curfile.seek(rel_pos)
+        self._curfile.seek(pos - self._curidx.offset)
 
     def tell(self):
         if self.closed:
             raise ValueError('I/O operation on closed file')
+        if self.prefetched:
+            return self._curfile.tell()
         if self._curfile is None:
             return self.size
         return self._curidx.offset + self._curfile.tell()
@@ -282,6 +319,9 @@ class ChunkedFileBlobIndexWrapper(object):
     def read(self, n=-1):
         if self.closed:
             raise ValueError('I/O operation on closed file')
+
+        if self.prefetched:
+            return self._curfile.read(n)
 
         result = bytearray()
 

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -242,8 +242,7 @@ class ChunkedFileBlobIndexWrapper(object):
         self.close()
 
     def _nextidx(self):
-        if self.prefetched:
-            self._
+        assert not self.prefetched, 'this makes no sense'
         old_file = self._curfile
         try:
             try:

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -39,16 +39,16 @@ class FileTest(TestCase):
         with file1.getfile() as fp:
             assert fp.read().decode('utf-8') == 'foo bar'
             fp.seek(2)
-            fp.tell() == 2
+            assert fp.tell() == 2
             assert fp.read().decode('utf-8') == 'o bar'
             fp.seek(0)
-            fp.tell() == 0
+            assert fp.tell() == 0
             assert fp.read().decode('utf-8') == 'foo bar'
             fp.seek(4)
-            fp.tell() == 4
+            assert fp.tell() == 4
             assert fp.read().decode('utf-8') == 'bar'
             fp.seek(1000)
-            fp.tell() == 1000
+            assert fp.tell() == 7
 
             with self.assertRaises(IOError):
                 fp.seek(-1)

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import os
+
 from django.core.files.base import ContentFile
 
 from sentry.models import File, FileBlob
@@ -48,7 +50,7 @@ class FileTest(TestCase):
             assert fp.tell() == 4
             assert fp.read().decode('utf-8') == 'bar'
             fp.seek(1000)
-            assert fp.tell() == 7
+            assert fp.tell() == 1000
 
             with self.assertRaises(IOError):
                 fp.seek(-1)
@@ -61,3 +63,17 @@ class FileTest(TestCase):
 
         with self.assertRaises(ValueError):
             fp.read()
+
+    def test_multi_chunk_prefetch(self):
+        random_data = os.urandom(1 << 16)
+
+        fileobj = ContentFile(random_data)
+        file = File.objects.create(
+            name='test.bin',
+            type='default',
+            size=len(random_data),
+        )
+        file.putfile(fileobj, 128)
+
+        f = file.getfile(prefetch=True)
+        assert f.read() == random_data


### PR DESCRIPTION
This changes the behavior of the File object to match standard Python behavior
(in particular it read until the end by default), removes some unused tempfile
handling in the underlying s3 object and adds a prefetch feature where up to
4 threads will fetch blobs and put it into tempfiles.

This should help us fetch dsym files faster from S3. Prefetch is opt in and
disabled by default.