### PR TITLE
fix(email): Fix bug with empty `Reply-To` sets

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -315,7 +315,7 @@ class MessageBuilder(object):
             reply_to = headers['X-Sentry-Reply-To']
         else:
             reply_to = set(reply_to or ())
-            reply_to.remove(to)
+            reply_to.discard(to)
             reply_to = ', '.join(reply_to)
 
         if reply_to:


### PR DESCRIPTION
If `mail.enable-replies` is disabled or `X-Sentry-Reply-To` is empty or
not present, sending email could fail if the `To` address is not present
in the `Reply-To` list, since `set.remove` throws a `KeyError` if the
key isn't present in the set. `set.discard` doesn't.