### PR TITLE
feat: User notification endpoint returns settings for all projects

### DIFF
--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -63,11 +63,11 @@ class UserNotificationDetailsTest(APITestCase):
         )
         resp = self.client.get(url, format='json')
 
-        assert resp.data.get('deployNotifications') == 3
-        assert resp.data.get('personalActivityNotifications') is False
-        assert resp.data.get('selfAssignOnResolve') is False
-        assert resp.data.get('subscribeByDefault') is True
-        assert resp.data.get('workflowNotifications') == 0
+        assert resp.data.get('deployNotifications').get('default') == 3
+        assert resp.data.get('personalActivityNotifications').get('default') is False
+        assert resp.data.get('selfAssignOnResolve').get('default') is False
+        assert resp.data.get('subscribeByDefault').get('default') is True
+        assert resp.data.get('workflowNotifications').get('default') == 0
 
     def test_saves_and_returns_values(self):
         user = self.create_user(email='a@example.com')
@@ -87,11 +87,11 @@ class UserNotificationDetailsTest(APITestCase):
 
         assert resp.status_code == 200
 
-        assert resp.data.get('deployNotifications') == 2
-        assert resp.data.get('personalActivityNotifications') is True
-        assert resp.data.get('selfAssignOnResolve') is True
-        assert resp.data.get('subscribeByDefault') is True
-        assert resp.data.get('workflowNotifications') == 0
+        assert resp.data.get('deployNotifications').get('default') == 2
+        assert resp.data.get('personalActivityNotifications').get('default') is True
+        assert resp.data.get('selfAssignOnResolve').get('default') is True
+        assert resp.data.get('subscribeByDefault').get('default') is True
+        assert resp.data.get('workflowNotifications').get('default') == 0
 
     def test_reject_invalid_values(self):
         user = self.create_user(email='a@example.com')


### PR DESCRIPTION
This PR modifies the user notification endpoint to return the full set of user notification settings. It now includes all of the per-project notification settings in addition to the global user defaults