### PR TITLE
feat(tsdb): Add environments to relevant write path operations

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -194,7 +194,7 @@ def create_sample_time_series(event, release=None):
         tsdb.incr_multi((
             (tsdb.models.project, project.id),
             (tsdb.models.group, group.id),
-        ), now, count)
+        ), now, count, environment_id=environment.id)
         tsdb.incr_multi((
             (tsdb.models.organization_total_received, project.organization_id),
             (tsdb.models.project_total_forwarded, project.id),
@@ -242,7 +242,7 @@ def create_sample_time_series(event, release=None):
         tsdb.incr_multi((
             (tsdb.models.project, group.project.id),
             (tsdb.models.group, group.id),
-        ), now, count)
+        ), now, count, environment_id=environment.id)
         tsdb.incr_multi((
             (tsdb.models.organization_total_received, project.organization_id),
             (tsdb.models.project_total_received, project.id),

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -676,7 +676,7 @@ class EventManager(object):
         if release:
             counters.append((tsdb.models.release, release.id))
 
-        tsdb.incr_multi(counters, timestamp=event.datetime)
+        tsdb.incr_multi(counters, timestamp=event.datetime, environment_id=environment.id)
 
         frequencies = [
             # (tsdb.models.frequent_projects_by_organization, {
@@ -745,7 +745,8 @@ class EventManager(object):
                     (tsdb.models.users_affected_by_group, group.id, (event_user.tag_value, )),
                     (tsdb.models.users_affected_by_project, project.id, (event_user.tag_value, )),
                 ),
-                timestamp=event.datetime
+                timestamp=event.datetime,
+                environment_id=environment.id,
             )
 
         if is_new and release:

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -249,13 +249,19 @@ def truncate_denormalizations(group):
         group_id=group.id,
     ).delete()
 
+    environment_ids = list(
+        Environment.objects.filter(
+            projects=group.project
+        ).values_list('id', flat=True)
+    )
+
     tsdb.delete([
         tsdb.models.group,
-    ], [group.id])
+    ], [group.id], environment_ids=environment_ids)
 
     tsdb.delete_distinct_counts([
         tsdb.models.users_affected_by_group,
-    ], [group.id])
+    ], [group.id], environment_ids=environment_ids)
 
     tsdb.delete_frequencies(
         [


### PR DESCRIPTION
Adds environment IDs to all write, merge, and delete operations for:

- `project`,
- `group`,
- `release`,
- `users_affected_by_group`, and
- `users_affected_by_project` models.