### PR TITLE
feat: Symbolication of minidump events

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -38,7 +38,7 @@ class EventAppleCrashReportEndpoint(Endpoint):
 
         Event.objects.bind_nodes([event], 'data')
 
-        if event.platform != 'cocoa':
+        if event.platform not in ('cocoa', 'native'):
             return HttpResponse(
                 {
                     'message': 'Only cocoa events can return an apple crash report',

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -32,7 +32,8 @@ SIM_PATH = '/Developer/CoreSimulator/Devices/'
 SIM_APP_PATH = '/Containers/Bundle/Application/'
 MAC_OS_PATH = '.app/Contents/'
 
-_internal_function_re = re.compile(r'(kscm_|kscrash_|KSCrash |SentryClient |RNSentry )')
+_internal_function_re = re.compile(
+    r'(kscm_|kscrash_|KSCrash |SentryClient |RNSentry )')
 
 KNOWN_GARBAGE_SYMBOLS = set([
     '_mh_execute_header',
@@ -105,7 +106,7 @@ class Symbolizer(object):
     """
 
     def __init__(self, project, object_lookup, referenced_images,
-                 arch=None, on_dsym_file_referenced=None):
+                 on_dsym_file_referenced=None):
         if not isinstance(object_lookup, ObjectLookup):
             object_lookup = ObjectLookup(object_lookup)
         self.object_lookup = object_lookup
@@ -113,8 +114,6 @@ class Symbolizer(object):
         self.symcaches = ProjectDSymFile.dsymcache.get_symcaches(
             project, referenced_images,
             on_dsym_file_referenced=on_dsym_file_referenced)
-
-        self.arch = arch
 
     def _process_frame(self, sym, obj, package=None, addr_off=0):
         frame = {
@@ -142,7 +141,8 @@ class Symbolizer(object):
         fn = obj.name
         if not fn:
             return False
-        is_mac_platform = (sdk_info is not None and sdk_info['sdk_name'].lower() == 'macos')
+        is_mac_platform = (
+            sdk_info is not None and sdk_info['sdk_name'].lower() == 'macos')
         if not (
             fn.startswith(APP_BUNDLE_PATHS) or (SIM_PATH in fn and SIM_APP_PATH in fn) or
             (is_mac_platform and MAC_OS_PATH in fn)
@@ -222,7 +222,8 @@ class Symbolizer(object):
             # errors.
             if self._is_optional_dsym(obj, sdk_info=sdk_info):
                 return []
-            raise SymbolicationFailed(type=EventError.NATIVE_MISSING_SYMBOL, obj=obj)
+            raise SymbolicationFailed(
+                type=EventError.NATIVE_MISSING_SYMBOL, obj=obj)
         return [self._process_frame(s, obj, addr_off=obj.addr) for s in reversed(rv)]
 
     def _convert_symbolserver_match(self, instruction_addr, symbolserver_match, obj):
@@ -244,13 +245,6 @@ class Symbolizer(object):
         ]
 
     def symbolize_frame(self, instruction_addr, sdk_info=None, symbolserver_match=None):
-        # If we do not have a CPU name we fail.  We currently only support
-        # a single cpu architecture.
-        if self.arch is None:
-            raise SymbolicationFailed(
-                type=EventError.NATIVE_INTERNAL_FAILURE, message='Found multiple architectures.'
-            )
-
         obj = self.object_lookup.find_object(instruction_addr)
         if obj is None:
             raise SymbolicationFailed(type=EventError.NATIVE_UNKNOWN_IMAGE)

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -24,14 +24,19 @@ const RawExceptionContent = React.createClass({
     };
   },
 
+  isNative() {
+    let { platform } = this.props;
+    return platform === 'cocoa' || platform === 'native';
+  },
+
   componentDidMount() {
-    if (this.props.platform == 'cocoa') {
+    if (this.isNative()) {
       this.fetchAppleCrashReport();
     }
   },
 
   componentDidUpdate(prevProps) {
-    if (this.props.platform == 'cocoa' && this.props.type !== prevProps.type) {
+    if (this.isNative() && this.props.type !== prevProps.type) {
       this.fetchAppleCrashReport();
     }
   },
@@ -76,7 +81,7 @@ const RawExceptionContent = React.createClass({
           this.props.platform,
           exc
         );
-      if (this.props.platform == 'cocoa') {
+      if (this.isNative()) {
         if (this.state.loading) content = <LoadingIndicator />;
         else if (this.state.error) content = <LoadingError onRetry={this.fetchData} />;
         else if (!this.state.loading && this.state.crashReport != '') {

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -24,11 +24,6 @@ const RawExceptionContent = React.createClass({
     };
   },
 
-  isNative() {
-    let { platform } = this.props;
-    return platform === 'cocoa' || platform === 'native';
-  },
-
   componentDidMount() {
     if (this.isNative()) {
       this.fetchAppleCrashReport();
@@ -39,6 +34,11 @@ const RawExceptionContent = React.createClass({
     if (this.isNative() && this.props.type !== prevProps.type) {
       this.fetchAppleCrashReport();
     }
+  },
+
+  isNative() {
+    let { platform } = this.props;
+    return platform === 'cocoa' || platform === 'native';
   },
 
   getAppleCrashReportEndpoint() {

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -22,7 +22,8 @@ SWIFT_OBJECT_NAME = (
     "SentryTest.app/Frameworks/libswiftCore.dylib"
 )
 
-SDK_INFO = {"sdk_name": "iOS", "version_major": 9, "version_minor": 3, "version_patchlevel": 0}
+SDK_INFO = {"sdk_name": "iOS", "version_major": 9,
+            "version_minor": 3, "version_patchlevel": 0}
 
 
 def patched_symbolize_app_frame(self, instruction_addr, img, sdk_info=None):
@@ -170,7 +171,8 @@ class BasicResolvingFileTest(TestCase):
         def make_processors(data, infos):
             return [NativeStacktraceProcessor(data, infos)]
 
-        event_data = process_stacktraces(event_data, make_processors=make_processors)
+        event_data = process_stacktraces(
+            event_data, make_processors=make_processors)
 
         bt = event_data['sentry.interfaces.Exception']['values'][0]['stacktrace']
         frames = bt['frames']
@@ -240,7 +242,6 @@ class BasicInAppTest(TestCase):
                     '2DA67FF5-2643-44D6-8FFF-1B6BC78C9912',
                 ]
             ),
-            arch='arm64'
         )
 
         assert sym.is_in_app(4295121764)


### PR DESCRIPTION
This is a followup on #6416 and enables frame symbolication without changing much of the current pipeline. CFI stackwalking is still missing, but the scanned stacktraces have sufficient quality.

See comments below for a couple of quirks.

**NOTE**: Since I changed some of the code determining final frames, we might regress with grouping somewhere.

<img width="947" alt="screen shot 2017-10-25 at 15 59 30" src="https://user-images.githubusercontent.com/1433023/32004780-e07cdfe6-b9a2-11e7-9f5e-eda139e3bd94.png">
