### PR TITLE
fix: Correctly serialize uuids on proguard error reporting

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -64,7 +64,7 @@ class JavaStacktraceProcessor(StacktraceProcessor):
             self.data.setdefault('errors',
                                  []).append({
                                      'type': error_type,
-                                     'mapping_uuid': image_uuid,
+                                     'mapping_uuid': six.text_type(image_uuid),
                                  })
             report_processing_issue(
                 self.data,
@@ -72,9 +72,11 @@ class JavaStacktraceProcessor(StacktraceProcessor):
                 object='mapping:%s' % image_uuid,
                 type=error_type,
                 data={
-                    'mapping_uuid': image_uuid,
+                    'mapping_uuid': six.text_type(image_uuid),
                 }
             )
+
+        return True
 
     def process_frame(self, processable_frame, processing_task):
         new_module = None

--- a/tests/sentry/lang/java/test_plugin.py
+++ b/tests/sentry/lang/java/test_plugin.py
@@ -6,7 +6,7 @@ from six import BytesIO
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 
-from sentry.models import Event, ProcessingIssue
+from sentry.models import Event
 from sentry.testutils import TestCase
 
 PROGUARD_UUID = '6dc7fdb0-d2fb-4c8e-9d6b-bb1aa98929b1'

--- a/tests/sentry/lang/java/test_plugin.py
+++ b/tests/sentry/lang/java/test_plugin.py
@@ -6,7 +6,7 @@ from six import BytesIO
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 
-from sentry.models import Event
+from sentry.models import Event, ProcessingIssue
 from sentry.testutils import TestCase
 
 PROGUARD_UUID = '6dc7fdb0-d2fb-4c8e-9d6b-bb1aa98929b1'
@@ -17,6 +17,8 @@ org.slf4j.helpers.Util$ClassContextSecurityManager -> org.a.b.g$a:
     69:69:java.lang.Class[] getExtraClassContext() -> a
     65:65:void <init>(org.slf4j.helpers.Util$1) -> <init>
 '''
+PROGUARD_BUG_UUID = '071207ac-b491-4a74-957c-2c94fd9594f2'
+PROGUARD_BUG_SOURCE = b'x'
 
 
 class BasicResolvingIntegrationTest(TestCase):
@@ -105,3 +107,82 @@ class BasicResolvingIntegrationTest(TestCase):
             'org.slf4j.helpers.Util$ClassContextSecurityManager '
             'in getExtraClassContext'
         )
+
+    def test_error_on_resolving(self):
+        url = reverse(
+            'sentry-api-0-dsym-files',
+            kwargs={
+                'organization_slug': self.project.organization.slug,
+                'project_slug': self.project.slug,
+            }
+        )
+
+        self.login_as(user=self.user)
+
+        out = BytesIO()
+        f = zipfile.ZipFile(out, 'w')
+        f.writestr('proguard/%s.txt' % PROGUARD_BUG_UUID, PROGUARD_BUG_SOURCE)
+        f.close()
+
+        response = self.client.post(
+            url, {
+                'file':
+                SimpleUploadedFile('symbols.zip', out.getvalue(),
+                                   content_type='application/zip'),
+            },
+            format='multipart'
+        )
+        assert response.status_code == 201, response.content
+        assert len(response.data) == 1
+
+        event_data = {
+            "sentry.interfaces.User": {
+                "ip_address": "31.172.207.97"
+            },
+            "extra": {},
+            "project": self.project.id,
+            "platform": "java",
+            "debug_meta": {
+                "images": [{
+                    "type": "proguard",
+                    "uuid": PROGUARD_BUG_UUID,
+                }]
+            },
+            "sentry.interfaces.Exception": {
+                "values": [
+                    {
+                        'stacktrace': {
+                            "frames": [
+                                {
+                                    "function": "a",
+                                    "abs_path": None,
+                                    "module": "org.a.b.g$a",
+                                    "filename": None,
+                                    "lineno": 67,
+                                },
+                                {
+                                    "function": "a",
+                                    "abs_path": None,
+                                    "module": "org.a.b.g$a",
+                                    "filename": None,
+                                    "lineno": 69,
+                                },
+                            ]
+                        },
+                        "type": "RuntimeException",
+                        "value": "Shit broke yo"
+                    }
+                ]
+            },
+        }
+
+        resp = self._postWithHeader(event_data)
+        assert resp.status_code == 200
+
+        event = Event.objects.get()
+
+        assert len(event.data['errors']) == 1
+        assert event.data['errors'][0] == {
+            'mapping_uuid': u'071207ac-b491-4a74-957c-2c94fd9594f2',
+            'type': 'proguard_missing_lineno',
+        }


### PR DESCRIPTION
This fixes that on errors we did not correctly record the error.