### PR TITLE
fix: Change superuser usage to be utility functions

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -7,6 +7,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import ScopedPermission
 from sentry.app import raven
 from sentry.auth import access
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     ApiKey, Organization, OrganizationMemberTeam, OrganizationStatus, Project, ReleaseProject, Team
 )
@@ -148,7 +149,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         if not (has_valid_api_key or request.user.is_authenticated()):
             return []
 
-        if has_valid_api_key or request.is_superuser() or organization.flags.allow_joinleave:
+        if has_valid_api_key or is_active_superuser(request) or organization.flags.allow_joinleave:
             allowed_teams = Team.objects.filter(organization=organization).values_list(
                 'id', flat=True
             )

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -4,6 +4,7 @@ from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import ScopedPermission
 from sentry.models import User
+from sentry.auth.superuser import is_active_superuser
 
 
 class UserPermission(ScopedPermission):
@@ -14,7 +15,7 @@ class UserPermission(ScopedPermission):
             return True
         if request.auth:
             return False
-        if request.is_superuser():
+        if is_active_superuser(request):
             return True
         return False
 

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -5,9 +5,10 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework.response import Response
 
 from sentry.api.authentication import QuietBasicAuthentication
-from sentry.models import Authenticator
 from sentry.api.base import Endpoint
 from sentry.api.serializers import serialize
+from sentry.auth.superuser import is_active_superuser
+from sentry.models import Authenticator
 from sentry.utils import auth
 
 
@@ -33,7 +34,7 @@ class AuthIndexEndpoint(Endpoint):
             return Response(status=400)
 
         data = serialize(request.user, request.user)
-        data['isSuperuser'] = request.is_superuser()
+        data['isSuperuser'] = is_active_superuser(request)
         return Response(data)
 
     def post(self, request):

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -13,6 +13,7 @@ from sentry.api.base import DocSection, Endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.paginator import DateTimePaginator, OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
 from sentry.models import (
     AuditLogEntryEvent, Organization, OrganizationMember, OrganizationMemberTeam,
@@ -64,7 +65,7 @@ class OrganizationIndexEndpoint(Endpoint):
                 queryset = queryset.filter(id=request.auth.project.organization_id)
             elif request.auth.organization is not None:
                 queryset = queryset.filter(id=request.auth.organization.id)
-        elif member_only or not request.is_superuser():
+        elif member_only or not is_active_superuser(request):
             queryset = queryset.filter(
                 id__in=OrganizationMember.objects.filter(
                     user=request.user,

--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -8,6 +8,7 @@ from sentry.api.bases.organization import (OrganizationEndpoint, OrganizationPer
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamWithProjectsSerializer
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     AuditLogEntryEvent, OrganizationAccessRequest, OrganizationMember, OrganizationMemberTeam, Team
 )
@@ -45,7 +46,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
 
     def _can_access(self, request, member):
         # TODO(dcramer): ideally org owners/admins could perform these actions
-        if request.is_superuser():
+        if is_active_superuser(request):
             return True
 
         if not request.user.is_authenticated():

--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -8,6 +8,7 @@ from sentry.api.base import DocSection, Endpoint
 from sentry.api.bases.project import ProjectPermission
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize, ProjectWithOrganizationSerializer
+from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
 from sentry.models import (Project, ProjectPlatform, ProjectStatus)
 from sentry.search.utils import tokenize_query
@@ -59,7 +60,7 @@ class ProjectIndexEndpoint(Endpoint):
                 )
             else:
                 queryset = queryset.none()
-        elif not request.is_superuser():
+        elif not is_active_superuser(request):
             queryset = queryset.filter(
                 team__organizationmember__user=request.user,
             )

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import DetailedUserSerializer
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import User, UserOption
 
 
@@ -69,7 +70,7 @@ class UserDetailsEndpoint(UserEndpoint):
         return Response(data)
 
     def put(self, request, user):
-        if request.is_superuser():
+        if is_active_superuser(request):
             serializer_cls = AdminUserSerializer
         else:
             serializer_cls = UserSerializer

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -7,6 +7,7 @@ from six.moves import zip
 
 from sentry.app import env
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     OrganizationAccessRequest, OrganizationMemberTeam, Project, ProjectStatus, Team
 )
@@ -36,7 +37,7 @@ class TeamSerializer(Serializer):
         else:
             access_requests = frozenset()
 
-        is_superuser = (request and request.is_superuser() and request.user == user)
+        is_superuser = (request and is_active_superuser(request) and request.user == user)
         result = {}
         for team in item_list:
             is_member = team.id in memberships

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -15,13 +15,14 @@ from sentry.models import (
     UserOption,
     UserEmail,
 )
+from sentry.auth.superuser import is_active_superuser
 from sentry.utils.avatar import get_gravatar_url
 
 
 @register(User)
 class UserSerializer(Serializer):
     def _get_identities(self, item_list, user):
-        if not (env.request and env.request.is_superuser()):
+        if not (env.request and is_active_superuser(env.request)):
             item_list = [x for x in item_list if x == user]
 
         queryset = AuthIdentity.objects.filter(

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -7,6 +7,7 @@ import warnings
 from django.conf import settings
 
 from sentry import roles
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import AuthIdentity, AuthProvider, OrganizationMember
 
 
@@ -107,7 +108,7 @@ def from_request(request, organization, scopes=None):
     if not organization:
         return DEFAULT
 
-    if request.is_superuser():
+    if is_active_superuser(request):
         # we special case superuser so that if they're a member of the org
         # they must still follow SSO checks, but they gain global access
         try:

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -1,3 +1,14 @@
+"""
+Superuser in Sentry works differently than the native Django implementation.
+
+In Sentry a user must achieve the following to be treated as a superuser:
+
+- ``User.is_superuser`` must be True
+- If configured, the user must be accessing Sentry from a privileged IP (``SUPERUSER_ALLOWED_IPS``)
+- The user must have a valid 'superuser session', which is a secondary session on top of their
+  standard auth. This session has a shorter lifespan.
+"""
+
 from __future__ import absolute_import
 
 import ipaddress

--- a/src/sentry/debug/middleware.py
+++ b/src/sentry/debug/middleware.py
@@ -9,6 +9,9 @@ from django.utils.encoding import force_text
 from django.utils.html import escape
 from six.moves import _thread as thread
 
+from sentry.auth.superuser import is_active_superuser
+
+
 WRAPPER = """
 <!DOCTYPE html>
 <html>
@@ -49,7 +52,7 @@ class DebugMiddleware(object):
             return
         if not settings.SENTRY_DEBUGGER:
             return False
-        if not request.is_superuser():
+        if not is_active_superuser(request):
             return False
         if 'text/html' not in request.META.get('HTTP_ACCEPT', '*/*'):
             return False

--- a/src/sentry/django_admin.py
+++ b/src/sentry/django_admin.py
@@ -3,10 +3,12 @@ from __future__ import absolute_import
 from copy import copy
 from django.contrib import admin
 
+from sentry.auth.superuser import is_active_superuser
+
 
 class RestrictiveAdminSite(admin.AdminSite):
     def has_permission(self, request):
-        return request.is_superuser()
+        return is_active_superuser(request)
 
 
 def make_site():

--- a/src/sentry/middleware/profiler.py
+++ b/src/sentry/middleware/profiler.py
@@ -13,6 +13,8 @@ from django.conf import settings
 from django.http import HttpResponse
 from six import StringIO
 
+from sentry.auth.superuser import is_active_superuser
+
 words_re = re.compile(r'\s+')
 
 group_prefix_re = [
@@ -40,7 +42,7 @@ class ProfileMiddleware(object):
             return False
         if settings.DEBUG:
             return True
-        if request.is_superuser():
+        if is_active_superuser(request):
             return True
         return False
 

--- a/src/sentry/middleware/superuser.py
+++ b/src/sentry/middleware/superuser.py
@@ -11,7 +11,10 @@ class SuperuserMiddleware(object):
         # setting `Vary: Cookie` as a response header which will
         # break HTTP caching entirely.
         self.__skip_caching = request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES)
+
         if self.__skip_caching:
+            # XXX(dcramer): support legacy is_superuser calls for unauthenticated requests
+            request.is_superuser = lambda: False
             return
 
         su = Superuser(request)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -27,6 +27,7 @@ class TeamManager(BaseManager):
         """
         Returns a list of all teams a user has some level of access to.
         """
+        from sentry.auth.superuser import is_active_superuser
         from sentry.models import (
             OrganizationMemberTeam,
             Project,
@@ -39,7 +40,7 @@ class TeamManager(BaseManager):
 
         base_team_qs = self.filter(organization=organization, status=TeamStatus.VISIBLE)
 
-        if env.request and env.request.is_superuser() or settings.SENTRY_PUBLIC:
+        if env.request and is_active_superuser(env.request) or settings.SENTRY_PUBLIC:
             team_list = list(base_team_qs)
         else:
             try:

--- a/src/sentry/utils/debug.py
+++ b/src/sentry/utils/debug.py
@@ -17,6 +17,8 @@ from django.conf import settings
 from django.http import HttpResponse
 from six import StringIO
 
+from sentry.auth.superuser import is_active_superuser
+
 words_re = re.compile(r'\s+')
 
 group_prefix_re = [
@@ -32,7 +34,7 @@ class ProfileMiddleware(object):
             return False
         if settings.DEBUG:
             return True
-        if hasattr(request, 'user') and request.is_superuser():
+        if hasattr(request, 'user') and is_active_superuser(request):
             return True
         return False
 

--- a/src/sentry/web/decorators.py
+++ b/src/sentry/web/decorators.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseRedirect
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
 
+from sentry.auth.superuser import is_active_superuser
 from sentry.utils import auth
 from sentry.web.helpers import render_to_response
 
@@ -43,7 +44,7 @@ def signed_auth_required(func):
 def requires_admin(func):
     @wraps(func)
     def wrapped(request, *args, **kwargs):
-        if not request.is_superuser():
+        if not is_active_superuser(request):
             return render_to_response('sentry/missing_permissions.html', {}, request, status=400)
         return func(request, *args, **kwargs)
 

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -9,6 +9,7 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 
+from sentry.auth.superuser import is_active_superuser
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
 from sentry.models import AuthProvider, Organization, OrganizationStatus
@@ -161,7 +162,7 @@ class AuthLoginView(BaseView):
         if request.user.is_authenticated():
             # if the user is a superuser, but not 'superuser authenticated'
             # we allow them to re-authenticate to gain superuser status
-            if not request.user.is_superuser or request.is_superuser():
+            if not request.user.is_superuser or is_active_superuser(request):
                 return self.handle_authenticated(request, *args, **kwargs)
 
         request.session.set_test_cookie()

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -13,6 +13,7 @@ from sudo.views import redirect_to_sudo
 
 from sentry import roles
 from sentry.auth import access
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     Organization, OrganizationMember, OrganizationStatus, Project, ProjectStatus,
     Team, TeamStatus
@@ -55,7 +56,7 @@ class OrganizationMixin(object):
             organization_slug = request.session.get('activeorg')
 
         if organization_slug is not None:
-            if request.is_superuser():
+            if is_active_superuser(request):
                 try:
                     active_organization = Organization.objects.get_from_cache(
                         slug=organization_slug,
@@ -386,7 +387,7 @@ class OrganizationView(BaseView):
         can_admin = request.access.has_scope('member:admin')
 
         allowed_roles = []
-        if can_admin and not request.is_superuser():
+        if can_admin and not is_active_superuser(request):
             acting_member = OrganizationMember.objects.get(
                 user=request.user,
                 organization=organization,
@@ -399,7 +400,7 @@ class OrganizationView(BaseView):
                     if r.priority <= roles.get(acting_member.role).priority
                 ]
                 can_admin = bool(allowed_roles)
-        elif request.is_superuser():
+        elif is_active_superuser(request):
             allowed_roles = roles.get_all()
         return (can_admin, allowed_roles, )
 


### PR DESCRIPTION
Change nearly all calls to use `is_active_superuser` over implied `request.is_superuser state`.

This also corrects an issue where our 500 template attempts to render react context, which attempts to serialize the user, which then attempts to check superuser status.

Fixes SENTRY-575