### PR TITLE
feat(schemas): Model most of event validation as schema

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -15,7 +15,6 @@ import jsonschema
 import logging
 import re
 import six
-import uuid
 import zlib
 
 from collections import MutableMapping
@@ -23,21 +22,15 @@ from datetime import datetime, timedelta
 from django.core.exceptions import SuspiciousOperation
 from django.utils.crypto import constant_time_compare
 from gzip import GzipFile
+from itertools import groupby
 from six import BytesIO
 from time import time
 
-from sentry import filters, tagstore
+from sentry import filters
 from sentry.cache import default_cache
-from sentry.constants import (
-    CLIENT_RESERVED_ATTRS,
-    DEFAULT_LOG_LEVEL,
-    LOG_LEVELS_MAP,
-    MAX_TAG_VALUE_LENGTH,
-    MAX_TAG_KEY_LENGTH,
-    VALID_PLATFORMS,
-)
-from sentry.db.models import BoundedIntegerField
+from sentry.constants import CLIENT_RESERVED_ATTRS, DEFAULT_LOG_LEVEL, LOG_LEVELS_MAP
 from sentry.interfaces.base import get_interface, InterfaceValidationError
+from sentry.interfaces.schemas import STORE_SCHEMA, TAGS_TUPLES_SCHEMA
 from sentry.event_manager import EventManager
 from sentry.models import EventError, ProjectKey
 from sentry.tasks.store import preprocess_event, \
@@ -48,7 +41,7 @@ from sentry.utils.http import origin_from_request
 from sentry.utils.data_filters import is_valid_ip, \
     is_valid_release, is_valid_error_message, FilterStatKeys
 from sentry.utils.strings import decompress
-from sentry.utils.validators import is_float, is_event_id
+from sentry.utils.validators import is_float
 
 try:
     # Attempt to load ujson if it's installed.
@@ -97,10 +90,6 @@ class APIRateLimited(APIError):
 
 
 class InvalidTimestamp(Exception):
-    pass
-
-
-class InvalidFingerprint(Exception):
     pass
 
 
@@ -359,17 +348,6 @@ class ClientApiHelper(object):
 
         return data
 
-    def _process_fingerprint(self, data):
-        if not isinstance(data['fingerprint'], (list, tuple)):
-            raise InvalidFingerprint
-
-        result = []
-        for bit in data['fingerprint']:
-            if not isinstance(bit, six.string_types + six.integer_types + (float, )):
-                raise InvalidFingerprint
-            result.append(six.text_type(bit))
-        return result
-
     def parse_client_as_sdk(self, value):
         if not value:
             return
@@ -412,219 +390,81 @@ class ClientApiHelper(object):
 
         return (False, None)
 
+    def validate_and_default_from_schema(self, data, schema, name=None):
+        errors = []
+
+        # Go through the schema, removing or defaulting any keys
+        # TODO raise any non-keyed errors? (eg disallowed keys)
+        validator = jsonschema.Draft4Validator(schema, types={'array': (list, tuple)})
+        val_errors = validator.iter_errors(data)
+        keyed_errors = reversed([e for e in val_errors if len(e.path)])
+
+        # Values that need to be defaulted or deleted because they are not valid.
+        for key, group in groupby(keyed_errors, lambda e: e.path[0]):
+            ve = six.next(group)
+            errors.append({
+                'type': EventError.VALUE_TOO_LONG if ve.validator.startswith('max') else EventError.INVALID_DATA,
+                'name': name or key,
+                'value': data[key],
+            })
+
+            if 'default' in ve.schema:
+                default = ve.schema['default']
+                data[key] = default() if callable(default) else default
+            else:
+                del data[key]
+                self.log.debug(ve)
+
+        # Values that are missing entirely, but are required and should be defaulted
+        if 'properties' in schema and 'required' in schema:
+            for p in schema['required']:
+                if p not in data and p in schema['properties'] and 'default' in schema['properties'][p]:
+                    default = schema['properties'][p]['default']
+                    data[p] = default() if callable(default) else default
+
+        return errors
+
     def validate_data(self, project, data):
         # TODO(dcramer): move project out of the data packet
         data['project'] = project.id
 
-        data['errors'] = []
+        errors = []
 
-        if data.get('culprit'):
-            if not isinstance(data['culprit'], six.string_types):
-                raise APIForbidden('Invalid value for culprit')
+        # Before validating with a schema, attempt to cast values to their desired types
+        # so that the schema doesn't have to take every type variation into account.
+        text = six.text_type
+        fingerprint_types = six.string_types + six.integer_types + (float, )
+        casts = {
+            'environment': lambda v: text(v),
+            'fingerprint': lambda v: map(text, v) if isinstance(v, list) and all(isinstance(f, fingerprint_types) for f in v) else v,
+            'release': lambda v: six.text_type(v),
+            'dist': lambda v: text(v).strip(),
+            'time_spent': lambda v: int(v),
+            'exception': lambda v: {'values': v} if isinstance(v, (tuple, list)) else v,
+            'breadcrumbs': lambda v: {'values': v} if isinstance(v, (tuple, list)) else v,
+            'tags': lambda v: [(text(v_k.replace(' ', '-')), text(v_v)) for (v_k, v_v) in dict(v).items()],
+            'timestamp': lambda v: self._process_data_timestamp(v),
+        }
 
-        if not data.get('event_id'):
-            data['event_id'] = uuid.uuid4().hex
-        elif not isinstance(data['event_id'], six.string_types):
-            raise APIForbidden('Invalid value for event_id')
-
-        if len(data['event_id']) > 32:
-            self.log.debug(
-                'Discarded value for event_id due to length (%d chars)', len(
-                    data['event_id'])
-            )
-            data['errors'].append(
-                {
-                    'type': EventError.VALUE_TOO_LONG,
-                    'name': 'event_id',
-                    'value': data['event_id'],
-                }
-            )
-            data['event_id'] = uuid.uuid4().hex
-        elif not is_event_id(data['event_id']):
-            self.log.debug(
-                'Discarded invalid value for event_id: %r', data['event_id'], exc_info=True
-            )
-            data['errors'].append(
-                {
-                    'type': EventError.INVALID_DATA,
-                    'name': 'event_id',
-                    'value': data['event_id'],
-                }
-            )
-            data['event_id'] = uuid.uuid4().hex
-
-        if 'timestamp' in data:
-            try:
-                self._process_data_timestamp(data)
-            except InvalidTimestamp as e:
-                self.log.debug(
-                    'Discarded invalid value for timestamp: %r', data['timestamp'], exc_info=True
-                )
-                data['errors'].append(
-                    {
+        for c in casts:
+            if data.get(c):
+                try:
+                    data[c] = casts[c](data[c])
+                except Exception:
+                    errors.append({
                         'type': EventError.INVALID_DATA,
-                        'name': 'timestamp',
-                        'value': data['timestamp'],
-                    }
-                )
-                del data['timestamp']
+                        'name': c,
+                        'value': data[c],
+                    })
+                    del data[c]
 
-        if 'fingerprint' in data:
-            try:
-                self._process_fingerprint(data)
-            except InvalidFingerprint as e:
-                self.log.debug(
-                    'Discarded invalid value for fingerprint: %r',
-                    data['fingerprint'],
-                    exc_info=True
-                )
-                data['errors'].append(
-                    {
-                        'type': EventError.INVALID_DATA,
-                        'name': 'fingerprint',
-                        'value': data['fingerprint'],
-                    }
-                )
-                del data['fingerprint']
-
-        if 'platform' not in data or data['platform'] not in VALID_PLATFORMS:
-            data['platform'] = 'other'
-
-        if data.get('modules') and type(data['modules']) != dict:
-            self.log.debug(
-                'Discarded invalid type for modules: %s', type(data['modules']))
-            data['errors'].append(
-                {
-                    'type': EventError.INVALID_DATA,
-                    'name': 'modules',
-                    'value': data['modules'],
-                }
-            )
-            del data['modules']
-
-        if data.get('extra') is not None and type(data['extra']) != dict:
-            self.log.debug('Discarded invalid type for extra: %s',
-                           type(data['extra']))
-            data['errors'].append(
-                {
-                    'type': EventError.INVALID_DATA,
-                    'name': 'extra',
-                    'value': data['extra'],
-                }
-            )
-            del data['extra']
-
-        if data.get('tags') is not None:
-            if type(data['tags']) == dict:
-                data['tags'] = list(data['tags'].items())
-            elif not isinstance(data['tags'], (list, tuple)):
-                self.log.debug(
-                    'Discarded invalid type for tags: %s', type(data['tags']))
-                data['errors'].append(
-                    {
-                        'type': EventError.INVALID_DATA,
-                        'name': 'tags',
-                        'value': data['tags'],
-                    }
-                )
-                del data['tags']
+        main_errors = self.validate_and_default_from_schema(data, STORE_SCHEMA)
+        errors.extend(main_errors)
 
         if data.get('tags'):
-            # remove any values which are over 32 characters
-            tags = []
-            for pair in data['tags']:
-                try:
-                    k, v = pair
-                except ValueError:
-                    self.log.debug('Discarded invalid tag value: %r', pair)
-                    data['errors'].append(
-                        {
-                            'type': EventError.INVALID_DATA,
-                            'name': 'tags',
-                            'value': pair,
-                        }
-                    )
-                    continue
-
-                if not isinstance(k, six.string_types):
-                    try:
-                        k = six.text_type(k)
-                    except Exception:
-                        self.log.debug(
-                            'Discarded invalid tag key: %r', type(k))
-                        data['errors'].append(
-                            {
-                                'type': EventError.INVALID_DATA,
-                                'name': 'tags',
-                                'value': pair,
-                            }
-                        )
-                        continue
-
-                if not isinstance(v, six.string_types):
-                    try:
-                        v = six.text_type(v)
-                    except Exception:
-                        self.log.debug(
-                            'Discarded invalid tag value: %s=%r', k, type(v))
-                        data['errors'].append(
-                            {
-                                'type': EventError.INVALID_DATA,
-                                'name': 'tags',
-                                'value': pair,
-                            }
-                        )
-                        continue
-
-                if len(k) > MAX_TAG_KEY_LENGTH or len(v) > MAX_TAG_VALUE_LENGTH:
-                    self.log.debug('Discarded invalid tag: %s=%s', k, v)
-                    data['errors'].append(
-                        {
-                            'type': EventError.INVALID_DATA,
-                            'name': 'tags',
-                            'value': pair,
-                        }
-                    )
-                    continue
-
-                # support tags with spaces by converting them
-                k = k.replace(' ', '-')
-
-                if tagstore.is_reserved_key(k):
-                    self.log.debug('Discarding reserved tag key: %s', k)
-                    data['errors'].append(
-                        {
-                            'type': EventError.INVALID_DATA,
-                            'name': 'tags',
-                            'value': pair,
-                        }
-                    )
-                    continue
-
-                if not tagstore.is_valid_key(k):
-                    self.log.debug('Discarded invalid tag key: %s', k)
-                    data['errors'].append(
-                        {
-                            'type': EventError.INVALID_DATA,
-                            'name': 'tags',
-                            'value': pair,
-                        }
-                    )
-                    continue
-
-                if not tagstore.is_valid_value(v):
-                    self.log.debug('Discard invalid tag value: %s', v)
-                    data['errors'].append(
-                        {
-                            'type': EventError.INVALID_DATA,
-                            'name': 'tags',
-                            'value': pair,
-                        }
-                    )
-                    continue
-
-                tags.append((k, v))
-            data['tags'] = tags
+            tag_errors = self.validate_and_default_from_schema(
+                data['tags'], TAGS_TUPLES_SCHEMA, name='tags')
+            errors.extend(tag_errors)
 
         for k in list(iter(data)):
             if k in CLIENT_RESERVED_ATTRS:
@@ -640,29 +480,11 @@ class ClientApiHelper(object):
                 interface = get_interface(k)
             except ValueError:
                 self.log.debug('Ignored unknown attribute: %s', k)
-                data['errors'].append({
+                errors.append({
                     'type': EventError.INVALID_ATTRIBUTE,
                     'name': k,
                 })
                 continue
-
-            if type(value) != dict:
-                # HACK(dcramer): the exception/breadcrumbs interface supports a
-                # list as the value. We should change this in a new protocol
-                # version.
-                if type(value) in (list, tuple):
-                    value = {'values': value}
-                else:
-                    self.log.debug(
-                        'Invalid parameter for value: %s (%r)', k, type(value))
-                    data['errors'].append(
-                        {
-                            'type': EventError.INVALID_DATA,
-                            'name': k,
-                            'value': value,
-                        }
-                    )
-                    continue
 
             try:
                 inst = interface.to_python(value)
@@ -674,7 +496,7 @@ class ClientApiHelper(object):
                     log = self.log.error
                 log('Discarded invalid value for interface: %s (%r)',
                     k, value, exc_info=True)
-                data['errors'].append(
+                errors.append(
                     {
                         'type': EventError.INVALID_DATA,
                         'name': k,
@@ -713,7 +535,7 @@ class ClientApiHelper(object):
                         log = self.log.error
                     log('Discarded invalid value for interface: %s (%r)',
                         k, value, exc_info=True)
-                    data['errors'].append(
+                    errors.append(
                         {
                             'type': EventError.INVALID_DATA,
                             'name': k,
@@ -723,91 +545,12 @@ class ClientApiHelper(object):
 
         level = data.get('level') or DEFAULT_LOG_LEVEL
         if isinstance(level, six.string_types) and not level.isdigit():
-            # assume it's something like 'warning'
-            try:
-                data['level'] = LOG_LEVELS_MAP[level]
-            except KeyError as e:
-                self.log.debug('Discarded invalid logger value: %s', level)
-                data['errors'].append(
-                    {
-                        'type': EventError.INVALID_DATA,
-                        'name': 'level',
-                        'value': level,
-                    }
-                )
-                data['level'] = LOG_LEVELS_MAP.get(
-                    DEFAULT_LOG_LEVEL, DEFAULT_LOG_LEVEL)
+            data['level'] = LOG_LEVELS_MAP.get(level, LOG_LEVELS_MAP[DEFAULT_LOG_LEVEL])
 
-        if data.get('release'):
-            data['release'] = six.text_type(data['release'])
-            if len(data['release']) > 64:
-                data['errors'].append(
-                    {
-                        'type': EventError.VALUE_TOO_LONG,
-                        'name': 'release',
-                        'value': data['release'],
-                    }
-                )
-                del data['release']
+        if data.get('dist') and not data.get('release'):
+            data['dist'] = None
 
-        if data.get('dist'):
-            data['dist'] = six.text_type(data['dist']).strip()
-            if not data.get('release'):
-                data['dist'] = None
-            elif len(data['dist']) > 64:
-                data['errors'].append(
-                    {
-                        'type': EventError.VALUE_TOO_LONG,
-                        'name': 'dist',
-                        'value': data['dist'],
-                    }
-                )
-                del data['dist']
-            elif _dist_re.match(data['dist']) is None:
-                data['errors'].append(
-                    {
-                        'type': EventError.INVALID_DATA,
-                        'name': 'dist',
-                        'value': data['dist'],
-                    }
-                )
-                del data['dist']
-
-        if data.get('environment'):
-            data['environment'] = six.text_type(data['environment'])
-            if len(data['environment']) > 64:
-                data['errors'].append(
-                    {
-                        'type': EventError.VALUE_TOO_LONG,
-                        'name': 'environment',
-                        'value': data['environment'],
-                    }
-                )
-                del data['environment']
-
-        if data.get('time_spent'):
-            try:
-                data['time_spent'] = int(data['time_spent'])
-            except (ValueError, TypeError):
-                data['errors'].append(
-                    {
-                        'type': EventError.INVALID_DATA,
-                        'name': 'time_spent',
-                        'value': data['time_spent'],
-                    }
-                )
-                del data['time_spent']
-            else:
-                if data['time_spent'] > BoundedIntegerField.MAX_VALUE:
-                    data['errors'].append(
-                        {
-                            'type': EventError.VALUE_TOO_LONG,
-                            'name': 'time_spent',
-                            'value': data['time_spent'],
-                        }
-                    )
-                    del data['time_spent']
-
+        data['errors'] = errors
         return data
 
     def ensure_does_not_have_ip(self, data):
@@ -896,15 +639,15 @@ class SecurityApiHelper(ClientApiHelper):
             raise APIError('Invalid security report: %s' % str(e).splitlines()[0])
 
         def clean(d):
-            return dict(filter(lambda x: x[1], d.items()))
+            return dict(filter(lambda x: x[1] is not None, d.items()))
 
-        data.update({
+        data.update(clean({
             'logger': 'csp',
             'project': project.id,
             'message': instance.get_message(),
             'culprit': instance.get_culprit(),
             instance.get_path(): instance.to_json(),
-            'errors': [],
+            'tags': instance.get_tags(),
 
             'sentry.interfaces.User': {
                 'ip_address': self.context.ip_address,
@@ -922,50 +665,19 @@ class SecurityApiHelper(ClientApiHelper):
                     'Referer': instance.get_referrer(),
                 })
             },
-        })
+        }))
 
-        # Copy/pasted from above in ClientApiHelper.validate_data
-        if data.get('release'):
-            data['release'] = six.text_type(data['release'])
-            if len(data['release']) > 64:
-                data['errors'].append(
-                    {
-                        'type': EventError.VALUE_TOO_LONG,
-                        'name': 'release',
-                        'value': data['release'],
-                    }
-                )
-                del data['release']
+        errors = []
 
-        tags = []
-        for k, v in instance.get_tags():
-            if not v:
-                continue
-            if len(v) > MAX_TAG_VALUE_LENGTH:
-                self.log.debug('Discarded invalid tag: %s=%s', k, v)
-                data['errors'].append(
-                    {
-                        'type': EventError.INVALID_DATA,
-                        'name': 'tags',
-                        'value': (k, v),
-                    }
-                )
-                continue
-            if not tagstore.is_valid_value(v):
-                self.log.debug('Discard invalid tag value: %s', v)
-                data['errors'].append(
-                    {
-                        'type': EventError.INVALID_DATA,
-                        'name': 'tags',
-                        'value': (k, v),
-                    }
-                )
-                continue
-            tags.append((k, v))
+        main_errors = self.validate_and_default_from_schema(data, STORE_SCHEMA)
+        errors.extend(main_errors)
 
-        if tags:
-            data['tags'] = tags
+        if data.get('tags'):
+            tag_errors = self.validate_and_default_from_schema(
+                data['tags'], TAGS_TUPLES_SCHEMA, name='tags')
+            errors.extend(tag_errors)
 
+        data['errors'] = errors
         return data
 
 

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -474,7 +474,9 @@ STORE_SCHEMA = {
         'sentry.interfaces.Exception': {},  # EXCEPTION_INTERFACE_SCHEMA,
 
         # Messages:
-        'message': {},
+        # 'message' is not an alias for the sentry.interfaces.Message interface
+        # but instead is a raw string that will be wrapped in a Message interface
+        'message': {'type': 'string'},
         'logentry': {},  # MESSAGE_INTERFACE_SCHEMA,
         'sentry.interfaces.Message': {},  # MESSAGE_INTERFACE_SCHEMA,
 

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -177,11 +177,11 @@ class Hpkp(SecurityReport):
         return "Public key pinning validation failed for '{self.hostname}'".format(self=self)
 
     def get_tags(self):
-        return (
+        return [
             ('port', six.text_type(self.port)),
             ('include-subdomains', json.dumps(self.include_subdomains)),
             ('hostname', self.hostname),
-        )
+        ]
 
     def get_origin(self):
         return self.hostname  # not quite origin, but the domain that failed pinning
@@ -265,15 +265,15 @@ class Csp(SecurityReport):
 
     def get_culprit(self):
         if not self.violated_directive:
-            return ''
+            return None
         bits = [d for d in self.violated_directive.split(' ') if d]
         return ' '.join([bits[0]] + [self._normalize_value(b) for b in bits[1:]])
 
     def get_tags(self):
-        return (
+        return [
             ('effective-directive', self.effective_directive),
             ('blocked-uri', self._sanitized_blocked_uri()),
-        )
+        ]
 
     def get_origin(self):
         return self.document_uri

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -37,6 +37,8 @@ def better_default_encoder(o):
         return list(o)
     elif isinstance(o, decimal.Decimal):
         return six.text_type(o)
+    elif callable(o):
+        return '<function>'
     raise TypeError(repr(o) + ' is not JSON serializable')
 
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -22,6 +22,7 @@ from sentry import quotas, tsdb
 from sentry.coreapi import (
     APIError, APIForbidden, APIRateLimited, ClientApiHelper, SecurityApiHelper, LazyData,
 )
+from sentry.interfaces import schemas
 from sentry.interfaces.base import get_interface
 from sentry.models import Project, OrganizationOption, Organization
 from sentry.signals import (
@@ -490,6 +491,11 @@ class StoreView(APIView):
         )
 
         return event_id
+
+
+class StoreSchemaView(BaseView):
+    def get(self, request, **kwargs):
+        return HttpResponse(json.dumps(schemas.STORE_SCHEMA), content_type='application/json')
 
 
 class SecurityReportView(StoreView):

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -120,6 +120,7 @@ urlpatterns += patterns(
         api.crossdomain_xml,
         name='sentry-api-crossdomain-xml'
     ),
+    url(r'^api/store/schema$', api.StoreSchemaView.as_view(), name='sentry-api-store-schema'),
 
     # The static version is either a 10 digit timestamp, a sha1, or md5 hash
     url(

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -15,7 +15,6 @@ from sentry.coreapi import (
     APIUnauthorized,
     Auth,
     ClientApiHelper,
-    InvalidFingerprint,
     InvalidTimestamp,
     get_interface,
     SecurityApiHelper,
@@ -121,29 +120,6 @@ class ProjectIdFromAuthTest(BaseAPITest):
         self.assertRaises(APIUnauthorized, self.helper.project_id_from_auth, auth)
 
 
-class ProcessFingerprintTest(BaseAPITest):
-    def test_invalid_as_string(self):
-        self.assertRaises(
-            InvalidFingerprint, self.helper._process_fingerprint, {
-                'fingerprint': '2012-01-01T10:30:45',
-            }
-        )
-
-    def test_invalid_component(self):
-        self.assertRaises(
-            InvalidFingerprint, self.helper._process_fingerprint, {
-                'fingerprint': ['foo', ['bar']],
-            }
-        )
-
-    def simple(self):
-        data = self.helper._process_fingerprint({
-            'fingerprint': ['{{default}}', 1, 'bar', 4.5],
-        })
-        self.assertTrue('fingerprint' in data)
-        self.assertEquals(data['fingerprint'], ['{{default}}', '1', 'bar', '4.5'])
-
-
 class ProcessDataTimestampTest(BaseAPITest):
     def test_iso_timestamp(self):
         d = datetime(2012, 1, 1, 10, 30, 45)
@@ -241,9 +217,6 @@ class ValidateDataTest(BaseAPITest):
         assert data['errors'][0]['type'] == 'invalid_data'
         assert data['errors'][0]['name'] == 'event_id'
         assert data['errors'][0]['value'] == 'xyz'
-
-    def test_invalid_event_id_raises(self):
-        self.assertRaises(APIError, self.helper.validate_data, self.project, {'event_id': 1})
 
     def test_unknown_attribute(self):
         data = self.helper.validate_data(self.project, {
@@ -348,11 +321,10 @@ class ValidateDataTest(BaseAPITest):
                 'tags': [('foo', 'bar'), ('biz', 'baz', 'boz')],
             }
         )
-        assert data['tags'] == [('foo', 'bar')]
         assert len(data['errors']) == 1
         assert data['errors'][0]['type'] == 'invalid_data'
         assert data['errors'][0]['name'] == 'tags'
-        assert data['errors'][0]['value'] == ('biz', 'baz', 'boz')
+        assert data['errors'][0]['value'] == [('foo', 'bar'), ('biz', 'baz', 'boz')]
 
     def test_reserved_tags(self):
         data = self.helper.validate_data(
@@ -386,9 +358,6 @@ class ValidateDataTest(BaseAPITest):
             'extra': 'bar',
         })
         assert 'extra' not in data
-
-    def test_invalid_culprit_raises(self):
-        self.assertRaises(APIError, self.helper.validate_data, self.project, {'culprit': 1})
 
     def test_release_too_long(self):
         data = self.helper.validate_data(self.project, {
@@ -506,6 +475,27 @@ class ValidateDataTest(BaseAPITest):
             'time_spent': '123',
         })
         assert data['time_spent'] == 123
+
+    def test_fingerprints(self):
+        data = self.helper.validate_data(self.project, {
+            'fingerprint': '2012-01-01T10:30:45',
+        })
+        assert not data.get('fingerprint')
+        assert data['errors'][0]['type'] == 'invalid_data'
+        assert data['errors'][0]['name'] == 'fingerprint'
+
+        data = self.helper.validate_data(self.project, {
+            'fingerprint': ['foo', ['bar']],
+        })
+        assert not data.get('fingerprint')
+        assert data['errors'][0]['type'] == 'invalid_data'
+        assert data['errors'][0]['name'] == 'fingerprint'
+
+        data = self.helper.validate_data(self.project, {
+            'fingerprint': ['{{default}}', 1, 'bar', 4.5],
+        })
+        assert data.get('fingerprint') == ['{{default}}', '1', 'bar', '4.5']
+        assert len(data['errors']) == 0
 
 
 class SafelyLoadJSONStringTest(BaseAPITest):
@@ -735,7 +725,6 @@ class SecurityApiHelperTest(BaseAPITest):
         assert result['release'] == 'abc123'
         assert result['errors'] == []
         assert 'message' in result
-        assert 'culprit' in result
         assert result['tags'] == [
             ('port', '443'),
             ('include-subdomains', 'false'),


### PR DESCRIPTION
This takes most of the imperative validation code in validate_data
and uses declarative JSON schema to validate it instead. There is an
associated helper method that uses the schema validation errors to do
the same things as the old code, namely deleting invalid keys, or
defaulting them if there is an applicable default.

There is a pre-validation casting step that forces some of the values to be
certain types before we apply the schema validation. This is to avoid
having to create a bunch of special cases in the schema for eg. values
that are either integers OR numeric strings. In theory this casting code
could be removed completely if all clients were well behaved and only
sent data for a given key in a single correct format.

I had to make minor changes to some tests as the choice to raise an
APIError on some types of invalid keys (eg. non-string event_id value)
but not on others (event_id too long, too short, etc) seemed kinda
arbitrary anyway and it would have made for some messy special case code
to fix.