### PR TITLE
 fix(minidump): Handle Temporary and InMemory uploaded files

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -48,7 +48,7 @@ setproctitle>=1.1.7,<1.2.0
 statsd>=3.1.0,<3.2.0
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=2.0.0,<3.0.0
+symbolic>=2.0.1,<3.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -586,7 +586,7 @@ class MinidumpView(StoreView):
         except KeyError:
             raise APIError('Missing minidump upload')
 
-        merge_minidump_event(data, minidump.temporary_file_path())
+        merge_minidump_event(data, minidump)
         response_or_event_id = self.process(request, data=data, **kwargs)
         if isinstance(response_or_event_id, HttpResponse):
             return response_or_event_id


### PR DESCRIPTION
Implements support for both `InMemoryUploadedFile` and `TemporaryUploadedFile` when processing minidumps. Depends on getsentry/symbolic#32 and getsentry/sentry#6844.
The actual change is just the last commit.