### PR TITLE
fix: More visually pleasing padding on the share url

### DIFF
--- a/src/sentry/static/sentry/app/components/shareIssue.jsx
+++ b/src/sentry/static/sentry/app/components/shareIssue.jsx
@@ -61,7 +61,7 @@ class ShareUrlContainer extends React.Component {
             style={{
               flex: 1,
               border: 'none',
-              padding: 4,
+              padding: '4px 6px 4px 10px',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
               overflow: 'hidden'


### PR DESCRIPTION
![localhost_8000_sentry-4v_python_issues_265_ 1](https://user-images.githubusercontent.com/1421724/31794049-cedf99d0-b4d5-11e7-87a8-54a0488a9237.png)
↓
![localhost_8000_sentry-4v_python_issues_265_](https://user-images.githubusercontent.com/1421724/31794050-cf0b7a46-b4d5-11e7-8ea8-a9258f4d2d3d.png)
