### PR TITLE
ref: Change SentryInternalClient to use regular pipeline

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -781,6 +781,7 @@ SENTRY_LOGIN_URL = None
 
 # Default project ID (for internal errors)
 SENTRY_PROJECT = 1
+SENTRY_PROJECT_KEY = None
 
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT = None

--- a/src/sentry/utils/raven.py
+++ b/src/sentry/utils/raven.py
@@ -4,11 +4,14 @@ import copy
 import inspect
 import logging
 import raven
-import sentry
+import six
+import time
 
 from django.conf import settings
-from django.db.utils import DatabaseError
+from django.test import RequestFactory
 from raven.contrib.django.client import DjangoClient
+from raven.utils import get_auth_header
+from sentry.models import ProjectKey
 
 from . import metrics
 
@@ -27,6 +30,8 @@ def is_current_event_safe():
 
 
 class SentryInternalClient(DjangoClient):
+    request_factory = RequestFactory()
+
     def is_enabled(self):
         if getattr(settings, 'DISABLE_RAVEN', False):
             return False
@@ -43,9 +48,6 @@ class SentryInternalClient(DjangoClient):
         return super(SentryInternalClient, self).capture(*args, **kwargs)
 
     def send(self, **kwargs):
-        # TODO(dcramer): this should respect rate limits/etc and use the normal
-        # pipeline
-
         # Report the issue to an upstream Sentry if active
         # NOTE: we don't want to check self.is_enabled() like normal, since
         # is_enabled behavior is overridden in this class. We explicitly
@@ -60,69 +62,38 @@ class SentryInternalClient(DjangoClient):
         if not is_current_event_safe():
             return
 
-        # Force raven-python encoding of this event, so that edge cases like
-        # non JSON-serializable objects are handled.
-        kwargs = self.decode(self.encode(kwargs))
+        key = None
+        if settings.SENTRY_PROJECT_KEY is not None:
+            key = ProjectKey.objects.filter(
+                id=settings.SENTRY_PROJECT_KEY,
+                project=settings.SENTRY_PROJECT).first()
+        if key is None:
+            key = ProjectKey.get_default(settings.SENTRY_PROJECT)
+        if key is None:
+            return
 
-        from sentry import tsdb
-        from sentry.coreapi import ClientApiHelper
-        from sentry.event_manager import EventManager
-        from sentry.models import Project
-
-        helper = ClientApiHelper(
-            agent='raven-python/%s (sentry %s)' % (raven.VERSION, sentry.VERSION),
-            project_id=settings.SENTRY_PROJECT,
-            version=self.protocol_version,
+        client_string = 'raven-python/%s' % (raven.VERSION,)
+        headers = {
+            'HTTP_X_SENTRY_AUTH': get_auth_header(
+                protocol=self.protocol_version,
+                timestamp=time.time(),
+                client=client_string,
+                api_key=key.public_key,
+                api_secret=key.secret_key,
+            ),
+            'HTTP_CONTENT_ENCODING': self.get_content_encoding(),
+        }
+        request = self.request_factory.post(
+            '/api/store',
+            data=self.encode(kwargs),
+            content_type='application/octet-stream',
+            **headers
         )
-
-        try:
-            project = Project.objects.get_from_cache(id=settings.SENTRY_PROJECT)
-        except DatabaseError:
-            self.error_logger.error('Unable to fetch internal project', exc_info=True)
-            return
-        except Project.DoesNotExist:
-            self.error_logger.error(
-                'Internal project (id=%s) does not exist', settings.SENTRY_PROJECT
-            )
-            return
-        except Exception:
-            self.error_logger.error(
-                'Unable to fetch internal project for some unknown reason', exc_info=True
-            )
-            return
-
-        helper.context.bind_project(project)
-
-        metrics.incr('events.total')
-
-        kwargs['project'] = project.id
-        try:
-            # This in theory is the right way to do it because validate
-            # also normalizes currently, but we just send in data already
-            # normalised in the raven client now.
-            # data = helper.validate_data(kwargs)
-            data = kwargs
-            manager = EventManager(data)
-            data = manager.normalize()
-            tsdb.incr_multi(
-                [
-                    (tsdb.models.project_total_received, project.id),
-                    (tsdb.models.organization_total_received, project.organization_id),
-                ]
-            )
-            helper.insert_data_to_database(data)
-        except Exception as e:
-            if self.raise_send_errors:
-                raise
-            message = kwargs.get('message')
-            if not message:
-                msg_interface = kwargs.get('sentry.interface.Message', {})
-                message = msg_interface.get(
-                    'formatted', msg_interface.get('message', 'unknown error')
-                )
-            self.error_logger.error(
-                'Unable to record event: %s\nEvent was: %r', e, message, exc_info=True
-            )
+        from sentry.web.api import StoreView
+        StoreView.as_view()(
+            request,
+            project_id=six.text_type(settings.SENTRY_PROJECT),
+        )
 
 
 class SentryInternalFilter(logging.Filter):


### PR DESCRIPTION
Send the event to the StoreApi view so that it goes through all the
regular steps instead of reimplementing them in this Client.