### PR TITLE
feat(logging): Turn some logs into metrics automatically.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -617,11 +617,20 @@ LOGGING = {
             'filters': ['sentry:internal'],
             'class': 'raven.contrib.django.handlers.SentryHandler',
         },
+        'metrics': {
+            'level': 'WARNING',
+            'filters': ['important_django_request'],
+            'class': 'sentry.logging.handlers.MetricsLogHandler',
+        },
     },
     'filters': {
         'sentry:internal': {
             '()': 'sentry.utils.raven.SentryInternalFilter',
         },
+        'important_django_request': {
+            '()': 'sentry.logging.handlers.MessageContainsFilter',
+            'contains': ["CSRF"]
+        }
     },
     'root': {
         'level': 'NOTSET',
@@ -632,7 +641,7 @@ LOGGING = {
     'overridable': ['celery', 'sentry'],
     'loggers': {
         'celery': {
-            'level': 'WARN',
+            'level': 'WARNING',
         },
         'sentry': {
             'level': 'INFO',
@@ -666,8 +675,8 @@ LOGGING = {
             'level': 'INFO',
         },
         'django.request': {
-            'level': 'ERROR',
-            'handlers': ['console'],
+            'level': 'WARNING',
+            'handlers': ['console', 'metrics'],
             'propagate': False,
         },
         'toronado': {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -622,6 +622,11 @@ LOGGING = {
             'filters': ['important_django_request'],
             'class': 'sentry.logging.handlers.MetricsLogHandler',
         },
+        'django_internal': {
+            'level': 'WARNING',
+            'filters': ['sentry:internal', 'important_django_request'],
+            'class': 'raven.contrib.django.handlers.SentryHandler',
+        },
     },
     'filters': {
         'sentry:internal': {
@@ -676,7 +681,7 @@ LOGGING = {
         },
         'django.request': {
             'level': 'WARNING',
-            'handlers': ['console', 'metrics'],
+            'handlers': ['console', 'metrics', 'django_internal'],
             'propagate': False,
         },
         'toronado': {

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -6,13 +6,16 @@ sentry.logging.handlers
 """
 from __future__ import absolute_import
 
-import six
 import logging
+import re
+import six
 
 from django.utils.timezone import now
 from simplejson import JSONEncoder
 from structlog import get_logger
 from structlog.processors import _json_fallback_handler
+
+from sentry.utils import metrics
 
 _default_encoder = JSONEncoder(
     separators=(',', ':'),
@@ -83,3 +86,40 @@ class StructLogHandler(logging.StreamHandler):
                 kwargs['positional_args'] = (record.args, )
 
         logger.log(**kwargs)
+
+
+class MessageContainsFilter(logging.Filter):
+    """
+    A logging filter that allows log records where the message
+    contains given substring(s).
+
+    contains -- a string or list of strings to match
+    """
+
+    def __init__(self, contains):
+        if not isinstance(contains, list):
+            contains = [contains]
+        if not all(isinstance(c, six.string_types) for c in contains):
+            raise TypeError("'contains' must be a string or list of strings")
+        self.contains = contains
+
+    def filter(self, record):
+        message = record.getMessage()
+        return any(c in message for c in self.contains)
+
+
+class MetricsLogHandler(logging.Handler):
+    def emit(self, record, logger=get_logger()):
+        """
+        Turn something like:
+            > django.request: Forbidden (CSRF cookie not set.): /account
+        into:
+            > django.request.forbidden_csrf_cookie_not_set
+        and track it as an incremented counter.
+        """
+        key = record.name + '.' + record.getMessage()
+        key = key.lower()
+        key = re.subn("\s+", "_", key)[0]
+        key = re.subn("[^a-z0-9_.]", "", key)[0]
+        key = ".".join(key.split(".")[:3])
+        metrics.incr(key)

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -112,14 +112,14 @@ class MetricsLogHandler(logging.Handler):
     def emit(self, record, logger=get_logger()):
         """
         Turn something like:
-            > django.request: Forbidden (CSRF cookie not set.): /account
+            > django.request.Forbidden (CSRF cookie not set.): /account
         into:
             > django.request.forbidden_csrf_cookie_not_set
         and track it as an incremented counter.
         """
         key = record.name + '.' + record.getMessage()
         key = key.lower()
-        key = re.subn("\s+", "_", key)[0]
-        key = re.subn("[^a-z0-9_.]", "", key)[0]
+        key = re.sub("\s+", "_", key)
+        key = re.sub("[^a-z0-9_.]", "", key)
         key = ".".join(key.split(".")[:3])
         metrics.incr(key)

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -108,6 +108,10 @@ class MessageContainsFilter(logging.Filter):
         return any(c in message for c in self.contains)
 
 
+whitespace_re = re.compile("\s+")
+metrics_badchars_re = re.compile("[^a-z0-9_.]")
+
+
 class MetricsLogHandler(logging.Handler):
     def emit(self, record, logger=get_logger()):
         """
@@ -119,7 +123,7 @@ class MetricsLogHandler(logging.Handler):
         """
         key = record.name + '.' + record.getMessage()
         key = key.lower()
-        key = re.sub("\s+", "_", key)
-        key = re.sub("[^a-z0-9_.]", "", key)
+        key = whitespace_re.sub("_", key)
+        key = metrics_badchars_re.sub("", key)
         key = ".".join(key.split(".")[:3])
         metrics.incr(key)

--- a/tests/sentry/logging/test_handler.py
+++ b/tests/sentry/logging/test_handler.py
@@ -60,3 +60,15 @@ def test_emit(record, out, handler, logger):
     expected = dict(level=logging.INFO, event='msg', name='name')
     expected.update(out)
     logger.log.assert_called_once_with(**expected)
+
+
+@mock.patch('sentry.logging.handlers.metrics')
+def test_log_to_metric(metrics):
+    logger = logging.getLogger('django.request')
+    logger.warn("CSRF problem")
+    metrics.incr.assert_called_once_with('django.request.csrf_problem')
+
+    metrics.reset_mock()
+
+    logger.warn("Some other problem we don't care about")
+    assert metrics.incr.call_count == 0


### PR DESCRIPTION
Constructed a logger that reports log records as incremented metrics and a filter so that only "interesting" ones get tracked. First usage is to track CSRF errors created by the django CSRF middleware as counters.

Could easily be used to also count other types of framework/django logs which are currently being ignored (or only printed to the console).

Also added a regular sentry logger for the django errors, filtered to just the CSRF ones too