### PR TITLE
fix(native): Fix a bad ctor call to LineInfo

### DIFF
--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -250,6 +250,7 @@ class Symbolizer(object):
                 sym_addr=parse_addr(symbolserver_match['addr']),
                 instr_addr=parse_addr(instruction_addr),
                 line=None,
+                lang=None,
                 symbol=symbol,
             ), obj, package=symbolserver_match['object_name'])
         ]


### PR DESCRIPTION
This fixes SENTRY-5FK