### PR TITLE
fix: Default IP addresses post-validation

### DIFF
--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -1027,6 +1027,17 @@ class EventManagerTest(TransactionTestCase):
         )
         manager.normalize({'client_ip': '1.2.3.4'})
 
+        manager = EventManager(
+            self.make_event(
+                **{
+                    'sentry.interfaces.Http': {
+                        'env': None,
+                    }
+                }
+            )
+        )
+        manager.normalize({'client_ip': '1.2.3.4'})
+
 
 class ProcessDataTimestampTest(TestCase):
     def test_iso_timestamp(self):


### PR DESCRIPTION
Turns out `env` can be null too.

In order not to drive myself insane accounting for every permutation
of garbage data. I am doing the {{auto}} IP address defaulting after
schema validation has taken place. That way I can be certain that the
interfaces are not malformed.

Fixes SENTRY-59V