### PR TITLE
lint: Disallow str.format and require unicode.format

### DIFF
--- a/src/sentry/lint/sentry_check.py
+++ b/src/sentry/lint/sentry_check.py
@@ -78,6 +78,9 @@ class SentryVisitor(ast.NodeVisitor):
 
     def visit_Call(self, node):
         if isinstance(node.func, ast.Attribute):
+            if node.func.attr == B315.method and isinstance(
+                    node.func.value, ast.Str) and isinstance(node.func.value.s, bytes):
+                self.errors.append(B315(node.lineno, node.col_offset))
             for bug in (B301, B302, B305):
                 if node.func.attr in bug.methods:
                     call_path = '.'.join(self.compose_call_path(node.func.value))
@@ -106,7 +109,7 @@ class SentryVisitor(ast.NodeVisitor):
         if node.attr in B101.methods:
             self.errors.append(
                 B101(
-                    message="B101: Avoid using the {} mock call as it is "
+                    message=u"B101: Avoid using the {} mock call as it is "
                     "confusing and prone to causing invalid test "
                     "behavior.".format(node.attr),
                     lineno=node.lineno,
@@ -351,3 +354,10 @@ B314 = partial(
     message="B314: print functions or statements are not allowed.",
     type=SentryCheck,
 )
+
+B315 = partial(
+    error,
+    message="B315: use unicode.format instead of str.format.",
+    type=SentryCheck,
+)
+B315.method = 'format'


### PR DESCRIPTION
Hopefully this catches a whole class of bugs related to unintentionally
using str.format. I feel strongly that if you want to actually format
into a byte string, you can just use `unicode.format()` then `encode`
back to bytes. It's also worth noting that in python3, `bytes.format`
doesn't even exist, and only allows `str.format`.

Note that this isn't perfect because of python being a dynamic typed language. It won't detect a case such as:

```python
a = '{}'
a.format('something')
```

since it's nontrivial to determine what type `a` is. At AST time, you only get a Name node with an id. In theory, this can probably be walked to figure out wtf it is, but probably not worth the effort. This covers any case of `'{}'.format(thing)` when using a literal.

This can also be `# noqa`'d out of. But it's worth mentioning that this behavior then is not python2/3 compatible since if you do explicitly want bytes, python3 will yell since `bytes.format` doesn't exist.