### PR TITLE
fix: select2 field in custom ignore count modal

### DIFF
--- a/src/sentry/static/sentry/app/components/customIgnoreCountModal.jsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreCountModal.jsx
@@ -58,11 +58,9 @@ export default React.createClass({
             <div className="control-group m-b-1">
               <h6 className="nav-header">{t('Time window')}</h6>
               <Select2Field
-                className="form-control"
                 value={window}
                 name="window"
                 onChange={v => this.onChange('window', v)}
-                style={{padding: '3px 10px'}}
                 choices={[['', ' '], ...this.props.windowChoices]}
                 placeholder={t('e.g. per hour')}
                 allowClear={true}


### PR DESCRIPTION
![sentry-slack-test-mq4ayywhtw ngrok io_default_heart_issues_37_ 1](https://user-images.githubusercontent.com/1421724/34185968-7e17797c-e4dd-11e7-9cc2-c73f660c5dfa.png)
↓
![sentry-slack-test-mq4ayywhtw ngrok io_default_heart_issues_37_](https://user-images.githubusercontent.com/1421724/34185969-7e3602c0-e4dd-11e7-8fe7-b61cb6bc5c54.png)
