### PR TITLE
fix(auditlog): Added platform to deletedproject

### DIFF
--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -65,6 +65,7 @@ def create_project_delete_log(entry):
     delete_log.name = project.name
     delete_log.slug = project.slug
     delete_log.date_created = project.date_added
+    delete_log.platform = project.platform
 
     delete_log.organization_id = entry.organization.id
     delete_log.organization_name = entry.organization.name

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -21,6 +21,7 @@ class CreateAuditEntryTest(TestCase):
         self.org = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.org)
         self.project = self.create_project(team=self.team)
+        self.project.update(platform='java')
 
     def assert_no_delete_log_created(self):
         assert not DeletedOrganization.objects.filter(slug=self.org.slug).exists()
@@ -101,3 +102,4 @@ class CreateAuditEntryTest(TestCase):
 
         deleted_project = DeletedProject.objects.get(slug=self.project.slug)
         self.assert_valid_deleted_log(deleted_project, self.project)
+        assert deleted_project.platform == self.project.platform

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -20,8 +20,7 @@ class CreateAuditEntryTest(TestCase):
         self.req = FakeHttpRequest(self.user)
         self.org = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.org)
-        self.project = self.create_project(team=self.team)
-        self.project.update(platform='java')
+        self.project = self.create_project(team=self.team, platform='java')
 
     def assert_no_delete_log_created(self):
         assert not DeletedOrganization.objects.filter(slug=self.org.slug).exists()


### PR DESCRIPTION
The platform is a field that is used by the growth team, since deletedproject is a table for user support, platform has been added. There are no migration changes here, simply filling in the column with data moving forward.