### PR TITLE
fix(schemas): Allow anything but \r or \n in logger names 

### DIFF
--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -293,7 +293,7 @@ EVENT_SCHEMA = {
         },
         'logger': {
             'type': 'string',
-            'pattern': r'^[a-zA-Z0-9$_\.:-]+$',
+            'pattern': r'^[^\r\n]+\Z',  # \Z because $ matches before a trailing newline
             'default': '',
         },
         'platform': {

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -623,7 +623,7 @@ class EventManagerTest(TransactionTestCase):
         ).exists()
 
     def test_bad_logger(self):
-        manager = EventManager(self.make_event(logger='foo bar'))
+        manager = EventManager(self.make_event(logger="foo\nbar"))
         data = manager.normalize()
         assert data['logger'] == DEFAULT_LOGGER_NAME
 


### PR DESCRIPTION
This is a fix for a specific user support ticket. Their logger has a name like `foo.bar.[/api].[web]`.

As @alex-hofsteede pointed out the regex was used before the schema system and so nothing has really changed except that we now show the user an error and so more people are noticing/asking.

I'm putting up a PR because it's easy, but open to discussion here.

There are some options I see:

1. Tell the customer we only want to support more basic logger names, and they need to change them on their end.
2. Continue adding characters like this as users complain.
3. Open up the regex more, like say `[^\r\n]` or something.

As for 1, I'm not sure why we'd care and want to restrict users. But maybe this is an environment name fiasco waiting to happen? Probably @dcramer or someone knows better why the regex was/is the way it was/is.