### PR TITLE
fix: deal with User interface sent as null

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -546,7 +546,6 @@ class LazyData(MutableMapping):
         data['project'] = self._project.id
         data['key_id'] = self._key.id
         data['sdk'] = data.get('sdk') or helper.parse_client_as_sdk(auth.client)
-        data['sdk']['client_ip'] = self._client_ip
 
         # mutates data
         manager = EventManager(data, version=auth.version)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -463,6 +463,9 @@ class EventManager(object):
         elif client_ip and (is_public or data.get('platform') in add_ip_platforms):
             data.setdefault('sentry.interfaces.User', {}).setdefault('ip_address', client_ip)
 
+        if client_ip and data.get('sdk'):
+            data['sdk']['client_ip'] = client_ip
+
         # Trim values
         data['logger'] = trim(data['logger'].strip(), 64)
         trim_dict(data['extra'], max_size=settings.SENTRY_MAX_EXTRA_VARIABLE_SIZE)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -350,7 +350,7 @@ class EventManager(object):
                     'env', {}).get('REMOTE_ADDR') == '{{auto}}':
                 data['sentry.interfaces.Http']['env']['REMOTE_ADDR'] = client_ip
 
-            if data.get('sentry.interfaces.User', {}).get('ip_address') == '{{auto}}':
+            if (data.get('sentry.interfaces.User') or {}).get('ip_address') == '{{auto}}':
                 data['sentry.interfaces.User']['ip_address'] = client_ip
 
         # Validate main event body and tags against schema

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -346,7 +346,7 @@ class EventManager(object):
         # Fill in ip addresses marked as {{auto}}
         client_ip = request_env.get('client_ip')
         if client_ip:
-            if data.get('sentry.interfaces.Http', {}).get(
+            if (data.get('sentry.interfaces.Http') or {}).get(
                     'env', {}).get('REMOTE_ADDR') == '{{auto}}':
                 data['sentry.interfaces.Http']['env']['REMOTE_ADDR'] = client_ip
 

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -1015,12 +1015,13 @@ class EventManagerTest(TransactionTestCase):
             signal=event_saved,
         )
 
-    def test_null_interfaces_no_exception(self):
+    def test_bad_interfaces_no_exception(self):
         manager = EventManager(
             self.make_event(
                 **{
                     'sentry.interfaces.User': None,
                     'sentry.interfaces.Http': None,
+                    'sdk': 'A string for sdk is not valid'
                 }
             )
         )

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -1015,6 +1015,17 @@ class EventManagerTest(TransactionTestCase):
             signal=event_saved,
         )
 
+    def test_null_interfaces_no_exception(self):
+        manager = EventManager(
+            self.make_event(
+                **{
+                    'sentry.interfaces.User': None,
+                    'sentry.interfaces.Http': None,
+                }
+            )
+        )
+        manager.normalize({'client_ip': '1.2.3.4'})
+
 
 class ProcessDataTimestampTest(TestCase):
     def test_iso_timestamp(self):


### PR DESCRIPTION
Can't use get() defaulting as it doesn't use the default when the key
exists and is None.

fixes: SENTRY-59T