### PR TITLE
Change psycopg2 version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -28,7 +28,7 @@ percy>=0.4.5
 petname>=2.0,<2.1
 Pillow>=3.2.0,<=4.2.1
 progressbar2>=3.10,<3.11
-psycopg2>=2.6.0,<2.7.0
+psycopg2>=2.7.0
 pytest>=3.1.2,<3.2.0
 pytest-django>=2.9.1,<2.10.0
 pytest-html>=1.9.0,<1.10.0


### PR DESCRIPTION
In process of installing package sentry from pip with PostgreSQL 10, I has acquired exception, that vesrion is not allowed.