### PR TITLE
fix(babel): make styled components easier to debug in dev

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -29,7 +29,7 @@
   "env": {
     "development": {
       "plugins": [
-        ["emotion", {"sourceMap": true}]
+        ["emotion", {"sourceMap": true, "autoLabel": true}]
       ]
     },
     "test": {


### PR DESCRIPTION
Adds component name to end of styled component classes in dev:

<img width="645" alt="screen shot 2018-01-05 at 2 07 20 pm" src="https://user-images.githubusercontent.com/30713/34630679-128059de-f222-11e7-868c-83fb70eb877d.png">
