### PR TITLE
fix(organizations): Fix organization status as_choices

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -104,7 +104,8 @@ class Organization(Model):
     slug = models.SlugField(unique=True)
     status = BoundedPositiveIntegerField(
         choices=OrganizationStatus.as_choices(),
-        # this only needs to use `.value` because of south
+        # south will generate a default value of `'<OrganizationStatus.ACTIVE: 0>'`
+        # if `.value` is ommited
         default=OrganizationStatus.ACTIVE.value
     )
     date_added = models.DateTimeField(default=timezone.now)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -53,7 +53,7 @@ class OrganizationStatus(IntEnum):
             # realistically Enum shouldn't even creating these, but alas
             if name.startswith('_'):
                 continue
-            result.append((member, member.label))
+            result.append((member.value, member.label))
         return tuple(result)
 
 

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -105,7 +105,7 @@ class Organization(Model):
     status = BoundedPositiveIntegerField(
         choices=OrganizationStatus.as_choices(),
         # south will generate a default value of `'<OrganizationStatus.ACTIVE: 0>'`
-        # if `.value` is ommited
+        # if `.value` is omitted
         default=OrganizationStatus.ACTIVE.value
     )
     date_added = models.DateTimeField(default=timezone.now)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -104,7 +104,8 @@ class Organization(Model):
     slug = models.SlugField(unique=True)
     status = BoundedPositiveIntegerField(
         choices=OrganizationStatus.as_choices(),
-        default=OrganizationStatus.ACTIVE
+        # this only needs to use `.value` because of south
+        default=OrganizationStatus.ACTIVE.value
     )
     date_added = models.DateTimeField(default=timezone.now)
     members = models.ManyToManyField(


### PR DESCRIPTION
this was breaking the default value in south when generating migrations:
```
'sentry.organization': {
    'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '<OrganizationStatus.ACTIVE: 0>'})
...

},
```
this changes the result from
```
((<OrganizationStatus.ACTIVE: 0>, 'active'),
 (<OrganizationStatus.PENDING_DELETION: 1>, 'pending deletion'),
 (<OrganizationStatus.DELETION_IN_PROGRESS: 2>, 'deletion in progress'))
```
to
`((0, 'active'), (1, 'pending deletion'), (2, 'deletion in progress'))`

since the model definition was the only place this i don't think there'll be a problem? but let me know if there's a better way to fix this.