### PR TITLE
feat(reprocessing): Set timeouts for raw event deletion to defaults

### DIFF
--- a/src/sentry/tasks/reprocessing.py
+++ b/src/sentry/tasks/reprocessing.py
@@ -45,7 +45,7 @@ def create_reprocessing_report(project_id, event_id):
     return ReprocessingReport.objects.create(project_id=project_id, event_id=event_id)
 
 
-@instrumented_task(name='sentry.tasks.clear_expired_raw_events', time_limit=15, soft_time_limit=10)
+@instrumented_task(name='sentry.tasks.clear_expired_raw_events')
 def clear_expired_raw_events():
     from sentry.models import RawEvent, ProcessingIssue
 


### PR DESCRIPTION
We should probably also look into what this delete does but at the
very least we should consider looking at setting this to the default
timeouts.