### PR TITLE
Add more guided SSO unlink flow for org users

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -18,6 +18,7 @@ from django.utils.encoding import force_bytes
 from hashlib import md5
 from structlog import get_logger
 from uuid import uuid4
+from six.moves.urllib.parse import urlencode
 
 from sentry import roles
 from sentry.db.models import (
@@ -174,6 +175,39 @@ class OrganizationMember(Model):
             context=context,
         )
         msg.send_async([self.get_email()])
+
+    def send_sso_unlink_email(self, disabler, provider):
+        from sentry.utils.email import MessageBuilder
+        from sentry.models import LostPasswordHash
+
+        email = self.get_email()
+
+        recover_uri = '{path}?{query}'.format(
+            path=reverse('sentry-account-recover'),
+            query=urlencode({'email': email}),
+        )
+
+        context = {
+            'email': email,
+            'recover_url': absolute_uri(recover_uri),
+            'has_password': self.user.password,
+            'organization': self.organization,
+            'disabler': disabler,
+            'provider': provider,
+        }
+
+        if not self.user.password:
+            password_hash = LostPasswordHash.for_user(self.user)
+            context['set_password_url'] = password_hash.get_absolute_url(mode='set_password')
+
+        msg = MessageBuilder(
+            subject='Action Required for %s' % (self.organization.name, ),
+            template='sentry/emails/auth-sso-disabled.txt',
+            html_template='sentry/emails/auth-sso-disabled.html',
+            type='organization.auth_sso_disabled',
+            context=context,
+        )
+        msg.send_async([email])
 
     def get_display_name(self):
         if self.user_id:

--- a/src/sentry/templates/sentry/account/set_password/confirm.html
+++ b/src/sentry/templates/sentry/account/set_password/confirm.html
@@ -1,0 +1,24 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Set Password" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+    <h3>{% trans "Set Password" %}</h3>
+
+    <p>{% trans "Set your account password below." %}</p>
+    <form method="POST" action="">
+        {% csrf_token %}
+        {{ form|as_crispy_errors }}
+
+        {% for field in form %}
+        	{{ field|as_crispy_field }}
+        {% endfor %}
+
+        <fieldset class="form-actions">
+            <button type="submit" class="btn btn-primary">{% trans "Set Password" %}</button>
+        </fieldset>
+    </form>
+{% endblock %}

--- a/src/sentry/templates/sentry/account/set_password/failure.html
+++ b/src/sentry/templates/sentry/account/set_password/failure.html
@@ -1,0 +1,14 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Set Password" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+	<h3>{% trans "Set Password" %}</h3>
+	<p>{% blocktrans %}This password link has expired. Request a new password recovery code to set
+	your account password{% endblocktrans %}</p>
+
+	<p><a href="{% url 'sentry-account-recover' %}" class="btn btn-primary">Request Reset Code</a></p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/auth-sso-disabled.html
+++ b/src/sentry/templates/sentry/emails/auth-sso-disabled.html
@@ -1,0 +1,28 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+  <h3>Single Sign-On disabled</h3>
+
+  <p>
+    <strong>{{ provider.name }}</strong> Single Sign-On has been disabled for the
+    <strong>{{ organization.name }}</strong> organization.
+  </p>
+
+  {% if has_password %}
+    <p>
+      You can now login using your email <strong>{{ email }}</strong>, and password. If you forgot
+      your password you can always <a href="{{ recover_url }}">reset it</a>.
+    </p>
+  {% else %}
+    <p>
+      You can now login using your email <strong>{{ email }}</strong>, however you'll first have to
+      set a password for your account.
+    </p>
+
+    <p><a href="{{ set_password_url }}" class="btn">Set your password</a></p>
+  {% endif %}
+
+  <p><small>SSO was disabled by <strong>{{ disabler.email }}</strong></small></p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/auth-sso-disabled.txt
+++ b/src/sentry/templates/sentry/emails/auth-sso-disabled.txt
@@ -1,0 +1,13 @@
+{{ provider.name }} Single Sign-On has been disabled for the {{ organization_name }} organization.
+
+{% if has_password %}
+You can now login using your email {{ email }}, and password. If you forgot your password you can always reset it by visiting the following url:
+
+{{ recover_url }}
+{% else %}
+You can now login using your email {{ email }}, however you'll first have to set a password for your account by visiting the following url:
+
+{{ set_password_url }}
+{% endif %}
+
+SSO was disabled by {{ disabler.email }}

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -8,6 +8,7 @@ sentry.web.frontend.accounts
 from __future__ import absolute_import
 
 import logging
+from functools import partial, update_wrapper
 
 import six
 
@@ -43,16 +44,6 @@ from sentry.utils import auth
 logger = logging.getLogger('sentry.accounts')
 
 
-def send_password_recovery_mail(request, user):
-    password_hash, created = LostPasswordHash.objects.get_or_create(user=user)
-    if not password_hash.is_valid():
-        password_hash.date_added = timezone.now()
-        password_hash.set_hash()
-        password_hash.save()
-    password_hash.send_recover_mail(request)
-    return password_hash
-
-
 @login_required
 def login_redirect(request):
     login_url = auth.get_login_redirect(request)
@@ -60,12 +51,11 @@ def login_redirect(request):
 
 
 def expired(request, user):
-    password_hash = send_password_recovery_mail(request, user)
-    return render_to_response(
-        'sentry/account/recover/expired.html', {
-            'email': password_hash.user.email,
-        }, request
-    )
+    password_hash = LostPasswordHash.for_user(user)
+    password_hash.send_email(request)
+
+    context = {'email': password_hash.user.email}
+    return render_to_response('sentry/account/recover/expired.html', context, request)
 
 
 def recover(request):
@@ -88,31 +78,40 @@ def recover(request):
         )
         logger.warning('recover.rate-limited', extra=extra)
 
-    form = RecoverPasswordForm(request.POST or None)
+    prefill = {'user': request.GET.get('email')}
+
+    form = RecoverPasswordForm(request.POST or None, initial=prefill)
     extra['user_recovered'] = form.data.get('user')
 
     if form.is_valid():
-        password_hash = send_password_recovery_mail(request, form.cleaned_data['user'])
+        email = form.cleaned_data['user']
+        password_hash = LostPasswordHash.for_user(email)
+        password_hash.send_email(request)
 
         extra['passwordhash_id'] = password_hash.id
         extra['user_id'] = password_hash.user_id
 
         logger.info('recover.sent', extra=extra)
-        return render_to_response(
-            'sentry/account/recover/sent.html', {
-                'email': password_hash.user.email,
-            }, request
-        )
 
-    context = {
-        'form': form,
-    }
+        tpl = 'sentry/account/recover/sent.html'
+        context = {'email': password_hash.user.email}
+
+        return render_to_response(tpl, context, request)
+
     if form._errors:
         logger.warning('recover.error', extra=extra)
-    return render_to_response('sentry/account/recover/index.html', context, request)
+
+    tpl = 'sentry/account/recover/index.html'
+    context = {'form': form}
+
+    return render_to_response(tpl, context, request)
 
 
-def recover_confirm(request, user_id, hash):
+def get_template(name, mode):
+    return 'sentry/account/{}/{}.html'.format(mode, name)
+
+
+def recover_confirm(request, user_id, hash, mode='recover'):
     try:
         password_hash = LostPasswordHash.objects.get(user=user_id, hash=hash)
         if not password_hash.is_valid():
@@ -121,47 +120,48 @@ def recover_confirm(request, user_id, hash):
         user = password_hash.user
 
     except LostPasswordHash.DoesNotExist:
-        context = {}
-        tpl = 'sentry/account/recover/failure.html'
+        tpl = get_template('failure', mode)
+        return render_to_response(tpl, {}, request)
 
+    if request.method == 'POST':
+        form = ChangePasswordRecoverForm(request.POST)
+        if form.is_valid():
+            with transaction.atomic():
+                user.set_password(form.cleaned_data['password'])
+                user.refresh_session_nonce(request)
+                user.save()
+
+                # Ugly way of doing this, but Django requires the backend be set
+                user = authenticate(
+                    username=user.username,
+                    password=form.cleaned_data['password'],
+                )
+
+                login_user(request, user)
+
+                password_hash.delete()
+
+                capture_security_activity(
+                    account=user,
+                    type='password-changed',
+                    actor=request.user,
+                    ip_address=request.META['REMOTE_ADDR'],
+                    send_email=True,
+                )
+
+            return login_redirect(request)
     else:
-        tpl = 'sentry/account/recover/confirm.html'
+        form = ChangePasswordRecoverForm()
 
-        if request.method == 'POST':
-            form = ChangePasswordRecoverForm(request.POST)
-            if form.is_valid():
-                with transaction.atomic():
-                    user.set_password(form.cleaned_data['password'])
-                    user.refresh_session_nonce(request)
-                    user.save()
-
-                    # Ugly way of doing this, but Django requires the backend be set
-                    user = authenticate(
-                        username=user.username,
-                        password=form.cleaned_data['password'],
-                    )
-
-                    login_user(request, user)
-
-                    password_hash.delete()
-
-                    capture_security_activity(
-                        account=user,
-                        type='password-changed',
-                        actor=request.user,
-                        ip_address=request.META['REMOTE_ADDR'],
-                        send_email=True,
-                    )
-
-                return login_redirect(request)
-        else:
-            form = ChangePasswordRecoverForm()
-
-        context = {
-            'form': form,
-        }
+    tpl = get_template('confirm', mode)
+    context = {'form': form}
 
     return render_to_response(tpl, context, request)
+
+
+# Set password variation of password recovery
+set_password_confirm = partial(recover_confirm, mode='set_password')
+set_password_confirm = update_wrapper(set_password_confirm, recover)
 
 
 @login_required

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -12,7 +12,7 @@ from sentry import features, roles
 from sentry.auth import manager
 from sentry.auth.helper import AuthHelper
 from sentry.auth.providers.saml2 import SAML2Provider, HAS_SAML2
-from sentry.models import AuditLogEntryEvent, AuthProvider, OrganizationMember
+from sentry.models import AuditLogEntryEvent, AuthProvider, OrganizationMember, User
 from sentry.plugins import Response
 from sentry.tasks.auth import email_missing_links
 from sentry.utils import db
@@ -72,6 +72,9 @@ class OrganizationAuthSettingsView(OrganizationView):
                     ~getattr(OrganizationMember.flags, 'sso:invalid'),
                 ),
             )
+
+        user_ids = OrganizationMember.objects.filter(organization=organization).values('user')
+        User.objects.filter(id__in=user_ids).update(is_managed=False)
 
         auth_provider.delete()
 

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -197,6 +197,11 @@ urlpatterns += patterns(
         accounts.recover_confirm,
         name='sentry-account-recover-confirm'
     ),
+    url(
+        r'^account/password/confirm/(?P<user_id>[\d]+)/(?P<hash>[0-9a-zA-Z]+)/$',
+        accounts.set_password_confirm,
+        name='sentry-account-set-password-confirm'
+    ),
     url(r'^account/settings/$', accounts.account_settings,
         name='sentry-account-settings'),
     url(

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -65,7 +65,7 @@ class LostPasswordTest(TestCase):
         request.META['REMOTE_ADDR'] = '1.1.1.1'
 
         with self.options({'system.url-prefix': 'http://testserver'}), self.tasks():
-            self.password_hash.send_recover_mail(request)
+            self.password_hash.send_email(request)
 
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]

--- a/tests/sentry/tasks/test_auth.py
+++ b/tests/sentry/tasks/test_auth.py
@@ -4,32 +4,39 @@ from django.core import mail
 
 from sentry.models import AuthProvider, OrganizationMember
 from sentry.testutils import TestCase
-from sentry.tasks.auth import email_missing_links
+from sentry.tasks.auth import email_missing_links, email_unlink_notifications
 
 
 class EmailMissingLinksTest(TestCase):
-    def test_simple(self):
-        user = self.create_user(email='bar@example.com')
-        organization = self.create_organization(owner=user, name='Test')
-        provider = AuthProvider.objects.create(
-            organization=organization,
+    def setUp(self):
+        super(EmailMissingLinksTest, self).setUp()
+        self.user = self.create_user(email='bar@example.com')
+        self.organization = self.create_organization(owner=self.user, name='Test')
+        self.provider = AuthProvider.objects.create(
+            organization=self.organization,
             provider='dummy',
         )
         OrganizationMember.objects.create_or_update(
-            user=user,
-            organization=organization,
-            values={
-                'flags': getattr(OrganizationMember.flags, 'sso:linked'),
-            },
+            user=self.user,
+            organization=self.organization,
+            values={'flags': getattr(OrganizationMember.flags, 'sso:linked')},
         )
-        user2 = self.create_user(email='baz@example.com')
+        self.user2 = self.create_user(email='baz@example.com')
         OrganizationMember.objects.create(
-            user=user2,
-            organization=organization,
+            user=self.user2,
+            organization=self.organization,
             flags=0,
         )
+
+    def test_email_missing_links(self):
         with self.tasks():
-            email_missing_links(organization.id, user.id, provider.provider)
+            email_missing_links(self.organization.id, self.user.id, self.provider.provider)
 
         assert len(mail.outbox) == 1
-        assert mail.outbox[0].to == [user2.email]
+        assert mail.outbox[0].to == [self.user2.email]
+
+    def test_email_unlink_notifications(self):
+        with self.tasks():
+            email_unlink_notifications(self.organization.id, self.user.id, self.provider.provider)
+
+        assert len(mail.outbox) == 2

--- a/tests/sentry/web/frontend/accounts/tests.py
+++ b/tests/sentry/web/frontend/accounts/tests.py
@@ -263,7 +263,7 @@ class RecoverPasswordTest(TestCase):
         assert 'form' in resp.context
         assert 'user' in resp.context['form'].errors
 
-    @mock.patch('sentry.models.LostPasswordHash.send_recover_mail')
+    @mock.patch('sentry.models.LostPasswordHash.send_email')
     def test_valid_username(self, send_recover_mail):
         resp = self.client.post(self.path, {
             'user': self.user.username

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -100,6 +100,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert not getattr(member.flags, 'sso:invalid')
 
     def test_disable_provider(self):
+        self.user.update(is_managed=True)
         organization = self.create_organization(name='foo', owner=self.user)
 
         auth_provider = AuthProvider.objects.create(
@@ -135,3 +136,4 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         om = OrganizationMember.objects.get(id=om.id)
 
         assert not getattr(om.flags, 'sso:linked')
+        assert not om.user.is_managed

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from mock import patch
 
 from sentry.models import AuthIdentity, AuthProvider, OrganizationMember
 from sentry.testutils import AuthProviderTestCase, PermissionTestCase
@@ -99,7 +100,8 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert getattr(member.flags, 'sso:linked')
         assert not getattr(member.flags, 'sso:invalid')
 
-    def test_disable_provider(self):
+    @patch('sentry.web.frontend.organization_auth_settings.email_unlink_notifications')
+    def test_disable_provider(self, email_unlink_notifications):
         self.user.update(is_managed=True)
         organization = self.create_organization(name='foo', owner=self.user)
 
@@ -137,3 +139,5 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
 
         assert not getattr(om.flags, 'sso:linked')
         assert not om.user.is_managed
+
+        assert email_unlink_notifications.delay.called


### PR DESCRIPTION
When disabling SSO on an organization we now do two things

 1. **All** organization member users have their `is_managed` flag set to false. This allows users to set their passwords using the recover account flow.

 2. **All** organization members are notified that SSO has been disabled.

    If the user *has* a password then they will simply be notified that they must now login using their email and password:

    > You can now login using your email user@example.com, and password. If you forgot your password you can always [reset it](#).

    If the user **does not** have a password they will be provided with a link to set their password. This link uses a tailored password recovery flow:

    > You can now login using your email user@example.com, however you'll first have to set a password for your account.

Screenshots:
![localhost_8000_debug_mail_sso-unlinked_ 3](https://user-images.githubusercontent.com/1421724/32196507-248e59e2-bd7e-11e7-8daa-3e678d2a8d8d.png)
![localhost_8000_debug_mail_sso-unlinked_no-password 2](https://user-images.githubusercontent.com/1421724/32196506-247779fc-bd7e-11e7-9cfe-2dac0587efb8.png)
