### PR TITLE
fix(search): Added id to the list of things the group searchbar says you can search

### DIFF
--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -152,7 +152,7 @@ const GroupEvents = React.createClass({
         <div style={{marginBottom: 20}}>
           <SearchBar
             defaultQuery=""
-            placeholder={t('search event message or tags')}
+            placeholder={t('search event id, message, or tags')}
             query={this.state.query}
             onSearch={this.onSearch}
           />


### PR DESCRIPTION
Changed the placeholder in the group search bar so that event id is added.