### PR TITLE
feat(api): Project plugins endpoint returns all plugins

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ Schema Changes
 - Drop index on ``EventTag(project_id, key_id, value_id)``
 - Increased length of ``Release.ref`` and ``Release.version`` to 250
 
+API Changes
+~~~~~~~~~~~
+- Project plugins endpoint returns every configurable plugin, and includes additional information about each one
+
 Version 8.22
 ------------
 

--- a/src/sentry/api/endpoints/project_plugins.py
+++ b/src/sentry/api/endpoints/project_plugins.py
@@ -13,7 +13,6 @@ class ProjectPluginsEndpoint(ProjectEndpoint):
         context = serialize(
             [
                 plugin for plugin in plugins.configurable_for_project(project, version=None)
-                if plugin.has_plugin_conf()
             ], request.user, PluginSerializer(project)
         )
         return Response(context)

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -6,6 +6,7 @@ from sentry.api.serializers import Serializer
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 from sentry.models import ProjectOption
+from django.utils.text import slugify
 
 
 class PluginSerializer(Serializer):
@@ -32,10 +33,12 @@ class PluginSerializer(Serializer):
         d = {
             'id': obj.slug,
             'name': six.text_type(obj.get_title()),
+            'slug': slugify(six.text_type(obj.get_title())),
             'shortName': six.text_type(obj.get_short_title()),
             'type': obj.get_plugin_type(),
             'canDisable': obj.can_disable,
             'isTestable': hasattr(obj, 'is_testable') and obj.is_testable(),
+            'hasConfiguration': obj.has_project_conf(),
             'metadata': obj.get_metadata(),
             'contexts': contexts,
             'status': obj.get_status(),
@@ -48,6 +51,16 @@ class PluginSerializer(Serializer):
         }
         if self.project:
             d['enabled'] = obj.is_enabled(self.project)
+
+        if obj.version:
+            d['version'] = six.text_type(obj.version)
+
+        if obj.author:
+            d['author'] = {
+                'name': six.text_type(obj.author),
+                'url': six.text_type(obj.author_url)
+            }
+
         return d
 
 

--- a/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
@@ -239,7 +239,9 @@ export default class ProjectAlertSettings extends AsyncView {
         <PluginList
           organization={organization}
           project={this.state.project}
-          pluginList={this.state.pluginList.filter(p => p.type === 'notification')}
+          pluginList={this.state.pluginList.filter(
+            p => p.type === 'notification' && p.hasConfiguration
+          )}
           onEnablePlugin={this.onEnablePlugin}
           onDisablePlugin={this.onDisablePlugin}
         />

--- a/src/sentry/static/sentry/app/views/projectDataForwarding.jsx
+++ b/src/sentry/static/sentry/app/views/projectDataForwarding.jsx
@@ -118,7 +118,9 @@ export default React.createClass({
         this.setState({
           error: false,
           loading: false,
-          pluginList: data.filter(p => p.type === 'data-forwarding'),
+          pluginList: data.filter(
+            p => p.type === 'data-forwarding' && p.hasConfiguration
+          ),
         });
       },
       error: () => {

--- a/src/sentry/static/sentry/app/views/projectReleaseTracking.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleaseTracking.jsx
@@ -58,7 +58,9 @@ const ProjectReleaseTracking = React.createClass({
     this.api.request(`/projects/${orgId}/${projectId}/plugins/`, {
       success: data => {
         this.setState({
-          pluginList: data.filter(p => p.type === 'release-tracking'),
+          pluginList: data.filter(
+            p => p.type === 'release-tracking' && p.hasConfiguration
+          ),
         });
       },
       error: () => {


### PR DESCRIPTION
Project plugins endpoint returns all configurable plugins and includes additional information for each:
`slug`, `hasConfiguration`, `version`, `author.name`, `author.url`,

These fields will be needed in order to migrate the Project Integrations page to React