### PR TITLE
fix(ui): Fix UI permissions for role/team select in member details

### DIFF
--- a/src/sentry/static/sentry/app/views/inviteMember/inviteMember.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/inviteMember.jsx
@@ -191,6 +191,7 @@ const InviteMember = React.createClass({
             </div>
             {error && error.role && <p className="error alert-error">{error.role}</p>}
             <RoleSelect
+              enforceAllowed
               roleList={roleList}
               selectedRole={selectedRole}
               setRole={slug => this.setState({selectedRole: slug})}

--- a/src/sentry/static/sentry/app/views/inviteMember/roleSelect.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/roleSelect.jsx
@@ -7,13 +7,18 @@ import {t} from '../../locale';
 
 const RoleSelect = React.createClass({
   propTypes: {
+    /**
+     * Whether to disable or not using `allowed` prop from API request
+     */
+    enforceAllowed: PropTypes.bool,
+    disabled: PropTypes.bool,
     selectedRole: PropTypes.string,
     roleList: PropTypes.array,
     setRole: PropTypes.func,
   },
 
   render() {
-    let {roleList, selectedRole} = this.props;
+    let {disabled, enforceAllowed, roleList, selectedRole} = this.props;
 
     return (
       <div className="new-invite-team box">
@@ -24,14 +29,15 @@ const RoleSelect = React.createClass({
           <ul className="radio-inputs">
             {roleList.map((role, i) => {
               let {desc, name, id, allowed} = role;
+              let isDisabled = disabled || (enforceAllowed && !allowed);
               return (
                 <li
                   className="radio"
                   key={id}
-                  onClick={() => allowed && this.props.setRole(id)}
-                  style={allowed ? {} : {color: 'grey', cursor: 'default'}}
+                  onClick={() => !isDisabled && this.props.setRole(id)}
+                  style={!isDisabled ? {} : {color: 'grey', cursor: 'default'}}
                 >
-                  <label style={allowed ? {} : {cursor: 'default'}}>
+                  <label style={!isDisabled ? {} : {cursor: 'default'}}>
                     <Radio id={id} value={name} checked={id === selectedRole} readOnly />
                     {name}
                     <div className="help-block">{desc}</div>

--- a/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
@@ -7,13 +7,14 @@ import {t} from '../../locale';
 
 const TeamSelect = React.createClass({
   propTypes: {
+    disabled: PropTypes.bool,
     selectedTeams: PropTypes.instanceOf(Set),
     teams: PropTypes.array,
     toggleTeam: PropTypes.func,
   },
 
   render() {
-    let {teams, selectedTeams, toggleTeam} = this.props;
+    let {disabled, teams, selectedTeams, toggleTeam} = this.props;
     //no need to select a team when there's only one option
     if (teams.length < 2) return null;
     return (
@@ -27,6 +28,7 @@ const TeamSelect = React.createClass({
               <label className="checkbox">
                 <Checkbox
                   id={slug}
+                  disabled={disabled}
                   checked={selectedTeams.has(slug)}
                   onChange={e => {
                     toggleTeam(slug);

--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationMemberDetail.jsx
@@ -5,13 +5,14 @@ import {resendMemberInvite, updateMember} from '../../../../actionCreators/membe
 import {t} from '../../../../locale';
 import AsyncView from '../../../asyncView';
 import Button from '../../../../components/buttons/button';
+import ConfigStore from '../../../../stores/configStore';
 import DateTime from '../../../../components/dateTime';
 import IndicatorStore from '../../../../stores/indicatorStore';
 import NotFound from '../../../../components/errors/notFound';
-import recreateRoute from '../../../../utils/recreateRoute';
 import RoleSelect from '../../../inviteMember/roleSelect';
 import SentryTypes from '../../../../proptypes';
 import TeamSelect from '../../../inviteMember/teamSelect';
+import recreateRoute from '../../../../utils/recreateRoute';
 
 class OrganizationMemberDetail extends AsyncView {
   static contextTypes = {
@@ -64,7 +65,7 @@ class OrganizationMemberDetail extends AsyncView {
     })
       .then(() => {
         IndicatorStore.add('Saved', 'success', {duration: 5000});
-        let members = recreateRoute('members/', {
+        let members = recreateRoute('', {
           routes: this.props.routes,
           params: this.props.params,
           stepBack: -1,
@@ -128,6 +129,12 @@ class OrganizationMemberDetail extends AsyncView {
 
     let email = member.email;
     let inviteLink = member.invite_link;
+
+    let currentUser = ConfigStore.get('user');
+    let isCurrentUser = currentUser.email === email;
+    let disabled = isCurrentUser;
+    let roleSelectDisabled = disabled;
+    let teamSelectDisabled = disabled;
 
     return (
       <div>
@@ -204,6 +211,8 @@ class OrganizationMemberDetail extends AsyncView {
         </div>
 
         <RoleSelect
+          enforceAllowed={false}
+          disabled={roleSelectDisabled}
           roleList={member.roles}
           selectedRole={member.role}
           setRole={slug => this.setState({member: {...member, role: slug}})}
@@ -211,6 +220,7 @@ class OrganizationMemberDetail extends AsyncView {
 
         <TeamSelect
           teams={teams}
+          disabled={teamSelectDisabled}
           selectedTeams={new Set(member.teams)}
           toggleTeam={this.handleToggleTeam}
         />

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -69,6 +69,7 @@ exports[`CreateProject render() should render roles when available and allowed, 
         </TextField>
       </div>
       <RoleSelect
+        enforceAllowed={true}
         roleList={
           Array [
             Object {


### PR DESCRIPTION
Members detail was incorrectly using the same behavior as invite member (where roles are disabled for roles you cannot invite for).


Also disable UI controls if you're trying to modify your own membership details