### PR TITLE
Use schema for User.

### DIFF
--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -21,7 +21,6 @@ from sentry.interfaces.base import Interface, InterfaceValidationError
 from sentry.interfaces.schemas import validate_and_default_interface
 from sentry.utils.safe import trim, trim_dict, trim_pairs
 from sentry.utils.http import heuristic_decode
-from sentry.utils.validators import validate_ip
 from sentry.web.helpers import render_to_string
 
 # Instead of relying on a list of hardcoded methods, just loosly match
@@ -192,17 +191,9 @@ class Http(Interface):
         if body:
             body = trim(body, settings.SENTRY_MAX_HTTP_BODY_SIZE)
 
-        env = data.get('env', {})
-        # TODO (alex) This could also be accomplished with schema (with formats)
-        if 'REMOTE_ADDR' in env:
-            try:
-                validate_ip(env['REMOTE_ADDR'], required=False)
-            except ValueError:
-                del env['REMOTE_ADDR']
-
         kwargs['inferred_content_type'] = inferred_content_type
         kwargs['cookies'] = trim_pairs(format_cookies(cookies))
-        kwargs['env'] = trim_dict(env)
+        kwargs['env'] = trim_dict(data.get('env', {}))
         kwargs['headers'] = trim_pairs(headers)
         kwargs['data'] = fix_broken_encoding(body)
         kwargs['url'] = urlunsplit((scheme, netloc, path, '', ''))

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -1,19 +1,8 @@
 from __future__ import absolute_import
 
-import ipaddress
 import re
-import six
 
 EVENT_ID_RE = re.compile(r'^[a-fA-F0-9]{32}$')
-
-
-def validate_ip(value, required=True):
-    if not required and not value:
-        return
-
-    # will raise a ValueError
-    ipaddress.ip_network(six.text_type(value), strict=False)
-    return value
 
 
 def is_float(var):

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -479,7 +479,7 @@ class CspReportTest(TestCase):
         assert output['message'] == e.data['sentry.interfaces.Message']['message']
         for key, value in six.iteritems(output['tags']):
             assert e.get_tag(key) == value
-        self.assertDictContainsSubset(output['data'], e.data.data, e.data.data)
+        self.assertDictContainsSubset(output['data'], e.data.data)
 
     def assertReportRejected(self, input):
         resp = self._postCspWithHeader(input)

--- a/tests/sentry/interfaces/test_user.py
+++ b/tests/sentry/interfaces/test_user.py
@@ -61,3 +61,20 @@ class UserTest(TestCase):
     def test_serialize_unserialize_behavior(self):
         result = type(self.interface).to_python(self.interface.to_json())
         assert result.to_json() == self.interface.to_json()
+
+    def test_trim(self):
+        user = User.to_python({
+            'id': 'A' * 129,
+            'username': 'A' * 129,
+        })
+        assert len(user.id) == 128
+        assert len(user.username) == 128
+
+    def test_nones(self):
+        user = User.to_python({
+            'id': 1,
+            'username': None,
+            'name': None,
+            'data': None,
+        })
+        assert user.to_json() == {'id': '1'}


### PR DESCRIPTION
Replace a lot of manual user validation with schema. Use format checker
with jsonschema to validate things like IP addresss.

One change in behavior is that email addresses are now invalid (and
discarded) if they exceed the maximum length, they are not trimmed.
Raising InterfaceValidationError on invalid email and IP address is
behavior retained from original code.