### PR TITLE
fix(settings): Fix submit error in admin settings

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/apiForm.jsx
+++ b/src/sentry/static/sentry/app/components/forms/apiForm.jsx
@@ -11,7 +11,13 @@ export default class ApiForm extends Form {
     ...Form.propTypes,
     onSubmit: PropTypes.func,
     apiMethod: PropTypes.string.isRequired,
-    apiEndpoint: PropTypes.string.isRequired
+    apiEndpoint: PropTypes.string.isRequired,
+    disabledFields: PropTypes.array,
+  };
+
+  static defaultProps = {
+    ...Form.defaultProps,
+    disabledFields: [],
   };
 
   constructor(props, context) {
@@ -31,6 +37,11 @@ export default class ApiForm extends Form {
     }
 
     let {data} = this.state;
+
+    // Excludes disabled fields
+    data = Object.keys(data)
+      .filter(key => this.props.disabledFields.indexOf(key) === -1)
+      .reduce((obj, key) => Object.assign(obj, {[key]: data[key]}), {});
 
     this.props.onSubmit && this.props.onSubmit(data);
     this.setState(

--- a/src/sentry/static/sentry/app/views/adminSettings.jsx
+++ b/src/sentry/static/sentry/app/views/adminSettings.jsx
@@ -29,6 +29,7 @@ export default class AdminSettings extends AsyncView {
 
     let initialData = {};
     let fields = {};
+    let disabledFields = [];
     for (let key of optionsAvailable) {
       // TODO(dcramer): we should not be mutating options
       let option = data[key] || {field: {}};
@@ -39,6 +40,9 @@ export default class AdminSettings extends AsyncView {
         initialData[key] = option.value;
       }
       fields[key] = getOptionField(key, option.field);
+      if (option.field && option.field.disabled) {
+        disabledFields.push(key);
+      }
     }
 
     return (
@@ -50,6 +54,7 @@ export default class AdminSettings extends AsyncView {
           apiEndpoint={this.getEndpoint()}
           onSubmit={this.onSubmit}
           initialData={initialData}
+          disabledFields={disabledFields}
           requireChanges={true}>
           <h4>General</h4>
           {fields['system.url-prefix']}

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -67,6 +67,13 @@ export default class InstallWizard extends AsyncView {
     return data;
   }
 
+  getDisabledFields() {
+    let options = this.state.data;
+    let disabledFields = Object.keys(options)
+      .filter(k => options[k].field && options[k].field.disabled);
+    return disabledFields;
+  }
+
   getTitle() {
     return t('Setup Sentry');
   }
@@ -111,6 +118,7 @@ export default class InstallWizard extends AsyncView {
         apiEndpoint={this.getEndpoint()}
         submitLabel={t('Continue')}
         initialData={this.getInitialData()}
+        disabledFields={this.getDisabledFields()}
         onSubmitSuccess={this.props.onConfigured}>
         <p>
           {t('Complete setup by filling out the required configuration.')}

--- a/tests/js/spec/views/__snapshots__/adminSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/adminSettings.spec.jsx.snap
@@ -13,6 +13,19 @@ exports[`AdminSettings render() renders 1`] = `
       apiMethod="PUT"
       cancelLabel="Cancel"
       className="form-stacked"
+      disabledFields={
+        Array [
+          "system.url-prefix",
+          "system.admin-email",
+          "system.support-email",
+          "system.security-email",
+          "system.rate-limit",
+          "auth.allow-registration",
+          "auth.ip-rate-limit",
+          "auth.user-rate-limit",
+          "api.rate-limit.org-create",
+        ]
+      }
       footerClass="form-actions align-right"
       initialData={
         Object {

--- a/tests/js/spec/views/__snapshots__/apiNewToken.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiNewToken.spec.jsx.snap
@@ -34,6 +34,7 @@ exports[`ApiNewToken render() renders 1`] = `
       apiMethod="POST"
       cancelLabel="Cancel"
       className="form-stacked api-new-token"
+      disabledFields={Array []}
       footerClass="form-actions align-right"
       initialData={
         Object {

--- a/tests/js/spec/views/__snapshots__/organizationApiKeyDetailsView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationApiKeyDetailsView.spec.jsx.snap
@@ -25,6 +25,7 @@ exports[`OrganizationApiKeyDetailsView renders 1`] = `
         apiMethod="PUT"
         cancelLabel="Cancel"
         className="form-stacked"
+        disabledFields={Array []}
         footerClass="form-actions align-right"
         initialData={
           Object {

--- a/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
@@ -16,6 +16,7 @@ exports[`OrganizationCreate render() renders correctly 1`] = `
       apiMethod="POST"
       cancelLabel="Cancel"
       className="form-stacked"
+      disabledFields={Array []}
       footerClass="form-actions align-right"
       initialData={
         Object {

--- a/tests/js/spec/views/__snapshots__/teamCreate.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamCreate.spec.jsx.snap
@@ -16,6 +16,7 @@ exports[`TeamCreate render() renders correctly 1`] = `
       apiMethod="POST"
       cancelLabel="Cancel"
       className="form-stacked"
+      disabledFields={Array []}
       footerClass="form-actions align-right"
       onSubmitSuccess={[Function]}
       requireChanges={true}

--- a/tests/js/spec/views/__snapshots__/teamSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamSettings.spec.jsx.snap
@@ -15,6 +15,7 @@ exports[`TeamSettings render() renders 1`] = `
         apiMethod="PUT"
         cancelLabel="Cancel"
         className="form-stacked"
+        disabledFields={Array []}
         footerClass="form-actions align-right"
         initialData={
           Object {


### PR DESCRIPTION
It is a front-end bug which occurs when `system.url-prefix` was defined in `config.yml`. The backend API will report an assertion error when we submit form in admin settings without this change.

> This setting is defined in config.yml and may not be changed via the web UI