### PR TITLE
ref: Extract EventTag interactions out to TagStorage abstraction

### DIFF
--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -44,6 +44,7 @@ class TagStorage(Service):
         'get_or_create_group_tag_key',
         'create_group_tag_value',
         'get_or_create_group_tag_value',
+        'create_event_tag',
 
         'get_tag_key',
         'get_tag_keys',
@@ -75,6 +76,7 @@ class TagStorage(Service):
         'get_group_ids_for_users',
         'get_group_tag_values_for_users',
         'get_tags_for_search_filter',
+        'get_event_tag_qs',
     )
 
     def is_valid_key(self, key):
@@ -143,6 +145,12 @@ class TagStorage(Service):
     def get_or_create_group_tag_value(self, project_id, group_id, key, value, **kwargs):
         """
         >>> get_or_create_group_tag_value(1, 2, "key1", "value1")
+        """
+        raise NotImplementedError
+
+    def create_event_tag(self, project_id, group_id, event_id, key_id, value_id):
+        """
+        >>> create_event_tag(1, 2, 3, 4, 5)
         """
         raise NotImplementedError
 
@@ -315,5 +323,11 @@ class TagStorage(Service):
     def get_tags_for_search_filter(self, project_id, tags):
         """
         >>> get_tags_for_search_filter(1, [('key1', 'value1'), ('key2', 'value2')])
+        """
+        raise NotImplementedError
+
+    def get_event_tag_qs(self, **kwargs):
+        """
+        >>> get_event_tag_qs(event_id=1, key_id=2)
         """
         raise NotImplementedError

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -13,7 +13,7 @@ from sentry.event_manager import (
     ScoreClause, generate_culprit, get_hashes_for_event, md5_from_hash
 )
 from sentry.models import (
-    Activity, Environment, Event, EventMapping, EventTag, EventUser, Group, GroupHash, GroupRelease,
+    Activity, Environment, Event, EventMapping, EventUser, Group, GroupHash, GroupRelease,
     GroupTagValue, Project, Release, UserReport
 )
 from sentry.similarity import features
@@ -217,7 +217,7 @@ def migrate_events(caches, project, source_id, destination_id, fingerprints, eve
     for event in events:
         event.group = destination
 
-    EventTag.objects.filter(
+    tagstore.get_event_tag_qs(
         project_id=project.id,
         event_id__in=event_id_set,
     ).update(group_id=destination_id)

--- a/tests/sentry/api/endpoints/test_group_events.py
+++ b/tests/sentry/api/endpoints/test_group_events.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import six
 
 from sentry import tagstore
-from sentry.models import EventTag
 from sentry.testutils import APITestCase
 
 
@@ -40,21 +39,21 @@ class GroupEventsTest(APITestCase):
         tagvalue_2 = tagstore.create_tag_value(project_id=group.project_id, key='bar', value='biz')
         tagvalue_3 = tagstore.create_tag_value(project_id=group.project_id, key='bar', value='buz')
 
-        EventTag.objects.create(
+        tagstore.create_event_tag(
             project_id=group.project_id,
             group_id=group.id,
             event_id=event_1.id,
             key_id=tagkey_1.id,
             value_id=tagvalue_1.id,
         )
-        EventTag.objects.create(
+        tagstore.create_event_tag(
             project_id=group.project_id,
             group_id=group.id,
             event_id=event_2.id,
             key_id=tagkey_2.id,
             value_id=tagvalue_2.id,
         )
-        EventTag.objects.create(
+        tagstore.create_event_tag(
             project_id=group.project_id,
             group_id=group.id,
             event_id=event_1.id,

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import
 
 from uuid import uuid4
 
+from sentry import tagstore
 from sentry.models import (
-    Event, EventMapping, EventTag, Group, GroupAssignee, GroupHash, GroupMeta, GroupRedirect,
+    Event, EventMapping, Group, GroupAssignee, GroupHash, GroupMeta, GroupRedirect,
     ScheduledDeletion
 )
 from sentry.tasks.deletion import run_deletion
@@ -22,8 +23,9 @@ class DeleteGroupTest(TestCase):
             event_id='a' * 32,
             group_id=group.id,
         )
-        EventTag.objects.create(
+        tagstore.create_event_tag(
             event_id=event.id,
+            group_id=group.id,
             project_id=project.id,
             key_id=1,
             value_id=1,
@@ -59,7 +61,7 @@ class DeleteGroupTest(TestCase):
             event_id='a' * 32,
             group_id=group.id,
         ).exists()
-        assert not EventTag.objects.filter(event_id=event.id).exists()
+        assert not tagstore.get_event_tag_qs(event_id=event.id).exists()
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
         assert not Group.objects.filter(id=group.id).exists()

--- a/tests/sentry/deletions/test_tagkey.py
+++ b/tests/sentry/deletions/test_tagkey.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry import tagstore
-from sentry.models import EventTag, ScheduledDeletion
+from sentry.models import ScheduledDeletion
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TestCase
 
@@ -19,7 +19,7 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_group_tag_value(
             key=key, value=value, group_id=group.id, project_id=project.id
         )
-        EventTag.objects.create(
+        tagstore.create_event_tag(
             key_id=tk.id,
             group_id=group.id,
             value_id=1,
@@ -34,7 +34,7 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_group_tag_value(
             key=key, value=value, group_id=group2.id, project_id=project2.id
         )
-        EventTag.objects.create(
+        tagstore.create_event_tag(
             key_id=tk2.id,
             group_id=group2.id,
             value_id=1,
@@ -68,9 +68,9 @@ class DeleteTagKeyTest(TestCase):
             assert False  # verify exception thrown
         except tagstore.TagKeyNotFound:
             pass
-        assert not EventTag.objects.filter(key_id=tk.id).exists()
+        assert not tagstore.get_event_tag_qs(key_id=tk.id).exists()
 
         assert tagstore.get_tag_key(project2.id, key) is not None
         assert tagstore.get_group_tag_key(group2.id, key) is not None
         assert tagstore.get_group_tag_value(group2.id, key, value) is not None
-        assert EventTag.objects.filter(key_id=tk2.id).exists()
+        assert tagstore.get_event_tag_qs(key_id=tk2.id).exists()

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from mock import Mock, patch
 
 from sentry import tagstore
-from sentry.models import EventTag, Group, GroupSnooze, GroupStatus
+from sentry.models import Group, GroupSnooze, GroupStatus
 from sentry.testutils import TestCase
 from sentry.tasks.merge import merge_group
 from sentry.tasks.post_process import index_event_tags, post_process_group
@@ -124,7 +124,7 @@ class IndexEventTagsTest(TestCase):
                 tags=[('foo', 'bar'), ('biz', 'baz')],
             )
 
-        tags = list(EventTag.objects.filter(
+        tags = list(tagstore.get_event_tag_qs(
             event_id=event.id,
         ).values_list('key_id', 'value_id'))
         assert len(tags) == 2
@@ -161,7 +161,7 @@ class IndexEventTagsTest(TestCase):
                 tags=[('foo', 'bar'), ('biz', 'baz')],
             )
 
-        queryset = EventTag.objects.filter(
+        queryset = tagstore.get_event_tag_qs(
             event_id=event.id,
         )
         assert queryset.count() == 2


### PR DESCRIPTION
Not a lot going on here. Pulled into abstraction so it can be managed and so the model/table can be swapped out as needed.
