### PR TITLE
feat(ingest): Measure event reporting latency

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -852,7 +852,13 @@ class EventManager(object):
         if is_regression and not raw:
             regression_signal.send_robust(sender=Group, instance=group)
 
-        metrics.timing('event.latency', received_timestamp - recorded_timestamp)
+        metrics.timing(
+            'events.latency',
+            received_timestamp - recorded_timestamp,
+            tags={
+                'project_id': project.id,
+            },
+        )
 
         return event
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -504,7 +504,8 @@ class EventManager(object):
         else:
             transaction_name = culprit
 
-        date = datetime.fromtimestamp(data.pop('timestamp'))
+        recorded_timestamp = data.pop('timestamp')
+        date = datetime.fromtimestamp(recorded_timestamp)
         date = date.replace(tzinfo=timezone.utc)
 
         kwargs = {
@@ -636,6 +637,7 @@ class EventManager(object):
         event.message = message
         kwargs['message'] = message
 
+        received_timestamp = event.data.get('received') or float(event.datetime.strftime('%s'))
         group_kwargs = kwargs.copy()
         group_kwargs.update(
             {
@@ -646,8 +648,7 @@ class EventManager(object):
                 'first_seen': date,
                 'active_at': date,
                 'data': {
-                    'last_received':
-                    event.data.get('received') or float(event.datetime.strftime('%s')),
+                    'last_received': received_timestamp,
                     'type':
                     event_type.key,
                     # we cache the events metadata on the group to ensure its
@@ -850,6 +851,8 @@ class EventManager(object):
         # TODO: move this to the queue
         if is_regression and not raw:
             regression_signal.send_robust(sender=Group, instance=group)
+
+        metrics.timing('event.latency', received_timestamp - recorded_timestamp)
 
         return event
 


### PR DESCRIPTION
This measures the difference between self-reported event timestamps and the timestamp when the server received the message.