### PR TITLE
feat(tags): Add environment_id to tagstore incr and bulk get APIs

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -50,7 +50,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint, EnvironmentMixin):
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
-        queryset = tagstore.get_group_tag_value_qs(group.id, lookup_key)
+        queryset = tagstore.get_group_tag_value_qs(group.id, environment_id, lookup_key)
 
         sort = request.GET.get('sort')
         if sort == 'date':

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -37,7 +37,13 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
         lookup_key = tagstore.prefix_reserved_key(key)
 
         try:
-            updated, tagkey = tagstore.delete_tag_key(project.id, lookup_key)
+            environment_id = self._get_environment_id_from_request(request, project.organization_id)
+        except Environment.DoesNotExist:
+            # if the environment doesn't exist then the tag can't possibly exist
+            raise ResourceDoesNotExist
+
+        try:
+            updated, tagkey = tagstore.delete_tag_key(project.id, environment_id, lookup_key)
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -43,11 +43,11 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
             raise ResourceDoesNotExist
 
         try:
-            updated, tagkey = tagstore.delete_tag_key(project.id, environment_id, lookup_key)
+            deleted = tagstore.delete_tag_keys(project.id, environment_id, lookup_key)
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
-        if updated:
+        for tagkey in deleted:
             self.create_audit_entry(
                 request=request,
                 organization=project.organization,

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -43,7 +43,8 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
             raise ResourceDoesNotExist
 
         try:
-            deleted = tagstore.delete_tag_keys(project.id, environment_id, lookup_key)
+            deleted = tagstore.delete_tag_keys(
+                project.id, lookup_key, environment_id=environment_id)
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -39,7 +39,11 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
-        queryset = tagstore.get_tag_value_qs(project.id, tagkey.key, query=request.GET.get('query'))
+        queryset = tagstore.get_tag_value_qs(
+            project.id,
+            environment_id,
+            tagkey.key,
+            query=request.GET.get('query'))
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -141,7 +141,8 @@ class GroupSerializer(Serializer):
             ).select_related('user')
         )
 
-        user_counts = tagstore.get_group_values_seen([g.id for g in item_list], 'sentry:user')
+        user_counts = tagstore.get_group_values_seen(
+            [g.id for g in item_list], environment_id=None, key='sentry:user')
 
         ignore_items = {g.group_id: g for g in GroupSnooze.objects.filter(
             group__in=item_list,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -756,7 +756,7 @@ class EventManager(object):
                 }
             )
 
-        safe_execute(Group.objects.add_tags, group, tags, _with_transaction=False)
+        safe_execute(Group.objects.add_tags, group, environment, tags, _with_transaction=False)
 
         if not raw:
             if not project.first_event:

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -83,17 +83,6 @@ class Event(Model):
 
     project = property(_get_project, _set_project)
 
-    @property
-    def environment(self):
-        from sentry.models import Environment
-
-        if not hasattr(self, '_environment_cache'):
-            self._environment_cache = Environment.get_or_create(
-                project=self.project,
-                name=self.get_tag('environment'),
-            )
-        return self._environment_cache
-
     def get_legacy_message(self):
         msg_interface = self.data.get('sentry.interfaces.Message', {
             'message': self.message,

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -83,6 +83,17 @@ class Event(Model):
 
     project = property(_get_project, _set_project)
 
+    @property
+    def environment(self):
+        from sentry.models import Environment
+
+        if not hasattr(self, '_environment_cache'):
+            self._environment_cache = Environment.get_or_create(
+                project=self.project,
+                name=self.get_tag('environment'),
+            )
+        return self._environment_cache
+
     def get_legacy_message(self):
         msg_interface = self.data.get('sentry.interfaces.Message', {
             'message': self.message,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -150,7 +150,7 @@ class GroupManager(BaseManager):
 
         return Group.objects.get(id=group_id)
 
-    def add_tags(self, group, tags):
+    def add_tags(self, group, environment, tags):
         project_id = group.project_id
         date = group.last_seen
 
@@ -160,12 +160,12 @@ class GroupManager(BaseManager):
             else:
                 key, value, data = tag_item
 
-            tagstore.incr_tag_value_times_seen(project_id, key, value, {
+            tagstore.incr_tag_value_times_seen(project_id, environment.id, key, value, {
                 'last_seen': date,
                 'data': data,
             })
 
-            tagstore.incr_group_tag_value_times_seen(group.id, key, value, {
+            tagstore.incr_group_tag_value_times_seen(group.id, environment.id, key, value, {
                 'project_id': project_id,
                 'last_seen': date,
             })
@@ -437,4 +437,5 @@ class Group(Model):
         )
 
     def count_users_seen(self):
-        return tagstore.get_group_values_seen(self.id, 'sentry:user')[self.id]
+        return tagstore.get_group_values_seen(
+            self.id, environment_id=None, key='sentry:user')[self.id]

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -233,9 +233,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def delete_tag_key(self, project_id, key):
+    def delete_tag_key(self, project_id, environment_id, key):
         """
-        >>> delete_tag_key(1, "key1")
+        >>> delete_tag_key(1, 2, "key1")
         """
         raise NotImplementedError
 
@@ -251,27 +251,29 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def incr_tag_key_values_seen(self, project_id, key, count=1):
+    def incr_tag_key_values_seen(self, project_id, environment_id, key, count=1):
         """
-        >>> incr_tag_key_values_seen(1, "key1")
-        """
-        raise NotImplementedError
-
-    def incr_tag_value_times_seen(self, project_id, key, value, extra=None, count=1):
-        """
-        >>> incr_tag_value_times_seen(1, "key1", "value1")
+        >>> incr_tag_key_values_seen(1, 2, "key1")
         """
         raise NotImplementedError
 
-    def incr_group_tag_key_values_seen(self, project_id, group_id, key, count=1):
+    def incr_tag_value_times_seen(self, project_id, environment_id,
+                                  key, value, extra=None, count=1):
         """
-        >>> incr_group_tag_key_values_seen(1, 2, "key1")
+        >>> incr_tag_value_times_seen(1, 2, "key1", "value1")
         """
         raise NotImplementedError
 
-    def incr_group_tag_value_times_seen(self, group_id, key, value, extra=None, count=1):
+    def incr_group_tag_key_values_seen(self, project_id, group_id, environment_id, key, count=1):
         """
-        >>> incr_group_tag_value_times_seen(1, "key1", "value1")
+        >>> incr_group_tag_key_values_seen(1, 2, 3, "key1")
+        """
+        raise NotImplementedError
+
+    def incr_group_tag_value_times_seen(
+            self, group_id, environment_id, key, value, extra=None, count=1):
+        """
+        >>> incr_group_tag_value_times_seen(1, 2, "key1", "value1")
         """
         raise NotImplementedError
 
@@ -281,21 +283,21 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_tag_value_qs(self, project_id, key, query=None):
+    def get_tag_value_qs(self, project_id, environment_id, key, query=None):
         """
-        >>> get_tag_value_qs(1, 'environment', query='prod')
-        """
-        raise NotImplementedError
-
-    def get_group_tag_value_qs(self, group_id, key):
-        """
-        >>> get_group_tag_value_qs(1, 'environment')
+        >>> get_tag_value_qs(1, 2, 'environment', query='prod')
         """
         raise NotImplementedError
 
-    def get_group_values_seen(self, group_ids, key):
+    def get_group_tag_value_qs(self, group_id, environment_id, key):
         """
-        >>> get_group_values_seen([1, 2], 'key1')
+        >>> get_group_tag_value_qs(1, 2, 'environment')
+        """
+        raise NotImplementedError
+
+    def get_group_values_seen(self, group_ids, environment_id, key):
+        """
+        >>> get_group_values_seen([1, 2], 3, 'key1')
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -58,7 +58,7 @@ class TagStorage(Service):
         'get_group_tag_value',
         'get_group_tag_values',
 
-        'delete_tag_key',
+        'delete_tag_keys',
         'delete_all_group_tag_keys',
         'delete_all_group_tag_values',
 
@@ -232,9 +232,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def delete_tag_key(self, project_id, environment_id, key):
+    def delete_tag_keys(self, project_id, key, environment_id=None):
         """
-        >>> delete_tag_key(1, 2, "key1")
+        >>> delete_tag_keys(1, "key1")
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -72,7 +72,6 @@ class TagStorage(Service):
         'incr_tag_value_times_seen',
         'incr_group_tag_key_values_seen',
         'incr_group_tag_value_times_seen',
-        'update_project_for_group',
         'get_group_ids_for_users',
         'get_group_tag_values_for_users',
         'get_tags_for_search_filter',
@@ -175,9 +174,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def create_event_tags(self, project_id, group_id, event_id, tags):
+    def create_event_tags(self, project_id, group_id, environment_id, event_id, tags):
         """
-        >>> create_event_tags(1, 2, 3, [(4, 5)])
+        >>> create_event_tags(1, 2, 3, 4, [(5, 6)])
         """
         raise NotImplementedError
 
@@ -322,12 +321,6 @@ class TagStorage(Service):
     def get_last_release(self, group_id):
         """
         >>> get_last_release(1)
-        """
-        raise NotImplementedError
-
-    def update_project_for_group(self, group_id, old_project_id, new_project_id):
-        """
-        >>> update_project_for_group(1, 2, 3)
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -232,9 +232,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def delete_tag_keys(self, project_id, key, environment_id=None):
+    def delete_tag_keys(self, project_id, keys, environment_id=None):
         """
-        >>> delete_tag_keys(1, "key1")
+        >>> delete_tag_keys(1, ["key1"])
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -101,7 +101,7 @@ class LegacyTagStorage(TagStorage):
         return GroupTagValue.objects.get_or_create(
             project_id=project_id, group_id=group_id, key=key, value=value, **kwargs)
 
-    def create_event_tags(self, project_id, group_id, event_id, tags):
+    def create_event_tags(self, project_id, group_id, environment_id, event_id, tags):
         try:
             # don't let a duplicate break the outer transaction
             with transaction.atomic():
@@ -449,12 +449,6 @@ class LegacyTagStorage(TagStorage):
             return None
 
         return last_release.value
-
-    def update_project_for_group(self, group_id, old_project_id, new_project_id):
-        GroupTagValue.objects.filter(
-            project_id=old_project_id,
-            group_id=group_id,
-        ).update(project_id=new_project_id)
 
     def get_group_ids_for_users(self, project_ids, event_users, limit=100):
         return list(GroupTagValue.objects.filter(

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -241,7 +241,7 @@ class LegacyTagStorage(TagStorage):
 
         return list(qs)
 
-    def delete_tag_key(self, project_id, key):
+    def delete_tag_key(self, project_id, environment_id, key):
         from .tasks import delete_tag_key
 
         tagkey = self.get_tag_key(project_id, environment_id=None, key=key, status=None)
@@ -266,7 +266,7 @@ class LegacyTagStorage(TagStorage):
             group_id=group_id,
         ).delete()
 
-    def incr_tag_key_values_seen(self, project_id, key, count=1):
+    def incr_tag_key_values_seen(self, project_id, environment_id, key, count=1):
         buffer.incr(TagKey, {
             'values_seen': count,
         }, {
@@ -274,7 +274,8 @@ class LegacyTagStorage(TagStorage):
             'key': key,
         })
 
-    def incr_tag_value_times_seen(self, project_id, key, value, extra=None, count=1):
+    def incr_tag_value_times_seen(self, project_id, environment_id,
+                                  key, value, extra=None, count=1):
         buffer.incr(TagValue, {
             'times_seen': count,
         }, {
@@ -283,7 +284,7 @@ class LegacyTagStorage(TagStorage):
             'value': value,
         }, extra)
 
-    def incr_group_tag_key_values_seen(self, project_id, group_id, key, count=1):
+    def incr_group_tag_key_values_seen(self, project_id, group_id, environment_id, key, count=1):
         buffer.incr(GroupTagKey, {
             'values_seen': count,
         }, {
@@ -292,7 +293,8 @@ class LegacyTagStorage(TagStorage):
             'key': key,
         })
 
-    def incr_group_tag_value_times_seen(self, group_id, key, value, extra=None, count=1):
+    def incr_group_tag_value_times_seen(
+            self, group_id, environment_id, key, value, extra=None, count=1):
         buffer.incr(GroupTagValue, {
             'times_seen': count,
         }, {
@@ -357,7 +359,7 @@ class LegacyTagStorage(TagStorage):
 
         return matches
 
-    def get_group_values_seen(self, group_ids, key):
+    def get_group_values_seen(self, group_ids, environment_id, key):
         if isinstance(group_ids, six.integer_types):
             qs = GroupTagKey.objects.filter(group_id=group_ids)
         else:
@@ -523,7 +525,7 @@ class LegacyTagStorage(TagStorage):
                 ).count(),
             )
 
-    def get_tag_value_qs(self, project_id, key, query=None):
+    def get_tag_value_qs(self, project_id, environment_id, key, query=None):
         queryset = TagValue.objects.filter(
             project_id=project_id,
             key=key,
@@ -534,7 +536,7 @@ class LegacyTagStorage(TagStorage):
 
         return queryset
 
-    def get_group_tag_value_qs(self, group_id, key):
+    def get_group_tag_value_qs(self, group_id, environment_id, key):
         return GroupTagValue.objects.filter(
             group_id=group_id,
             key=key,

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -241,12 +241,12 @@ class LegacyTagStorage(TagStorage):
 
         return list(qs)
 
-    def delete_tag_keys(self, project_id, key, environment_id=None):
+    def delete_tag_keys(self, project_id, keys, environment_id=None):
         from .tasks import delete_tag_key as delete_tag_key_task
 
         deleted = []
 
-        for tagkey in self.get_tag_keys(project_id, environment_id, key, status=None):
+        for tagkey in self.get_tag_keys(project_id, environment_id, keys, status=None):
             updated = TagKey.objects.filter(
                 id=tagkey.id,
                 status=TagKeyStatus.VISIBLE,

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -147,7 +147,10 @@ class LegacyTagStorage(TagStorage):
             qs = qs.filter(status=status)
 
         if keys is not None:
-            qs = qs.filter(key__in=keys)
+            if isinstance(keys, six.string_types):
+                qs = qs.filter(key=keys)
+            else:
+                qs = qs.filter(key__in=keys)
 
         return list(qs)
 

--- a/src/sentry/tagstore/legacy/receivers.py
+++ b/src/sentry/tagstore/legacy/receivers.py
@@ -27,7 +27,9 @@ def record_project_tag_count(filters, created, **kwargs):
     if not project_id:
         project_id = filters['project'].id
 
-    tagstore.incr_tag_key_values_seen(project_id, filters['key'])
+    environment_id = filters.get('environment_id')
+
+    tagstore.incr_tag_key_values_seen(project_id, environment_id, filters['key'])
 
 
 @buffer_incr_complete.connect(sender=GroupTagValue, weak=False)
@@ -42,8 +44,9 @@ def record_group_tag_count(filters, created, extra, **kwargs):
         project_id = extra['project']
 
     group_id = filters['group_id']
+    environment_id = filters.get('environment_id')
 
-    tagstore.incr_group_tag_key_values_seen(project_id, group_id, filters['key'])
+    tagstore.incr_group_tag_key_values_seen(project_id, group_id, environment_id, filters['key'])
 
 
 post_save.connect(

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -241,7 +241,8 @@ def _rehash_group_events(group, limit=100):
             )
             event.update(group_id=new_group.id)
             if event.data.get('tags'):
-                Group.objects.add_tags(new_group, event.data['tags'])
+                Group.objects.add_tags(new_group, event.environment, event.data['tags'])
+
     return bool(event_list)
 
 

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -214,6 +214,13 @@ def _get_event_environment(event, project, cache):
             environment = Environment.get_for_organization_id(
                 project.organization_id, environment_name)
         except Environment.DoesNotExist:
+            logger.warn(
+                'event.environment.does_not_exist',
+                extra={
+                    'project_id': project.id,
+                    'environment_name': environment_name,
+                }
+            )
             environment = Environment.get_or_create(project, environment_name)
 
         cache[environment_name] = environment

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -142,6 +142,7 @@ def index_event_tags(organization_id, project_id, event_id, tags,
     tagstore.create_event_tags(
         project_id=project_id,
         group_id=group_id,
+        environment_id=environment_id,
         event_id=event_id,
         tags=tag_ids,
     )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -92,17 +92,6 @@ def post_process_group(event, is_new, is_regression, is_sample, **kwargs):
     )
 
 
-def record_additional_tags(event):
-    from sentry.models import Group
-
-    added_tags = []
-    for plugin in plugins.for_project(event.project, version=2):
-        added_tags.extend(safe_execute(
-            plugin.get_tags, event, _with_transaction=False) or ())
-    if added_tags:
-        Group.objects.add_tags(event.group, added_tags)
-
-
 def process_snoozes(group):
     from sentry.models import GroupSnooze, GroupStatus
 

--- a/src/sentry/web/frontend/group_tag_export.py
+++ b/src/sentry/web/frontend/group_tag_export.py
@@ -92,7 +92,7 @@ class GroupTagExportView(ProjectView, CsvMixin, EnvironmentMixin):
             callbacks = []
 
         queryset = RangeQuerySetWrapper(
-            tagstore.get_group_tag_value_qs(group.id, lookup_key),
+            tagstore.get_group_tag_value_qs(group.id, environment_id, lookup_key),
             callbacks=callbacks,
         )
 

--- a/tests/sentry/api/endpoints/test_group_events.py
+++ b/tests/sentry/api/endpoints/test_group_events.py
@@ -60,6 +60,7 @@ class GroupEventsTest(APITestCase):
         tagstore.create_event_tags(
             project_id=group.project_id,
             group_id=group.id,
+            environment_id=self.environment.id,
             event_id=event_1.id,
             tags=[
                 (tagkey_1.id, tagvalue_1.id),
@@ -69,6 +70,7 @@ class GroupEventsTest(APITestCase):
         tagstore.create_event_tags(
             project_id=group.project_id,
             group_id=group.id,
+            environment_id=self.environment.id,
             event_id=event_2.id,
             tags=[
                 (tagkey_2.id, tagvalue_2.id),

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -27,6 +27,7 @@ class DeleteGroupTest(TestCase):
             event_id=event.id,
             group_id=group.id,
             project_id=project.id,
+            environment_id=self.environment.id,
             tags=[
                 (1, 1),
             ],

--- a/tests/sentry/deletions/test_tagkey.py
+++ b/tests/sentry/deletions/test_tagkey.py
@@ -34,6 +34,7 @@ class DeleteTagKeyTest(TestCase):
             group_id=group.id,
             project_id=project.id,
             event_id=1,
+            environment_id=self.environment.id,
             tags=[
                 (tk.id, 1),
             ]
@@ -53,6 +54,7 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_event_tags(
             group_id=group2.id,
             project_id=project.id,
+            environment_id=self.environment.id,
             event_id=1,
             tags=[
                 (tk2.id, 1),

--- a/tests/sentry/manager/tests.py
+++ b/tests/sentry/manager/tests.py
@@ -17,11 +17,18 @@ class SentryManagerTest(TestCase):
     def test_add_tags(self):
         event = Group.objects.from_kwargs(1, message='rrr')
         group = event.group
+        environment = self.create_environment()
 
         with self.tasks():
-            Group.objects.add_tags(group, tags=(('foo', 'bar'), ('foo', 'baz'), ('biz', 'boz')))
+            Group.objects.add_tags(group, environment, tags=(
+                ('foo', 'bar'), ('foo', 'baz'), ('biz', 'boz')))
 
-        results = sorted(tagstore.get_group_tag_values(group.id, None, 'foo'), key=lambda x: x.id)
+        results = sorted(
+            tagstore.get_group_tag_values(
+                group.id,
+                environment_id=None,
+                keys=['foo']),
+            key=lambda x: x.id)
         assert len(results) == 2
         res = results[0]
         self.assertEquals(res.value, 'bar')
@@ -30,7 +37,12 @@ class SentryManagerTest(TestCase):
         self.assertEquals(res.value, 'baz')
         self.assertEquals(res.times_seen, 1)
 
-        results = sorted(tagstore.get_group_tag_values(group.id, None, 'biz'), key=lambda x: x.id)
+        results = sorted(
+            tagstore.get_group_tag_values(
+                group.id,
+                environment_id=None,
+                keys=['biz']),
+            key=lambda x: x.id)
         assert len(results) == 1
         res = results[0]
         self.assertEquals(res.value, 'boz')

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -211,6 +211,7 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_event_tags(
             group_id=group.id,
             project_id=project.id,
+            environment_id=self.environment.id,
             event_id=1,
             tags=[
                 (tk.id, 1),
@@ -232,6 +233,7 @@ class DeleteTagKeyTest(TestCase):
         tagstore.create_event_tags(
             group_id=group2.id,
             project_id=project.id,
+            environment_id=self.environment.id,
             event_id=1,
             tags=[
                 (tk2.id, 1)
@@ -286,6 +288,7 @@ class DeleteGroupTest(TestCase):
             event_id=event.id,
             group_id=group.id,
             project_id=project.id,
+            environment_id=self.environment.id,
             tags=[
                 (1, 1),
             ],

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -184,7 +184,7 @@ class DeleteProjectTest(TestCase):
 
 class DeleteTagKeyTest(TestCase):
     def test_simple(self):
-        from sentry.tagstore.legacy.tasks import delete_tag_key
+        from sentry.tagstore.legacy.tasks import delete_tag_key as delete_tag_key_task
 
         team = self.create_team(name='test', slug='test')
         project = self.create_project(team=team, name='test1', slug='test1')
@@ -241,7 +241,7 @@ class DeleteTagKeyTest(TestCase):
         )
 
         with self.tasks():
-            delete_tag_key(object_id=tk.id)
+            delete_tag_key_task(object_id=tk.id)
 
             assert tagstore.get_event_tag_qs(key_id=tk.id).exists()
             try:

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -205,11 +205,12 @@ class UnmergeTestCase(TestCase):
             },
         ])
 
+        environment = Environment.objects.create(
+            organization_id=project.organization_id,
+            name='production',
+        )
         EnvironmentProject.objects.create(
-            environment=Environment.objects.create(
-                organization_id=project.organization_id,
-                name='production',
-            ),
+            environment=environment,
             project=project,
         )
 
@@ -252,6 +253,7 @@ class UnmergeTestCase(TestCase):
             with self.tasks():
                 Group.objects.add_tags(
                     source,
+                    environment,
                     tags=event.get_tags(),
                 )
 


### PR DESCRIPTION
I think this is the last one until #6427 gets merged so I can start making use of the environment stuff.

As usual the legacy backend doesn't actually do anything with environment since that info isn't in the DB. The v2 backend will be able to implement these and actually use the environment.