### PR TITLE
fix(tests): Unbreak travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 filter_secrets: false
-sudo: false
+group: deprecated-2017Q4
 dist: trusty
+sudo: required
 language: python
 rvm:
   - 2.2


### PR DESCRIPTION
Switch to `sudo: required` and specified the deprecated image in `group` to unbreak the changes to `pg_config` that break the build.

References:
https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch
https://docs.travis-ci.com/user/reference/trusty/#Fully-virtualized-via-sudo%3A-required