### PR TITLE
feat(api): Dont allow member updates to own membership

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -228,13 +228,15 @@ class UpdateOrganizationMemberTest(APITestCase):
         member_om = OrganizationMember.objects.get(id=member_om.id)
         assert member_om.role == 'admin'
 
-    def test_can_note_update_own_membership(self):
+    def test_can_not_update_own_membership(self):
         self.login_as(user=self.user)
 
         organization = self.create_organization(name='foo', owner=self.user)
 
+        member_om = OrganizationMember.objects.get(user_id=self.user.id)
+
         path = reverse(
-            'sentry-api-0-organization-member-details', args=[organization.slug, self.user.id]
+            'sentry-api-0-organization-member-details', args=[organization.slug, member_om.id]
         )
 
         self.login_as(self.user)
@@ -244,7 +246,7 @@ class UpdateOrganizationMemberTest(APITestCase):
         })
         assert resp.status_code == 400
 
-        member_om = OrganizationMember.objects.get(id=self.user.id)
+        member_om = OrganizationMember.objects.get(user_id=self.user.id)
         assert member_om.role == 'owner'
 
     def test_can_update_teams(self):


### PR DESCRIPTION
Also adds `isOnlyOwner` to member details response.