### PR TITLE
Don't hard-cap EventMapping retention at 7d.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -197,7 +197,7 @@ def cleanup(days, project, concurrency, max_procs, silent, model, router, timed)
     # Deletions that use `BulkDeleteQuery` (and don't need to worry about child relations)
     # (model, datetime_field, order_by)
     BULK_QUERY_DELETES = [
-        (models.EventMapping, 'date_added', None),
+        (models.EventMapping, 'date_added', '-date_added'),
         (models.GroupEmailThread, 'date', None),
         (models.GroupRuleStatus, 'date_added', None),
     ] + EXTRA_BULK_QUERY_DELETES

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -332,7 +332,7 @@ def cleanup(days, project, concurrency, max_procs, silent, model, router, timed)
         BulkDeleteQuery(
             model=models.EventMapping,
             dtfield='date_added',
-            days=min(days, 7),
+            days=days,
             project_id=project_id,
             order_by='-date_added'
         ).execute()

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -197,6 +197,7 @@ def cleanup(days, project, concurrency, max_procs, silent, model, router, timed)
     # Deletions that use `BulkDeleteQuery` (and don't need to worry about child relations)
     # (model, datetime_field, order_by)
     BULK_QUERY_DELETES = [
+        (models.EventMapping, 'date_added', None),
         (models.GroupEmailThread, 'date', None),
         (models.GroupRuleStatus, 'date_added', None),
     ] + EXTRA_BULK_QUERY_DELETES
@@ -320,22 +321,6 @@ def cleanup(days, project, concurrency, max_procs, silent, model, router, timed)
                 task = create_deletion_task(
                     days, project_id, model, dtfield, order_by)
                 _chunk_until_complete(task)
-
-    # EventMapping is fairly expensive and is special cased as it's likely you
-    # won't need a reference to an event for nearly as long
-    if not silent:
-        click.echo("Removing expired values for EventMapping")
-    if is_filtered(models.EventMapping):
-        if not silent:
-            click.echo('>> Skipping EventMapping')
-    else:
-        BulkDeleteQuery(
-            model=models.EventMapping,
-            dtfield='date_added',
-            days=days,
-            project_id=project_id,
-            order_by='-date_added'
-        ).execute()
 
     # Clean up FileBlob instances which are no longer used and aren't super
     # recent (as there could be a race between blob creation and reference)


### PR DESCRIPTION
Since EventMapping is now only written to when an Event is sampled, the volume of this table has dropped dramatically.