### PR TITLE
feat(tags): Add environment_id to tagstore basic get APIs

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -27,7 +27,7 @@ from .authentication import ApiKeyAuthentication, TokenAuthentication
 from .paginator import Paginator
 from .permissions import NoPermission
 
-__all__ = ['DocSection', 'Endpoint', 'StatsMixin']
+__all__ = ['DocSection', 'Endpoint', 'EnvironmentMixin', 'StatsMixin']
 
 ONE_MINUTE = 60
 ONE_HOUR = ONE_MINUTE * 60
@@ -258,7 +258,7 @@ class EnvironmentMixin(object):
         )
 
 
-class StatsMixin(EnvironmentMixin):
+class StatsMixin(object):
     def _parse_args(self, request):
         resolution = request.GET.get('resolution')
         if resolution:

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -18,7 +18,7 @@ from rest_framework.views import APIView
 
 from sentry import tsdb
 from sentry.app import raven
-from sentry.models import ApiKey, AuditLogEntry
+from sentry.models import ApiKey, AuditLogEntry, Environment
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin
@@ -246,7 +246,19 @@ class Endpoint(APIView):
         return response
 
 
-class StatsMixin(object):
+class EnvironmentMixin(object):
+    def _get_environment_from_request(self, request, organization_id):
+        environment = request.GET.get('environment')
+        if environment is None:
+            return None
+
+        return Environment.get_for_organization_id(
+            name=environment,
+            organization_id=organization_id,
+        )
+
+
+class StatsMixin(EnvironmentMixin):
     def _parse_args(self, request):
         resolution = request.GET.get('resolution')
         if resolution:

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -248,6 +248,8 @@ class Endpoint(APIView):
 
 class EnvironmentMixin(object):
     def _get_environment_from_request(self, request, organization_id):
+        # TODO: cache env on request to avoid hitting memcached over and over
+
         environment = request.GET.get('environment')
         if environment is None:
             return None

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -247,6 +247,11 @@ class Endpoint(APIView):
 
 
 class EnvironmentMixin(object):
+    def _get_environment_id_from_request(self, request, organization_id):
+        environment = self._get_environment_from_request(request, organization_id)
+
+        return environment and environment.id
+
     def _get_environment_from_request(self, request, organization_id):
         # TODO: cache env on request to avoid hitting memcached over and over
 

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -253,16 +253,19 @@ class EnvironmentMixin(object):
         return environment and environment.id
 
     def _get_environment_from_request(self, request, organization_id):
-        # TODO: cache env on request to avoid hitting memcached over and over
+        if not hasattr(request, '_cached_environment'):
+            environment_param = request.GET.get('environment')
+            if environment_param is None:
+                environment = None
+            else:
+                environment = Environment.get_for_organization_id(
+                    name=environment_param,
+                    organization_id=organization_id,
+                )
 
-        environment = request.GET.get('environment')
-        if environment is None:
-            return None
+            request._cached_environment = environment
 
-        return Environment.get_for_organization_id(
-            name=environment,
-            organization_id=organization_id,
-        )
+        return request._cached_environment
 
 
 class StatsMixin(object):

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -212,11 +212,12 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             last_release = self._get_release_info(request, group, last_release)
 
         try:
-            environment = self._get_environment_from_request(request, group.project.organization_id)
+            environment_id = self._get_environment_id_from_request(
+                request, group.project.organization_id)
         except Environment.DoesNotExist:
             tags = []
         else:
-            tags = tagstore.get_group_tag_keys(group.id, environment and environment.id, limit=100)
+            tags = tagstore.get_group_tag_keys(group.id, environment_id, limit=100)
 
         participants = list(
             User.objects.filter(

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 
 from sentry import tsdb, tagstore
 from sentry.api import client
-from sentry.api.base import DocSection
+from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.plugin import PluginSerializer
@@ -67,7 +67,7 @@ STATUS_CHOICES = {
 }
 
 
-class GroupDetailsEndpoint(GroupEndpoint):
+class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
     doc_section = DocSection.EVENTS
 
     def _get_activity(self, request, group, num):

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -53,13 +53,13 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
 
             if query_kwargs['tags']:
                 try:
-                    environment = self._get_environment_from_request(
+                    environment_id = self._get_environment_id_from_request(
                         request, group.project.organization_id)
                 except Environment.DoesNotExist:
                     event_ids = []
                 else:
                     event_ids = tagstore.get_group_event_ids(
-                        group.project_id, group.id, environment and environment.id, query_kwargs['tags'])
+                        group.project_id, group.id, environment_id, query_kwargs['tags'])
 
                 if event_ids:
                     events = events.filter(

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry import tagstore
-from sentry.api.base import DocSection
+from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.paginator import DateTimePaginator
@@ -20,7 +20,7 @@ def list_available_samples_scenario(runner):
     runner.request(method='GET', path='/issues/%s/events/' % group.id)
 
 
-class GroupEventsEndpoint(GroupEndpoint):
+class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
     doc_section = DocSection.EVENTS
 
     @attach_scenarios([list_available_samples_scenario])

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -7,7 +7,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.paginator import DateTimePaginator
-from sentry.models import Event, Group
+from sentry.models import Environment, Event, Group
 from sentry.search.utils import parse_query
 from sentry.utils.apidocs import scenario, attach_scenarios
 from rest_framework.response import Response
@@ -52,8 +52,15 @@ class GroupEventsEndpoint(GroupEndpoint):
                 )
 
             if query_kwargs['tags']:
-                event_ids = tagstore.get_group_event_ids(
-                    group.project_id, group.id, query_kwargs['tags'])
+                try:
+                    environment = self._get_environment_from_request(
+                        request, group.project.organization_id)
+                except Environment.DoesNotExist:
+                    event_ids = []
+                else:
+                    event_ids = tagstore.get_group_event_ids(
+                        group.project_id, group.id, environment and environment.id, query_kwargs['tags'])
+
                 if event_ids:
                     events = events.filter(
                         id__in=event_ids,

--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -5,7 +5,7 @@ import six
 from rest_framework.response import Response
 
 from sentry import tagstore
-from sentry.api.base import DocSection
+from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
@@ -22,7 +22,7 @@ def list_tag_details_scenario(runner):
     )
 
 
-class GroupTagKeyDetailsEndpoint(GroupEndpoint):
+class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
     doc_section = DocSection.EVENTS
 
     # XXX: this scenario does not work for some inexplicable reasons

--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -41,12 +41,11 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         lookup_key = tagstore.prefix_reserved_key(key)
 
         try:
-            environment = self._get_environment_from_request(request, group.project.organization_id)
+            environment_id = self._get_environment_id_from_request(
+                request, group.project.organization_id)
         except Environment.DoesNotExist:
             # if the environment doesn't exist then the tag can't possibly exist
             raise ResourceDoesNotExist
-
-        environment_id = environment and environment.id
 
         try:
             tag_key = tagstore.get_tag_key(group.project_id, environment_id, lookup_key)

--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -9,7 +9,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Group
+from sentry.models import Environment, Group
 from sentry.utils.apidocs import scenario
 
 
@@ -41,17 +41,26 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         lookup_key = tagstore.prefix_reserved_key(key)
 
         try:
-            tag_key = tagstore.get_tag_key(group.project_id, lookup_key)
+            environment = self._get_environment_from_request(request, group.project.organization_id)
+        except Environment.DoesNotExist:
+            # if the environment doesn't exist then the tag can't possibly exist
+            raise ResourceDoesNotExist
+
+        environment_id = environment and environment.id
+
+        try:
+            tag_key = tagstore.get_tag_key(group.project_id, environment_id, lookup_key)
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
         try:
-            group_tag_key = tagstore.get_group_tag_key(group.id, lookup_key)
+            group_tag_key = tagstore.get_group_tag_key(group.id, environment_id, lookup_key)
         except tagstore.GroupTagKeyNotFound:
             raise ResourceDoesNotExist
 
-        total_values = tagstore.get_group_tag_value_count(group.id, lookup_key)
-        top_values = tagstore.get_top_group_tag_values(group.id, lookup_key, limit=9)
+        total_values = tagstore.get_group_tag_value_count(group.id, environment_id, lookup_key)
+        top_values = tagstore.get_top_group_tag_values(
+            group.id, environment_id, lookup_key, limit=9)
 
         data = {
             'id': six.text_type(tag_key.id),

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -6,20 +6,30 @@ from collections import defaultdict
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
+from sentry.models import Environment
 
 
-class GroupTagsEndpoint(GroupEndpoint):
+class GroupTagsEndpoint(GroupEndpoint, EnvironmentMixin):
     def get(self, request, group):
-        group_tag_keys = tagstore.get_group_tag_keys(group.id)
+        try:
+            environment_id = self._get_environment_id_from_request(
+                request, group.project.organization_id)
+        except Environment.DoesNotExist:
+            group_tag_keys = []
+        else:
+            group_tag_keys = tagstore.get_group_tag_keys(group.id, environment_id)
 
         # O(N) db access
         data = []
         all_top_values = []
         for group_tag_key in group_tag_keys:
-            total_values = tagstore.get_group_tag_value_count(group.id, group_tag_key.key)
-            top_values = tagstore.get_top_group_tag_values(group.id, group_tag_key.key, limit=10)
+            total_values = tagstore.get_group_tag_value_count(
+                group.id, environment_id, group_tag_key.key)
+            top_values = tagstore.get_top_group_tag_values(
+                group.id, environment_id, group_tag_key.key, limit=10)
 
             all_top_values.extend(top_values)
 

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -3,18 +3,25 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import AuditLogEntryEvent
+from sentry.models import AuditLogEntryEvent, Environment
 
 
-class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
+class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
     def get(self, request, project, key):
         lookup_key = tagstore.prefix_reserved_key(key)
 
         try:
-            tagkey = tagstore.get_tag_key(project.id, lookup_key)
+            environment_id = self._get_environment_id_from_request(request, project.organization_id)
+        except Environment.DoesNotExist:
+            # if the environment doesn't exist then the tag can't possibly exist
+            raise ResourceDoesNotExist
+
+        try:
+            tagkey = tagstore.get_tag_key(project.id, environment_id, lookup_key)
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -20,7 +20,7 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
             tag_keys = sorted(
                 tagstore.get_tag_keys(
                     project.id,
-                    environment_id
+                    environment_id,
                 ),
                 key=lambda x: x.key)
 

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -5,12 +5,24 @@ import six
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.models import Environment
 
 
-class ProjectTagsEndpoint(ProjectEndpoint):
+class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
     def get(self, request, project):
-        tag_keys = sorted(tagstore.get_tag_keys(project.id), key=lambda x: x.key)
+        try:
+            environment_id = self._get_environment_id_from_request(request, project.organization_id)
+        except Environment.DoesNotExist:
+            tag_keys = []
+        else:
+            tag_keys = sorted(
+                tagstore.get_tag_keys(
+                    project.id,
+                    environment_id
+                ),
+                key=lambda x: x.key)
 
         data = []
         for tag_key in tag_keys:

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -171,8 +171,10 @@ class ReleaseSerializer(Serializer):
             ).distinct())
 
         tags = {}
-        tvs = tagstore.get_tag_values(project_ids, 'sentry:release',
-                                      [o.version for o in item_list])
+        tvs = tagstore.get_tag_values(project_ids,
+                                      environment_id=None,
+                                      key='sentry:release',
+                                      values=[o.version for o in item_list])
         for tv in tvs:
             val = tags.get(tv.value)
             tags[tv.value] = {

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -354,7 +354,8 @@ class Group(Model):
 
     def get_tags(self):
         if not hasattr(self, '_tag_cache'):
-            group_tags = [gtk.key for gtk in tagstore.get_group_tag_keys(self.id)]
+            group_tags = set(
+                [gtk.key for gtk in tagstore.get_group_tag_keys(self.id, environment_id=None)])
 
             results = []
             for key in group_tags:

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -181,55 +181,55 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_tag_key(self, project_id, key, status=TagKeyStatus.VISIBLE):
+    def get_tag_key(self, project_id, environment_id, key, status=TagKeyStatus.VISIBLE):
         """
-        >>> get_tag_key(1, "key1")
-        """
-        raise NotImplementedError
-
-    def get_tag_keys(self, project_ids, keys=None, status=TagKeyStatus.VISIBLE):
-        """
-        >>> get_tag_key([1, 2], ["key1", "key2"])
-        >>> get_tag_key(1, ["key1", "key2"])
+        >>> get_tag_key(1, 2, "key1")
         """
         raise NotImplementedError
 
-    def get_tag_value(self, project_id, key, value):
+    def get_tag_keys(self, project_ids, environment_id, keys=None, status=TagKeyStatus.VISIBLE):
         """
-        >>> get_tag_value(1, "key1", "value1")
+        >>> get_tag_key([1, 2], 3, ["key1", "key2"])
+        >>> get_tag_key(1, 3, ["key1", "key2"])
         """
         raise NotImplementedError
 
-    def get_tag_values(self, project_ids, key, values=None):
+    def get_tag_value(self, project_id, environment_id, key, value):
+        """
+        >>> get_tag_value(1, 2, "key1", "value1")
+        """
+        raise NotImplementedError
+
+    def get_tag_values(self, project_ids, environment_id, key, values=None):
         """
         >>> get_tag_values([1, 2], "key1", ["value1, "value2"])
         >>> get_tag_values(1, "key1", ["value1, "value2"])
         """
         raise NotImplementedError
 
-    def get_group_tag_key(self, group_id, key):
+    def get_group_tag_key(self, group_id, environment_id, key):
         """
-        >>> get_group_tag_key(1, "key1")
-        """
-        raise NotImplementedError
-
-    def get_group_tag_keys(self, group_ids, keys=None, limit=None):
-        """
-        >>> get_group_tag_keys([1, 2], ["key1", "key2"])
-        >>> get_group_tag_keys(1, ["key1", "key2"])
+        >>> get_group_tag_key(1, 2, "key1")
         """
         raise NotImplementedError
 
-    def get_group_tag_value(self, group_id, key, value):
+    def get_group_tag_keys(self, group_ids, environment_id, keys=None, limit=None):
         """
-        >>> get_group_tag_value(1, "key1", "value1")
+        >>> get_group_tag_keys([1, 2], 3, ["key1", "key2"])
+        >>> get_group_tag_keys(1, 3, ["key1", "key2"])
         """
         raise NotImplementedError
 
-    def get_group_tag_values(self, group_ids, keys=None, values=None):
+    def get_group_tag_value(self, group_id, environment_id, key, value):
         """
-        >>> get_group_tag_values([1, 2], ["key1", "key2"], ["value1", "value2"])
-        >>> get_group_tag_values(1, ["key1", "key2"], ["value1", "value2"])
+        >>> get_group_tag_value(1, 2, "key1", "value1")
+        """
+        raise NotImplementedError
+
+    def get_group_tag_values(self, group_ids, environment_id, keys=None, values=None):
+        """
+        >>> get_group_tag_values([1, 2], 3, ["key1", "key2"], ["value1", "value2"])
+        >>> get_group_tag_values(1, 3, ["key1", "key2"], ["value1", "value2"])
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -275,9 +275,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_event_ids(self, project_id, group_id, tags):
+    def get_group_event_ids(self, project_id, group_id, environment_id, tags):
         """
-        >>> get_group_event_ids(1, 2, {'key1': 'value1', 'key2': 'value2'})
+        >>> get_group_event_ids(1, 2, 3, {'key1': 'value1', 'key2': 'value2'})
         """
         raise NotImplementedError
 
@@ -299,15 +299,15 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_tag_value_count(self, group_id, key):
+    def get_group_tag_value_count(self, group_id, environment_id, key):
         """
-        >>> get_group_tag_value_count(1, 'key1')
+        >>> get_group_tag_value_count(1, 2, 'key1')
         """
         raise NotImplementedError
 
-    def get_top_group_tag_values(self, group_id, key, limit=3):
+    def get_top_group_tag_values(self, group_id, environment_id, key, limit=3):
         """
-        >>> get_top_group_tag_values(1, 'key1')
+        >>> get_top_group_tag_values(1, 2, 'key1')
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -121,7 +121,7 @@ class LegacyTagStorage(TagStorage):
         except IntegrityError:
             pass
 
-    def get_tag_key(self, project_id, key, status=TagKeyStatus.VISIBLE):
+    def get_tag_key(self, project_id, environment_id, key, status=TagKeyStatus.VISIBLE):
         from sentry.tagstore.exceptions import TagKeyNotFound
 
         qs = TagKey.objects.filter(
@@ -137,7 +137,7 @@ class LegacyTagStorage(TagStorage):
         except TagKey.DoesNotExist:
             raise TagKeyNotFound
 
-    def get_tag_keys(self, project_ids, keys=None, status=TagKeyStatus.VISIBLE):
+    def get_tag_keys(self, project_ids, environment_id, keys=None, status=TagKeyStatus.VISIBLE):
         if isinstance(project_ids, six.integer_types):
             qs = TagKey.objects.filter(project_id=project_ids)
         else:
@@ -151,7 +151,7 @@ class LegacyTagStorage(TagStorage):
 
         return list(qs)
 
-    def get_tag_value(self, project_id, key, value):
+    def get_tag_value(self, project_id, environment_id, key, value):
         from sentry.tagstore.exceptions import TagValueNotFound
 
         try:
@@ -163,7 +163,7 @@ class LegacyTagStorage(TagStorage):
         except TagValue.DoesNotExist:
             raise TagValueNotFound
 
-    def get_tag_values(self, project_ids, key, values=None):
+    def get_tag_values(self, project_ids, environment_id, key, values=None):
         qs = TagValue.objects.filter(key=key)
 
         if isinstance(project_ids, six.integer_types):
@@ -181,7 +181,7 @@ class LegacyTagStorage(TagStorage):
 
         return list(qs)
 
-    def get_group_tag_key(self, group_id, key):
+    def get_group_tag_key(self, group_id, environment_id, key):
         from sentry.tagstore.exceptions import GroupTagKeyNotFound
 
         try:
@@ -192,7 +192,7 @@ class LegacyTagStorage(TagStorage):
         except GroupTagKey.DoesNotExist:
             raise GroupTagKeyNotFound
 
-    def get_group_tag_keys(self, group_ids, keys=None, limit=None):
+    def get_group_tag_keys(self, group_ids, environment_id, keys=None, limit=None):
         if isinstance(group_ids, six.integer_types):
             qs = GroupTagKey.objects.filter(group_id=group_ids)
         else:
@@ -209,7 +209,7 @@ class LegacyTagStorage(TagStorage):
 
         return list(qs)
 
-    def get_group_tag_value(self, group_id, key, value):
+    def get_group_tag_value(self, group_id, environment_id, key, value):
         from sentry.tagstore.exceptions import GroupTagValueNotFound
 
         try:
@@ -221,7 +221,7 @@ class LegacyTagStorage(TagStorage):
         except GroupTagValue.DoesNotExist:
             raise GroupTagValueNotFound
 
-    def get_group_tag_values(self, group_ids, keys=None, values=None):
+    def get_group_tag_values(self, group_ids, environment_id, keys=None, values=None):
         if isinstance(group_ids, six.integer_types):
             qs = GroupTagValue.objects.filter(group_id=group_ids)
         else:

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -244,7 +244,7 @@ class LegacyTagStorage(TagStorage):
     def delete_tag_key(self, project_id, key):
         from .tasks import delete_tag_key
 
-        tagkey = self.get_tag_key(project_id, key, status=None)
+        tagkey = self.get_tag_key(project_id, environment_id=None, key=key, status=None)
 
         updated = TagKey.objects.filter(
             id=tagkey.id,

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -301,7 +301,7 @@ class LegacyTagStorage(TagStorage):
             'value': value,
         }, extra)
 
-    def get_group_event_ids(self, project_id, group_id, tags):
+    def get_group_event_ids(self, project_id, group_id, environment_id, tags):
         tagkeys = dict(
             TagKey.objects.filter(
                 project_id=project_id,
@@ -367,7 +367,7 @@ class LegacyTagStorage(TagStorage):
             key=key,
         ).values_list('group_id', 'values_seen'))
 
-    def get_group_tag_value_count(self, group_id, key):
+    def get_group_tag_value_count(self, group_id, environment_id, key):
         if db.is_postgres():
             # This doesnt guarantee percentage is accurate, but it does ensure
             # that the query has a maximum cost
@@ -395,7 +395,7 @@ class LegacyTagStorage(TagStorage):
             last_seen__gte=cutoff,
         ).aggregate(t=Sum('times_seen'))['t']
 
-    def get_top_group_tag_values(self, group_id, key, limit=3):
+    def get_top_group_tag_values(self, group_id, environment_id, key, limit=3):
         if db.is_postgres():
             # This doesnt guarantee percentage is accurate, but it does ensure
             # that the query has a maximum cost
@@ -513,7 +513,7 @@ class LegacyTagStorage(TagStorage):
         return matches
 
     def update_group_tag_key_values_seen(self, group_ids):
-        instances = self.get_group_tag_keys(group_ids)
+        instances = self.get_group_tag_keys(group_ids, environment_id=None)
         for instance in instances:
             instance.update(
                 values_seen=GroupTagValue.objects.filter(

--- a/src/sentry/web/frontend/project_tags.py
+++ b/src/sentry/web/frontend/project_tags.py
@@ -1,12 +1,24 @@
 from __future__ import absolute_import
 
 from sentry import tagstore
+from sentry.api.base import EnvironmentMixin
+from sentry.models import Environment
 from sentry.web.frontend.base import ProjectView
 
 
-class ProjectTagsView(ProjectView):
+class ProjectTagsView(ProjectView, EnvironmentMixin):
     def get(self, request, organization, team, project):
-        tag_list = sorted(tagstore.get_tag_keys(project.id), key=lambda x: x.key)
+        try:
+            environment_id = self._get_environment_id_from_request(request, project.organization_id)
+        except Environment.DoesNotExist:
+            tag_list = []
+        else:
+            tag_list = sorted(
+                tagstore.get_tag_keys(
+                    project.id,
+                    environment_id
+                ),
+                key=lambda x: x.key)
 
         context = {
             'tag_list': tag_list,

--- a/src/sentry/web/frontend/project_tags.py
+++ b/src/sentry/web/frontend/project_tags.py
@@ -16,7 +16,7 @@ class ProjectTagsView(ProjectView, EnvironmentMixin):
             tag_list = sorted(
                 tagstore.get_tag_keys(
                     project.id,
-                    environment_id
+                    environment_id,
                 ),
                 key=lambda x: x.key)
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -173,10 +173,10 @@ class SentryRemoteTest(TestCase):
 
         assert instance.message == 'hello'
 
-        assert tagstore.get_tag_key(self.project.id, 'foo') is not None
-        assert tagstore.get_tag_value(self.project.id, 'foo', 'bar') is not None
-        assert tagstore.get_group_tag_key(instance.group_id, 'foo') is not None
-        assert tagstore.get_group_tag_value(instance.group_id, 'foo', 'bar') is not None
+        assert tagstore.get_tag_key(self.project.id, None, 'foo') is not None
+        assert tagstore.get_tag_value(self.project.id, None, 'foo', 'bar') is not None
+        assert tagstore.get_group_tag_key(instance.group_id, None, 'foo') is not None
+        assert tagstore.get_group_tag_value(instance.group_id, None, 'foo', 'bar') is not None
 
     def test_timestamp(self):
         timestamp = timezone.now().replace(

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -66,6 +66,7 @@ class ProjectTagKeyDeleteTest(APITestCase):
 
         assert tagstore.get_tag_key(
             project.id,
+            None,  # environment_id
             tagkey.key,
             status=TagKeyStatus.PENDING_DELETION
         ).status == TagKeyStatus.PENDING_DELETION

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -88,8 +88,8 @@ class ReleaseSerializerTest(TestCase):
         # should be sum of all projects
         assert result['newGroups'] == 2
         # should be tags from all projects
-        tagvalue1 = tagstore.get_tag_value(project.id, key, value)
-        tagvalue2 = tagstore.get_tag_value(project2.id, key, value)
+        tagvalue1 = tagstore.get_tag_value(project.id, None, key, value)
+        tagvalue2 = tagstore.get_tag_value(project2.id, None, key, value)
         assert result['firstEvent'] == tagvalue2.first_seen
         assert result['lastEvent'] == tagvalue1.last_seen
         assert result['commitCount'] == 1

--- a/tests/sentry/deletions/test_tagkey.py
+++ b/tests/sentry/deletions/test_tagkey.py
@@ -66,28 +66,28 @@ class DeleteTagKeyTest(TestCase):
             run_deletion(deletion.id)
 
         try:
-            tagstore.get_group_tag_value(group.id, key, value)
+            tagstore.get_group_tag_value(group.id, None, key, value)
             assert False  # verify exception thrown
         except tagstore.GroupTagValueNotFound:
             pass
         try:
-            tagstore.get_group_tag_key(group.id, key)
+            tagstore.get_group_tag_key(group.id, None, key)
             assert False  # verify exception thrown
         except tagstore.GroupTagKeyNotFound:
             pass
         try:
-            tagstore.get_tag_value(project.id, key, value)
+            tagstore.get_tag_value(project.id, None, key, value)
             assert False  # verify exception thrown
         except tagstore.TagValueNotFound:
             pass
         try:
-            tagstore.get_tag_key(project.id, key)
+            tagstore.get_tag_key(project.id, None, key)
             assert False  # verify exception thrown
         except tagstore.TagKeyNotFound:
             pass
 
-        assert tagstore.get_tag_key(project2.id, key) is not None
-        assert tagstore.get_group_tag_key(group2.id, key) is not None
-        assert tagstore.get_group_tag_value(group2.id, key, value) is not None
+        assert tagstore.get_tag_key(project2.id, None, key) is not None
+        assert tagstore.get_group_tag_key(group2.id, None, key) is not None
+        assert tagstore.get_group_tag_value(group2.id, None, key, value) is not None
         assert tagstore.get_event_tag_qs(key_id=tk.id).exists()
         assert tagstore.get_event_tag_qs(key_id=tk2.id).exists()

--- a/tests/sentry/manager/tests.py
+++ b/tests/sentry/manager/tests.py
@@ -21,7 +21,7 @@ class SentryManagerTest(TestCase):
         with self.tasks():
             Group.objects.add_tags(group, tags=(('foo', 'bar'), ('foo', 'baz'), ('biz', 'boz')))
 
-        results = sorted(tagstore.get_group_tag_values(group.id, 'foo'), key=lambda x: x.id)
+        results = sorted(tagstore.get_group_tag_values(group.id, None, 'foo'), key=lambda x: x.id)
         assert len(results) == 2
         res = results[0]
         self.assertEquals(res.value, 'bar')
@@ -30,7 +30,7 @@ class SentryManagerTest(TestCase):
         self.assertEquals(res.value, 'baz')
         self.assertEquals(res.times_seen, 1)
 
-        results = sorted(tagstore.get_group_tag_values(group.id, 'biz'), key=lambda x: x.id)
+        results = sorted(tagstore.get_group_tag_values(group.id, None, 'biz'), key=lambda x: x.id)
         assert len(results) == 1
         res = results[0]
         self.assertEquals(res.value, 'boz')

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -22,7 +22,7 @@ class EnsureReleaseExistsTest(TestCase):
             value='1.0',
         )
 
-        tv = tagstore.get_tag_value(self.project.id, 'sentry:release', '1.0')
+        tv = tagstore.get_tag_value(self.project.id, None, 'sentry:release', '1.0')
         assert tv.data['release_id']
 
         release = Release.objects.get(id=tv.data['release_id'])

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -131,24 +131,28 @@ class IndexEventTagsTest(TestCase):
         assert len(tags) == 2
 
         tagkey = tagstore.get_tag_key(
-            key='foo',
             project_id=self.project.id,
+            environment_id=None,
+            key='foo',
         )
         tagvalue = tagstore.get_tag_value(
+            project_id=self.project.id,
+            environment_id=None,
             key='foo',
             value='bar',
-            project_id=self.project.id,
         )
         assert (tagkey.id, tagvalue.id) in tags
 
         tagkey = tagstore.get_tag_key(
-            key='biz',
             project_id=self.project.id,
+            environment_id=None,
+            key='biz',
         )
         tagvalue = tagstore.get_tag_value(
+            project_id=self.project.id,
+            environment_id=None,
             key='biz',
             value='baz',
-            project_id=self.project.id,
         )
         assert (tagkey.id, tagvalue.id) in tags
 

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -243,29 +243,29 @@ class DeleteTagKeyTest(TestCase):
 
             assert tagstore.get_event_tag_qs(key_id=tk.id).exists()
             try:
-                tagstore.get_group_tag_value(group.id, key, value)
+                tagstore.get_group_tag_value(group.id, None, key, value)
                 assert False  # verify exception thrown
             except tagstore.GroupTagValueNotFound:
                 pass
             try:
-                tagstore.get_group_tag_key(group.id, key)
+                tagstore.get_group_tag_key(group.id, None, key)
                 assert False  # verify exception thrown
             except tagstore.GroupTagKeyNotFound:
                 pass
             try:
-                tagstore.get_tag_value(project.id, key, value)
+                tagstore.get_tag_value(project.id, None, key, value)
                 assert False  # verify exception thrown
             except tagstore.TagValueNotFound:
                 pass
             try:
-                tagstore.get_tag_key(project.id, key)
+                tagstore.get_tag_key(project.id, None, key)
                 assert False  # verify exception thrown
             except tagstore.TagKeyNotFound:
                 pass
 
-        assert tagstore.get_tag_key(project2.id, key) is not None
-        assert tagstore.get_group_tag_key(group2.id, key) is not None
-        assert tagstore.get_group_tag_value(group2.id, key, value) is not None
+        assert tagstore.get_tag_key(project2.id, None, key) is not None
+        assert tagstore.get_group_tag_key(group2.id, None, key) is not None
+        assert tagstore.get_group_tag_value(group2.id, None, key, value) is not None
         assert tagstore.get_event_tag_qs(key_id=tk2.id).exists()
 
 

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -122,15 +122,16 @@ class MergeGroupTest(TestCase):
             merge_group(other.id, target.id)
 
         assert not Group.objects.filter(id=other.id).exists()
-        assert len(tagstore.get_group_tag_keys(other.id)) == 0
-        assert len(tagstore.get_group_tag_values(other.id)) == 0
+        assert len(tagstore.get_group_tag_keys(other.id, None)) == 0
+        assert len(tagstore.get_group_tag_values(other.id, None)) == 0
 
         for key, values_seen in output_group_tag_keys.items():
-            assert tagstore.get_group_tag_key(target.id, key).values_seen == values_seen
+            assert tagstore.get_group_tag_key(target.id, None, key).values_seen == values_seen
 
         for (key, value), times_seen in output_group_tag_values.items():
             assert tagstore.get_group_tag_value(
                 group_id=target.id,
+                environment_id=None,
                 key=key,
                 value=value,
             ).times_seen == times_seen

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -296,7 +296,7 @@ class UnmergeTestCase(TestCase):
             )
 
         assert set(
-            [(gtk.key, gtk.values_seen) for gtk in tagstore.get_group_tag_keys(source.id)]
+            [(gtk.key, gtk.values_seen) for gtk in tagstore.get_group_tag_keys(source.id, None)]
         ) == set([
             (u'color', 3),
             (u'environment', 1),
@@ -305,7 +305,7 @@ class UnmergeTestCase(TestCase):
 
         assert set(
             [(gtv.key, gtv.value, gtv.times_seen)
-             for gtv in tagstore.get_group_tag_values(source.id)]
+             for gtv in tagstore.get_group_tag_values(source.id, environment_id=None)]
         ) == set([
             (u'color', u'red', 6),
             (u'color', u'green', 6),
@@ -406,7 +406,7 @@ class UnmergeTestCase(TestCase):
         ])
 
         assert set(
-            [(gtk.key, gtk.values_seen) for gtk in tagstore.get_group_tag_keys(source.id)]
+            [(gtk.key, gtk.values_seen) for gtk in tagstore.get_group_tag_keys(source.id, None)]
         ) == set([
             (u'color', 3),
             (u'environment', 1),
@@ -415,7 +415,8 @@ class UnmergeTestCase(TestCase):
 
         assert set(
             [(gtv.key, gtv.value, gtv.times_seen,
-              gtv.first_seen, gtv.last_seen) for gtv in tagstore.get_group_tag_values(source.id)]
+              gtv.first_seen, gtv.last_seen)
+             for gtv in tagstore.get_group_tag_values(source.id, environment_id=None)]
         ) == set([
             (u'color', u'red', 4, now + shift(0), now + shift(9), ),
             (u'color', u'green', 3, now + shift(1), now + shift(7), ),
@@ -457,7 +458,7 @@ class UnmergeTestCase(TestCase):
             (u'production', now + shift(10), now + shift(16), ),
         ])
 
-        assert set([(gtk.key, gtk.values_seen) for gtk in tagstore.get_group_tag_keys(source.id)]
+        assert set([(gtk.key, gtk.values_seen) for gtk in tagstore.get_group_tag_keys(source.id, None)]
                    ) == set(
             [
                 (u'color', 3),
@@ -468,7 +469,8 @@ class UnmergeTestCase(TestCase):
 
         assert set(
             [(gtv.key, gtv.value, gtv.times_seen,
-              gtv.first_seen, gtv.last_seen) for gtv in tagstore.get_group_tag_values(destination.id)]
+              gtv.first_seen, gtv.last_seen)
+             for gtv in tagstore.get_group_tag_values(destination.id, environment_id=None)]
         ) == set([
             (u'color', u'red', 2, now + shift(12), now + shift(15), ),
             (u'color', u'green', 3, now + shift(10), now + shift(16), ),


### PR DESCRIPTION
* The legacy `tagstore` backend (the only one right now) does nothing with the `environment_id` by design.
* Tests are still environment agnostic, so they all use `None` (any environment)

The main thing in this PR is `EnvironmentMixin` and adding support for filtering on `environment` in the API endpoints.

I am slowly working my way down the list of `tagstore` methods, trying to keep the PRs manageable.