### PR TITLE
feat: Add generic too-big-for-session object store utility

### DIFF
--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -44,14 +44,14 @@ class RedisSessionStore(object):
 
     @property
     def session_key(self):
-        return 'store:{}'.format(self.prefix)
+        return u'store:{}'.format(self.prefix)
 
     @property
     def redis_key(self):
         return self.request.session.get(self.session_key)
 
     def regenerate(self, initial_state={}):
-        redis_key = 'session-cache:{}:{}'.format(self.prefix, uuid4().hex)
+        redis_key = u'session-cache:{}:{}'.format(self.prefix, uuid4().hex)
 
         self.request.session[self.session_key] = redis_key
 

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -50,7 +50,10 @@ class RedisSessionStore(object):
     def redis_key(self):
         return self.request.session.get(self.session_key)
 
-    def regenerate(self, initial_state={}):
+    def regenerate(self, initial_state=None):
+        if initial_state is None:
+            initial_state = {}
+
         redis_key = u'session-cache:{}:{}'.format(self.prefix, uuid4().hex)
 
         self.request.session[self.session_key] = redis_key

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -1,0 +1,92 @@
+from __future__ import absolute_import, print_function
+
+from uuid import uuid4
+
+from sentry.utils.redis import clusters
+from sentry.utils.json import dumps, loads
+
+EXPIRATION_TTL = 10 * 60
+
+
+class RedisSessionStore(object):
+    """
+    RedisSessionStore provides a convinience object, which when initalized will
+    store attributes assigned to it into redis. The redis key is stored into
+    the request session. Useful for storing data too large to be stored into
+    the session cookie.
+
+    >>> store = RedisSessionStore(request, 'store-name')
+    >>> store.regenerate()
+    >>> store.some_value = 'my value'
+
+    The value will be available across requests as long as the same same store
+    name is used.
+
+    >>> store.some_value
+    'my value'
+
+    The store may be destroyed before it expires using the ``clear`` method.
+
+    >>> store.clear()
+
+    It's important to note that the session store will expire if values are not
+    modified within the provided ttl.
+    """
+
+    def __init__(self, request, prefix, ttl=EXPIRATION_TTL):
+        self.__dict__['request'] = request
+        self.__dict__['prefix'] = prefix
+        self.__dict__['ttl'] = ttl
+
+    @property
+    def _client(self):
+        return clusters.get('default').get_local_client_for_key(self.redis_key)
+
+    @property
+    def session_key(self):
+        return 'store:{}'.format(self.prefix)
+
+    @property
+    def redis_key(self):
+        return self.request.session.get(self.session_key)
+
+    def regenerate(self, initial_state={}):
+        redis_key = 'session-cache:{}:{}'.format(self.prefix, uuid4().hex)
+
+        self.request.session[self.session_key] = redis_key
+
+        value = dumps(initial_state)
+        self._client.setex(redis_key, self.ttl, value)
+
+    def clear(self):
+        if not self.redis_key:
+            return
+
+        self._client.delete(self.redis_key)
+        del self.request.session[self.session_key]
+
+    def is_valid(self):
+        return self.redis_key and self._client.get(self.redis_key)
+
+    def get_state(self):
+        if not self.redis_key:
+            return None
+
+        state_json = self._client.get(self.redis_key)
+        if not state_json:
+            return None
+
+        return loads(state_json)
+
+    def __getattr__(self, key):
+        state = self.get_state()
+        return state[key] if state else None
+
+    def __setattr__(self, key, value):
+        state = self.get_state()
+
+        if state is None:
+            return
+
+        state[key] = value
+        self._client.setex(self.redis_key, self.ttl, dumps(state))

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -15,6 +15,13 @@ class RedisSessionStore(object):
     the request session. Useful for storing data too large to be stored into
     the session cookie.
 
+    NOTE: Assigning attributes immediately saves their value back into the
+          redis key assigned for this store. Be aware of the multiple
+          round-trips implication of this.
+
+    NOTE: This object is subject to race conditions on updating valeus as the
+          entire object value is stored in one redis key.
+
     >>> store = RedisSessionStore(request, 'store-name')
     >>> store.regenerate()
     >>> store.some_value = 'my value'

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -83,7 +83,11 @@ class RedisSessionStore(object):
 
     def __getattr__(self, key):
         state = self.get_state()
-        return state[key] if state else None
+
+        try:
+            return state[key] if state else None
+        except KeyError as e:
+            raise AttributeError(e)
 
     def __setattr__(self, key, value):
         state = self.get_state()

--- a/tests/sentry/utils/test_session_store.py
+++ b/tests/sentry/utils/test_session_store.py
@@ -22,6 +22,9 @@ class RedisSessionStoreTestCase(TestCase):
         assert store2.is_valid()
         assert store2.some_value == 'test_value'
 
+        with self.assertRaises(AttributeError):
+            store.missing_key
+
         store.clear()
 
     def test_store_complex_object(self):

--- a/tests/sentry/utils/test_session_store.py
+++ b/tests/sentry/utils/test_session_store.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+
+from django.http import HttpRequest
+
+from sentry.testutils import TestCase
+from sentry.utils.session_store import RedisSessionStore
+
+
+class RedisSessionStoreTestCase(TestCase):
+    def test_store_values(self):
+        request = HttpRequest()
+        request.session = {}
+
+        store = RedisSessionStore(request, 'test-store')
+        store.regenerate()
+
+        assert 'store:test-store' in request.session
+
+        store.some_value = 'test_value'
+        store2 = RedisSessionStore(request, 'test-store')
+
+        assert store2.is_valid()
+        assert store2.some_value == 'test_value'
+
+        store.clear()
+
+    def test_store_complex_object(self):
+        request = HttpRequest()
+        request.session = {}
+
+        store = RedisSessionStore(request, 'test-store')
+        store.regenerate({
+            'some_value': {'deep_object': 'value'},
+        })
+
+        store2 = RedisSessionStore(request, 'test-store')
+
+        assert store2.some_value['deep_object'] == 'value'
+
+        store.clear()
+
+    def test_uninitialized_store(self):
+        request = HttpRequest()
+        request.session = {}
+
+        store = RedisSessionStore(request, 'test-store')
+
+        assert not store.is_valid()
+        assert store.get_state() is None
+        assert store.some_key is None
+
+        store.setting_but_no_state = 'anything'
+        assert store.setting_but_no_state is None
+
+        store.clear()


### PR DESCRIPTION
This is the cleaned up and util-itized version of GH-6245. This will be used as part of extracting the 'pipeline' module from the auth and integrations modules.

No rush on review.