### PR TITLE
fix: Actually convert fingerprints to strings.

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -472,7 +472,7 @@ class ClientApiHelper(object):
 
         if 'fingerprint' in data:
             try:
-                self._process_fingerprint(data)
+                data['fingerprint'] = self._process_fingerprint(data)
             except InvalidFingerprint as e:
                 self.log.debug(
                     'Discarded invalid value for fingerprint: %r',


### PR DESCRIPTION
Found this when comparing results to new json schema validation. The
list of stringified fingerprints is never actually used because
`_process_fingerprint` doesn't mutate the data directly. This code should
be going away any minute now, but I have to fix it here to get a clean
comparison.