### PR TITLE
ref: Don't use EventMapping for non-sampled events

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -20,7 +20,7 @@ from sentry.api.serializers.models.group import (
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.db.models.query import create_or_update
 from sentry.models import (
-    Activity, EventMapping, Group, GroupAssignee, GroupBookmark, GroupHash, GroupResolution,
+    Activity, Group, GroupAssignee, GroupBookmark, GroupHash, GroupResolution,
     GroupSeen, GroupShare, GroupSnooze, GroupStatus, GroupSubscription, GroupSubscriptionReason,
     GroupTombstone, Release, TOMBSTONE_FIELDS_FROM_GROUP, UserOption
 )
@@ -277,14 +277,10 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             if len(query) == 32:
                 # check to see if we've got an event ID
                 try:
-                    mapping = EventMapping.objects.get(
-                        project_id=project.id,
-                        event_id=query,
-                    )
-                except EventMapping.DoesNotExist:
+                    matching_group = Group.objects.from_event_id(project, query)
+                except Group.DoesNotExist:
                     pass
                 else:
-                    matching_group = Group.objects.get(id=mapping.group_id)
                     try:
                         matching_event = Event.objects.get(
                             event_id=query, project_id=project.id)

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -10,7 +10,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize, ProjectUserReportSerializer
 from sentry.api.paginator import DateTimePaginator
-from sentry.models import (Event, EventMapping, EventUser, Group, GroupStatus, UserReport)
+from sentry.models import (Event, EventUser, Group, GroupStatus, UserReport)
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -102,15 +102,9 @@ class ProjectUserReportsEndpoint(ProjectEndpoint):
             report.event_user_id = euser.id
 
         try:
-            mapping = EventMapping.objects.get(
-                event_id=report.event_id,
-                project_id=project.id,
-            )
-        except EventMapping.DoesNotExist:
-            # XXX(dcramer): the system should fill this in later
+            report.group = Group.objects.from_event_id(project, report.event_id)
+        except Group.DoesNotExist:
             pass
-        else:
-            report.group = Group.objects.get(id=mapping.group_id)
 
         try:
             with transaction.atomic():

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -629,21 +629,24 @@ class EventManager(object):
                     }
                 )
                 return event
-        else:
-            if Event.objects.filter(
-                project_id=project.id,
-                event_id=event_id,
-            ).exists():
-                self.logger.info(
-                    'duplicate.found',
-                    exc_info=True,
-                    extra={
-                        'event_uuid': event_id,
-                        'project_id': project.id,
-                        'model': Event.__name__,
-                    }
-                )
-                return event
+
+        # We now always need to check the Event table for dupes
+        # since EventMapping isn't exactly the canonical source of truth.
+        if Event.objects.filter(
+            project_id=project.id,
+            event_id=event_id,
+        ).exists():
+            self.logger.info(
+                'duplicate.found',
+                exc_info=True,
+                extra={
+                    'event_uuid': event_id,
+                    'project_id': project.id,
+                    'group_id': group.id,
+                    'model': Event.__name__,
+                }
+            )
+            return event
 
         environment = Environment.get_or_create(
             project=project,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -608,12 +608,12 @@ class EventManager(object):
         # store a reference to the group id to guarantee validation of isolation
         event.data.bind_ref(event)
 
-        # When sampling is enabled, the only canonical source of truth
-        # is the EventMapping table. Otherwise, without sampling enabled,
-        # the source of truth can be relied on the Event table itself.
-        # As a bonus, when sampling is not enabled, we can avoid writing
-        # an EventMapping row entirely since it's redundant to the Event table.
-        if features.has('projects:sample-events', project=project):
+        # When an event was sampled, the canonical source of truth
+        # is the EventMapping table since we aren't going to be writing out an actual
+        # Event row. Otherwise, if the Event isn't being sampled, we can safely
+        # rely on the Event table itself as the source of truth and ignore
+        # EventMapping since it's redundant information.
+        if is_sample:
             try:
                 with transaction.atomic(using=router.db_for_write(EventMapping)):
                     EventMapping.objects.create(project=project, group=group, event_id=event_id)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -132,7 +132,7 @@ class GroupManager(BaseManager):
         for model in Event, EventMapping:
             try:
                 group_id = model.objects.filter(
-                    project_id=self.id,
+                    project_id=project.id,
                     event_id=event_id,
                 ).values_list('group_id', flat=True)[0]
                 break

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -126,19 +126,23 @@ class GroupManager(BaseManager):
         from sentry.models import EventMapping, Event
         group_id = None
 
+        # Look up event_id in both Event and EventMapping,
+        # and bail when it matches one of them, prioritizing
+        # Event since it contains more history.
         for model in Event, EventMapping:
             try:
                 group_id = model.objects.filter(
                     project_id=self.id,
                     event_id=event_id,
                 ).values_list('group_id', flat=True)[0]
+                break
             except IndexError:
-                # Raise a Group.DoesNotExist here since it makes
-                # more logical sense since this is intending to resolve
-                # a group_id.
                 pass
 
         if group_id is None:
+            # Raise a Group.DoesNotExist here since it makes
+            # more logical sense since this is intending to resolve
+            # a Group.
             raise Group.DoesNotExist()
 
         return Group.objects.get(id=group_id)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -135,7 +135,10 @@ class GroupManager(BaseManager):
                     project_id=project.id,
                     event_id=event_id,
                 ).values_list('group_id', flat=True)[0]
-                break
+
+                # It's possible that group_id is NULL
+                if group_id is not None:
+                    break
             except IndexError:
                 pass
 

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -77,11 +77,35 @@ class EventManagerTest(TransactionTestCase):
         should_sample.return_value = True
         event_id = 'a' * 32
 
-        manager = EventManager(self.make_event())
+        manager = EventManager(self.make_event(event_id=event_id))
         event = manager.save(1)
 
+        # This is a brand new event, so it is actually saved.
+        # In this case, we don't need an EventMapping, but we
+        # do need the Event.
+        assert not EventMapping.objects.filter(
+            group_id=event.group_id,
+            event_id=event_id,
+        ).exists()
+
+        assert Event.objects.filter(
+            event_id=event_id,
+        ).exists()
+
+        event_id = 'b' * 32
+
+        manager = EventManager(self.make_event(event_id=event_id))
+        event = manager.save(1)
+
+        # This second is a dupe, so should be sampled
+        # For a sample, we want to store the EventMapping,
+        # but don't need to store the Event
         assert EventMapping.objects.filter(
             group_id=event.group_id,
+            event_id=event_id,
+        ).exists()
+
+        assert not Event.objects.filter(
             event_id=event_id,
         ).exists()
 


### PR DESCRIPTION
Historically, EventMapping was used for pairing the string UUID "event_id" to the Group which it came from. This was primarily useful and important when Events were being sampled, and there was little guarantee that a specific Event row would actually exist, so EventMapping was used as the canonical source of all event_id -> group mappings.

Now, with the advent of being able to disable sampling, it doesn't make sense to store redundant data in EventMapping. We could just leverage the canonical Event table.

This helps with 2 things:

* Most of sentry.io data is not sampled anymore, so we'd save a considerable amount of data in the eventmapping table.
* EventMapping is pruned to 7 day history, which means looking up an event that is more than 7 days ago fails, since the mapping has been deleted. If we always look at Event, there's access for full history instead of maintaining this secondary lookup.