### PR TITLE
ref(api): Moved project_platform serializer to API serializers

### DIFF
--- a/src/sentry/api/endpoints/project_platforms.py
+++ b/src/sentry/api/endpoints/project_platforms.py
@@ -2,14 +2,8 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.serializers import serialize, register, Serializer
 from sentry.models import ProjectPlatform
-
-
-@register(ProjectPlatform)
-class ProjectPlatformSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
-        return {'platform': obj.platform, 'dateCreated': obj.date_added}
+from sentry.api.serializers import serialize
 
 
 class ProjectPlatformsEndpoint(ProjectEndpoint):

--- a/src/sentry/api/serializers/models/project_platform.py
+++ b/src/sentry/api/serializers/models/project_platform.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+from sentry.api.serializers import register, Serializer
+from sentry.models import ProjectPlatform
+
+
+@register(ProjectPlatform)
+class ProjectPlatformSerializer(Serializer):
+    """
+    Tracks usage of a platform for a given project.
+
+    Note: This model is used solely for analytics.
+    """
+
+    def serialize(self, obj, attrs, user):
+        return {'platform': obj.platform, 'dateCreated': obj.date_added}

--- a/src/sentry/models/projectplatform.py
+++ b/src/sentry/models/projectplatform.py
@@ -9,6 +9,8 @@ from sentry.db.models import (Model, BoundedBigIntegerField, sane_repr)
 class ProjectPlatform(Model):
     """
     Tracks usage of a platform for a given project.
+
+    Note: This model is used solely for analytics.
     """
     __core__ = False
 


### PR DESCRIPTION
Moved project_platform serializer to sentry/api/serializer/models. Added additional comments specifying that the project_platform entity is used for analytics.