### PR TITLE
feat(api): Allow organizations to be restored via the API

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -9,7 +9,7 @@ from sentry.app import raven
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
-    ApiKey, Organization, OrganizationMemberTeam, OrganizationStatus, Project, ReleaseProject, Team
+    ApiKey, Organization, OrganizationMemberTeam, Project, ReleaseProject, Team
 )
 from sentry.utils import auth
 
@@ -120,9 +120,6 @@ class OrganizationEndpoint(Endpoint):
                 slug=organization_slug,
             )
         except Organization.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        if organization.status != OrganizationStatus.VISIBLE:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, organization)

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -56,9 +56,7 @@ class OrganizationIndexEndpoint(Endpoint):
         """
         member_only = request.GET.get('member') in ('1', 'true')
 
-        queryset = Organization.objects.filter(
-            status=OrganizationStatus.VISIBLE,
-        )
+        queryset = Organization.objects.all()
 
         if request.auth and not request.user.is_authenticated():
             if hasattr(request.auth, 'project'):
@@ -94,6 +92,15 @@ class OrganizationIndexEndpoint(Endpoint):
                     )
                 elif key == 'id':
                     queryset = queryset.filter(id__in=value)
+                elif key == 'status':
+                    try:
+                        queryset = queryset.filter(status__in=[
+                            OrganizationStatus[v.upper()] for v in value
+                        ])
+                    except KeyError:
+                        queryset = queryset.none()
+                else:
+                    queryset = queryset.none()
 
         sort_by = request.GET.get('sortBy')
         if sort_by == 'members':

--- a/src/sentry/web/frontend/restore_organization.py
+++ b/src/sentry/web/frontend/restore_organization.py
@@ -7,7 +7,8 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import Organization, OrganizationStatus, AuditLogEntryEvent
+from sentry.api import client
+from sentry.models import Organization, OrganizationStatus
 from sentry.web.frontend.base import OrganizationView
 from sentry.web.helpers import render_to_response
 
@@ -54,29 +55,21 @@ class RestoreOrganizationView(OrganizationView):
         return render_to_response('sentry/restore-organization.html', context, self.request)
 
     def post(self, request, organization):
-        if organization.status != OrganizationStatus.PENDING_DELETION:
+        deletion_statuses = [
+            OrganizationStatus.PENDING_DELETION,
+            OrganizationStatus.DELETION_IN_PROGRESS]
+
+        if organization.status not in deletion_statuses:
             messages.add_message(request, messages.ERROR, ERR_MESSAGES[organization.status])
             return self.redirect(reverse('sentry'))
 
         updated = Organization.objects.filter(
             id=organization.id,
-            status=OrganizationStatus.PENDING_DELETION,
+            status__in=deletion_statuses,
         ).update(status=OrganizationStatus.VISIBLE)
         if updated:
-            self.create_audit_entry(
-                request=request,
-                organization=organization,
-                target_object=organization.id,
-                event=AuditLogEntryEvent.ORG_RESTORE,
-                data=organization.get_audit_log_data(),
-            )
-            delete_logger.info(
-                'object.delete.canceled',
-                extra={
-                    'object_id': organization.id,
-                    'model': Organization.__name__,
-                }
-            )
+            client.put('/organizations/{}/'.format(organization.slug), data={
+                'cancelDeletion': True,
+            }, request=request)
             messages.add_message(request, messages.SUCCESS, MSG_RESTORE_SUCCESS)
-
         return self.redirect(reverse('sentry-organization-home', args=[organization.slug]))

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -284,6 +284,23 @@ class OrganizationUpdateTest(APITestCase):
 
         assert not options.get('sentry:sensitive_fields')
 
+    def test_cancel_delete(self):
+        org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-organization-details', kwargs={
+                'organization_slug': org.slug,
+            }
+        )
+        response = self.client.put(
+            url, data={
+                'cancelDeletion': True,
+            }
+        )
+        assert response.status_code == 200, (response.status_code, response.content)
+        org = Organization.objects.get(id=org.id)
+        assert org.status == OrganizationStatus.VISIBLE
+
 
 class OrganizationDeleteTest(APITestCase):
     @patch('sentry.api.endpoints.organization_details.uuid4')

--- a/tests/sentry/web/frontend/test_restore_organization.py
+++ b/tests/sentry/web/frontend/test_restore_organization.py
@@ -66,7 +66,7 @@ class RemoveOrganizationTest(TestCase):
 
         assert org.status == OrganizationStatus.VISIBLE
 
-    def test_too_late(self):
+    def test_too_late_still_restores(self):
         Organization.objects.filter(
             id=self.organization.id,
         ).update(status=OrganizationStatus.DELETION_IN_PROGRESS)
@@ -77,4 +77,4 @@ class RemoveOrganizationTest(TestCase):
 
         org = Organization.objects.get(id=self.organization.id)
 
-        assert org.status == OrganizationStatus.DELETION_IN_PROGRESS
+        assert org.status == OrganizationStatus.VISIBLE


### PR DESCRIPTION
This exposes 'cancelDeletion' on the PUT /organizations/:id/ endpoint and moves the restore organization server-rendered view to use the endpoint.

Additionally it:

- allows restoration even after a deletion has begun (accept the consequences).
- exposes 'status' in the organization details API
- allows fetching data for organizations which are in deletion phases