### PR TITLE
Don't show model or family if they aren't set

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -87,7 +87,7 @@ const DeviceContextType = React.createClass({
           ['?Name', name],
           ['?Family', family],
           ['?Model', model + (model_id ? ` (${model_id})` : '')],
-          ['Architecture', arch],
+          ['?Architecture', arch],
           ['?Battery Level', defined(battery_level) ? `${battery_level}%` : null],
           ['?Orientation', orientation],
           ['?Memory', memory],

--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -85,8 +85,8 @@ const DeviceContextType = React.createClass({
         data={data}
         knownData={[
           ['?Name', name],
-          ['Family', family],
-          ['Model', model + (model_id ? ` (${model_id})` : '')],
+          ['?Family', family],
+          ['?Model', model + (model_id ? ` (${model_id})` : '')],
           ['Architecture', arch],
           ['?Battery Level', defined(battery_level) ? `${battery_level}%` : null],
           ['?Orientation', orientation],

--- a/src/sentry/static/sentry/app/components/events/contexts/os.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/os.jsx
@@ -17,8 +17,8 @@ const OsContextType = React.createClass({
         data={data}
         knownData={[
           ['?Name', name],
-          ['Version', version + (build ? ` (${build})` : '')],
-          ['Kernel Version', kernel_version],
+          ['?Version', version + (build ? ` (${build})` : '')],
+          ['?Kernel Version', kernel_version],
           ['?Rooted', defined(rooted) ? (rooted ? 'yes' : 'no') : null],
         ]}
         alias={this.props.alias}


### PR DESCRIPTION
I like that we can see device information automatically when using `sentry-cli` but it seems like they should be hidden here:

![untitled](https://user-images.githubusercontent.com/9503662/33900802-b9b6ff02-df3d-11e7-921e-d6e49f309028.png)

https://github.com/getsentry/sentry-cli/issues/187