### PR TITLE
fix: Correct 'try again' link on recovery failure page

### DIFF
--- a/src/sentry/templates/sentry/account/recover/failure.html
+++ b/src/sentry/templates/sentry/account/recover/failure.html
@@ -7,6 +7,6 @@
 
 {% block auth_main %}
 	<h2>{% trans "Recover Account" %}</h2>
-	{% url 'sentry-recover-account' as link %}
+	{% url 'sentry-account-recover' as link %}
 	<p>{% blocktrans %}We were unable to confirm your identity. Either the link you followed is invalid, or it has expired. You can always <a href="{{ link }}">try again</a>.{% endblocktrans %}</p>
 {% endblock %}


### PR DESCRIPTION
The reverse name was incorrect.

https://github.com/getsentry/sentry/blob/9849b2a43dc00a94a11124ea420e269513b89ae6/src/sentry/web/urls.py#L194