### PR TITLE
fix: Remove tag management page form, drop unused caching, fix None check

### DIFF
--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -10,7 +10,7 @@ from sentry.api.bases.project import ProjectEndpoint
 
 class ProjectTagsEndpoint(ProjectEndpoint):
     def get(self, request, project):
-        tag_keys = tagstore.get_tag_keys(project.id)
+        tag_keys = sorted(tagstore.get_tag_keys(project.id), key=lambda x: x.key)
 
         data = []
         for tag_key in tag_keys:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -190,17 +190,6 @@ class Project(Model):
                 return True
         return False
 
-    def get_tags(self):
-        from sentry import tagstore
-
-        if not hasattr(self, '_tag_cache'):
-            tags = self.get_option('tags', None)
-            if tags is None:
-                tags = [t for t in (tk.key for tk in tagstore.get_tag_keys(self.id))]
-            self._tag_cache = tags
-
-        return self._tag_cache
-
     # TODO: Make these a mixin
     def update_option(self, *args, **kwargs):
         from sentry.models import ProjectOption

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -139,7 +139,7 @@ class LegacyTagStorage(TagStorage):
         if status:
             qs = qs.filter(status=status)
 
-        return list(qs.order_by('key'))
+        return list(qs)
 
     def get_tag_value(self, project_id, key, value):
         from sentry.tagstore.exceptions import TagValueNotFound

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -139,6 +139,9 @@ class LegacyTagStorage(TagStorage):
         if status is not None:
             qs = qs.filter(status=status)
 
+        if keys is not None:
+            qs = qs.filter(key__in=keys)
+
         return list(qs)
 
     def get_tag_value(self, project_id, key, value):

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -122,7 +122,7 @@ class LegacyTagStorage(TagStorage):
             key=key,
         )
 
-        if status:
+        if status is not None:
             qs = qs.filter(status=status)
 
         try:
@@ -136,7 +136,7 @@ class LegacyTagStorage(TagStorage):
         else:
             qs = TagKey.objects.filter(project_id__in=project_ids)
 
-        if status:
+        if status is not None:
             qs = qs.filter(status=status)
 
         return list(qs)

--- a/src/sentry/templates/sentry/projects/manage_tags.html
+++ b/src/sentry/templates/sentry/projects/manage_tags.html
@@ -12,41 +12,35 @@
   {% if tag_list %}
     <p>{% blocktrans with link='https://docs.sentry.io/hosted/learn/context/' %}Each event in Sentry may be annotated with various tags (key and value pairs). Learn how to <a href="{{ link }}">add custom tags</a>.{% endblocktrans %}</p>
 
-    <form action="" method="post">
-      {% csrf_token %}
-      {{ form|as_crispy_errors }}
-
-      <div class="panel panel-default">
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Tags</th>
-              <th style="width:20px">&nbsp;</th>
+    <div class="panel panel-default">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Tags</th>
+            <th style="width:20px">&nbsp;</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for tag in tag_list %}
+            <tr data-tagkey="{{ tag.key }}">
+              <td>
+                <h5 style="margin-bottom: 10px;">{{ tag.get_label }} <small>({{ tag.key }})</small></h5>
+              </td>
+              <td>
+              {% comment %}
+                Make sure this onclick is wrapped in single quotes
+                and not double quotes becuase the value is being
+                JSON encoded and can't put double quotes within
+                double quotes.
+              {% endcomment %}
+                <a class="btn btn-sm btn-default" href="javascript:void(0)"
+                    onclick='removeTagKey({{ tag.key|to_json }})'><span class="icon icon-trash"></span></a>
+              </td>
             </tr>
-          </thead>
-          <tbody>
-            {% for tag in tag_list %}
-              <tr data-tagkey="{{ tag.key }}">
-                <td>
-                  <h5 style="margin-bottom: 10px;">{{ tag.get_label }} <small>({{ tag.key }})</small></h5>
-                </td>
-                <td>
-                {% comment %}
-                  Make sure this onclick is wrapped in single quotes
-                  and not double quotes becuase the value is being
-                  JSON encoded and can't put double quotes within
-                  double quotes.
-                {% endcomment %}
-                  <a class="btn btn-sm btn-default" href="javascript:void(0)"
-                     onclick='removeTagKey({{ tag.key|to_json }})'><span class="icon icon-trash"></span></a>
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      <button type="submit" name="op" value="save" class="btn btn-primary">{% trans "Save Changes" %}</button>
-    </form>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   {% else %}
     <p>{% trans "We have not yet recorded any tags for this project." %}</p>
   {% endif %}

--- a/src/sentry/web/frontend/project_tags.py
+++ b/src/sentry/web/frontend/project_tags.py
@@ -6,7 +6,7 @@ from sentry.web.frontend.base import ProjectView
 
 class ProjectTagsView(ProjectView):
     def get(self, request, organization, team, project):
-        tag_list = tagstore.get_tag_keys(project.id)
+        tag_list = sorted(tagstore.get_tag_keys(project.id), key=lambda x: x.key)
 
         context = {
             'tag_list': tag_list,

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -60,4 +60,8 @@ class ProjectTagKeyDeleteTest(APITestCase):
 
         mock_delete_tag_key.delay.assert_called_once_with(object_id=tagkey.id)
 
-        assert tagstore.get_tag_key(project.id, tagkey.key).status == TagKeyStatus.PENDING_DELETION
+        assert tagstore.get_tag_key(
+            project.id,
+            tagkey.key,
+            status=TagKeyStatus.PENDING_DELETION
+        ).status == TagKeyStatus.PENDING_DELETION


### PR DESCRIPTION
Fixes GH-6428

1. Fix broken falsey check on status (I forgot Python)
2. Removes old unused form on tag management page (must have been used for editing labels in the past).
3. Remove TagKey caching which was originally used in two places (before tagstore) which have been removed (as of #6433). Originally from: https://github.com/getsentry/sentry/blob/83a8334cae44b448a14e582be0365f04527b2f2c/src/sentry/models/tagkey.py#L40-L52


