### PR TITLE
fix(shared-group): decrease the size of 'details' link

### DIFF
--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
@@ -95,11 +95,11 @@ const SharedGroupDetails = React.createClass({
           <div className="container">
             <div className="box box-modal">
               <div className="box-header">
-                <a href="/">
+                <a className="logo" href="/">
                   <span className="icon-sentry-logo-full" />
                 </a>
                 {this.state.group.permalink &&
-                  <a className="pull-right" href={this.state.group.permalink}>
+                  <a className="details" href={this.state.group.permalink}>
                     {t('Details')}
                   </a>}
               </div>

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -2085,21 +2085,19 @@ pre.val, span.val {
 
     > .box {
       > .box-header {
-        padding: 15px 30px;
+        padding: 15px 30px 13px;
         display: flex;
         align-items: center;
 
         a {
-          .icon-sentry-logo-full {
+
+          &.logo {
             font-size: 20px;
+            flex: 1;
           }
           &:hover {
             color: @gray-dark;
           }
-        }
-
-        .pull-right {
-          align-self: flex-end;
         }
 
         .back-to, .pull-right a {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -2085,14 +2085,21 @@ pre.val, span.val {
 
     > .box {
       > .box-header {
-        padding: 15px 30px 10px;
+        padding: 15px 30px;
+        display: flex;
+        align-items: center;
 
         a {
-          font-size: 20px;
-
+          .icon-sentry-logo-full {
+            font-size: 20px;
+          }
           &:hover {
             color: @gray-dark;
           }
+        }
+
+        .pull-right {
+          align-self: flex-end;
         }
 
         .back-to, .pull-right a {
@@ -2109,10 +2116,6 @@ pre.val, span.val {
         }
       }
     }
-  }
-
-  .box-content {
-
   }
 
   .container {


### PR DESCRIPTION
Before:

<img width="960" alt="screen shot 2017-10-19 at 11 05 23 am" src="https://user-images.githubusercontent.com/30713/31786470-73494af2-b4bd-11e7-972c-fb5f91a938be.png">

After:

<img width="960" alt="screen shot 2017-10-19 at 11 04 48 am" src="https://user-images.githubusercontent.com/30713/31786476-78093c00-b4bd-11e7-8272-d2089c1293e8.png">
