### PR TITLE
fix(csp): Fix transposed names

### DIFF
--- a/src/sentry/interfaces/csp.py
+++ b/src/sentry/interfaces/csp.py
@@ -101,10 +101,10 @@ class Csp(Interface):
         # We want to distinguish between the different script-src
         # violations that happen in
         if _is_unsafe_script(directive, uri) and self.violated_directive:
-            if "'unsafe-inline" in self.violated_directive:
-                uri = "'unsafe-eval'"
+            if "'unsafe-inline'" in self.violated_directive:
+                uri = "'unsafe-inline'"
             elif "'unsafe-eval'" in self.violated_directive:
-                uri = "'unsafe-inline"
+                uri = "'unsafe-eval'"
 
         return [directive, uri]
 
@@ -121,9 +121,9 @@ class Csp(Interface):
         # so we want to attempt to guess which it was
         if _is_unsafe_script(directive, uri) and self.violated_directive:
             if "'unsafe-inline'" in self.violated_directive:
-                tmpl = "Blocked unsafe eval() 'script'"
-            elif "'unsafe-eval'" in self.violated_directive:
                 tmpl = "Blocked unsafe inline 'script'"
+            elif "'unsafe-eval'" in self.violated_directive:
+                tmpl = "Blocked unsafe eval() 'script'"
 
         if tmpl is None:
             try:

--- a/tests/sentry/interfaces/test_csp.py
+++ b/tests/sentry/interfaces/test_csp.py
@@ -187,7 +187,7 @@ class CspTest(TestCase):
                 violated_directive="script-src 'unsafe-inline'",
             )
         )
-        assert result.get_message() == "Blocked unsafe eval() 'script'"
+        assert result.get_message() == "Blocked unsafe inline 'script'"
 
         result = Csp.to_python(
             dict(
@@ -197,7 +197,7 @@ class CspTest(TestCase):
                 violated_directive="script-src 'unsafe-eval'",
             )
         )
-        assert result.get_message() == "Blocked unsafe inline 'script'"
+        assert result.get_message() == "Blocked unsafe eval() 'script'"
 
         result = Csp.to_python(
             dict(


### PR DESCRIPTION
eval and inline were transposed, and in one case missing a single quote.