### PR TITLE
ref(react): Change Org Teams routes to be child of org settings

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -129,6 +129,18 @@ const orgSettingsRoutes = [
     path="settings/"
     component={errorHandler(OrganizationSettings)}
   />,
+
+  <Route key="team-details" path="teams/:teamId/" component={errorHandler(TeamDetails)}>
+    <IndexRedirect to="settings/" />
+    <Route path="settings/" component={errorHandler(TeamSettings)} />
+    <Route path="members/" component={errorHandler(TeamMembers)} />
+  </Route>,
+
+  <Route key="teams" path="teams/" component={errorHandler(OrganizationTeams)} />,
+
+  <Route key="all-teams" path="all-teams/" component={errorHandler(OrganizationTeams)}>
+    <IndexRoute component={errorHandler(AllTeamsList)} />
+  </Route>,
 ];
 
 function routes() {
@@ -193,34 +205,16 @@ function routes() {
       <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <IndexRoute component={errorHandler(OrganizationDashboard)} />
 
+        <Route
+          path="/organizations/:orgId/teams/new/"
+          component={errorHandler(TeamCreate)}
+        />
+
         <Route path="/organizations/:orgId/" component={OrganizationHomeContainer}>
           {hooksOrgRoutes}
           {orgSettingsRoutes}
         </Route>
 
-        <Route
-          path="/organizations/:orgId/teams/"
-          component={errorHandler(OrganizationTeams)}
-        />
-        <Route
-          path="/organizations/:orgId/teams/new/"
-          component={errorHandler(TeamCreate)}
-        />
-        <Route
-          path="/organizations/:orgId/teams/:teamId/"
-          component={errorHandler(TeamDetails)}
-        >
-          <IndexRedirect to="settings/" />
-          <Route path="settings/" component={errorHandler(TeamSettings)} />
-          <Route path="members/" component={errorHandler(TeamMembers)} />
-        </Route>
-
-        <Route
-          path="/organizations/:orgId/all-teams/"
-          component={errorHandler(OrganizationTeams)}
-        >
-          <IndexRoute component={errorHandler(AllTeamsList)} />
-        </Route>
         <Route
           path="/organizations/:orgId/issues/assigned/"
           component={errorHandler(MyIssuesAssignedToMe)}

--- a/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/index.jsx
@@ -4,7 +4,6 @@ import Reflux from 'reflux';
 import {t} from '../../locale';
 import ApiMixin from '../../mixins/apiMixin';
 import ListLink from '../../components/listLink';
-import OrganizationHomeContainer from '../../components/organizations/homeContainer';
 import OrganizationState from '../../mixins/organizationState';
 import TeamStore from '../../stores/teamStore';
 import {sortArray} from '../../utils';
@@ -61,44 +60,42 @@ const OrganizationTeams = React.createClass({
     let activeTeams = this.state.teamList.filter(team => team.isMember);
 
     return (
-      <OrganizationHomeContainer>
-        <div className="row">
-          <div className="col-md-9">
-            <div className="team-list">
-              <ul className="nav nav-tabs border-bottom">
-                <ListLink to={`/organizations/${org.slug}/teams/`}>
-                  {t('Your Teams')}
-                </ListLink>
-                <ListLink to={`/organizations/${org.slug}/all-teams/`}>
-                  {t('All Teams')}{' '}
-                  <span className="badge badge-soft">{allTeams.length}</span>
-                </ListLink>
-              </ul>
-              {this.props.children /* should be AllTeamsList */ ? (
-                React.cloneElement(this.props.children, {
-                  organization: org,
-                  teamList: allTeams,
-                  access,
-                  openMembership:
-                    features.has('open-membership') || access.has('org:write'),
-                })
-              ) : (
-                <ExpandedTeamList
-                  organization={org}
-                  teamList={activeTeams}
-                  projectStats={this.state.projectStats}
-                  hasTeams={allTeams.length !== 0}
-                  access={access}
-                />
-              )}
-            </div>
+      <div className="row">
+        <div className="col-md-9">
+          <div className="team-list">
+            <ul className="nav nav-tabs border-bottom">
+              <ListLink to={`/organizations/${org.slug}/teams/`}>
+                {t('Your Teams')}
+              </ListLink>
+              <ListLink to={`/organizations/${org.slug}/all-teams/`}>
+                {t('All Teams')}{' '}
+                <span className="badge badge-soft">{allTeams.length}</span>
+              </ListLink>
+            </ul>
+            {this.props.children /* should be AllTeamsList */ ? (
+              React.cloneElement(this.props.children, {
+                organization: org,
+                teamList: allTeams,
+                access,
+                openMembership:
+                  features.has('open-membership') || access.has('org:write'),
+              })
+            ) : (
+              <ExpandedTeamList
+                organization={org}
+                teamList={activeTeams}
+                projectStats={this.state.projectStats}
+                hasTeams={allTeams.length !== 0}
+                access={access}
+              />
+            )}
           </div>
-          <OrganizationStatOverview
-            orgId={this.props.params.orgId}
-            className="col-md-3 stats-column"
-          />
         </div>
-      </OrganizationHomeContainer>
+        <OrganizationStatOverview
+          orgId={this.props.params.orgId}
+          className="col-md-3 stats-column"
+        />
+      </div>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/teamDetails.jsx
+++ b/src/sentry/static/sentry/app/views/teamDetails.jsx
@@ -8,7 +8,6 @@ import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import MenuItem from '../components/menuItem';
 import OrganizationState from '../mixins/organizationState';
-import OrganizationHomeContainer from '../components/organizations/homeContainer';
 import {t} from '../locale';
 
 const TeamDetails = React.createClass({
@@ -90,7 +89,7 @@ const TeamDetails = React.createClass({
     let access = this.getAccess();
 
     return (
-      <OrganizationHomeContainer>
+      <div>
         <h3>{team.name}</h3>
 
         {access.has('team:admin') && (
@@ -108,7 +107,7 @@ const TeamDetails = React.createClass({
           team,
           onTeamChange: this.onTeamChange,
         })}
-      </OrganizationHomeContainer>
+      </div>
     );
   },
 });


### PR DESCRIPTION
Team Settings now nested under org settings route (that has
`<OrganizationHomeContainer>` as parent), except for Team Create.