### PR TITLE
fix: More randomness in create_environment names, always create

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -274,11 +274,14 @@ class Fixtures(object):
 
     def create_environment(self, **kwargs):
         project = kwargs.get('project', self.project)
-        name = kwargs.get('name', petname.Generate(1, ' ', letters=10))
-        return Environment.get_or_create(
-            project=project,
-            name=name
+        name = kwargs.get('name', petname.Generate(3, ' ', letters=10)[:64])
+        env = Environment.objects.create(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            name=name,
         )
+        env.add_project(project)
+        return env
 
     def create_project(self, **kwargs):
         if not kwargs.get('name'):


### PR DESCRIPTION
Petname count was low and I think the duplicate was being hidden by `get_or_create`.