### PR TITLE
fix: Prevent commit marker tooltips flickering on hover

### DIFF
--- a/src/sentry/static/sentry/less/components/charts.less
+++ b/src/sentry/static/sentry/less/components/charts.less
@@ -43,6 +43,8 @@
     position: relative;
     float: left;
     width: 0;
+    bottom: -5px;
+    left: -5px;
 
     &:hover {
       > span {
@@ -51,9 +53,11 @@
       }
     }
 
-    &.first-seen > span {
-      background: @pink;
+    &.first-seen {
       left: -13px;
+      > span {
+        background: @pink;
+      }
     }
 
     &.last-seen > span {
@@ -63,17 +67,10 @@
     > span {
       z-index: 2;
       position: absolute;
-      bottom: -5px;
-      left: -5px;
       border: 2px solid #fff;
       .square(10px);
       background: gray;
       border-radius: 8px;
-    }
-
-    &.first-seen > span {
-    }
-    &.last-seen > span {
     }
   }
 }


### PR DESCRIPTION

![bug](https://user-images.githubusercontent.com/1779792/33737545-64255c96-db4b-11e7-8453-58e3933960bd.gif)
