### PR TITLE
feat(2fa): Added a resend code link to sms 2fa page

### DIFF
--- a/src/sentry/templates/sentry/twofactor.html
+++ b/src/sentry/templates/sentry/twofactor.html
@@ -30,7 +30,7 @@
             {{ field|as_crispy_field }}
           {% endfor %}
           {% if interface.interface_id == "sms" %}
-            <a class="info" onclick="location.reload(true)" >Resend Code</a>
+            <a class="info" href="" >Resend Code</a>
           {% endif %}
         {% endblock %}
 

--- a/src/sentry/templates/sentry/twofactor.html
+++ b/src/sentry/templates/sentry/twofactor.html
@@ -29,6 +29,9 @@
           {% for field in form %}
             {{ field|as_crispy_field }}
           {% endfor %}
+          {% if interface.interface_id == "sms" %}
+            <a class="info" onclick="location.reload(true)" >Resend Code</a>
+          {% endif %}
         {% endblock %}
 
         {% block twofactor_submit %}


### PR DESCRIPTION
Add a link to the sms two-factor authentication page to resend code for the case the user does not have their phone immediately handy before the time limit is up.