### PR TITLE
ref: Extract tag labels to tagstore, remove unnecessary queries

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -56,7 +56,7 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         data = {
             'id': six.text_type(tag_key.id),
             'key': key,
-            'name': tag_key.get_label(),
+            'name': tagstore.get_tag_key_label(tag_key.key),
             'uniqueValues': group_tag_key.values_seen,
             'totalValues': total_values,
             'topValues': serialize(top_values, request.user),

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -29,7 +29,7 @@ class GroupTagsEndpoint(GroupEndpoint):
                 {
                     'id': six.text_type(tag_key.id),
                     'key': tagstore.get_standardized_key(tag_key.key),
-                    'name': tag_key.get_label(),
+                    'name': tagstore.get_tag_key_label(tag_key.key),
                     'uniqueValues': tag_key.values_seen,
                     'totalValues': total_values,
                 }

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -18,7 +18,7 @@ class ProjectTagsEndpoint(ProjectEndpoint):
                 {
                     'id': six.text_type(tag_key.id),
                     'key': tagstore.get_standardized_key(tag_key.key),
-                    'name': tag_key.get_label(),
+                    'name': tagstore.get_tag_key_label(tag_key.key),
                     'uniqueValues': tag_key.values_seen,
                 }
             )

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -124,7 +124,7 @@ class GroupSerializer(Serializer):
             ).select_related('user')
         )
 
-        user_counts = tagstore.get_values_seen([g.id for g in item_list], 'sentry:user')
+        user_counts = tagstore.get_group_values_seen([g.id for g in item_list], 'sentry:user')
 
         ignore_items = {g.group_id: g for g in GroupSnooze.objects.filter(
             group__in=item_list,

--- a/src/sentry/api/serializers/models/grouptagkey.py
+++ b/src/sentry/api/serializers/models/grouptagkey.py
@@ -10,21 +10,11 @@ from sentry.models import GroupTagKey
 @register(GroupTagKey)
 class GroupTagKeySerializer(Serializer):
     def get_attrs(self, item_list, user):
-        tag_labels = {
-            t.key: t.get_label()
-            for t in
-            tagstore.get_tag_keys(item_list[0].project_id, [i.key for i in item_list])
-        }
-
         result = {}
         for item in item_list:
             key = tagstore.get_standardized_key(item.key)
-            try:
-                label = tag_labels[item.key]
-            except KeyError:
-                label = key
             result[item] = {
-                'name': label,
+                'name': tagstore.get_tag_key_label(item.key),
                 'key': key,
             }
 

--- a/src/sentry/api/serializers/models/grouptagvalue.py
+++ b/src/sentry/api/serializers/models/grouptagvalue.py
@@ -4,7 +4,7 @@ import six
 
 from sentry import tagstore
 from sentry.api.serializers import Serializer, register
-from sentry.models import GroupTagValue, Release
+from sentry.models import GroupTagValue
 
 
 @register(GroupTagValue)
@@ -12,21 +12,8 @@ class GroupTagValueSerializer(Serializer):
     def get_attrs(self, item_list, user):
         result = {}
         for item in item_list:
-            label = item.value
-            if item.key == 'sentry:user':
-                if item.value.startswith('id:'):
-                    label = item.value[len('id:'):]
-                elif item.value.startswith('email:'):
-                    label = item.value[len('email:'):]
-                elif item.value.startswith('username:'):
-                    label = item.value[len('username:'):]
-                elif item.value.startswith('ip:'):
-                    label = item.value[len('ip:'):]
-            elif item.key == 'sentry:release':
-                label = Release.get_display_version(item.value)
-
             result[item] = {
-                'name': label,
+                'name': tagstore.get_tag_value_label(item.key, item.value),
             }
 
         return result

--- a/src/sentry/api/serializers/models/tagkey.py
+++ b/src/sentry/api/serializers/models/tagkey.py
@@ -13,6 +13,6 @@ class TagKeySerializer(Serializer):
         return {
             'id': six.text_type(obj.id),
             'key': tagstore.get_standardized_key(obj.key),
-            'name': obj.get_label(),
+            'name': tagstore.get_tag_key_label(obj.key),
             'uniqueValues': obj.values_seen,
         }

--- a/src/sentry/api/serializers/models/tagvalue.py
+++ b/src/sentry/api/serializers/models/tagvalue.py
@@ -10,30 +10,10 @@ from sentry.models import EventUser, TagValue
 @register(TagValue)
 class TagValueSerializer(Serializer):
     def get_attrs(self, item_list, user):
-        user_tags = [i.value for i in item_list if i.key == 'sentry:user']
-
-        tag_labels = {}
-        if user_tags:
-            tag_labels.update(
-                {
-                    ('sentry:user', k): v.get_label()
-                    for k, v in six.iteritems(
-                        EventUser.for_tags(
-                            project_id=item_list[0].project_id,
-                            values=user_tags,
-                        )
-                    )
-                }
-            )
-
         result = {}
         for item in item_list:
-            try:
-                label = tag_labels[(item.key, item.value)]
-            except KeyError:
-                label = item.get_label()
             result[item] = {
-                'name': label,
+                'name': tagstore.get_tag_value_label(item.key, item.value),
             }
         return result
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -318,22 +318,11 @@ class Group(Model):
         if not hasattr(self, '_tag_cache'):
             group_tags = [gtk.key for gtk in tagstore.get_group_tag_keys(self.id)]
 
-            tag_keys = dict(
-                (t.key, t) for t in tagstore.get_tag_keys(self.project_id, group_tags)
-            )
-
             results = []
             for key in group_tags:
-                try:
-                    tag_key = tag_keys[key]
-                except KeyError:
-                    label = key.replace('_', ' ').title()
-                else:
-                    label = tag_key.get_label()
-
                 results.append({
                     'key': key,
-                    'label': label,
+                    'label': tagstore.get_tag_key_label(key),
                 })
 
             self._tag_cache = sorted(results, key=lambda x: x['label'])
@@ -413,4 +402,4 @@ class Group(Model):
         )
 
     def count_users_seen(self):
-        return tagstore.get_values_seen(self.id, 'sentry:user')[self.id]
+        return tagstore.get_group_values_seen(self.id, 'sentry:user')[self.id]

--- a/src/sentry/models/tagkey.py
+++ b/src/sentry/models/tagkey.py
@@ -11,7 +11,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.tagstore import TagKeyStatus
-from sentry.constants import MAX_TAG_KEY_LENGTH, TAG_LABELS
+from sentry.constants import MAX_TAG_KEY_LENGTH
 from sentry.db.models import (Model, BoundedPositiveIntegerField, sane_repr)
 
 
@@ -42,9 +42,9 @@ class TagKey(Model):
     __repr__ = sane_repr('project_id', 'key')
 
     def get_label(self):
-        return self.label \
-            or TAG_LABELS.get(self.key) \
-            or self.key.replace('_', ' ').title()
+        from sentry import tagstore
+
+        return tagstore.get_tag_key_label(self.key)
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/models/tagvalue.py
+++ b/src/sentry/models/tagvalue.py
@@ -14,7 +14,6 @@ from sentry.constants import MAX_TAG_KEY_LENGTH, MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
     Model, BoundedPositiveIntegerField, GzippedDictField, BaseManager, sane_repr
 )
-from sentry.models import Release
 
 
 class TagValue(Model):
@@ -43,7 +42,6 @@ class TagValue(Model):
     __repr__ = sane_repr('project_id', 'key', 'value')
 
     def get_label(self):
-        # HACK(dcramer): quick and dirty way to hack in better display states
-        if self.key == 'sentry:release':
-            return Release.get_display_version(self.value)
-        return self.value
+        from sentry import tagstore
+
+        return tagstore.get_tag_value_label(self.key, self.value)

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -350,7 +350,7 @@ class LegacyTagStorage(TagStorage):
             key=key,
         )
 
-    def get_values_seen(self, group_ids, key):
+    def get_group_values_seen(self, group_ids, key):
         if isinstance(group_ids, six.integer_types):
             qs = GroupTagKey.objects.filter(group_id=group_ids)
         else:


### PR DESCRIPTION
The label logic already existed in GroupTagValue serializer. This pulled
that logic out and re-uses it so some other queries can be removed.