### PR TITLE
fix: Handle tagstore model moves in buffer processing

### DIFF
--- a/src/sentry/utils/imports.py
+++ b/src/sentry/utils/imports.py
@@ -11,6 +11,15 @@ import pkgutil
 import six
 
 
+MODEL_MOVES = {
+    'sentry.models.tagkey.TagKey': 'sentry.tagstore.legacy.models.tagkey.TagKey',
+    'sentry.models.tagvalue.tagvalue': 'sentry.tagstore.legacy.models.tagvalue.TagValue',
+    'sentry.models.grouptagkey.GroupTagKey': 'sentry.tagstore.legacy.models.grouptagkey.GroupTagKey',
+    'sentry.models.grouptagvalue.GroupTagValue': 'sentry.tagstore.legacy.models.grouptagvalue.GroupTagValue',
+    'sentry.models.eventtag.EventTag': 'sentry.tagstore.legacy.models.eventtag.EventTag',
+}
+
+
 class ModuleProxyCache(dict):
     def __missing__(self, key):
         if '.' not in key:
@@ -36,6 +45,7 @@ def import_string(path):
 
     >>> cls = import_string('sentry.models.Group')
     """
+    path = MODEL_MOVES.get(path, path)
     result = _cache[path]
     return result
 


### PR DESCRIPTION
Longer term this will be part of a 'registry' system but this will
prevent short term bugs.