### PR TITLE
vscode: Respect setup.cfg when formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,7 @@
     },
 
     "[python]": {
-        "editor.formatOnSave": false
+        "editor.formatOnSave": true
     },
 
     "python.linting.pylintEnabled": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,14 +36,12 @@
     },
 
     "[python]": {
-        "editor.formatOnSave": true
+        "editor.formatOnSave": false
     },
 
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
-    "python.formatting.provider": "autopep8",
     // https://github.com/DonJayamanne/pythonVSCode/issues/992
-    "python.formatting.yapfArgs": ["--style", "${workspaceRoot}/setup.cfg"],
     "python.pythonPath": "${env.WORKON_HOME}/sentry/bin/python",
     // test discovery is sluggish and the UI around running
     // tests is often in your way and misclicked

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,6 +41,8 @@
 
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
+    "python.formatting.provider": "autopep8",
+    "python.formatting.autopep8Args": ["--global-config", "${workspaceRoot}/setup.cfg"],
     // https://github.com/DonJayamanne/pythonVSCode/issues/992
     "python.pythonPath": "${env.WORKON_HOME}/sentry/bin/python",
     // test discovery is sluggish and the UI around running


### PR DESCRIPTION
Update: we found the fix.

---

Not sure who else uses `vscode` to tag.

Can we please disable this? For some reason `autopep8` in `vscode` is *very* different than our pre-commit hook. If I save any file it changes dozens of lines.

I work with an unstaged change to my config that changes the formatter to `yapf` because it doesn't re-format as much stuff. I'm also OK with changing it do that but I'm confused on which one we're actually supposed to be using. But when switching branches/committing/stashing I often lose/forget my unstaged diff and then I lose a bunch of time turning this back off.

This happens whether or not I launch `vscode` form my virtualenv. I don't have a system `autopep8`, and I run the latest `vscode`.

The only other thing I can think to do is format the entire codebase autopep8... but I thought we did that? Or was that yapf?

System:
```
$ which autopep8
autopep8 not found
```

Virtualenv:
```
$ autopep8 --version
autopep8 1.3.3 (pycodestyle: 2.0.0)
```