### PR TITLE
fix(auditlog): Add member data to log entry

### DIFF
--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -152,6 +152,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             request=request,
             organization_id=organization.id,
             target_object=om.id,
+            data=om.get_audit_log_data(),
             event=AuditLogEntryEvent.MEMBER_INVITE if settings.SENTRY_ENABLE_INVITES else AuditLogEntryEvent.MEMBER_ADD,
         )
 


### PR DESCRIPTION
fixes SENTRY-515

the audit code in the old form view was:

```
 AuditLogEntry.objects.create(		
 -            organization=organization,		
 -            actor=actor,		
 -            ip_address=ip_address,		
 -            target_object=om.id,		
 -            event=AuditLogEntryEvent.MEMBER_INVITE,		
 -            data=om.get_audit_log_data(),		
 -        )		
```