### PR TITLE
feat(auditlog): Add audit log for org settings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Version 8.23 (Unreleased)
 -------------------------
 - Experiemental implementation of slack actions via a new Integrations and Identity API.
+- Display the organization setting that was updated, along with the old/new value, in the Audit Log.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -163,7 +163,8 @@ class OrganizationSerializer(serializers.Serializer):
                 option_inst.value = self.init_data[key]
                 # check if ORG_OPTIONS changed
                 if option_inst.has_changed('value'):
-                    changed_data[key] = option_inst.value
+                    old_val = option_inst.old_value('value')
+                    changed_data[key] = 'from {} to {}'.format(old_val, option_inst.value)
                 option_inst.save()
 
         if 'openMembership' in self.init_data:
@@ -181,11 +182,11 @@ class OrganizationSerializer(serializers.Serializer):
         if 'slug' in self.init_data:
             org.slug = self.init_data['slug']
 
-        fields = {
+        org_tracked_field = {
             'name': org.name,
             'slug': org.slug,
             'default_role': org.default_role,
-            'flag_fields': {
+            'flag_field': {
                 'allow_joinleave': org.flags.allow_joinleave.is_set,
                 'enhanced_privacy': org.flags.enhanced_privacy.is_set,
                 'disable_shared_issues': org.flags.disable_shared_issues.is_set,
@@ -194,15 +195,16 @@ class OrganizationSerializer(serializers.Serializer):
         }
 
         # check if fields changed
-        for f, v in six.iteritems(fields):
-            if f is not 'flag_fields':
+        for f, v in six.iteritems(org_tracked_field):
+            if f is not 'flag_field':
                 if org.has_changed(f):
-                    changed_data[f] = v
+                    old_val = org.old_value(f)
+                    changed_data[f] = 'from {} to {}'.format(old_val, v)
             else:
                 # check if flag fields changed
-                for f, v in six.iteritems(fields['flag_fields']):
+                for f, v in six.iteritems(org_tracked_field['flag_field']):
                     if org.flag_has_changed(f):
-                        changed_data[f] = v
+                        changed_data[f] = 'to {}'.format(v)
 
         org.save()
 

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 from copy import copy
 import logging
 import six
-from copy import copy
 
 from bitfield.types import BitHandler
 from django.db import models

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 from copy import copy
 import logging
 import six
+from copy import copy
 
 from bitfield.types import BitHandler
 from django.db import models

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -197,7 +197,7 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.ORG_ADD:
             return 'created the organization'
         elif self.event == AuditLogEntryEvent.ORG_EDIT:
-            return 'edited the organization setting(s): ' + (', '.join('{} to {}'.format(k, v)
+            return 'edited the organization setting(s): ' + (', '.join('{} {}'.format(k, v)
                                                                        for k, v in self.data.items()))
         elif self.event == AuditLogEntryEvent.ORG_REMOVE:
             return 'removed the organization'

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -197,7 +197,8 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.ORG_ADD:
             return 'created the organization'
         elif self.event == AuditLogEntryEvent.ORG_EDIT:
-            return 'edited the organization'
+            # TODO(kelly): Better way to display the key
+            return 'edited the organization setting(s): %s' % ', '.join(self.data.keys())
         elif self.event == AuditLogEntryEvent.ORG_REMOVE:
             return 'removed the organization'
         elif self.event == AuditLogEntryEvent.ORG_RESTORE:

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -197,8 +197,8 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.ORG_ADD:
             return 'created the organization'
         elif self.event == AuditLogEntryEvent.ORG_EDIT:
-            # TODO(kelly): Better way to display the key
-            return 'edited the organization setting(s): %s' % ', '.join(self.data.keys())
+            return 'edited the organization setting(s): ' + (', '.join('{} to {}'.format(k, v)
+                                                                       for k, v in self.data.items()))
         elif self.event == AuditLogEntryEvent.ORG_REMOVE:
             return 'removed the organization'
         elif self.event == AuditLogEntryEvent.ORG_RESTORE:

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -1,13 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.models import (
-    << << << < HEAD
-    Commit, File, OrganizationMember, OrganizationMemberTeam, Project, Release, ReleaseCommit,
-    ReleaseEnvironment, ReleaseFile, Team, TotpInterface
-    == == == =
-    Commit, File, OrganizationMember, OrganizationMemberTeam, OrganizationOption, Project, Release, ReleaseCommit,
-    ReleaseEnvironment, ReleaseFile, Team
-    >> >>>> > add check for org settings changes, display the changed setting, add tests
+    Commit, File, OrganizationMember, OrganizationMemberTeam, OrganizationOption, Project, Release, ReleaseCommit, ReleaseEnvironment, ReleaseFile, Team, TotpInterface
 )
 from sentry.testutils import TestCase
 from django.core import mail


### PR DESCRIPTION
Audit log will now display which organization setting was updated, the old value, and the new value:

## Before
<img width="510" alt="screen shot 2018-01-12 at 11 55 10 am" src="https://user-images.githubusercontent.com/20312973/34892818-7f4a5db8-f78f-11e7-9bd3-6697cc49b13e.png">



## After
<img width="727" alt="screen shot 2018-01-17 at 2 59 49 pm" src="https://user-images.githubusercontent.com/20312973/35072122-228ac4f2-fb98-11e7-92c3-09a021d000ea.png">



Need to add:
- [x] bitfield changes
- [x] `ORG_OPTIONS` changes
- [x] Rate Limit changes
- [x] how the changed field/value is displayed

cc @denamwangi @ehfeng 