### PR TITLE
feat: No longer require secret in dsn

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -368,7 +368,10 @@ class MinidumpApiHelper(ClientApiHelper):
         if not key:
             raise APIUnauthorized('Unable to find authentication information')
 
-        auth = Auth({'sentry_key': key}, is_public=True)
+        # Minidump requests are always "trusted".  We at this point only
+        # use is_public to identify requests that have an origin set (via
+        # CORS)
+        auth = Auth({'sentry_key': key}, is_public=False)
         auth.client = 'sentry-minidump'
         return auth
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -227,14 +227,6 @@ class APIView(BaseView):
             project.organization = Organization.objects.get_from_cache(
                 id=project.organization_id)
 
-            if auth.version != '2.0' and \
-               origin is not None and not is_valid_origin(origin, project):
-                if project:
-                    tsdb.incr(
-                        tsdb.models.project_total_received_cors, project.id)
-                raise APIForbidden(
-                    'Missing required Origin or Referer header')
-
             response = super(APIView, self).dispatch(
                 request=request, project=project, auth=auth, helper=helper, key=key, **kwargs
             )

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -227,26 +227,13 @@ class APIView(BaseView):
             project.organization = Organization.objects.get_from_cache(
                 id=project.organization_id)
 
-            if auth.version != '2.0':
-                if not auth.secret_key:
-                    # If we're missing a secret_key, check if we are allowed
-                    # to do a CORS request.
-
-                    # If we're missing an Origin/Referrer header entirely,
-                    # we only want to support this on GET requests. By allowing
-                    # un-authenticated CORS checks for POST, we basially
-                    # are obsoleting our need for a secret key entirely.
-                    if origin is None and request.method != 'GET':
-                        raise APIForbidden(
-                            'Missing required attribute in authentication header: sentry_secret'
-                        )
-
-                    if not is_valid_origin(origin, project):
-                        if project:
-                            tsdb.incr(
-                                tsdb.models.project_total_received_cors, project.id)
-                        raise APIForbidden(
-                            'Missing required Origin or Referer header')
+            if auth.version != '2.0' and \
+               origin is not None and not is_valid_origin(origin, project):
+                if project:
+                    tsdb.incr(
+                        tsdb.models.project_total_received_cors, project.id)
+                raise APIForbidden(
+                    'Missing required Origin or Referer header')
 
             response = super(APIView, self).dispatch(
                 request=request, project=project, auth=auth, helper=helper, key=key, **kwargs

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -227,13 +227,6 @@ class SentryRemoteTest(TestCase):
         instance = Event.objects.get()
         assert instance.message == 'hello'
 
-    @override_settings(SENTRY_ALLOW_ORIGIN='sentry.io')
-    def test_get_without_referer(self):
-        self.project.update_option('sentry:origins', '')
-        kwargs = {'message': 'hello'}
-        resp = self._getWithReferer(kwargs, referer=None, protocol='4')
-        assert resp.status_code == 403, (resp.status_code, resp.get('X-Sentry-Error'))
-
     @override_settings(SENTRY_ALLOW_ORIGIN='*')
     def test_get_without_referer_allowed(self):
         self.project.update_option('sentry:origins', '')
@@ -248,20 +241,6 @@ class SentryRemoteTest(TestCase):
         assert resp.status_code == 200, resp.content
         instance = Event.objects.get()
         assert instance.message == 'hello'
-
-    @override_settings(SENTRY_ALLOW_ORIGIN='sentry.io')
-    def test_post_without_referer(self):
-        self.project.update_option('sentry:origins', '')
-        kwargs = {'message': 'hello'}
-        resp = self._postWithReferer(kwargs, referer=None, protocol='4')
-        assert resp.status_code == 403, (resp.status_code, resp.get('X-Sentry-Error'))
-
-    @override_settings(SENTRY_ALLOW_ORIGIN='*')
-    def test_post_without_referer_allowed(self):
-        self.project.update_option('sentry:origins', '')
-        kwargs = {'message': 'hello'}
-        resp = self._postWithReferer(kwargs, referer=None, protocol='4')
-        assert resp.status_code == 403, (resp.status_code, resp.get('X-Sentry-Error'))
 
     def test_signature(self):
         kwargs = {'message': 'hello'}

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -242,6 +242,20 @@ class SentryRemoteTest(TestCase):
         instance = Event.objects.get()
         assert instance.message == 'hello'
 
+    @override_settings(SENTRY_ALLOW_ORIGIN='sentry.io')
+    def test_post_without_referer(self):
+        self.project.update_option('sentry:origins', '')
+        kwargs = {'message': 'hello'}
+        resp = self._postWithReferer(kwargs, referer=None, protocol='4')
+        assert resp.status_code == 200, (resp.status_code, resp.get('X-Sentry-Error'))
+
+    @override_settings(SENTRY_ALLOW_ORIGIN='*')
+    def test_post_without_referer_allowed(self):
+        self.project.update_option('sentry:origins', '')
+        kwargs = {'message': 'hello'}
+        resp = self._postWithReferer(kwargs, referer=None, protocol='4')
+        assert resp.status_code == 200, (resp.status_code, resp.get('X-Sentry-Error'))
+
     def test_signature(self):
         kwargs = {'message': 'hello'}
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -232,7 +232,7 @@ class SentryRemoteTest(TestCase):
         self.project.update_option('sentry:origins', '')
         kwargs = {'message': 'hello'}
         resp = self._getWithReferer(kwargs, referer=None, protocol='4')
-        assert resp.status_code == 200, (resp.status_code, resp.get('X-Sentry-Error'))
+        assert resp.status_code == 200, resp.content
 
     @override_settings(SENTRY_ALLOW_ORIGIN='sentry.io')
     def test_correct_data_with_post_referer(self):
@@ -247,14 +247,25 @@ class SentryRemoteTest(TestCase):
         self.project.update_option('sentry:origins', '')
         kwargs = {'message': 'hello'}
         resp = self._postWithReferer(kwargs, referer=None, protocol='4')
-        assert resp.status_code == 200, (resp.status_code, resp.get('X-Sentry-Error'))
+        assert resp.status_code == 200, resp.content
 
     @override_settings(SENTRY_ALLOW_ORIGIN='*')
     def test_post_without_referer_allowed(self):
         self.project.update_option('sentry:origins', '')
         kwargs = {'message': 'hello'}
         resp = self._postWithReferer(kwargs, referer=None, protocol='4')
-        assert resp.status_code == 200, (resp.status_code, resp.get('X-Sentry-Error'))
+        assert resp.status_code == 200, resp.content
+
+    @override_settings(SENTRY_ALLOW_ORIGIN='google.com')
+    def test_post_with_invalid_origin(self):
+        self.project.update_option('sentry:origins', 'sentry.io')
+        kwargs = {'message': 'hello'}
+        resp = self._postWithReferer(
+            kwargs,
+            referer='https://getsentry.net',
+            protocol='4'
+        )
+        assert resp.status_code == 403, resp.content
 
     def test_signature(self):
         kwargs = {'message': 'hello'}


### PR DESCRIPTION
This pull request removes the requirement to have a secret key
for submissions.  The security improvements of the secret key have
become less and less useful as SDKs started to ship the secret key
to clients and we do not have much logic on the server any more that
draws a line between public and non public requests.

Now a request is public if an origin is set.