### PR TITLE
build: Disable parallel make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-CPUS ?= $(shell sysctl -n hw.ncpu 2> /dev/null || echo 1)
-MAKEFLAGS += --jobs=$(CPUS)
 NPM_ROOT = ./node_modules
 STATIC_DIR = src/sentry/static/sentry
 


### PR DESCRIPTION
This causes issues with Yarn as it does not appear to lock its installation command.