### PR TITLE
fix: Allow greater max_depth

### DIFF
--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -45,7 +45,7 @@ def safe_execute(func, *args, **kwargs):
 def trim(
     value,
     max_size=settings.SENTRY_MAX_VARIABLE_SIZE,
-    max_depth=3,
+    max_depth=6,
     object_hook=None,
     _depth=0,
     _size=0,


### PR DESCRIPTION
Rationale is, sometimes we get things like POST bodies that are shorter
than max_size, but are deeply nested. In those cases we _could_ easily
return a perfect reproduction of the nested data without going over max_size,
but becuase of max_depth, we were mutating the data to strings.

There may be other tradeoffs here that I haven't considered though.

Fixes https://github.com/getsentry/sentry/issues/5303