### PR TITLE
Clean up logic around exception type/value

### DIFF
--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -63,13 +63,14 @@ class SingleException(Interface):
 
         type = data.get('type')
         value = data.get('value')
-        if not type and ':' in value.split(' ', 1)[0]:
-            type, value = value.split(':', 1)
-            # in case of TypeError: foo (no space)
-            value = value.strip()
-
-        if value is not None and not isinstance(value, six.string_types):
+        if isinstance(value, six.string_types):
+            if type is None and ':' in value.split(' ', 1)[0]:
+                type, value = value.split(':', 1)
+                # in case of TypeError: foo (no space)
+                value = value.strip()
+        elif value is not None:
             value = json.dumps(value)
+
         value = trim(value, 4096)
 
         mechanism = data.get('mechanism')

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -71,6 +71,14 @@ class ExceptionTest(TestCase):
         assert inst.values[0].value == 'hello world'
         assert inst.values[0].module == 'foo.bar'
 
+    def test_non_string_value_with_no_type(self):
+        inst = Exception.to_python(
+            {
+                'value': {'foo': 'bar'},
+            }
+        )
+        assert inst.values[0].value == '{"foo":"bar"}'
+
     def test_serialize_unserialize_behavior(self):
         result = type(self.interface).to_python(self.interface.to_json())
         assert result.to_json() == self.interface.to_json()


### PR DESCRIPTION
Only if value is a string, can we `split()` it. Otherwise if it is not `None` we can `json.dumps()` it.

Should fix SENTRY-3XB https://sentry.io/sentry/sentry/issues/317019975/