### PR TITLE
feat(api): Add environment filtering parameter to filterable statistics endpoints

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -243,7 +243,7 @@ class EnvironmentMixin(object):
 
 
 class StatsMixin(object):
-    def _parse_args(self, request):
+    def _parse_args(self, request, environment_id=None):
         resolution = request.GET.get('resolution')
         if resolution:
             resolution = self._parse_resolution(resolution)
@@ -266,6 +266,7 @@ class StatsMixin(object):
             'start': start,
             'end': end,
             'rollup': resolution,
+            'environment_id': environment_id,
         }
 
     def _parse_resolution(self, value):

--- a/src/sentry/api/endpoints/group_stats.py
+++ b/src/sentry/api/endpoints/group_stats.py
@@ -3,14 +3,27 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry import tsdb
-from sentry.api.base import StatsMixin
+from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.group import GroupEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import Environment
 
 
-class GroupStatsEndpoint(GroupEndpoint, StatsMixin):
+class GroupStatsEndpoint(GroupEndpoint, EnvironmentMixin, StatsMixin):
     def get(self, request, group):
+        try:
+            environment_id = self._get_environment_id_from_request(
+                request,
+                group.project.organization_id,
+            )
+        except Environment.DoesNotExist:
+            raise ResourceDoesNotExist
+
         data = tsdb.get_range(
-            model=tsdb.models.group, keys=[group.id], **self._parse_args(request)
+            model=tsdb.models.group, keys=[group.id], **self._parse_args(
+                request,
+                environment_id,
+            )
         )[group.id]
 
         return Response(data)

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry import tsdb
-from sentry.api.base import DocSection, StatsMixin
+from sentry.api.base import DocSection, EnvironmentMixin, StatsMixin
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.models import Project, Team
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import Environment, Project, Team
 from sentry.utils.apidocs import attach_scenarios, scenario
 
 
@@ -14,7 +15,7 @@ def retrieve_event_counts_organization(runner):
     runner.request(method='GET', path='/organizations/%s/stats/' % runner.org.slug)
 
 
-class OrganizationStatsEndpoint(OrganizationEndpoint, StatsMixin):
+class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMixin):
     doc_section = DocSection.ORGANIZATIONS
 
     @attach_scenarios([retrieve_event_counts_organization])
@@ -73,6 +74,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, StatsMixin):
 
         stat_model = None
         stat = request.GET.get('stat', 'received')
+        query_kwargs = {}
         if stat == 'received':
             if group == 'project':
                 stat_model = tsdb.models.project_total_received
@@ -91,11 +93,19 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, StatsMixin):
         elif stat == 'generated':
             if group == 'project':
                 stat_model = tsdb.models.project
+                try:
+                    query_kwargs['environment_id'] = self._get_environment_id_from_request(
+                        request,
+                        organization.id,
+                    )
+                except Environment.DoesNotExist:
+                    raise ResourceDoesNotExist
 
         if stat_model is None:
             raise ValueError('Invalid group: %s, stat: %s' % (group, stat))
 
-        data = tsdb.get_range(model=stat_model, keys=keys, **self._parse_args(request))
+        data = tsdb.get_range(model=stat_model, keys=keys, **
+                              self._parse_args(request, **query_kwargs))
 
         if group == 'organization':
             data = data[organization.id]

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -104,8 +104,8 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
         if stat_model is None:
             raise ValueError('Invalid group: %s, stat: %s' % (group, stat))
 
-        data = tsdb.get_range(model=stat_model, keys=keys, **
-                              self._parse_args(request, **query_kwargs))
+        data = tsdb.get_range(model=stat_model, keys=keys,
+                              **self._parse_args(request, **query_kwargs))
 
         if group == 'organization':
             data = data[organization.id]

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -5,13 +5,22 @@ import six
 from rest_framework.response import Response
 
 from sentry.app import tsdb
-from sentry.api.base import StatsMixin
+from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.models import Group
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import Environment, Group
 
 
-class ProjectGroupStatsEndpoint(ProjectEndpoint, StatsMixin):
+class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
     def get(self, request, project):
+        try:
+            environment_id = self._get_environment_id_from_request(
+                request,
+                project.organization_id,
+            )
+        except Environment.DoesNotExist:
+            raise ResourceDoesNotExist
+
         group_ids = request.GET.getlist('id')
         if not group_ids:
             return Response(status=204)
@@ -22,6 +31,11 @@ class ProjectGroupStatsEndpoint(ProjectEndpoint, StatsMixin):
         if not group_ids:
             return Response(status=204)
 
-        data = tsdb.get_range(model=tsdb.models.group, keys=group_ids, **self._parse_args(request))
+        data = tsdb.get_range(
+            model=tsdb.models.group, keys=group_ids, **self._parse_args(
+                request,
+                environment_id,
+            )
+        )
 
         return Response({six.text_type(k): v for k, v in data.items()})

--- a/src/sentry/api/endpoints/project_user_stats.py
+++ b/src/sentry/api/endpoints/project_user_stats.py
@@ -5,20 +5,33 @@ from django.utils import timezone
 from rest_framework.response import Response
 
 from sentry.app import tsdb
+from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import Environment
 
 
-class ProjectUserStatsEndpoint(ProjectEndpoint):
+class ProjectUserStatsEndpoint(EnvironmentMixin, ProjectEndpoint):
     def get(self, request, project):
+        try:
+            environment_id = self._get_environment_id_from_request(
+                request,
+                project.organization_id,
+            )
+        except Environment.DoesNotExist:
+            raise ResourceDoesNotExist
+
         now = timezone.now()
         then = now - timedelta(days=30)
 
+        # TODO(tkaemming): Rollup doesn't actually work correctly here
         results = tsdb.rollup(
             tsdb.get_distinct_counts_series(
                 tsdb.models.users_affected_by_project,
                 (project.id, ),
                 then,
                 now,
+                environment_id=environment_id,
             ), 3600 * 24
         )[project.id]
 


### PR DESCRIPTION
This is closely related to GH-6498 which added similar functionality for tags.

This doesn't comprehensively add filtering to all API endpoints that include time series data as part of the response (`GroupDetailsEndpoint` for example includes time series data, and isn't included in this change, as well as some serializers) but this takes the first step by adding it to endpoints that are primarily responsible for returning time series data.