### PR TITLE
chore(models): Stop writing to groupcommitresolution

### DIFF
--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -4,7 +4,7 @@ from django.db import IntegrityError, transaction
 from django.db.models.signals import post_save
 
 from sentry.models import (
-    Activity, Commit, GroupAssignee, GroupCommitResolution, GroupLink, Project, Release
+    Activity, Commit, GroupAssignee, GroupLink, Project, Release
 )
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
 
@@ -53,12 +53,6 @@ def resolved_in_commit(instance, created, **kwargs):
     for group in groups:
         try:
             with transaction.atomic():
-                # TODO(maxbittker) remove this call after new grouplink is confirmed working
-                GroupCommitResolution.objects.create(
-                    group_id=group.id,
-                    commit_id=instance.id,
-                )
-                # dual write to prepare for data migration
                 GroupLink.objects.create(
                     group_id=group.id,
                     project_id=group.project_id,

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -4,7 +4,7 @@ import datetime
 import six
 
 from sentry.models import (
-    Commit, CommitAuthor, Group, GroupCommitResolution, GroupRelease, GroupResolution, GroupLink, GroupStatus,
+    Commit, CommitAuthor, Group, GroupRelease, GroupResolution, GroupLink, GroupStatus,
     Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject, Repository
 )
 
@@ -142,7 +142,6 @@ class SetCommitsTestCase(TestCase):
             key='lskfslknsdkcsnlkdflksfdkls',
         )
 
-        assert GroupCommitResolution.objects.filter(group_id=group.id, commit_id=commit.id).exists()
         assert GroupLink.objects.filter(
             group_id=group.id,
             linked_type=GroupLink.LinkedType.commit,
@@ -262,14 +261,6 @@ class SetCommitsTestCase(TestCase):
             commit__key='c' * 40,
             commit__repository_id=repo.id,
             release=release,
-        ).exists()
-
-        assert GroupCommitResolution.objects.filter(
-            group_id=group.id,
-            commit_id=Commit.objects.get(
-                key='c' * 40,
-                repository_id=repo.id,
-            ).id,
         ).exists()
 
         assert GroupLink.objects.filter(
@@ -395,7 +386,6 @@ class SetCommitsTestCase(TestCase):
             'repository': repo.name,
         }])
 
-        assert GroupCommitResolution.objects.filter(group_id=group.id, commit_id=commit.id).exists()
         assert GroupLink.objects.filter(
             group_id=group.id,
             linked_type=GroupLink.LinkedType.commit,
@@ -433,7 +423,6 @@ class SetCommitsTestCase(TestCase):
             'repository': repo.name,
         }])
 
-        assert GroupCommitResolution.objects.filter(group_id=group.id, commit_id=commit.id).exists()
         assert GroupLink.objects.filter(
             group_id=group.id,
             linked_type=GroupLink.LinkedType.commit,

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from sentry import tagstore
 from sentry.models import (
-    Activity, Commit, CommitAuthor, GroupAssignee, GroupCommitResolution, GroupLink, OrganizationMember,
+    Activity, Commit, CommitAuthor, GroupAssignee, GroupLink, OrganizationMember,
     Release, Repository, UserEmail
 )
 from sentry.testutils import TestCase
@@ -65,11 +65,6 @@ class ResolvedInCommitTest(TestCase):
             message='Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
         )
 
-        assert GroupCommitResolution.objects.filter(
-            group_id=group.id,
-            commit_id=commit.id,
-        ).exists()
-
         assert GroupLink.objects.filter(
             group_id=group.id,
             linked_type=GroupLink.LinkedType.commit,
@@ -88,10 +83,6 @@ class ResolvedInCommitTest(TestCase):
             message='Foo Biz\n\nFixes {}-12F'.format(
                 self.project.slug.upper()),
         )
-
-        assert not GroupCommitResolution.objects.filter(
-            commit_id=commit.id,
-        ).exists()
 
         assert not GroupLink.objects.filter(
             linked_type=GroupLink.LinkedType.commit,
@@ -116,11 +107,6 @@ class ResolvedInCommitTest(TestCase):
                 email=self.user.email,
             )
         )
-
-        assert GroupCommitResolution.objects.filter(
-            group_id=group.id,
-            commit_id=commit.id,
-        ).exists()
 
         assert GroupLink.objects.filter(
             group_id=group.id,
@@ -151,11 +137,6 @@ class ResolvedInCommitTest(TestCase):
                 email=user.email,
             )
         )
-
-        assert GroupCommitResolution.objects.filter(
-            group_id=group.id,
-            commit_id=commit.id,
-        ).exists()
 
         assert GroupLink.objects.filter(
             group_id=group.id,


### PR DESCRIPTION
We use grouplink now, so there's no need to query this any more