### PR TITLE
fix: GH-6472 follow up, remove btn-group from nested plugin button

### DIFF
--- a/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/issuePluginActions.jsx
@@ -95,7 +95,7 @@ const IssuePluginActions = React.createClass({
     } else {
       // # TODO(dcramer): remove plugin.title check in Sentry 8.22+
       button = (
-        <div className={'btn-group btn-plugin-' + plugin.slug}>
+        <div className={'btn-plugin-' + plugin.slug}>
           <DropdownLink
             caret={false}
             className="btn btn-default btn-sm"


### PR DESCRIPTION
In GH-6472 we added the btn-group to the issuePluginActions root element, nested buttons should now *not* have this class, fixing double padding.

![image](https://user-images.githubusercontent.com/1421724/32814398-c89f95be-c963-11e7-9000-e47b54db3e07.png)
↓
![image](https://user-images.githubusercontent.com/1421724/32814394-c4311746-c963-11e7-91dd-7ac4e4735bef.png)

