### PR TITLE
ref(metrics): Add flag to skip internal metrics logging

### DIFF
--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -83,9 +83,9 @@ class InternalMetrics(object):
 internal = InternalMetrics()
 
 
-def incr(key, amount=1, instance=None, tags=None):
+def incr(key, amount=1, instance=None, tags=None, skip_internal=False):
     sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-    if _should_sample():
+    if not skip_internal and _should_sample():
         internal.incr(key, instance, tags, amount)
     try:
         backend.incr(key, instance, tags, amount, sample_rate)


### PR DESCRIPTION
Lots of metrics that we add lately trying to measure performance and
whatnot are pretty overkill for hammering into tsdb. This provides an
opt-in flag that we can toggle to stop that behavior.