### PR TITLE
feat(ui): Change `<LazyLoad>` and code split Account Notifications

### DIFF
--- a/docs-ui/components/lazyLoad.stories.js
+++ b/docs-ui/components/lazyLoad.stories.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import LazyLoad from 'sentry-ui/lazyLoad';
+
+storiesOf('LazyLoad', module).add(
+  'default',
+  withInfo('Lazy loads a view/component')(() => {
+    const MyComponent = () => (
+      <div>View that is loaded after 1000ms to simulate dynamic import</div>
+    );
+
+    const getComponent = () =>
+      new Promise(resolve => setTimeout(() => resolve(MyComponent), 1000));
+
+    return <LazyLoad component={getComponent} />;
+  })
+);

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "dev-proxy": "node scripts/devproxy.js",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=375,1280"
+    "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=375,1280",
+    "webpack-profile": "yarn -s webpack --profile --json > stats.json"
   },
   "jest": {
     "snapshotSerializers": [
@@ -111,6 +112,7 @@
     ],
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/tests/js/helpers/importStyleMock.js",
+      "\\.(svg)$": "<rootDir>/tests/js/helpers/svgMock.js",
       "jquery": "<rootDir>/src/sentry/static/sentry/__mocks__/jquery.jsx",
       "integration-docs-platforms": "<rootDir>/tests/fixtures/integration-docs/_platforms.json"
     },

--- a/src/sentry/static/sentry/app/components/lazyLoad.jsx
+++ b/src/sentry/static/sentry/app/components/lazyLoad.jsx
@@ -1,35 +1,123 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import Raven from 'raven-js';
+import React from 'react';
 
+import {t} from '../locale';
+import LoadingError from './loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 
 class LazyLoad extends React.Component {
   static propTypes = {
     hideBusy: PropTypes.bool,
+    hideError: PropTypes.bool,
     /**
-     * specifically needs to be a thenable
+     * Function that returns a promise of a React.Component
+     * Alias property for `getComponent` to maintain compatibility w/ existing components
      */
     component: PropTypes.func,
+
+    /**
+     * Function that returns a promise of a React.Component
+     */
+    getComponent: PropTypes.func,
+
+    /**
+     * Also accepts a route object from react-router that has a `getComponent` property
+     */
+    route: PropTypes.shape({
+      path: PropTypes.string,
+      getComponent: PropTypes.func,
+    }),
   };
 
   constructor(...args) {
     super(...args);
     this.state = {
       Component: null,
+      error: null,
     };
   }
 
   componentDidMount() {
-    this.props.component().then(Component => {
-      this.setState({Component});
-    });
+    this.fetchComponent();
   }
 
+  componentWillReceiveProps(nextProps, nextState) {
+    // This is to handle the following case:
+    // <Route path="a/">
+    //   <Route path="b/" component={LazyLoad} getComponent={...} />
+    //   <Route path="c/" component={LazyLoad} getComponent={...} />
+    // </Route>
+    //
+    // `LazyLoad` will get not fully remount when we switch between `b` and `c`,
+    // instead will just re-render.  Refetch if route paths are different
+    if (nextProps.route && nextProps.route.path === this.props.route.path) return;
+
+    // If `this.fetchComponent` is not in callback,
+    // then there's no guarantee that new Component will be rendered
+    this.setState(
+      {
+        Component: null,
+      },
+      this.fetchComponent
+    );
+  }
+
+  getComponentGetter = () =>
+    this.props.component || this.props.getComponent || this.props.route.getComponent;
+
+  fetchComponent = () => {
+    let getComponent = this.getComponentGetter();
+
+    getComponent()
+      .then(
+        Component => {
+          this.setState({
+            Component,
+          });
+        },
+        err => {
+          this.setState({
+            error: err,
+          });
+        }
+      )
+      .catch(err => {
+        // eslint-disable-next-line no-console
+        console.warn(err);
+        Raven.captureException(err);
+        this.setState({
+          error: err,
+        });
+      });
+  };
+
+  fetchRetry = () => {
+    this.setState(
+      {
+        error: null,
+      },
+      () => this.fetchComponent()
+    );
+  };
+
   render() {
+    let {Component, error} = this.state;
     // eslint-disable-next-line no-unused-vars
-    let {hideBusy, component, ...otherProps} = this.props;
-    if (!this.state.Component && !hideBusy) return <LoadingIndicator />;
-    return <this.state.Component {...otherProps} />;
+    let {hideBusy, hideError, component, getComponent, ...otherProps} = this.props;
+
+    if (error && !hideError) {
+      return (
+        <LoadingError
+          onRetry={this.fetchRetry}
+          message={t('There was an error loading a component.')}
+        />
+      );
+    }
+
+    if (!Component && !hideBusy) return <LoadingIndicator />;
+
+    return <Component {...otherProps} />;
   }
 }
 

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -2,12 +2,9 @@ import {Redirect, Route, IndexRoute, IndexRedirect} from 'react-router';
 import React from 'react';
 
 import AccountAuthorizations from './views/accountAuthorizations';
-import AccountLayout from './views/accountLayout';
-import AccountSettingsLayout from './views/settings/account/accountSettingsLayout';
-import AccountNotifications from './views/settings/account/accountNotifications';
-import AccountNotificationFineTuning from './views/settings/account/accountNotificationFineTuning';
-import AccountEmails from './views/settings/account/accountEmails';
 import AccountAvatar from './views/settings/account/avatar';
+import AccountEmails from './views/settings/account/accountEmails';
+import AccountLayout from './views/accountLayout';
 
 import AdminBuffer from './views/adminBuffer';
 import AdminLayout from './views/adminLayout';
@@ -36,6 +33,7 @@ import GroupTags from './views/groupTags';
 import GroupUserReports from './views/groupUserReports';
 import HookStore from './stores/hookStore';
 import InviteMember from './views/inviteMember/inviteMember';
+import LazyLoad from './components/lazyLoad';
 import MyIssuesAssignedToMe from './views/myIssues/assignedToMe';
 import MyIssuesBookmarked from './views/myIssues/bookmarked';
 import MyIssuesViewed from './views/myIssues/viewed';
@@ -59,7 +57,6 @@ import OrganizationProjectsView from './views/settings/organization/projects/org
 import OrganizationRateLimits from './views/organizationRateLimits';
 import OrganizationRepositoriesView from './views/organizationRepositoriesView';
 import OrganizationGeneralSettingsView from './views/settings/organization/general/organizationGeneralSettingsView';
-import OrganizationSettingsLayout from './views/settings/organization/organizationSettingsLayout';
 import OrganizationStats from './views/organizationStats';
 import OrganizationTeams from './views/organizationTeams';
 import ProjectAlertRules from './views/projectAlertRules';
@@ -87,7 +84,6 @@ import ProjectReleaseTracking from './views/projectReleaseTracking';
 import ProjectReleases from './views/projectReleases';
 import ProjectSavedSearches from './views/projectSavedSearches';
 import ProjectSettings from './views/projectSettings';
-import ProjectSettingsLayout from './views/settings/project/projectSettingsLayout';
 import ProjectUserReportSettings from './views/projectUserReportSettings';
 import ProjectUserReports from './views/projectUserReports';
 import ProjectPlugins from './views/projectPlugins';
@@ -100,8 +96,6 @@ import ReleaseNewEvents from './views/releaseNewEvents';
 import ReleaseOverview from './views/releases/releaseOverview';
 import RouteNotFound from './views/routeNotFound';
 import SetCallsignsAction from './views/requiredAdminActions/setCallsigns';
-import SettingsIndex from './views/settings/settingsIndex';
-import SettingsWrapper from './views/settings/settingsWrapper';
 import SettingsProjectProvider from './views/settings/settingsProjectProvider';
 import SharedGroupDetails from './views/sharedGroupDetails';
 import Stream from './views/stream';
@@ -118,16 +112,27 @@ function appendTrailingSlash(nextState, replaceState) {
   }
 }
 
+function getDefaultModule(module) {
+  return module.default;
+}
+
 const accountSettingsRoutes = [
   <IndexRedirect key="account-settings-index" to="notifications/" />,
   <Route key="notifications/" path="notifications/" name="Notifications">
-    <IndexRoute component={errorHandler(AccountNotifications)} />,
+    <IndexRoute
+      getComponent={() =>
+        import('./views/settings/account/accountNotifications').then(getDefaultModule)}
+      component={errorHandler(LazyLoad)}
+    />
     <Route
-      key="project-alerts/"
       path="project-alerts/"
       name="Fine Tune Alerts"
-      component={errorHandler(AccountNotificationFineTuning)}
-    />,
+      getComponent={() =>
+        import('./views/settings/account/accountNotificationFineTuning').then(
+          getDefaultModule
+        )}
+      component={errorHandler(LazyLoad)}
+    />
   </Route>,
   <Route
     key="emails/"
@@ -412,12 +417,28 @@ function routes() {
         newnew
         path="/settings/"
         name="Settings"
-        component={errorHandler(SettingsWrapper)}
+        getComponent={() =>
+          import('./views/settings/settingsWrapper').then(getDefaultModule)}
+        component={errorHandler(LazyLoad)}
       >
-        <IndexRoute component={errorHandler(SettingsIndex)} />
-        <Route path="account/" name="Account" component={AccountSettingsLayout}>
+        <IndexRoute
+          getComponent={() =>
+            import('./views/settings/settingsIndex').then(getDefaultModule)}
+          component={errorHandler(LazyLoad)}
+        />
+
+        <Route
+          path="account/"
+          name="Account"
+          getComponent={() =>
+            import('./views/settings/account/accountSettingsLayout').then(
+              getDefaultModule
+            )}
+          component={LazyLoad}
+        >
           {accountSettingsRoutes}
         </Route>
+
         <Route path="organization/">
           <IndexRoute component={errorHandler(OrganizationPicker)} />
 
@@ -426,7 +447,13 @@ function routes() {
             path=":orgId/"
             component={errorHandler(OrganizationContext)}
           >
-            <Route component={errorHandler(OrganizationSettingsLayout)}>
+            <Route
+              getComponent={() =>
+                import('./views/settings/organization/organizationSettingsLayout').then(
+                  getDefaultModule
+                )}
+              component={errorHandler(LazyLoad)}
+            >
               {orgSettingsRoutes}
             </Route>
 
@@ -435,7 +462,11 @@ function routes() {
               <Route
                 name="Project"
                 path=":projectId/"
-                component={errorHandler(ProjectSettingsLayout)}
+                getComponent={() =>
+                  import('./views/settings/project/projectSettingsLayout').then(
+                    getDefaultModule
+                  )}
+                component={errorHandler(LazyLoad)}
               >
                 <Route component={errorHandler(SettingsProjectProvider)}>
                   {projectSettingsRoutes}

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -112,25 +112,27 @@ function appendTrailingSlash(nextState, replaceState) {
   }
 }
 
-function getDefaultModule(module) {
-  return module.default;
-}
+/**
+ * Use react-router to lazy load a route. Use this for codesplitting containers (e.g. SettingsLayout)
+ *
+ * The method for lazy loading a route leaf node is using the <LazyLoad> component + `componentPromise`.
+ * The reason for this is because react-router handles the route tree better and if we use <LazyLoad> it will end
+ * up having to re-render more components than necesssary.
+ */
+const lazyLoad = cb => m => cb(null, m.default);
 
 const accountSettingsRoutes = [
   <IndexRedirect key="account-settings-index" to="notifications/" />,
   <Route key="notifications/" path="notifications/" name="Notifications">
     <IndexRoute
-      getComponent={() =>
-        import('./views/settings/account/accountNotifications').then(getDefaultModule)}
+      componentPromise={() => import('./views/settings/account/accountNotifications')}
       component={errorHandler(LazyLoad)}
     />
     <Route
       path="project-alerts/"
       name="Fine Tune Alerts"
-      getComponent={() =>
-        import('./views/settings/account/accountNotificationFineTuning').then(
-          getDefaultModule
-        )}
+      componentPromise={() =>
+        import('./views/settings/account/accountNotificationFineTuning')}
       component={errorHandler(LazyLoad)}
     />
   </Route>,
@@ -417,24 +419,19 @@ function routes() {
         newnew
         path="/settings/"
         name="Settings"
-        getComponent={() =>
-          import('./views/settings/settingsWrapper').then(getDefaultModule)}
-        component={errorHandler(LazyLoad)}
+        getComponent={(loc, cb) =>
+          import('./views/settings/settingsWrapper').then(lazyLoad(cb))}
       >
         <IndexRoute
-          getComponent={() =>
-            import('./views/settings/settingsIndex').then(getDefaultModule)}
-          component={errorHandler(LazyLoad)}
+          getComponent={(loc, cb) =>
+            import('./views/settings/settingsIndex').then(lazyLoad(cb))}
         />
 
         <Route
           path="account/"
           name="Account"
-          getComponent={() =>
-            import('./views/settings/account/accountSettingsLayout').then(
-              getDefaultModule
-            )}
-          component={LazyLoad}
+          getComponent={(loc, cb) =>
+            import('./views/settings/account/accountSettingsLayout').then(lazyLoad(cb))}
         >
           {accountSettingsRoutes}
         </Route>
@@ -448,11 +445,10 @@ function routes() {
             component={errorHandler(OrganizationContext)}
           >
             <Route
-              getComponent={() =>
+              getComponent={(loc, cb) =>
                 import('./views/settings/organization/organizationSettingsLayout').then(
-                  getDefaultModule
+                  lazyLoad(cb)
                 )}
-              component={errorHandler(LazyLoad)}
             >
               {orgSettingsRoutes}
             </Route>
@@ -462,11 +458,10 @@ function routes() {
               <Route
                 name="Project"
                 path=":projectId/"
-                getComponent={() =>
+                getComponent={(loc, cb) =>
                   import('./views/settings/project/projectSettingsLayout').then(
-                    getDefaultModule
+                    lazyLoad(cb)
                   )}
-                component={errorHandler(LazyLoad)}
               >
                 <Route component={errorHandler(SettingsProjectProvider)}>
                   {projectSettingsRoutes}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -238,7 +238,7 @@ class FormField extends React.Component {
         </FormFieldDescription>
 
         <FormFieldControlErrorWrapper inline={inline}>
-          <FormFieldControlWrapper shrink="0">
+          <FormFieldControlWrapper>
             <FormFieldControl flex="1">
               <Observer>
                 {() => {

--- a/tests/js/helpers/svgMock.js
+++ b/tests/js/helpers/svgMock.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+module.exports = {default: {id: 'test', viewBox: {}}};

--- a/tests/js/spec/components/lazyLoad.spec.jsx
+++ b/tests/js/spec/components/lazyLoad.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import LazyLoad from 'app/components/lazyLoad';
+
+jest.mock('raven-js');
+
+describe('LazyLoad', function() {
+  it('renders with a loading indicator when promise is not resolved yet', function() {
+    let promise = new Promise((resolve, reject) => {});
+    let getComponent = () => promise;
+    let wrapper = shallow(<LazyLoad component={getComponent} />);
+
+    // Should be loading
+    expect(wrapper.find('LoadingIndicator').length).toBe(1);
+  });
+
+  it('renders when given a promise of a "button" component', async function() {
+    let res;
+    let promise = new Promise((resolve, reject) => {
+      res = resolve;
+    });
+    let getComponent = () => promise;
+    let wrapper = mount(<LazyLoad component={getComponent} />);
+
+    // Should be loading
+    expect(wrapper.find('LoadingIndicator').length).toBe(1);
+
+    // resolve with button
+    let ResolvedComponent = 'button';
+    res(ResolvedComponent);
+
+    await promise;
+    wrapper.update();
+    expect(wrapper.state('Component')).toEqual('button');
+    expect(wrapper.find('button').length).toBe(1);
+    expect(wrapper.find('LoadingIndicator').length).toBe(0);
+  });
+
+  it('renders with error message when promise is rejected', async function() {
+    let reject;
+    let promise = new Promise((resolve, rej) => {
+      reject = rej;
+    });
+    let getComponent = () => promise;
+    let wrapper;
+
+    try {
+      wrapper = mount(<LazyLoad component={getComponent} />);
+
+      reject(new Error('Could not load component'));
+      await promise;
+    } catch (err) {
+      // ignore
+    }
+
+    wrapper.update();
+    expect(wrapper.find('LoadingIndicator').length).toBe(0);
+    expect(wrapper.find('LoadingError').length).toBe(1);
+  });
+});


### PR DESCRIPTION
- `<LazyLoad>`:
   - Adds tests + storybook
   - shows error message on errors
   - accepts react-router `route` object with `getComponent` property that is
   a function that returns a promise of a React.Component (Component that will
   be dynamically imported)

 - Change to code split new settings layouts as well as `<AccountNotifications>`