### PR TITLE
fix: Clean up ip_address defaulting.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -313,6 +313,7 @@ class EventManager(object):
             'tags': lambda v: [(text(v_k).replace(' ', '-').strip(), text(v_v).strip()) for (v_k, v_v) in dict(v).items()],
             'timestamp': lambda v: process_timestamp(v),
             'platform': lambda v: v if v in VALID_PLATFORMS else 'other',
+            'sentry.interfaces.Message': lambda v: v if isinstance(v, dict) else {'message': v},
 
             # These can be sent as lists and need to be converted to {'values': [...]}
             'exception': to_values,

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -21,6 +21,7 @@ from sentry.interfaces.base import Interface, InterfaceValidationError
 from sentry.interfaces.schemas import validate_and_default_interface
 from sentry.utils.safe import trim, trim_dict, trim_pairs
 from sentry.utils.http import heuristic_decode
+from sentry.utils.validators import validate_ip
 from sentry.web.helpers import render_to_string
 
 # Instead of relying on a list of hardcoded methods, just loosly match
@@ -191,9 +192,17 @@ class Http(Interface):
         if body:
             body = trim(body, settings.SENTRY_MAX_HTTP_BODY_SIZE)
 
+        env = data.get('env', {})
+        # TODO (alex) This could also be accomplished with schema (with formats)
+        if 'REMOTE_ADDR' in env:
+            try:
+                validate_ip(env['REMOTE_ADDR'], required=False)
+            except ValueError:
+                del env['REMOTE_ADDR']
+
         kwargs['inferred_content_type'] = inferred_content_type
         kwargs['cookies'] = trim_pairs(format_cookies(cookies))
-        kwargs['env'] = trim_dict(data.get('env') or {})
+        kwargs['env'] = trim_dict(env)
         kwargs['headers'] = trim_pairs(headers)
         kwargs['data'] = fix_broken_encoding(body)
         kwargs['url'] = urlunsplit((scheme, netloc, path, '', ''))

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -384,6 +384,7 @@ EVENT_SCHEMA = {
 
         # Other reserved keys. (some are added in processing)
         'project': {'type': ['number', 'string']},
+        'key_id': {},
         'errors': {'type': 'array'},
         'checksum': {},
         'site': {},

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -912,6 +912,9 @@ class EventManagerTest(TransactionTestCase):
         }
 
     def test_message_attribute_goes_to_formatted(self):
+        # The combining of 'message' and 'sentry.interfaces.Message' is a bit
+        # of a compatibility hack, and ideally we would just enforce a stricter
+        # schema instead of combining them like this.
         manager = EventManager(
             self.make_event(
                 **{
@@ -927,6 +930,22 @@ class EventManagerTest(TransactionTestCase):
         assert event.data['sentry.interfaces.Message'] == {
             'message': 'hello world',
             'formatted': 'world hello',
+        }
+
+    def test_message_attribute_interface_both_strings(self):
+        manager = EventManager(
+            self.make_event(
+                **{
+                    'sentry.interfaces.Message': 'a plain string',
+                    'message': 'another string',
+                }
+            )
+        )
+        manager.normalize()
+        event = manager.save(self.project.id)
+        assert event.data['sentry.interfaces.Message'] == {
+            'message': 'a plain string',
+            'formatted': 'another string',
         }
 
     def test_throws_when_matches_discarded_hash(self):


### PR DESCRIPTION
Make ip_address defaulting happen consistently in one place
and update the tests.

fix: Deal with bad message interface data.

Add a cast to deal with the Message interface being sent as a string.
Ideally this would actuallly just be in the schema and we would reject it,
but we have existing logic to insert 'message' into
'sentry.interface.Message' that I don't want to break.

fixes: SENTRY-58P, SENTRY-58M