### PR TITLE
ref(tagstore): Calculate current time only once in create_event_tags

### DIFF
--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -197,6 +197,8 @@ class LegacyTagStorage(TagStorage):
                 project_id, environment_id, key, value)
             tag_ids.append((tagkey.id, tagvalue.id))
 
+        date_added = timezone.now()
+
         try:
             # don't let a duplicate break the outer transaction
             with transaction.atomic():
@@ -210,6 +212,7 @@ class LegacyTagStorage(TagStorage):
                         event_id=event_id,
                         key_id=key_id,
                         value_id=value_id,
+                        date_added=date_added,
                     )
                     for key_id, value_id in tag_ids
                 ])

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -232,6 +232,8 @@ class V2TagStorage(TagStorage):
                 project_id, environment_id, key, value, key_id=tagkey.id)
             tag_ids.append((tagkey.id, tagvalue.id))
 
+        date_added = timezone.now()
+
         try:
             # don't let a duplicate break the outer transaction
             with transaction.atomic():
@@ -245,6 +247,7 @@ class V2TagStorage(TagStorage):
                         event_id=event_id,
                         key_id=key_id,
                         value_id=value_id,
+                        date_added=date_added,
                     )
                     for key_id, value_id in tag_ids
                 ])


### PR DESCRIPTION
Every event is now inserted at the same time. In some cases more than
100 being inserted at once.

Right now, this falls back on the Django default behavior for each
EventTag object and stamps out a `timezone.now()` call.

This just simply avoids the overhead and we explicitly assign a value to
all of them at the same time. There's no reason to calculate a new value
for each row.