### PR TITLE
feat: Implement generic pipelining utility

### DIFF
--- a/src/sentry/utils/pipeline.py
+++ b/src/sentry/utils/pipeline.py
@@ -50,7 +50,7 @@ class NestedPipelineView(PipelineView):
     will NOT be called, instead it's data will be bound into the parent
     pipeline and the parents pipeline moved to the next step.
 
-    Useful for embeding an identity authentication pipeline.
+    Useful for embedding an identity authentication pipeline.
     """
 
     def __init__(self, bind_key, pipeline_cls, provider_key, config={}):
@@ -88,7 +88,7 @@ class NestedPipelineView(PipelineView):
 class ProviderPipeline(object):
     """
     ProviderPipeline provides a mechanism to guide the user through a request
-    'pipeline', where each view may be copleted by calling the ``next_step``
+    'pipeline', where each view may be completed by calling the ``next_step``
     pipeline method to traverse through the pipe.
 
     The provider pipeline works with a Provider object which provides the
@@ -97,12 +97,12 @@ class ProviderPipeline(object):
 
     :provider_manager:
     A class property that must be specified to allow for lookup of a provider
-    implmentation object given it's key.
+    implementation object given it's key.
 
     :provider_model_cls:
     The Provider model object represents the instance of an object implementing
     the PipelineableProvider interface. This is used to look up the instance
-    when cosntructing an in progress pipleine (get_for_request).
+    when constructing an in progress pipleine (get_for_request).
 
     :config:
     A object that specifies additional pipeline and provider runtime
@@ -197,7 +197,7 @@ class ProviderPipeline(object):
 
     def finish_pipeline(self):
         """
-        Called when the pipeline complets the final step.
+        Called when the pipeline completes the final step.
         """
         raise NotImplementedError
 

--- a/src/sentry/utils/pipeline.py
+++ b/src/sentry/utils/pipeline.py
@@ -134,7 +134,10 @@ class Pipeline(object):
 
         return cls(request, organization, provider_key, provider_model, config)
 
-    def __init__(self, request, organization, provider_key, provider_model=None, config={}):
+    def __init__(self, request, organization, provider_key, provider_model=None, config=None):
+        if config is None:
+            config = {}
+
         self.request = request
         self.organization = organization
         self.state = RedisSessionStore(request, self.pipeline_name)

--- a/src/sentry/utils/pipeline.py
+++ b/src/sentry/utils/pipeline.py
@@ -6,10 +6,10 @@ from sentry.utils.session_store import RedisSessionStore
 from sentry.utils.hashlib import md5_text
 
 
-class PipelineableProvider(object):
+class PipelineProvider(object):
     """
-    A class implementing the PipelineableProvider interface provides the
-    pipeline views that the ProviderPipeline will traverse through.
+    A class implementing the PipelineProvider interface provides the pipeline
+    views that the Pipeline will traverse through.
     """
 
     def get_pipeline(self):
@@ -85,13 +85,13 @@ class NestedPipelineView(PipelineView):
         return nested_pipeline.current_step()
 
 
-class ProviderPipeline(object):
+class Pipeline(object):
     """
-    ProviderPipeline provides a mechanism to guide the user through a request
+    Pipeline provides a mechanism to guide the user through a request
     'pipeline', where each view may be completed by calling the ``next_step``
     pipeline method to traverse through the pipe.
 
-    The provider pipeline works with a Provider object which provides the
+    The pipeline works with a PipelineProvider object which provides the
     pipeline views and is made available to the views through the passed in
     pipeline.
 
@@ -101,7 +101,7 @@ class ProviderPipeline(object):
 
     :provider_model_cls:
     The Provider model object represents the instance of an object implementing
-    the PipelineableProvider interface. This is used to look up the instance
+    the PipelineProvider interface. This is used to look up the instance
     when constructing an in progress pipleine (get_for_request).
 
     :config:

--- a/src/sentry/utils/pipeline.py
+++ b/src/sentry/utils/pipeline.py
@@ -1,0 +1,211 @@
+from __future__ import absolute_import, print_function
+
+from sentry.models import Organization
+from sentry.web.frontend.base import BaseView
+from sentry.utils.session_store import RedisSessionStore
+from sentry.utils.hashlib import md5_text
+
+
+class PipelineableProvider(object):
+    """
+    A class implementing the PipelineableProvider interface provides the
+    pipeline views that the ProviderPipeline will traverse through.
+    """
+
+    def get_pipeline(self):
+        """
+        Returns a list of instantiated views which implement the PipelineView
+        class. Each view will be dispatched in order.
+        >>> return [OAuthInitView(), OAuthCallbackView()]
+        """
+        raise NotImplementedError
+
+    def set_config(self, config):
+        """
+        Use set_config to allow additional provider configuration be assend to
+        the provider instance. This is useful for example when nesting
+        pipelines and the provider needs to be configured differently.
+        """
+        self.config = config
+
+
+class PipelineView(BaseView):
+    """
+    A class implementing the PipelineView may be used in a PipleineProviders
+    get_pipeline list.
+    """
+
+    def dispatch(self, request, pipeline):
+        """
+        Called on request, the active pipeline is passed in which can and
+        should be used to bind data and traverse the pipeline.
+        """
+        raise NotImplementedError
+
+
+class NestedPipelineView(PipelineView):
+    """
+    A NestedPipelineView can be used within other pipelines to process another
+    pipeline within a pipeline. Note that the nested pipelines finish_pipeline
+    will NOT be called, instead it's data will be bound into the parent
+    pipeline and the parents pipeline moved to the next step.
+
+    Useful for embeding an identity authentication pipeline.
+    """
+
+    def __init__(self, bind_key, pipeline_cls, provider_key, config={}):
+        self.provider_key = provider_key
+        self.config = config
+
+        class NestedPipeline(pipeline_cls):
+            def set_parent_pipeline(self, parent_pipeline):
+                self.parent_pipeline = parent_pipeline
+
+            def finish_pipeline(self):
+                self.parent_pipeline.bind_state(bind_key, self.fetch_state())
+                self.clear_session()
+
+                return self.parent_pipeline.next_step()
+
+        self.pipeline_cls = NestedPipeline
+
+    def dispatch(self, request, pipeline):
+        nested_pipeline = self.pipeline_cls(
+            organization=pipeline.organization,
+            request=request,
+            provider_key=self.provider_key,
+            config=self.config,
+        )
+
+        nested_pipeline.set_parent_pipeline(pipeline)
+
+        if not nested_pipeline.is_valid():
+            nested_pipeline.initialize()
+
+        return nested_pipeline.current_step()
+
+
+class ProviderPipeline(object):
+    """
+    ProviderPipeline provides a mechanism to guide the user through a request
+    'pipeline', where each view may be copleted by calling the ``next_step``
+    pipeline method to traverse through the pipe.
+
+    The provider pipeline works with a Provider object which provides the
+    pipeline views and is made available to the views through the passed in
+    pipeline.
+
+    :provider_manager:
+    A class property that must be specified to allow for lookup of a provider
+    implmentation object given it's key.
+
+    :provider_model_cls:
+    The Provider model object represents the instance of an object implementing
+    the PipelineableProvider interface. This is used to look up the instance
+    when cosntructing an in progress pipleine (get_for_request).
+
+    :config:
+    A object that specifies additional pipeline and provider runtime
+    configurations. An example of usage is for OAuth Identity providers, for
+    overriding the scopes. The config object will be passed into the provider
+    using the ``set_config`` method.
+    """
+    pipeline_name = None
+    provider_manager = None
+    provider_model_cls = None
+
+    @classmethod
+    def get_for_request(cls, request):
+        state = RedisSessionStore(request, cls.pipeline_name)
+        if not state.is_valid():
+            return None
+
+        organization_id = state.org_id
+        if not organization_id:
+            return None
+
+        provider_model = None
+        if state.provider_model_id:
+            provider_model = cls.provider_model_cls.objects.get(id=state.provider_model_id)
+
+        organization = Organization.objects.get(id=state.org_id)
+        provider_key = state.provider_key
+        config = state.config
+
+        return cls(request, organization, provider_key, provider_model, config)
+
+    def __init__(self, request, organization, provider_key, provider_model=None, config={}):
+        self.request = request
+        self.organization = organization
+        self.state = RedisSessionStore(request, self.pipeline_name)
+        self.provider = self.provider_manager.get(provider_key)
+        self.provider_model = provider_model
+
+        self.config = config
+        self.provider.set_config(config)
+
+        self.pipeline = self.provider.get_pipeline()
+
+        # we serialize the pipeline to be ['fqn.PipelineView', ...] which
+        # allows us to determine if the pipeline has changed during the auth
+        # flow or if the user is somehow circumventing a chunk of it
+        pipe_ids = ['{}.{}'.format(type(v).__module__, type(v).__name__) for v in self.pipeline]
+        self.signature = md5_text(*pipe_ids).hexdigest()
+
+    def is_valid(self):
+        return self.state.is_valid() and self.state.signature == self.signature
+
+    def initialize(self):
+        self.state.regenerate({
+            'uid': self.request.user.id if self.request.user.is_authenticated() else None,
+            'provider_model_id': self.provider_model.id if self.provider_model else None,
+            'provider_key': self.provider.key,
+            'org_id': self.organization.id,
+            'step_index': 0,
+            'signature': self.signature,
+            'config': self.config,
+            'data': {},
+        })
+
+    def clear_session(self):
+        self.state.clear()
+
+    def current_step(self):
+        """
+        Render the current step.
+        """
+        step_index = self.state.step_index
+
+        if step_index == len(self.pipeline):
+            return self.finish_pipeline()
+
+        return self.pipeline[step_index].dispatch(
+            request=self.request,
+            pipeline=self,
+        )
+
+    def error(self, message):
+        # TODO: Implement this here
+        raise NotImplementedError
+
+    def next_step(self):
+        """
+        Render the next step.
+        """
+        self.state.step_index += 1
+        return self.current_step()
+
+    def finish_pipeline(self):
+        """
+        Called when the pipeline complets the final step.
+        """
+        raise NotImplementedError
+
+    def bind_state(self, key, value):
+        data = self.state.data
+        data[key] = value
+
+        self.state.data = data
+
+    def fetch_state(self, key=None):
+        return self.state.data if key is None else self.state.data.get(key)

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -30,7 +30,7 @@ class DummpyPipeline(ProviderPipeline):
     provider_manager = DummyProviderManager()
 
     def finish_pipeline(self):
-        self.finished = 1
+        self.finished = True
 
 
 class PipelineTestCase(TestCase):
@@ -47,7 +47,8 @@ class PipelineTestCase(TestCase):
 
         assert 'some_config' in pipeline.provider.config
 
-        pipeline.finished = 0
+        # Test state
+        pipeline.finished = False
         pipeline.dispatch_count = 0
 
         # Pipeline has two steps, ensure both steps compete. Usually the
@@ -62,7 +63,7 @@ class PipelineTestCase(TestCase):
 
         pipeline.next_step()
         assert pipeline.dispatch_count == 2
-        assert pipeline.finished == 1
+        assert pipeline.finished
 
         pipeline.clear_session()
         assert not pipeline.state.is_valid()

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -3,11 +3,7 @@ from __future__ import absolute_import
 from django.http import HttpRequest
 
 from sentry.testutils import TestCase
-from sentry.utils.pipeline import (
-    PipelineableProvider,
-    PipelineView,
-    ProviderPipeline,
-)
+from sentry.utils.pipeline import PipelineProvider, PipelineView, ProviderPipeline
 
 
 class PipelineStep(PipelineView):
@@ -16,7 +12,7 @@ class PipelineStep(PipelineView):
         pipeline.bind_state('some_state', 'value')
 
 
-class DummyProvider(PipelineableProvider):
+class DummyProvider(PipelineProvider):
     key = 'dummy'
     pipeline = [PipelineStep(), PipelineStep()]
 

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -20,14 +20,11 @@ class DummyProvider(PipelineProvider):
         return self.pipeline
 
 
-class DummyProviderManager(object):
-    def get(self, provider_key):
-        return DummyProvider()
-
-
 class DummpyPipeline(Pipeline):
     pipeline_name = 'test_pipeline'
-    provider_manager = DummyProviderManager()
+
+    # Simplify tests, the manager can just be a dict.
+    provider_manager = {'dummy': DummyProvider()}
 
     def finish_pipeline(self):
         self.finished = True

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -50,10 +50,9 @@ class PipelineTestCase(TestCase):
         pipeline.finished = 0
         pipeline.dispatch_count = 0
 
-        # Piepline has two steps, ensure both steps compete.
-        # Usually the dispatch itself would be the one calling the current_step
-        # and next_step methods after it determins if it can move forward a
-        # step.
+        # Pipeline has two steps, ensure both steps compete. Usually the
+        # dispatch itself would be the one calling the current_step and
+        # next_step methods after it determines if it can move forward a step.
         pipeline.current_step()
         assert pipeline.dispatch_count == 1
         assert pipeline.fetch_state('some_state') == 'value'

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -16,7 +16,7 @@ class DummyProvider(PipelineProvider):
     key = 'dummy'
     pipeline = [PipelineStep(), PipelineStep()]
 
-    def get_pipeline(self):
+    def get_pipeline_views(self):
         return self.pipeline
 
 

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -37,7 +37,7 @@ class PipelineTestCase(TestCase):
         request.session = {}
         request.user = self.user
 
-        pipeline = DummpyPipeline(request, org, 'dummy', {'some_config': True})
+        pipeline = DummpyPipeline(request, org, 'dummy', config={'some_config': True})
         pipeline.initialize()
 
         assert pipeline.is_valid()

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.http import HttpRequest
 
 from sentry.testutils import TestCase
-from sentry.utils.pipeline import PipelineProvider, PipelineView, ProviderPipeline
+from sentry.utils.pipeline import PipelineProvider, PipelineView, Pipeline
 
 
 class PipelineStep(PipelineView):
@@ -25,7 +25,7 @@ class DummyProviderManager(object):
         return DummyProvider()
 
 
-class DummpyPipeline(ProviderPipeline):
+class DummpyPipeline(Pipeline):
     pipeline_name = 'test_pipeline'
     provider_manager = DummyProviderManager()
 

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -25,7 +25,7 @@ class DummyProvider(PipelineableProvider):
 
 
 class DummyProviderManager(object):
-    def get(self, provider):
+    def get(self, provider_key):
         return DummyProvider()
 
 

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import
+
+from django.http import HttpRequest
+
+from sentry.testutils import TestCase
+from sentry.utils.pipeline import (
+    PipelineableProvider,
+    PipelineView,
+    ProviderPipeline,
+)
+
+
+class PipelineStep(PipelineView):
+    def dispatch(self, request, pipeline):
+        pipeline.called += 1
+        pipeline.bind_state('some_state', 'value')
+
+
+class DummyProvider(PipelineableProvider):
+    key = 'dummy'
+    pipeline = [PipelineStep(), PipelineStep()]
+
+    def get_pipeline(self):
+        return self.pipeline
+
+
+class DummyProviderManager(object):
+    def get(self, provider):
+        return DummyProvider()
+
+
+class DummpyPipeline(ProviderPipeline):
+    pipeline_name = 'test_pipeline'
+    provider_manager = DummyProviderManager()
+
+    def finish_pipeline(self):
+        self.finished = 1
+
+
+class PipelineTestCase(TestCase):
+    def test_simple_pipeline(self):
+        org = self.create_organization()
+        request = HttpRequest()
+        request.session = {}
+        request.user = self.user
+
+        pipeline = DummpyPipeline(request, org, 'dummy', {'some_config': True})
+        pipeline.initialize()
+
+        assert 'some_config' in pipeline.provider.config
+
+        pipeline.called = 0
+
+        # Piepline has two steps, ensure both steps compete
+        pipeline.current_step()
+        assert pipeline.called == 1
+        assert pipeline.fetch_state('some_state') == 'value'
+
+        pipeline.next_step()
+        assert pipeline.called == 2
+
+        pipeline.next_step()
+        assert pipeline.called == 2
+        assert pipeline.finished == 1
+        assert pipeline.is_valid()
+
+        pipeline.clear_session()
+        assert not pipeline.state.is_valid()
+
+    def test_invalidated_pipeline(self):
+        org = self.create_organization()
+        request = HttpRequest()
+        request.session = {}
+        request.user = self.user
+
+        pipeline = DummpyPipeline(request, org, 'dummy')
+        pipeline.initialize()
+
+        assert pipeline.is_valid()
+
+        # Mutate the provider, Remove an item from the pipeline, thus
+        # invalidating the pipeline.
+        prev_pipeline = DummyProvider.pipeline
+        DummyProvider.pipeline = [PipelineStep()]
+
+        pipeline = DummpyPipeline.get_for_request(request)
+
+        assert not pipeline.is_valid()
+
+        DummyProvider.pipeline = prev_pipeline

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -81,7 +81,7 @@ class PipelineTestCase(TestCase):
         prev_pipeline = DummyProvider.pipeline
         DummyProvider.pipeline = [PipelineStep()]
 
-        pipeline = DummpyPipeline.get_for_request(request)
+        pipeline = DummyPipeline.get_for_request(request)
 
         assert not pipeline.is_valid()
 

--- a/tests/sentry/utils/test_pipeline.py
+++ b/tests/sentry/utils/test_pipeline.py
@@ -20,7 +20,7 @@ class DummyProvider(PipelineProvider):
         return self.pipeline
 
 
-class DummpyPipeline(Pipeline):
+class DummyPipeline(Pipeline):
     pipeline_name = 'test_pipeline'
 
     # Simplify tests, the manager can just be a dict.
@@ -37,7 +37,7 @@ class PipelineTestCase(TestCase):
         request.session = {}
         request.user = self.user
 
-        pipeline = DummpyPipeline(request, org, 'dummy', config={'some_config': True})
+        pipeline = DummyPipeline(request, org, 'dummy', config={'some_config': True})
         pipeline.initialize()
 
         assert pipeline.is_valid()
@@ -71,7 +71,7 @@ class PipelineTestCase(TestCase):
         request.session = {}
         request.user = self.user
 
-        pipeline = DummpyPipeline(request, org, 'dummy')
+        pipeline = DummyPipeline(request, org, 'dummy')
         pipeline.initialize()
 
         assert pipeline.is_valid()


### PR DESCRIPTION
This is a generic implementation of the pipeline helper (renaming to just pipeline) used in the auth and integrations modules. This extracts most of the pipelineing and state managment into a single base class that can be subclassed for specific pipeline types.

Future PRs will 1) refactor the auth and integration module to use this pipeline utility, and 2) make use of the pipeline utility for a new identity pipeline.