### PR TITLE
ref(saml): Harden the ACS endpoint

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -129,6 +129,9 @@ class AuthHelper(object):
     @classmethod
     def get_for_request(cls, request):
         state = RedisBackedState(request)
+        if not state.is_valid():
+            return None
+
         organization_id = state.org_id
         if not organization_id:
             logging.info('Invalid SSO data found')


### PR DESCRIPTION
This fixes a few breaking issues with the SAML ACS endpoint:

 1. Setup of a SAML2 provider was broken during the ACS setup, as the dispatch would always assume it was IdP initiated authentication due to the brittle 'auth' session key check, which changed in 03c045373.

    This caused it to fall through logic in the AuthOrganizationLoginView which flow through the `sentry.web.frontend.Base.respond` method causing SENTRY-4ZP.

 2. This also cause similar problems when no provider is configured and the user attempts to do IdP initiated auth. This is fixed by re-implementing the IdP initiated auth flow directly in the handler instead of dispatching to the AuthOrganizationLoginView which has logic more specific to sentry user initiated login.