### PR TITLE
fix(slack): str.format misuse

### DIFF
--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -41,7 +41,7 @@ class SlackEventEndpoint(Endpoint):
 
     def _attachment_for(self, group):
         return {
-            'fallback': '[{}] {}'.format(group.project.slug, group.title),
+            'fallback': u'[{}] {}'.format(group.project.slug, group.title),
             'title': group.title,
             'title_link': self._add_notification_referrer_param(group.get_absolute_url()),
         }


### PR DESCRIPTION
Fixes SENTRY-51F

(fwiw this is at least the 10th bug I've fixed by changing `str.format` -> `unicode.format`, would love if we stopped doing this and always used `unicode.format` or had a lint rule to enforce it. I think we almost never want str.format and is always an oversight. Also `%` formatting is still great and handles all of these cases gracefully by just upgrading to unicode when needed.)