### PR TITLE
fix: Add missing 'active' class to Account settings 'Close Account'

### DIFF
--- a/src/sentry/templates/sentry/bases/account.html
+++ b/src/sentry/templates/sentry/bases/account.html
@@ -30,7 +30,7 @@
         <ul class="dropdown-menu dropdown-menu-right">
           <li><a href="{% absolute_uri '/account/authorizations/' %}">{% trans "Authorized Applications" %}</a></li>
           <li{% if page == 'identities' %} class="active"{% endif %}><a href="{% url 'sentry-account-settings-identities' %}">{% trans "Identities" %}</a></li>
-          <li><a href="{% url 'sentry-remove-account' %}">{% trans "Close Account" %}</a></li>
+          <li{% if page == 'remove_account' %} class="active"{% endif %}><a href="{% url 'sentry-remove-account' %}">{% trans "Close Account" %}</a></li>
         </ul>
       </div>
       <ul class="nav nav-tabs border-bottom">

--- a/src/sentry/web/frontend/remove_account.py
+++ b/src/sentry/web/frontend/remove_account.py
@@ -80,6 +80,7 @@ class RemoveAccountView(BaseView):
 
         context = {
             'form': form,
+            'page': 'remove_account',
             'organization_results': org_results,
         }
 


### PR DESCRIPTION
Highlights the menu item on this page

![image](https://user-images.githubusercontent.com/1421724/32813546-afb78dc6-c95f-11e7-9c5b-b19e74070917.png)
