### PR TITLE
feat(Org Settings): Contrast, Chrome, and Crumb improvements

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -141,7 +141,7 @@ const HomeSidebar = React.createClass({
             {t('Projects & Teams')}
           </ListLink>
           {access.has('org:read') && (
-            <ListLink to={`/organizations/${orgId}/stats/`}>{t('Stats')}</ListLink>
+            <ListLink to={`${pathPrefix}/stats/`}>{t('Stats')}</ListLink>
           )}
         </ul>
         <div>

--- a/src/sentry/static/sentry/app/icons/sentryIcon.jsx
+++ b/src/sentry/static/sentry/app/icons/sentryIcon.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import classNames from 'classnames';
+
+class SentryIcon extends React.Component {
+  render() {
+    let {className, ...props} = this.props;
+
+    return <span {...props} className={classNames('icon-sentry-logo', className)} />;
+  }
+}
+
+export default SentryIcon;

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -213,7 +213,12 @@ const orgSettingsRoutes = [
     component={errorHandler(OrganizationTeams)}
   />,
 
-  <Route key="org-stats" path="stats/" component={errorHandler(OrganizationStats)} />,
+  <Route
+    key="org-stats"
+    name="Stats"
+    path="stats/"
+    component={errorHandler(OrganizationStats)}
+  />,
 ];
 
 const projectSettingsRoutes = [

--- a/src/sentry/static/sentry/app/utils/theme.js
+++ b/src/sentry/static/sentry/app/utils/theme.js
@@ -1,11 +1,11 @@
 const theme = {
-  offWhite: '#FBFBFC',
+  offWhite: '#F8F7F9',
 
-  gray1: '#C1B8CA',
-  gray2: '#9788A5',
-  gray3: '#655674',
-  gray4: '',
-  gray5: '#2F2837',
+  gray1: '#BDB4C7',
+  gray2: '#9585A3',
+  gray3: '#645574',
+  gray4: '#4A3E56',
+  gray5: '#302839',
 
   blue: '#4674ca',
   blueLight: '#608EE4',
@@ -41,8 +41,8 @@ const theme = {
   purpleDark: '#5346AE',
   purpleDarkest: '#392C94',
 
-  borderLight: '#E7E1EC',
-  borderDark: '#D5CFDB',
+  borderLight: '#E2DBE8',
+  borderDark: '#D1CAD8',
   borderRadius: '4px',
 
   dropShadowLight: '0 2px 0 rgba(37, 11, 54, 0.04)',

--- a/src/sentry/static/sentry/app/utils/theme.js
+++ b/src/sentry/static/sentry/app/utils/theme.js
@@ -69,7 +69,7 @@ const theme = {
     },
   },
 
-  type: {
+  text: {
     family: '"Rubik", "Avenir Next", sans-serif',
     familyMono: 'Monaco, monospace',
     lineHeightHeading: '1.15',

--- a/src/sentry/static/sentry/app/utils/theme.js
+++ b/src/sentry/static/sentry/app/utils/theme.js
@@ -1,5 +1,5 @@
 const theme = {
-  offWhite: '#F8F7F9',
+  offWhite: '#FAF9FB',
 
   gray1: '#BDB4C7',
   gray2: '#9585A3',

--- a/src/sentry/static/sentry/app/utils/theme.js
+++ b/src/sentry/static/sentry/app/utils/theme.js
@@ -43,11 +43,7 @@ const theme = {
 
   borderLight: '#E7E1EC',
   borderDark: '#D5CFDB',
-
-  fontFamily: '"Rubik", "Avenir Next", sans-serif',
-  fontFamilyMono: 'Monaco, monospace',
-
-  radius: '4px',
+  borderRadius: '4px',
 
   dropShadowLight: '0 2px 0 rgba(37, 11, 54, 0.04)',
   dropShadowHeavy: '0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)',
@@ -70,6 +66,18 @@ const theme = {
       border: '#E7C0BC',
       textLight: '#92635f',
       textDark: '#5d3e3b',
+    },
+  },
+
+  type: {
+    family: '"Rubik", "Avenir Next", sans-serif',
+    familyMono: 'Monaco, monospace',
+    lineHeightHeading: '1.15',
+    lineHeightBody: '1.4',
+    size: {
+      default: '12px',
+      small: '14px',
+      large: '18px',
     },
   },
 };

--- a/src/sentry/static/sentry/app/views/settings/components/forms/styled/styles.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/styled/styles.jsx
@@ -8,6 +8,7 @@ const inputStyles = props => css`
   border-radius: 2px;
   padding: 10px;
   transition: border 0.2s ease;
+  resize: vertical;
 
   &:focus {
     outline: none;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/textareaField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/textareaField.jsx
@@ -7,7 +7,7 @@ export default class TextareaField extends InputField {
     return (
       <InputField
         {...this.props}
-        field={({children, ...fieldProps}) => <Textarea {...fieldProps} />}
+        field={({children, onKeyDown, ...fieldProps}) => <Textarea {...fieldProps} />}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/components/panel.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/panel.jsx
@@ -2,7 +2,7 @@ import styled from 'react-emotion';
 
 const Panel = styled.div`
   background: #fff;
-  border-radius: ${p => p.theme.radius};
+  border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.borderDark};
   box-shadow: ${p => p.theme.dropShadowLight};
   margin-bottom: 30px;

--- a/src/sentry/static/sentry/app/views/settings/components/panelHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/panelHeader.jsx
@@ -6,7 +6,7 @@ import PanelHeading from './panelHeading';
 
 const StyledPanelHeader = styled.div`
   border-bottom: 1px solid ${p => p.theme.borderDark};
-  border-radius: ${p => p.theme.radius} ${p => p.theme.radius} 0 0;
+  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   background: ${p => p.theme.offWhite}
   padding: ${p => (p.disablePadding ? '15px 0' : '15px 20px')};
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/views/settings/components/panelItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/panelItem.jsx
@@ -1,0 +1,9 @@
+import styled from 'react-emotion';
+import {Flex} from 'grid-emotion';
+
+export default styled(Flex)`
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+  &:last-child {
+    border: 0;
+  }
+`;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBackButton.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBackButton.jsx
@@ -1,0 +1,50 @@
+import {Link} from 'react-router';
+import React from 'react';
+import styled from 'react-emotion';
+
+import SentryIcon from '../../../icons/sentryIcon';
+import SentryTypes from '../../../proptypes';
+import replaceRouterParams from '../../../utils/replaceRouterParams';
+import withLatestContext from '../../../utils/withLatestContext';
+
+const BackButtonWrapper = styled(Link)`
+  color: ${p => p.theme.gray3};
+  &:hover {
+    color: ${p => p.theme.gray5};
+  }
+`;
+
+const SentryCrumb = styled(SentryIcon)`
+  font-size: 20px;
+  margin-right: 4px;
+`;
+
+class BackButton extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization,
+    project: SentryTypes.Project,
+  };
+
+  render() {
+    let {params, organization, project} = this.props;
+
+    let projectId = params.projectId || (project && project.slug);
+    let orgId = params.orgId || (organization && organization.slug);
+    let url = projectId ? '/:orgId/:projectId/' : '/:orgId/';
+
+    return (
+      <BackButtonWrapper
+        to={replaceRouterParams(url, {
+          orgId,
+          projectId,
+        })}
+      >
+        <SentryCrumb />
+      </BackButtonWrapper>
+    );
+  }
+}
+
+const SettingsBackButton = withLatestContext(BackButton);
+
+export default SettingsBackButton;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
@@ -6,6 +6,7 @@ import Crumb from './crumb.styled';
 import Link from '../../../components/link';
 import LoadingIndicator from '../../../components/loadingIndicator';
 import SentryTypes from '../../../proptypes';
+import SettingsBackButton from './settingsBackButton';
 import SettingsBreadcrumbDivider from './settingsBreadcrumbDivider';
 import SettingsBreadcrumbDropdown from './settingsBreadcrumbDropdown';
 import recreateRoute from '../../../utils/recreateRoute';
@@ -183,9 +184,10 @@ class SettingsBreadcrumb extends React.Component {
     return (
       <Breadcrumbs>
         <Crumb>
-          <span className="icon-sentry-logo" style={{fontSize: 20, marginRight: 4}} />
+          <SettingsBackButton params={params} />
           <SettingsBreadcrumbDivider />
         </Crumb>
+
         {routesWithNames.map((route, i) => {
           let isLast = i === lastRouteIndex;
           let createMenu = MENUS[route.name];

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
@@ -182,6 +182,10 @@ class SettingsBreadcrumb extends React.Component {
     let lastRouteIndex = routesWithNames.length - 1;
     return (
       <Breadcrumbs>
+        <Crumb>
+          <span className="icon-sentry-logo" style={{fontSize: 20, marginRight: 4}} />
+          <SettingsBreadcrumbDivider />
+        </Crumb>
         {routesWithNames.map((route, i) => {
           let isLast = i === lastRouteIndex;
           let createMenu = MENUS[route.name];

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumbDivider.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumbDivider.jsx
@@ -7,7 +7,7 @@ import IconChevronRight from '../../../icons/icon-chevron-right';
 const StyledDivider = styled.span`
   display: inline-block;
   margin-left: 6px;
-  color: ${p => p.theme.gray1};
+  color: ${p => p.theme.borderDark};
   position: relative;
   top: -1px;
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumbDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumbDropdown.jsx
@@ -17,7 +17,7 @@ const Menu = styled.div`
   border: 1px solid ${p => p.theme.borderDark};
   box-shadow: ${p => p.theme.dropShadowHeavy};
   transition: 0.1s all ease;
-  border-radius: ${p => p.theme.radius};
+  border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
 
   ${p =>

--- a/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
@@ -27,7 +27,7 @@ class SettingsPageHeading extends React.Component {
 
 const Wrapper = styled.div`
   display: flex;
-  align-items: center;
+  align-items: top;
   font-size: 14px;
   box-shadow: inset 0 -1px 0 ${p => p.theme.borderLight};
   margin-bottom: 30px;
@@ -48,7 +48,7 @@ const Label = styled.div`
 
 // Label text only
 const LabelText = styled.span`
-  padding: 14px 0;
+  padding: 0 0 15px;
 `;
 
 export default SettingsPageHeading;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsSearch.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsSearch.jsx
@@ -28,7 +28,7 @@ const SearchInputIcon = styled(IconSearch)`
 const SearchInput = styled.input`
   transition: border-color 0.15s ease;
   font-size: 14px;
-  width: 220px;
+  width: 260px;
   line-height: 1;
   padding: 5px 8px 4px 28px;
   border: 1px solid ${p => p.theme.borderDark};

--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationAccessRequests.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationAccessRequests.jsx
@@ -1,20 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Flex, Box} from 'grid-emotion';
-import {withTheme} from 'emotion-theming';
-import styled from 'react-emotion';
 
 import {t, tct} from '../../../../locale';
 import Button from '../../../../components/buttons/button';
 import Panel from '../../components/panel';
 import PanelBody from '../../components/panelBody';
-import SpreadLayout from '../../../../components/spreadLayout';
 import PanelHeader from '../../components/panelHeader';
+import PanelItem from '../../components/panelItem';
 import SentryTypes from '../../../../proptypes';
-
-const PendingRow = withTheme(styled(SpreadLayout)`
-  border-bottom: 1px solid ${p => p.theme.borderLight};
-`);
 
 class OrganizationAccessRequests extends React.Component {
   static propTypes = {
@@ -65,7 +59,7 @@ class OrganizationAccessRequests extends React.Component {
               member.user &&
               (member.user.name || member.user.email || member.user.username);
             return (
-              <PendingRow key={id}>
+              <PanelItem key={id} align="center">
                 <Box p={2} flex="1">
                   {tct('[name] requests access to the [team] team.', {
                     name: <strong>{displayName}</strong>,
@@ -90,7 +84,7 @@ class OrganizationAccessRequests extends React.Component {
                     {t('Deny')}
                   </Button>
                 </Box>
-              </PendingRow>
+              </PanelItem>
             );
           })}
         </PanelBody>

--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationMemberRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationMemberRow.jsx
@@ -12,7 +12,9 @@ import LoadingIndicator from '../../../../components/loadingIndicator';
 import SentryTypes from '../../../../proptypes';
 import recreateRoute from '../../../../utils/recreateRoute';
 
-const UserName = styled(Link)`font-size: 16px;`;
+const UserName = styled(Link)`
+  font-size: 16px;
+`;
 
 const Email = styled.div`
   color: ${p => p.theme.gray3};
@@ -26,8 +28,6 @@ const Row = styled(Flex)`
     border: 0;
   }
 `;
-
-const TextCenter = styled.div`text-align: center;`;
 
 export default class OrganizationMemberRow extends React.PureComponent {
   static propTypes = {
@@ -107,7 +107,7 @@ export default class OrganizationMemberRow extends React.PureComponent {
     let isInviting = status === 'loading';
 
     return (
-      <Row align="center" py={1}>
+      <Row align="center" py={2}>
         <Box pl={2}>
           <Avatar style={{width: 32, height: 32}} user={user ? user : {email}} />
         </Box>
@@ -168,12 +168,12 @@ export default class OrganizationMemberRow extends React.PureComponent {
           )}
         </Box>
 
-        <Box px={2} w={100}>
+        <Box px={2} w={140}>
           {roleName}
         </Box>
 
         {showRemoveButton || showLeaveButton ? (
-          <Box px={2} w={120}>
+          <Box px={2} w={140}>
             {showRemoveButton &&
               canRemoveMember && (
                 <Confirm

--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
@@ -250,10 +250,10 @@ class OrganizationMembersView extends OrganizationSettingsView {
               <Box px={2} w={180}>
                 {t('Status')}
               </Box>
-              <Box px={2} w={100}>
+              <Box px={2} w={140}>
                 {t('Role')}
               </Box>
-              <Box px={2} w={120}>
+              <Box px={2} w={140}>
                 {t('Actions')}
               </Box>
             </Flex>

--- a/src/sentry/static/sentry/app/views/settings/organization/stats/organizationStats.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/stats/organizationStats.jsx
@@ -5,6 +5,9 @@ import LoadingError from '../../../../components/loadingError';
 import LoadingIndicator from '../../../../components/loadingIndicator';
 import StackedBarChart from '../../../../components/stackedBarChart';
 import Pagination from '../../../../components/pagination';
+import Panel from '../../components/panel';
+import PanelBody from '../../components/panelBody';
+import PanelHeader from '../../components/panelHeader';
 import SettingsPageHeader from '../../components/settingsPageHeader';
 
 import ProjectTable from './projectTable';
@@ -82,30 +85,28 @@ class OrganizationStats extends React.Component {
             </div>
           )}
         </div>
-        <div className="organization-stats">
+        <div>
           {statsLoading ? (
             <LoadingIndicator />
           ) : statsError ? (
             <LoadingError onRetry={this.fetchData} />
           ) : (
-            <div className="bar-chart">
+            <Panel className="bar-chart">
               <StackedBarChart
                 points={orgStats}
                 height={150}
                 label="events"
-                className="standard-barchart"
+                className="standard-barchart b-a-0 m-b-0"
                 barClasses={['accepted', 'rate-limited', 'black-listed']}
                 tooltip={this.renderTooltip}
               />
-            </div>
+            </Panel>
           )}
         </div>
 
-        <div className="box">
-          <div className="box-header">
-            <h3>{t('Events by Project')}</h3>
-          </div>
-          <div className="box-content">
+        <Panel>
+          <PanelHeader>{t('Events by Project')}</PanelHeader>
+          <PanelBody>
             {statsLoading || projectsLoading ? (
               <LoadingIndicator />
             ) : projectsError ? (
@@ -118,8 +119,8 @@ class OrganizationStats extends React.Component {
                 projectMap={projectMap}
               />
             )}
-          </div>
-        </div>
+          </PanelBody>
+        </Panel>
         {pageLinks && <Pagination pageLinks={pageLinks} {...this.props} />}
       </div>
     );

--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import IconChevronLeft from '../../icons/icon-chevron-left';
+import IconCircleExclamation from '../../icons/icon-circle-exclamation';
 import SettingsActivity from './components/settingsActivity';
 import SettingsBreadcrumb from './components/settingsBreadcrumb';
 import SettingsHeader from './components/settingsHeader';
@@ -13,8 +14,20 @@ import replaceRouterParams from '../../utils/replaceRouterParams';
 import withLatestContext from '../../utils/withLatestContext';
 import SentryTypes from '../../proptypes';
 
+const StyledIconCircleExclamation = styled(IconCircleExclamation)`
+  color: ${p => p.theme.blue};
+  opacity: 0.6;
+`;
+
 let StyledWarning = styled.div`
   margin-bottom: 30px;
+  background: ${p => p.theme.alert.info.background};
+  border: 1px solid ${p => p.theme.alert.info.border};
+  padding: 15px 20px;
+  border-radius: ${p => p.theme.borderRadius};
+  line-height: ${p => p.theme.type.lineHeightBody};
+  font-size: ${p => p.theme.type.size.small};
+  box-shadow: ${p => p.theme.dropShadowLight};
 `;
 // TODO(billy): Temp
 let NewSettingsWarning = ({location = {}}) => {
@@ -33,9 +46,17 @@ let NewSettingsWarning = ({location = {}}) => {
   };
   let Component = isRouter ? Link : 'a';
   return (
-    <StyledWarning className="alert alert-warning">
-      These settings are currently in beta. Please report any issues. You can temporarily
-      visit the <Component {...linkProps}>old settings page</Component> if necessary.
+    <StyledWarning>
+      <Flex align="center">
+        <Box w={32} mr={2}>
+          <StyledIconCircleExclamation size="32" />
+        </Box>
+        <Box>
+          These settings are currently in beta. Please report any issues. You can
+          temporarily visit the <Component {...linkProps}>old settings page</Component> if
+          necessary.
+        </Box>
+      </Flex>
     </StyledWarning>
   );
 };
@@ -121,9 +142,8 @@ class SettingsLayout extends React.Component {
             </Box>
           )}
           <Content>
-            <NewSettingsWarning location={this.props.location} />
-
             {children}
+            <NewSettingsWarning location={this.props.location} />
           </Content>
         </Flex>
         <SettingsActivity />

--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -21,8 +21,8 @@ let StyledWarning = styled.div`
   border: 1px solid ${p => p.theme.alert.info.border};
   padding: 15px 20px;
   border-radius: ${p => p.theme.borderRadius};
-  line-height: ${p => p.theme.type.lineHeightBody};
-  font-size: ${p => p.theme.type.size.small};
+  line-height: ${p => p.theme.text.lineHeightBody};
+  font-size: ${p => p.theme.text.size.small};
   box-shadow: ${p => p.theme.dropShadowLight};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -4,15 +4,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import IconChevronLeft from '../../icons/icon-chevron-left';
 import IconCircleExclamation from '../../icons/icon-circle-exclamation';
 import SettingsActivity from './components/settingsActivity';
 import SettingsBreadcrumb from './components/settingsBreadcrumb';
 import SettingsHeader from './components/settingsHeader';
 import SettingsSearch from './components/settingsSearch';
-import replaceRouterParams from '../../utils/replaceRouterParams';
-import withLatestContext from '../../utils/withLatestContext';
-import SentryTypes from '../../proptypes';
 
 const StyledIconCircleExclamation = styled(IconCircleExclamation)`
   color: ${p => p.theme.blue};
@@ -29,6 +25,7 @@ let StyledWarning = styled.div`
   font-size: ${p => p.theme.type.size.small};
   box-shadow: ${p => p.theme.dropShadowLight};
 `;
+
 // TODO(billy): Temp
 let NewSettingsWarning = ({location = {}}) => {
   // TODO(billy): Remove this warning when ready
@@ -61,54 +58,6 @@ let NewSettingsWarning = ({location = {}}) => {
   );
 };
 
-const BackButtonWrapper = styled(Link)`
-  position: fixed;
-  display: block;
-  left: 20px;
-  font-size: 18px;
-  color: ${p => p.theme.gray3};
-  &:hover {
-    color: ${p => p.theme.gray5};
-  }
-`;
-
-const BackIcon = styled.span`
-  color: ${p => p.theme.gray1};
-  position: relative;
-  top: -2px;
-  margin-right: 8px;
-`;
-
-class BackButtonComponent extends React.Component {
-  static propTypes = {
-    organization: SentryTypes.Organization,
-    project: SentryTypes.Project,
-  };
-
-  render() {
-    let {params, organization, project} = this.props;
-
-    let projectId = params.projectId || (project && project.slug);
-    let orgId = params.orgId || (organization && organization.slug);
-    let url = projectId ? '/:orgId/:projectId/' : '/:orgId/';
-
-    return (
-      <BackButtonWrapper
-        to={replaceRouterParams(url, {
-          orgId,
-          projectId,
-        })}
-      >
-        <BackIcon>
-          <IconChevronLeft size="15" />
-        </BackIcon>Back
-      </BackButtonWrapper>
-    );
-  }
-}
-
-const BackButton = withLatestContext(BackButtonComponent);
-
 const Content = styled(Box)`
   flex: 1;
 `;
@@ -129,7 +78,6 @@ class SettingsLayout extends React.Component {
     return (
       <div>
         <SettingsHeader>
-          {/* <BackButton params={params} /> */}
           <Box flex="1">
             <SettingsBreadcrumb params={params} routes={childRoutes} route={childRoute} />
           </Box>

--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -129,7 +129,7 @@ class SettingsLayout extends React.Component {
     return (
       <div>
         <SettingsHeader>
-          <BackButton params={params} />
+          {/* <BackButton params={params} /> */}
           <Box flex="1">
             <SettingsBreadcrumb params={params} routes={childRoutes} route={childRoute} />
           </Box>

--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -20,7 +20,7 @@ const StyledIconCircleExclamation = styled(IconCircleExclamation)`
 `;
 
 let StyledWarning = styled.div`
-  margin-bottom: 30px;
+  margin: 30px 0;
   background: ${p => p.theme.alert.info.background};
   border: 1px solid ${p => p.theme.alert.info.border};
   padding: 15px 20px;

--- a/src/sentry/static/sentry/app/views/settings/team/allTeamsList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/allTeamsList.jsx
@@ -4,6 +4,7 @@ import {Link} from 'react-router';
 
 import SentryTypes from '../../../proptypes';
 
+import Panel from '../components/panel';
 import AllTeamsRow from './allTeamsRow';
 import {tct} from '../../../locale';
 
@@ -32,13 +33,7 @@ const AllTeamsList = React.createClass({
     });
 
     if (teamNodes.length !== 0) {
-      return (
-        <div className="panel panel-default">
-          <table className="table">
-            <tbody>{teamNodes}</tbody>
-          </table>
-        </div>
-      );
+      return <Panel>{teamNodes}</Panel>;
     }
 
     return tct(

--- a/src/sentry/static/sentry/app/views/settings/team/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/allTeamsRow.jsx
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
+import {Box} from 'grid-emotion';
 
 import ApiMixin from '../../../mixins/apiMixin';
 import AlertActions from '../../../actions/alertActions';
+import PanelItem from '../components/panelItem';
 import {t} from '../../../locale';
 
 // TODO(dcramer): this isnt great UX
@@ -91,11 +93,11 @@ const AllTeamsRow = React.createClass({
   render() {
     let {access, team, urlPrefix, openMembership} = this.props;
     return (
-      <tr>
-        <td>
-          <h5>{team.name}</h5>
-        </td>
-        <td className="actions align-right">
+      <PanelItem align="center">
+        <Box w={1 / 2} p={2}>
+          {team.name}
+        </Box>
+        <Box w={1 / 2} p={2} style={{textAlign: 'right'}}>
           {this.state.loading ? (
             <a className="btn btn-default btn-sm btn-loading btn-disabled">...</a>
           ) : team.isMember ? (
@@ -122,8 +124,8 @@ const AllTeamsRow = React.createClass({
               {t('Team Settings')}
             </Link>
           )}
-        </td>
-      </tr>
+        </Box>
+      </PanelItem>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/settings/team/expandedTeamList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/expandedTeamList.jsx
@@ -2,15 +2,30 @@ import {Link} from 'react-router';
 import LazyLoad from 'react-lazy-load';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import {sortArray} from '../../../utils';
 import {t, tct} from '../../../locale';
 import ApiMixin from '../../../mixins/apiMixin';
 import {update} from '../../../actionCreators/projects';
+
 import TooltipMixin from '../../../mixins/tooltip';
 import BarChart from '../../../components/barChart';
+import Panel from '../components/panel';
+import PanelHeader from '../components/panelHeader';
 import ProjectLabel from '../../../components/projectLabel';
 import SentryTypes from '../../../proptypes';
+
+const TeamHeaderLink = styled(Link)`
+  color: ${p => p.theme.gray3};
+  margin-left: 20px;
+  text-transform: none;
+  font-weight: normal;
+
+  &:hover {
+    color: ${p => p.theme.gray4};
+  }
+`;
 
 const ExpandedTeamList = React.createClass({
   propTypes: {
@@ -87,23 +102,20 @@ const ExpandedTeamList = React.createClass({
     // TODO: make this cleaner
     let access = this.props.access;
     return (
-      <div className="box" key={team.slug}>
-        <div className="box-header">
+      <Panel>
+        <PanelHeader>
           <div className="pull-right actions hidden-xs">
-            <a className="leave-team" onClick={this.leaveTeam.bind(this, team)}>
+            <TeamHeaderLink onClick={this.leaveTeam.bind(this, team)}>
               {t('Leave Team')}
-            </a>
+            </TeamHeaderLink>
             {access.has('team:write') && (
-              <Link
-                className="team-settings"
-                to={`${this.urlPrefix()}teams/${team.slug}/settings/`}
-              >
+              <TeamHeaderLink to={`${this.urlPrefix()}teams/${team.slug}/settings/`}>
                 {t('Team Settings')}
-              </Link>
+              </TeamHeaderLink>
             )}
           </div>
-          <h3>{team.name}</h3>
-        </div>
+          {team.name}
+        </PanelHeader>
         <div className="box-content">
           <table className="table table-no-top-border m-b-0">
             {team.projects.length
@@ -111,7 +123,7 @@ const ExpandedTeamList = React.createClass({
               : this.renderNoProjects(team)}
           </table>
         </div>
-      </div>
+      </Panel>
     );
   },
 

--- a/tests/js/spec/views/__snapshots__/organizationAccessRequests.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationAccessRequests.spec.jsx.snap
@@ -17,7 +17,9 @@ exports[`OrganizationAccessRequests renders list 1`] = `
     </Flex>
   </PanelHeader>
   <Styled(div)>
-    <WithTheme(Styled(SpreadLayout))>
+    <Styled(Base)
+      align="center"
+    >
       <Box
         flex="1"
         p={2}
@@ -61,7 +63,7 @@ exports[`OrganizationAccessRequests renders list 1`] = `
           Deny
         </Button>
       </Box>
-    </WithTheme(Styled(SpreadLayout))>
+    </Styled(Base)>
   </Styled(div)>
 </Styled(div)>
 `;

--- a/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -6,10 +6,10 @@ exports[`OrganizationApiKeysList renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: top;
+  -webkit-box-align: top;
+  -ms-flex-align: top;
+  align-items: top;
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin-bottom: 30px;
@@ -39,7 +39,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
 }
 
 .glamor-0 {
-  padding: 14px 0;
+  padding: 0 0 15px;
 }
 
 .glamor-6 {

--- a/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
@@ -6,10 +6,10 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: top;
+  -webkit-box-align: top;
+  -ms-flex-align: top;
+  align-items: top;
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin-bottom: 30px;
@@ -39,7 +39,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
 }
 
 .glamor-0 {
-  padding: 14px 0;
+  padding: 0 0 15px;
 }
 
 .glamor-84 {
@@ -97,22 +97,15 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
 
 .glamor-12 {
   box-sizing: border-box;
-  width: 100px;
-  padding-left: 16px;
-  padding-right: 16px;
-}
-
-.glamor-14 {
-  box-sizing: border-box;
-  width: 120px;
+  width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
 .glamor-38 {
   box-sizing: border-box;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -347,12 +340,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                           </Box>
                           <Box
                             px={2}
-                            w={100}
+                            w={140}
                           >
                             <Base
                               className="glamor-12"
                               px={2}
-                              w={100}
+                              w={140}
                             >
                               <div
                                 className="glamor-12"
@@ -364,15 +357,15 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                           </Box>
                           <Box
                             px={2}
-                            w={120}
+                            w={140}
                           >
                             <Base
-                              className="glamor-14"
+                              className="glamor-12"
                               px={2}
-                              w={120}
+                              w={140}
                             >
                               <div
-                                className="glamor-14"
+                                className="glamor-12"
                                 is={null}
                               >
                                 Actions
@@ -448,12 +441,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
               >
                 <Styled(Base)
                   align="center"
-                  py={1}
+                  py={2}
                 >
                   <Base
                     align="center"
                     className="glamor-38 glamor-39"
-                    py={1}
+                    py={2}
                   >
                     <div
                       className="glamor-38 glamor-39"
@@ -582,12 +575,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                       </Box>
                       <Box
                         px={2}
-                        w={100}
+                        w={140}
                       >
                         <Base
                           className="glamor-12"
                           px={2}
-                          w={100}
+                          w={140}
                         >
                           <div
                             className="glamor-12"
@@ -597,15 +590,15 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                       </Box>
                       <Box
                         px={2}
-                        w={120}
+                        w={140}
                       >
                         <Base
-                          className="glamor-14"
+                          className="glamor-12"
                           px={2}
-                          w={120}
+                          w={140}
                         >
                           <div
-                            className="glamor-14"
+                            className="glamor-12"
                             is={null}
                           >
                             <Button
@@ -702,12 +695,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
               >
                 <Styled(Base)
                   align="center"
-                  py={1}
+                  py={2}
                 >
                   <Base
                     align="center"
                     className="glamor-38 glamor-39"
-                    py={1}
+                    py={2}
                   >
                     <div
                       className="glamor-38 glamor-39"
@@ -835,12 +828,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                       </Box>
                       <Box
                         px={2}
-                        w={100}
+                        w={140}
                       >
                         <Base
                           className="glamor-12"
                           px={2}
-                          w={100}
+                          w={140}
                         >
                           <div
                             className="glamor-12"
@@ -850,15 +843,15 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                       </Box>
                       <Box
                         px={2}
-                        w={120}
+                        w={140}
                       >
                         <Base
-                          className="glamor-14"
+                          className="glamor-12"
                           px={2}
-                          w={120}
+                          w={140}
                         >
                           <div
-                            className="glamor-14"
+                            className="glamor-12"
                             is={null}
                           >
                             <Button
@@ -955,12 +948,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
               >
                 <Styled(Base)
                   align="center"
-                  py={1}
+                  py={2}
                 >
                   <Base
                     align="center"
                     className="glamor-38 glamor-39"
-                    py={1}
+                    py={2}
                   >
                     <div
                       className="glamor-38 glamor-39"
@@ -1088,12 +1081,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                       </Box>
                       <Box
                         px={2}
-                        w={100}
+                        w={140}
                       >
                         <Base
                           className="glamor-12"
                           px={2}
-                          w={100}
+                          w={140}
                         >
                           <div
                             className="glamor-12"
@@ -1103,15 +1096,15 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                       </Box>
                       <Box
                         px={2}
-                        w={120}
+                        w={140}
                       >
                         <Base
-                          className="glamor-14"
+                          className="glamor-12"
                           px={2}
-                          w={120}
+                          w={140}
                         >
                           <div
-                            className="glamor-14"
+                            className="glamor-12"
                             is={null}
                           >
                             <Button
@@ -1166,10 +1159,10 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: top;
+  -webkit-box-align: top;
+  -ms-flex-align: top;
+  align-items: top;
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin-bottom: 30px;
@@ -1199,7 +1192,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
 }
 
 .glamor-0 {
-  padding: 14px 0;
+  padding: 0 0 15px;
 }
 
 .glamor-84 {
@@ -1257,22 +1250,15 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
 
 .glamor-12 {
   box-sizing: border-box;
-  width: 100px;
-  padding-left: 16px;
-  padding-right: 16px;
-}
-
-.glamor-14 {
-  box-sizing: border-box;
-  width: 120px;
+  width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
 .glamor-38 {
   box-sizing: border-box;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1507,12 +1493,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                           </Box>
                           <Box
                             px={2}
-                            w={100}
+                            w={140}
                           >
                             <Base
                               className="glamor-12"
                               px={2}
-                              w={100}
+                              w={140}
                             >
                               <div
                                 className="glamor-12"
@@ -1524,15 +1510,15 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                           </Box>
                           <Box
                             px={2}
-                            w={120}
+                            w={140}
                           >
                             <Base
-                              className="glamor-14"
+                              className="glamor-12"
                               px={2}
-                              w={120}
+                              w={140}
                             >
                               <div
-                                className="glamor-14"
+                                className="glamor-12"
                                 is={null}
                               >
                                 Actions
@@ -1608,12 +1594,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
               >
                 <Styled(Base)
                   align="center"
-                  py={1}
+                  py={2}
                 >
                   <Base
                     align="center"
                     className="glamor-38 glamor-39"
-                    py={1}
+                    py={2}
                   >
                     <div
                       className="glamor-38 glamor-39"
@@ -1777,12 +1763,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                       </Box>
                       <Box
                         px={2}
-                        w={100}
+                        w={140}
                       >
                         <Base
                           className="glamor-12"
                           px={2}
-                          w={100}
+                          w={140}
                         >
                           <div
                             className="glamor-12"
@@ -1792,15 +1778,15 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                       </Box>
                       <Box
                         px={2}
-                        w={120}
+                        w={140}
                       >
                         <Base
-                          className="glamor-14"
+                          className="glamor-12"
                           px={2}
-                          w={120}
+                          w={140}
                         >
                           <div
-                            className="glamor-14"
+                            className="glamor-12"
                             is={null}
                           >
                             <Button
@@ -1897,12 +1883,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
               >
                 <Styled(Base)
                   align="center"
-                  py={1}
+                  py={2}
                 >
                   <Base
                     align="center"
                     className="glamor-38 glamor-39"
-                    py={1}
+                    py={2}
                   >
                     <div
                       className="glamor-38 glamor-39"
@@ -2066,12 +2052,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                       </Box>
                       <Box
                         px={2}
-                        w={100}
+                        w={140}
                       >
                         <Base
                           className="glamor-12"
                           px={2}
-                          w={100}
+                          w={140}
                         >
                           <div
                             className="glamor-12"
@@ -2081,15 +2067,15 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                       </Box>
                       <Box
                         px={2}
-                        w={120}
+                        w={140}
                       >
                         <Base
-                          className="glamor-14"
+                          className="glamor-12"
                           px={2}
-                          w={120}
+                          w={140}
                         >
                           <div
-                            className="glamor-14"
+                            className="glamor-12"
                             is={null}
                           >
                             <Button
@@ -2186,12 +2172,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
               >
                 <Styled(Base)
                   align="center"
-                  py={1}
+                  py={2}
                 >
                   <Base
                     align="center"
                     className="glamor-38 glamor-39"
-                    py={1}
+                    py={2}
                   >
                     <div
                       className="glamor-38 glamor-39"
@@ -2319,12 +2305,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                       </Box>
                       <Box
                         px={2}
-                        w={100}
+                        w={140}
                       >
                         <Base
                           className="glamor-12"
                           px={2}
-                          w={100}
+                          w={140}
                         >
                           <div
                             className="glamor-12"
@@ -2334,15 +2320,15 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                       </Box>
                       <Box
                         px={2}
-                        w={120}
+                        w={140}
                       >
                         <Base
-                          className="glamor-14"
+                          className="glamor-12"
                           px={2}
-                          w={120}
+                          w={140}
                         >
                           <div
-                            className="glamor-14"
+                            className="glamor-12"
                             is={null}
                           >
                             <Button


### PR DESCRIPTION
This is the first round of cleanup. It:

- Makes text colors and borders 3-4% darker.
- Converts Your teams, All Teams, and other Box-based wrappers to use our Panel component
- Introduces a `PanelItem` component for Flex-based panel rows that need padding and a bottom-border
- Removes the back button in favor of a top level sentry logo breadcrumb
- Moves beta notice below the content
- Locks textarea resize to vertical only

<img width="1120" alt="screen shot 2017-12-12 at 4 18 23 pm" src="https://user-images.githubusercontent.com/30713/33915430-349df544-df58-11e7-8f86-a9f3059ba845.png">
