### PR TITLE
fix(filters): Include Exception interface in message filter checks

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -407,6 +407,15 @@ class ClientApiHelper(object):
         if error_message and not is_valid_error_message(project, error_message):
             return (True, FilterStatKeys.ERROR_MESSAGE)
 
+        for exception_interface in data.get('sentry.interfaces.Exception', {}).get('values', []):
+            message_bits = filter(None, map(exception_interface.get, ['type', 'value']))
+            if len(message_bits) == 2:
+                if not is_valid_error_message(project, u'{}: {}'.format(*message_bits)):
+                    return (True, FilterStatKeys.ERROR_MESSAGE)
+            elif len(message_bits) == 1:
+                if not is_valid_error_message(project, message_bits[0]):
+                    return (True, FilterStatKeys.ERROR_MESSAGE)
+
         for filter_cls in filters.all():
             filter_obj = filter_cls(project)
             if filter_obj.is_enabled() and filter_obj.test(data):

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -408,13 +408,9 @@ class ClientApiHelper(object):
             return (True, FilterStatKeys.ERROR_MESSAGE)
 
         for exception_interface in data.get('sentry.interfaces.Exception', {}).get('values', []):
-            message_bits = filter(None, map(exception_interface.get, ['type', 'value']))
-            if len(message_bits) == 2:
-                if not is_valid_error_message(project, u'{}: {}'.format(*message_bits)):
-                    return (True, FilterStatKeys.ERROR_MESSAGE)
-            elif len(message_bits) == 1:
-                if not is_valid_error_message(project, message_bits[0]):
-                    return (True, FilterStatKeys.ERROR_MESSAGE)
+            message = u': '.join(filter(None, map(exception_interface.get, ['type', 'value'])))
+            if message and not is_valid_error_message(project, message):
+                return (True, FilterStatKeys.ERROR_MESSAGE)
 
         for filter_cls in filters.all():
             filter_obj = filter_cls(project)

--- a/tests/sentry/test_coreapi.py
+++ b/tests/sentry/test_coreapi.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+from collections import namedtuple
+
+import mock
+from sentry.coreapi import ClientApiHelper
+from sentry.testutils import TestCase
+from sentry.utils.data_filters import FilterStatKeys
+
+
+class ClientApiHelperTestCase(TestCase):
+    @mock.patch('sentry.coreapi.is_valid_error_message')
+    def test_should_filter_message(self, mock_is_valid_error_message):
+
+        TestItem = namedtuple('TestItem', 'value formatted result')
+
+        helper = ClientApiHelper()
+
+        items = [
+            TestItem(
+                {'type': 'UnfilteredException'},
+                'UnfilteredException',
+                True,
+            ),
+            TestItem(
+                {'value': 'This is an unfiltered exception.'},
+                'This is an unfiltered exception.',
+                True,
+            ),
+            TestItem(
+                {'type': 'UnfilteredException', 'value': 'This is an unfiltered exception.'},
+                'UnfilteredException: This is an unfiltered exception.',
+                True,
+            ),
+            TestItem(
+                {'type': 'FilteredException', 'value': 'This is a filtered exception.'},
+                'FilteredException: This is a filtered exception.',
+                False,
+            ),
+        ]
+
+        data = {
+            'sentry.interfaces.Exception': {
+                'values': [item.value for item in items]
+            },
+        }
+
+        mock_is_valid_error_message.side_effect = [item.result for item in items]
+
+        assert helper.should_filter(self.project, data) == (True, FilterStatKeys.ERROR_MESSAGE)
+
+        assert mock_is_valid_error_message.call_args_list == [
+            mock.call(self.project, item.formatted) for item in items]


### PR DESCRIPTION
This brings parity to server side behavior and the SDK behavior, as implemented by getsentry/raven-js@b81a3f6eeca032f2449e2cfe576b53ef4da0dfc7.

Fixes GH-6534.