### PR TITLE
fix(vscode): VSCode exclude path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
         "**/*.pyc": true,
         "**/*.min.js": true,
         "**/*.js.map": true,
-        "static/dist/": true,
+        "static/": true,
         "node_modules": true,
         "htmlcov": true,
         "build": true,


### PR DESCRIPTION
this one is slightly better for search (removes dupes from symlink)