### PR TITLE
fix(alerts): Clarify terminology in default rule label

### DIFF
--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_save
 
 from sentry.models import Project, Rule
 
-DEFAULT_RULE_LABEL = 'Send a notification for new events'
+DEFAULT_RULE_LABEL = 'Send a notification for new issues'
 DEFAULT_RULE_DATA = {
     'match': 'all',
     'conditions': [


### PR DESCRIPTION
This rule sends a notification when an issue is created, not when a new
event is seen (which would be a lot more frequenty), so this updated
label reflects that.