### PR TITLE
feat(account): Update subscriptions page

### DIFF
--- a/src/sentry/templates/sentry/account/subscriptions.html
+++ b/src/sentry/templates/sentry/account/subscriptions.html
@@ -20,18 +20,42 @@
     {% endif %}
 
     <legend class="m-t-0">Subscriptions</legend>
+
+    <p>
+    Sentry is committed to respecting your inbox; we'll never sell your data. Opt-in to receive the latest news and
+    product updates about Sentry.
+    </p>
+
+    <table class="table">
+      <tbody>
     {% for subscription in subscriptions.subscriptions %}
-        <div class="row p-b-1">
-            <div class="col-md-9">
-                <h5>{{ subscription.list_name }}</h5>
+        <tr>
+          <td>
+            <h5>{{ subscription.list_name }}</h5>
+            {% if subscription.list_description %}
+            <p class="help-block">
+              {{ subscription.list_description }}
+            </p>
+            {% endif %}
+          </td>
+          <td class="align-right">
+              <div data-list-id="{{ subscription.list_id }}" class="switch switch-lg{% if subscription.subscribed %} switch-on{% endif %}" role="checkbox">
+                  <span class="switch-toggle"></span>
+              </div>
+              <div>
+            {% if subscription.subscribed %}
+            <p class="help-block">
+              <small>
+                {% firstof subscription.email email.email %} on {{subscription.subscribed_date|date:'SHORT_DATE_FORMAT' }}
+              </small>
+            </p>
+            {% endif %}
             </div>
-            <div class="col-md-3 align-right" style="padding-right: 25px">
-                <div data-list-id="{{ subscription.list_id }}" class="switch switch-lg{% if subscription.subscribed %} switch-on{% endif %}" role="checkbox">
-                    <span class="switch-toggle"></span>
-                </div>
-            </div>
-        </div>
+          </td>
+        </tr>
     {% endfor %}
+      </tbody>
+    </table>
 
     <script>
     $('div.switch').click(function(){

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -194,7 +194,7 @@ class RegistrationForm(forms.ModelForm):
     subscribe = forms.BooleanField(
         label=_('Subscribe to product updates newsletter'),
         required=False,
-        initial=True,
+        initial=False,
     )
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Update the layout of the account subscriptions page to clarify when a user opted in, and eventually allow us to provide more context about the newsletter.

Current:
![image](https://user-images.githubusercontent.com/245199/33957645-10b3b408-dff7-11e7-944b-1aba2cf9bee6.png)

New unsubscribed state:
![image](https://user-images.githubusercontent.com/245199/33957661-1cad4ba2-dff7-11e7-88de-c8f2996d5407.png)

New subscribed state:
![image](https://user-images.githubusercontent.com/245199/33957656-175d071e-dff7-11e7-8587-ffcf8137c464.png)
