### PR TITLE
feat(workflow): Use GroupLink for commit resolution

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,7 @@
     },
 
     "[python]": {
-        "editor.formatOnSave": true
+        "editor.formatOnSave": false
     },
 
     "python.linting.pylintEnabled": false,

--- a/src/sentry/api/endpoints/issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/issues_resolved_in_release.py
@@ -9,7 +9,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.models import (
     Group,
-    GroupCommitResolution,
+    GroupLink,
     GroupResolution,
     Release,
     ReleaseCommit,
@@ -45,8 +45,9 @@ class IssuesResolvedInReleaseEndpoint(ProjectEndpoint):
             ).values_list('group_id', flat=True)
         )
         group_ids |= set(
-            GroupCommitResolution.objects.filter(
-                commit_id__in=ReleaseCommit.objects.filter(
+            GroupLink.objects.filter(
+                linked_type=GroupLink.LinkedType.commit,
+                linked_id__in=ReleaseCommit.objects.filter(
                     release=release,
                 ).values_list(
                     'commit_id',

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -473,12 +473,12 @@ class Release(Model):
                 linked_type=GroupLink.LinkedType.commit,
                 linked_id__in=ReleaseCommit.objects.filter(release=self)
                 .values_list('commit_id', flat=True),
-            ).extra(select={'commit_id': 'linked_id'}).values_list('group_id', 'commit_id')
+            ).values_list('group_id', 'linked_id')
         )
 
         user_by_author = {None: None}
-        for group_id, commit_id in commit_resolutions:
-            author = commit_author_by_commit.get(commit_id)
+        for group_id, linked_id in commit_resolutions:
+            author = commit_author_by_commit.get(linked_id)
             if author not in user_by_author:
                 try:
                     user_by_author[author] = author.find_users()[0]

--- a/src/sentry/plugins/sentry_mail/activity/release.py
+++ b/src/sentry/plugins/sentry_mail/activity/release.py
@@ -9,7 +9,7 @@ from django.db.models import Count
 
 from sentry.db.models.query import in_iexact
 from sentry.models import (
-    CommitFileChange, Deploy, Environment, Group, GroupSubscriptionReason, GroupCommitResolution,
+    CommitFileChange, Deploy, Environment, Group, GroupSubscriptionReason, GroupLink,
     Release, ReleaseCommit, Repository, Team, User, UserEmail, UserOption, UserOptionValue
 )
 from sentry.utils.http import absolute_uri
@@ -86,8 +86,9 @@ class ReleaseActivityEmail(ActivityEmail):
                 row['project']: row['num_groups']
                 for row in Group.objects.filter(
                     project__in=self.projects,
-                    id__in=GroupCommitResolution.objects.filter(
-                        commit_id__in=ReleaseCommit.objects.filter(
+                    id__in=GroupLink.objects.filter(
+                        linked_type=GroupLink.LinkedType.commit,
+                        linked_id__in=ReleaseCommit.objects.filter(
                             release=self.release,
                         ).values_list('commit_id', flat=True),
                     ).values_list('group_id', flat=True),

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -53,6 +53,7 @@ def resolved_in_commit(instance, created, **kwargs):
     for group in groups:
         try:
             with transaction.atomic():
+                # TODO(maxbittker) remove this call after new grouplink is confirmed working
                 GroupCommitResolution.objects.create(
                     group_id=group.id,
                     commit_id=instance.id,

--- a/tests/sentry/api/endpoints/test_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_issues_resolved_in_release.py
@@ -5,7 +5,7 @@ import six
 
 from sentry.models import (
     Commit,
-    GroupCommitResolution,
+    GroupLink,
     GroupResolution,
     Release,
     ReleaseCommit,
@@ -52,10 +52,10 @@ class IssuesResolvedInReleaseEndpointTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]['id'] == six.text_type(group.id)
 
-    def test_shows_issues_from_groupcommitresolution(self):
+    def test_shows_issues_from_grouplink(self):
         """
         tests that the endpoint will correctly retrieve issues resolved
-        in a release from the GroupCommitResolution model
+        in a release from the GroupLink model
         """
         user = self.create_user('foo@example.com', is_superuser=True)
         project = self.create_project(
@@ -94,7 +94,13 @@ class IssuesResolvedInReleaseEndpointTest(APITestCase):
             commit=commit2,
             order=0,
         )
-        GroupCommitResolution.objects.create(group_id=group.id, commit_id=commit.id)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=commit.id,
+        )
         url = reverse(
             'sentry-api-0-release-resolved',
             kwargs={
@@ -113,7 +119,7 @@ class IssuesResolvedInReleaseEndpointTest(APITestCase):
     def test_does_not_return_duplicate_groups(self):
         """
         tests that the endpoint will correctly retrieve issues resolved
-        in a release from the GroupCommitResolution and GroupResolution model
+        in a release from the GroupLink and GroupResolution model
         but will not return the groups twice if they appear in both
         """
         user = self.create_user('foo@example.com', is_superuser=True)
@@ -153,7 +159,13 @@ class IssuesResolvedInReleaseEndpointTest(APITestCase):
             commit=commit2,
             order=0,
         )
-        GroupCommitResolution.objects.create(group_id=group.id, commit_id=commit.id)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=commit.id,
+        )
         GroupResolution.objects.create(
             group=group,
             release=release,
@@ -177,7 +189,7 @@ class IssuesResolvedInReleaseEndpointTest(APITestCase):
     def test_return_groups_from_both_types(self):
         """
         tests that the endpoint will correctly retrieve issues resolved
-        in a release from both the GroupCommitResolution and GroupResolution model
+        in a release from both the GroupLink and GroupResolution model
         """
         user = self.create_user('foo@example.com', is_superuser=True)
         project = self.create_project(
@@ -217,7 +229,13 @@ class IssuesResolvedInReleaseEndpointTest(APITestCase):
             commit=commit2,
             order=0,
         )
-        GroupCommitResolution.objects.create(group_id=group.id, commit_id=commit.id)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=commit.id,
+        )
         GroupResolution.objects.create(
             group=group2,
             release=release,


### PR DESCRIPTION
Essentially, i replaced each usage of groupcommitresolution with grouplink, except for writes which i kept both.