### PR TITLE
fix(plugins): Camel case stored password field in api to match frontend

### DIFF
--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -93,7 +93,7 @@ def serialize_field(project, plugin, field):
     if field.get('type') != 'secret':
         data['value'] = plugin.get_option(field['name'], project)
     else:
-        data['has_saved_value'] = bool(field.get('has_saved_value', False))
+        data['hasSavedValue'] = bool(field.get('has_saved_value', False))
         data['prefix'] = field.get('prefix', '')
 
     return data


### PR DESCRIPTION
fixes this behavior:
![screenshot 2017-12-08 14 42 53](https://user-images.githubusercontent.com/5026776/33788258-1cbef692-dc26-11e7-9e3a-a53c2342ca35.png)

cc @mikellykels @MeredithAnya 