### PR TITLE
fix(grouping): Make Stacktrace interface `is_url` check more restrictive

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -140,8 +140,11 @@ def is_newest_frame_first(event):
     return newest_first
 
 
+scheme_prefix_re = re.compile('^([a-z]+[a-z+-\.]*)://', re.IGNORECASE)
+
+
 def is_url(filename):
-    return filename.startswith(('file:', 'http:', 'https:'))
+    return scheme_prefix_re.match(filename) is not None
 
 
 def remove_function_outliers(function):

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -140,6 +140,8 @@ def is_newest_frame_first(event):
     return newest_first
 
 
+# Matches a URL prefixed with a scheme and authority component as defined in
+# RFC 3986, Sec. 3.1: https://tools.ietf.org/html/rfc3986#section-3.1
 scheme_prefix_re = re.compile('^([a-z]+[a-z+-\.]*)://', re.IGNORECASE)
 
 

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -9,9 +9,17 @@ from django.template.loader import render_to_string
 from exam import fixture
 
 from sentry.interfaces.base import InterfaceValidationError
-from sentry.interfaces.stacktrace import (Frame, Stacktrace, get_context, slim_frame_data)
+from sentry.interfaces.stacktrace import (Frame, Stacktrace, get_context, slim_frame_data, is_url)
 from sentry.models import Event
 from sentry.testutils import TestCase
+
+
+def test_is_url():
+    assert is_url('http://example.org/') is True
+    assert is_url('https://example.org/') is True
+    assert is_url('file:///tmp/filename') is True
+    assert is_url('applewebdata://00000000-0000-1000-8080-808080808080') is True
+    assert is_url('data:,') is False  # no authority
 
 
 class GetContextTest(TestCase):


### PR DESCRIPTION
This updates the `Stacktrace` interface's `is_url` method (and associated helper method) to return `True` for any URL that begins with a URL scheme as defined by [RFC 3986, Section 3.1](https://www.ietf.org/rfc/rfc3986.txt).

This does not account for:

1. protocol relative URLs (empty scheme),
2. URLs that do not have an "authority" component (incl. `mailto:`, `data:`, etc.),
3. other strings that are not syntactically valid URLs that coincidentally begin with a sequence of bytes that are in the form of a valid URL scheme,
4. bikeshed conversations about the distinction between a URI, a URL, and a URN.