### PR TITLE
fix(security): Validate webhook URLs correctly

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -14,18 +14,17 @@ from sentry.http import is_valid_url, safe_urlopen
 from sentry.utils.safe import safe_execute
 
 
+def split_urls(value):
+    if not value:
+        return ()
+    return filter(bool, (url.strip() for url in value.splitlines()))
+
+
 def validate_urls(value, **kwargs):
-    output = []
-    for url in value.split('\n'):
-        url = url.strip()
-        if not url:
-            continue
-        if not url.startswith(('http://', 'https://')):
-            raise PluginError('Not a valid URL.')
-        if not is_valid_url(url):
-            raise PluginError('Not a valid URL.')
-        output.append(url)
-    return '\n'.join(output)
+    urls = split_urls(value)
+    if any((not u.startswith(('http://', 'https://')) or not is_valid_url(u)) for u in urls):
+        raise PluginError('Not a valid URL.')
+    return '\n'.join(urls)
 
 
 class WebHooksOptionsForm(notify.NotificationConfigurationForm):
@@ -37,10 +36,6 @@ class WebHooksOptionsForm(notify.NotificationConfigurationForm):
         ),
         help_text=_('Enter callback URLs to POST new events to (one per line).')
     )
-
-    def clean_url(self):
-        value = self.cleaned_data.get('url')
-        return validate_urls(value)
 
 
 class WebHooksPlugin(notify.NotificationPlugin):
@@ -97,10 +92,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
         return data
 
     def get_webhook_urls(self, project):
-        urls = self.get_option('urls', project)
-        if not urls:
-            return ()
-        return filter(bool, urls.strip().splitlines())
+        return split_urls(self.get_option('urls', project))
 
     def send_webhook(self, url, payload):
         return safe_urlopen(

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -3,13 +3,15 @@
 from __future__ import absolute_import
 
 import json
+import pytest
 import responses
 
 from exam import fixture
 
+from sentry.exceptions import PluginError
 from sentry.models import Rule
 from sentry.plugins import Notification
-from sentry.plugins.sentry_webhooks.plugin import WebHooksPlugin
+from sentry.plugins.sentry_webhooks.plugin import validate_urls, WebHooksPlugin, WebHooksOptionsForm
 from sentry.testutils import TestCase
 
 
@@ -21,16 +23,12 @@ class WebHooksPluginTest(TestCase):
     @responses.activate
     def test_simple_notification(self):
         responses.add(responses.POST, 'http://example.com')
-
         group = self.create_group(message='Hello world')
         event = self.create_event(
             group=group, message='Hello world', tags={'level': 'warning'}, id=24
         )
-
         rule = Rule.objects.create(project=self.project, label='my rule')
-
         notification = Notification(event=event, rule=rule)
-
         self.project.update_option('webhooks:urls', 'http://example.com')
 
         self.plugin.notify(notification)
@@ -38,8 +36,17 @@ class WebHooksPluginTest(TestCase):
         assert len(responses.calls) == 1
 
         payload = json.loads(responses.calls[0].request.body)
-
         assert payload['level'] == 'warning'
         assert payload['message'] == 'Hello world'
         assert payload['event']['id'] == 24
         assert payload['event']['event_id'] == event.event_id
+
+    def test_webhook_validation(self):
+        # Test that you can't sneak a bad domain into the list of webhooks
+        # without it being validated by delmiting with \r instead of \n
+        bad_urls = 'http://example.com\rftp://baddomain.com'
+        form = WebHooksOptionsForm(data={'urls': bad_urls})
+        form.is_valid()
+
+        with pytest.raises(PluginError):
+            validate_urls(form.cleaned_data.get('urls'))


### PR DESCRIPTION
Refactor webhook URL validation to use the same function for both the
form validation and the webhook notifying so that we validate the same
set of URLs as we end up sending webhooks to. Also remove clean_url() as
it appears to be unused (and had a bug)

Fixes SEN-01-005