### PR TITLE
chore(vscode): Python extension moved

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,9 +4,8 @@
     "recommendations": [
         "dzannotti.vscode-babel-coloring",
         "esbenp.prettier-vscode",
-        "donjayamanne.python",
+        "ms-python.python",
         "dbaeumer.vscode-eslint",
-        "lextudio.restructuredtext",
-        "jmlntw.vscode-ensure-single-final-newline"
+        "lextudio.restructuredtext"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
         "src/sentry/static/sentry/dist/": true
     },
     "files.trimTrailingWhitespace": true,
-    "files.ensureSingleFinalNewline": true,
+    "files.trimFinalNewlines": true,
 
     "eslint.options": {
         "configFile": ".eslintrc"


### PR DESCRIPTION
https://blogs.msdn.microsoft.com/pythonengineering/2017/11/09/don-jayamanne-joins-microsoft/

the newline extension is also deprecated in favor of this option