### PR TITLE
fix(trials): Add hookstore and url for getsentry org chooser react page

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -346,6 +346,11 @@ function routes() {
     hooksOrgRoutes.push(cb());
   });
 
+  let hooksPreOrgRoutes = [];
+  HookStore.get('routes:pre-organization').forEach(cb => {
+    hooksPreOrgRoutes.push(cb());
+  });
+
   return (
     <Route path="/" component={errorHandler(App)}>
       <Route path="/account/" component={errorHandler(AccountLayout)}>
@@ -422,7 +427,7 @@ function routes() {
           />
         </Route>
       </Route>
-
+      {hooksPreOrgRoutes}
       <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <IndexRoute component={errorHandler(OrganizationDashboard)} />
 

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -10,6 +10,7 @@ let validHookNames = new Set([
   'organization:dashboard:secondary-column',
   'routes',
   'routes:admin',
+  'routes:pre-organization',
   'routes:organization',
   'project:data-forwarding:disabled',
   'project:rate-limits:disabled',

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -342,6 +342,7 @@ urlpatterns += patterns(
     # Organizations
     url(r'^(?P<organization_slug>[\w_-]+)/$',
         react_page_view, name='sentry-organization-home'),
+    url(r'^organizations/chooser/$', generic_react_page_view),
     url(r'^organizations/new/$', generic_react_page_view),
     url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/api-keys/$',


### PR DESCRIPTION
This integrates the getsentry route for the `OrganizationChooser` react page from [this gs pr #1606](https://github.com/getsentry/getsentry/pull/1606) which is currently in review. 