### PR TITLE
fix(security): Trim whitespace from emails

### DIFF
--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -513,7 +513,7 @@ def show_emails(request):
         return HttpResponseRedirect(request.path)
 
     if 'primary' in request.POST:
-        new_primary = request.POST['new_primary_email'].lower()
+        new_primary = request.POST['new_primary_email'].lower().strip()
 
         if User.objects.filter(Q(email__iexact=new_primary) | Q(username__iexact=new_primary)
                                ).exclude(id=user.id).exists():
@@ -549,12 +549,12 @@ def show_emails(request):
 
     if email_form.is_valid():
 
-        alternative_email = email_form.cleaned_data['alt_email'].lower()
+        alternative_email = email_form.cleaned_data['alt_email'].lower().strip()
 
         # check if this alternative email already exists for user
         if alternative_email and not UserEmail.objects.filter(
             user=user, email__iexact=alternative_email
-        ):
+        ).exists():
             # create alternative email for user
             try:
                 with transaction.atomic():

--- a/tests/sentry/web/frontend/accounts/tests.py
+++ b/tests/sentry/web/frontend/accounts/tests.py
@@ -50,6 +50,37 @@ class AppearanceSettingsTest(TestCase):
         assert options.get('clock_24_hours') is True
 
 
+class SettingsEmailTest(TestCase):
+    @fixture
+    def path(self):
+        return reverse('sentry-account-settings-emails')
+
+    def test_change_primary_email(self):
+        self.login_as(self.user)
+        self.create_user('foo@example.com')
+
+        # setting primary email changes it
+        self.client.post(self.path, {
+            'new_primary_email': 'foo1@example.com',
+            'primary': 1
+        })
+        assert User.objects.get(id=self.user.id).email == 'foo1@example.com'
+
+        # setting primary email to an existing user's email leaves it unchanged
+        self.client.post(self.path, {
+            'new_primary_email': 'foo@example.com',
+            'primary': 1
+        })
+        assert User.objects.get(id=self.user.id).email == 'foo1@example.com'
+
+        # setting primary to existing email + whitespace leaves it unchanged
+        self.client.post(self.path, {
+            'new_primary_email': 'foo@example.com\n\n',
+            'primary': 1
+        })
+        assert User.objects.get(id=self.user.id).email == 'foo1@example.com'
+
+
 class SettingsTest(TestCase):
     @fixture
     def path(self):


### PR DESCRIPTION
Don't allow setting email to an existing email by appending whitespace. Add test.

Fixes SEN-01-009