### PR TITLE
ref: Be consistent about h3 usage

### DIFF
--- a/src/sentry/templates/sentry/account/recover/confirm.html
+++ b/src/sentry/templates/sentry/account/recover/confirm.html
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Recover Account" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
-    <h2>{% trans "Recover Account" %}</h2>
+    <h3>{% trans "Recover Account" %}</h3>
 
     <p>{% trans "You have confirmed your email, and may now update your password below." %}</p>
     <form method="POST" action="">

--- a/src/sentry/templates/sentry/account/recover/expired.html
+++ b/src/sentry/templates/sentry/account/recover/expired.html
@@ -7,7 +7,7 @@
 
 {% block auth_main %}
 
-  <h2>{% trans "Password Expired" %}</h2>
+  <h3>{% trans "Password Expired" %}</h3>
   <p>{% blocktrans %}The password on your account expired.{% endblocktrans %}</p>
 
 	<p>{% blocktrans %}We have sent an email to the address registered with this account containing further instructions to reset your password.{% endblocktrans %}</p>

--- a/src/sentry/templates/sentry/account/recover/failure.html
+++ b/src/sentry/templates/sentry/account/recover/failure.html
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Recover Account" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
-	<h2>{% trans "Recover Account" %}</h2>
+	<h3>{% trans "Recover Account" %}</h3>
 	{% url 'sentry-account-recover' as link %}
 	<p>{% blocktrans %}We were unable to confirm your identity. Either the link you followed is invalid, or it has expired. You can always <a href="{{ link }}">try again</a>.{% endblocktrans %}</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/account/recover/index.html
+++ b/src/sentry/templates/sentry/account/recover/index.html
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Recover Account" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
-  <h3>{% trans "Recover Account" %}</h2>
+  <h3>{% trans "Recover Account" %}</h3>
   <p>{% blocktrans %}We will send a confirmation email to this address:{% endblocktrans %}</p>
 
   <form class="form-stacked" action="" method="post">

--- a/src/sentry/templates/sentry/account/recover/sent.html
+++ b/src/sentry/templates/sentry/account/recover/sent.html
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Recover Account" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
-	<h2>{% trans "Recover Account" %}</h2>
+	<h3>{% trans "Recover Account" %}</h3>
 
 	<p>{% blocktrans %}We have sent an email to the address registered with this account containing further instructions to reset your password.{% endblocktrans %}</p>
 {% endblock %}


### PR DESCRIPTION
There was really only one heading that incorrectly closed a h3 with a h2, but h3 seems to fit a little better as it's not overly bulky on these templates.