### PR TITLE
feat(ui): Change team settings route hierarchy

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeSidebar.jsx
@@ -129,19 +129,9 @@ const HomeSidebar = React.createClass({
           >
             {t('Dashboard')}
           </ListLink>
-          <ListLink
-            to={`${pathPrefix}/teams/`}
-            isActive={() => {
-              // return true if path matches /organizations/slug-name/teams/ OR /organizations/slug-name/all-teams/
-              return /^\/organizations\/[^\/]+\/(teams|all-teams)\/$/.test(
-                this.context.location.pathname
-              );
-            }}
-          >
-            {t('Projects & Teams')}
-          </ListLink>
+          <ListLink to={`${pathPrefix}/teams/`}>{t('Projects & Teams')}</ListLink>
           {access.has('org:read') && (
-            <ListLink to={`/organizations/${orgId}/stats/`}>{t('Stats')}</ListLink>
+            <ListLink to={`${pathPrefix}/stats/`}>{t('Stats')}</ListLink>
           )}
         </ul>
         <div>

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -188,31 +188,32 @@ const orgSettingsRoutes = [
     component={errorHandler(OrganizationGeneralSettingsView)}
   />,
 
-  <Route
-    key="team-details"
-    name="Teams"
-    path="teams/:teamId/"
-    component={errorHandler(TeamDetails)}
-  >
-    <IndexRedirect to="settings/" />
-    <Route path="settings/" name="Settings" component={errorHandler(TeamSettings)} />
-    <Route path="members/" name="Members" component={errorHandler(TeamMembers)} />
+  <Route key="teams" name="Project & Teams" path="teams/">
+    <IndexRedirect to="your-teams" />
+    <Route
+      path="all-teams/"
+      name="All Teams"
+      allTeams
+      component={errorHandler(OrganizationTeams)}
+    />
+
+    <Route
+      name="Your Teams"
+      path="your-teams/"
+      component={errorHandler(OrganizationTeams)}
+    />
+
+    <Route
+      key="team-details"
+      name="Team"
+      path=":teamId/"
+      component={errorHandler(TeamDetails)}
+    >
+      <IndexRedirect to="settings/" />
+      <Route path="settings/" name="Settings" component={errorHandler(TeamSettings)} />
+      <Route path="members/" name="Members" component={errorHandler(TeamMembers)} />
+    </Route>
   </Route>,
-
-  <Route
-    key="teams"
-    path="teams/"
-    name="Teams"
-    component={errorHandler(OrganizationTeams)}
-  />,
-
-  <Route
-    key="all-teams"
-    path="all-teams/"
-    name="All Teams"
-    allTeams
-    component={errorHandler(OrganizationTeams)}
-  />,
 
   <Route key="org-stats" path="stats/" component={errorHandler(OrganizationStats)} />,
 ];

--- a/src/sentry/static/sentry/app/views/organizationTeams/organizationTeamsView.jsx
+++ b/src/sentry/static/sentry/app/views/organizationTeams/organizationTeamsView.jsx
@@ -38,15 +38,15 @@ class OrganizationTeamsView extends React.Component {
 
     if (!organization) return null;
 
-    let urlPrefix = recreateRoute('', {routes, params, stepBack: -1});
+    let urlPrefix = recreateRoute('', {routes, params, stepBack: -2});
 
     return (
       <div className="row">
         <div className="col-md-9">
           <div className="team-list">
             <ul className="nav nav-tabs border-bottom">
-              <ListLink to={`${urlPrefix}teams/`}>{t('Your Teams')}</ListLink>
-              <ListLink to={`${urlPrefix}all-teams/`}>
+              <ListLink to={`${urlPrefix}teams/your-teams/`}>{t('Your Teams')}</ListLink>
+              <ListLink to={`${urlPrefix}teams/all-teams/`}>
                 {t('All Teams')}{' '}
                 <span className="badge badge-soft">{allTeams.length}</span>
               </ListLink>

--- a/src/sentry/static/sentry/app/views/settings/team/organizationTeamsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/organizationTeamsView.jsx
@@ -37,13 +37,14 @@ class OrganizationTeamsView extends React.Component {
 
     if (!organization) return null;
 
-    let urlPrefix = recreateRoute('', {routes, params, stepBack: -1});
+    let teamRoute = routes.find(({path}) => path === 'teams/');
+    let urlPrefix = recreateRoute(teamRoute, {routes, params, stepBack: -1});
 
     return (
       <div className="team-list">
         <ul className="nav nav-tabs border-bottom">
-          <ListLink to={`${urlPrefix}teams/`}>{t('Your Teams')}</ListLink>
-          <ListLink to={`${urlPrefix}all-teams/`}>
+          <ListLink to={`${urlPrefix}teams/your-teams/`}>{t('Your Teams')}</ListLink>
+          <ListLink to={`${urlPrefix}teams/all-teams/`}>
             {t('All Teams')} <span className="badge badge-soft">{allTeams.length}</span>
           </ListLink>
         </ul>

--- a/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
@@ -7,7 +7,6 @@ import Button from '../../../components/buttons/button';
 import LoadingError from '../../../components/loadingError';
 import LoadingIndicator from '../../../components/loadingIndicator';
 import OrganizationState from '../../../mixins/organizationState';
-import recreateRoute from '../../../utils/recreateRoute';
 import {t} from '../../../locale';
 
 const TeamMembers = React.createClass({
@@ -65,7 +64,7 @@ const TeamMembers = React.createClass({
     if (this.state.loading) return <LoadingIndicator />;
     else if (this.state.error) return <LoadingError onRetry={this.fetchData} />;
 
-    let {params, routes} = this.props;
+    let {params} = this.props;
 
     let access = this.getAccess();
 
@@ -77,7 +76,7 @@ const TeamMembers = React.createClass({
               priority="primary"
               size="small"
               className="pull-right"
-              to={`${recreateRoute('members/new/', {routes, params, stepBack: -2})}`}
+              to={`/settings/organization/${params.orgId}/members/new/`}
             >
               <span className="icon-plus" /> {t('Invite Member')}
             </Button>
@@ -110,11 +109,7 @@ const TeamMembers = React.createClass({
                     <Avatar user={member} size={80} />
                     <h5>
                       <Link
-                        to={`${recreateRoute(`members/${member.id}`, {
-                          routes,
-                          params,
-                          stepBack: -2,
-                        })}`}
+                        to={`/settings/organization/${params.orgId}/members/${member.id}`}
                       >
                         {member.email}
                       </Link>


### PR DESCRIPTION
Change team settings route hierarchy so that navigation is active works
as expected without path regexes.

Change "your teams" to have an explicit route path (previously was just
index route for "teams/")