### PR TITLE
fix(user reports): properly align feedback date

### DIFF
--- a/src/sentry/static/sentry/app/components/events/userReport.jsx
+++ b/src/sentry/static/sentry/app/components/events/userReport.jsx
@@ -23,27 +23,29 @@ const EventUserReport = React.createClass({
             <li className="activity-note">
               <Avatar user={report} size={64} className="avatar" />
               <div className="activity-bubble">
-                <TimeSince date={report.dateCreated} />
-                <div className="activity-author">
-                  {report.name}
-                  <small>{report.email}</small>
-                  {/* event_id might be undefined for legacy accounts */}
-                  {report.event.id && (
-                    <small>
-                      <Link
-                        to={`/${orgId}/${projectId}/issues/${issueId}/events/${report
-                          .event.id}`}
-                      >
-                        View event
-                      </Link>
-                    </small>
-                  )}
+                <div>
+                  <TimeSince date={report.dateCreated} />
+                  <div className="activity-author">
+                    {report.name}
+                    <small>{report.email}</small>
+                    {/* event_id might be undefined for legacy accounts */}
+                    {report.event.id && (
+                      <small>
+                        <Link
+                          to={`/${orgId}/${projectId}/issues/${issueId}/events/${report
+                            .event.id}`}
+                        >
+                          View event
+                        </Link>
+                      </small>
+                    )}
+                  </div>
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: utils.nl2br(utils.urlize(utils.escape(report.comments))),
+                    }}
+                  />
                 </div>
-                <p
-                  dangerouslySetInnerHTML={{
-                    __html: utils.nl2br(utils.urlize(utils.escape(report.comments))),
-                  }}
-                />
               </div>
             </li>
           </ul>


### PR DESCRIPTION
This adds a missing div that's apparently needed to align the date properly.

Before:

<img width="777" alt="screen shot 2017-12-18 at 2 27 19 pm" src="https://user-images.githubusercontent.com/30713/34131233-a12d4394-e3ff-11e7-8b90-eeacdbd70e99.png">

After:

<img width="777" alt="screen shot 2017-12-18 at 2 26 29 pm" src="https://user-images.githubusercontent.com/30713/34131216-8943b04c-e3ff-11e7-868e-014ff5e41fce.png">

