### PR TITLE
build: Bump symbolic to 1.1.3

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -46,7 +46,7 @@ setproctitle>=1.1.7,<1.2.0
 statsd>=3.1.0,<3.2.0
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=1.1.0,<2.0.0
+symbolic>=1.1.3,<2.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23


### PR DESCRIPTION
This sets a mimimum verison of 1.1.3 for symbolic.  This ships a bunch
of fixes for proguard and other things.
