### PR TITLE
feat(react): Change DropdownLink to be pure react

### DIFF
--- a/scripts/devproxy.js
+++ b/scripts/devproxy.js
@@ -15,6 +15,10 @@ if (!WEBPACK_DEV_PORT || !WEBPACK_DEV_PROXY || !SENTRY_DEVSERVER_PORT) {
 }
 
 const createProxy = function(proxy, req, res, port, cb) {
+  if (res.headersSent) {
+    return;
+  }
+
   proxy.web(req, res, {target: 'http://localhost:' + port}, function(e, r) {
     cb && cb(e, r);
     if (e) {

--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -22,6 +22,8 @@ export class Client {
     });
   }
 
+  clear() {}
+
   merge(params, options) {
     let path = '/projects/' + params.orgId + '/' + params.projectId + '/issues/';
     return this.request(path, {

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {browserHistory} from 'react-router';
-import jQuery from 'jquery';
 import classNames from 'classnames';
 
 import ApiMixin from '../../mixins/apiMixin';
@@ -37,22 +35,81 @@ const ProjectSelector = React.createClass({
 
   getInitialState() {
     return {
+      isOpen: false,
       filter: '',
       currentIndex: -1,
       ...this.getProjectState({filter: ''})
     };
   },
 
-  componentDidUpdate(prevProps, prevState) {
-    // XXX(dcramer): fix odd dedraw issue as of Chrome 45.0.2454.15 dev (64-bit)
-    let node = jQuery(ReactDOM.findDOMNode(this.refs.container));
-    node.hide().show(0);
-  },
-
   componentWillUnmount() {
     if (this.filterBlurTimeout) {
       clearTimeout(this.filterBlurTimeout);
     }
+  },
+
+  urlPrefix() {
+    let org = this.props.organization;
+    return `/organizations/${org.slug}`;
+  },
+
+  /**
+   * Returns an object with the target project url. If
+   * the router is present, passed as the 'to' property.
+   * If not, passed as an absolute URL via the 'href' property.
+   */
+  getProjectUrlProps(project) {
+    let org = this.props.organization;
+    let path = `/${org.slug}/${project.slug}/`;
+
+    if (this.context.location) {
+      return {to: path};
+    } else {
+      return {href: path};
+    }
+  },
+
+  getProjectState(state) {
+    state = state || this.state;
+    let org = this.props.organization;
+    let filter = state.filter.toLowerCase();
+    let projectList = [];
+    let activeTeam;
+    let activeProject;
+    org.teams.forEach(team => {
+      if (!team.isMember) {
+        return;
+      }
+      team.projects.forEach(project => {
+        if (project.slug == this.props.projectId) {
+          activeProject = project;
+          activeTeam = team;
+        }
+        let fullName = [team.name, project.name, team.slug, project.slug]
+          .join(' ')
+          .toLowerCase();
+        if (filter && fullName.indexOf(filter) === -1) {
+          return;
+        }
+        projectList.push([team, project]);
+      });
+    });
+    return {
+      projectList,
+      activeTeam,
+      activeProject
+    };
+  },
+
+  onFilterBlur() {
+    // HACK: setTimeout because blur might be caused by clicking
+    // project link; in which case, will close dropdown before
+    // link click is processed. Why 200ms? Decently short time
+    // period that seemed to work in all browsers.
+    this.filterBlurTimeout = setTimeout(() => {
+      this.filterBlurTimeout = null;
+      this.onClose();
+    }, 200);
   },
 
   onFilterChange(evt) {
@@ -63,39 +120,68 @@ const ProjectSelector = React.createClass({
     });
   },
 
-  onKeyUp(evt) {
-    if (evt.key === 'Escape' || evt.keyCode === 27) {
-      // blur handler should additionally hide dropdown
-      this.close();
+  onFilterClick(e) {
+    e.stopPropagation();
+  },
+
+  onFilterMount(ref) {
+    if (ref) {
+      ref.focus();
     }
   },
 
-  onFilterBlur() {
-    // HACK: setTimeout because blur might be caused by clicking
-    // project link; in which case, will close dropdown before
-    // link click is processed. Why 200ms? Decently short time
-    // period that seemed to work in all browsers.
-    this.filterBlurTimeout = setTimeout(() => {
-      this.filterBlurTimeout = null;
-      this.close();
-    }, 200);
+  onKeyDown(evt) {
+    let projects = this.state.projectList;
+    if (evt.key === 'Down' || evt.keyCode === 40) {
+      if (this.state.currentIndex + 1 < projects.length) {
+        this.setState({
+          currentIndex: this.state.currentIndex + 1
+        });
+      }
+    } else if (evt.key === 'Up' || evt.keyCode === 38) {
+      if (this.state.currentIndex > 0) {
+        this.setState({
+          currentIndex: this.state.currentIndex - 1
+        });
+      }
+    } else if (evt.key === 'Enter' || evt.keyCode === 13) {
+      if (this.state.currentIndex > -1) {
+        let url = this.getProjectUrlProps(projects[this.state.currentIndex][1]);
+        if (url.to) {
+          browserHistory.pushState(null, url.to);
+        } else if (url.href) {
+          window.location = url.href;
+        }
+
+        this.onClose();
+      }
+    }
   },
 
-  urlPrefix() {
-    let org = this.props.organization;
-    return `/organizations/${org.slug}`;
+  onKeyUp(evt) {
+    if (evt.key === 'Escape' || evt.keyCode === 27) {
+      // blur handler should additionally hide dropdown
+      this.onClose();
+    }
   },
 
-  close() {
+  onOpen() {
     this.setState({
+      isOpen: true
+    });
+    // Not sure if this is still necessary
+    // this.setState(state => ({
+    // ...this.getProjectState(state)
+    // }));
+  },
+
+  onClose() {
+    this.setState({
+      isOpen: false,
       filter: '',
       currentIndex: -1,
       ...this.getProjectState({filter: ''})
     });
-    // dropdownLink might not exist because we try to close within
-    // onFilterBlur above after a timeout. My hunch is that sometimes
-    // this DOM element is removed within the 200ms, so we error out.
-    this.refs.dropdownLink && this.refs.dropdownLink.close();
   },
 
   getProjectNode(team, project, highlightText, hasSingleTeam, isSelected) {
@@ -163,22 +249,6 @@ const ProjectSelector = React.createClass({
     );
   },
 
-  /**
-   * Returns an object with the target project url. If
-   * the router is present, passed as the 'to' property.
-   * If not, passed as an absolute URL via the 'href' property.
-   */
-  getProjectUrlProps(project) {
-    let org = this.props.organization;
-    let path = `/${org.slug}/${project.slug}/`;
-
-    if (this.context.location) {
-      return {to: path};
-    } else {
-      return {href: path};
-    }
-  },
-
   getLinkNode(team, project) {
     let org = this.props.organization;
     let label = this.getProjectLabel(team, project);
@@ -197,81 +267,6 @@ const ProjectSelector = React.createClass({
         </Link>
       </span>
     );
-  },
-
-  onOpen(evt) {
-    if (this.refs.filter) {
-      ReactDOM.findDOMNode(this.refs.filter).focus();
-      this.setState({
-        ...this.getProjectState(this.state)
-      });
-    }
-  },
-
-  onClose() {
-    this.setState({
-      filter: '',
-      currentIndex: -1,
-      ...this.getProjectState({filter: ''})
-    });
-  },
-
-  onKeyDown(evt) {
-    let projects = this.state.projectList;
-    if (evt.key === 'Down' || evt.keyCode === 40) {
-      if (this.state.currentIndex + 1 < projects.length) {
-        this.setState({
-          currentIndex: this.state.currentIndex + 1
-        });
-      }
-    } else if (evt.key === 'Up' || evt.keyCode === 38) {
-      if (this.state.currentIndex > 0) {
-        this.setState({
-          currentIndex: this.state.currentIndex - 1
-        });
-      }
-    } else if (evt.key === 'Enter' || evt.keyCode === 13) {
-      if (this.state.currentIndex > -1) {
-        let url = this.getProjectUrlProps(projects[this.state.currentIndex][1]);
-        if (url.to) {
-          browserHistory.pushState(null, url.to);
-        } else if (url.href) {
-          window.location = url.href;
-        }
-      }
-    }
-  },
-
-  getProjectState(state) {
-    state = state || this.state;
-    let org = this.props.organization;
-    let filter = state.filter.toLowerCase();
-    let projectList = [];
-    let activeTeam;
-    let activeProject;
-    org.teams.forEach(team => {
-      if (!team.isMember) {
-        return;
-      }
-      team.projects.forEach(project => {
-        if (project.slug == this.props.projectId) {
-          activeProject = project;
-          activeTeam = team;
-        }
-        let fullName = [team.name, project.name, team.slug, project.slug]
-          .join(' ')
-          .toLowerCase();
-        if (filter && fullName.indexOf(filter) === -1) {
-          return;
-        }
-        projectList.push([team, project]);
-      });
-    });
-    return {
-      projectList,
-      activeTeam,
-      activeProject
-    };
   },
 
   renderProjectList({organization: org, projects, filter, hasProjectWrite}) {
@@ -345,6 +340,7 @@ const ProjectSelector = React.createClass({
             ref="dropdownLink"
             title=""
             topLevelClasses={dropdownClassNames}
+            isOpen={this.state.isOpen}
             onOpen={this.onOpen}
             onClose={this.onClose}>
 
@@ -358,7 +354,8 @@ const ProjectSelector = React.createClass({
                   onKeyUp={this.onKeyUp}
                   onKeyDown={this.onKeyDown}
                   onBlur={this.onFilterBlur}
-                  ref="filter"
+                  onClick={this.onFilterClick}
+                  ref={this.onFilterMount}
                 />
               </li>}
 

--- a/tests/js/spec/components/__snapshots__/dropdownLink.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownLink.spec.jsx.snap
@@ -2,52 +2,32 @@
 
 exports[`DropdownLink renders and anchors to left by default 1`] = `
 <span
-  className="top-level-class dropdown"
+  className="dropdown top-level-class"
 >
   <a
-    className="dropdown-toggle"
-    data-toggle="dropdown"
+    className="dropdown-actor dropdown-toggle"
+    onClick={[Function]}
   >
     test
     <i
       className="icon-arrow-down"
     />
   </a>
-  <ul
-    className="dropdown-menu"
-  >
-    <div>
-      1
-    </div>
-    <div>
-      2
-    </div>
-  </ul>
 </span>
 `;
 
 exports[`DropdownLink renders and anchors to right 1`] = `
 <span
-  className="top-level-class pull-right anchor-right dropdown"
+  className="dropdown top-level-class pull-right anchor-right"
 >
   <a
-    className="dropdown-menu-right dropdown-toggle"
-    data-toggle="dropdown"
+    className="dropdown-actor dropdown-menu-right dropdown-toggle"
+    onClick={[Function]}
   >
     test
     <i
       className="icon-arrow-down"
     />
   </a>
-  <ul
-    className="dropdown-menu"
-  >
-    <div>
-      1
-    </div>
-    <div>
-      2
-    </div>
-  </ul>
 </span>
 `;

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -94,6 +94,8 @@ describe('AssigneeSelector', function() {
 
   describe('loading', function() {
     let assigneeSelector;
+    let openMenu;
+
     beforeEach(function() {
       // Reset sandbox because we don't want <LoadingIndicator /> stubbed
       this.sandbox.restore();
@@ -105,13 +107,16 @@ describe('AssigneeSelector', function() {
       MemberListStore.items = [];
       MemberListStore.loaded = false;
       assigneeSelector = mount(<AssigneeSelector id="1337" />);
+      openMenu = () => assigneeSelector.find('a').simulate('click');
     });
 
     it('should initially have loading state', function() {
+      openMenu();
       expect(assigneeSelector.find('LoadingIndicator').exists()).toBe(true);
     });
 
     it('does not have loading state and shows member list after calling MemberListStore.loadInitialData', function() {
+      openMenu();
       MemberListStore.loadInitialData([USER_1, USER_2]);
 
       expect(assigneeSelector.find('Avatar').length).toBe(2);
@@ -119,6 +124,7 @@ describe('AssigneeSelector', function() {
     });
 
     it('does NOT update member list after initial load', function() {
+      openMenu();
       MemberListStore.loadInitialData([USER_1, USER_2]);
 
       expect(assigneeSelector.find('Avatar').length).toBe(2);
@@ -132,13 +138,20 @@ describe('AssigneeSelector', function() {
   });
 
   describe('onFilterKeyDown()', function() {
+    let assigneeSelector;
+    let assignTo;
+
     beforeEach(function() {
       MemberListStore.loaded = true;
-      let assigneeSelector = (this.assigneeSelector = mount(
-        <AssigneeSelector id="1337" />
-      ));
+      if (assigneeSelector) {
+        assigneeSelector.unmount();
+      }
 
-      this.assignTo = this.sandbox.stub(assigneeSelector.instance(), 'assignTo');
+      assigneeSelector = mount(<AssigneeSelector id="1337" />);
+      // open menu
+      assigneeSelector.find('a').simulate('click');
+
+      assignTo = this.sandbox.stub(assigneeSelector.instance(), 'assignTo');
     });
 
     afterEach(function() {
@@ -146,43 +159,45 @@ describe('AssigneeSelector', function() {
     });
 
     it('should assign the first filtered member when the Enter key is pressed and filter is truthy', function() {
-      let assigneeSelector = this.assigneeSelector;
       assigneeSelector.setState({filter: 'Jane'});
 
-      let filterEl = assigneeSelector.instance().filterRef;
-      let filter = assigneeSelector.findWhere(node => node.node === filterEl);
+      let filter = assigneeSelector.find('input');
       filter.simulate('keyDown', {key: 'Enter', keyCode: 13, which: 13});
 
-      expect(this.assignTo.calledOnce).toBeTruthy();
-      expect(this.assignTo.lastCall.args[0]).toHaveProperty('name', 'Jane Doe');
+      expect(assignTo.calledOnce).toBeTruthy();
+      expect(assignTo.lastCall.args[0]).toHaveProperty('name', 'Jane Doe');
     });
 
     it('should do nothing when the Enter key is pressed, but filter is the empty string', function() {
-      let assigneeSelector = this.assigneeSelector;
       assigneeSelector.setState({filter: ''});
 
-      let filterEl = assigneeSelector.instance().filterRef;
-      let filter = assigneeSelector.findWhere(node => node.node === filterEl);
+      let filter = assigneeSelector.find('input');
       filter.simulate('keyDown', {key: 'Enter', keyCode: 13, which: 13});
 
-      expect(this.assignTo.notCalled).toBeTruthy();
+      expect(assignTo.notCalled).toBeTruthy();
     });
 
     it('should do nothing if a non-Enter key is pressed', function() {
-      let assigneeSelector = this.assigneeSelector;
       assigneeSelector.setState({filter: 'Jane'});
 
-      let filterEl = assigneeSelector.instance().filterRef;
-      let filter = assigneeSelector.findWhere(node => node.node === filterEl);
+      let filter = assigneeSelector.find('input');
       filter.simulate('keyDown', {key: 'h', keyCode: 72, which: 72});
-      expect(this.assignTo.notCalled).toBeTruthy();
+      expect(assignTo.notCalled).toBeTruthy();
     });
   });
 
   describe('onFilterKeyUp()', function() {
+    let assigneeSelector;
     beforeEach(function() {
       MemberListStore.loaded = true;
-      this.assigneeSelector = mount(<AssigneeSelector id="1337" />);
+      if (assigneeSelector) {
+        assigneeSelector.unmount();
+      }
+
+      assigneeSelector = mount(<AssigneeSelector id="1337" />);
+
+      // open menu
+      assigneeSelector.find('a').simulate('click');
     });
 
     afterEach(function() {
@@ -190,21 +205,14 @@ describe('AssigneeSelector', function() {
     });
 
     it('should close the dropdown when keyup is triggered with the Escape key', function() {
-      let assigneeSelector = this.assigneeSelector;
-      let closeStub = this.sandbox.stub(assigneeSelector.instance().dropdownRef, 'close');
-
-      let filterEl = assigneeSelector.instance().filterRef;
-      let filter = assigneeSelector.findWhere(node => node.node === filterEl);
+      let filter = assigneeSelector.find('input');
       filter.simulate('keyUp', {key: 'Escape'});
 
-      expect(closeStub.calledOnce).toBeTruthy();
+      expect(assigneeSelector.state('isOpen')).toBe(false);
     });
 
     it('should update the local filter state if any other key is pressed', function() {
-      let assigneeSelector = this.assigneeSelector;
-
-      let filterEl = assigneeSelector.instance().filterRef;
-      let filter = assigneeSelector.findWhere(node => node.node === filterEl);
+      let filter = assigneeSelector.find('input');
       filter.simulate('keyUp', {target: {value: 'foo'}});
       expect(assigneeSelector.state('filter')).toEqual('foo');
     });

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import DropdownLink from 'app/components/dropdownLink';
 
 describe('DropdownLink', function() {
@@ -12,39 +11,178 @@ describe('DropdownLink', function() {
     menuClasses: ''
   };
 
-  describe('componentWillUnmount()', function() {
-    it('should remove event handlers before unmounting', function() {
-      let dropdownlink = TestUtils.renderIntoDocument(<DropdownLink {...INPUT_1} />);
+  describe('jQuery event listeners', function() {
+    let wrapper;
 
-      let handlers = jQuery._data(dropdownlink.refs.dropdownToggle.parentNode, 'events');
-      expect(handlers).toBeInstanceOf(Object);
+    beforeEach(function() {
+      if (wrapper) {
+        wrapper.unmount();
+      }
+      jQuery(document).off('click');
 
-      dropdownlink.componentWillUnmount(dropdownlink);
+      wrapper = mount(<DropdownLink title="test"><li>hi</li></DropdownLink>);
+    });
 
-      handlers = jQuery._data(dropdownlink.refs.dropdownToggle.parentNode, 'events');
-      expect(handlers).toBe(undefined);
+    it('has document event listeners only when dropdown menu is open', function() {
+      let events = jQuery._data(document, 'events');
+      expect(events).toBeUndefined();
+
+      // Open
+      wrapper.find('a').simulate('click');
+      events = jQuery._data(document, 'events');
+      expect(events.click.length).toBe(1);
+
+      // Close
+      wrapper.find('a').simulate('click');
+      events = jQuery._data(document, 'events');
+      expect(events).toBeUndefined();
+    });
+
+    it('clears event listeners after unmount', function() {
+      let events = jQuery._data(document, 'events');
+      expect(events).toBeUndefined();
+
+      // Open
+      wrapper.find('a').simulate('click');
+      events = jQuery._data(document, 'events');
+      expect(events.click.length).toBe(1);
+
+      // Close
+      wrapper.unmount();
+      events = jQuery._data(document, 'events');
+      expect(events).toBeUndefined();
     });
   });
 
-  it('renders and anchors to left by default', function() {
-    let component = shallow(
-      <DropdownLink {...INPUT_1}>
-        <div>1</div>
-        <div>2</div>
-      </DropdownLink>
-    );
+  describe('renders', function() {
+    it('and anchors to left by default', function() {
+      let component = shallow(
+        <DropdownLink {...INPUT_1}>
+          <div>1</div>
+          <div>2</div>
+        </DropdownLink>
+      );
 
-    expect(component).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
+    });
+
+    it('and anchors to right', function() {
+      let component = shallow(
+        <DropdownLink {...INPUT_1} anchorRight>
+          <div>1</div>
+          <div>2</div>
+        </DropdownLink>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 
-  it('renders and anchors to right', function() {
-    let component = shallow(
-      <DropdownLink {...INPUT_1} anchorRight>
-        <div>1</div>
-        <div>2</div>
-      </DropdownLink>
-    );
+  describe('Uncontrolled', function() {
+    let wrapper;
 
-    expect(component).toMatchSnapshot();
+    beforeEach(function() {
+      if (wrapper) {
+        wrapper.unmount();
+      }
+
+      wrapper = mount(<DropdownLink title="test"><li>hi</li></DropdownLink>);
+    });
+
+    describe('While Closed', function() {
+      it('displays dropdown menu when dropdown actor button clicked', function() {
+        expect(wrapper.find('li').length).toBe(0);
+        expect(wrapper.state('isOpen')).toBe(false);
+
+        // open
+        wrapper.find('a').simulate('click');
+        expect(wrapper.state('isOpen')).toBe(true);
+        expect(wrapper.find('li').length).toBe(1);
+      });
+    });
+    describe('While Opened', function() {
+      beforeEach(function() {
+        // Opens dropdown menu
+        wrapper.find('a').simulate('click');
+      });
+
+      it('closes when clicked outside', function() {
+        jQuery(document).click();
+        expect(wrapper.state('isOpen')).toBe(false);
+      });
+
+      it('closes when dropdown actor button is clicked', function() {
+        wrapper.find('a').simulate('click');
+        expect(wrapper.state('isOpen')).toBe(false);
+      });
+
+      it('closes when dropdown menu item is clicked', function() {
+        wrapper.find('li').simulate('click');
+        expect(wrapper.state('isOpen')).toBe(false);
+      });
+
+      it('does not close when menu is clicked and `keepMenuOpen` is on', function() {
+        wrapper = mount(
+          <DropdownLink title="test" keepMenuOpen><li>hi</li></DropdownLink>
+        );
+        wrapper.find('a').simulate('click');
+        wrapper.find('li').simulate('click');
+        expect(wrapper.state('isOpen')).toBe(true);
+        wrapper.unmount();
+      });
+    });
+  });
+
+  describe('Controlled', function() {
+    let wrapper;
+
+    beforeEach(function() {
+      if (wrapper) {
+        wrapper.unmount();
+      }
+    });
+    describe('Opened', function() {
+      beforeEach(function() {
+        wrapper = mount(
+          <DropdownLink isOpen={true} title="test"><li>hi</li></DropdownLink>
+        );
+      });
+
+      it('does not close when menu is clicked', function() {
+        // open
+        wrapper.find('li').simulate('click');
+        // State does not change
+        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.find('.dropdown-menu').length).toBe(1);
+      });
+
+      it('does not close when document is clicked', function() {
+        jQuery(document).click();
+        // State does not change
+        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.find('.dropdown-menu').length).toBe(1);
+      });
+
+      it('does not close when dropdown actor is clicked', function() {
+        wrapper.find('a').simulate('click');
+        // State does not change
+        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.find('.dropdown-menu').length).toBe(1);
+      });
+    });
+    describe('Closed', function() {
+      beforeEach(function() {
+        wrapper = mount(
+          <DropdownLink isOpen={false} title="test"><li>hi</li></DropdownLink>
+        );
+      });
+
+      it('does not open when dropdown actor is clicked', function() {
+        wrapper.find('a').simulate('click');
+        // State does not change
+        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.find('.dropdown-menu').length).toBe(0);
+      });
+    });
   });
 });

--- a/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
+++ b/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
@@ -50,17 +50,19 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
         anchorRight={false}
         caret={true}
         disabled={false}
+        isOpen={true}
+        keepMenuOpen={false}
         onClose={[Function]}
         onOpen={[Function]}
         title=""
         topLevelClasses="project-dropdown"
       >
         <span
-          className="project-dropdown dropdown"
+          className="dropdown project-dropdown open"
         >
           <a
-            className="dropdown-toggle"
-            data-toggle="dropdown"
+            className="dropdown-actor dropdown-toggle"
+            onClick={[Function]}
           >
             <i
               className="icon-arrow-down"
@@ -68,6 +70,7 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
           </a>
           <ul
             className="dropdown-menu"
+            onClick={[Function]}
           >
             <li
               className="project-filter"
@@ -75,6 +78,7 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
               <input
                 onBlur={[Function]}
                 onChange={[Function]}
+                onClick={[Function]}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 placeholder="Filter projects"
@@ -168,17 +172,19 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
         anchorRight={false}
         caret={true}
         disabled={false}
+        isOpen={true}
+        keepMenuOpen={false}
         onClose={[Function]}
         onOpen={[Function]}
         title=""
         topLevelClasses="project-dropdown"
       >
         <span
-          className="project-dropdown dropdown"
+          className="dropdown project-dropdown open"
         >
           <a
-            className="dropdown-toggle"
-            data-toggle="dropdown"
+            className="dropdown-actor dropdown-toggle"
+            onClick={[Function]}
           >
             <i
               className="icon-arrow-down"
@@ -186,6 +192,7 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
           </a>
           <ul
             className="dropdown-menu"
+            onClick={[Function]}
           >
             <li
               className="project-filter"
@@ -193,6 +200,7 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
               <input
                 onBlur={[Function]}
                 onChange={[Function]}
+                onClick={[Function]}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 placeholder="Filter projects"
@@ -275,6 +283,8 @@ exports[`ProjectSelector render() lists projects and has filter 1`] = `
       anchorRight={false}
       caret={true}
       disabled={false}
+      isOpen={false}
+      keepMenuOpen={false}
       onClose={[Function]}
       onOpen={[Function]}
       title=""
@@ -286,6 +296,7 @@ exports[`ProjectSelector render() lists projects and has filter 1`] = `
         <input
           onBlur={[Function]}
           onChange={[Function]}
+          onClick={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           placeholder="Filter projects"
@@ -334,6 +345,8 @@ exports[`ProjectSelector render() should show empty message and create project b
       anchorRight={false}
       caret={true}
       disabled={false}
+      isOpen={false}
+      keepMenuOpen={false}
       onClose={[Function]}
       onOpen={[Function]}
       title=""
@@ -386,6 +399,8 @@ exports[`ProjectSelector render() should show empty message with no projects but
       anchorRight={false}
       caret={true}
       disabled={false}
+      isOpen={false}
+      keepMenuOpen={false}
       onClose={[Function]}
       onOpen={[Function]}
       title=""
@@ -456,17 +471,19 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
         anchorRight={false}
         caret={true}
         disabled={false}
+        isOpen={true}
+        keepMenuOpen={false}
         onClose={[Function]}
         onOpen={[Function]}
         title=""
         topLevelClasses="project-dropdown is-empty"
       >
         <span
-          className="project-dropdown is-empty dropdown"
+          className="dropdown project-dropdown is-empty open"
         >
           <a
-            className="dropdown-toggle"
-            data-toggle="dropdown"
+            className="dropdown-actor dropdown-toggle"
+            onClick={[Function]}
           >
             <i
               className="icon-arrow-down"
@@ -474,6 +491,7 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
           </a>
           <ul
             className="dropdown-menu"
+            onClick={[Function]}
           >
             <li
               className="project-filter"
@@ -481,6 +499,7 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
               <input
                 onBlur={[Function]}
                 onChange={[Function]}
+                onClick={[Function]}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 placeholder="Filter projects"

--- a/tests/js/spec/components/projectHeader/projectSelector.spec.jsx
+++ b/tests/js/spec/components/projectHeader/projectSelector.spec.jsx
@@ -26,7 +26,12 @@ describe('ProjectSelector', function() {
     ],
     access: []
   };
+
   describe('render()', function() {
+    beforeEach(function() {
+      jQuery(document).off('click');
+    });
+
     it('should show empty message with no projects button, when no projects, and has no "project:write" access', function() {
       let wrapper = shallow(
         <ProjectSelector
@@ -72,6 +77,7 @@ describe('ProjectSelector', function() {
 
     it('can filter projects by team name/project name', function() {
       let wrapper = mount(<ProjectSelector organization={mockOrg} projectId="" />, {});
+      wrapper.find('.dropdown-actor').simulate('click');
 
       const input = wrapper.find('.project-filter input');
       // Team name contains test
@@ -83,6 +89,7 @@ describe('ProjectSelector', function() {
 
     it('can filter projects by project name', function() {
       let wrapper = mount(<ProjectSelector organization={mockOrg} projectId="" />, {});
+      wrapper.find('.dropdown-actor').simulate('click');
 
       const input = wrapper.find('.project-filter input');
       input.value = 'another';
@@ -91,8 +98,28 @@ describe('ProjectSelector', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('does not close dropdown when input is clicked', function() {
+      let wrapper = mount(<ProjectSelector organization={mockOrg} projectId="" />, {});
+      wrapper.find('.dropdown-actor').simulate('click');
+
+      const input = wrapper.find('.project-filter input');
+      input.simulate('click', {target: input});
+
+      expect(wrapper.find('.dropdown-menu').length).toBe(1);
+    });
+
+    it('closes dropdown when project is selected', function() {
+      let wrapper = mount(<ProjectSelector organization={mockOrg} projectId="" />, {});
+      wrapper.find('.dropdown-actor').simulate('click');
+
+      // Select first project
+      wrapper.find('.dropdown-menu [role="presentation"] a').first().simulate('click');
+      expect(wrapper.find('.dropdown-menu').length).toBe(0);
+    });
+
     it('shows empty filter message when filtering has no results', function() {
       let wrapper = mount(<ProjectSelector organization={mockOrg} projectId="" />, {});
+      wrapper.find('.dropdown-actor').simulate('click');
 
       const input = wrapper.find('.project-filter input');
       input.value = 'Foo';

--- a/tests/js/spec/views/__snapshots__/organizationIntegrations.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationIntegrations.spec.jsx.snap
@@ -22,14 +22,15 @@ exports[`OrganizationIntegrations render() with a provider renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
+          keepMenuOpen={false}
           title="Add Integration"
         >
           <span
-            className="pull-right anchor-right dropdown"
+            className="dropdown pull-right anchor-right open"
           >
             <a
-              className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-              data-toggle="dropdown"
+              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+              onClick={[Function]}
             >
               Add Integration
               <i
@@ -38,6 +39,7 @@ exports[`OrganizationIntegrations render() with a provider renders 1`] = `
             </a>
             <ul
               className="dropdown-menu"
+              onClick={[Function]}
             >
               <MenuItem
                 noAnchor={true}
@@ -114,14 +116,15 @@ exports[`OrganizationIntegrations render() with a provider renders with a reposi
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
+          keepMenuOpen={false}
           title="Add Integration"
         >
           <span
-            className="pull-right anchor-right dropdown"
+            className="dropdown pull-right anchor-right open"
           >
             <a
-              className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-              data-toggle="dropdown"
+              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+              onClick={[Function]}
             >
               Add Integration
               <i
@@ -130,6 +133,7 @@ exports[`OrganizationIntegrations render() with a provider renders with a reposi
             </a>
             <ul
               className="dropdown-menu"
+              onClick={[Function]}
             >
               <MenuItem
                 noAnchor={true}
@@ -290,6 +294,7 @@ exports[`OrganizationIntegrations render() without any providers is loading when
         caret={true}
         className="btn btn-primary btn-sm"
         disabled={false}
+        keepMenuOpen={false}
         title="Add Integration"
       />
     </div>
@@ -347,14 +352,15 @@ exports[`OrganizationIntegrations render() without any providers renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
+          keepMenuOpen={false}
           title="Add Integration"
         >
           <span
-            className="pull-right anchor-right dropdown"
+            className="dropdown pull-right anchor-right open"
           >
             <a
-              className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-              data-toggle="dropdown"
+              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+              onClick={[Function]}
             >
               Add Integration
               <i
@@ -363,6 +369,7 @@ exports[`OrganizationIntegrations render() without any providers renders 1`] = `
             </a>
             <ul
               className="dropdown-menu"
+              onClick={[Function]}
             />
           </span>
         </DropdownLink>

--- a/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -20,14 +20,15 @@ exports[`OrganizationRepositories render() with a provider renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
+          keepMenuOpen={false}
           title="Add Repository"
         >
           <span
-            className="pull-right anchor-right dropdown"
+            className="dropdown pull-right anchor-right open"
           >
             <a
-              className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-              data-toggle="dropdown"
+              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+              onClick={[Function]}
             >
               Add Repository
               <i
@@ -36,6 +37,7 @@ exports[`OrganizationRepositories render() with a provider renders 1`] = `
             </a>
             <ul
               className="dropdown-menu"
+              onClick={[Function]}
             >
               <MenuItem
                 noAnchor={true}
@@ -179,14 +181,15 @@ exports[`OrganizationRepositories render() with a provider renders with a reposi
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
+          keepMenuOpen={false}
           title="Add Repository"
         >
           <span
-            className="pull-right anchor-right dropdown"
+            className="dropdown pull-right anchor-right open"
           >
             <a
-              className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-              data-toggle="dropdown"
+              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+              onClick={[Function]}
             >
               Add Repository
               <i
@@ -195,6 +198,7 @@ exports[`OrganizationRepositories render() with a provider renders with a reposi
             </a>
             <ul
               className="dropdown-menu"
+              onClick={[Function]}
             >
               <MenuItem
                 noAnchor={true}
@@ -454,6 +458,7 @@ exports[`OrganizationRepositories render() without any providers is loading when
         caret={true}
         className="btn btn-primary btn-sm"
         disabled={false}
+        keepMenuOpen={false}
         title="Add Repository"
       />
     </div>
@@ -509,14 +514,15 @@ exports[`OrganizationRepositories render() without any providers renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
+          keepMenuOpen={false}
           title="Add Repository"
         >
           <span
-            className="pull-right anchor-right dropdown"
+            className="dropdown pull-right anchor-right open"
           >
             <a
-              className="btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
-              data-toggle="dropdown"
+              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle"
+              onClick={[Function]}
             >
               Add Repository
               <i
@@ -525,6 +531,7 @@ exports[`OrganizationRepositories render() without any providers renders 1`] = `
             </a>
             <ul
               className="dropdown-menu"
+              onClick={[Function]}
             />
           </span>
         </DropdownLink>

--- a/tests/js/spec/views/organizationIntegrations.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations.spec.jsx
@@ -48,6 +48,7 @@ describe('OrganizationIntegrations', function() {
           },
           childContextTypes
         });
+        wrapper.find('.dropdown-actor').simulate('click');
         expect(wrapper.state('loading')).toBe(false);
         expect(wrapper).toMatchSnapshot();
       });
@@ -60,6 +61,7 @@ describe('OrganizationIntegrations', function() {
           body: {providers: [TestStubs.GitHubIntegrationProvider()]}
         });
       });
+
       it('renders', function() {
         Client.addMockResponse({
           url: '/organizations/org-slug/integrations/',
@@ -73,9 +75,11 @@ describe('OrganizationIntegrations', function() {
           },
           childContextTypes
         });
+        wrapper.find('.dropdown-actor').simulate('click');
         expect(wrapper.state('loading')).toBe(false);
         expect(wrapper).toMatchSnapshot();
       });
+
       it('renders with a repository', function() {
         Client.addMockResponse({
           url: '/organizations/org-slug/integrations/',
@@ -89,6 +93,7 @@ describe('OrganizationIntegrations', function() {
           },
           childContextTypes
         });
+        wrapper.find('.dropdown-actor').simulate('click');
         expect(wrapper.state('loading')).toBe(false);
         expect(wrapper).toMatchSnapshot();
       });

--- a/tests/js/spec/views/organizationRepositories.spec.jsx
+++ b/tests/js/spec/views/organizationRepositories.spec.jsx
@@ -48,6 +48,7 @@ describe('OrganizationRepositories', function() {
           },
           childContextTypes
         });
+        wrapper.find('.dropdown-actor').simulate('click');
         expect(wrapper.state('loading')).toBe(false);
         expect(wrapper).toMatchSnapshot();
       });
@@ -73,6 +74,7 @@ describe('OrganizationRepositories', function() {
           },
           childContextTypes
         });
+        wrapper.find('.dropdown-actor').simulate('click');
         expect(wrapper.state('loading')).toBe(false);
         expect(wrapper).toMatchSnapshot();
       });
@@ -89,6 +91,7 @@ describe('OrganizationRepositories', function() {
           },
           childContextTypes
         });
+        wrapper.find('.dropdown-actor').simulate('click');
         expect(wrapper.state('loading')).toBe(false);
         expect(wrapper).toMatchSnapshot();
       });


### PR DESCRIPTION
Refactored `<DropdownLink`> to remove dependency on bootstrap's dropdown. Reason for this is because there's no way (afaik) to keep the dropdown menu open. #6295 requires a dropdown to remain on screen while you interact with components inside of the menu.

Summary of changes:
* Removes bootstrap/js/dropdown from `<DropdownLink>`
* Cannot remove js dependency because of Accounts django view + probably getsentry
* Does not render dropdown menu unless it is visible
* Creates a click listener on `document` when dropdown menu appears to listen for
  clicks outside of dropdown menu
* Becomes a "controlled" component if `isOpen` prop is used in `<DropdownLink>`
* Refactored `<AssigneeSelector>` and `<ProjectSelector>` to account for above
* Adds more tests around when/how dropdown menu can open/close