### PR TITLE
 feat(api): Add API endpoints for auth provider

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -92,9 +92,18 @@ class OrganizationIntegrationsPermission(OrganizationPermission):
     }
 
 
-class OrganizationApiKeysPermission(OrganizationPermission):
+class OrganizationAdminPermission(OrganizationPermission):
     scope_map = {
         'GET': ['org:admin'],
+        'POST': ['org:admin'],
+        'PUT': ['org:admin'],
+        'DELETE': ['org:admin'],
+    }
+
+
+class OrganizationAuthProviderPermission(OrganizationPermission):
+    scope_map = {
+        'GET': ['org:read'],
         'POST': ['org:admin'],
         'PUT': ['org:admin'],
         'DELETE': ['org:admin'],

--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationApiKeysPermission
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAdminPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import ApiKey, AuditLogEntryEvent
@@ -16,7 +16,7 @@ class ApiKeySerializer(serializers.ModelSerializer):
 
 
 class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationApiKeysPermission, )
+    permission_classes = (OrganizationAdminPermission, )
 
     def get(self, request, organization, api_key_id):
         """

--- a/src/sentry/api/endpoints/organization_api_key_index.py
+++ b/src/sentry/api/endpoints/organization_api_key_index.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from rest_framework import status
 from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationApiKeysPermission
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAdminPermission
 from sentry.api.serializers import serialize
 from sentry.models import ApiKey, AuditLogEntryEvent
 
@@ -17,7 +17,7 @@ DEFAULT_SCOPES = [
 
 
 class OrganizationApiKeyIndexEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationApiKeysPermission, )
+    permission_classes = (OrganizationAdminPermission, )
 
     def get(self, request, organization):
         """

--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+
+from django.utils.translation import ugettext_lazy as _
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAuthProviderPermission
+from sentry.api.serializers import serialize
+from sentry.models import AuthProvider
+
+ERR_NO_SSO = _('The SSO feature is not enabled for this organization.')
+
+
+class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationAuthProviderPermission, )
+
+    def get(self, request, organization):
+        """
+        Retrieve details about Organization's SSO settings and
+        currently installed auth_provider
+        ``````````````````````````````````````````````````````
+
+        :pparam string organization_slug: the organization short name
+        :auth: required
+        """
+        if not features.has('organizations:sso', organization, actor=request.user):
+            return Response(ERR_NO_SSO, status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            auth_provider = AuthProvider.objects.get(
+                organization=organization,
+            )
+        except AuthProvider.DoesNotExist:
+            # This is a valid state where org does not have an auth provider
+            # configured, make sure we respond with a 20x
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        # cache organization so that we don't need to query for org when serializing
+        auth_provider._organization_cache = organization
+
+        return Response(serialize(auth_provider, request.user))

--- a/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+from django.utils.translation import ugettext_lazy as _
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAdminPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import AuthProvider
+from sentry.tasks.auth import email_missing_links
+
+ERR_NO_SSO = _('The SSO feature is not enabled for this organization.')
+
+
+class OrganizationAuthProviderSendRemindersEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationAdminPermission, )
+
+    def post(self, request, organization):
+        if not features.has('organizations:sso', organization, actor=request.user):
+            return Response(ERR_NO_SSO, status=403)
+
+        try:
+            auth_provider = AuthProvider.objects.get(
+                organization=organization,
+            )
+        except AuthProvider.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        email_missing_links.delay(
+            organization.id, request.user.id, auth_provider.key)
+        return Response(status=200)

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.auth import manager
+from sentry.auth.providers.saml2 import SAML2Provider, HAS_SAML2
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAdminPermission
+from sentry.api.serializers import serialize
+
+
+class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationAdminPermission, )
+
+    def get(self, request, organization):
+        """
+        List available auth providers that are available to use for an Organization
+        ```````````````````````````````````````````````````````````````````````````
+
+        :pparam string organization_slug: the organization short name
+        :auth: required
+        """
+        provider_list = []
+        for k, v in manager:
+            if issubclass(v, SAML2Provider) and not HAS_SAML2:
+                continue
+
+            feature = v.required_feature
+            if feature and not features.has(feature, organization, actor=request.user):
+                continue
+
+            provider_list.append((k, v.name))
+
+        return Response(serialize(provider_list, request.user))

--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+import six
+
+from django.core.urlresolvers import reverse
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import AuthProvider, OrganizationMember
+from sentry.utils.http import absolute_uri
+
+
+@register(AuthProvider)
+class AuthProviderSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        organization = obj.organization
+        pending_links_count = OrganizationMember.objects.filter(
+            organization=organization,
+            flags=~getattr(OrganizationMember.flags, 'sso:linked'),
+        ).count()
+
+        return {
+            'id': six.text_type(obj.id),
+            'provider_name': obj.provider,
+            'pending_links_count': pending_links_count,
+            'login_url': absolute_uri(reverse('sentry-organization-home', args=[organization.slug])),
+            'default_role': organization.default_role,
+            'require_link': not obj.flags.allow_unlinked,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -37,6 +37,9 @@ from .endpoints.organization_activity import OrganizationActivityEndpoint
 from .endpoints.organization_auditlogs import OrganizationAuditLogsEndpoint
 from .endpoints.organization_api_key_index import OrganizationApiKeyIndexEndpoint
 from .endpoints.organization_api_key_details import OrganizationApiKeyDetailsEndpoint
+from .endpoints.organization_auth_providers import OrganizationAuthProvidersEndpoint
+from .endpoints.organization_auth_provider_details import OrganizationAuthProviderDetailsEndpoint
+from .endpoints.organization_auth_provider_send_reminders import OrganizationAuthProviderSendRemindersEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
 from .endpoints.organization_shortid import ShortIdLookupEndpoint
 from .endpoints.organization_slugs import SlugsUpdateEndpoint
@@ -228,6 +231,21 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/audit-logs/$',
         OrganizationAuditLogsEndpoint.as_view(),
         name='sentry-api-0-organization-audit-logs'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/auth-provider/$',
+        OrganizationAuthProviderDetailsEndpoint.as_view(),
+        name='sentry-api-0-organization-auth-provider'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/auth-providers/$',
+        OrganizationAuthProvidersEndpoint.as_view(),
+        name='sentry-api-0-organization-auth-providers'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/auth-provider/send-reminders/$',
+        OrganizationAuthProviderSendRemindersEndpoint.as_view(),
+        name='sentry-api-0-organization-auth-provider-send-reminders'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/config/integrations/$',

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -324,20 +324,20 @@ class PermissionTestCase(TestCase):
         )
         self.team = self.create_team(organization=self.organization)
 
-    def assert_can_access(self, user, path, method='GET'):
+    def assert_can_access(self, user, path, method='GET', **kwargs):
         self.login_as(user)
-        resp = getattr(self.client, method.lower())(path)
+        resp = getattr(self.client, method.lower())(path, **kwargs)
         assert resp.status_code >= 200 and resp.status_code < 300
 
-    def assert_cannot_access(self, user, path, method='GET'):
+    def assert_cannot_access(self, user, path, method='GET', **kwargs):
         self.login_as(user)
-        resp = getattr(self.client, method.lower())(path)
+        resp = getattr(self.client, method.lower())(path, **kwargs)
         assert resp.status_code >= 300
 
-    def assert_member_can_access(self, path):
-        return self.assert_role_can_access(path, 'member')
+    def assert_member_can_access(self, path, **kwargs):
+        return self.assert_role_can_access(path, 'member', **kwargs)
 
-    def assert_teamless_member_can_access(self, path):
+    def assert_teamless_member_can_access(self, path, **kwargs):
         user = self.create_user(is_superuser=False)
         self.create_member(
             user=user,
@@ -346,15 +346,15 @@ class PermissionTestCase(TestCase):
             teams=[],
         )
 
-        self.assert_can_access(user, path)
+        self.assert_can_access(user, path, **kwargs)
 
-    def assert_member_cannot_access(self, path):
-        return self.assert_role_cannot_access(path, 'member')
+    def assert_member_cannot_access(self, path, **kwargs):
+        return self.assert_role_cannot_access(path, 'member', **kwargs)
 
-    def assert_manager_cannot_access(self, path):
-        return self.assert_role_cannot_access(path, 'manager')
+    def assert_manager_cannot_access(self, path, **kwargs):
+        return self.assert_role_cannot_access(path, 'manager', **kwargs)
 
-    def assert_teamless_member_cannot_access(self, path):
+    def assert_teamless_member_cannot_access(self, path, **kwargs):
         user = self.create_user(is_superuser=False)
         self.create_member(
             user=user,
@@ -363,12 +363,12 @@ class PermissionTestCase(TestCase):
             teams=[],
         )
 
-        self.assert_cannot_access(user, path)
+        self.assert_cannot_access(user, path, **kwargs)
 
-    def assert_team_admin_can_access(self, path):
-        return self.assert_role_can_access(path, 'owner')
+    def assert_team_admin_can_access(self, path, **kwargs):
+        return self.assert_role_can_access(path, 'owner', **kwargs)
 
-    def assert_teamless_admin_can_access(self, path):
+    def assert_teamless_admin_can_access(self, path, **kwargs):
         user = self.create_user(is_superuser=False)
         self.create_member(
             user=user,
@@ -377,12 +377,12 @@ class PermissionTestCase(TestCase):
             teams=[],
         )
 
-        self.assert_can_access(user, path)
+        self.assert_can_access(user, path, **kwargs)
 
-    def assert_team_admin_cannot_access(self, path):
-        return self.assert_role_cannot_access(path, 'admin')
+    def assert_team_admin_cannot_access(self, path, **kwargs):
+        return self.assert_role_cannot_access(path, 'admin', **kwargs)
 
-    def assert_teamless_admin_cannot_access(self, path):
+    def assert_teamless_admin_cannot_access(self, path, **kwargs):
         user = self.create_user(is_superuser=False)
         self.create_member(
             user=user,
@@ -391,33 +391,22 @@ class PermissionTestCase(TestCase):
             teams=[],
         )
 
-        self.assert_cannot_access(user, path)
+        self.assert_cannot_access(user, path, **kwargs)
 
-    def assert_team_owner_can_access(self, path):
-        return self.assert_role_can_access(path, 'owner')
+    def assert_team_owner_can_access(self, path, **kwargs):
+        return self.assert_role_can_access(path, 'owner', **kwargs)
 
-    def assert_owner_can_access(self, path):
-        return self.assert_role_can_access(path, 'owner')
+    def assert_owner_can_access(self, path, **kwargs):
+        return self.assert_role_can_access(path, 'owner', **kwargs)
 
-    def assert_owner_cannot_access(self, path):
-        return self.assert_role_cannot_access(path, 'owner')
+    def assert_owner_cannot_access(self, path, **kwargs):
+        return self.assert_role_cannot_access(path, 'owner', **kwargs)
 
-    def assert_non_member_cannot_access(self, path):
+    def assert_non_member_cannot_access(self, path, **kwargs):
         user = self.create_user(is_superuser=False)
-        self.assert_cannot_access(user, path)
+        self.assert_cannot_access(user, path, **kwargs)
 
-    def assert_role_can_access(self, path, role):
-        user = self.create_user(is_superuser=False)
-        self.create_member(
-            user=user,
-            organization=self.organization,
-            role=role,
-            teams=[self.team],
-        )
-
-        self.assert_can_access(user, path)
-
-    def assert_role_cannot_access(self, path, role):
+    def assert_role_can_access(self, path, role, **kwargs):
         user = self.create_user(is_superuser=False)
         self.create_member(
             user=user,
@@ -426,7 +415,18 @@ class PermissionTestCase(TestCase):
             teams=[self.team],
         )
 
-        self.assert_cannot_access(user, path)
+        self.assert_can_access(user, path, **kwargs)
+
+    def assert_role_cannot_access(self, path, role, **kwargs):
+        user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user,
+            organization=self.organization,
+            role=role,
+            teams=[self.team],
+        )
+
+        self.assert_cannot_access(user, path, **kwargs)
 
 
 class PluginTestCase(TestCase):

--- a/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import PermissionTestCase
+
+
+class OrganizationAuthProviderPermissionTest(PermissionTestCase):
+    def setUp(self):
+        super(OrganizationAuthProviderPermissionTest, self).setUp()
+        self.path = reverse(
+            'sentry-api-0-organization-auth-provider',
+            args=[self.organization.slug]
+        )
+
+    def test_member_can_get(self):
+        with self.feature('organizations:sso'):
+            self.assert_member_can_access(self.path)

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase, PermissionTestCase
+
+
+class OrganizationAuthProvidersPermissionTest(PermissionTestCase):
+    def setUp(self):
+        super(OrganizationAuthProvidersPermissionTest, self).setUp()
+        self.path = reverse(
+            'sentry-api-0-organization-auth-providers',
+            args=[self.organization.slug]
+        )
+
+    def test_teamless_admin_cannot_load(self):
+        with self.feature('organizations:sso'):
+            self.assert_teamless_admin_cannot_access(self.path)
+
+    def test_team_admin_cannot_load(self):
+        with self.feature('organizations:sso'):
+            self.assert_team_admin_cannot_access(self.path)
+
+    def test_manager_cannot_load(self):
+        with self.feature('organizations:sso'):
+            self.assert_role_cannot_access(self.path, 'manager')
+
+    def test_owner_can_load(self):
+        with self.feature('organizations:sso'):
+            self.assert_owner_can_access(self.path)
+
+
+class OrganizationAuthProviders(APITestCase):
+    def test_get_list_of_auth_providers(self):
+        organization = self.create_organization(name='foo', owner=self.user)
+
+        path = reverse('sentry-api-0-organization-auth-providers',
+                       args=[organization.slug])
+
+        self.login_as(self.user)
+
+        with self.feature('organizations:sso'):
+            resp = self.client.get(path)
+
+        assert resp.status_code == 200
+
+        assert 'dummy' in [k for k, v in resp.data]


### PR DESCRIPTION
This only adds API endpoints for ~~configuring~~ listing an auth provider.  #6302 adds views to use these endpoints.

@EvanPurkhiser Since you've been working on this stuff, maybe you have some insights here.