### PR TITLE
fix: Use json encoding in trim() when we have reached max depth.

### DIFF
--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.db import transaction
 from django.utils.encoding import force_text
 
+from sentry.utils import json
 from sentry.utils.strings import truncatechars
 
 
@@ -65,7 +66,7 @@ def trim(
 
     if _depth > max_depth:
         if not isinstance(value, six.string_types):
-            value = repr(value)
+            value = json.dumps(value)
         return trim(value, _size=_size, max_size=max_size)
 
     elif isinstance(value, dict):

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -25,7 +25,7 @@ class TrimTest(TestCase):
     def test_idempotent(self):
         trm = partial(trim, max_depth=2)
         a = {'a': {'b': {'c': {'d': 1}}}}
-        assert trm(a) == {'a': {'b': {'c': "{'d': 1}"}}}
+        assert trm(a) == {'a': {'b': {'c': '{"d":1}'}}}
         assert trm(trm(trm(trm(a)))) == trm(a)
 
     def test_sorted_trim(self):
@@ -38,6 +38,20 @@ class TrimTest(TestCase):
 
         assert trm(alpha) == expected
         assert trm(reverse) == expected
+
+    def test_max_depth(self):
+        trm = partial(trim, max_depth=2)
+        a = {'a': {'b': {'c': 'd'}}}
+        assert trm(a) == a
+
+        a = {'a': {'b': {'c': u'd'}}}
+        assert trm(a) == {'a': {'b': {'c': 'd'}}}
+
+        a = {'a': {'b': {'c': {u'd': u'e'}}}}
+        assert trm(a) == {'a': {'b': {'c': '{"d":"e"}'}}}
+
+        a = {'a': {'b': {'c': []}}}
+        assert trm(a) == {'a': {'b': {'c': '[]'}}}
 
 
 class TrimDictTest(TestCase):


### PR DESCRIPTION
When we reach the max depth (3) of a nested dictionary, we serialize
the remaining levels (and potentially truncate the resulting string if
it is too long). This change just uses json.dumps() instead of repr() so
that the resulting string doesn't contain python-specific junk like
`u'foo'`.

Related issue: https://github.com/getsentry/sentry/issues/5303