### PR TITLE
ref(minidump): Use breakpad arch parser from symbolic

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -48,7 +48,7 @@ setproctitle>=1.1.7,<1.2.0
 statsd>=3.1.0,<3.2.0
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=2.0.1,<3.0.0
+symbolic>=2.0.2,<3.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -6,7 +6,7 @@ import logging
 
 from collections import namedtuple
 from django.core.files.uploadedfile import InMemoryUploadedFile, TemporaryUploadedFile
-from symbolic import parse_addr, arch_from_macho, arch_is_known, ProcessState
+from symbolic import parse_addr, arch_from_breakpad, arch_from_macho, arch_is_known, ProcessState
 
 from sentry.interfaces.contexts import DeviceContextType
 
@@ -25,11 +25,6 @@ VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)\s+(.*)')
 # Mapping of well-known minidump OS constants to our internal names
 MINIDUMP_OS_TYPES = {
     'Mac OS X': 'macOS',
-}
-
-# Mapping of well-known minidump CPU families to our internal names
-MINIDUMP_CPU_FAMILIES = {
-    'amd64': 'x86_64',
 }
 
 AppInfo = namedtuple('AppInfo', ['id', 'version', 'build', 'name'])
@@ -179,7 +174,7 @@ def merge_minidump_event(data, minidump):
     device = context.setdefault('device', {})
     os['type'] = 'os'  # Required by "get_sdk_from_event"
     os['name'] = MINIDUMP_OS_TYPES.get(info.os_name, info.os_name)
-    device['arch'] = MINIDUMP_CPU_FAMILIES.get(info.cpu_family, info.cpu_family)
+    device['arch'] = arch_from_breakpad(info.cpu_family)
 
     # Breakpad reports the version and build number always in one string,
     # but a version number is guaranteed even on certain linux distros.


### PR DESCRIPTION
Symbolic `2.0.2` release is currently in progress.