### PR TITLE
fix: validate sample events

### DIFF
--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 import six
 
 from sentry.constants import DATA_ROOT, INTEGRATION_ID_TO_PLATFORM_DATA
+from sentry.coreapi import ClientApiHelper
 from sentry.event_manager import EventManager
 from sentry.interfaces.user import User as UserInterface
 from sentry.utils import json
@@ -207,6 +208,7 @@ def create_sample_event(project, platform=None, default=None,
 
     data.update(kwargs)
 
+    data = ClientApiHelper().validate_data(data)
     manager = EventManager(data)
     manager.normalize()
     return manager.save(project.id, raw=raw)


### PR DESCRIPTION
These events were not passing through the full validation steps and
we were missing an event processing error caused by the timestamp being
too old in `tests/acceptance/test_issue_details.py`. This in turn caused
visual diffs between my schemas branch and master.

Whether to fix the test as well so that the sample events don't generate
an error is an open question.