### PR TITLE
ref: Remove unused 'strict_mode' attribute on saml2 dummy provider

### DIFF
--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -31,8 +31,6 @@ dummy_provider_config = {
 
 
 class DummySAML2Provider(SAML2Provider):
-    strict_mode = False
-
     def get_saml_setup_pipeline(self):
         return []
 


### PR DESCRIPTION
This was used briefly while I was writing these tests, but looks like it slipped in.