### PR TITLE
feat: Add reprocessing revisions

### DIFF
--- a/src/sentry/models/dsymfile.py
+++ b/src/sentry/models/dsymfile.py
@@ -34,7 +34,8 @@ from sentry.db.models import FlexibleForeignKey, Model, \
 from sentry.models.file import File
 from sentry.utils.zip import safe_extract_zip
 from sentry.constants import KNOWN_DSYM_TYPES
-from sentry.reprocessing import resolve_processing_issue
+from sentry.reprocessing import resolve_processing_issue, \
+    bump_reprocessing_revision
 
 
 logger = logging.getLogger(__name__)
@@ -351,6 +352,9 @@ def create_files_from_dsym_zip(fileobj, project,
             if uuids_to_update:
                 symcache_update.delay(project_id=project.id,
                                       uuids=uuids_to_update)
+
+        # Uploading new dsysm changes the reprocessing revision
+        bump_reprocessing_revision(project)
 
         return rv
     finally:

--- a/src/sentry/reprocessing.py
+++ b/src/sentry/reprocessing.py
@@ -1,5 +1,34 @@
 from __future__ import absolute_import
 
+import uuid
+
+
+REPROCESSING_OPTION = 'sentry:processing-rev'
+
+
+def get_reprocessing_revision(project, cached=True):
+    """Returns the current revision of the projects reprocessing config set."""
+    from sentry.models import ProjectOption, Project
+    if cached:
+        return ProjectOption.objects.get_value(project, REPROCESSING_OPTION)
+    try:
+        if isinstance(project, Project):
+            project = project.id
+        return ProjectOption.objects.get(
+            project=project,
+            key=REPROCESSING_OPTION
+        )
+    except ProjectOption.DoesNotExist:
+        pass
+
+
+def bump_reprocessing_revision(project):
+    """Bumps the reprocessing revision."""
+    from sentry.models import ProjectOption
+    rev = uuid.uuid4().hex
+    ProjectOption.objects.set_value(project, REPROCESSING_OPTION, rev)
+    return rev
+
 
 def report_processing_issue(event_data, scope, object=None, type=None, data=None):
     """Reports a processing issue for a given scope and object.  Per


### PR DESCRIPTION
We update a hash in the project option set every time we upload new
debug symbols so that we do not get into concurrency issues when
reprocessing issues are created.

Before if a task was failing with a processing issue while the issue was
resolve a processing issue could be persisted forever.  How instead of
persisting a processing issue we immediately retry the task in case the
reprocessing revision changed.