### PR TITLE
fix: SentryInternalClient crashing on some log types.

### DIFF
--- a/src/sentry/utils/raven.py
+++ b/src/sentry/utils/raven.py
@@ -60,6 +60,10 @@ class SentryInternalClient(DjangoClient):
         if not is_current_event_safe():
             return
 
+        # Force raven-python encoding of this event, so that edge cases like
+        # non JSON-serializable objects are handled.
+        kwargs = self.decode(self.encode(kwargs))
+
         from sentry import tsdb
         from sentry.coreapi import ClientApiHelper
         from sentry.event_manager import EventManager


### PR DESCRIPTION
[Log messages from Django](https://docs.djangoproject.com/en/2.0/topics/logging/#django-request)
contain a `request` object which is not JSON serializable. The regular
Raven `Client` has a pretty bulletproof JSON encoder which handles these
objects, but SentryInternalClient didn't use it, so there is an
exception thrown further down the stack in `insert_data_to_database`
when it comes across these objects. This fix forces the Raven JSON
encoding of the event.

This is not a very efficient solution, but it is at least simple.