### PR TITLE
fix(dropdown): Fix actions menu in stream

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -659,6 +659,7 @@ const StreamActions = React.createClass({
                 caret={false}
                 className="btn btn-sm btn-default hidden-xs action-more"
                 title={<span className="icon-ellipsis" />}
+                alwaysRenderMenu
               >
                 <MenuItem noAnchor={true}>
                   <ActionLink


### PR DESCRIPTION
Dropdowns with modals need `alwaysRenderMenu` prop