### PR TITLE
ref(tsdb): Add test for RedisTSDB frequency table merge operation.

### DIFF
--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -393,7 +393,7 @@ class RedisTSDBTest(TestCase):
             model,
             {
                 'organization:1': ("project:1", "project:2", "project:3", "project:4", "project:5"),
-                'organization:2': ("project:1", ),
+                'organization:2': ("project:1", "project:2", "project:3", "project:4", "project:5"),
             },
             now - timedelta(hours=1),
             now,
@@ -408,6 +408,43 @@ class RedisTSDBTest(TestCase):
             },
             'organization:2': {
                 "project:1": 0.0,
+                "project:2": 0.0,
+                "project:3": 0.0,
+                "project:4": 0.0,
+                "project:5": 1.5,
+            },
+        }
+
+        self.db.merge_frequencies(
+            model,
+            'organization:1',
+            ['organization:2'],
+            now,
+        )
+
+        assert self.db.get_frequency_totals(
+            model,
+            {
+                'organization:1': ("project:1", "project:2", "project:3", "project:4", "project:5"),
+                'organization:2': ("project:1", "project:2", "project:3", "project:4", "project:5"),
+            },
+            now - timedelta(hours=1),
+            now,
+            rollup=rollup,
+        ) == {
+            'organization:1': {
+                "project:1": 1.0 + 1.0,
+                "project:2": 2.0 + 2.0,
+                "project:3": 3.0 + 3.0,
+                "project:4": 4.0,
+                "project:5": 1.5,
+            },
+            'organization:2': {
+                "project:1": 0.0,
+                "project:2": 0.0,
+                "project:3": 0.0,
+                "project:4": 0.0,
+                "project:5": 0.0,
             },
         }
 


### PR DESCRIPTION
I realized this wasn't part of the test suite as part of GH-6256 and wanted to make sure this was covered independently so that adding environment filters doesn't cause it to regress.