### PR TITLE
fix(db): RangeQuerySetWrapper may exit too early

### DIFF
--- a/tests/sentry/utils/query/tests.py
+++ b/tests/sentry/utils/query/tests.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from sentry.models import User
 from sentry.testutils import TestCase
-from sentry.utils.query import merge_into
+from sentry.utils.query import merge_into, RangeQuerySetWrapper
 
 
 class MergeIntoTest(TestCase):
@@ -14,3 +14,28 @@ class MergeIntoTest(TestCase):
 
         # make sure we didn't remove the instance
         assert User.objects.filter(id=user_1.id).exists()
+
+
+class RangeQuerySetWrapperTest(TestCase):
+    def test_basic(self):
+        total = 10
+
+        for _ in xrange(total):
+            self.create_user()
+
+        qs = User.objects.all()
+
+        assert len(list(RangeQuerySetWrapper(qs, step=2))) == total
+        assert len(list(RangeQuerySetWrapper(qs, limit=5))) == 5
+
+    def test_loop_and_delete(self):
+        total = 10
+        for _ in xrange(total):
+            self.create_user()
+
+        qs = User.objects.all()
+
+        for user in RangeQuerySetWrapper(qs, step=2):
+            user.delete()
+
+        assert User.objects.all().count() == 0


### PR DESCRIPTION
RQSW was fetching `result.{order_by}` after yielding the result to the
caller. It then subsequently checks `if cur_value is None` before
breaking the loop.

What this means is that if you have a loop and you happen to delete the
last object within the chunk, `result.pk` ends up being `None` since
`result.delete()` ends up binding `None` to `pk`.

This changes the logic to pluck off the value before yielding and using
the `pk` strictly for comparisons as well, since this is exactly what
`model == model` does internally. But doesn't break when `.pk`
might have been mutated.