### PR TITLE
fix(events): Dont expose client_ip in JSON

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -200,6 +200,8 @@ class Event(Model):
         data['time_spent'] = self.time_spent
         data['tags'] = self.get_tags()
         for k, v in sorted(six.iteritems(self.data)):
+            if k == 'sdk':
+                v = {v_k: v_v for v_k, v_v in six.iteritems(v) if v_k != 'client_ip'}
             data[k] = v
         return data
 

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -47,6 +47,20 @@ class EventTest(TestCase):
 
         assert event1.get_email_subject() == 'foo Bar production@0 $ baz ${tag:invalid} $invalid'
 
+    def test_as_dict_hides_client_ip(self):
+        event = self.create_event(
+            data={'sdk': {
+                'name': 'foo',
+                'version': '1.0',
+                'client_ip': '127.0.0.1',
+            }}
+        )
+        result = event.as_dict()
+        assert result['sdk'] == {
+            'name': 'foo',
+            'version': '1.0',
+        }
+
 
 class EventGetLegacyMessageTest(TestCase):
     def test_message(self):


### PR DESCRIPTION
The ``client_ip`` attribute is not intended to be exposed outside of system admins. This is correctly enforced in our modern API serialization, but was never respected in the legacy Event JSON endpoint.