### PR TITLE
ref(api): Centralize create_audit_entry for api and frontend

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -93,7 +93,7 @@ class Endpoint(APIView):
             return Response(context, status=500)
 
     def create_audit_entry(self, request, transaction_id=None, **kwargs):
-        return create_audit_entry(request, transaction_id, **kwargs)
+        return create_audit_entry(request, transaction_id, audit_logger, **kwargs)
 
     def initialize_request(self, request, *args, **kwargs):
         rv = super(Endpoint, self).initialize_request(request, *args, **kwargs)

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -18,10 +18,10 @@ from rest_framework.views import APIView
 
 from sentry import tsdb
 from sentry.app import raven
-from sentry.models import ApiKey, AuditLogEntry, Environment
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin
+from sentry.utils.audit import create_audit_entry
 
 from .authentication import ApiKeyAuthentication, TokenAuthentication
 from .paginator import Paginator
@@ -93,35 +93,7 @@ class Endpoint(APIView):
             return Response(context, status=500)
 
     def create_audit_entry(self, request, transaction_id=None, **kwargs):
-        user = request.user if request.user.is_authenticated() else None
-        api_key = request.auth if isinstance(request.auth, ApiKey) else None
-
-        entry = AuditLogEntry(
-            actor=user, actor_key=api_key, ip_address=request.META['REMOTE_ADDR'], **kwargs
-        )
-
-        # Only create a real AuditLogEntry record if we are passing an event type
-        # otherwise, we want to still log to our actual logging
-        if entry.event is not None:
-            entry.save()
-
-        extra = {
-            'ip_address': entry.ip_address,
-            'organization_id': entry.organization_id,
-            'object_id': entry.target_object,
-            'entry_id': entry.id,
-            'actor_label': entry.actor_label
-        }
-        if entry.actor_id:
-            extra['actor_id'] = entry.actor_id
-        if entry.actor_key_id:
-            extra['actor_key_id'] = entry.actor_key_id
-        if transaction_id is not None:
-            extra['transaction_id'] = transaction_id
-
-        audit_logger.info(entry.get_event_display(), extra=extra)
-
-        return entry
+        return create_audit_entry(request, transaction_id, **kwargs)
 
     def initialize_request(self, request, *args, **kwargs):
         rv = super(Endpoint, self).initialize_request(request, *args, **kwargs)

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -18,6 +18,7 @@ from rest_framework.views import APIView
 
 from sentry import tsdb
 from sentry.app import raven
+from sentry.models import Environment
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin
@@ -26,6 +27,7 @@ from sentry.utils.audit import create_audit_entry
 from .authentication import ApiKeyAuthentication, TokenAuthentication
 from .paginator import Paginator
 from .permissions import NoPermission
+
 
 __all__ = ['DocSection', 'Endpoint', 'EnvironmentMixin', 'StatsMixin']
 

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+from sentry.models import ApiKey, AuditLogEntry
+
+import logging
+audit_logger = logging.getLogger('sentry.audit.api')
+
+
+def create_audit_entry(request, transaction_id=None, **kwargs):
+
+    user = request.user if request.user.is_authenticated() else None
+    api_key = request.auth if hasattr(request, 'auth') \
+        and isinstance(request.auth, ApiKey) else None
+
+    entry = AuditLogEntry(
+        actor=user, actor_key=api_key, ip_address=request.META['REMOTE_ADDR'], **kwargs
+    )
+
+    # Only create a real AuditLogEntry record if we are passing an event type
+    # otherwise, we want to still log to our actual logging
+    if entry.event is not None:
+        entry.save()
+
+    extra = {
+        'ip_address': entry.ip_address,
+        'organization_id': entry.organization_id,
+        'object_id': entry.target_object,
+        'entry_id': entry.id,
+        'actor_label': entry.actor_label
+    }
+    if entry.actor_id:
+        extra['actor_id'] = entry.actor_id
+    if entry.actor_key_id:
+        extra['actor_key_id'] = entry.actor_key_id
+    if transaction_id is not None:
+        extra['transaction_id'] = transaction_id
+
+    audit_logger.info(entry.get_event_display(), extra=extra)
+
+    return entry

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 from sentry.models import ApiKey, AuditLogEntry
 
-import logging
-audit_logger = logging.getLogger('sentry.audit.api')
 
-
-def create_audit_entry(request, transaction_id=None, **kwargs):
+def create_audit_entry(request, transaction_id=None, logger=None, **kwargs):
 
     user = request.user if request.user.is_authenticated() else None
     api_key = request.auth if hasattr(request, 'auth') \
@@ -34,6 +31,7 @@ def create_audit_entry(request, transaction_id=None, **kwargs):
     if transaction_id is not None:
         extra['transaction_id'] = transaction_id
 
-    audit_logger.info(entry.get_event_display(), extra=extra)
+    if logger:
+        logger.info(entry.get_event_display(), extra=extra)
 
     return entry

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -276,7 +276,7 @@ class BaseView(View, OrganizationMixin):
         )
 
     def create_audit_entry(self, request, transaction_id=None, **kwargs):
-        return create_audit_entry(request, transaction_id, **kwargs)
+        return create_audit_entry(request, transaction_id, audit_logger, **kwargs)
 
 
 class OrganizationView(BaseView):

--- a/tests/sentry/utils/audit/__init__.py
+++ b/tests/sentry/utils/audit/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from django.contrib.auth.models import AnonymousUser
+
+from sentry.models import ApiKey
+from sentry.testutils import APITestCase
+from sentry.utils.audit import create_audit_entry
+
+
+class FakeHttpRequest(object):
+    def __init__(self, user):
+        self.user = user
+
+
+class CreateAuditEntryTest(APITestCase):
+
+    def test_audit_entry_api(self):
+        org = self.create_organization()
+        apikey = ApiKey.objects.create(
+            organization=org,
+            allowed_origins='*',
+        )
+
+        req = FakeHttpRequest(AnonymousUser())
+        req.META = {
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_AUTHORIZATION': apikey
+        }
+        req.auth = apikey
+
+        entry_args = {}
+        entry = create_audit_entry(req, None, **entry_args)
+        assert entry.actor_key == req.META['HTTP_AUTHORIZATION']
+        assert entry.actor is None
+        assert entry.ip_address == req.META['REMOTE_ADDR']
+
+    def test_audit_entry_frontend(self):
+        req = FakeHttpRequest(self.create_user())
+        req.META = {
+            'REMOTE_ADDR': '127.0.0.1',
+        }
+
+        entry_args = {}
+        entry = create_audit_entry(req, None, **entry_args)
+        assert entry.actor == req.user
+        assert entry.ip_address == req.META['REMOTE_ADDR']

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -8,8 +8,9 @@ from sentry.utils.audit import create_audit_entry
 
 
 class FakeHttpRequest(object):
-    def __init__(self, user):
+    def __init__(self, user, META):
         self.user = user
+        self.META = META
 
 
 class CreateAuditEntryTest(APITestCase):
@@ -20,27 +21,21 @@ class CreateAuditEntryTest(APITestCase):
             organization=org,
             allowed_origins='*',
         )
-
-        req = FakeHttpRequest(AnonymousUser())
-        req.META = {
+        meta = {
             'REMOTE_ADDR': '127.0.0.1',
             'HTTP_AUTHORIZATION': apikey
         }
+        req = FakeHttpRequest(AnonymousUser(), meta)
         req.auth = apikey
 
-        entry_args = {}
-        entry = create_audit_entry(req, None, **entry_args)
+        entry = create_audit_entry(req)
         assert entry.actor_key == req.META['HTTP_AUTHORIZATION']
         assert entry.actor is None
         assert entry.ip_address == req.META['REMOTE_ADDR']
 
     def test_audit_entry_frontend(self):
-        req = FakeHttpRequest(self.create_user())
-        req.META = {
-            'REMOTE_ADDR': '127.0.0.1',
-        }
+        req = FakeHttpRequest(self.create_user(), {'REMOTE_ADDR': '127.0.0.1'})
 
-        entry_args = {}
-        entry = create_audit_entry(req, None, **entry_args)
+        entry = create_audit_entry(req)
         assert entry.actor == req.user
         assert entry.ip_address == req.META['REMOTE_ADDR']

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -8,9 +8,9 @@ from sentry.utils.audit import create_audit_entry
 
 
 class FakeHttpRequest(object):
-    def __init__(self, user, META):
+    def __init__(self, user):
         self.user = user
-        self.META = META
+        self.META = {'REMOTE_ADDR': '127.0.0.1'}
 
 
 class CreateAuditEntryTest(APITestCase):
@@ -21,21 +21,19 @@ class CreateAuditEntryTest(APITestCase):
             organization=org,
             allowed_origins='*',
         )
-        meta = {
-            'REMOTE_ADDR': '127.0.0.1',
-            'HTTP_AUTHORIZATION': apikey
-        }
-        req = FakeHttpRequest(AnonymousUser(), meta)
+
+        req = FakeHttpRequest(AnonymousUser(), )
         req.auth = apikey
 
         entry = create_audit_entry(req)
-        assert entry.actor_key == req.META['HTTP_AUTHORIZATION']
+        assert entry.actor_key == apikey
         assert entry.actor is None
         assert entry.ip_address == req.META['REMOTE_ADDR']
 
     def test_audit_entry_frontend(self):
-        req = FakeHttpRequest(self.create_user(), {'REMOTE_ADDR': '127.0.0.1'})
-
+        req = FakeHttpRequest(self.create_user())
         entry = create_audit_entry(req)
+
         assert entry.actor == req.user
+        assert entry.actor_key is None
         assert entry.ip_address == req.META['REMOTE_ADDR']


### PR DESCRIPTION
Both base.py for api and frontend used nearly identical methods for creating audit log entries. Move common functionality to utils.