### PR TITLE
ref(workflow): Refactor "teams" action creators

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/teams.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/teams.jsx
@@ -1,0 +1,96 @@
+import TeamActions from '../actions/teamActions';
+
+const doCallback = (params = {}, name, ...args) => {
+  if (typeof params[name] === 'function') {
+    params[name](...args);
+  }
+};
+
+// Fetch teams for org
+export function fetchTeams(api, params, options) {
+  TeamActions.fetchAll(params.orgId);
+  return api.request(`/teams/${params.orgId}/`, {
+    success: data => {
+      TeamActions.fetchAllSuccess(params.orgId, data);
+      doCallback(options, 'success', data);
+    },
+    error: error => {
+      TeamActions.fetchAllError(params.orgId, error);
+      doCallback(options, 'error', error);
+    },
+  });
+}
+
+export function fetchTeamDetails(api, params, options) {
+  TeamActions.fetchDetails(params.teamId);
+  return api.request(`/teams/${params.orgId}/${params.teamId}/`, {
+    success: data => {
+      TeamActions.fetchDetailsSuccess(params.teamId, data);
+      doCallback(options, 'success', data);
+    },
+    error: error => {
+      TeamActions.fetchDetailsError(params.teamId, error);
+      doCallback(options, 'error', error);
+    },
+  });
+}
+
+export function updateTeam(api, params, options) {
+  let id = api.uniqueId();
+  let endpoint = `/teams/${params.orgId}/${params.teamId}/`;
+  TeamActions.update(id, params.teamId, params.data);
+
+  return api.request(endpoint, {
+    method: 'PUT',
+    data: params.data,
+    success: data => {
+      TeamActions.updateSuccess(id, params.teamId, data);
+      doCallback(options, 'success', data);
+    },
+    error: error => {
+      TeamActions.updateError(id, params.teamId, error);
+      doCallback(options, 'error', error);
+    },
+  });
+}
+
+export function joinTeam(api, params, options) {
+  let endpoint = `/organizations/${params.orgId}/members/${params.memberId ||
+    'me'}/teams/${params.teamId}/`;
+  let id = api.uniqueId();
+
+  TeamActions.update(id, params.teamId);
+
+  return api.request(endpoint, {
+    method: 'POST',
+    data: params.data,
+    success: data => {
+      TeamActions.updateSuccess(id, params.teamId, data);
+      doCallback(options, 'success', data);
+    },
+    error: error => {
+      TeamActions.updateError(id, params.teamId, error);
+      doCallback(options, 'error', error);
+    },
+  });
+}
+
+export function leaveTeam(api, params, options) {
+  let endpoint = `/organizations/${params.orgId}/members/${params.memberId ||
+    'me'}/teams/${params.teamId}/`;
+  let id = api.uniqueId();
+
+  TeamActions.update(id, params.teamId);
+
+  return api.request(endpoint, {
+    method: 'DELETE',
+    success: data => {
+      TeamActions.updateSuccess(id, params.teamId, data);
+      doCallback(options, 'success', data);
+    },
+    error: error => {
+      TeamActions.updateError(id, params.teamId, error);
+      doCallback(options, 'error', error);
+    },
+  });
+}

--- a/src/sentry/static/sentry/app/actions/teamActions.jsx
+++ b/src/sentry/static/sentry/app/actions/teamActions.jsx
@@ -1,5 +1,15 @@
 import Reflux from 'reflux';
 
-let TeamActions = Reflux.createActions(['update', 'updateError', 'updateSuccess']);
+let TeamActions = Reflux.createActions([
+  'update',
+  'updateError',
+  'updateSuccess',
+  'fetchAll',
+  'fetchAllSuccess',
+  'fetchAllError',
+  'fetchDetails',
+  'fetchDetailsSuccess',
+  'fetchDetailsError',
+]);
 
 export default TeamActions;

--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -2,7 +2,6 @@ import $ from 'jquery';
 import _ from 'lodash';
 
 import GroupActions from './actions/groupActions';
-import TeamActions from './actions/teamActions';
 
 export class Request {
   constructor(xhr) {
@@ -109,6 +108,20 @@ export class Client {
     );
 
     return this.activeRequests[id];
+  }
+
+  requestPromise(path, options = {}) {
+    return new Promise((resolve, reject) => {
+      this.request(path, {
+        ...options,
+        success: (data, ...args) => {
+          resolve(data);
+        },
+        error: (error, ...args) => {
+          reject(error);
+        },
+      });
+    });
   }
 
   _chain(...funcs) {
@@ -224,62 +237,6 @@ export class Client {
         },
         error: error => {
           GroupActions.assignToError(id, params.id, error);
-        },
-      },
-      options
-    );
-  }
-
-  joinTeam(params, options) {
-    let path =
-      '/organizations/' +
-      params.orgId +
-      '/members/' +
-      (params.memberId || 'me') +
-      '/teams/' +
-      params.teamId +
-      '/';
-    let id = this.uniqueId();
-
-    TeamActions.update(id, params.teamId);
-
-    return this._wrapRequest(
-      path,
-      {
-        method: 'POST',
-        success: response => {
-          TeamActions.updateSuccess(id, params.teamId, response);
-        },
-        error: error => {
-          TeamActions.updateError(id, params.teamId, error);
-        },
-      },
-      options
-    );
-  }
-
-  leaveTeam(params, options) {
-    let path =
-      '/organizations/' +
-      params.orgId +
-      '/members/' +
-      (params.memberId || 'me') +
-      '/teams/' +
-      params.teamId +
-      '/';
-    let id = this.uniqueId();
-
-    TeamActions.update(id, params.teamId);
-
-    return this._wrapRequest(
-      path,
-      {
-        method: 'DELETE',
-        success: response => {
-          TeamActions.updateSuccess(id, params.teamId, response);
-        },
-        error: error => {
-          TeamActions.updateError(id, params.teamId, error);
         },
       },
       options

--- a/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/missingProjectMembership.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import AlertActions from '../actions/alertActions';
+import IndicatorStore from '../stores/indicatorStore';
+import {joinTeam} from '../actionCreators/teams';
 import ApiMixin from '../mixins/apiMixin';
 import {t} from '../locale';
 
@@ -25,7 +26,8 @@ const MissingProjectMembership = React.createClass({
       loading: true,
     });
 
-    this.api.joinTeam(
+    joinTeam(
+      this.api,
       {
         orgId: this.props.organization.slug,
         teamId: this.props.team.slug,
@@ -42,10 +44,10 @@ const MissingProjectMembership = React.createClass({
             loading: false,
             error: true,
           });
-          AlertActions.addAlert({
-            message: 'There was an error while trying to join the team.',
-            type: 'error',
-          });
+          IndicatorStore.add(
+            t('There was an error while trying to leave the team.'),
+            'error'
+          );
         },
       }
     );

--- a/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/allTeamsRow.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {Link} from 'react-router';
 
 import ApiMixin from '../../mixins/apiMixin';
-import AlertActions from '../../actions/alertActions';
+import IndicatorStore from '../../stores/indicatorStore';
+import {joinTeam, leaveTeam} from '../../actionCreators/teams';
 import {t} from '../../locale';
 
 // TODO(dcramer): this isnt great UX
@@ -30,7 +31,8 @@ const AllTeamsRow = React.createClass({
       loading: true,
     });
 
-    this.api.joinTeam(
+    joinTeam(
+      this.api,
       {
         orgId: this.props.organization.slug,
         teamId: this.props.team.slug,
@@ -47,10 +49,10 @@ const AllTeamsRow = React.createClass({
             loading: false,
             error: true,
           });
-          AlertActions.addAlert({
-            message: t('There was an error while trying to join the team.'),
-            type: 'error',
-          });
+          IndicatorStore.add(
+            t('There was an error while trying to join the team.'),
+            'error'
+          );
         },
       }
     );
@@ -61,7 +63,8 @@ const AllTeamsRow = React.createClass({
       loading: true,
     });
 
-    this.api.leaveTeam(
+    leaveTeam(
+      this.api,
       {
         orgId: this.props.organization.slug,
         teamId: this.props.team.slug,
@@ -78,10 +81,10 @@ const AllTeamsRow = React.createClass({
             loading: false,
             error: true,
           });
-          AlertActions.addAlert({
-            message: t('There was an error while trying to leave the team.'),
-            type: 'error',
-          });
+          IndicatorStore.add(
+            t('There was an error while trying to leave the team.'),
+            'error'
+          );
         },
       }
     );

--- a/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/expandedTeamList.jsx
@@ -5,6 +5,8 @@ import LazyLoad from 'react-lazy-load';
 
 import ApiMixin from '../../mixins/apiMixin';
 import {update as projectUpdate} from '../../actionCreators/projects';
+import {leaveTeam} from '../../actionCreators/teams';
+import IndicatorStore from '../../stores/indicatorStore';
 import BarChart from '../../components/barChart';
 import ProjectLabel from '../../components/projectLabel';
 import SentryTypes from '../../proptypes';
@@ -37,10 +39,21 @@ const ExpandedTeamList = React.createClass({
 
   leaveTeam(team) {
     // TODO(dcramer): handle loading indicator
-    this.api.leaveTeam({
-      orgId: this.props.organization.slug,
-      teamId: team.slug,
-    });
+    leaveTeam(
+      this.api,
+      {
+        orgId: this.props.organization.slug,
+        teamId: team.slug,
+      },
+      {
+        error: () => {
+          IndicatorStore.add(
+            t('There was an error while trying to leave the team.'),
+            'error'
+          );
+        },
+      }
+    );
   },
 
   urlPrefix() {


### PR DESCRIPTION
* Moves `joinTeam`/`leaveTeam` from `api.jsx` to its own action creators
* Adds additional team actionCreators that are unused here
* Adds `requestPromise` to API class that returns a promise

This includes work for sentry9