### PR TITLE
feat(api): Add "invite link" and "teams" to members details

### DIFF
--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -1,16 +1,18 @@
 from __future__ import absolute_import
 
 import six
+from collections import defaultdict
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.models import OrganizationMember
+from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 
 
 @register(OrganizationMember)
 class OrganizationMemberSerializer(Serializer):
     def get_attrs(self, item_list, user):
         # TODO(dcramer): assert on relations
-        users = {d['id']: d for d in serialize(set(i.user for i in item_list if i.user_id), user)}
+        users = {d['id']: d for d in serialize(
+            set(i.user for i in item_list if i.user_id), user)}
 
         return {
             item: {
@@ -33,4 +35,42 @@ class OrganizationMemberSerializer(Serializer):
             },
             'dateCreated': obj.date_added,
         }
+        return d
+
+
+class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
+    def get_attrs(self, item_list, user):
+        attrs = super(OrganizationMemberWithTeamsSerializer,
+                      self).get_attrs(item_list, user)
+
+        member_team_map = list(OrganizationMemberTeam.objects.filter(
+            organizationmember__in=item_list).values(
+            'organizationmember_id', 'team_id'))
+
+        teams = {team.id: team for team in Team.objects.filter(
+            id__in=[item['team_id'] for item in member_team_map])}
+        results = defaultdict(list)
+
+        # results is a map of member id -> team_slug[]
+        for m in member_team_map:
+            results[m['organizationmember_id']].append(
+                teams[m['team_id']].slug)
+
+        for item in item_list:
+            teams = results.get(item.id, [])
+            try:
+                attrs[item]['teams'] = teams
+            except KeyError:
+                attrs[item] = {
+                    'teams': teams
+                }
+
+        return attrs
+
+    def serialize(self, obj, attrs, user):
+        d = super(OrganizationMemberWithTeamsSerializer,
+                  self).serialize(obj, attrs, user)
+
+        d['teams'] = attrs.get('teams', [])
+
         return d

--- a/src/sentry/api/serializers/models/role.py
+++ b/src/sentry/api/serializers/models/role.py
@@ -7,10 +7,13 @@ from sentry.api.serializers import Serializer
 class RoleSerializer(Serializer):
 
     def serialize(self, obj, attrs, *args, **kwargs):
+        allowed_roles = kwargs.get('allowed_roles') or []
+
         return {
             'id': six.text_type(obj.id),
             'name': obj.name,
             'desc': obj.desc,
             'scopes': obj.scopes,
             'is_global': obj.is_global,
+            'allowed': obj in allowed_roles
         }

--- a/src/sentry/static/sentry/app/views/inviteMember/inviteMember.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/inviteMember.jsx
@@ -39,10 +39,10 @@ const InviteMember = React.createClass({
     let {slug} = this.getOrganization();
     this.api.request(`/organizations/${slug}/members/me/`, {
       method: 'GET',
-      success: ({allowed_roles}) => {
-        this.setState({roleList: allowed_roles, loading: false});
-        if (allowed_roles.filter(({_, allowed}) => allowed).length === 0) {
-          //not allowed to invite, redirect
+      success: ({roles}) => {
+        this.setState({roleList: roles, loading: false});
+        if (!roles || roles.filter(({allowed}) => allowed).length === 0) {
+          // not allowed to invite, redirect
           this.redirectToMemberPage();
         }
       },

--- a/src/sentry/static/sentry/app/views/inviteMember/roleSelect.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/roleSelect.jsx
@@ -22,8 +22,8 @@ const RoleSelect = React.createClass({
         </div>
         <div className="box-content with-padding">
           <ul className="radio-inputs">
-            {roleList.map(({role, allowed}, i) => {
-              let {desc, name, id} = role;
+            {roleList.map((role, i) => {
+              let {desc, name, id, allowed} = role;
               return (
                 <li
                   className="radio"

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -73,19 +73,15 @@ exports[`CreateProject render() should render roles when available and allowed, 
           Array [
             Object {
               "allowed": true,
-              "role": Object {
-                "desc": "a normal member",
-                "id": "1",
-                "name": "member",
-              },
+              "desc": "a normal member",
+              "id": "1",
+              "name": "member",
             },
             Object {
               "allowed": true,
-              "role": Object {
-                "desc": "another role",
-                "id": "2",
-                "name": "bar",
-              },
+              "desc": "another role",
+              "id": "2",
+              "name": "bar",
             },
           ]
         }

--- a/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
+++ b/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
@@ -55,13 +55,11 @@ describe('CreateProject', function() {
       Client.addMockResponse({
         url: '/organizations/testOrg/members/me/',
         body: {
-          allowed_roles: [
+          roles: [
             {
-              role: {
-                id: '1',
-                name: 'member',
-                desc: 'a normal member',
-              },
+              id: '1',
+              name: 'member',
+              desc: 'a normal member',
               allowed: true,
             },
           ],
@@ -96,13 +94,11 @@ describe('CreateProject', function() {
       Client.addMockResponse({
         url: '/organizations/testOrg/members/me/',
         body: {
-          allowed_roles: [
+          roles: [
             {
-              role: {
-                id: '1',
-                name: 'member',
-                desc: 'a normal member',
-              },
+              id: '1',
+              name: 'member',
+              desc: 'a normal member',
               allowed: false,
             },
           ],
@@ -128,15 +124,9 @@ describe('CreateProject', function() {
       Client.addMockResponse({
         url: '/organizations/testOrg/members/me/',
         body: {
-          allowed_roles: [
-            {
-              role: {id: '1', name: 'member', desc: 'a normal member'},
-              allowed: true,
-            },
-            {
-              role: {id: '2', name: 'bar', desc: 'another role'},
-              allowed: true,
-            },
+          roles: [
+            {id: '1', name: 'member', desc: 'a normal member', allowed: true},
+            {id: '2', name: 'bar', desc: 'another role', allowed: true},
           ],
         },
       });

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -4,7 +4,8 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from mock import patch
 
-from sentry.models import (AuthProvider, OrganizationMember)
+from sentry.models import (
+    AuthProvider, OrganizationMember, OrganizationMemberTeam)
 from sentry.testutils import APITestCase
 
 
@@ -28,8 +29,66 @@ class UpdateOrganizationMemberTest(APITestCase):
 
         resp = self.client.put(path, data={'reinvite': 1})
 
-        assert resp.status_code == 204
+        assert resp.status_code == 200
         mock_send_invite_email.assert_called_once_with()
+
+    @patch('sentry.models.OrganizationMember.send_invite_email')
+    def test_member_no_regenerate_invite_pending_member(self, mock_send_invite_email):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+        member_om = self.create_member(
+            organization=organization,
+            email='foo@example.com',
+            role='member',
+        )
+        old_invite = member_om.get_invite_link()
+
+        member = self.create_user('baz@example.com')
+        self.create_member(
+            organization=organization,
+            user=member,
+            role='member',
+        )
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
+        )
+
+        self.login_as(member)
+
+        resp = self.client.put(path, data={'reinvite': 1, 'regenerate': 1})
+
+        assert resp.status_code == 403
+        member_om = OrganizationMember.objects.get(id=member_om.id)
+        assert old_invite == member_om.get_invite_link()
+        assert not mock_send_invite_email.mock_calls
+
+    @patch('sentry.models.OrganizationMember.send_invite_email')
+    def test_regenerate_invite_pending_member(self, mock_send_invite_email):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+        member_om = self.create_member(
+            organization=organization,
+            email='foo@example.com',
+            role='member',
+        )
+        old_invite = member_om.get_invite_link()
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
+        )
+
+        self.login_as(self.user)
+
+        resp = self.client.put(path, data={'reinvite': 1, 'regenerate': 1})
+
+        assert resp.status_code == 200
+        member_om = OrganizationMember.objects.get(id=member_om.id)
+        assert old_invite != member_om.get_invite_link()
+        mock_send_invite_email.assert_called_once_with()
+        assert resp.data['invite_link'] == member_om.get_invite_link()
 
     def test_reinvite_sso_link(self):
         self.login_as(user=self.user)
@@ -56,8 +115,206 @@ class UpdateOrganizationMemberTest(APITestCase):
         with self.tasks():
             resp = self.client.put(path, data={'reinvite': 1})
 
-        assert resp.status_code == 204
+        assert resp.status_code == 200
         assert len(mail.outbox) == 1
+
+    # Normal users can not see invite link
+    def test_get_member_invite_link_for_admin(self):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+
+        # User that will be pending
+        pending_member_om = self.create_member(
+            user=None,
+            email='bar@example.com',
+            organization=organization,
+            role='member',
+            teams=[],
+        )
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, pending_member_om.id]
+        )
+
+        self.login_as(self.user)
+
+        resp = self.client.get(path)
+
+        assert resp.status_code == 200
+        assert resp.data['invite_link'] != ''
+
+    # Normal users can not see invite link
+    def test_get_member_no_invite_link(self):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+
+        # User that will be pending
+        pending_member_om = self.create_member(
+            user=None,
+            email='bar@example.com',
+            organization=organization,
+            role='member',
+            teams=[],
+        )
+
+        member = self.create_user('baz@example.com')
+        self.create_member(
+            organization=organization,
+            user=member,
+            role='member',
+        )
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, pending_member_om.id]
+        )
+
+        self.login_as(member)
+
+        resp = self.client.get(path)
+
+        assert resp.status_code == 200
+        assert 'invite_link' not in resp.data
+
+    def test_get_member_list_teams(self):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+        team = self.create_team(organization=organization, name='Team')
+
+        member = self.create_user('baz@example.com')
+        member_om = self.create_member(
+            organization=organization,
+            user=member,
+            role='member',
+            teams=[team]
+        )
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
+        )
+
+        self.login_as(self.user)
+
+        resp = self.client.get(path)
+
+        assert resp.status_code == 200
+        assert team.slug in resp.data['teams']
+
+    def test_can_update_teams(self):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+        foo = self.create_team(organization=organization, name='Team Foo')
+        bar = self.create_team(organization=organization, name='Team Bar')
+
+        member = self.create_user('baz@example.com')
+        member_om = self.create_member(
+            organization=organization,
+            user=member,
+            role='member',
+            teams=[]
+        )
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
+        )
+
+        self.login_as(self.user)
+
+        resp = self.client.put(path, data={
+            'teams': [foo.slug, bar.slug]
+        })
+        assert resp.status_code == 200
+
+        member_teams = OrganizationMemberTeam.objects.filter(
+            organizationmember=member_om)
+        team_ids = map(lambda x: x.team_id, member_teams)
+        assert foo.id in team_ids
+        assert bar.id in team_ids
+
+        member_om = OrganizationMember.objects.get(id=member_om.id)
+
+        teams = map(lambda team: team.slug, member_om.teams.all())
+        assert foo.slug in teams
+        assert bar.slug in teams
+
+    def test_can_not_update_with_invalid_team(self):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+
+        member = self.create_user('baz@example.com')
+        member_om = self.create_member(
+            organization=organization,
+            user=member,
+            role='member',
+            teams=[]
+        )
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
+        )
+
+        self.login_as(self.user)
+
+        resp = self.client.put(path, data={
+            'teams': ['invalid-team']
+        })
+        assert resp.status_code == 400
+
+        member_om = OrganizationMember.objects.get(id=member_om.id)
+        teams = map(lambda team: team.slug, member_om.teams.all())
+        assert len(teams) == 0
+
+    def test_can_update_role(self):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+        member = self.create_user('baz@example.com')
+        member_om = self.create_member(
+            organization=organization,
+            user=member,
+            role='member',
+            teams=[]
+        )
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
+        )
+
+        self.login_as(self.user)
+
+        resp = self.client.put(path, data={'role': 'admin'})
+        assert resp.status_code == 200
+
+        member_om = OrganizationMember.objects.get(
+            organization=organization, user=member)
+        assert member_om.role == 'admin'
+
+    def test_can_not_update_with_invalid_role(self):
+        self.login_as(user=self.user)
+
+        organization = self.create_organization(name='foo', owner=self.user)
+        member = self.create_user('baz@example.com')
+        member_om = self.create_member(
+            organization=organization,
+            user=member,
+            role='member',
+            teams=[]
+        )
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
+        )
+
+        self.login_as(self.user)
+
+        resp = self.client.put(path, data={'role': 'invalid-role'})
+        assert resp.status_code == 400
+        member_om = OrganizationMember.objects.get(
+            organization=organization, user=member)
+        assert member_om.role == 'member'
 
     @patch('sentry.models.OrganizationMember.send_sso_link_email')
     def test_cannot_reinvite_normal_member(self, mock_send_sso_link_email):
@@ -179,7 +436,8 @@ class DeleteOrganizationMemberTest(APITestCase):
             user=other_user,
         )
 
-        path = reverse('sentry-api-0-organization-member-details', args=[organization.slug, 'me'])
+        path = reverse('sentry-api-0-organization-member-details',
+                       args=[organization.slug, 'me'])
 
         self.login_as(other_user)
 


### PR DESCRIPTION
* Returns invite link for `member:admin`
* Returns list of teams member belongs to
* Allow `member:admin` to regenerate invite codes for pending members
* Change `PUT` member details to accept role/teams and update -- responds with updated `member`