### PR TITLE
chore(python): don't autoformat migrations

### DIFF
--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -264,7 +264,12 @@ def py_format(file_list=None):
 
     py_file_list = get_python_files(file_list)
 
-    return run_formatter(['autopep8', '--in-place', '-j0'], py_file_list)
+    # Don't format migration files
+    py_excluding_migrations = [
+        x for x in py_file_list if 'src/sentry/south_migrations' not in x
+    ]
+
+    return run_formatter(['autopep8', '--in-place', '-j0'], py_excluding_migrations)
 
 
 def run_formatter(cmd, file_list, prompt_on_changes=True):


### PR DESCRIPTION
it's arguably annoying and not helpful
  