### PR TITLE
If device.model not defined return null isntead of ''

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -86,7 +86,7 @@ class DeviceContextType extends React.Component {
         knownData={[
           ['?Name', name],
           ['?Family', family],
-          ['?Model', model + (model_id ? ` (${model_id})` : '')],
+          ['?Model', model + (model_id ? ` (${model_id})` : null)],
           ['?Architecture', arch],
           ['?Battery Level', defined(battery_level) ? `${battery_level}%` : null],
           ['?Orientation', orientation],


### PR DESCRIPTION
I think I see the problem here. Returning an empty string instead of null.

https://github.com/getsentry/sentry/issues/6830