### PR TITLE
feat(api): Add environment filtering to additional TSDB queries

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import functools
 import logging
 import six
 import time
@@ -221,9 +222,15 @@ class Endpoint(APIView):
 
 
 class EnvironmentMixin(object):
+    def _get_environment_id_func(self, request, organization_id):
+        return functools.partial(
+            self._get_environment_id_from_request,
+            request,
+            organization_id,
+        )
+
     def _get_environment_id_from_request(self, request, organization_id):
         environment = self._get_environment_from_request(request, organization_id)
-
         return environment and environment.id
 
     def _get_environment_from_request(self, request, organization_id):

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -223,6 +223,18 @@ class Endpoint(APIView):
 
 class EnvironmentMixin(object):
     def _get_environment_id_func(self, request, organization_id):
+        """\
+        Creates a function that when called returns the environment_id
+        associated with a request object, or ``None`` if no environment was
+        provided. If the environment doesn't exist, an ``Environment.DoesNotExist``
+        exception will be raised.
+
+        This returns as a callable since some objects outside of the API
+        endpoint need to handle the "environment was provided but does not
+        exist" state in addition to the two non-exceptional states (the
+        environment was provided and exists, or the environment was not
+        provided.)
+        """
         return functools.partial(
             self._get_environment_id_from_request,
             request,

--- a/src/sentry/api/bases/organizationissues.py
+++ b/src/sentry/api/bases/organizationissues.py
@@ -51,22 +51,22 @@ class OrganizationIssuesEndpoint(OrganizationMemberEndpoint):
             project__status=ProjectStatus.VISIBLE,
         )
 
+        def on_results(results):
+            results = serialize(
+                results, request.user, StreamGroupSerializer(
+                    stats_period=stats_period,
+                )
+            )
+
+            if request.GET.get('status') == 'unresolved':
+                results = [r for r in results if r['status'] == 'unresolved']
+
+            return results
+
         return self.paginate(
             request=request,
             queryset=queryset,
             order_by='-sort_by',
             paginator_cls=OffsetPaginator,
-            on_results=lambda x: self._on_results(request, x, stats_period),
+            on_results=on_results,
         )
-
-    def _on_results(self, request, results, stats_period):
-        results = serialize(
-            results, request.user, StreamGroupSerializer(
-                stats_period=stats_period,
-            )
-        )
-
-        if request.GET.get('status') == 'unresolved':
-            results = [r for r in results if r['status'] == 'unresolved']
-
-        return results

--- a/src/sentry/api/bases/organizationissues.py
+++ b/src/sentry/api/bases/organizationissues.py
@@ -56,12 +56,12 @@ class OrganizationIssuesEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
         def on_results(results):
             results = serialize(
                 results, request.user, StreamGroupSerializer(
-                    stats_period=stats_period,
-                    get_environment_id=functools.partial(
+                    environment_id_func=functools.partial(
                         self._get_environment_id_from_request,
                         request,
                         organization.id,
                     ),
+                    stats_period=stats_period,
                 )
             )
 

--- a/src/sentry/api/bases/organizationissues.py
+++ b/src/sentry/api/bases/organizationissues.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import functools
 from rest_framework.response import Response
 
 from sentry.api.base import EnvironmentMixin
@@ -56,11 +55,7 @@ class OrganizationIssuesEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
         def on_results(results):
             results = serialize(
                 results, request.user, StreamGroupSerializer(
-                    environment_id_func=functools.partial(
-                        self._get_environment_id_from_request,
-                        request,
-                        organization.id,
-                    ),
+                    environment_id_func=self._get_environment_id_func(request, organization.id),
                     stats_period=stats_period,
                 )
             )

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -198,11 +198,8 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             environment_id = self._get_environment_id_from_request(
                 request, group.project.organization_id)
         except Environment.DoesNotExist:
-            # TODO(tkaemming): Find a less insane way to do this
-            # TODO(tkaemming): This method isn't actually exposed on the backend, lol
             get_range = lambda model, keys, start, end, **kwargs: \
-                {k: [(t, 0) for t in tsdb.backend.get_optimal_rollup_series(start, end)[1]]
-                 for k in keys}
+                {k: tsdb.make_series(0, start, end) for k in keys}
             tags = []
         else:
             get_range = functools.partial(tsdb.get_range, environment_id=environment_id)

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from datetime import timedelta
+import functools
 import logging
 from uuid import uuid4
 
@@ -306,7 +307,12 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                         StreamGroupSerializer(
                             stats_period=stats_period,
                             matching_event_id=getattr(
-                                matching_event, 'id', None)
+                                matching_event, 'id', None),
+                            get_environment_id=functools.partial(
+                                self._get_environment_id_from_request,
+                                request,
+                                project.organization_id,
+                            ),
                         )
                     )
                 )

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -340,7 +340,13 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         context = serialize(
             results, request.user, StreamGroupSerializer(
-                stats_period=stats_period))
+                stats_period=stats_period,
+                get_environment_id=functools.partial(
+                    self._get_environment_id_from_request,
+                    request,
+                    project.organization_id,
+                ),
+            ))
 
         # HACK: remove auto resolved entries
         if query_kwargs.get('status') == GroupStatus.UNRESOLVED:

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -302,12 +302,12 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
             serializer = functools.partial(
                 StreamGroupSerializer,
-                stats_period=stats_period,
-                get_environment_id=functools.partial(
+                environment_id_func=functools.partial(
                     self._get_environment_id_from_request,
                     request,
                     project.organization_id,
                 ),
+                stats_period=stats_period,
             )
 
             if matching_group is not None:

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -270,8 +270,17 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             # disable stats
             stats_period = None
 
-        query = request.GET.get('query', '').strip()
+        serializer = functools.partial(
+            StreamGroupSerializer,
+            environment_id_func=functools.partial(
+                self._get_environment_id_from_request,
+                request,
+                project.organization_id,
+            ),
+            stats_period=stats_period,
+        )
 
+        query = request.GET.get('query', '').strip()
         if query:
             matching_group = None
             matching_event = None
@@ -299,16 +308,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                     )
                 except Group.DoesNotExist:
                     matching_group = None
-
-            serializer = functools.partial(
-                StreamGroupSerializer,
-                environment_id_func=functools.partial(
-                    self._get_environment_id_from_request,
-                    request,
-                    project.organization_id,
-                ),
-                stats_period=stats_period,
-            )
 
             if matching_group is not None:
                 response = Response(

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -272,11 +272,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         serializer = functools.partial(
             StreamGroupSerializer,
-            environment_id_func=functools.partial(
-                self._get_environment_id_from_request,
-                request,
-                project.organization_id,
-            ),
+            environment_id_func=self._get_environment_id_func(request, project.organization_id),
             stats_period=stats_period,
         )
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -13,9 +13,9 @@ from sentry import tagstore, tsdb
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import LOG_LEVELS, StatsPeriod
 from sentry.models import (
-    Environment, Group, GroupAssignee, GroupBookmark, GroupMeta, GroupResolution,
-    GroupSeen, GroupSnooze, GroupShare, GroupStatus, GroupSubscription,
-    GroupSubscriptionReason, User, UserOption, UserOptionValue
+    Environment, Group, GroupAssignee, GroupBookmark, GroupMeta, GroupResolution, GroupSeen, GroupSnooze,
+    GroupShare, GroupStatus, GroupSubscription, GroupSubscriptionReason, User, UserOption,
+    UserOptionValue
 )
 from sentry.utils.db import attach_foreignkey
 from sentry.utils.http import absolute_uri

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -35,8 +35,8 @@ disabled = object()
 
 @register(Group)
 class GroupSerializer(Serializer):
-    def __init__(self, environment_id_func=lambda: None):
-        self.environment_id_func = environment_id_func
+    def __init__(self, environment_id_func=None):
+        self.environment_id_func = environment_id_func if environment_id_func is not None else lambda: None
 
     def _get_subscriptions(self, item_list, user):
         """
@@ -332,7 +332,7 @@ class StreamGroupSerializer(GroupSerializer):
         '24h': StatsPeriod(24, timedelta(hours=1)),
     }
 
-    def __init__(self, environment_id_func=lambda: None, stats_period=None, matching_event_id=None):
+    def __init__(self, environment_id_func=None, stats_period=None, matching_event_id=None):
         super(StreamGroupSerializer, self).__init__(environment_id_func)
 
         if stats_period is not None:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -362,6 +362,7 @@ class StreamGroupSerializer(GroupSerializer):
             except Environment.DoesNotExist:
                 stats = {
                     key: tsdb.make_series(
+                        0,
                         start=now - ((segments - 1) * interval),
                         end=now,
                         rollup=int(interval.total_seconds()),

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -89,14 +89,18 @@ class GroupDetailsTest(APITestCase):
 
         from sentry.api.endpoints.group_details import tsdb
 
-        with mock.patch('sentry.api.endpoints.group_details.tsdb.get_range', side_effect=tsdb.get_range) as get_range:
+        with mock.patch(
+                'sentry.api.endpoints.group_details.tsdb.get_range',
+                side_effect=tsdb.get_range) as get_range:
             response = self.client.get(url, {'environment': 'production'}, format='json')
             assert response.status_code == 200
             assert get_range.call_count == 2
             for args, kwargs in get_range.call_args_list:
                 assert kwargs['environment_id'] == environment.id
 
-        with mock.patch('sentry.api.endpoints.group_details.tsdb.make_series', side_effect=tsdb.make_series) as make_series:
+        with mock.patch(
+                'sentry.api.endpoints.group_details.tsdb.make_series',
+                side_effect=tsdb.make_series) as make_series:
             response = self.client.get(url, {'environment': 'invalid'}, format='json')
             assert response.status_code == 200
             assert make_series.call_count == 2

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import mock
 import six
 
 from datetime import timedelta
@@ -7,7 +8,7 @@ from django.utils import timezone
 
 from sentry import tagstore
 from sentry.models import (
-    Activity, Group, GroupHash, GroupAssignee, GroupBookmark, GroupResolution, GroupSeen,
+    Activity, Environment, Group, GroupHash, GroupAssignee, GroupBookmark, GroupResolution, GroupSeen,
     GroupSnooze, GroupSubscription, GroupStatus, GroupTombstone, Release
 )
 from sentry.testutils import APITestCase
@@ -77,6 +78,28 @@ class GroupDetailsTest(APITestCase):
         url = '/api/0/issues/{}/'.format(group3.id)
         response = self.client.get(url, format='json')
         assert response.status_code == 404
+
+    def test_environment(self):
+        group = self.create_group()
+        self.login_as(user=self.user)
+
+        environment = Environment.get_or_create(group.project, 'production')
+
+        url = '/api/0/issues/{}/'.format(group.id)
+
+        from sentry.api.endpoints.group_details import tsdb
+
+        with mock.patch('sentry.api.endpoints.group_details.tsdb.get_range', side_effect=tsdb.get_range) as get_range:
+            response = self.client.get(url, {'environment': 'production'}, format='json')
+            assert response.status_code == 200
+            assert get_range.call_count == 2
+            for args, kwargs in get_range.call_args_list:
+                assert kwargs['environment_id'] == environment.id
+
+        with mock.patch('sentry.api.endpoints.group_details.tsdb.make_series', side_effect=tsdb.make_series) as make_series:
+            response = self.client.get(url, {'environment': 'invalid'}, format='json')
+            assert response.status_code == 200
+            assert make_series.call_count == 2
 
 
 class GroupUpdateTest(APITestCase):

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import mock
 import six
 
 from datetime import timedelta
@@ -10,8 +11,9 @@ from django.utils import timezone
 from mock import patch
 
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.models import (
-    GroupResolution, GroupSnooze, GroupStatus,
+    Environment, GroupResolution, GroupSnooze, GroupStatus,
     GroupSubscription, UserOption, UserOptionValue
 )
 from sentry.testutils import TestCase
@@ -267,3 +269,37 @@ class GroupSerializerTest(TestCase):
 
         result = serialize(group)
         assert not result['isSubscribed']
+
+
+class StreamGroupSerializerTestCase(TestCase):
+    def test_environment(self):
+        group = self.group
+
+        environment = Environment.get_or_create(group.project, 'production')
+
+        from sentry.api.serializers.models.group import tsdb
+
+        with mock.patch('sentry.api.serializers.models.group.tsdb.get_range', side_effect=tsdb.get_range) as get_range:
+            serialize(
+                [group],
+                serializer=StreamGroupSerializer(
+                    environment_id_func=lambda: environment.id,
+                    stats_period='14d',
+                ),
+            )
+            assert get_range.call_count == 1
+            for args, kwargs in get_range.call_args_list:
+                assert kwargs['environment_id'] == environment.id
+
+        def get_invalid_environment():
+            raise Environment.DoesNotExist()
+
+        with mock.patch('sentry.api.serializers.models.group.tsdb.make_series', side_effect=tsdb.make_series) as make_series:
+            serialize(
+                [group],
+                serializer=StreamGroupSerializer(
+                    environment_id_func=get_invalid_environment,
+                    stats_period='14d',
+                )
+            )
+            assert make_series.call_count == 1

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -279,7 +279,9 @@ class StreamGroupSerializerTestCase(TestCase):
 
         from sentry.api.serializers.models.group import tsdb
 
-        with mock.patch('sentry.api.serializers.models.group.tsdb.get_range', side_effect=tsdb.get_range) as get_range:
+        with mock.patch(
+                'sentry.api.serializers.models.group.tsdb.get_range',
+                side_effect=tsdb.get_range) as get_range:
             serialize(
                 [group],
                 serializer=StreamGroupSerializer(
@@ -294,7 +296,9 @@ class StreamGroupSerializerTestCase(TestCase):
         def get_invalid_environment():
             raise Environment.DoesNotExist()
 
-        with mock.patch('sentry.api.serializers.models.group.tsdb.make_series', side_effect=tsdb.make_series) as make_series:
+        with mock.patch(
+                'sentry.api.serializers.models.group.tsdb.make_series',
+                side_effect=tsdb.make_series) as make_series:
             serialize(
                 [group],
                 serializer=StreamGroupSerializer(


### PR DESCRIPTION
This adds environment filtering to additional TSDB queries in endpoints and serializers that are not strictly responsible for serving metrics data.

See also: GH-6623