### PR TITLE
fix(ui): keep icon circle exclamation stroke from exceeding viewbox

### DIFF
--- a/src/sentry/static/sentry/app/icons/icon-circle-exclamation.svg
+++ b/src/sentry/static/sentry/app/icons/icon-circle-exclamation.svg
@@ -1,7 +1,7 @@
-<svg viewBox="0 0 15 15">
+<svg viewBox="0 0 18 18">
   <g stroke="currentColor" fill="none" stroke-linejoin="round" stroke-linecap="round">
-    <circle cx="7.5" cy="7.5" r="7" />
-    <path d="M7.5,3.5 L7.5,8.5" />
-    <path d="M7.5,10.5 L7.5,11.5" />
+    <circle cx="9" cy="9" r="8"></circle>
+    <path d="M9,5 L9,10"></path>
+    <path d="M9,12 L9,13"></path>
   </g>
 </svg>

--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -11,7 +11,7 @@ import SettingsHeader from './components/settingsHeader';
 import SettingsSearch from './components/settingsSearch';
 
 const StyledIconCircleExclamation = styled(props => (
-  <InlineSvg size="32px" src="icon-circle-exclamation" {...props} />
+  <InlineSvg size="36px" src="icon-circle-exclamation" {...props} />
 ))`
   color: ${p => p.theme.blue};
   opacity: 0.6;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/435981/34543900-219c1ede-f098-11e7-92b6-77fb94720551.png)

![image](https://user-images.githubusercontent.com/435981/34543886-0f6a40d8-f098-11e7-966f-7c518ccad77e.png)

Stroked circles in svg render funny. As the viewbox expands you will get crop errors because the stroke as it is rendered is different from the circle as a vector.

There really isn't a fabulous way to fix this that I know of, other than converting everything to fills, but opening up the viewbox seemed like a good place to start.


  