### PR TITLE
fix(Python 3) from six.moves import xrange for Python 3

### DIFF
--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -34,6 +34,8 @@ from sentry.utils.samples import load_data
 from sentry.web.decorators import login_required
 from sentry.web.helpers import render_to_response, render_to_string
 
+from six.moves import xrange
+
 logger = logging.getLogger(__name__)
 
 loremipsum = Generator()

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -8,6 +8,8 @@ from sentry.digests.backends.base import InvalidState
 from sentry.digests.backends.redis import RedisBackend
 from sentry.testutils import TestCase
 
+from six.moves import xrange
+
 
 class RedisBackendTestCase(TestCase):
     def test_basic(self):

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -10,6 +10,7 @@ from sentry import tagstore
 from sentry.testutils import TestCase
 from sentry.models import GroupSnooze
 from sentry.tsdb import backend as tsdb
+from six.moves import xrange
 
 
 class GroupSnoozeTest(TestCase):

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -15,6 +15,7 @@ from sentry.quotas.redis import (
 )
 from sentry.testutils import TestCase
 from sentry.utils.redis import clusters
+from six.moves import xrange
 
 
 def test_is_rate_limited_script():

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -12,6 +12,7 @@ from sentry.rules.conditions.event_frequency import (
     EventFrequencyCondition, EventUniqueUserFrequencyCondition
 )
 from sentry.testutils.cases import RuleTestCase
+from six.moves import xrange
 
 
 class FrequencyConditionMixin(object):

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -18,6 +18,7 @@ from sentry.tasks.reports import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.utils.dates import to_datetime, to_timestamp
+from six.moves import xrange
 
 
 @pytest.yield_fixture(scope="module")

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -28,7 +28,6 @@ from sentry.utils.dates import to_timestamp
 from sentry.utils import redis
 from six.moves import xrange
 
-
 # Use the default redis client as a cluster client in the similarity index
 index = _make_index_backend(redis.clusters.get('default').get_local_client(0))
 

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -26,6 +26,8 @@ from sentry.tasks.unmerge import (
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
 from sentry.utils import redis
+from six.moves import xrange
+
 
 # Use the default redis client as a cluster client in the similarity index
 index = _make_index_backend(redis.clusters.get('default').get_local_client(0))

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -26,6 +26,7 @@ from sentry.tasks.unmerge import (
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
 from sentry.utils import redis
+
 from six.moves import xrange
 
 # Use the default redis client as a cluster client in the similarity index

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from sentry.testutils import TestCase
 from sentry.tsdb.base import BaseTSDB, ONE_MINUTE, ONE_HOUR, ONE_DAY
 from sentry.utils.dates import to_timestamp
+from six.moves import xrange
 
 
 class BaseTSDBTest(TestCase):

--- a/tests/sentry/utils/test_iterators.py
+++ b/tests/sentry/utils/test_iterators.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import pytest
 
 from sentry.utils.iterators import advance, chunked, shingle
+from six.moves import xrange
 
 
 def test_chunked():


### PR DESCRIPTION
Each file uses __xrange()__ but that builtin was removed from Python 3 in favor of __range()__.  These modifications should be compatible with both Python 2 and Python 3.

The Travis failure does not make sense for these changes.  Can someone with permissions, please __restart the Travis build__?