### PR TITLE
feat(tsdb): Enable marking clusters as non-durable for writes

### DIFF
--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -38,6 +38,12 @@ CountMinScript = Script(
 
 
 class SuppressionWrapper(object):
+    """\
+    Wraps a context manager and prevents exceptions raised by exiting the
+    wrapped context manager from propagating. Exceptions that were raised in
+    the context, however, are still propagated.
+    """
+
     def __init__(self, wrapped, types=(Exception,)):
         self.wrapped = wrapped
         self.types = types

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -137,6 +137,15 @@ class RedisTSDB(BaseTSDB):
         )
 
     def get_cluster(self, environment_id):
+        """\
+        Returns a 2-tuple of the form ``(cluster, durable)``.
+
+        When a cluster is marked as "durable", any exception raised while
+        attempting to write data to the cluster is propagated. When the cluster
+        is *not* marked as "durable", exceptions raised while attempting to
+        write data to the cluster are *not* propagated. This flag does not have
+        an effect on read operations.
+        """
         return self.cluster, True
 
     def get_cluster_groups(self, environment_ids):

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -638,8 +638,12 @@ class RedisTSDB(BaseTSDB):
 
         rollups = self.get_active_series(start, end, timestamp)
 
-        for (cluster, duraable), environment_ids in self.get_cluster_groups(environment_ids):
-            with cluster.fanout() as client:
+        for (cluster, durable), environment_ids in self.get_cluster_groups(environment_ids):
+            manager = cluster.fanout()
+            if not durable:
+                manager = SuppressionWrapper(manager)
+
+            with manager as client:
                 for rollup, series in rollups.items():
                     for timestamp in series:
                         for model in models:

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -18,20 +18,19 @@ from sentry.utils.dates import to_datetime, to_timestamp
 def test_suppression_wrapper():
 
     @contextmanager
-    def wrapper():
+    def raise_after():
         yield
         raise Exception('Boom!')
 
     with pytest.raises(Exception):
-        with wrapper():
+        with raise_after():
             pass
 
-    with pytest.raises(RuntimeError):
-        with SuppressionWrapper(wrapper()):
-            raise RuntimeError
-
-    with SuppressionWrapper(wrapper()):
+    with SuppressionWrapper(raise_after()):
         pass
+
+    with SuppressionWrapper(raise_after()):
+        raise Exception('should not propagate')
 
 
 class RedisTSDBTest(TestCase):


### PR DESCRIPTION
This prevents failing to write to these clusters from failing the entire write operation.