### PR TITLE
Fix lambda expressions for Python 3

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -32,7 +32,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         # unexpected behavior, but still possible.)
         return Response(
             filter(
-                lambda (group_id__scores): group_id__scores[0] is not None,
+                lambda group_id__scores: group_id__scores[0] is not None,
                 map(
                     lambda group_id__scores: (serialized_groups.get(group_id__scores[0]), group_id__scores[1], ),
                     results,

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -18,7 +18,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
             limit = int(limit) + 1  # the target group will always be included
 
         results = filter(
-            lambda group_id, scores: group_id != group.id,
+            lambda group_id__scores: group_id__scores[0] != group.id,
             features.compare(group, limit=limit)
         )
 
@@ -32,9 +32,9 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         # unexpected behavior, but still possible.)
         return Response(
             filter(
-                lambda group_id, scores: group_id is not None,
+                lambda (group_id__scores): group_id__scores[0] is not None,
                 map(
-                    lambda group_id, scores: (serialized_groups.get(group_id), scores, ),
+                    lambda group_id__scores: (serialized_groups.get(group_id__scores[0]), group_id__scores[1], ),
                     results,
                 ),
             ),

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -18,7 +18,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
             limit = int(limit) + 1  # the target group will always be included
 
         results = filter(
-            lambda (group_id, scores): group_id != group.id,
+            lambda group_id, scores: group_id != group.id,
             features.compare(group, limit=limit)
         )
 
@@ -32,9 +32,9 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         # unexpected behavior, but still possible.)
         return Response(
             filter(
-                lambda (group_id, scores): group_id is not None,
+                lambda group_id, scores: group_id is not None,
                 map(
-                    lambda (group_id, scores): (serialized_groups.get(group_id), scores, ),
+                    lambda group_id, scores: (serialized_groups.get(group_id), scores, ),
                     results,
                 ),
             ),

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -75,7 +75,7 @@ class GroupSerializer(Serializer):
                 group__in=list(
                     itertools.chain.from_iterable(
                         itertools.imap(
-                            lambda (project, groups): groups if not options.get(
+                            lambda project, groups: groups if not options.get(
                                 project.id,
                                 options.get(None)
                             ) == UserOptionValue.no_conversations else [],

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -75,8 +75,8 @@ class GroupSerializer(Serializer):
                 group__in=list(
                     itertools.chain.from_iterable(
                         itertools.imap(
-                            lambda project, groups: groups if not options.get(
-                                project.id,
+                            lambda project__groups: project__groups[1] if not options.get(
+                                project__groups[0].id,
                                 options.get(None)
                             ) == UserOptionValue.no_conversations else [],
                             projects.items(),

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -228,10 +228,10 @@ class RedisBackend(Backend):
                     raise
 
             records = map(
-                lambda key, value, timestamp: Record(
-                    key,
-                    self.codec.decode(value) if value is not None else None,
-                    float(timestamp),
+                lambda key__value__timestamp: Record(
+                    key__value__timestamp[0],
+                    self.codec.decode(key__value__timestamp[1]) if value is not None else None,
+                    float(key__value__timestamp[2]),
                 ),
                 response,
             )

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -230,7 +230,7 @@ class RedisBackend(Backend):
             records = map(
                 lambda key__value__timestamp: Record(
                     key__value__timestamp[0],
-                    self.codec.decode(key__value__timestamp[1]) if value is not None else None,
+                    self.codec.decode(key__value__timestamp[1]) if key__value__timestamp[1] is not None else None,
                     float(key__value__timestamp[2]),
                 ),
                 response,

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -228,7 +228,7 @@ class RedisBackend(Backend):
                     raise
 
             records = map(
-                lambda (key, value, timestamp): Record(
+                lambda key, value, timestamp: Record(
                     key,
                     self.codec.decode(value) if value is not None else None,
                     float(timestamp),

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -29,7 +29,7 @@ class EventFrequencyForm(forms.Form):
         choices=[
             (key, label)
             for key, (label, duration
-                      ) in sorted(intervals.items(), key=lambda key, label__duration: label__duration[1])
+                      ) in sorted(intervals.items(), key=lambda(key____label__duration: key____label__duration[1][1])
         ]
     )
     value = forms.IntegerField(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -29,7 +29,7 @@ class EventFrequencyForm(forms.Form):
         choices=[
             (key, label)
             for key, (label, duration
-                      ) in sorted(intervals.items(), key=lambda (key, (label, duration)): duration)
+                      ) in sorted(intervals.items(), key=lambda key, label__duration: label__duration[1])
         ]
     )
     value = forms.IntegerField(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -29,7 +29,7 @@ class EventFrequencyForm(forms.Form):
         choices=[
             (key, label)
             for key, (label, duration
-                      ) in sorted(intervals.items(), key=lambda(key____label__duration: key____label__duration[1][1])
+                      ) in sorted(intervals.items(), key=lambda key____label__duration: key____label__duration[1][1])
         ]
     )
     value = forms.IntegerField(

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -16,9 +16,9 @@ def get_application_chunks(exception):
     application code "chunks": blocks of contiguously called application code.
     """
     return map(
-        lambda in_app, frames: list(frames),
+        lambda in_app__frames: list(in_app__frames[1]),
         itertools.ifilter(
-            lambda in_app, frames: in_app,
+            lambda in_app__frames: in_app__frames[0],
             itertools.groupby(
                 exception.stacktrace.frames,
                 key=lambda frame: frame.in_app,
@@ -180,9 +180,9 @@ class FeatureSet(object):
                         labels.append(label)
 
         return map(
-            lambda key, scores: (
-                int(key),
-                dict(zip(labels, scores)),
+            lambda key__scores: (
+                int(key__score[0],
+                dict(zip(labels, key__scores[1])),
             ),
             self.index.classify(
                 scope,
@@ -201,9 +201,9 @@ class FeatureSet(object):
         items = [(self.aliases[label], thresholds.get(label, 0), ) for label in features]
 
         return map(
-            lambda key, scores: (
-                int(key),
-                dict(zip(features, scores)),
+            lambda key__scores: (
+                int(key__scores[0]),
+                dict(zip(features, key__scores[1])),
             ),
             self.index.compare(
                 self.__get_scope(group.project),

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -181,7 +181,7 @@ class FeatureSet(object):
 
         return map(
             lambda key__scores: (
-                int(key__score[0],
+                int(key__scores[0]),
                 dict(zip(labels, key__scores[1])),
             ),
             self.index.classify(

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -16,9 +16,9 @@ def get_application_chunks(exception):
     application code "chunks": blocks of contiguously called application code.
     """
     return map(
-        lambda (in_app, frames): list(frames),
+        lambda in_app, frames: list(frames),
         itertools.ifilter(
-            lambda (in_app, frames): in_app,
+            lambda in_app, frames: in_app,
             itertools.groupby(
                 exception.stacktrace.frames,
                 key=lambda frame: frame.in_app,
@@ -180,7 +180,7 @@ class FeatureSet(object):
                         labels.append(label)
 
         return map(
-            lambda (key, scores): (
+            lambda key, scores: (
                 int(key),
                 dict(zip(labels, scores)),
             ),
@@ -201,7 +201,7 @@ class FeatureSet(object):
         items = [(self.aliases[label], thresholds.get(label, 0), ) for label in features]
 
         return map(
-            lambda (key, scores): (
+            lambda key, scores: (
                 int(key),
                 dict(zip(features, scores)),
             ),

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -697,7 +697,7 @@ def deliver_organization_user_report(timestamp, duration, organization_id, user_
     projects = list(projects)
 
     inclusion_predicates = [
-        lambda interval____project__report: interval____project__report[1][1] is not None,
+        lambda interval, project__report: project__report[1] is not None,
         has_valid_aggregates,
     ]
 

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -697,7 +697,7 @@ def deliver_organization_user_report(timestamp, duration, organization_id, user_
     projects = list(projects)
 
     inclusion_predicates = [
-        lambda interval, project__report: project__report[1] is not None,
+        lambda interval____project__report: interval____project__report[1][1] is not None,
         has_valid_aggregates,
     ]
 
@@ -770,7 +770,7 @@ def build_project_breakdown_series(reports):
         operator.itemgetter(0),
         sorted(
             reports.items(),
-            key=lambda instance, report: sum(sum(values) for timestamp, values in report[0]),
+            key=lambda instance__report: sum(sum(values) for timestamp, values in instance__report[1][0]),
             reverse=True,
         ),
     )[:len(colors)]
@@ -781,12 +781,12 @@ def build_project_breakdown_series(reports):
     # largest color blocks are at the bottom and it feels appropriately
     # weighted.)
     selections = map(
-        lambda instance, color: (
+        lambda instance__color: (
             Key(
-                instance.slug,
-                instance.get_absolute_url(),
-                color,
-                get_legend_data(reports[instance]),
+                instance__color[0].slug,
+                instance__color[0].get_absolute_url(),
+                instance__color[1],
+                get_legend_data(reports[instance__color[0]]),
             ),
             reports[instance],
         ),

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -788,7 +788,7 @@ def build_project_breakdown_series(reports):
                 instance__color[1],
                 get_legend_data(reports[instance__color[0]]),
             ),
-            reports[instance],
+            reports[instance__color[0]],
         ),
         zip(
             instances,

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -697,7 +697,7 @@ def deliver_organization_user_report(timestamp, duration, organization_id, user_
     projects = list(projects)
 
     inclusion_predicates = [
-        lambda interval, (project, report): report is not None,
+        lambda interval, project__report: project__report[1] is not None,
         has_valid_aggregates,
     ]
 
@@ -770,7 +770,7 @@ def build_project_breakdown_series(reports):
         operator.itemgetter(0),
         sorted(
             reports.items(),
-            key=lambda (instance, report): sum(sum(values) for timestamp, values in report[0]),
+            key=lambda instance, report: sum(sum(values) for timestamp, values in report[0]),
             reverse=True,
         ),
     )[:len(colors)]
@@ -781,7 +781,7 @@ def build_project_breakdown_series(reports):
     # largest color blocks are at the bottom and it feels appropriately
     # weighted.)
     selections = map(
-        lambda (instance, color): (
+        lambda instance, color: (
             Key(
                 instance.slug,
                 instance.get_absolute_url(),

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -18,8 +18,8 @@ def shingle(n, iterator):
     """
     return itertools.izip(
         *map(
-            lambda i__iterator: advance(i__iterator[0], i__iterator[0]),
-            enumerate(itertools.tee(i_iterator[1], n)),
+            lambda i__iterator: advance(i__iterator[0], i__iterator[1]),
+            enumerate(itertools.tee(iterator, n)),
         )
     )
 

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -18,8 +18,8 @@ def shingle(n, iterator):
     """
     return itertools.izip(
         *map(
-            lambda i, iterator: advance(i, iterator),
-            enumerate(itertools.tee(iterator, n)),
+            lambda i__iterator: advance(i__iterator[0], i__iterator[0]),
+            enumerate(itertools.tee(i_iterator[1], n)),
         )
     )
 

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -18,7 +18,7 @@ def shingle(n, iterator):
     """
     return itertools.izip(
         *map(
-            lambda (i, iterator): advance(i, iterator),
+            lambda i, iterator: advance(i, iterator),
             enumerate(itertools.tee(iterator, n)),
         )
     )

--- a/tests/sentry/similarity/test_signatures.py
+++ b/tests/sentry/similarity/test_signatures.py
@@ -22,7 +22,7 @@ class MinHashSignatureBuilderTestCase(TestCase):
 
         results = Counter(
             map(
-                lambda (l, r): l == r,
+                lambda l, r: l == r,
                 zip(
                     get_signature(a),
                     get_signature(b),

--- a/tests/sentry/similarity/test_signatures.py
+++ b/tests/sentry/similarity/test_signatures.py
@@ -22,7 +22,7 @@ class MinHashSignatureBuilderTestCase(TestCase):
 
         results = Counter(
             map(
-                lambda l, r: l == r,
+                lambda l__r: l__r[0] == l__r[1],
                 zip(
                     get_signature(a),
                     get_signature(b),


### PR DESCRIPTION
Fixes #6030  In Python 3, __lambda (a, b):__ is a syntax error while __lambda a, b:__ is valid Python.  However, as noted in the comments below, these two formulation are not syntactically equivalent.  The first takes a single iterable with at least two values while the second takes two discrete values.

In this PR, `lambda (a, b):` is rewritten as `lambda a__b:`(note double the underscore).  Then in the _body_ of the lambda `a` is rewritten as `a__b[0]` and `b` is rewritten as `a__b[1]`.  It is a bit verbose but works in both Python 2 and Python 3.

@mattrobenolt @tkaemming @dcramer Please review these changes based on the comments in #6030 

If these are the correct changes then for the first time we can create an Abstract Syntax Tree for all Python files in this repo in both Python 2 and Python 3 without finding syntax errors or undefined names.
* python2 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
* python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics