### PR TITLE
feat: libsourcemap -> symbolic (#6348)

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -19,7 +19,6 @@ hiredis>=0.1.0,<0.2.0
 honcho>=0.7.0,<0.8.0
 kombu==3.0.35
 ipaddress>=1.0.16,<1.1.0
-libsourcemap>=0.8.2,<0.9.0
 loremipsum>=1.0.5,<1.1.0
 lxml>=3.4.1
 mock>=0.8.0,<1.1
@@ -47,7 +46,7 @@ setproctitle>=1.1.7,<1.2.0
 statsd>=3.1.0,<3.2.0
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=0.9.8,<1.0.0
+symbolic>=1.0.3,<2.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 import uuid
 
-from libsourcemap import ProguardView
+from symbolic import ProguardMappingView
 from sentry.plugins import Plugin2
 from sentry.stacktraces import StacktraceProcessor
 from sentry.models import ProjectDSymFile, EventError
@@ -52,7 +52,7 @@ class JavaStacktraceProcessor(StacktraceProcessor):
             if dsym_path is None:
                 error_type = EventError.PROGUARD_MISSING_MAPPING
             else:
-                view = ProguardView.from_path(dsym_path)
+                view = ProguardMappingView.from_path(dsym_path)
                 if not view.has_line_info:
                     error_type = EventError.PROGUARD_MISSING_LINENO
                 else:

--- a/src/sentry/lang/javascript/cache.py
+++ b/src/sentry/lang/javascript/cache.py
@@ -1,8 +1,15 @@
 from __future__ import absolute_import, print_function
 
+from six import text_type
+from symbolic import SourceView
 from sentry.utils.strings import codec_lookup
 
 __all__ = ['SourceCache', 'SourceMapCache']
+
+
+def is_utf8(codec):
+    name = codec_lookup(codec).name
+    return name in ('utf-8', 'ascii')
 
 
 class SourceCache(object):
@@ -20,55 +27,33 @@ class SourceCache(object):
             url = self._aliases[url]
         return url
 
-    def get(self, url, raw=False):
-        url = self._get_canonical_url(url)
-        try:
-            parsed, rv = self._cache[url]
-        except KeyError:
-            return None
-
-        # We have already gotten this file and we've
-        # decoded the response, so just return
-        if parsed:
-            parsed, raw_body = rv
-            if raw:
-                return raw_body
-            return parsed
-
-        # Otherwise, we have a 2-tuple that needs to be applied
-        body, encoding = rv
-
-        # Our body is lazily evaluated if it
-        # comes from libsourcemap
-        if callable(body):
-            body = body()
-
-        raw_body = body
-        body = body.decode(codec_lookup(encoding, 'utf-8').name, 'replace').split(u'\n')
-
-        # Set back a marker to indicate we've parsed this url
-        self._cache[url] = (True, (body, raw_body))
-        return body
+    def get(self, url):
+        return self._cache.get(self._get_canonical_url(url))
 
     def get_errors(self, url):
         url = self._get_canonical_url(url)
         return self._errors.get(url, [])
 
-    def alias(self, u1, u2):
-        if u1 == u2:
-            return
-
-        if u1 in self._cache or u1 not in self._aliases:
-            self._aliases[u1] = u1
-        else:
-            self._aliases[u2] = u1
+    def alias(self, alias, target):
+        if alias != target:
+            self._aliases[alias] = target
 
     def add(self, url, source, encoding=None):
         url = self._get_canonical_url(url)
-        # Insert into the cache, an unparsed (source, encoding)
-        # tuple. This allows the source to be split and decoded
-        # on demand when first accessed.
-        self._cache[url] = (False, (source, encoding))
+
+        if not isinstance(source, SourceView):
+            if isinstance(source, text_type):
+                source = source.encode('utf-8')
+            # If an encoding is provided and it's not utf-8 compatible
+            # we try to re-encoding the source and create a source view
+            # from it.
+            elif encoding is not None and not is_utf8(encoding):
+                try:
+                    source = source.decode(encoding).encode('utf-8')
+                except UnicodeError:
+                    pass
+            source = SourceView.from_bytes(source)
+        self._cache[url] = source
 
     def add_error(self, url, error):
         url = self._get_canonical_url(url)

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from os.path import splitext
 from requests.utils import get_encoding_from_headers
 from six.moves.urllib.parse import urljoin, urlsplit
-from libsourcemap import from_json as view_from_json
+from symbolic import SourceMapView
 
 # In case SSL is unavailable (light builds) we can't import this here.
 try:
@@ -391,7 +391,7 @@ def fetch_sourcemap(url, project=None, release=None, dist=None, allow_scraping=T
         )
         body = result.body
     try:
-        return view_from_json(body)
+        return SourceMapView.from_json_bytes(body)
     except Exception as exc:
         # This is in debug because the product shows an error already.
         logger.debug(six.text_type(exc), exc_info=True)
@@ -526,7 +526,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
 
         # This might fail but that's okay, we try with a different path a
         # bit later down the road.
-        source = self.get_source(frame['abs_path'])
+        source = self.get_sourceview(frame['abs_path'])
 
         in_app = None
         new_frame = dict(frame)
@@ -549,11 +549,20 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
 
             sourcemap_label = http.expose_url(sourcemap_label)
 
+            if frame.get('function'):
+                minified_function_name = frame['function']
+                minified_source = self.get_sourceview(frame['abs_path'])
+            else:
+                minified_function_name = minified_source = None
+
             try:
                 # Errors are 1-indexed in the frames, so we need to -1 to get
                 # zero-indexed value from tokens.
                 assert frame['lineno'] > 0, "line numbers are 1-indexed"
-                token = sourcemap_view.lookup_token(frame['lineno'] - 1, frame['colno'] - 1)
+                token = sourcemap_view.lookup(frame['lineno'] - 1,
+                                              frame['colno'] - 1,
+                                              minified_function_name,
+                                              minified_source)
             except Exception:
                 token = None
                 all_errors.append(
@@ -580,7 +589,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 logger.debug(
                     'Mapping compressed source %r to mapping in %r', frame['abs_path'], abs_path
                 )
-                source = self.get_source(abs_path)
+                source = self.get_sourceview(abs_path)
 
             if not source:
                 errors = cache.get_errors(abs_path)
@@ -599,17 +608,12 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 new_frame['lineno'] = token.src_line + 1
                 new_frame['colno'] = token.src_col + 1
 
-                # Find the original function name with a bit of guessing
-                original_function_name = None
+                # Try to use the function name we got from symbolic
+                original_function_name = token.function_name
 
                 # In the ideal case we can use the function name from the
                 # frame and the location to resolve the original name
                 # through the heuristics in our sourcemap library.
-                if frame.get('function'):
-                    minified_source = self.get_source(frame['abs_path'], raw=True)
-                    original_function_name = sourcemap_view.get_original_function_name(
-                        token.dst_line, token.dst_col, frame['function'],
-                        minified_source)
                 if original_function_name is None:
                     last_token = None
 
@@ -696,7 +700,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
     def expand_frame(self, frame, source=None):
         if frame.get('lineno') is not None:
             if source is None:
-                source = self.get_source(frame['abs_path'])
+                source = self.get_sourceview(frame['abs_path'])
                 if source is None:
                     logger.debug('No source found for %s', frame['abs_path'])
                     return False
@@ -707,10 +711,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             return True
         return False
 
-    def get_source(self, filename, raw=False):
+    def get_sourceview(self, filename):
         if filename not in self.cache:
             self.cache_source(filename)
-        return self.cache.get(filename, raw=raw)
+        return self.cache.get(filename)
 
     def cache_source(self, filename):
         sourcemaps = self.sourcemaps
@@ -766,12 +770,12 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         sourcemaps.add(sourcemap_url, sourcemap_view)
 
         # cache any inlined sources
-        for src_id, source in sourcemap_view.iter_sources():
-            if sourcemap_view.has_source_contents(src_id):
+        for src_id, source_name in sourcemap_view.iter_sources():
+            source_view = sourcemap_view.get_sourceview(src_id)
+            if source_view is not None:
                 self.cache.add(
-                    urljoin(sourcemap_url, source),
-                    lambda view=sourcemap_view, id=src_id: view.get_source_contents(id),
-                    None,
+                    urljoin(sourcemap_url, source_name),
+                    source_view
                 )
 
     def populate_source_cache(self, frames):

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -206,13 +206,17 @@ def codec_lookup(encoding, default='utf-8'):
     Note: the default value is not sanity checked and would
     bypass these checks."""
 
+    def _get_default():
+        if default is not None:
+            return codecs.lookup(default)
+
     if not encoding:
-        return codecs.lookup(default)
+        return _get_default()
 
     try:
         info = codecs.lookup(encoding)
     except (LookupError, TypeError):
-        return codecs.lookup(default)
+        return _get_default()
 
     try:
         # Check for `CodecInfo._is_text_encoding`.
@@ -221,13 +225,13 @@ def codec_lookup(encoding, default='utf-8'):
         # introduced into 2.7.12, so versions prior to this will
         # raise, but this is the best we can do.
         if not info._is_text_encoding:
-            return codecs.lookup(default)
+            return _get_default()
     except AttributeError:
         pass
 
     # `undefined` is special a special encoding in python that 100% of
     # the time will raise, so ignore it.
     if info.name == 'undefined':
-        return codecs.lookup(default)
+        return _get_default()
 
     return info

--- a/tests/sentry/lang/javascript/test_cache.py
+++ b/tests/sentry/lang/javascript/test_cache.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+from sentry.lang.javascript.cache import SourceCache
+
+
+class BasicCacheTest(TestCase):
+    def test_basic_features(self):
+        cache = SourceCache()
+
+        url = 'http://example.com/foo.js'
+
+        assert url not in cache
+        assert cache.get(url) is None
+
+        cache.add(url, b'foo\nbar')
+        assert url in cache
+        assert cache.get(url) is not None
+        assert cache.get(url)[0] == u'foo'
+
+        cache.alias(url + 'x', url)
+        assert url + 'x' in cache
+        assert cache.get(url + 'x')[0] == u'foo'
+
+    def test_encoding_fallback(self):
+        cache = SourceCache()
+
+        url = 'http://example.com/foo.js'
+
+        # fall back to utf-8
+        cache.add(url, b'foobar', encoding='utf-32')
+        assert cache.get(url)[0] == u'foobar'
+
+    def test_encoding_support(self):
+        cache = SourceCache()
+        url = 'http://example.com/foo.js'
+
+        # fall back to utf-8
+        cache.add(url, 'foobar'.encode('utf-32'), encoding='utf-32')
+        assert cache.get(url)[0] == u'foobar'

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import pytest
 import responses
 import six
-from libsourcemap import Token
+from symbolic import SourceMapTokenMatch
 
 from mock import patch
 from requests.exceptions import RequestException
@@ -399,18 +399,20 @@ class GenerateModuleTest(TestCase):
 class FetchSourcemapTest(TestCase):
     def test_simple_base64(self):
         smap_view = fetch_sourcemap(base64_sourcemap)
-        tokens = [Token(1, 0, '/test.js', 0, 0, 0, None)]
+        tokens = [SourceMapTokenMatch(0, 0, 1, 0, src='/test.js', src_id=0)]
 
         assert list(smap_view) == tokens
-        assert smap_view.get_source_contents(0) == 'console.log("hello, World!")'
+        sv = smap_view.get_sourceview(0)
+        assert sv.get_source() == u'console.log("hello, World!")'
         assert smap_view.get_source_name(0) == u'/test.js'
 
     def test_base64_without_padding(self):
         smap_view = fetch_sourcemap(base64_sourcemap.rstrip('='))
-        tokens = [Token(1, 0, '/test.js', 0, 0, 0, None)]
+        tokens = [SourceMapTokenMatch(0, 0, 1, 0, src='/test.js', src_id=0)]
 
         assert list(smap_view) == tokens
-        assert smap_view.get_source_contents(0) == 'console.log("hello, World!")'
+        sv = smap_view.get_sourceview(0)
+        assert sv.get_source() == u'console.log("hello, World!")'
         assert smap_view.get_source_name(0) == u'/test.js'
 
     def test_broken_base64(self):


### PR DESCRIPTION
This commits changes handling in sentry from libsourcemap to symbolic
for JavaScript and proguard.

It replaces #6348 which had some regressions regarding invalid utf-8
characters and missing source lines.