### PR TITLE
feat(api): Search related events by event ID

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -40,6 +40,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         )
 
         query = request.GET.get('query')
+
         if query:
             try:
                 query_kwargs = parse_query(group.project, query, request.user)
@@ -49,6 +50,8 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             if query_kwargs['query']:
                 events = events.filter(
                     message__icontains=query_kwargs['query'],
+                ) | events.filter(
+                    event_id__iexact=query_kwargs['query'],
                 )
 
             if query_kwargs['tags']:

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -49,10 +49,12 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
                 return Response({'detail': six.text_type(exc)}, status=400)
 
             if query_kwargs['query']:
-                events = events.filter(
-                    Q(message__icontains=query_kwargs['query']) | Q(
-                        event_id__iexact=query_kwargs['query'])
-                )
+                q = Q(message__icontains=query_kwargs['query'])
+
+                if len(query) == 32:
+                    q |= Q(event_id__exact=query_kwargs['query'])
+
+                events = events.filter(q)
 
             if query_kwargs['tags']:
                 try:

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -12,6 +12,7 @@ from sentry.search.utils import parse_query
 from sentry.utils.apidocs import scenario, attach_scenarios
 from rest_framework.response import Response
 from sentry.search.utils import InvalidQuery
+from django.db.models import Q
 
 
 @scenario('ListAvailableSamples')
@@ -49,9 +50,8 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
 
             if query_kwargs['query']:
                 events = events.filter(
-                    message__icontains=query_kwargs['query'],
-                ) | events.filter(
-                    event_id__iexact=query_kwargs['query'],
+                    Q(message__icontains=query_kwargs['query']) | Q(
+                        event_id__iexact=query_kwargs['query'])
                 )
 
             if query_kwargs['tags']:

--- a/tests/sentry/api/endpoints/test_group_events.py
+++ b/tests/sentry/api/endpoints/test_group_events.py
@@ -120,3 +120,51 @@ class GroupEventsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
+
+    def test_search_event_by_id(self):
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+        event_1 = self.create_event('a' * 32, group=group)
+        self.create_event('b' * 32, group=group)
+        query = event_1.event_id
+
+        url = '/api/0/issues/{}/events/?query={}'.format(group.id, query)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['eventID'] == event_1.event_id
+
+    def test_search_event_by_message(self):
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+        event_1 = self.create_event(event_id='a' * 32, group=group, message="foo bar hello world")
+
+        event_2 = self.create_event(event_id='b' * 32, group=group, message='this bar hello world ')
+
+        query_1 = "foo"
+        query_2 = "hello+world"
+
+        # Single Word Query
+        url = '/api/0/issues/{}/events/?query={}'.format(group.id, query_1)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == six.text_type(
+            event_1.id) and response.data[0]['eventID'] == event_1.event_id
+
+        # Multiple Word Query
+        url = '/api/0/issues/{}/events/?query={}'.format(group.id, query_2)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert sorted(map(lambda x: x['id'], response.data)) == sorted(
+            [
+                six.text_type(event_1.id),
+                six.text_type(event_2.id),
+            ]
+        )


### PR DESCRIPTION
Implemented the functionality to search for event_id. Created tests for both searching events by message (preexisting functionality) and searching events by event_id (new feature). 

Fixes #5825