### PR TITLE
feat(minidump): Allow to pass event data in minidump request

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -37,6 +37,7 @@ python-dateutil>=2.0.0,<3.0.0
 python-memcached>=1.53,<2.0.0
 python-openid>=2.2
 PyYAML>=3.11,<3.12
+querystring_parser>=1.2.3,<2.0.0
 raven>=5.29.0,<6.0.0
 redis>=2.10.3,<2.10.6
 requests[security]>=2.18.4,<2.19.0

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -27,7 +27,6 @@ from sentry import filters
 from sentry.cache import default_cache
 from sentry.interfaces.csp import Csp
 from sentry.event_manager import EventManager
-from sentry.lang.native.utils import merge_minidump_event
 from sentry.models import ProjectKey
 from sentry.tasks.store import preprocess_event, \
     preprocess_event_from_reprocessing
@@ -381,50 +380,6 @@ class MinidumpApiHelper(ClientApiHelper):
         auth = Auth({'sentry_key': key}, is_public=True)
         auth.client = 'sentry-minidump'
         return auth
-
-    def validate_data(self, data):
-        try:
-            release = data.pop('release')
-        except KeyError:
-            release = None
-
-        # Minidump request payloads do not have the same structure as
-        # usual events from other SDKs. Most importantly, all parameters
-        # passed in the POST body are only "extra" information. The
-        # actual information is in the "upload_file_minidump" field.
-
-        # At this point, we only extract the bare minimum information
-        # needed to continue processing. If all validations pass, the
-        # event will be inserted into the database, at which point we
-        # can process the minidump and extract a little more information.
-
-        validated = {
-            'platform': 'native',
-            'extra': data,
-            'errors': [],
-            'sentry.interfaces.User': {
-                'ip_address': self.context.ip_address,
-            },
-        }
-
-        # Copy/pasted from above in ClientApiHelper.validate_data
-        if release:
-            release = six.text_type(release)
-
-        return validated
-
-    def insert_data_to_database(self, data, start_time=None, from_reprocessing=False):
-        # Seems like the event is valid and we can do some more expensive
-        # work on the minidump. We process the minidump to extract some more
-        # information to populate the initial callstacks and exception
-        # information.
-        minidump = data['extra'].pop('upload_file_minidump')
-        merge_minidump_event(data, minidump.temporary_file_path())
-
-        # Continue with persisting the event in the usual manner and
-        # schedule default preprocessing tasks
-        super(MinidumpApiHelper, self).insert_data_to_database(
-            data, start_time, from_reprocessing)
 
 
 class CspApiHelper(ClientApiHelper):

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -26,6 +26,11 @@ MINIDUMP_OS_TYPES = {
     'Mac OS X': 'macOS',
 }
 
+# Mapping of well-known minidump CPU families to our internal names
+MINIDUMP_CPU_FAMILIES = {
+    'amd64': 'x86_64',
+}
+
 AppInfo = namedtuple('AppInfo', ['id', 'version', 'build', 'name'])
 
 
@@ -168,7 +173,7 @@ def merge_minidump_event(data, minidump_path):
     device = context.setdefault('device', {})
     os['type'] = 'os'  # Required by "get_sdk_from_event"
     os['name'] = MINIDUMP_OS_TYPES.get(info.os_name, info.os_name)
-    device['arch'] = info.cpu_family
+    device['arch'] = MINIDUMP_CPU_FAMILIES.get(info.cpu_family, info.cpu_family)
 
     # Breakpad reports the version and build number always in one string,
     # but a version number is guaranteed even on certain linux distros.


### PR DESCRIPTION
Allows passing fields of the sentry event interface via the `sentry` form field in minidump POST requests. All other fields are assigned as `extra` inside the event. Uses `querystring_parser` to construct a nested object from the bracket syntax (`foo[bar][0][blubb]`).

The event is then passed to the usual `process()` which also normalizes the data.

**Example:**

```
# request.POST
{
  'sentry[release]': 'test',
  'sentry[context][os][name]: 'foo',
  'something': 'else',
}

# event before minidump merge
{
  'release': u'test',
  'context': {
    'os': {'name': 'foo'},
  },
  'extra': {
    'something': 'else',
  },
}
```