### PR TITLE
fix(ui): Disable releases modal if releases set up

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -153,6 +153,14 @@ const OrganizationContext = React.createClass({
       return false;
     }
 
+    let setupReleases = tasks.find(
+      ({task, status}) => task === 6 && status === 'complete'
+    );
+
+    if (setupReleases) {
+      return false;
+    }
+
     // show it if they sent their first event more than 2 days ago
     return moment().diff(sentFirstEvent.dateCompleted, 'days') > 2;
   },


### PR DESCRIPTION
Add another condition where the releases modal will not display if releases have been set up.