### PR TITLE
ref(tags): Drop environment_id from everything but TagKey in v2

### DIFF
--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -80,6 +80,12 @@ def create_or_update(model, using=None, **kwargs):
         return affected, False
 
     create_kwargs = kwargs.copy()
+
+    # only use join filters for filtering (above) and not creation
+    for key in create_kwargs.keys():
+        if '__' in key:
+            create_kwargs.pop(key)
+
     inst = objects.model()
     for k, v in itertools.chain(six.iteritems(values), six.iteritems(defaults)):
         # XXX(dcramer): we want to support column shortcut on create so

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -80,12 +80,6 @@ def create_or_update(model, using=None, **kwargs):
         return affected, False
 
     create_kwargs = kwargs.copy()
-
-    # only use join filters for filtering (above) and not creation
-    for key in create_kwargs.keys():
-        if '__' in key:
-            create_kwargs.pop(key)
-
     inst = objects.model()
     for k, v in itertools.chain(six.iteritems(values), six.iteritems(defaults)):
         # XXX(dcramer): we want to support column shortcut on create so

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -69,9 +69,7 @@ class TagStorage(Service):
         'get_first_release',
         'get_last_release',
         'get_release_tags',
-        'incr_tag_key_values_seen',
         'incr_tag_value_times_seen',
-        'incr_group_tag_key_values_seen',
         'incr_group_tag_value_times_seen',
         'get_group_ids_for_users',
         'get_group_tag_values_for_users',
@@ -296,22 +294,10 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def incr_tag_key_values_seen(self, project_id, environment_id, key, count=1):
-        """
-        >>> incr_tag_key_values_seen(1, 2, "key1")
-        """
-        raise NotImplementedError
-
     def incr_tag_value_times_seen(self, project_id, environment_id,
                                   key, value, extra=None, count=1):
         """
         >>> incr_tag_value_times_seen(1, 2, "key1", "value1")
-        """
-        raise NotImplementedError
-
-    def incr_group_tag_key_values_seen(self, project_id, group_id, environment_id, key, count=1):
-        """
-        >>> incr_group_tag_key_values_seen(1, 2, 3, "key1")
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/south_migrations/0004_auto__del_tagkey__del_unique_tagkey_project_id_environment_id_key__del.py
+++ b/src/sentry/tagstore/south_migrations/0004_auto__del_tagkey__del_unique_tagkey_project_id_environment_id_key__del.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = True
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'GroupTagValue', fields ['project_id',
+        # 'group_id', 'environment_id', '_key', '_value']
+        db.delete_unique(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'group_id', 'environment_id', 'key_id', 'value_id'])
+
+        # Removing unique constraint on 'EventTag', fields ['event_id', 'key', 'value']
+        db.delete_unique(u'tagstore_eventtag', ['event_id', 'key_id', 'value_id'])
+
+        # Removing unique constraint on 'GroupTagKey', fields ['project_id',
+        # 'group_id', 'environment_id', '_key']
+        db.delete_unique(
+            u'tagstore_grouptagkey', [
+                'project_id', 'group_id', 'environment_id', 'key_id'])
+
+        # Removing unique constraint on 'TagValue', fields ['project_id',
+        # 'environment_id', '_key', 'value']
+        db.delete_unique(u'tagstore_tagvalue', ['project_id', 'environment_id', 'key_id', 'value'])
+
+        # Removing unique constraint on 'TagKey', fields ['project_id', 'environment_id', 'key']
+        db.delete_unique(u'tagstore_tagkey', ['project_id', 'environment_id', 'key'])
+
+        # Removing index on 'TagValue', fields ['project_id', '_key', 'last_seen']
+        db.delete_index(u'tagstore_tagvalue', ['project_id', 'key_id', 'last_seen'])
+
+        # Deleting model 'GroupTagKey'
+        db.delete_table(u'tagstore_grouptagkey')
+
+        # Removing index on 'EventTag', fields ['project_id', 'key', 'value']
+        db.delete_index(u'tagstore_eventtag', ['project_id', 'key_id', 'value_id'])
+
+        # Removing index on 'EventTag', fields ['group_id', 'key', 'value']
+        db.delete_index(u'tagstore_eventtag', ['group_id', 'key_id', 'value_id'])
+
+        # Removing index on 'EventTag', fields ['environment_id', 'key', 'value']
+        db.delete_index(u'tagstore_eventtag', ['environment_id', 'key_id', 'value_id'])
+
+        # Removing index on 'GroupTagValue', fields ['project_id', '_key', '_value', 'last_seen']
+        db.delete_index(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'key_id', 'value_id', 'last_seen'])
+
+        # Deleting model 'TagKey'
+        db.delete_table(u'tagstore_tagkey')
+
+        # Deleting model 'TagValue'
+        db.delete_table(u'tagstore_tagvalue')
+
+        # Deleting model 'EventTag'
+        db.delete_table(u'tagstore_eventtag')
+
+        # Deleting model 'GroupTagValue'
+        db.delete_table(u'tagstore_grouptagvalue')
+
+    def backwards(self, orm):
+        # Adding model 'TagKey'
+        db.create_table(u'tagstore_tagkey', (
+            ('status', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('environment_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True)),
+            ('values_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('key', self.gf('django.db.models.fields.CharField')(max_length=32)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('tagstore', ['TagKey'])
+
+        # Adding unique constraint on 'TagKey', fields ['project_id', 'environment_id', 'key']
+        db.create_unique(u'tagstore_tagkey', ['project_id', 'environment_id', 'key'])
+
+        # Adding model 'TagValue'
+        db.create_table(u'tagstore_tagvalue', (
+            ('times_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('environment_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True)),
+            ('_key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('first_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('data', self.gf('sentry.db.models.fields.gzippeddict.GzippedDictField')(null=True, blank=True)),
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('value', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('last_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+        ))
+        db.send_create_signal('tagstore', ['TagValue'])
+
+        # Adding unique constraint on 'TagValue', fields ['project_id',
+        # 'environment_id', '_key', 'value']
+        db.create_unique(u'tagstore_tagvalue', ['project_id', 'environment_id', 'key_id', 'value'])
+
+        # Adding model 'GroupTagKey'
+        db.create_table(u'tagstore_grouptagkey', (
+            ('environment_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True)),
+            ('values_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('_key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('group_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+        ))
+        db.send_create_signal('tagstore', ['GroupTagKey'])
+
+        # Adding unique constraint on 'GroupTagKey', fields ['project_id',
+        # 'group_id', 'environment_id', '_key']
+        db.create_unique(
+            u'tagstore_grouptagkey', [
+                'project_id', 'group_id', 'environment_id', 'key_id'])
+
+        # Adding model 'EventTag'
+        db.create_table(u'tagstore_eventtag', (
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')()),
+            ('environment_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')()),
+            ('key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('event_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')()),
+            ('date_added', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, db_index=True)),
+            ('group_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')()),
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('value', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagValue'], db_column='value_id')),
+        ))
+        db.send_create_signal('tagstore', ['EventTag'])
+
+        # Adding unique constraint on 'EventTag', fields ['event_id', 'key', 'value']
+        db.create_unique(u'tagstore_eventtag', ['event_id', 'key_id', 'value_id'])
+
+        # Adding model 'GroupTagValue'
+        db.create_table(u'tagstore_grouptagvalue', (
+            ('_value', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagValue'], db_column='value_id')),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('environment_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True)),
+            ('times_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('_key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('first_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+            ('group_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('last_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+        ))
+        db.send_create_signal('tagstore', ['GroupTagValue'])
+
+        # Adding unique constraint on 'GroupTagValue', fields ['project_id',
+        # 'group_id', 'environment_id', '_key', '_value']
+        db.create_unique(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'group_id', 'environment_id', 'key_id', 'value_id'])
+
+        # Adding index on 'GroupTagValue', fields ['project_id', '_key', '_value', 'last_seen']
+        db.create_index(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'key_id', 'value_id', 'last_seen'])
+
+        # Adding index on 'EventTag', fields ['environment_id', 'key', 'value']
+        db.create_index(u'tagstore_eventtag', ['environment_id', 'key_id', 'value_id'])
+
+        # Adding index on 'EventTag', fields ['group_id', 'key', 'value']
+        db.create_index(u'tagstore_eventtag', ['group_id', 'key_id', 'value_id'])
+
+        # Adding index on 'EventTag', fields ['project_id', 'key', 'value']
+        db.create_index(u'tagstore_eventtag', ['project_id', 'key_id', 'value_id'])
+
+        # Adding index on 'TagValue', fields ['project_id', '_key', 'last_seen']
+        db.create_index(u'tagstore_tagvalue', ['project_id', 'key_id', 'last_seen'])
+
+    models = {
+
+    }
+
+    complete_apps = ['tagstore']

--- a/src/sentry/tagstore/south_migrations/0005_auto__add_tagvalue__add_unique_tagvalue_project_id__key_value__add_ind.py
+++ b/src/sentry/tagstore/south_migrations/0005_auto__add_tagvalue__add_unique_tagvalue_project_id__key_value__add_ind.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = True
+
+    def forwards(self, orm):
+        # Adding model 'TagValue'
+        db.create_table(u'tagstore_tagvalue', (
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('_key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('value', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('data', self.gf('sentry.db.models.fields.gzippeddict.GzippedDictField')(null=True, blank=True)),
+            ('times_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('last_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+            ('first_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+        ))
+        db.send_create_signal('tagstore', ['TagValue'])
+
+        # Adding unique constraint on 'TagValue', fields ['project_id', '_key', 'value']
+        db.create_unique(u'tagstore_tagvalue', ['project_id', 'key_id', 'value'])
+
+        # Adding index on 'TagValue', fields ['project_id', '_key', 'last_seen']
+        db.create_index(u'tagstore_tagvalue', ['project_id', 'key_id', 'last_seen'])
+
+        # Adding model 'TagKey'
+        db.create_table(u'tagstore_tagkey', (
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('environment_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True)),
+            ('key', self.gf('django.db.models.fields.CharField')(max_length=32)),
+            ('values_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('status', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+        ))
+        db.send_create_signal('tagstore', ['TagKey'])
+
+        # Adding unique constraint on 'TagKey', fields ['project_id', 'environment_id', 'key']
+        db.create_unique(u'tagstore_tagkey', ['project_id', 'environment_id', 'key'])
+
+        # Adding model 'GroupTagKey'
+        db.create_table(u'tagstore_grouptagkey', (
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('group_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('_key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('values_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+        ))
+        db.send_create_signal('tagstore', ['GroupTagKey'])
+
+        # Adding unique constraint on 'GroupTagKey', fields ['project_id', 'group_id', '_key']
+        db.create_unique(u'tagstore_grouptagkey', ['project_id', 'group_id', 'key_id'])
+
+        # Adding model 'EventTag'
+        db.create_table(u'tagstore_eventtag', (
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')()),
+            ('group_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')()),
+            ('event_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')()),
+            ('key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('value', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagValue'], db_column='value_id')),
+            ('date_added', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, db_index=True)),
+        ))
+        db.send_create_signal('tagstore', ['EventTag'])
+
+        # Adding unique constraint on 'EventTag', fields ['event_id', 'key', 'value']
+        db.create_unique(u'tagstore_eventtag', ['event_id', 'key_id', 'value_id'])
+
+        # Adding index on 'EventTag', fields ['project_id', 'key', 'value']
+        db.create_index(u'tagstore_eventtag', ['project_id', 'key_id', 'value_id'])
+
+        # Adding index on 'EventTag', fields ['group_id', 'key', 'value']
+        db.create_index(u'tagstore_eventtag', ['group_id', 'key_id', 'value_id'])
+
+        # Adding model 'GroupTagValue'
+        db.create_table(u'tagstore_grouptagvalue', (
+            ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
+            ('project_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('group_id', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(db_index=True)),
+            ('times_seen', self.gf('sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(default=0)),
+            ('_key', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagKey'], db_column='key_id')),
+            ('_value', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                to=orm['tagstore.TagValue'], db_column='value_id')),
+            ('last_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+            ('first_seen', self.gf('django.db.models.fields.DateTimeField')(
+                default=datetime.datetime.now, null=True, db_index=True)),
+        ))
+        db.send_create_signal('tagstore', ['GroupTagValue'])
+
+        # Adding unique constraint on 'GroupTagValue', fields ['project_id',
+        # 'group_id', '_key', '_value']
+        db.create_unique(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'group_id', 'key_id', 'value_id'])
+
+        # Adding index on 'GroupTagValue', fields ['project_id', '_key', '_value', 'last_seen']
+        db.create_index(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'key_id', 'value_id', 'last_seen'])
+
+    def backwards(self, orm):
+        # Removing index on 'GroupTagValue', fields ['project_id', '_key', '_value', 'last_seen']
+        db.delete_index(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'key_id', 'value_id', 'last_seen'])
+
+        # Removing unique constraint on 'GroupTagValue', fields ['project_id',
+        # 'group_id', '_key', '_value']
+        db.delete_unique(
+            u'tagstore_grouptagvalue', [
+                'project_id', 'group_id', 'key_id', 'value_id'])
+
+        # Removing index on 'EventTag', fields ['group_id', 'key', 'value']
+        db.delete_index(u'tagstore_eventtag', ['group_id', 'key_id', 'value_id'])
+
+        # Removing index on 'EventTag', fields ['project_id', 'key', 'value']
+        db.delete_index(u'tagstore_eventtag', ['project_id', 'key_id', 'value_id'])
+
+        # Removing unique constraint on 'EventTag', fields ['event_id', 'key', 'value']
+        db.delete_unique(u'tagstore_eventtag', ['event_id', 'key_id', 'value_id'])
+
+        # Removing unique constraint on 'GroupTagKey', fields ['project_id', 'group_id', '_key']
+        db.delete_unique(u'tagstore_grouptagkey', ['project_id', 'group_id', 'key_id'])
+
+        # Removing unique constraint on 'TagKey', fields ['project_id', 'environment_id', 'key']
+        db.delete_unique(u'tagstore_tagkey', ['project_id', 'environment_id', 'key'])
+
+        # Removing index on 'TagValue', fields ['project_id', '_key', 'last_seen']
+        db.delete_index(u'tagstore_tagvalue', ['project_id', 'key_id', 'last_seen'])
+
+        # Removing unique constraint on 'TagValue', fields ['project_id', '_key', 'value']
+        db.delete_unique(u'tagstore_tagvalue', ['project_id', 'key_id', 'value'])
+
+        # Deleting model 'TagValue'
+        db.delete_table(u'tagstore_tagvalue')
+
+        # Deleting model 'TagKey'
+        db.delete_table(u'tagstore_tagkey')
+
+        # Deleting model 'GroupTagKey'
+        db.delete_table(u'tagstore_grouptagkey')
+
+        # Deleting model 'EventTag'
+        db.delete_table(u'tagstore_eventtag')
+
+        # Deleting model 'GroupTagValue'
+        db.delete_table(u'tagstore_grouptagvalue')
+
+    models = {
+        'tagstore.eventtag': {
+            'Meta': {'unique_together': "(('event_id', 'key', 'value'),)", 'object_name': 'EventTag', 'index_together': "(('project_id', 'key', 'value'), ('group_id', 'key', 'value'))"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'event_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'value': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagValue']", 'db_column': "'value_id'"})
+        },
+        'tagstore.grouptagkey': {
+            'Meta': {'unique_together': "(('project_id', 'group_id', '_key'),)", 'object_name': 'GroupTagKey'},
+            '_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'tagstore.grouptagvalue': {
+            'Meta': {'unique_together': "(('project_id', 'group_id', '_key', '_value'),)", 'object_name': 'GroupTagValue', 'index_together': "(('project_id', '_key', '_value', 'last_seen'),)"},
+            '_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            '_value': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagValue']", 'db_column': "'value_id'"}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'tagstore.tagkey': {
+            'Meta': {'unique_together': "(('project_id', 'environment_id', 'key'),)", 'object_name': 'TagKey'},
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'tagstore.tagvalue': {
+            'Meta': {'unique_together': "(('project_id', '_key', 'value'),)", 'object_name': 'TagValue', 'index_together': "(('project_id', '_key', 'last_seen'),)"},
+            '_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True', 'blank': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['tagstore']

--- a/src/sentry/tagstore/tasks.py
+++ b/src/sentry/tagstore/tasks.py
@@ -41,6 +41,7 @@ def delete_tag_key(object_id, model=None, transaction_id=None, **kwargs):
     if has_more:
         delete_tag_key.apply_async(
             kwargs={'object_id': object_id,
+                    'model': model,
                     'transaction_id': transaction_id},
             countdown=15,
         )

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -559,7 +559,6 @@ class V2TagStorage(TagStorage):
                     SELECT tagstore_grouptagvalue.id,
                            tagstore_grouptagvalue.project_id,
                            tagstore_grouptagvalue.group_id,
-                           tagstore_grouptagvalue.environment_id,
                            tagstore_grouptagvalue.times_seen,
                            tagstore_grouptagvalue.key_id,
                            tagstore_grouptagvalue.value_id,

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -403,7 +403,7 @@ class V2TagStorage(TagStorage):
                         },
                         filters={
                             'project_id': project_id,
-                            '_key__environment_id': env,  # TODO
+                            '_key__environment_id': env,
                             '_key_id': tagkey.id,
                             'value': value,
                         },
@@ -418,7 +418,7 @@ class V2TagStorage(TagStorage):
                     filters={
                         'project_id': project_id,
                         'group_id': group_id,
-                        '_key__environment_id': environment_id,  # TODO
+                        '_key__environment_id': environment_id,
                         '_key_id': key,
                     })
 
@@ -435,7 +435,7 @@ class V2TagStorage(TagStorage):
                         filters={
                             'project_id': project_id,
                             'group_id': group_id,
-                            '_key__environment_id': env,  # TODO
+                            '_key__environment_id': env,
                             '_key_id': tagkey.id,
                             '_value_id': tagvalue.id,
                         },
@@ -731,7 +731,11 @@ class V2TagStorage(TagStorage):
 
     def _get_environment_filter(self, environment_id, join=False):
         """\
-        TODO
+        Returns a dict to be used in ORM queries to filter by
+        `environment_id`.
+
+        If `join` is true it will join across the `_key` column that non-TagKey
+        models have in order to reach the `environment_id` there.
         """
         prefix = "_key__" if join else ""
         if environment_id is None:

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -403,7 +403,7 @@ class V2TagStorage(TagStorage):
                         },
                         filters={
                             'project_id': project_id,
-                            'environment_id': env,  # TODO
+                            '_key__environment_id': env,  # TODO
                             '_key_id': tagkey.id,
                             'value': value,
                         },
@@ -418,7 +418,7 @@ class V2TagStorage(TagStorage):
                     filters={
                         'project_id': project_id,
                         'group_id': group_id,
-                        'environment_id': environment_id,  # TODO
+                        '_key__environment_id': environment_id,  # TODO
                         '_key_id': key,
                     })
 
@@ -435,7 +435,7 @@ class V2TagStorage(TagStorage):
                         filters={
                             'project_id': project_id,
                             'group_id': group_id,
-                            'environment_id': env,  # TODO
+                            '_key__environment_id': env,  # TODO
                             '_key_id': tagkey.id,
                             '_value_id': tagvalue.id,
                         },

--- a/src/sentry/tagstore/v2/models/eventtag.py
+++ b/src/sentry/tagstore/v2/models/eventtag.py
@@ -17,7 +17,6 @@ class EventTag(Model):
     __core__ = False
 
     project_id = BoundedPositiveIntegerField()
-    environment_id = BoundedPositiveIntegerField()
     group_id = BoundedPositiveIntegerField()
     event_id = BoundedPositiveIntegerField()
     key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
@@ -30,7 +29,6 @@ class EventTag(Model):
         index_together = (
             ('project_id', 'key', 'value'),
             ('group_id', 'key', 'value'),
-            ('environment_id', 'key', 'value'),
         )
 
     __repr__ = sane_repr('event_id', 'key', 'value')

--- a/src/sentry/tagstore/v2/models/grouptagkey.py
+++ b/src/sentry/tagstore/v2/models/grouptagkey.py
@@ -27,7 +27,6 @@ class GroupTagKey(Model):
 
     project_id = BoundedPositiveIntegerField(db_index=True)
     group_id = BoundedPositiveIntegerField(db_index=True)
-    environment_id = BoundedPositiveIntegerField(null=True)
     _key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
     values_seen = BoundedPositiveIntegerField(default=0)
 
@@ -35,9 +34,9 @@ class GroupTagKey(Model):
 
     class Meta:
         app_label = 'tagstore'
-        unique_together = (('project_id', 'group_id', 'environment_id', '_key'), )
+        unique_together = (('project_id', 'group_id', '_key'), )
 
-    __repr__ = sane_repr('project_id', 'group_id', 'environment_id', '_key')
+    __repr__ = sane_repr('project_id', 'group_id', '_key')
 
     @property
     def key(self):
@@ -50,12 +49,10 @@ class GroupTagKey(Model):
             with transaction.atomic(using=router.db_for_write(GroupTagKey)):
                 GroupTagKey.objects.filter(
                     group_id=new_group.id,
-                    environment_id=self.environment_id,
                     _key_id=self._key_id,
                 ).update(
                     values_seen=GroupTagValue.objects.filter(
                         group_id=new_group.id,
-                        environment_id=self.environment_id,
                         _key_id=self._key_id,
                     ).count()
                 )

--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -27,7 +27,6 @@ class GroupTagValue(Model):
 
     project_id = BoundedPositiveIntegerField(db_index=True)
     group_id = BoundedPositiveIntegerField(db_index=True)
-    environment_id = BoundedPositiveIntegerField(null=True)
     times_seen = BoundedPositiveIntegerField(default=0)
     _key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
     _value = FlexibleForeignKey('tagstore.TagValue', db_column='value_id')
@@ -40,7 +39,7 @@ class GroupTagValue(Model):
 
     class Meta:
         app_label = 'tagstore'
-        unique_together = (('project_id', 'group_id', 'environment_id', '_key', '_value'), )
+        unique_together = (('project_id', 'group_id', '_key', '_value'), )
         index_together = (('project_id', '_key', '_value', 'last_seen'), )
 
     __repr__ = sane_repr('project_id', 'group_id', '_key', '_value')
@@ -63,7 +62,6 @@ class GroupTagValue(Model):
             with transaction.atomic(using=router.db_for_write(GroupTagValue)):
                 new_obj = GroupTagValue.objects.get(
                     group_id=new_group.id,
-                    environment_id=self.environment_id,
                     _key_id=self._key_id,
                     _value_id=self._value_id,
                 )

--- a/src/sentry/tagstore/v2/models/tagvalue.py
+++ b/src/sentry/tagstore/v2/models/tagvalue.py
@@ -26,7 +26,6 @@ class TagValue(Model):
     __core__ = False
 
     project_id = BoundedPositiveIntegerField(db_index=True)
-    environment_id = BoundedPositiveIntegerField(null=True)
     _key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
     value = models.CharField(max_length=MAX_TAG_VALUE_LENGTH)
     data = GzippedDictField(blank=True, null=True)
@@ -40,10 +39,10 @@ class TagValue(Model):
 
     class Meta:
         app_label = 'tagstore'
-        unique_together = (('project_id', 'environment_id', '_key', 'value'), )
+        unique_together = (('project_id', '_key', 'value'), )
         index_together = (('project_id', '_key', 'last_seen'), )
 
-    __repr__ = sane_repr('project_id', 'environment_id', '_key', 'value')
+    __repr__ = sane_repr('project_id', '_key', 'value')
 
     @property
     def key(self):

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -148,7 +148,6 @@ class TagStorage(TestCase):
 
         assert TagValue.objects.filter(
             project_id=self.proj1.id,
-            environment_id=self.proj1env1.id,
             _key_id=tk.id,
             value=self.value1,
         ).count() == 1
@@ -224,7 +223,6 @@ class TagStorage(TestCase):
         assert GroupTagKey.objects.filter(
             project_id=self.proj1.id,
             group_id=self.proj1group1.id,
-            environment_id=self.proj1env1.id,
             _key_id=tk.id,
         ).count() == 1
         assert GroupTagKey.objects.all().count() == 1
@@ -301,7 +299,6 @@ class TagStorage(TestCase):
 
         tv = TagValue.objects.get(
             project_id=self.proj1.id,
-            environment_id=self.proj1env1.id,
             _key_id=tk.id,
             value=self.value1,
         )
@@ -310,7 +307,6 @@ class TagStorage(TestCase):
         assert GroupTagValue.objects.filter(
             project_id=self.proj1.id,
             group_id=self.proj1group1.id,
-            environment_id=self.proj1env1.id,
             _key_id=tk.id,
             _value_id=tv.id,
         ).count() == 1
@@ -335,7 +331,6 @@ class TagStorage(TestCase):
             assert EventTag.objects.get(
                 project_id=self.proj1.id,
                 group_id=self.proj1group1.id,
-                environment_id=self.proj1env1.id,
                 event_id=self.proj1group1event1.id,
                 key_id=k.id,
                 value_id=v.id,

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -148,6 +148,7 @@ class TagStorage(TestCase):
 
         assert TagValue.objects.filter(
             project_id=self.proj1.id,
+            _key__environment_id=self.proj1env1.id,
             _key_id=tk.id,
             value=self.value1,
         ).count() == 1
@@ -223,6 +224,7 @@ class TagStorage(TestCase):
         assert GroupTagKey.objects.filter(
             project_id=self.proj1.id,
             group_id=self.proj1group1.id,
+            _key__environment_id=self.proj1env1.id,
             _key_id=tk.id,
         ).count() == 1
         assert GroupTagKey.objects.all().count() == 1
@@ -299,6 +301,7 @@ class TagStorage(TestCase):
 
         tv = TagValue.objects.get(
             project_id=self.proj1.id,
+            _key__environment_id=self.proj1env1.id,
             _key_id=tk.id,
             value=self.value1,
         )
@@ -307,6 +310,7 @@ class TagStorage(TestCase):
         assert GroupTagValue.objects.filter(
             project_id=self.proj1.id,
             group_id=self.proj1group1.id,
+            _key__environment_id=self.proj1env1.id,
             _key_id=tk.id,
             _value_id=tv.id,
         ).count() == 1
@@ -331,6 +335,7 @@ class TagStorage(TestCase):
             assert EventTag.objects.get(
                 project_id=self.proj1.id,
                 group_id=self.proj1group1.id,
+                key__environment_id=self.proj1env1.id,
                 event_id=self.proj1group1event1.id,
                 key_id=k.id,
                 value_id=v.id,

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -257,7 +257,8 @@ class DeleteTagKeyTest(TestCase):
         )
 
         with self.tasks():
-            delete_tag_key_task(object_id=tk.id)
+            from sentry.tagstore.models import TagKey
+            delete_tag_key_task(object_id=tk.id, model=TagKey)
 
             try:
                 tagstore.get_group_tag_value(group.project_id, group.id, None, key, value)

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -421,7 +421,7 @@ class UnmergeTestCase(TestCase):
         ])
 
         if settings.SENTRY_TAGSTORE.startswith('sentry.tagstore.v2'):
-            env_filter = {'environment_id': environment.id}
+            env_filter = {'_key__environment_id': environment.id}
         else:
             env_filter = {}
 


### PR DESCRIPTION
The column was an unnecessary duplicate on everything but `TagKey` now that we use actual foreign keys. Other tables can filter on environment by doing a JOIN. Saves us some data/indexes.