### PR TITLE
Allowing to set a proxy for a request

### DIFF
--- a/src/sentry/http.py
+++ b/src/sentry/http.py
@@ -186,6 +186,7 @@ def safe_urlopen(
     allow_redirects=False,
     timeout=30,
     verify_ssl=True,
+    proxies=None,
     user_agent=None
 ):
     """
@@ -213,6 +214,9 @@ def safe_urlopen(
 
     if headers:
         kwargs['headers'] = headers
+
+    if proxies:
+        kwargs['proxies'] = proxies
 
     if method is None:
         method = 'POST' if (data or json) else 'GET'


### PR DESCRIPTION
Hi all!

With on-premise installation, sometimes connecting to the internet (mainly when using plugins like Slack, Github...) is allowed only using an internal proxy. But Sentry neither sentry-plugins give an option to configure it. 

This commit intend to be the first step to allow setting a proxy for a request, that could be configured someway like this in sentry.conf: 

sentry_proxies = {
  'https://hooks.slack.com': 'http://10.10.1.10:1080',
}

Ref: http://docs.python-requests.org/en/master/user/advanced/#proxies

What do you guys think? 
