### PR TITLE
ref: Change EventTag writes to write in bulk

### DIFF
--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -47,7 +47,7 @@ class TagStorage(Service):
         'get_or_create_group_tag_key',
         'create_group_tag_value',
         'get_or_create_group_tag_value',
-        'create_event_tag',
+        'create_event_tags',
 
         'get_tag_key',
         'get_tag_keys',
@@ -176,9 +176,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def create_event_tag(self, project_id, group_id, event_id, key_id, value_id):
+    def create_event_tags(self, project_id, group_id, event_id, tags):
         """
-        >>> create_event_tag(1, 2, 3, 4, 5)
+        >>> create_event_tags(1, 2, 3, [(4, 5)])
         """
         raise NotImplementedError
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -144,14 +144,15 @@ def index_event_tags(organization_id, project_id, event_id, tags,
         'project': project_id,
     })
 
+    tag_ids = []
     for key, value in tags:
         tagkey, _ = tagstore.get_or_create_tag_key(project_id, environment_id, key)
         tagvalue, _ = tagstore.get_or_create_tag_value(project_id, environment_id, key, value)
+        tag_ids.append((tagkey.id, tagvalue.id))
 
-        tagstore.create_event_tag(
-            project_id=project_id,
-            group_id=group_id,
-            event_id=event_id,
-            key_id=tagkey.id,
-            value_id=tagvalue.id,
-        )
+    tagstore.create_event_tags(
+        project_id=project_id,
+        group_id=group_id,
+        event_id=event_id,
+        tags=tag_ids,
+    )

--- a/tests/sentry/api/endpoints/test_group_events.py
+++ b/tests/sentry/api/endpoints/test_group_events.py
@@ -57,26 +57,22 @@ class GroupEventsTest(APITestCase):
             key='bar',
             value='buz')
 
-        tagstore.create_event_tag(
+        tagstore.create_event_tags(
             project_id=group.project_id,
             group_id=group.id,
             event_id=event_1.id,
-            key_id=tagkey_1.id,
-            value_id=tagvalue_1.id,
+            tags=[
+                (tagkey_1.id, tagvalue_1.id),
+                (tagkey_2.id, tagvalue_3.id),
+            ],
         )
-        tagstore.create_event_tag(
+        tagstore.create_event_tags(
             project_id=group.project_id,
             group_id=group.id,
             event_id=event_2.id,
-            key_id=tagkey_2.id,
-            value_id=tagvalue_2.id,
-        )
-        tagstore.create_event_tag(
-            project_id=group.project_id,
-            group_id=group.id,
-            event_id=event_1.id,
-            key_id=tagkey_2.id,
-            value_id=tagvalue_3.id,
+            tags=[
+                (tagkey_2.id, tagvalue_2.id),
+            ],
         )
 
         url = '/api/0/issues/{}/events/'.format(group.id)

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -23,12 +23,13 @@ class DeleteGroupTest(TestCase):
             event_id='a' * 32,
             group_id=group.id,
         )
-        tagstore.create_event_tag(
+        tagstore.create_event_tags(
             event_id=event.id,
             group_id=group.id,
             project_id=project.id,
-            key_id=1,
-            value_id=1,
+            tags=[
+                (1, 1),
+            ],
         )
         GroupAssignee.objects.create(
             group=group,

--- a/tests/sentry/deletions/test_tagkey.py
+++ b/tests/sentry/deletions/test_tagkey.py
@@ -30,12 +30,13 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_group_tag_value(
             key=key, value=value, group_id=group.id, project_id=project.id, environment_id=self.environment.id
         )
-        tagstore.create_event_tag(
-            key_id=tk.id,
+        tagstore.create_event_tags(
             group_id=group.id,
-            value_id=1,
             project_id=project.id,
             event_id=1,
+            tags=[
+                (tk.id, 1),
+            ]
         )
 
         project2 = self.create_project(team=team, name='test2')
@@ -49,12 +50,13 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_group_tag_value(
             key=key, value=value, group_id=group2.id, project_id=project2.id, environment_id=self.environment.id
         )
-        tagstore.create_event_tag(
-            key_id=tk2.id,
+        tagstore.create_event_tags(
             group_id=group2.id,
-            value_id=1,
             project_id=project.id,
             event_id=1,
+            tags=[
+                (tk2.id, 1),
+            ],
         )
 
         deletion = ScheduledDeletion.schedule(tk, days=0)

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -208,12 +208,13 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_group_tag_value(
             key=key, value=value, group_id=group.id, project_id=project.id, environment_id=self.environment.id
         )
-        tagstore.create_event_tag(
-            key_id=tk.id,
+        tagstore.create_event_tags(
             group_id=group.id,
-            value_id=1,
             project_id=project.id,
             event_id=1,
+            tags=[
+                (tk.id, 1),
+            ],
         )
 
         project2 = self.create_project(team=team, name='test2')
@@ -228,12 +229,13 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_group_tag_value(
             key=key, value=value, group_id=group2.id, project_id=project2.id, environment_id=self.environment.id
         )
-        tagstore.create_event_tag(
-            key_id=tk2.id,
+        tagstore.create_event_tags(
             group_id=group2.id,
-            value_id=1,
             project_id=project.id,
             event_id=1,
+            tags=[
+                (tk2.id, 1)
+            ],
         )
 
         with self.tasks():
@@ -280,12 +282,13 @@ class DeleteGroupTest(TestCase):
             event_id='a' * 32,
             group_id=group.id,
         )
-        tagstore.create_event_tag(
+        tagstore.create_event_tags(
             event_id=event.id,
             group_id=group.id,
             project_id=project.id,
-            key_id=1,
-            value_id=1,
+            tags=[
+                (1, 1),
+            ],
         )
         GroupAssignee.objects.create(
             group=group,


### PR DESCRIPTION
It's easily possible that this is 10+ at bare minimum, sometimes into
hundreds of tags per Event.

So changing this to a bulk write means we have 1 transaction and one big
INSERT query which should be considerable speed improvement.

We can get away with this since we currently have a UNIQUE on (event_id,
key_id, value_id), which means this is an all-or-nothing. Since each
call is bound to a single event, this single task never is called more
than once for the same event_id and expect a sum of tags. This means we
can simplify this by choosing not to handle that case at all and should
get a, theoretically, substantial boost in performance.