### PR TITLE
ref(ui): Refactor <DropdownLink> --> <DropdownMenu>

### DIFF
--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -243,6 +243,7 @@ const AssigneeSelector = React.createClass({
               onOpen={this.onDropdownOpen}
               onClose={this.onDropdownClose}
               isOpen={this.state.isOpen}
+              alwaysRenderMenu={false}
               title={
                 assignedTo ? (
                   <Avatar user={assignedTo} className="avatar" size={48} />

--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -2,33 +2,19 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
+import DropdownMenu from './dropdownMenu';
+
 class DropdownLink extends React.Component {
   static propTypes = {
+    ...DropdownMenu.propTypes,
+
     title: PropTypes.node,
     /** display dropdown caret */
     caret: PropTypes.bool,
     disabled: PropTypes.bool,
-    onOpen: PropTypes.func,
-    onClose: PropTypes.func,
-
-    /**
-     * Callback function to check if we should ignore click outside to
-     * hide dropdown menu
-     */
-    shouldIgnoreClickOutside: PropTypes.func,
-
-    /**
-     * If this is set, then this will become a "controlled" component.
-     * It will no longer set local state and dropdown visiblity will
-     * only follow `isOpen`.
-     */
-    isOpen: PropTypes.bool,
 
     /** anchors menu to the right */
     anchorRight: PropTypes.bool,
-
-    /** Keeps dropdown menu open when menu is clicked */
-    keepMenuOpen: PropTypes.bool,
 
     /**
      * Always render children of dropdown menu, this is included to support
@@ -39,129 +25,17 @@ class DropdownLink extends React.Component {
 
     topLevelClasses: PropTypes.string,
     menuClasses: PropTypes.string,
-
-    /**
-     * If this is set to true, the dropdown behaves as a "nested dropdown" and is
-     * triggered on mouse enter and mouse leave
-     */
-    isNestedDropdown: PropTypes.bool,
   };
 
   static defaultProps = {
     disabled: false,
     anchorRight: false,
-    keepMenuOpen: false,
     caret: true,
   };
 
   constructor(...args) {
     super(...args);
-    this.state = {
-      isOpen: false,
-    };
   }
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this.checkClickOutside, true);
-  }
-
-  // Gets open state from props or local state when appropriate
-  isOpen = () => {
-    let {isOpen} = this.props;
-    let isControlled = typeof isOpen !== 'undefined';
-    return (isControlled && isOpen) || this.state.isOpen;
-  };
-
-  // Checks if click happens inside of dropdown menu (or its button)
-  // Closes dropdownmenu if it is "outside"
-  checkClickOutside = e => {
-    let {shouldIgnoreClickOutside} = this.props;
-
-    if (!this.dropdownMenu) return;
-    // Dropdown menu itself
-    if (this.dropdownMenu.contains(e.target)) return;
-    // Button that controls visibility of dropdown menu
-    if (this.dropdownActor.contains(e.target)) return;
-
-    if (typeof shouldIgnoreClickOutside === 'function' && shouldIgnoreClickOutside(e))
-      return;
-
-    this.handleClose(e);
-  };
-
-  // Opens dropdown menu
-  handleOpen = e => {
-    let {onOpen, isOpen} = this.props;
-    let isControlled = typeof isOpen !== 'undefined';
-    if (!isControlled) {
-      this.setState({
-        isOpen: true,
-      });
-    }
-
-    if (typeof onOpen === 'function') {
-      onOpen(e);
-    }
-  };
-
-  // Decide whether dropdown should be closed when mouse leaves element
-  handleMouseLeave = e => {
-    const toElement = e.toElement || e.relatedTarget;
-
-    try {
-      if (this.dropdownMenu && !this.dropdownMenu.contains(toElement)) {
-        this.handleClose(e);
-      }
-    } catch (err) {
-      Raven.captureException(err, {
-        event: e,
-        toElement: e.toElement,
-        relatedTarget: e.relatedTarget,
-      });
-    }
-  };
-
-  // Closes dropdown menu
-  handleClose = e => {
-    let {onClose, isOpen} = this.props;
-    let isControlled = typeof isOpen !== 'undefined';
-    if (!isControlled) {
-      this.setState({isOpen: false});
-    }
-
-    if (typeof onClose === 'function') {
-      onClose(e);
-    }
-  };
-
-  // When dropdown menu is displayed and mounted to DOM,
-  // bind a click handler to `document` to listen for clicks outside of
-  // this component and close menu if so
-  handleMenuMount = ref => {
-    this.dropdownMenu = ref;
-
-    if (this.dropdownMenu) {
-      // 3rd arg = useCapture = so event capturing vs event bubbling
-      document.addEventListener('click', this.checkClickOutside, true);
-    } else {
-      document.removeEventListener('click', this.checkClickOutside, true);
-    }
-  };
-
-  handleToggle = e => {
-    if (this.isOpen()) {
-      this.handleClose(e);
-    } else {
-      this.handleOpen(e);
-    }
-  };
-
-  // Control whether we should hide dropdown menu when it is clicked
-  handleDropdownMenuClick = e => {
-    if (this.props.keepMenuOpen) return;
-
-    this.handleClose(e);
-  };
 
   render() {
     let {
@@ -174,53 +48,60 @@ class DropdownLink extends React.Component {
       className,
       alwaysRenderMenu,
       topLevelClasses,
-      isNestedDropdown,
+      ...otherProps,
     } = this.props;
 
     // Default anchor = left
     let isRight = anchorRight;
-    let shouldShowDropdown = this.isOpen();
-
-    let cx = classNames('dropdown-actor', className, {
-      'dropdown-menu-right': isRight,
-      'dropdown-toggle': true,
-      hover: shouldShowDropdown,
-      disabled,
-    });
-
-    let topLevelCx = classNames('dropdown', topLevelClasses, {
-      'pull-right': isRight,
-      'anchor-right': isRight,
-      open: shouldShowDropdown,
-    });
 
     // .dropdown-actor-title = flexbox to fix vertical alignment on firefox
     // Need the extra container because dropdown-menu alignment is off if `dropdown-actor` is a flexbox
     return (
-      <span className={topLevelCx}>
-        <a
-          className={cx}
-          ref={ref => (this.dropdownActor = ref)}
-          onClick={!isNestedDropdown && this.handleToggle}
-          onMouseEnter={isNestedDropdown && this.handleOpen}
-          onMouseLeave={isNestedDropdown && this.handleMouseLeave}
-        >
-          <span className="dropdown-actor-title">
-            <span>{title}</span>
-            {caret && <i className="icon-arrow-down" />}
-          </span>
-        </a>
-        {(shouldShowDropdown || alwaysRenderMenu) && (
-          <ul
-            ref={this.handleMenuMount}
-            onClick={this.handleDropdownMenuClick}
-            className={classNames(menuClasses, 'dropdown-menu')}
-            onMouseLeave={isNestedDropdown && this.handleMouseLeave}
-          >
-            {children}
-          </ul>
-        )}
-      </span>
+      <DropdownMenu {...otherProps}>
+        {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
+          let shouldRenderMenu = alwaysRenderMenu || isOpen;
+          let cx = classNames('dropdown-actor', className, {
+            'dropdown-menu-right': isRight,
+            'dropdown-toggle': true,
+            hover: isOpen,
+            disabled,
+          });
+          let topLevelCx = classNames('dropdown', topLevelClasses, {
+            'pull-right': isRight,
+            'anchor-right': isRight,
+            open: isOpen,
+          });
+
+          return (
+            <span
+              {...getRootProps({
+                className: topLevelCx,
+              })}
+            >
+              <a
+                {...getActorProps({
+                  className: cx,
+                })}
+              >
+                <div className="dropdown-actor-title">
+                  <span>{title}</span>
+                  {caret && <i className="icon-arrow-down" />}
+                </div>
+              </a>
+
+              {shouldRenderMenu && (
+                <ul
+                  {...getMenuProps({
+                    className: classNames(menuClasses, 'dropdown-menu'),
+                  })}
+                >
+                  {children}
+                </ul>
+              )}
+            </span>
+          );
+        }}
+      </DropdownMenu>
     );
   }
 }

--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -28,6 +28,7 @@ class DropdownLink extends React.Component {
   };
 
   static defaultProps = {
+    alwaysRenderMenu: true,
     disabled: false,
     anchorRight: false,
     caret: true,
@@ -48,7 +49,7 @@ class DropdownLink extends React.Component {
       className,
       alwaysRenderMenu,
       topLevelClasses,
-      ...otherProps,
+      ...otherProps
     } = this.props;
 
     // Default anchor = left

--- a/src/sentry/static/sentry/app/components/dropdownMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.jsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class DropdownMenu extends React.Component {
+  static propTypes = {
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
+    /**
+     * Callback for when we get a click outside of dropdown menus.
+     * Useful for when menu is controlled.
+     */
+    onClickOutside: PropTypes.func,
+
+    /**
+     * Callback function to check if we should ignore click outside to
+     * hide dropdown menu
+     */
+    shouldIgnoreClickOutside: PropTypes.func,
+
+    /**
+     * If this is set, then this will become a "controlled" component.
+     * It will no longer set local state and dropdown visiblity will
+     * only follow `isOpen`.
+     */
+    isOpen: PropTypes.bool,
+
+    /** Keeps dropdown menu open when menu is clicked */
+    keepMenuOpen: PropTypes.bool,
+
+    /**
+     * If this is set to true, the dropdown behaves as a "nested dropdown" and is
+     * triggered on mouse enter and mouse leave
+     */
+    isNestedDropdown: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    keepMenuOpen: false,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.state = {
+      isOpen: false,
+    };
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.checkClickOutside, true);
+  }
+
+  // Gets open state from props or local state when appropriate
+  isOpen = () => {
+    let {isOpen} = this.props;
+    let isControlled = typeof isOpen !== 'undefined';
+    return (isControlled && isOpen) || this.state.isOpen;
+  };
+
+  // Checks if click happens inside of dropdown menu (or its button)
+  // Closes dropdownmenu if it is "outside"
+  checkClickOutside = e => {
+    let {onClickOutside, shouldIgnoreClickOutside} = this.props;
+
+    if (!this.dropdownMenu) return;
+    // Dropdown menu itself
+    if (this.dropdownMenu.contains(e.target)) return;
+    // Button that controls visibility of dropdown menu
+    if (this.dropdownActor.contains(e.target)) return;
+
+    if (typeof shouldIgnoreClickOutside === 'function' && shouldIgnoreClickOutside(e))
+      return;
+
+    if (typeof onClickOutside === 'function') {
+      onClickOutside(e);
+    }
+
+    this.handleClose(e);
+  };
+
+  // Callback function from <DropdownMenu> to see if we should close menu
+  shouldIgnoreClickOutside = e => {
+    let {shouldIgnoreClickOutside} = this.props;
+    if (this.dropdownActor.contains(e.target)) return true;
+    if (typeof shouldIgnoreClickOutside === 'function') {
+      return shouldIgnoreClickOutside(e);
+    }
+
+    return false;
+  };
+
+  // Opens dropdown menu
+  handleOpen = e => {
+    let {onOpen, isOpen} = this.props;
+    let isControlled = typeof isOpen !== 'undefined';
+    if (!isControlled) {
+      this.setState({
+        isOpen: true,
+      });
+    }
+
+    if (typeof onOpen === 'function') {
+      onOpen(e);
+    }
+  };
+
+  // Decide whether dropdown should be closed when mouse leaves element
+  handleMouseLeave = e => {
+    const toElement = e.toElement || e.relatedTarget;
+
+    try {
+      if (this.dropdownMenu && !this.dropdownMenu.contains(toElement)) {
+        this.handleClose(e);
+      }
+    } catch (err) {
+      Raven.captureException(err, {
+        event: e,
+        toElement: e.toElement,
+        relatedTarget: e.relatedTarget,
+      });
+    }
+  };
+
+  // Closes dropdown menu
+  handleClose = e => {
+    let {onClose, isOpen} = this.props;
+    let isControlled = typeof isOpen !== 'undefined';
+
+    if (!isControlled) {
+      this.setState({isOpen: false});
+    }
+
+    if (typeof onClose === 'function') {
+      onClose(e);
+    }
+  };
+
+  // When dropdown menu is displayed and mounted to DOM,
+  // bind a click handler to `document` to listen for clicks outside of
+  // this component and close menu if so
+  handleMenuMount = ref => {
+    this.dropdownMenu = ref;
+
+    if (this.dropdownMenu) {
+      // 3rd arg = useCapture = so event capturing vs event bubbling
+      document.addEventListener('click', this.checkClickOutside, true);
+    } else {
+      document.removeEventListener('click', this.checkClickOutside, true);
+    }
+  };
+
+  handleToggle = e => {
+    if (this.isOpen()) {
+      this.handleClose(e);
+    } else {
+      this.handleOpen(e);
+    }
+  };
+
+  // Control whether we should hide dropdown menu when it is clicked
+  handleDropdownMenuClick = e => {
+    if (this.props.keepMenuOpen) return;
+
+    this.handleClose(e);
+  };
+
+  getRootProps = props => props;
+
+  getActorProps = ({onClick, ...props} = {}) => {
+    let {isNestedDropdown} = this.props;
+    return {
+      ...props,
+      ref: ref => (this.dropdownActor = ref),
+      onMouseEnter: (...args) => {
+        if (!isNestedDropdown) return;
+        this.handleOpen(...args);
+      },
+
+      onMouseLeave: (...args) => {
+        if (!isNestedDropdown) return;
+        this.handleMouseLeave(...args);
+      },
+      onClick: (...args) => {
+        // Note: clicking on an actor that has a nested menu will close the dropdown menus
+        // This is because we currently do not try to find the deepest non-nested dropdown menu
+        this.handleToggle(...args);
+
+        if (typeof onClick === 'function') {
+          onClick(...args);
+        }
+      },
+    };
+  };
+
+  getMenuProps = ({onClick, ...props} = {}) => {
+    let {isNestedDropdown} = this.props;
+    return {
+      ...props,
+      ref: this.handleMenuMount,
+      onMouseLeave: (...args) => {
+        if (!isNestedDropdown) return;
+        this.handleMouseLeave(...args);
+      },
+      onClick: e => {
+        // Note: clicking on an actor that has a nested menu will close the dropdown menus
+        // This is because we currently do not try to find the deepest non-nested dropdown menu
+        this.handleDropdownMenuClick(e);
+
+        if (typeof onClick === 'function') {
+          onClick(e);
+        }
+      },
+    };
+  };
+
+  render() {
+    let {children} = this.props;
+
+    // Default anchor = left
+    let shouldShowDropdown = this.isOpen();
+
+    return children({
+      isOpen: shouldShowDropdown,
+      getRootProps: this.getRootProps,
+      getActorProps: this.getActorProps,
+      getMenuProps: this.getMenuProps,
+    });
+  }
+}
+
+export default DropdownMenu;

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -322,7 +322,7 @@ const ProjectSelector = React.createClass({
     });
 
     return (
-      <div className="project-select" ref="container">
+      <div className="project-select">
         <h3>
           <Link to={`/${org.slug}/`} className="home-crumb">
             <span className="icon-home" />
@@ -331,12 +331,12 @@ const ProjectSelector = React.createClass({
             ? this.getLinkNode(this.state.activeTeam, this.state.activeProject)
             : t('Select a project')}
           <DropdownLink
-            ref="dropdownLink"
             title=""
             topLevelClasses={dropdownClassNames}
             isOpen={this.state.isOpen}
             onOpen={this.onOpen}
             onClose={this.onClose}
+            alwaysRenderMenu={false}
           >
             {(hasFilter || hasProjects) && (
               <li className="project-filter" key="_filter">

--- a/src/sentry/static/sentry/app/components/shareIssue.jsx
+++ b/src/sentry/static/sentry/app/components/shareIssue.jsx
@@ -213,7 +213,6 @@ class ShareIssue extends React.Component {
         title={title}
         onOpen={this.handleOpen}
         keepMenuOpen
-        alwaysRenderMenu
       >
         <li
           style={{

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -396,7 +396,7 @@ const DeleteActions = React.createClass({
 
   getInitialState() {
     return {
-      hooksDisabled: HookStore.get('project:discard-groups:disabled')
+      hooksDisabled: HookStore.get('project:discard-groups:disabled'),
     };
   },
 
@@ -407,11 +407,7 @@ const DeleteActions = React.createClass({
 
   renderDiscard() {
     return (
-        <DropdownLink
-          caret={true}
-          className="group-delete btn btn-default btn-sm"
-          alwaysRenderMenu
-        >
+      <DropdownLink caret={true} className="group-delete btn btn-default btn-sm">
         <li>
           <LinkWithConfirmation
             title={t('Discard')}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations.jsx
@@ -136,7 +136,6 @@ export default class OrganizationIntegrations extends AsyncView {
         <div className="pull-right">
           <DropdownLink
             anchorRight
-            alwaysRenderMenu
             className="btn btn-primary btn-sm"
             title={t('Add Integration')}
           >

--- a/src/sentry/static/sentry/app/views/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/organizationRepositories.jsx
@@ -309,7 +309,6 @@ class OrganizationRepositories extends OrganizationSettingsView {
         <div className="pull-right">
           <DropdownLink
             anchorRight
-            alwaysRenderMenu
             className="btn btn-primary btn-sm"
             title={t('Add Repository')}
           >

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -659,7 +659,6 @@ const StreamActions = React.createClass({
                 caret={false}
                 className="btn btn-sm btn-default hidden-xs action-more"
                 title={<span className="icon-ellipsis" />}
-                alwaysRenderMenu
               >
                 <MenuItem noAnchor={true}>
                   <ActionLink

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -229,7 +229,6 @@ const SavedSearchSelector = React.createClass({
               <QueryCount count={queryCount} max={queryMaxCount} />
             </span>
           }
-          alwaysRenderMenu
         >
           {children.length ? (
             children

--- a/tests/js/spec/components/__snapshots__/dropdownLink.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownLink.spec.jsx.snap
@@ -1,45 +1,109 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DropdownLink renders and anchors to left by default 1`] = `
-<span
-  className="dropdown top-level-class"
+<DropdownLink
+  alwaysRenderMenu={true}
+  anchorRight={false}
+  caret={true}
+  disabled={false}
+  menuClasses=""
+  onClose={[Function]}
+  onOpen={[Function]}
+  title="test"
+  topLevelClasses="top-level-class"
 >
-  <a
-    className="dropdown-actor dropdown-toggle"
-    onClick={[Function]}
+  <DropdownMenu
+    keepMenuOpen={false}
+    onClose={[Function]}
+    onOpen={[Function]}
   >
     <span
-      className="dropdown-actor-title"
+      className="dropdown top-level-class"
     >
-      <span>
-        test
-      </span>
-      <i
-        className="icon-arrow-down"
-      />
+      <a
+        className="dropdown-actor dropdown-toggle"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div
+          className="dropdown-actor-title"
+        >
+          <span>
+            test
+          </span>
+          <i
+            className="icon-arrow-down"
+          />
+        </div>
+      </a>
+      <ul
+        className="dropdown-menu"
+        onClick={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div>
+          1
+        </div>
+        <div>
+          2
+        </div>
+      </ul>
     </span>
-  </a>
-</span>
+  </DropdownMenu>
+</DropdownLink>
 `;
 
 exports[`DropdownLink renders and anchors to right 1`] = `
-<span
-  className="dropdown top-level-class pull-right anchor-right"
+<DropdownLink
+  alwaysRenderMenu={true}
+  anchorRight={true}
+  caret={true}
+  disabled={false}
+  menuClasses=""
+  onClose={[Function]}
+  onOpen={[Function]}
+  title="test"
+  topLevelClasses="top-level-class"
 >
-  <a
-    className="dropdown-actor dropdown-menu-right dropdown-toggle"
-    onClick={[Function]}
+  <DropdownMenu
+    keepMenuOpen={false}
+    onClose={[Function]}
+    onOpen={[Function]}
   >
     <span
-      className="dropdown-actor-title"
+      className="dropdown top-level-class pull-right anchor-right"
     >
-      <span>
-        test
-      </span>
-      <i
-        className="icon-arrow-down"
-      />
+      <a
+        className="dropdown-actor dropdown-menu-right dropdown-toggle"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div
+          className="dropdown-actor-title"
+        >
+          <span>
+            test
+          </span>
+          <i
+            className="icon-arrow-down"
+          />
+        </div>
+      </a>
+      <ul
+        className="dropdown-menu"
+        onClick={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div>
+          1
+        </div>
+        <div>
+          2
+        </div>
+      </ul>
     </span>
-  </a>
-</span>
+  </DropdownMenu>
+</DropdownLink>
 `;

--- a/tests/js/spec/components/__snapshots__/dropdownMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownMenu.spec.jsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DropdownMenu render prop getters all extend props and call original onClick handlers 1`] = `
+<DropdownMenu
+  keepMenuOpen={true}
+>
+  <span
+    className="root"
+    onClick={[Function]}
+  >
+    <button
+      className="actor"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      Open Dropdown
+    </button>
+    <ul
+      className="menu"
+      onClick={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <li>
+        Dropdown Menu Item 1
+      </li>
+    </ul>
+  </span>
+</DropdownMenu>
+`;
+
+exports[`DropdownMenu renders 1`] = `
+<DropdownMenu
+  keepMenuOpen={false}
+>
+  <span>
+    <button
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      Open Dropdown
+    </button>
+  </span>
+</DropdownMenu>
+`;

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -45,7 +45,7 @@ describe('DropdownLink', function() {
       }
 
       wrapper = mount(
-        <DropdownLink title="test">
+        <DropdownLink alwaysRenderMenu={false} title="test">
           <li>hi</li>
         </DropdownLink>
       );
@@ -85,7 +85,7 @@ describe('DropdownLink', function() {
 
       it('does not close when menu is clicked and `keepMenuOpen` is on', function() {
         wrapper = mount(
-          <DropdownLink title="test" keepMenuOpen>
+          <DropdownLink title="test" alwaysRenderMenu={false} keepMenuOpen>
             <li>hi</li>
           </DropdownLink>
         );
@@ -108,7 +108,7 @@ describe('DropdownLink', function() {
     describe('Opened', function() {
       beforeEach(function() {
         wrapper = mount(
-          <DropdownLink isOpen={true} title="test">
+          <DropdownLink isOpen={true} alwaysRenderMenu={false} title="test">
             <li>hi</li>
           </DropdownLink>
         );
@@ -136,7 +136,7 @@ describe('DropdownLink', function() {
     describe('Closed', function() {
       beforeEach(function() {
         wrapper = mount(
-          <DropdownLink isOpen={false} title="test">
+          <DropdownLink isOpen={false} alwaysRenderMenu={false} title="test">
             <li>hi</li>
           </DropdownLink>
         );
@@ -159,12 +159,18 @@ describe('DropdownLink', function() {
       }
 
       wrapper = mount(
-        <DropdownLink title="parent">
+        <DropdownLink title="parent" alwaysRenderMenu={false}>
           <li id="nested-actor">
-            <DropdownLink className="nested-menu" title="nested" isNestedDropdown={true}>
+            <DropdownLink
+              className="nested-menu"
+              alwaysRenderMenu={false}
+              title="nested"
+              isNestedDropdown={true}
+            >
               <li id="nested-actor-2">
                 <DropdownLink
                   className="nested-menu-2"
+                  alwaysRenderMenu={false}
                   title="nested #2"
                   isNestedDropdown={true}
                 >

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow, mount} from 'enzyme';
+import {mount} from 'enzyme';
 import DropdownLink from 'app/components/dropdownLink';
 
 describe('DropdownLink', function() {
@@ -8,12 +8,13 @@ describe('DropdownLink', function() {
     onOpen: () => {},
     onClose: () => {},
     topLevelClasses: 'top-level-class',
+    alwaysRenderMenu: true,
     menuClasses: '',
   };
 
   describe('renders', function() {
     it('and anchors to left by default', function() {
-      let component = shallow(
+      let component = mount(
         <DropdownLink {...INPUT_1}>
           <div>1</div>
           <div>2</div>
@@ -24,7 +25,7 @@ describe('DropdownLink', function() {
     });
 
     it('and anchors to right', function() {
-      let component = shallow(
+      let component = mount(
         <DropdownLink {...INPUT_1} anchorRight>
           <div>1</div>
           <div>2</div>
@@ -52,12 +53,10 @@ describe('DropdownLink', function() {
 
     describe('While Closed', function() {
       it('displays dropdown menu when dropdown actor button clicked', function() {
-        expect(wrapper.find('li').length).toBe(0);
-        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.find('li')).toHaveLength(0);
 
         // open
         wrapper.find('a').simulate('click');
-        expect(wrapper.state('isOpen')).toBe(true);
         expect(wrapper.find('li').length).toBe(1);
       });
     });
@@ -67,20 +66,21 @@ describe('DropdownLink', function() {
         wrapper.find('a').simulate('click');
       });
 
-      it.skip('closes when clicked outside', function() {
-        jQuery(document).click();
-        expect(wrapper.state('isOpen')).toBe(false);
-        expect(wrapper.instance().checkClickOutside).toHaveBeenCalled();
+      it('closes when clicked outside', function() {
+        const evt = document.createEvent('HTMLEvents');
+        evt.initEvent('click', false, true);
+        document.body.dispatchEvent(evt);
+        expect(wrapper.find('li').length).toBe(0);
       });
 
       it('closes when dropdown actor button is clicked', function() {
         wrapper.find('a').simulate('click');
-        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.find('li').length).toBe(0);
       });
 
       it('closes when dropdown menu item is clicked', function() {
         wrapper.find('li').simulate('click');
-        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.find('li').length).toBe(0);
       });
 
       it('does not close when menu is clicked and `keepMenuOpen` is on', function() {
@@ -91,7 +91,7 @@ describe('DropdownLink', function() {
         );
         wrapper.find('a').simulate('click');
         wrapper.find('li').simulate('click');
-        expect(wrapper.state('isOpen')).toBe(true);
+        expect(wrapper.find('li').length).toBe(1);
         wrapper.unmount();
       });
     });
@@ -118,21 +118,18 @@ describe('DropdownLink', function() {
         // open
         wrapper.find('li').simulate('click');
         // State does not change
-        expect(wrapper.state('isOpen')).toBe(false);
         expect(wrapper.find('.dropdown-menu').length).toBe(1);
       });
 
       it('does not close when document is clicked', function() {
         jQuery(document).click();
         // State does not change
-        expect(wrapper.state('isOpen')).toBe(false);
         expect(wrapper.find('.dropdown-menu').length).toBe(1);
       });
 
       it('does not close when dropdown actor is clicked', function() {
         wrapper.find('a').simulate('click');
         // State does not change
-        expect(wrapper.state('isOpen')).toBe(false);
         expect(wrapper.find('.dropdown-menu').length).toBe(1);
       });
     });
@@ -148,7 +145,6 @@ describe('DropdownLink', function() {
       it('does not open when dropdown actor is clicked', function() {
         wrapper.find('a').simulate('click');
         // State does not change
-        expect(wrapper.state('isOpen')).toBe(false);
         expect(wrapper.find('.dropdown-menu').length).toBe(0);
       });
     });
@@ -164,21 +160,60 @@ describe('DropdownLink', function() {
 
       wrapper = mount(
         <DropdownLink title="parent">
-          <DropdownLink title="nested" isNestedDropdown={true}>
-            Test
-          </DropdownLink>
+          <li id="nested-actor">
+            <DropdownLink className="nested-menu" title="nested" isNestedDropdown={true}>
+              <li id="nested-actor-2">
+                <DropdownLink
+                  className="nested-menu-2"
+                  title="nested #2"
+                  isNestedDropdown={true}
+                >
+                  <li id="nested-actor-3">Hello</li>
+                </DropdownLink>
+              </li>
+            </DropdownLink>
+          </li>
+          <li id="no-nest">Item 2</li>
         </DropdownLink>
       );
+
+      // Start when menu open
+      wrapper.find('a').simulate('click');
+    });
+
+    it('closes when top-level actor is clicked', function() {
+      wrapper
+        .find('a')
+        .first()
+        .simulate('click');
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
     });
 
     it('Opens / closes on mouse enter and leave', function() {
-      wrapper.find('a').simulate('click');
       wrapper.find('.dropdown-menu a').simulate('mouseEnter');
       expect(wrapper.find('.dropdown-menu').length).toBe(2);
 
-      wrapper.find('.dropdown-menu a').simulate('mouseLeave');
+      wrapper.find('.nested-menu').simulate('mouseLeave');
 
       expect(wrapper.find('.dropdown-menu').length).toBe(1);
+    });
+
+    it('closes when first level nested actor is clicked', function() {
+      wrapper.find('#nested-actor').simulate('click');
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
+    });
+
+    it('closes when second level nested actor is clicked', function() {
+      wrapper.find('.nested-menu').simulate('mouseEnter');
+      wrapper.find('.nested-menu-2 span').simulate('click');
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
+    });
+
+    it('closes when third level nested actor is clicked', function() {
+      wrapper.find('.nested-menu').simulate('mouseEnter');
+      wrapper.find('.nested-menu-2').simulate('mouseEnter');
+      wrapper.find('#nested-actor-3').simulate('click');
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
     });
   });
 });

--- a/tests/js/spec/components/dropdownMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownMenu.spec.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import DropdownMenu from 'app/components/dropdownMenu';
+
+describe('DropdownMenu', function() {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <DropdownMenu>
+        {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+          return (
+            <span {...getRootProps({})}>
+              <button {...getActorProps({})}>Open Dropdown</button>
+              {isOpen && (
+                <ul {...getMenuProps({})}>
+                  <li>Dropdown Menu Item 1</li>
+                </ul>
+              )}
+            </span>
+          );
+        }}
+      </DropdownMenu>
+    );
+  });
+
+  it('renders', function() {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('can toggle dropdown menu with actor', function() {
+    wrapper.find('button').simulate('click');
+    expect(wrapper.state('isOpen')).toBe(true);
+    expect(wrapper.find('ul')).toHaveLength(1);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.state('isOpen')).toBe(false);
+    expect(wrapper.find('ul')).toHaveLength(0);
+  });
+
+  it('closes dropdown when clicking on anything in menu', function() {
+    wrapper.find('button').simulate('click');
+    wrapper.find('li').simulate('click');
+    expect(wrapper.state('isOpen')).toBe(false);
+    expect(wrapper.find('ul')).toHaveLength(0);
+  });
+
+  it('closes dropdown when clicking outside of menu', function() {
+    wrapper.find('button').simulate('click');
+    // Simulate click on document
+    const evt = document.createEvent('HTMLEvents');
+    evt.initEvent('click', false, true);
+    document.body.dispatchEvent(evt);
+
+    expect(wrapper.find('ul')).toHaveLength(0);
+  });
+
+  it('keeps dropdown open when clicking on anything in menu with `keepMenuOpen` prop', function() {
+    wrapper = mount(
+      <DropdownMenu keepMenuOpen>
+        {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+          return (
+            <span {...getRootProps({})}>
+              <button {...getActorProps({})}>Open Dropdown</button>
+              {isOpen && (
+                <ul {...getMenuProps({})}>
+                  <li>Dropdown Menu Item 1</li>
+                </ul>
+              )}
+            </span>
+          );
+        }}
+      </DropdownMenu>
+    );
+
+    wrapper.find('button').simulate('click');
+    wrapper.find('li').simulate('click');
+    expect(wrapper.state('isOpen')).toBe(true);
+    expect(wrapper.find('ul')).toHaveLength(1);
+  });
+
+  it('render prop getters all extend props and call original onClick handlers', function() {
+    let rootClick = jest.fn();
+    let actorClick = jest.fn();
+    let menuClick = jest.fn();
+
+    wrapper = mount(
+      <DropdownMenu keepMenuOpen>
+        {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+          return (
+            <span
+              {...getRootProps({
+                className: 'root',
+                onClick: rootClick,
+              })}
+            >
+              <button
+                {...getActorProps({
+                  className: 'actor',
+                  onClick: actorClick,
+                })}
+              >
+                Open Dropdown
+              </button>
+              {isOpen && (
+                <ul
+                  {...getMenuProps({
+                    className: 'menu',
+                    onClick: menuClick,
+                  })}
+                >
+                  <li>Dropdown Menu Item 1</li>
+                </ul>
+              )}
+            </span>
+          );
+        }}
+      </DropdownMenu>
+    );
+
+    print(wrapper.find('button'));
+    wrapper.find('span').simulate('click');
+    expect(rootClick).toHaveBeenCalled();
+    wrapper.find('button').simulate('click');
+    expect(actorClick).toHaveBeenCalled();
+    wrapper.find('li').simulate('click');
+    expect(menuClick).toHaveBeenCalled();
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
+++ b/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
@@ -47,6 +47,7 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
       </Link>
       Select a project
       <DropdownLink
+        alwaysRenderMenu={false}
         anchorRight={false}
         caret={true}
         disabled={false}
@@ -183,6 +184,7 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
       </Link>
       Select a project
       <DropdownLink
+        alwaysRenderMenu={false}
         anchorRight={false}
         caret={true}
         disabled={false}
@@ -308,6 +310,7 @@ exports[`ProjectSelector render() lists projects and has filter 1`] = `
     </Link>
     Select a project
     <DropdownLink
+      alwaysRenderMenu={false}
       anchorRight={false}
       caret={true}
       disabled={false}
@@ -369,6 +372,7 @@ exports[`ProjectSelector render() should show empty message and create project b
     </Link>
     Select a project
     <DropdownLink
+      alwaysRenderMenu={false}
       anchorRight={false}
       caret={true}
       disabled={false}
@@ -422,6 +426,7 @@ exports[`ProjectSelector render() should show empty message with no projects but
     </Link>
     Select a project
     <DropdownLink
+      alwaysRenderMenu={false}
       anchorRight={false}
       caret={true}
       disabled={false}
@@ -493,6 +498,7 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
       </Link>
       Select a project
       <DropdownLink
+        alwaysRenderMenu={false}
         anchorRight={false}
         caret={true}
         disabled={false}

--- a/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
+++ b/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
@@ -51,76 +51,85 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
         caret={true}
         disabled={false}
         isOpen={true}
-        keepMenuOpen={false}
         onClose={[Function]}
         onOpen={[Function]}
         title=""
         topLevelClasses="project-dropdown"
       >
-        <span
-          className="dropdown project-dropdown open"
+        <DropdownMenu
+          isOpen={true}
+          keepMenuOpen={false}
+          onClose={[Function]}
+          onOpen={[Function]}
         >
-          <a
-            className="dropdown-actor dropdown-toggle hover"
-            onClick={[Function]}
+          <span
+            className="dropdown project-dropdown open"
           >
-            <span
-              className="dropdown-actor-title"
+            <a
+              className="dropdown-actor dropdown-toggle hover"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
-              <span />
-              <i
-                className="icon-arrow-down"
-              />
-            </span>
-          </a>
-          <ul
-            className="dropdown-menu"
-            onClick={[Function]}
-          >
-            <li
-              className="project-filter"
-            >
-              <input
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                placeholder="Filter projects"
-                type="text"
-                value="another"
-              />
-            </li>
-            <MenuItem
-              className=""
-              href="/org/another-project/"
-              linkClassName=""
+              <div
+                className="dropdown-actor-title"
+              >
+                <span />
+                <i
+                  className="icon-arrow-down"
+                />
+              </div>
+            </a>
+            <ul
+              className="dropdown-menu"
+              onClick={[Function]}
+              onMouseLeave={[Function]}
             >
               <li
-                className=""
-                href={null}
-                role="presentation"
-                title={null}
+                className="project-filter"
               >
-                <a
-                  className=""
-                  href="/org/another-project/"
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
                   onClick={[Function]}
-                  tabIndex="-1"
-                >
-                  <span>
-                    <strong
-                      className="highlight"
-                    >
-                      Another
-                    </strong>
-                     Project
-                  </span>
-                </a>
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  placeholder="Filter projects"
+                  type="text"
+                  value="another"
+                />
               </li>
-            </MenuItem>
-          </ul>
-        </span>
+              <MenuItem
+                className=""
+                href="/org/another-project/"
+                linkClassName=""
+              >
+                <li
+                  className=""
+                  href={null}
+                  role="presentation"
+                  title={null}
+                >
+                  <a
+                    className=""
+                    href="/org/another-project/"
+                    onClick={[Function]}
+                    tabIndex="-1"
+                  >
+                    <span>
+                      <strong
+                        className="highlight"
+                      >
+                        Another
+                      </strong>
+                       Project
+                    </span>
+                  </a>
+                </li>
+              </MenuItem>
+            </ul>
+          </span>
+        </DropdownMenu>
       </DropdownLink>
     </h3>
   </div>
@@ -178,97 +187,106 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
         caret={true}
         disabled={false}
         isOpen={true}
-        keepMenuOpen={false}
         onClose={[Function]}
         onOpen={[Function]}
         title=""
         topLevelClasses="project-dropdown"
       >
-        <span
-          className="dropdown project-dropdown open"
+        <DropdownMenu
+          isOpen={true}
+          keepMenuOpen={false}
+          onClose={[Function]}
+          onOpen={[Function]}
         >
-          <a
-            className="dropdown-actor dropdown-toggle hover"
-            onClick={[Function]}
+          <span
+            className="dropdown project-dropdown open"
           >
-            <span
-              className="dropdown-actor-title"
+            <a
+              className="dropdown-actor dropdown-toggle hover"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
-              <span />
-              <i
-                className="icon-arrow-down"
-              />
-            </span>
-          </a>
-          <ul
-            className="dropdown-menu"
-            onClick={[Function]}
-          >
-            <li
-              className="project-filter"
-            >
-              <input
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                placeholder="Filter projects"
-                type="text"
-                value="TEST"
-              />
-            </li>
-            <MenuItem
-              className=""
-              href="/org/another-project/"
-              linkClassName=""
+              <div
+                className="dropdown-actor-title"
+              >
+                <span />
+                <i
+                  className="icon-arrow-down"
+                />
+              </div>
+            </a>
+            <ul
+              className="dropdown-menu"
+              onClick={[Function]}
+              onMouseLeave={[Function]}
             >
               <li
-                className=""
-                href={null}
-                role="presentation"
-                title={null}
+                className="project-filter"
               >
-                <a
-                  className=""
-                  href="/org/another-project/"
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
                   onClick={[Function]}
-                  tabIndex="-1"
-                >
-                  Another Project
-                </a>
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  placeholder="Filter projects"
+                  type="text"
+                  value="TEST"
+                />
               </li>
-            </MenuItem>
-            <MenuItem
-              className=""
-              href="/org/test-project/"
-              linkClassName=""
-            >
-              <li
+              <MenuItem
                 className=""
-                href={null}
-                role="presentation"
-                title={null}
+                href="/org/another-project/"
+                linkClassName=""
               >
-                <a
+                <li
                   className=""
-                  href="/org/test-project/"
-                  onClick={[Function]}
-                  tabIndex="-1"
+                  href={null}
+                  role="presentation"
+                  title={null}
                 >
-                  <span>
-                    <strong
-                      className="highlight"
-                    >
-                      Test
-                    </strong>
-                     Project
-                  </span>
-                </a>
-              </li>
-            </MenuItem>
-          </ul>
-        </span>
+                  <a
+                    className=""
+                    href="/org/another-project/"
+                    onClick={[Function]}
+                    tabIndex="-1"
+                  >
+                    Another Project
+                  </a>
+                </li>
+              </MenuItem>
+              <MenuItem
+                className=""
+                href="/org/test-project/"
+                linkClassName=""
+              >
+                <li
+                  className=""
+                  href={null}
+                  role="presentation"
+                  title={null}
+                >
+                  <a
+                    className=""
+                    href="/org/test-project/"
+                    onClick={[Function]}
+                    tabIndex="-1"
+                  >
+                    <span>
+                      <strong
+                        className="highlight"
+                      >
+                        Test
+                      </strong>
+                       Project
+                    </span>
+                  </a>
+                </li>
+              </MenuItem>
+            </ul>
+          </span>
+        </DropdownMenu>
       </DropdownLink>
     </h3>
   </div>
@@ -294,7 +312,6 @@ exports[`ProjectSelector render() lists projects and has filter 1`] = `
       caret={true}
       disabled={false}
       isOpen={false}
-      keepMenuOpen={false}
       onClose={[Function]}
       onOpen={[Function]}
       title=""
@@ -356,7 +373,6 @@ exports[`ProjectSelector render() should show empty message and create project b
       caret={true}
       disabled={false}
       isOpen={false}
-      keepMenuOpen={false}
       onClose={[Function]}
       onOpen={[Function]}
       title=""
@@ -410,7 +426,6 @@ exports[`ProjectSelector render() should show empty message with no projects but
       caret={true}
       disabled={false}
       isOpen={false}
-      keepMenuOpen={false}
       onClose={[Function]}
       onOpen={[Function]}
       title=""
@@ -482,65 +497,74 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
         caret={true}
         disabled={false}
         isOpen={true}
-        keepMenuOpen={false}
         onClose={[Function]}
         onOpen={[Function]}
         title=""
         topLevelClasses="project-dropdown is-empty"
       >
-        <span
-          className="dropdown project-dropdown is-empty open"
+        <DropdownMenu
+          isOpen={true}
+          keepMenuOpen={false}
+          onClose={[Function]}
+          onOpen={[Function]}
         >
-          <a
-            className="dropdown-actor dropdown-toggle hover"
-            onClick={[Function]}
+          <span
+            className="dropdown project-dropdown is-empty open"
           >
-            <span
-              className="dropdown-actor-title"
+            <a
+              className="dropdown-actor dropdown-toggle hover"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
-              <span />
-              <i
-                className="icon-arrow-down"
-              />
-            </span>
-          </a>
-          <ul
-            className="dropdown-menu"
-            onClick={[Function]}
-          >
-            <li
-              className="project-filter"
-            >
-              <input
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                placeholder="Filter projects"
-                type="text"
-                value="Foo"
-              />
-            </li>
-            <MenuItem
-              className="empty-projects-item"
-              noAnchor={true}
+              <div
+                className="dropdown-actor-title"
+              >
+                <span />
+                <i
+                  className="icon-arrow-down"
+                />
+              </div>
+            </a>
+            <ul
+              className="dropdown-menu"
+              onClick={[Function]}
+              onMouseLeave={[Function]}
             >
               <li
-                className="empty-projects-item"
-                href={null}
-                role="presentation"
-                title={null}
+                className="project-filter"
               >
-                <div
-                  className="empty-message"
-                >
-                  No projects found
-                </div>
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  placeholder="Filter projects"
+                  type="text"
+                  value="Foo"
+                />
               </li>
-            </MenuItem>
-          </ul>
-        </span>
+              <MenuItem
+                className="empty-projects-item"
+                noAnchor={true}
+              >
+                <li
+                  className="empty-projects-item"
+                  href={null}
+                  role="presentation"
+                  title={null}
+                >
+                  <div
+                    className="empty-message"
+                  >
+                    No projects found
+                  </div>
+                </li>
+              </MenuItem>
+            </ul>
+          </span>
+        </DropdownMenu>
       </DropdownLink>
     </h3>
   </div>

--- a/tests/js/spec/views/__snapshots__/organizationIntegrations.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationIntegrations.spec.jsx.snap
@@ -23,49 +23,55 @@ exports[`OrganizationIntegrations render() with a provider renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
-          keepMenuOpen={false}
           title="Add Integration"
         >
-          <span
-            className="dropdown pull-right anchor-right open"
+          <DropdownMenu
+            keepMenuOpen={false}
           >
-            <a
-              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
-              onClick={[Function]}
+            <span
+              className="dropdown pull-right anchor-right open"
             >
-              <span
-                className="dropdown-actor-title"
+              <a
+                className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
-                <span>
-                  Add Integration
-                </span>
-                <i
-                  className="icon-arrow-down"
-                />
-              </span>
-            </a>
-            <ul
-              className="dropdown-menu"
-              onClick={[Function]}
-            >
-              <MenuItem
-                noAnchor={true}
-              >
-                <li
-                  className=""
-                  href={null}
-                  role="presentation"
-                  title={null}
+                <div
+                  className="dropdown-actor-title"
                 >
-                  <a
-                    onClick={[Function]}
+                  <span>
+                    Add Integration
+                  </span>
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+              >
+                <MenuItem
+                  noAnchor={true}
+                >
+                  <li
+                    className=""
+                    href={null}
+                    role="presentation"
+                    title={null}
                   >
-                    GitHub
-                  </a>
-                </li>
-              </MenuItem>
-            </ul>
-          </span>
+                    <a
+                      onClick={[Function]}
+                    >
+                      GitHub
+                    </a>
+                  </li>
+                </MenuItem>
+              </ul>
+            </span>
+          </DropdownMenu>
         </DropdownLink>
       </div>
       <h3
@@ -124,49 +130,55 @@ exports[`OrganizationIntegrations render() with a provider renders with a reposi
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
-          keepMenuOpen={false}
           title="Add Integration"
         >
-          <span
-            className="dropdown pull-right anchor-right open"
+          <DropdownMenu
+            keepMenuOpen={false}
           >
-            <a
-              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
-              onClick={[Function]}
+            <span
+              className="dropdown pull-right anchor-right open"
             >
-              <span
-                className="dropdown-actor-title"
+              <a
+                className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
-                <span>
-                  Add Integration
-                </span>
-                <i
-                  className="icon-arrow-down"
-                />
-              </span>
-            </a>
-            <ul
-              className="dropdown-menu"
-              onClick={[Function]}
-            >
-              <MenuItem
-                noAnchor={true}
-              >
-                <li
-                  className=""
-                  href={null}
-                  role="presentation"
-                  title={null}
+                <div
+                  className="dropdown-actor-title"
                 >
-                  <a
-                    onClick={[Function]}
+                  <span>
+                    Add Integration
+                  </span>
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+              >
+                <MenuItem
+                  noAnchor={true}
+                >
+                  <li
+                    className=""
+                    href={null}
+                    role="presentation"
+                    title={null}
                   >
-                    GitHub
-                  </a>
-                </li>
-              </MenuItem>
-            </ul>
-          </span>
+                    <a
+                      onClick={[Function]}
+                    >
+                      GitHub
+                    </a>
+                  </li>
+                </MenuItem>
+              </ul>
+            </span>
+          </DropdownMenu>
         </DropdownLink>
       </div>
       <h3
@@ -308,7 +320,6 @@ exports[`OrganizationIntegrations render() without any providers is loading when
         caret={true}
         className="btn btn-primary btn-sm"
         disabled={false}
-        keepMenuOpen={false}
         title="Add Integration"
       />
     </div>
@@ -367,32 +378,38 @@ exports[`OrganizationIntegrations render() without any providers renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
-          keepMenuOpen={false}
           title="Add Integration"
         >
-          <span
-            className="dropdown pull-right anchor-right open"
+          <DropdownMenu
+            keepMenuOpen={false}
           >
-            <a
-              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
-              onClick={[Function]}
+            <span
+              className="dropdown pull-right anchor-right open"
             >
-              <span
-                className="dropdown-actor-title"
+              <a
+                className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
-                <span>
-                  Add Integration
-                </span>
-                <i
-                  className="icon-arrow-down"
-                />
-              </span>
-            </a>
-            <ul
-              className="dropdown-menu"
-              onClick={[Function]}
-            />
-          </span>
+                <div
+                  className="dropdown-actor-title"
+                >
+                  <span>
+                    Add Integration
+                  </span>
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+              />
+            </span>
+          </DropdownMenu>
         </DropdownLink>
       </div>
       <h3

--- a/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -21,93 +21,75 @@ exports[`OrganizationRepositories render() with a provider renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
-          keepMenuOpen={false}
           title="Add Repository"
         >
-          <span
-            className="dropdown pull-right anchor-right open"
+          <DropdownMenu
+            keepMenuOpen={false}
           >
-            <a
-              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
-              onClick={[Function]}
+            <span
+              className="dropdown pull-right anchor-right open"
             >
-              <span
-                className="dropdown-actor-title"
+              <a
+                className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
-                <span>
-                  Add Repository
-                </span>
-                <i
-                  className="icon-arrow-down"
-                />
-              </span>
-            </a>
-            <ul
-              className="dropdown-menu"
-              onClick={[Function]}
-            >
-              <MenuItem
-                noAnchor={true}
-              >
-                <li
-                  className=""
-                  href={null}
-                  role="presentation"
-                  title={null}
+                <div
+                  className="dropdown-actor-title"
                 >
-                  <AddRepositoryLink
-                    onSuccess={[Function]}
-                    orgId="org-slug"
-                    provider={
-                      Object {
-                        "config": Array [
-                          Object {
-                            "help": "Enter your repository name, including the owner.",
-                            "label": "Repository Name",
-                            "name": "name",
-                            "placeholder": "e.g. getsentry/sentry",
-                            "required": true,
-                            "type": "text",
-                          },
-                        ],
-                        "id": "github",
-                        "name": "GitHub",
-                      }
-                    }
+                  <span>
+                    Add Repository
+                  </span>
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+              >
+                <MenuItem
+                  noAnchor={true}
+                >
+                  <li
+                    className=""
+                    href={null}
+                    role="presentation"
+                    title={null}
                   >
-                    <a
-                      onClick={[Function]}
-                    >
-                      GitHub
-                      <Modal
-                        animation={false}
-                        autoFocus={true}
-                        backdrop={true}
-                        bsClass="modal"
-                        dialogComponentClass={[Function]}
-                        enforceFocus={true}
-                        keyboard={true}
-                        manager={
-                          ModalManager {
-                            "containers": Array [],
-                            "data": Array [],
-                            "handleContainerOverflow": true,
-                            "hideSiblingNodes": true,
-                            "modals": Array [],
-                          }
+                    <AddRepositoryLink
+                      onSuccess={[Function]}
+                      orgId="org-slug"
+                      provider={
+                        Object {
+                          "config": Array [
+                            Object {
+                              "help": "Enter your repository name, including the owner.",
+                              "label": "Repository Name",
+                              "name": "name",
+                              "placeholder": "e.g. getsentry/sentry",
+                              "required": true,
+                              "type": "text",
+                            },
+                          ],
+                          "id": "github",
+                          "name": "GitHub",
                         }
-                        onHide={[Function]}
-                        renderBackdrop={[Function]}
-                        restoreFocus={true}
-                        show={false}
+                      }
+                    >
+                      <a
+                        onClick={[Function]}
                       >
+                        GitHub
                         <Modal
+                          animation={false}
                           autoFocus={true}
                           backdrop={true}
-                          backdropClassName="modal-backdrop"
-                          backdropTransitionTimeout={150}
-                          containerClassName="modal-open"
-                          dialogTransitionTimeout={300}
+                          bsClass="modal"
+                          dialogComponentClass={[Function]}
                           enforceFocus={true}
                           keyboard={true}
                           manager={
@@ -119,20 +101,44 @@ exports[`OrganizationRepositories render() with a provider renders 1`] = `
                               "modals": Array [],
                             }
                           }
-                          onEntering={[Function]}
-                          onExited={[Function]}
                           onHide={[Function]}
                           renderBackdrop={[Function]}
                           restoreFocus={true}
                           show={false}
-                        />
-                      </Modal>
-                    </a>
-                  </AddRepositoryLink>
-                </li>
-              </MenuItem>
-            </ul>
-          </span>
+                        >
+                          <Modal
+                            autoFocus={true}
+                            backdrop={true}
+                            backdropClassName="modal-backdrop"
+                            backdropTransitionTimeout={150}
+                            containerClassName="modal-open"
+                            dialogTransitionTimeout={300}
+                            enforceFocus={true}
+                            keyboard={true}
+                            manager={
+                              ModalManager {
+                                "containers": Array [],
+                                "data": Array [],
+                                "handleContainerOverflow": true,
+                                "hideSiblingNodes": true,
+                                "modals": Array [],
+                              }
+                            }
+                            onEntering={[Function]}
+                            onExited={[Function]}
+                            onHide={[Function]}
+                            renderBackdrop={[Function]}
+                            restoreFocus={true}
+                            show={false}
+                          />
+                        </Modal>
+                      </a>
+                    </AddRepositoryLink>
+                  </li>
+                </MenuItem>
+              </ul>
+            </span>
+          </DropdownMenu>
         </DropdownLink>
       </div>
       <h3
@@ -189,93 +195,75 @@ exports[`OrganizationRepositories render() with a provider renders with a reposi
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
-          keepMenuOpen={false}
           title="Add Repository"
         >
-          <span
-            className="dropdown pull-right anchor-right open"
+          <DropdownMenu
+            keepMenuOpen={false}
           >
-            <a
-              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
-              onClick={[Function]}
+            <span
+              className="dropdown pull-right anchor-right open"
             >
-              <span
-                className="dropdown-actor-title"
+              <a
+                className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
-                <span>
-                  Add Repository
-                </span>
-                <i
-                  className="icon-arrow-down"
-                />
-              </span>
-            </a>
-            <ul
-              className="dropdown-menu"
-              onClick={[Function]}
-            >
-              <MenuItem
-                noAnchor={true}
-              >
-                <li
-                  className=""
-                  href={null}
-                  role="presentation"
-                  title={null}
+                <div
+                  className="dropdown-actor-title"
                 >
-                  <AddRepositoryLink
-                    onSuccess={[Function]}
-                    orgId="org-slug"
-                    provider={
-                      Object {
-                        "config": Array [
-                          Object {
-                            "help": "Enter your repository name, including the owner.",
-                            "label": "Repository Name",
-                            "name": "name",
-                            "placeholder": "e.g. getsentry/sentry",
-                            "required": true,
-                            "type": "text",
-                          },
-                        ],
-                        "id": "github",
-                        "name": "GitHub",
-                      }
-                    }
+                  <span>
+                    Add Repository
+                  </span>
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+              >
+                <MenuItem
+                  noAnchor={true}
+                >
+                  <li
+                    className=""
+                    href={null}
+                    role="presentation"
+                    title={null}
                   >
-                    <a
-                      onClick={[Function]}
-                    >
-                      GitHub
-                      <Modal
-                        animation={false}
-                        autoFocus={true}
-                        backdrop={true}
-                        bsClass="modal"
-                        dialogComponentClass={[Function]}
-                        enforceFocus={true}
-                        keyboard={true}
-                        manager={
-                          ModalManager {
-                            "containers": Array [],
-                            "data": Array [],
-                            "handleContainerOverflow": true,
-                            "hideSiblingNodes": true,
-                            "modals": Array [],
-                          }
+                    <AddRepositoryLink
+                      onSuccess={[Function]}
+                      orgId="org-slug"
+                      provider={
+                        Object {
+                          "config": Array [
+                            Object {
+                              "help": "Enter your repository name, including the owner.",
+                              "label": "Repository Name",
+                              "name": "name",
+                              "placeholder": "e.g. getsentry/sentry",
+                              "required": true,
+                              "type": "text",
+                            },
+                          ],
+                          "id": "github",
+                          "name": "GitHub",
                         }
-                        onHide={[Function]}
-                        renderBackdrop={[Function]}
-                        restoreFocus={true}
-                        show={false}
+                      }
+                    >
+                      <a
+                        onClick={[Function]}
                       >
+                        GitHub
                         <Modal
+                          animation={false}
                           autoFocus={true}
                           backdrop={true}
-                          backdropClassName="modal-backdrop"
-                          backdropTransitionTimeout={150}
-                          containerClassName="modal-open"
-                          dialogTransitionTimeout={300}
+                          bsClass="modal"
+                          dialogComponentClass={[Function]}
                           enforceFocus={true}
                           keyboard={true}
                           manager={
@@ -287,20 +275,44 @@ exports[`OrganizationRepositories render() with a provider renders with a reposi
                               "modals": Array [],
                             }
                           }
-                          onEntering={[Function]}
-                          onExited={[Function]}
                           onHide={[Function]}
                           renderBackdrop={[Function]}
                           restoreFocus={true}
                           show={false}
-                        />
-                      </Modal>
-                    </a>
-                  </AddRepositoryLink>
-                </li>
-              </MenuItem>
-            </ul>
-          </span>
+                        >
+                          <Modal
+                            autoFocus={true}
+                            backdrop={true}
+                            backdropClassName="modal-backdrop"
+                            backdropTransitionTimeout={150}
+                            containerClassName="modal-open"
+                            dialogTransitionTimeout={300}
+                            enforceFocus={true}
+                            keyboard={true}
+                            manager={
+                              ModalManager {
+                                "containers": Array [],
+                                "data": Array [],
+                                "handleContainerOverflow": true,
+                                "hideSiblingNodes": true,
+                                "modals": Array [],
+                              }
+                            }
+                            onEntering={[Function]}
+                            onExited={[Function]}
+                            onHide={[Function]}
+                            renderBackdrop={[Function]}
+                            restoreFocus={true}
+                            show={false}
+                          />
+                        </Modal>
+                      </a>
+                    </AddRepositoryLink>
+                  </li>
+                </MenuItem>
+              </ul>
+            </span>
+          </DropdownMenu>
         </DropdownLink>
       </div>
       <h3
@@ -471,7 +483,6 @@ exports[`OrganizationRepositories render() without any providers is loading when
         caret={true}
         className="btn btn-primary btn-sm"
         disabled={false}
-        keepMenuOpen={false}
         title="Add Repository"
       />
     </div>
@@ -528,32 +539,38 @@ exports[`OrganizationRepositories render() without any providers renders 1`] = `
           caret={true}
           className="btn btn-primary btn-sm"
           disabled={false}
-          keepMenuOpen={false}
           title="Add Repository"
         >
-          <span
-            className="dropdown pull-right anchor-right open"
+          <DropdownMenu
+            keepMenuOpen={false}
           >
-            <a
-              className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
-              onClick={[Function]}
+            <span
+              className="dropdown pull-right anchor-right open"
             >
-              <span
-                className="dropdown-actor-title"
+              <a
+                className="dropdown-actor btn btn-primary btn-sm dropdown-menu-right dropdown-toggle hover"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
-                <span>
-                  Add Repository
-                </span>
-                <i
-                  className="icon-arrow-down"
-                />
-              </span>
-            </a>
-            <ul
-              className="dropdown-menu"
-              onClick={[Function]}
-            />
-          </span>
+                <div
+                  className="dropdown-actor-title"
+                >
+                  <span>
+                    Add Repository
+                  </span>
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+              />
+            </span>
+          </DropdownMenu>
         </DropdownLink>
       </div>
       <h3


### PR DESCRIPTION
Refactor "dropdown" logic into `<DropdownMenu>`. This includes logic to
check for clicks outside of menu + actor.

`<DropdownLink>` is now a component that implements `<DropdownMenu>` by
providing a children function that renders the menu using a "root"
container, an "actor" (i.e. button with down caret), and  the "menu"


This is done so we can reuse logic in <DropdownMenu> for things like autocomplete.