### PR TITLE
ref(csp): Validate CSP reports with JSON schema

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -56,3 +56,4 @@ rb>=1.7.0,<2.0.0
 qrcode>=5.2.2,<6.0.0
 python-u2flib-server>=4.0.1,<4.1.0
 redis-py-cluster>=1.3.4,<1.4.0
+jsonschema==2.6.0

--- a/src/sentry/schemas/__init__.py
+++ b/src/sentry/schemas/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/schemas/security_reports.py
+++ b/src/sentry/schemas/security_reports.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+
+# NB this schema validates the version of the CSP report we create after
+# validate_data() which changes hyphens to underscores in the key names.
+
+CSP_POLICY_VIOLATION_REPORT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'effective_directive': {
+            'type': 'string',
+            'enum': [
+                'base-uri',
+                'child-src',
+                'connect-src',
+                'default-src',
+                'font-src',
+                'form-action',
+                'frame-ancestors',
+                'img-src',
+                'manifest-src',
+                'media-src',
+                'object-src',
+                'plugin-types',
+                'referrer',
+                'script-src',
+                'style-src',
+                'upgrade-insecure-requests',
+                # 'frame-src', # Deprecated (https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#frame-src)
+                # 'sandbox', # Unsupported
+            ],
+        },
+        'blocked_uri': {
+            'type': 'string',
+            'not': {
+                'enum': [
+                    'about',  # Noise from Chrome about page.
+                    'ms-browser-extension',
+                ],
+                'description': "URIs that are pure noise and will never be actionable.",
+            }
+        },
+        'document_uri': {'type': 'string'},
+        'original_policy': {'type': 'string'},
+        'referrer': {'type': 'string'},
+        'status_code': {'type': 'number'},
+        'violated_directive': {'type': 'string'},
+        'source_file': {'type': 'string'},
+        'line_number': {'type': 'number'},
+        'column_number': {'type': 'number'},
+    },
+    'allOf': [
+        {'required': ['effective_directive']},
+        {
+            'anyOf': [  # Require at least one of these keys.
+                {'required': ['blocked_uri']},
+                {'required': ['source_file']},
+            ]
+        }
+    ],
+    'additionalProperties': False,  # Don't allow any other keys.
+}
+
+SCHEMAS = {
+    'csp': CSP_POLICY_VIOLATION_REPORT_SCHEMA,
+    'hpkp': {},
+    'expect-ct': {},
+    'expect-staple': {},
+}

--- a/src/sentry/utils/csp.py
+++ b/src/sentry/utils/csp.py
@@ -6,12 +6,14 @@ sentry.utils.csp
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import
+import jsonschema
 
 from sentry.utils.http import is_valid_origin
+from sentry.schemas.security_reports import SCHEMAS
 
 # Default block list sourced from personal experience as well as
 # reputable blogs from Twitter and Dropbox
-DISALLOWED_SOURCES = (
+DEFAULT_DISALLOWED_SOURCES = (
     'chrome://*',
     'chrome-extension://*',
     'chromeinvokeimmediate://*'
@@ -58,72 +60,24 @@ DISALLOWED_SOURCES = (
     'netanalitics.space',
 )  # yapf: disable
 
-ALLOWED_DIRECTIVES = frozenset((
-    'base-uri',
-    'child-src',
-    'connect-src',
-    'default-src',
-    'font-src',
-    'form-action',
-    'frame-ancestors',
-    'img-src',
-    'manifest-src',
-    'media-src',
-    'object-src',
-    'plugin-types',
-    'referrer',
-    'script-src',
-    'style-src',
-    'upgrade-insecure-requests',
-
-    # Deprecated directives
-    # > Note: This directive is deprecated. Use child-src instead.
-    # > https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#frame-src
-    # 'frame-src',
-
-    # I don't really know what this even is.
-    # 'sandbox',
-))  # yapf: disable
-
-# URIs that are pure noise and will never be actionable
-DISALLOWED_BLOCKED_URIS = frozenset((
-    'about',
-    'ms-browser-extension',
-))  # yapf: disable
-
 
 def is_valid_csp_report(report, project=None):
-    # Some reports from Chrome report blocked-uri as just 'about'.
-    # In this case, this is not actionable and is just noisy.
-    # Observed in Chrome 45 and 46.
-    if report.get('effective_directive') not in ALLOWED_DIRECTIVES:
+    try:
+        jsonschema.validate(report, SCHEMAS['csp'])
+    except jsonschema.ValidationError:
         return False
 
-    blocked_uri = report.get('blocked_uri')
-    if blocked_uri in DISALLOWED_BLOCKED_URIS:
-        return False
-
-    source_file = report.get('source_file')
-
-    # We must have one of these to do anyting sensible
-    if not any((blocked_uri, source_file)):
-        return False
+    # Unfortunately the logic for disallowed sources is currently too complex
+    # to be represented in a JSON schema so we still need to do this manually.
+    uris = (report.get('blocked_uri'), report.get('source_file'))
+    disallowed = ()
 
     if project is None or bool(project.get_option('sentry:csp_ignored_sources_defaults', True)):
-        disallowed_sources = DISALLOWED_SOURCES
-    else:
-        disallowed_sources = ()
-
+        disallowed += DEFAULT_DISALLOWED_SOURCES
     if project is not None:
-        disallowed_sources += tuple(project.get_option('sentry:csp_ignored_sources', []))
+        disallowed += tuple(project.get_option('sentry:csp_ignored_sources', []))
 
-    if not disallowed_sources:
-        return True
-
-    if source_file and is_valid_origin(source_file, allowed=disallowed_sources):
-        return False
-
-    if blocked_uri and is_valid_origin(blocked_uri, allowed=disallowed_sources):
+    if disallowed and any(uri and is_valid_origin(uri, allowed=disallowed) for uri in uris):
         return False
 
     return True


### PR DESCRIPTION
In preparation for accepting other types of browser security reports,
start using JSON schema to validate the structure of these documents
to avoid duplicating a bunch of manual validation for the different
report types.