### PR TITLE
fix(auth): Remove unneeded auth helper identity link case

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -252,11 +252,6 @@ class AuthHelper(object):
         user = request.user
         organization = self.organization
 
-        # On SAML we don't have an id when doing the setup so we
-        # don't gonna attach the identity if that was not provided
-        if not identity:
-            return
-
         try:
             try:
                 # prioritize identifying by the SSO provider's user ID


### PR DESCRIPTION
This was specific to an early SAML implementation where the identity was
not requested at setup. The setup goes through the entire Auth flow now.

Introduced in 2b4c870c0800d8867077df56178538809d128327