### PR TITLE
fix(discard): Simplify minified frame hashing

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -433,6 +433,7 @@ class Frame(Interface):
         from sentry.filters.preprocess_hashes import UnableToGenerateHash
 
         platform = self.platform or platform
+        # TODO(jess): consider special casing mobile/native
         if platform == 'javascript':
             # Safari throws [native code] frames in for calls like ``forEach``
             # whereas Chrome ignores these. Let's remove it from the hashing algo

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -430,6 +430,8 @@ class Frame(Interface):
         return output
 
     def _get_unprocessed_hash(self, platform=None):
+        from sentry.filters.preprocess_hashes import UnableToGenerateHash
+
         platform = self.platform or platform
         if platform == 'javascript':
             # Safari throws [native code] frames in for calls like ``forEach``
@@ -441,8 +443,7 @@ class Frame(Interface):
             attrs = [self.filename, self.function, self.colno, self.lineno]
             if all(attrs):
                 return attrs
-            else:
-                return []
+            raise UnableToGenerateHash
         else:
             return self._get_processed_hash(platform=platform)
 

--- a/tests/sentry/filters/test_preprocess_hashes.py
+++ b/tests/sentry/filters/test_preprocess_hashes.py
@@ -241,8 +241,17 @@ class PreProcessingHashTest(TestCase):
         )
 
         assert get_preprocess_hash_inputs(event_data) == [[
+            u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/vendor.js',
             u'Object.receiveComponent',
+            22,
+            17866,
+            u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/vendor.js',
             u'ReactCompositeComponentWrapper.receiveComponent',
+            10,
+            74002,
+            u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/app.js',
             u'Constructor.render',
+            9,
+            47628,
             u'TypeError'
         ]]

--- a/tests/sentry/filters/test_preprocess_hashes.py
+++ b/tests/sentry/filters/test_preprocess_hashes.py
@@ -255,3 +255,64 @@ class PreProcessingHashTest(TestCase):
             47628,
             u'TypeError'
         ]]
+
+    def test_exception_with_stacktrace_raises(self):
+        data = {
+            'exception': {
+                'values': [
+                    {
+                        'stacktrace': {
+                            'frames': [
+                                {
+                                    'colno':
+                                    22,
+                                    'function':
+                                    u'Object.receiveComponent',
+                                    'in_app':
+                                    True,
+                                    'lineno':
+                                    17866
+                                }, {
+                                    'colno':
+                                    10,
+                                    'filename':
+                                    u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/vendor.js',
+                                    'function':
+                                    u'ReactCompositeComponentWrapper.receiveComponent',
+                                    'in_app':
+                                    True,
+                                    'lineno':
+                                    74002
+                                }, {
+                                    'colno':
+                                    9,
+                                    'filename':
+                                    u'/_static/373562702009df1692da6eb80a933139f29e094b/sentry/dist/app.js',
+                                    'function':
+                                    u'Constructor.render',
+                                    'in_app':
+                                    True,
+                                    'lineno':
+                                    47628
+                                }
+                            ],
+                            'frames_omitted':
+                            None,
+                            'registers':
+                            None
+                        },
+                        'thread_id': None,
+                        'type': u'TypeError',
+                        'value': u"Cannot set property 'b' of null"
+                    }
+                ]
+            }
+        }
+
+        event_data = self.make_event_data(
+            data=data,
+            platform='javascript',
+        )
+
+        with self.assertRaises(UnableToGenerateHash):
+            get_preprocess_hash_inputs(event_data)


### PR DESCRIPTION
Only use filename, function, colno, and lineno (and require all of them) to generate a minified hash for javascript. 