### PR TITLE
fix: Stop writing entire Team objects into audit log records

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -216,7 +216,7 @@ class OrganizationMember(Model):
                         organizationmember=self,
                         is_active=True,
                     ).values_list('team', flat=True)
-                )
+                ).values_list('id', flat=True)
             ),
             'has_global_access':
             self.has_global_access,


### PR DESCRIPTION
This was introduced in a80a1925de7ee63e5e8949f0b1adde75ffd41a85 and not
intended to be fully pickled Team objects. The code prior to that commit
was just storing ids.