### PR TITLE
fix(releases): Match short ids when commits are updated also

### DIFF
--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -45,10 +45,6 @@ def resolve_group_resolutions(instance, created, **kwargs):
 
 
 def resolved_in_commit(instance, created, **kwargs):
-    # TODO(dcramer): we probably should support an updated message
-    if not created:
-        return
-
     groups = instance.find_referenced_groups()
     for group in groups:
         try:

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -125,6 +125,34 @@ class ResolvedInCommitTest(TestCase):
             linked_type=GroupLink.LinkedType.commit,
             linked_id=commit.id).count() == 1
 
+    def test_removes_group_link_when_message_changes(self):
+        group = self.create_group()
+
+        repo = Repository.objects.create(
+            name='example',
+            organization_id=self.group.organization.id,
+        )
+
+        commit = Commit.objects.create(
+            key=sha1(uuid4().hex).hexdigest(),
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            message='Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
+        )
+
+        assert GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id).exists()
+
+        commit.message = 'no groups here'
+        commit.save()
+
+        assert not GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id).exists()
+
     def test_no_matching_group(self):
         repo = Repository.objects.create(
             name='example',

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -70,6 +70,61 @@ class ResolvedInCommitTest(TestCase):
             linked_type=GroupLink.LinkedType.commit,
             linked_id=commit.id).exists()
 
+    def test_updating_commit(self):
+        group = self.create_group()
+
+        repo = Repository.objects.create(
+            name='example',
+            organization_id=self.group.organization.id,
+        )
+
+        commit = Commit.objects.create(
+            key=sha1(uuid4().hex).hexdigest(),
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+        )
+
+        assert not GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id).exists()
+
+        commit.message = 'Foo Biz\n\nFixes {}'.format(group.qualified_short_id)
+        commit.save()
+
+        assert GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id).exists()
+
+    def test_updating_commit_with_existing_grouplink(self):
+        group = self.create_group()
+
+        repo = Repository.objects.create(
+            name='example',
+            organization_id=self.group.organization.id,
+        )
+
+        commit = Commit.objects.create(
+            key=sha1(uuid4().hex).hexdigest(),
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            message='Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
+        )
+
+        assert GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id).exists()
+
+        commit.message = 'Foo Bar Biz\n\nFixes {}'.format(group.qualified_short_id)
+        commit.save()
+
+        assert GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id).count() == 1
+
     def test_no_matching_group(self):
         repo = Repository.objects.create(
             name='example',


### PR DESCRIPTION
@dcramer was there a particular reason you didn't wanna do this on update? Because for [this case](https://github.com/getsentry/sentry/blob/master/src/sentry/models/release.py#L324) (backfilling) we definitely want to support it

cc @saragilford 