### PR TITLE
fix: Lookup nested values safely.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -41,7 +41,7 @@ from sentry.tasks.post_process import post_process_group
 from sentry.utils import metrics
 from sentry.utils.cache import default_cache
 from sentry.utils.db import get_db_engine
-from sentry.utils.safe import safe_execute, trim, trim_dict
+from sentry.utils.safe import safe_execute, trim, trim_dict, get_path
 from sentry.utils.strings import truncatechars
 from sentry.utils.validators import is_float
 from sentry.stacktraces import normalize_in_app
@@ -346,11 +346,10 @@ class EventManager(object):
         # Fill in ip addresses marked as {{auto}}
         client_ip = request_env.get('client_ip')
         if client_ip:
-            if (data.get('sentry.interfaces.Http') or {}).get(
-                    'env', {}).get('REMOTE_ADDR') == '{{auto}}':
+            if get_path(data, ['sentry.interfaces.Http', 'env', 'REMOTE_ADDR']) == '{{auto}}':
                 data['sentry.interfaces.Http']['env']['REMOTE_ADDR'] = client_ip
 
-            if (data.get('sentry.interfaces.User') or {}).get('ip_address') == '{{auto}}':
+            if get_path(data, ['sentry.interfaces.User', 'ip_address']) == '{{auto}}':
                 data['sentry.interfaces.User']['ip_address'] = client_ip
 
         # Validate main event body and tags against schema

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -118,3 +118,18 @@ def trim_dict(value, max_items=settings.SENTRY_MAX_DICTIONARY_ITEMS, **kwargs):
         if idx > max_items:
             del value[key]
     return value
+
+
+def get_path(data, path, default=None):
+    """
+    Looks up a path of properties in a nested dictionary safely.
+    Returns the value at the final level, or the default value if
+    property lookup failed at any step in the path.
+    """
+    if not isinstance(path, (list, tuple)) or len(path) == 0:
+        raise ValueError
+    for p in path:
+        if not isinstance(data, dict) or p not in data:
+            return default
+        data = data[p]
+    return data

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from functools import partial
 
 from sentry.testutils import TestCase
-from sentry.utils.safe import safe_execute, trim, trim_dict
+from sentry.utils.safe import safe_execute, trim, trim_dict, get_path
 
 a_very_long_string = 'a' * 1024
 
@@ -75,3 +75,14 @@ class SafeExecuteTest(TestCase):
                 raise Exception()
 
         assert safe_execute(Foo().simple, 1) is None
+
+
+class GetChainTest(TestCase):
+    def test_get_path(self):
+        assert get_path({}, ['a']) is None
+        assert get_path({}, ['a'], 1) == 1
+        assert get_path({'a': 2}, ['a']) == 2
+        assert get_path({'a': 2}, ['b']) is None
+        assert get_path({'a': 2}, ['b'], 1) == 1
+        assert get_path({'a': {'b': []}}, ['a', 'b']) == []
+        assert get_path({'a': []}, ['a', 'b']) is None


### PR DESCRIPTION
Created a safe nested `get` function so I don't have to play
whack-a-mole with potentially null values in lookup paths.

Fixes: SENTRY-59V