### PR TITLE
fix: Make trim idempotent

### DIFF
--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -64,7 +64,9 @@ def trim(
     }
 
     if _depth > max_depth:
-        return trim(repr(value), _size=_size, max_size=max_size)
+        if not isinstance(value, six.string_types):
+            value = repr(value)
+        return trim(value, _size=_size, max_size=max_size)
 
     elif isinstance(value, dict):
         result = {}

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from functools import partial
+
 from sentry.testutils import TestCase
 from sentry.utils.safe import safe_execute, trim, trim_dict
 
@@ -18,6 +20,12 @@ class TrimTest(TestCase):
     def test_nonascii(self):
         assert trim({'x': '\xc3\xbc'}) == {'x': '\xc3\xbc'}
         assert trim(['x', '\xc3\xbc']) == ['x', '\xc3\xbc']
+
+    def test_idempotent(self):
+        trim2 = partial(trim, max_depth=2)
+        a = {'a': {'b': {'c': {'d': 1}}}}
+        assert trim2(a) == {'a': {'b': {'c': "{'d': 1}"}}}
+        assert trim2(trim2(trim2(trim2(a)))) == trim2(a)
 
 
 class TrimDictTest(TestCase):


### PR DESCRIPTION
Multiple trim()s on the same nested data were creating big ugly strings
of escaped quotes because of all the repr()s of strings. This fixes
that.