### PR TITLE
fix: Only return tags from group in GroupTagsEndpoint

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -12,25 +12,23 @@ from sentry.api.serializers import serialize
 
 class GroupTagsEndpoint(GroupEndpoint):
     def get(self, request, group):
-        grouptagkeys = [gtk.key for gtk in tagstore.get_group_tag_keys(group.id)]
-
-        tag_keys = tagstore.get_tag_keys(group.project_id, grouptagkeys)
+        group_tag_keys = tagstore.get_group_tag_keys(group.id)
 
         # O(N) db access
         data = []
         all_top_values = []
-        for tag_key in tag_keys:
-            total_values = tagstore.get_group_tag_value_count(group.id, tag_key.key)
-            top_values = tagstore.get_top_group_tag_values(group.id, tag_key.key, limit=10)
+        for group_tag_key in group_tag_keys:
+            total_values = tagstore.get_group_tag_value_count(group.id, group_tag_key.key)
+            top_values = tagstore.get_top_group_tag_values(group.id, group_tag_key.key, limit=10)
 
             all_top_values.extend(top_values)
 
             data.append(
                 {
-                    'id': six.text_type(tag_key.id),
-                    'key': tagstore.get_standardized_key(tag_key.key),
-                    'name': tagstore.get_tag_key_label(tag_key.key),
-                    'uniqueValues': tag_key.values_seen,
+                    'id': six.text_type(group_tag_key.id),
+                    'key': tagstore.get_standardized_key(group_tag_key.key),
+                    'name': tagstore.get_tag_key_label(group_tag_key.key),
+                    'uniqueValues': group_tag_key.values_seen,
                     'totalValues': total_values,
                 }
             )

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -114,12 +114,7 @@ class LegacyTagStorage(TagStorage):
                 cache.set(key, result, 60)
             return result
 
-        qs = _get_base_qs()
-
-        if status:
-            qs = qs.filter(status=status)
-
-        return list(qs)
+        return list(_get_base_qs())
 
     def get_tag_value(self, project_id, key, value):
         from sentry.tagstore.exceptions import TagValueNotFound

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -6,35 +6,40 @@ from sentry.testutils import APITestCase
 
 class GroupTagsTest(APITestCase):
     def test_simple(self):
-        group = self.create_group()
-        group.data['tags'] = (['foo', 'bar'], ['biz', 'baz'])
-        group.save()
+        this_group = self.create_group()
+        this_group.data['tags'] = (['foo', 'bar'], ['biz', 'baz'])
+        this_group.save()
 
-        for key, value in group.data['tags']:
-            tagstore.create_tag_key(
-                project_id=group.project_id,
-                key=key,
-            )
-            tagstore.create_tag_value(
-                project_id=group.project_id,
-                key=key,
-                value=value,
-            )
-            tagstore.create_group_tag_key(
-                project_id=group.project_id,
-                group_id=group.id,
-                key=key,
-            )
-            tagstore.create_group_tag_value(
-                project_id=group.project_id,
-                group_id=group.id,
-                key=key,
-                value=value,
-            )
+        other_group = self.create_group()
+        other_group.data['tags'] = (['abc', 'xyz'], )
+        other_group.save()
+
+        for group in (this_group, other_group):
+            for key, value in group.data['tags']:
+                tagstore.create_tag_key(
+                    project_id=group.project_id,
+                    key=key,
+                )
+                tagstore.create_tag_value(
+                    project_id=group.project_id,
+                    key=key,
+                    value=value,
+                )
+                tagstore.create_group_tag_key(
+                    project_id=group.project_id,
+                    group_id=group.id,
+                    key=key,
+                )
+                tagstore.create_group_tag_value(
+                    project_id=group.project_id,
+                    group_id=group.id,
+                    key=key,
+                    value=value,
+                )
 
         self.login_as(user=self.user)
 
-        url = '/api/0/issues/{}/tags/'.format(group.id)
+        url = '/api/0/issues/{}/tags/'.format(this_group.id)
         response = self.client.get(url, format='json')
         assert response.status_code == 200, response.content
         assert len(response.data) == 2


### PR DESCRIPTION
This endpoint was returning every tag in a given project. In addition,
the `uniqueValues` was across the entire project.

---

This seems to have been broken for all time. Or at least going back to 2014 when I gave up on reading the history.

NOTE: This changes the `id` returned to be from the `GroupTagKey` instead of the `TagKey`. I don't know the important/use of having the `id` here, but considering it's the `GroupTagsEndpoint` this feels right. If returning the `TagKey`'s `id` is important I can refactor it to do that.

This was causing the tags page (and API endpoint) to be very noisy/confusing with empty tags that don't exist on the group:

![](https://d26dzxoao6i3hh.cloudfront.net/items/282d0f2V3I3w0A440T0F/Image%202017-10-13%20at%201.22.30%20PM.png?v=342c98b3)