### PR TITLE
fix: More idempotency issues with event serialization

### DIFF
--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -71,7 +71,8 @@ def trim(
     elif isinstance(value, dict):
         result = {}
         _size += 2
-        for k, v in six.iteritems(value):
+        for k in sorted(value.keys()):
+            v = value[k]
             trim_v = trim(v, _size=_size, **options)
             result[k] = trim_v
             _size += len(force_text(trim_v)) + 1

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -31,7 +31,8 @@ _sprintf_placeholder_re = re.compile(
 )
 
 
-def truncatechars(value, arg):
+def truncatechars(value, arg, ellipsis='...'):
+    # TODO (alex) could use unicode ellipsis: u'\u2026'
     """
     Truncates a string after a certain number of chars.
 
@@ -42,7 +43,7 @@ def truncatechars(value, arg):
     except ValueError:  # Invalid literal for int().
         return value  # Fail silently.
     if len(value) > length:
-        return value[:length - 3] + '...'
+        return value[:max(0, length - len(ellipsis))] + ellipsis
     return value
 
 

--- a/tests/sentry/utils/test_strings.py
+++ b/tests/sentry/utils/test_strings.py
@@ -5,7 +5,7 @@ import functools
 
 from sentry.utils.strings import (
     is_valid_dot_atom, iter_callsign_choices, soft_break, soft_hyphenate,
-    tokens_from_name, codec_lookup
+    tokens_from_name, codec_lookup, truncatechars
 )
 
 ZWSP = u'\u200b'  # zero width space
@@ -97,3 +97,21 @@ def test_is_valid_dot_atom():
     assert not is_valid_dot_atom('.foo.bar')
     assert not is_valid_dot_atom('foo.bar.')
     assert not is_valid_dot_atom('foo.\x00')
+
+
+def test_truncatechars():
+    assert truncatechars("12345", 6) == "12345"
+    assert truncatechars("12345", 5) == "12345"
+    assert truncatechars("12345", 4) == "1..."
+    assert truncatechars("12345", 3) == "..."
+    assert truncatechars("12345", 2) == "..."
+    assert truncatechars("12345", 1) == "..."
+    assert truncatechars("12345", 0) == "..."
+
+    assert truncatechars("12345", 6, ellipsis=u"\u2026") == u"12345"
+    assert truncatechars("12345", 5, ellipsis=u"\u2026") == u"12345"
+    assert truncatechars("12345", 4, ellipsis=u"\u2026") == u"123\u2026"
+    assert truncatechars("12345", 3, ellipsis=u"\u2026") == u"12\u2026"
+    assert truncatechars("12345", 2, ellipsis=u"\u2026") == u"1\u2026"
+    assert truncatechars("12345", 1, ellipsis=u"\u2026") == u"\u2026"
+    assert truncatechars("12345", 0, ellipsis=u"\u2026") == u"\u2026"


### PR DESCRIPTION
1. truncatechars had an integer underflow issue which caused strings to
be truncated using negative indexes, making them longer than they should
be. eg. `truncatechars("ABCDEFG", 1) => 'ABCDE...'`

2. Dictionaries were trimmed in arbitrary order, making the result
change between runs.