### PR TITLE
build(percy): Fix percy rendering w/ emotion

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -13,6 +13,7 @@ import * as Router from 'react-router';
 import ReactBootstrapModal from 'react-bootstrap/lib/Modal';
 import JsCookie from 'js-cookie';
 
+import './utils/emotion-setup';
 import * as api from './api';
 import * as il8n from './locale';
 import plugins from './plugins';

--- a/src/sentry/static/sentry/app/utils/emotion-setup.js
+++ b/src/sentry/static/sentry/app/utils/emotion-setup.js
@@ -1,9 +1,9 @@
 /* global process */
-import {sheet} from 'emotion';
 
 // NEEDS to be true for production because of performance
 // But travis builds with NODE_ENV = production, so turn off speed when
 // IS_PERCY is true (i.e. we are in TRAVIS and PERCY_TOKEN is set)
-
-let isSpeedy = process.env.IS_PERCY ? false : process.env.NODE_ENV !== 'development';
-sheet.speedy(isSpeedy);
+if (process.env.IS_PERCY) {
+  const sheet = require('emotion').sheet;
+  sheet.speedy(false);
+}

--- a/src/sentry/static/sentry/app/utils/emotion-setup.js
+++ b/src/sentry/static/sentry/app/utils/emotion-setup.js
@@ -1,0 +1,9 @@
+/* global process */
+import {sheet} from 'emotion';
+
+// NEEDS to be true for production because of performance
+// But travis builds with NODE_ENV = production, so turn off speed when
+// IS_PERCY is true (i.e. we are in TRAVIS and PERCY_TOKEN is set)
+
+let isSpeedy = process.env.IS_PERCY ? false : process.env.NODE_ENV !== 'development';
+sheet.speedy(isSpeedy);


### PR DESCRIPTION
emotion doesn't render styles into DOM when NODE_ENV == production, so add logic to do this when we are in a percy environment
  
- [x] - deploy and test on staging