### PR TITLE
feat(ui): Move API Applications to new settings

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/apiApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/apiApplication.jsx
@@ -1,0 +1,83 @@
+// import {createSearchMap} from './util';
+import {extractMultilineFields} from '../../utils';
+
+const forms = [
+  {
+    // Form "section"/"panel"
+    title: 'Application Details',
+    fields: [
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+
+        // additional data/props that is related to rendering of form field rather than data
+        label: 'Name',
+        help: 'e.g. My Application',
+      },
+      {
+        name: 'homepageUrl',
+        type: 'string',
+        required: false,
+        label: 'Homepage',
+        placeholder: 'e.g. https://example.com/',
+        help: "An optional link to your application's homepage",
+      },
+      {
+        name: 'privacyUrl',
+        type: 'string',
+        label: 'Privacy Policy',
+        placeholder: 'e.g. https://example.com/privacy',
+        help: 'An optional link to your Privacy Policy',
+      },
+      {
+        name: 'termsUrl',
+        type: 'string',
+        label: 'Terms of Service',
+        placeholder: 'e.g. https://example.com/terms',
+        help: 'An optional link to your Terms of Service agreement',
+      },
+    ],
+  },
+
+  {
+    title: 'Security',
+    fields: [
+      {
+        name: 'redirectUris',
+        type: 'string',
+        multiline: true,
+        placeholder: 'e.g. https://example.com/oauth/complete',
+        label: 'Authorized Redirect URIs',
+        help: 'Separate multiple entries with a newline.',
+        getValue: val => extractMultilineFields(val),
+        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+      },
+      {
+        name: 'allowedOrigins',
+        type: 'string',
+        multiline: true,
+        placeholder: 'e.g. example.com',
+        label: 'Authorized JavaScript Origins',
+        help: 'Separate multiple entries with a newline.',
+        getValue: val => extractMultilineFields(val),
+        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+      },
+    ],
+  },
+];
+
+export default forms;
+
+// generate search index from form fields
+// export const searchIndex = createSearchMap({
+// route: '/settings/organization/:orgId/settings/',
+// requireParams: ['orgId'],
+// formGroups: forms,
+// });
+
+// need to associate index -> form group -> route
+// so when we search for a term we need to find:
+//   * what field(s) it matches:
+//     * what form group it belongs to
+//     * what route that belongs to

--- a/src/sentry/static/sentry/app/data/forms/apiApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/apiApplication.jsx
@@ -1,4 +1,3 @@
-// import {createSearchMap} from './util';
 import {extractMultilineFields} from '../../utils';
 
 const forms = [
@@ -68,16 +67,3 @@ const forms = [
 ];
 
 export default forms;
-
-// generate search index from form fields
-// export const searchIndex = createSearchMap({
-// route: '/settings/organization/:orgId/settings/',
-// requireParams: ['orgId'],
-// formGroups: forms,
-// });
-
-// need to associate index -> form group -> route
-// so when we search for a term we need to find:
-//   * what field(s) it matches:
-//     * what form group it belongs to
-//     * what route that belongs to

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -173,6 +173,23 @@ const accountSettingsRoutes = [
       import(/*webpackChunkName: "AccountSocialIdentities"*/ './views/settings/account/accountIdentities')}
     component={errorHandler(LazyLoad)}
   />,
+
+  <Route key="api" path="api/" name="API">
+    <Route path="applications/" name="Applications">
+      <IndexRoute
+        componentPromise={() =>
+          import(/*webpackChunkName: "ApiApplications"*/ './views/settings/account/apiApplications')}
+        component={errorHandler(LazyLoad)}
+      />
+      <Route
+        path=":appId/"
+        name="Details"
+        componentPromise={() =>
+          import(/*webpackChunkName: "ApiApplicationDetails"*/ './views/settings/account/apiApplicationDetails')}
+        component={errorHandler(LazyLoad)}
+      />
+    </Route>
+  </Route>,
 ];
 
 const projectSettingsRoutes = [

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
@@ -1,0 +1,196 @@
+import {Box} from 'grid-emotion';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {
+  addErrorMessage,
+  addSuccessMessage,
+} from '../../../actionCreators/settingsIndicator';
+import {t} from '../../../locale';
+import AsyncView from '../../asyncView';
+import ConfigStore from '../../../stores/configStore';
+import Form from '../components/forms/form';
+import FormField from '../components/forms/formField';
+import JsonForm from '../components/forms/jsonForm';
+import Panel from '../components/panel';
+import PanelBody from '../components/panelBody';
+import PanelHeader from '../components/panelHeader';
+import TextCopyInput from '../components/forms/textCopyInput';
+import apiApplication from '../../../data/forms/apiApplication';
+
+class ApiApplicationDetails extends AsyncView {
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+
+  getDefaultState() {
+    return {
+      loading: true,
+      error: false,
+      app: null,
+      formData: null,
+      errors: {},
+    };
+  }
+
+  getFormData(app) {
+    return {
+      name: app.name,
+      homepageUrl: app.homepageUrl,
+      privacyUrl: app.privacyUrl,
+      termsUrl: app.termsUrl,
+      allowedOrigins: app.allowedOrigins.join('\n'),
+      redirectUris: app.redirectUris.join('\n'),
+    };
+  }
+
+  getEndpoints() {
+    return [['app', `/api-applications/${this.props.params.appId}/`]];
+  }
+
+  onFieldChange(name, value) {
+    let formData = this.state.formData;
+    formData[name] = value;
+    this.setState({
+      formData,
+    });
+  }
+
+  onRemoveApplication(app) {}
+
+  getTitle() {
+    return 'Application Details - Sentry';
+  }
+
+  handleSubmitSuccess = (change, model, id) => {
+    if (!model) return;
+
+    let label = model.getDescriptor(id, 'label');
+
+    if (!label) return;
+
+    addSuccessMessage(`Changed ${label} from "${change.old}" to "${change.new}"`, 2000, {
+      model,
+      id,
+    });
+
+    // Special case for slug, need to forward to new slug
+    if (typeof onSave === 'function') {
+      this.props.onSave(this.props.initialData, model.initialData);
+    }
+  };
+
+  renderBody() {
+    let urlPrefix = ConfigStore.get('urlPrefix');
+    console.log(this.props);
+
+    return (
+      <div>
+        <Form
+          apiMethod="PUT"
+          apiEndpoint={`/api-applications/${this.props.params.appId}/`}
+          saveOnBlur
+          allowUndo
+          initialData={this.state.app}
+          onSubmitSuccess={this.handleSubmitSuccess}
+          onSubmitError={err => addErrorMessage('Unable to save change')}
+        >
+          <Box>
+            <JsonForm location={this.props.location} forms={apiApplication} />
+
+            <Panel>
+              <PanelHeader>{t('Credentials')}</PanelHeader>
+
+              <PanelBody>
+                <FormField name="clientID" label="Client ID" overflow>
+                  {({value}) => {
+                    return (
+                      <div>
+                        <TextCopyInput>{value}</TextCopyInput>
+                      </div>
+                    );
+                  }}
+                </FormField>
+
+                <FormField
+                  overflow
+                  name="clientSecret"
+                  label="Client Secret"
+                  help={t(`Your secret is only available briefly after application creation. Make
+                  sure to save this value!`)}
+                >
+                  {({value}) => {
+                    return value ? (
+                      <TextCopyInput>{value}</TextCopyInput>
+                    ) : (
+                      <em>hidden</em>
+                    );
+                  }}
+                </FormField>
+
+                <FormField name="" label="Authorization URL">
+                  {({value}) => {
+                    return (
+                      <TextCopyInput>{`${urlPrefix}/oauth/authorize/`}</TextCopyInput>
+                    );
+                  }}
+                </FormField>
+
+                <FormField name="" label="Token URL">
+                  {() => {
+                    let value = `${urlPrefix}/oauth/token/`;
+                    return <TextCopyInput>{value}</TextCopyInput>;
+                  }}
+                </FormField>
+              </PanelBody>
+            </Panel>
+          </Box>
+        </Form>
+      </div>
+    );
+  }
+}
+
+export default ApiApplicationDetails;
+/*
+          <form onSubmit={this.onSubmit} className="form-stacked">
+            <h4>Application Details</h4>
+            <fieldset>
+              <legend>Credentials</legend>
+              <div className="control-group">
+                <label htmlFor="api-key">Client ID</label>
+                <div className="form-control disabled">
+                  <TextCopyInput>{app.clientID}</TextCopyInput>
+                </div>
+              </div>
+              <div className="control-group">
+                <label htmlFor="api-key">Client Secret</label>
+                <div className="form-control disabled">
+                  {app.clientSecret ? (
+                    <TextCopyInput>{app.clientSecret}</TextCopyInput>
+                  ) : (
+                    <em>hidden</em>
+                  )}
+                </div>
+                <p className="help-block">
+                  Your secret is only available briefly after application creation. Make
+                  sure to save this value!
+                </p>
+              </div>
+
+              <div className="control-group">
+                <label htmlFor="api-key">Authorization URL</label>
+                <div className="form-control disabled">
+                  <TextCopyInput>{`${urlPrefix}/oauth/authorize/`}</TextCopyInput>
+                </div>
+              </div>
+
+              <div className="control-group">
+                <label htmlFor="api-key">Token URL</label>
+                <div className="form-control disabled">
+                  <TextCopyInput>{`${urlPrefix}/oauth/token/`}</TextCopyInput>
+                </div>
+              </div>
+            </fieldset>
+          </form>
+          */

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
@@ -28,35 +28,13 @@ class ApiApplicationDetails extends AsyncView {
       loading: true,
       error: false,
       app: null,
-      formData: null,
       errors: {},
-    };
-  }
-
-  getFormData(app) {
-    return {
-      name: app.name,
-      homepageUrl: app.homepageUrl,
-      privacyUrl: app.privacyUrl,
-      termsUrl: app.termsUrl,
-      allowedOrigins: app.allowedOrigins.join('\n'),
-      redirectUris: app.redirectUris.join('\n'),
     };
   }
 
   getEndpoints() {
     return [['app', `/api-applications/${this.props.params.appId}/`]];
   }
-
-  onFieldChange(name, value) {
-    let formData = this.state.formData;
-    formData[name] = value;
-    this.setState({
-      formData,
-    });
-  }
-
-  onRemoveApplication(app) {}
 
   getTitle() {
     return 'Application Details - Sentry';
@@ -82,7 +60,6 @@ class ApiApplicationDetails extends AsyncView {
 
   renderBody() {
     let urlPrefix = ConfigStore.get('urlPrefix');
-    console.log(this.props);
 
     return (
       <div>
@@ -152,45 +129,3 @@ class ApiApplicationDetails extends AsyncView {
 }
 
 export default ApiApplicationDetails;
-/*
-          <form onSubmit={this.onSubmit} className="form-stacked">
-            <h4>Application Details</h4>
-            <fieldset>
-              <legend>Credentials</legend>
-              <div className="control-group">
-                <label htmlFor="api-key">Client ID</label>
-                <div className="form-control disabled">
-                  <TextCopyInput>{app.clientID}</TextCopyInput>
-                </div>
-              </div>
-              <div className="control-group">
-                <label htmlFor="api-key">Client Secret</label>
-                <div className="form-control disabled">
-                  {app.clientSecret ? (
-                    <TextCopyInput>{app.clientSecret}</TextCopyInput>
-                  ) : (
-                    <em>hidden</em>
-                  )}
-                </div>
-                <p className="help-block">
-                  Your secret is only available briefly after application creation. Make
-                  sure to save this value!
-                </p>
-              </div>
-
-              <div className="control-group">
-                <label htmlFor="api-key">Authorization URL</label>
-                <div className="form-control disabled">
-                  <TextCopyInput>{`${urlPrefix}/oauth/authorize/`}</TextCopyInput>
-                </div>
-              </div>
-
-              <div className="control-group">
-                <label htmlFor="api-key">Token URL</label>
-                <div className="form-control disabled">
-                  <TextCopyInput>{`${urlPrefix}/oauth/token/`}</TextCopyInput>
-                </div>
-              </div>
-            </fieldset>
-          </form>
-          */

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
@@ -1,0 +1,184 @@
+import {Box, Flex} from 'grid-emotion';
+import {Link} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+
+import {t} from '../../../locale';
+import ApiMixin from '../../../mixins/apiMixin';
+import AsyncView from '../../asyncView';
+import Button from '../../../components/buttons/button';
+import EmptyMessage from '../components/emptyMessage';
+import IndicatorStore from '../../../stores/indicatorStore';
+import Panel from '../components/panel';
+import PanelBody from '../components/panelBody';
+import PanelHeader from '../components/panelHeader';
+import Row from '../components/row';
+import SettingsPageHeader from '../components/settingsPageHeader';
+
+const ROUTE_PREFIX = '/settings/account/api/';
+
+const ApiApplicationRow = createReactClass({
+  displayName: 'ApiApplicationRow',
+
+  propTypes: {
+    app: PropTypes.object.isRequired,
+    onRemove: PropTypes.func.isRequired,
+  },
+
+  mixins: [ApiMixin],
+
+  getInitialState() {
+    return {
+      loading: false,
+    };
+  },
+
+  handleRemove() {
+    if (this.state.loading) return;
+
+    let app = this.props.app;
+
+    this.setState(
+      {
+        loading: true,
+      },
+      () => {
+        let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+        this.api.request(`/api-applications/${app.id}/`, {
+          method: 'DELETE',
+          success: data => {
+            IndicatorStore.remove(loadingIndicator);
+            this.props.onRemove(app);
+          },
+          error: () => {
+            IndicatorStore.remove(loadingIndicator);
+            IndicatorStore.add(
+              t('Unable to remove application. Please try again.'),
+              'error',
+              {
+                duration: 3000,
+              }
+            );
+          },
+        });
+      }
+    );
+  },
+
+  render() {
+    let app = this.props.app;
+
+    let btnClassName = 'btn btn-default';
+    if (this.state.loading) btnClassName += ' disabled';
+
+    return (
+      <Row justify="space-between" px={2} py={2}>
+        <Box flex="1">
+          <h4 style={{marginBottom: 5}}>
+            <Link to={`${ROUTE_PREFIX}applications/${app.id}/`}>{app.name}</Link>
+          </h4>
+          <small style={{color: '#999'}}>{app.clientID}</small>
+        </Box>
+
+        <Flex align="center">
+          <Box pl={2}>
+            <a
+              onClick={this.handleRemove}
+              className={btnClassName}
+              disabled={this.state.loading}
+            >
+              <span className="icon icon-trash" />
+            </a>
+          </Box>
+        </Flex>
+      </Row>
+    );
+  },
+});
+
+class ApiApplications extends AsyncView {
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+
+  getEndpoints() {
+    return [['appList', '/api-applications/']];
+  }
+
+  getTitle() {
+    return 'API Applications - Sentry';
+  }
+
+  handleCreateApplication = () => {
+    let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+    this.api.request('/api-applications/', {
+      method: 'POST',
+      success: app => {
+        IndicatorStore.remove(loadingIndicator);
+        this.context.router.push(`${ROUTE_PREFIX}applications/${app.id}/`);
+      },
+      error: error => {
+        IndicatorStore.remove(loadingIndicator);
+        IndicatorStore.add(t('Unable to remove application. Please try again.'), 'error');
+      },
+    });
+  };
+
+  handleRemoveApplication = app => {
+    this.setState({
+      appList: this.state.appList.filter(a => a.id !== app.id),
+    });
+  };
+
+  renderBody() {
+    let action = (
+      <Button
+        priority="primary"
+        size="small"
+        className="ref-create-application"
+        onClick={this.handleCreateApplication}
+      >
+        {t('Create New Application')}
+      </Button>
+    );
+
+    let isEmpty = this.state.appList.length === 0;
+
+    return (
+      <div>
+        <SettingsPageHeader label="API Applications" action={action} />
+
+        {isEmpty && (
+          <EmptyMessage>{t("You haven't created any applications yet.")}</EmptyMessage>
+        )}
+
+        {!isEmpty && (
+          <Panel>
+            <PanelHeader disablePadding>
+              <Flex align="center">
+                <Box px={2} flex="1">
+                  {t('Application Name')}
+                </Box>
+              </Flex>
+            </PanelHeader>
+
+            <PanelBody>
+              {this.state.appList.map(app => {
+                return (
+                  <ApiApplicationRow
+                    key={app.id}
+                    app={app}
+                    onRemove={this.handleRemoveApplication}
+                  />
+                );
+              })}
+            </PanelBody>
+          </Panel>
+        )}
+      </div>
+    );
+  }
+}
+
+export default ApiApplications;

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
@@ -147,7 +147,7 @@ class ApiApplications extends AsyncView {
 
     return (
       <div>
-        <SettingsPageHeader label="API Applications" action={action} />
+        <SettingsPageHeader title="API Applications" action={action} />
 
         {isEmpty && (
           <EmptyMessage>{t("You haven't created any applications yet.")}</EmptyMessage>

--- a/src/sentry/static/sentry/app/views/settings/account/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/navigationConfiguration.jsx
@@ -32,6 +32,15 @@ const accountNavigation = [
       },
     ],
   },
+  {
+    name: t('API'),
+    items: [
+      {
+        path: `${pathPrefix}/api/applications/`,
+        title: t('Applications'),
+      },
+    ],
+  },
 ];
 
 export default accountNavigation;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/formFieldDescription.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/formFieldDescription.jsx
@@ -1,16 +1,22 @@
-import {Box} from 'grid-emotion';
 import React from 'react';
-import styled from 'react-emotion';
+import styled, {css} from 'react-emotion';
 
-const FormFieldDescription = styled(({inline, ...props}) => <Box {...props} />)`
-  ${p =>
-    p.inline
-      ? `
-  width: 50%;
-  padding-right: 10px;
-  flex-shrink: 0;
-  `
-      : 'margin-bottom: 10px;'};
+const inlineStyle = p =>
+  p.inline
+    ? css`
+        width: 50%;
+        padding-right: 10px;
+        flex-shrink: 0;
+      `
+    : css`
+        margin-bottom: 10px;
+      `;
+
+const FormFieldDescription = styled(({inline, ...props}) => <label {...props} />)`
+  font-weight: normal;
+  margin-bottom: 0;
+
+  ${inlineStyle};
 `;
 
 export default FormFieldDescription;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/formFieldWrapper.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/formFieldWrapper.jsx
@@ -5,36 +5,36 @@ import {Flex} from 'grid-emotion';
 import SettingsInputField from '../styled/input';
 import SettingsTextAreaField from '../styled/textarea';
 
+const inlineStyle = p =>
+  p.inline
+    ? css`
+        align-items: center;
+      `
+    : css`
+        flex-direction: column;
+        align-items: stretch;
+      `;
+
+const highlightedStyle = p =>
+  p.highlighted
+    ? css`
+        outline: 1px solid ${p.theme.purple};
+      `
+    : '';
+
 const FormFieldWrapper = styled(({highlighted, inline, ...props}) => <Flex {...props} />)`
   padding: 0.9em 0 0.9em 1.3em;
   border-bottom: 1px solid ${p => p.theme.borderLight};
   transition: background 0.15s;
 
-  ${SettingsInputField}, ${SettingsTextAreaField} {
-    background: ${p => (p.error ? '#fff' : p.theme.offWhite)};
-    border: 1px solid ${p => p.theme.borderLight};
-
-    &:hover, &:focus { border: 1px solid ${p => p.theme.borderDark}}
-  }
-
-  ${p => {
-    if (p.inline) {
-      return 'align-items: center;';
-    } else {
-      return `
-        flex-direction: column;
-        align-items: stretch;
-      `;
+  &:hover,
+  &:focus {
+    ${SettingsInputField}, ${SettingsTextAreaField} {
+      border: 1px solid ${p => p.theme.borderDark};
     }
-  }} ${p => {
-  if (p.highlighted) {
-    return css`
-      outline: 1px solid ${p.theme.purple};
-    `;
-  } else {
-    return '';
   }
-}} &:last-child {
+
+  ${inlineStyle} ${highlightedStyle} &:last-child {
     border-bottom: none;
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -236,7 +236,7 @@ class FormField extends React.Component {
 
     return (
       <FormFieldWrapper inline={inline} highlighted={highlighted}>
-        <FormFieldDescription inline={inline}>
+        <FormFieldDescription inline={inline} htmlFor={id}>
           {label && (
             <FormFieldLabel>
               {label} {required && <FormFieldRequiredBadge />}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/styled/styles.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/styled/styles.jsx
@@ -1,34 +1,40 @@
 import {css} from 'react-emotion';
 
-const inputStyles = props => css`
-  color: ${props.theme.gray5};
-  display: block;
-  width: 100%;
-  border: 0;
-  border-radius: 2px;
-  padding: 0.5em;
-  transition: border 0.2s ease;
-  resize: vertical;
+const readOnlyStyle = props =>
+  props.readOnly
+    ? css`
+        cursor: default;
+      `
+    : '';
 
-  &:focus {
-    outline: none;
-    background: #f7f7f9;
-    border-bottom-color: ${p => props.theme.blue};
-  }
+const inputStyles = props => {
+  return css`
+    color: ${props.theme.gray5};
+    display: block;
+    width: 100%;
+    background: ${props.theme.offWhite};
+    border: 1px solid ${props.theme.borderLight};
+    border-radius: 2px;
+    padding: 0.5em;
+    transition: border 0.2s ease;
+    resize: vertical;
 
-  ${p => {
-    if (props.error) {
-      return css`
-    background: #f7f7f9;
-    &:hover, &:focus {
-      background: #f7f7f9};
+    ${readOnlyStyle(props)};
+
+    &:focus {
+      outline: none;
+      background: #fff;
     }
-    `;
+
+    &:hover,
+    &:focus {
+      border: 1px solid ${props.theme.borderDark};
     }
-    return '';
-  }} &::placeholder {
-    color: ${props.theme.gray2};
-  }
-`;
+
+    &::placeholder {
+      color: ${props.theme.gray2};
+    }
+  `;
+};
 
 export {inputStyles};

--- a/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
@@ -28,12 +28,12 @@ const StyledInput = styled(props => {
 const OverflowContainer = styled('div')`
   flex-grow: 1;
   border: none;
-  box-shadow: 0 2px rgba(0, 0, 0, 0.05);
 `;
 
 const StyledCopyButton = styled(Button)`
   flex-shrink: 1;
   border-radius: 0 0.25em 0.25em 0;
+  box-shadow: none;
 `;
 
 class TextCopyInput extends React.Component {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
@@ -6,39 +6,34 @@ import styled from 'react-emotion';
 
 import {inputStyles} from './styled/styles';
 import {selectText} from '../../../../utils/selectText';
-import AutoSelectText from '../../../../components/autoSelectText';
 import Button from '../../../../components/buttons/button';
 import Clipboard from '../../../../components/clipboard';
 import InlineSvg from '../../../../components/inlineSvg';
 
-const Wrapper = styled(Flex)`
-  display: flex;
-  max-width: 600px;
+const StyledInput = styled(props => {
+  return <input {...props} />;
+})`
+  ${inputStyles};
+  border-right-width: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+
+  &:hover,
+  &:focus {
+    background-color: ${p => p.theme.offWhite};
+    border-right-width: 0;
+  }
 `;
 
 const OverflowContainer = styled('div')`
   flex-grow: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  background: ${p => p.theme.offWhite};
-  border: 1px solid ${p => p.theme.borderLight};
-  border-right-width: 0;
-  border-radius: 0.25em 0 0 0.25em;
-  padding: 0.25em 1em;
+  border: none;
   box-shadow: 0 2px rgba(0, 0, 0, 0.05);
 `;
 
 const StyledCopyButton = styled(Button)`
   flex-shrink: 1;
   border-radius: 0 0.25em 0.25em 0;
-`;
-
-const StyledAutoSelectText = styled(AutoSelectText)`
-  ${inputStyles};
-  display: inline-block;
-  width: 100%;
-  padding: 0;
 `;
 
 class TextCopyInput extends React.Component {
@@ -68,14 +63,20 @@ class TextCopyInput extends React.Component {
 
     let {onCopy} = this.props;
 
-    // We use findDOMNode here because `this.textRef` is not a dom node,
-    // it's a ref to AutoSelectText
-    // eslint-disable-next-line react/no-find-dom-node
-    selectText(ReactDOM.findDOMNode(this.textRef));
+    this.handleSelectText();
 
     onCopy(this.props.children, e);
 
     e.stopPropagation();
+  };
+
+  handleSelectText = () => {
+    if (!this.textRef) return;
+
+    // We use findDOMNode here because `this.textRef` is not a dom node,
+    // it's a ref to AutoSelectText
+    // eslint-disable-next-line react/no-find-dom-node
+    selectText(ReactDOM.findDOMNode(this.textRef));
   };
 
   handleAutoMount = ref => {
@@ -86,18 +87,22 @@ class TextCopyInput extends React.Component {
     let {style, children} = this.props;
 
     return (
-      <Wrapper>
+      <Flex>
         <OverflowContainer>
-          <StyledAutoSelectText innerRef={this.handleAutoMount} style={style}>
-            {children}
-          </StyledAutoSelectText>
+          <StyledInput
+            readOnly
+            ref={this.handleAutoMount}
+            style={style}
+            value={children}
+            onClick={this.handleSelectText}
+          />
         </OverflowContainer>
         <Clipboard hideUnsupported onClick={this.handleCopyClick} value={children}>
           <StyledCopyButton size="xsmall" onClick={this.handleCopyClick}>
             <InlineSvg src="icon-clipboard" size="1.25em" />
           </StyledCopyButton>
         </Clipboard>
-      </Wrapper>
+      </Flex>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
@@ -21,8 +21,8 @@ const LINKS = {
   DOCUMENATATION_QUICKSTART: 'https://docs.sentry.io/quickstart/',
   DOCUMENTATION_CLI: 'https://docs.sentry.io/learn/cli/',
   DOCUMENTATION_API: 'https://docs.sentry.io/hosted/api/',
-  API: '/api/',
-  API_APPLICATION: '/api/application/',
+  API: '/settings/account/api/',
+  API_APPLICATION: '/settings/account/api/application/',
   MANAGE: '/manage/',
   FORUM: 'https://forum.sentry.io/',
   GITHUB_ISSUES: 'https://github.com/getsentry/sentry/issues',
@@ -108,7 +108,7 @@ class SettingsIndex extends React.Component {
           <Box w={1 / 3} px={2}>
             <Panel>
               <HomePanelHeader>
-                <HomeLink href="/account/settings/">
+                <HomeLink to="/settings/account/">
                   <HomeIcon color="blue">
                     <InlineSvg src="icon-user" size="44px" />
                   </HomeIcon>
@@ -125,12 +125,12 @@ class SettingsIndex extends React.Component {
                     </HomeLink>
                   </li>
                   <li>
-                    <HomeLink href="/account/settings/notifications/">
+                    <HomeLink to="/settings/account/notifications/">
                       {t('Notification Preferences')}
                     </HomeLink>
                   </li>
                   <li>
-                    <HomeLink href="/account/settings/avatar/">
+                    <HomeLink to="/settings/account/avatar/">
                       {t('Change my avatar')}
                     </HomeLink>
                   </li>

--- a/tests/js/spec/components/__snapshots__/textCopyInput.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/textCopyInput.spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextCopyInput renders 1`] = `
-<Styled(Base)>
+<Flex>
   <Styled(div)>
-    <Styled(AutoSelectText)
-      innerRef={[Function]}
-    >
-      Text to Copy
-    </Styled(AutoSelectText)>
+    <Styled(Component)
+      onClick={[Function]}
+      readOnly={true}
+      value="Text to Copy"
+    />
   </Styled(div)>
   <Clipboard
     errorMessage="Error copying to clipboard"
@@ -27,5 +27,5 @@ exports[`TextCopyInput renders 1`] = `
       />
     </Styled(Button)>
   </Clipboard>
-</Styled(Base)>
+</Flex>
 `;


### PR DESCRIPTION
Depends on ~#6885~, ~#6880~, ~#6879~, ~#6872~

Polish would be nice:
![image](https://user-images.githubusercontent.com/79684/34850265-0002eb5c-f6da-11e7-9e2b-4ad2c32a4842.png)

Need to style the "Credentials" inputs to make them look disabled. Also do we strictly rely on breadcrumbs + nav bar for navigation (i.e. do we want a Cancel button or something)?
![image](https://user-images.githubusercontent.com/79684/34850257-f27e1aec-f6d9-11e7-8076-c081f2bea6de.png)


