### PR TITLE
feat(discards): Add discarded hash filtering stats to tsdb

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -838,7 +838,9 @@ class ClientApiHelper(object):
             data.setdefault('sentry.interfaces.User', {})[
                 'ip_address'] = ip_address
 
-    def insert_data_to_database(self, data, from_reprocessing=False):
+    def insert_data_to_database(self, data, start_time=None, from_reprocessing=False):
+        if start_time is None:
+            start_time = time()
         # we might be passed LazyData
         if isinstance(data, LazyData):
             data = dict(data.items())
@@ -846,7 +848,7 @@ class ClientApiHelper(object):
         default_cache.set(cache_key, data, timeout=3600)
         task = from_reprocessing and \
             preprocess_event_from_reprocessing or preprocess_event
-        task.delay(cache_key=cache_key, start_time=time(),
+        task.delay(cache_key=cache_key, start_time=start_time,
                    event_id=data['event_id'])
 
 
@@ -904,7 +906,7 @@ class MinidumpApiHelper(ClientApiHelper):
 
         return validated
 
-    def insert_data_to_database(self, data, from_reprocessing=False):
+    def insert_data_to_database(self, data, start_time=None, from_reprocessing=False):
         # Seems like the event is valid and we can do some more expensive
         # work on the minidump. That is, persisting the file itself for
         # later postprocessing and extracting some more information from
@@ -924,7 +926,7 @@ class MinidumpApiHelper(ClientApiHelper):
         # Continue with persisting the event in the usual manner and
         # schedule default preprocessing tasks
         super(MinidumpApiHelper, self).insert_data_to_database(
-            data, from_reprocessing)
+            data, start_time, from_reprocessing)
 
 
 class CspApiHelper(ClientApiHelper):

--- a/src/sentry/static/sentry/app/views/projectFilters.jsx
+++ b/src/sentry/static/sentry/app/views/projectFilters.jsx
@@ -430,6 +430,7 @@ const ProjectFilters = React.createClass({
       'web-crawlers': 'Web Crawler',
       'invalid-csp': 'Invalid CSP',
       cors: 'CORS',
+      'discarded-hash': 'Discarded Group'
     };
   },
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -256,6 +256,7 @@ def save_event(cache_key=None, data=None, start_time=None, event_id=None, **kwar
     Saves an event to the database.
     """
     from sentry.event_manager import HashDiscarded, EventManager
+    from sentry import tsdb
 
     if cache_key:
         data = default_cache.get(cache_key)
@@ -286,6 +287,7 @@ def save_event(cache_key=None, data=None, start_time=None, event_id=None, **kwar
                 'description': exc.message,
             }
         )
+        tsdb.incr(tsdb.models.project_total_received_discarded, project, timestamp=start_time)
     finally:
         if cache_key:
             default_cache.delete(cache_key)

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -93,6 +93,8 @@ class TSDBModel(Enum):
     project_total_received_invalid_csp = 608
     # the number of events filtered by invalid origin
     project_total_received_cors = 609
+    # the number of events filtered because their group was discarded
+    project_total_received_discarded = 610
 
 
 class BaseTSDB(Service):

--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -26,6 +26,7 @@ class FilterStatKeys(object):
     WEB_CRAWLER = 'web-crawlers'
     INVALID_CSP = 'invalid-csp'
     CORS = 'cors'
+    DISCARDED_HASH = 'discarded-hash'
 
 FILTER_STAT_KEYS_TO_VALUES = {
     FilterStatKeys.IP_ADDRESS: tsdb.models.project_total_received_ip_address,
@@ -37,6 +38,7 @@ FILTER_STAT_KEYS_TO_VALUES = {
     FilterStatKeys.WEB_CRAWLER: tsdb.models.project_total_received_web_crawlers,
     FilterStatKeys.INVALID_CSP: tsdb.models.project_total_received_invalid_csp,
     FilterStatKeys.CORS: tsdb.models.project_total_received_cors,
+    FilterStatKeys.DISCARDED_HASH: tsdb.models.project_total_received_discarded,
 }
 
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import base64
-import datetime
 import logging
-import pytz
 import six
 import traceback
 
@@ -33,6 +31,7 @@ from sentry.quotas.base import RateLimit
 from sentry.utils import json, metrics
 from sentry.utils.data_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.utils.data_scrubber import SensitiveDataFilter
+from sentry.utils.dates import to_datetime
 from sentry.utils.http import (
     is_valid_origin,
     get_origins,
@@ -358,7 +357,7 @@ class StoreView(APIView):
             sender=type(self),
         )
         start_time = time()
-        tsdb_start_time = datetime.datetime.fromtimestamp(start_time).replace(tzinfo=pytz.utc)
+        tsdb_start_time = to_datetime(start_time)
         should_filter, filter_reason = helper.should_filter(
             project, data, ip_address=remote_addr)
         if should_filter:


### PR DESCRIPTION
This is setting the `start_time` earlier in ingestion, so not totally sure if that is going to have adverse consequences. The other thing I could do is have some separate `tsdb_time` arg, but that also seems gross.

This also passes an explicit timestamp to existing tsdb.incr calls.