### PR TITLE
fix: Fill in {{auto}} IPs on aliased interfaces.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -340,8 +340,14 @@ class EventManager(object):
             if get_path(data, ['sentry.interfaces.Http', 'env', 'REMOTE_ADDR']) == '{{auto}}':
                 data['sentry.interfaces.Http']['env']['REMOTE_ADDR'] = client_ip
 
+            if get_path(data, ['request', 'env', 'REMOTE_ADDR']) == '{{auto}}':
+                data['request']['env']['REMOTE_ADDR'] = client_ip
+
             if get_path(data, ['sentry.interfaces.User', 'ip_address']) == '{{auto}}':
                 data['sentry.interfaces.User']['ip_address'] = client_ip
+
+            if get_path(data, ['user', 'ip_address']) == '{{auto}}':
+                data['user']['ip_address'] = client_ip
 
         # Validate main event body and tags against schema
         is_valid, event_errors = validate_and_default_interface(data, 'event')

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -565,6 +565,14 @@ class EnsureHasIpTest(BaseAPITest):
         self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.User']['ip_address'] == '127.0.0.1'
 
+        out = {
+            'user': {
+                'ip_address': '{{auto}}',
+            },
+        }
+        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        assert out['sentry.interfaces.User']['ip_address'] == '127.0.0.1'
+
     def test_without_ip_values(self):
         out = {
             'platform': 'javascript',


### PR DESCRIPTION
Sometimes 'sentry.interfaces.User' is just sent as 'user', and we need
to fill in ip addresses marked '{{auto}}' before we have resolved the
interfaces to their canonical names.