### PR TITLE
fix: Trim user id properly

### DIFF
--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -57,9 +57,9 @@ class User(Interface):
         if not isinstance(extra_data, dict):
             extra_data = {}
 
-        ident = trim(data.pop('id', None), 128)
+        ident = data.pop('id', None)
         if ident:
-            ident = six.text_type(ident)
+            ident = trim(six.text_type(ident), 128)
         try:
             email = trim(validate_email(data.pop('email', None), False), MAX_EMAIL_FIELD_LENGTH)
         except ValueError:

--- a/tests/sentry/interfaces/test_user.py
+++ b/tests/sentry/interfaces/test_user.py
@@ -52,6 +52,12 @@ class UserTest(TestCase):
                 email='foo',
             ))
 
+    def test_id_long_dict(self):
+        u = User.to_python({
+            'id': {x: 'foobarbaz' for x in range(10)},  # dict longer than 128 chars
+        })
+        assert len(u.to_json()['id']) == 128
+
     def test_serialize_unserialize_behavior(self):
         result = type(self.interface).to_python(self.interface.to_json())
         assert result.to_json() == self.interface.to_json()


### PR DESCRIPTION
When the user id was a dict, it was not being trimmed properly to 128
chars because it was being serialized after being trimmed.

fixes: SENTRY-58T