### PR TITLE
refactor(settings): refactor settings page header to support titles and tabs

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
@@ -5,7 +5,7 @@ import SettingsPageHeader from '../components/settingsPageHeader';
 const AccountEmails = () => {
   return (
     <div>
-      <SettingsPageHeader label="Emails" />
+      <SettingsPageHeader title="Emails" />
     </div>
   );
 };

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
@@ -25,7 +25,7 @@ export default class AccountNotifications extends AsyncView {
   renderBody() {
     return (
       <div>
-        <SettingsPageHeader label="Notifications" />
+        <SettingsPageHeader title="Notifications" />
         <ApiForm
           initialData={this.state.data}
           apiMethod="PUT"

--- a/src/sentry/static/sentry/app/views/settings/components/settingsHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsHeader.jsx
@@ -7,13 +7,22 @@ const SettingsHeader = styled(Flex)`
   top: 0;
   height: 105px;
   width: 1010px;
-  background-image: linear-gradient(
-    to bottom,
-    #fcfcfc 0%,
-    #fcfcfc 80%,
-    rgba(255, 255, 255, 0.2) 100%
-  );
   z-index: ${p => p.theme.zIndex.header};
+  &:before {
+    position: absolute;
+    display: block;
+    content: '';
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 5px;
+    background-image: linear-gradient(
+      to bottom,
+      #fcfcfc 0%,
+      #fcfcfc 80%,
+      rgba(255, 255, 255, 0.2) 100%
+    );
+  }
 `;
 
 export default SettingsHeader;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsHeading.styled.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsHeading.styled.jsx
@@ -3,6 +3,7 @@ import styled from 'react-emotion';
 const SettingsHeading = styled.div`
   color: ${p => p.theme.gray3};
   font-size: 12px;
+  line-height: 1.3;
   font-weight: 600;
   text-transform: uppercase;
   margin-bottom: 20px;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
@@ -11,7 +11,6 @@ class SettingsPageHeading extends React.Component {
   };
 
   render() {
-    // Todo(ckj) support tabs
     return (
       <Wrapper tabs={this.props.tabs}>
         <Flex align="center">
@@ -31,7 +30,6 @@ const Wrapper = styled.div`
   margin: -20px 0 30px;
 `;
 
-// Label w/ border
 const Title = styled.div`
   font-size: 20px;
   font-weight: bold;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
@@ -1,54 +1,42 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
+import {Flex} from 'grid-emotion';
 
 class SettingsPageHeading extends React.Component {
   static propTypes = {
-    label: PropTypes.string,
+    title: PropTypes.string,
     action: PropTypes.node,
+    tabs: PropTypes.node,
   };
 
   render() {
     // Todo(ckj) support tabs
     return (
-      <Wrapper>
-        {this.props.label && (
-          <LabelContainer>
-            <Label>
-              <LabelText>{this.props.label}</LabelText>
-            </Label>
-          </LabelContainer>
-        )}
-        {this.props.action && <div>{this.props.action}</div>}
+      <Wrapper tabs={this.props.tabs}>
+        <Flex align="center">
+          {this.props.title && <Title>{this.props.title}</Title>}
+          {this.props.action && <div>{this.props.action}</div>}
+        </Flex>
+
+        {this.props.tabs && <div>{this.props.tabs}</div>}
       </Wrapper>
     );
   }
 }
 
 const Wrapper = styled.div`
-  display: flex;
-  align-items: top;
   font-size: 14px;
   box-shadow: inset 0 -1px 0 ${p => p.theme.borderLight};
-  margin-bottom: 30px;
-`;
-
-const LabelContainer = styled.div`
-  display: flex;
-  flex: 1;
+  margin: -20px 0 30px;
 `;
 
 // Label w/ border
-const Label = styled.div`
-  display: flex;
-  align-items: center;
+const Title = styled.div`
+  font-size: 20px;
   font-weight: bold;
-  border-bottom: 3px solid ${p => p.theme.purple};
-`;
-
-// Label text only
-const LabelText = styled.span`
-  padding: 0 0 15px;
+  margin: 20px 0;
+  flex: 1;
 `;
 
 export default SettingsPageHeading;

--- a/src/sentry/static/sentry/app/views/settings/organization/apiKeys/organizationApiKeysList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/apiKeys/organizationApiKeysList.jsx
@@ -51,7 +51,7 @@ class OrganizationApiKeysList extends React.Component {
     );
     return (
       <div>
-        <SettingsPageHeader label={t('API Keys')} action={action} />
+        <SettingsPageHeader title={t('API Keys')} action={action} />
 
         <TextBlock>
           {tct(

--- a/src/sentry/static/sentry/app/views/settings/organization/auditLog/auditLogList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/auditLog/auditLogList.jsx
@@ -67,7 +67,7 @@ class AuditLogList extends React.Component {
 
     return (
       <div>
-        <SettingsPageHeader label={t('Audit Log')} />
+        <SettingsPageHeader title={t('Audit Log')} />
 
         <SpreadLayout>
           <p>{t('Sentry keeps track of important events within your organization.')}</p>

--- a/src/sentry/static/sentry/app/views/settings/organization/auth/organizationAuthView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/auth/organizationAuthView.jsx
@@ -93,7 +93,7 @@ class OrganizationAuthView extends OrganizationSettingsView {
 
     return (
       <div>
-        <SettingsPageHeader label="Authentication" />
+        <SettingsPageHeader title="Authentication" />
         <Panel>
           <PanelHeader disablePadding>
             <Flex>

--- a/src/sentry/static/sentry/app/views/settings/organization/general/organizationGeneralSettingsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/general/organizationGeneralSettingsView.jsx
@@ -133,7 +133,7 @@ const OrganizationGeneralSettingsView = createReactClass({
         {!this.state.loading &&
           this.state.Form && (
             <div>
-              <SettingsPageHeader label={t('Organization Settings')} />
+              <SettingsPageHeader title={t('Organization Settings')} />
               <this.state.Form
                 {...this.props}
                 initialData={data}

--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
@@ -217,7 +217,8 @@ class OrganizationMembersView extends OrganizationSettingsView {
 
     let action = (
       <Button
-        priority="link"
+        priority="primary"
+        size="small"
         disabled={!canAddMembers}
         title={
           !canAddMembers
@@ -232,7 +233,7 @@ class OrganizationMembersView extends OrganizationSettingsView {
 
     return (
       <div>
-        <SettingsPageHeader label="Members" action={action} />
+        <SettingsPageHeader title="Members" action={action} />
 
         <OrganizationAccessRequests
           onApprove={this.handleApprove}

--- a/src/sentry/static/sentry/app/views/settings/organization/rateLimit/rateLimitView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/rateLimit/rateLimitView.jsx
@@ -150,7 +150,7 @@ const RateLimitView = createReactClass({
 
     return (
       <div>
-        <SettingsPageHeader label={t('Rate Limits')} />
+        <SettingsPageHeader title={t('Rate Limits')} />
 
         <Panel>
           <PanelHeader disablePadding>

--- a/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
@@ -66,7 +66,7 @@ class OrganizationRepositories extends React.Component {
     return (
       <div>
         <SettingsPageHeader
-          label={t('Repositories')}
+          title={t('Repositories')}
           action={
             <DropdownLink
               anchorRight

--- a/src/sentry/static/sentry/app/views/settings/organization/stats/organizationStats.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/stats/organizationStats.jsx
@@ -64,7 +64,7 @@ class OrganizationStats extends React.Component {
 
     return (
       <div>
-        <SettingsPageHeader label={t('Organization Stats')} />
+        <SettingsPageHeader title={t('Organization Stats')} />
         <div className="row">
           <div className="col-md-9">
             <p>

--- a/src/sentry/static/sentry/app/views/settings/team/organizationTeamsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/organizationTeamsView.jsx
@@ -7,6 +7,7 @@ import ExpandedTeamList from './expandedTeamList';
 import AllTeamsList from './allTeamsList';
 import ListLink from '../../../components/listLink';
 import recreateRoute from '../../../utils/recreateRoute';
+import SettingsPageHeader from '../components/settingsPageHeader';
 
 class OrganizationTeamsView extends React.Component {
   static propTypes = {
@@ -40,14 +41,18 @@ class OrganizationTeamsView extends React.Component {
     let teamRoute = routes.find(({path}) => path === 'teams/');
     let urlPrefix = recreateRoute(teamRoute, {routes, params, stepBack: -1});
 
+    let tabs = (
+      <ul className="nav nav-tabs border-bottom">
+        <ListLink to={`${urlPrefix}teams/your-teams/`}>{t('Your Teams')}</ListLink>
+        <ListLink to={`${urlPrefix}teams/all-teams/`}>
+          {t('All Teams')} <span className="badge badge-soft">{allTeams.length}</span>
+        </ListLink>
+      </ul>
+    );
+
     return (
       <div className="team-list">
-        <ul className="nav nav-tabs border-bottom">
-          <ListLink to={`${urlPrefix}teams/your-teams/`}>{t('Your Teams')}</ListLink>
-          <ListLink to={`${urlPrefix}teams/all-teams/`}>
-            {t('All Teams')} <span className="badge badge-soft">{allTeams.length}</span>
-          </ListLink>
-        </ul>
+        <SettingsPageHeader title={t('Projects & Teams')} tabs={tabs} />
         {route.allTeams /* should be AllTeamsList */ ? (
           <AllTeamsList
             urlPrefix={urlPrefix}

--- a/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -1,31 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OrganizationApiKeysList renders 1`] = `
-.glamor-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: top;
-  -webkit-box-align: top;
-  -ms-flex-align: top;
-  align-items: top;
+.glamor-6 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
-  margin-bottom: 30px;
+  margin: -20px 0 30px;
 }
 
 .glamor-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.glamor-2 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,30 +17,33 @@ exports[`OrganizationApiKeysList renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  font-weight: bold;
-  border-bottom: 3px solid;
 }
 
 .glamor-0 {
-  padding: 0 0 15px;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 20px 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
-.glamor-6 {
+.glamor-2 {
   margin-right: 4px;
 }
 
-.glamor-10 {
+.glamor-8 {
   line-height: 1.8;
 }
 
-.glamor-40 {
+.glamor-38 {
   background: #fff;
   border: 1px solid;
   margin-bottom: 30px;
   position: relative;
 }
 
-.glamor-24 {
+.glamor-22 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   background: padding:15px 0;
@@ -65,7 +51,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   font-size: 13px;
 }
 
-.glamor-22 {
+.glamor-20 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -75,19 +61,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   margin: 0;
 }
 
-.glamor-20 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.glamor-16 {
+.glamor-14 {
   box-sizing: border-box;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -102,7 +76,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   align-items: center;
 }
 
-.glamor-12 {
+.glamor-10 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -111,7 +85,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   flex: 1;
 }
 
-.glamor-14 {
+.glamor-12 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -120,14 +94,14 @@ exports[`OrganizationApiKeysList renders 1`] = `
   flex: 2;
 }
 
-.glamor-18 {
+.glamor-16 {
   box-sizing: border-box;
   width: 100px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-34 {
+.glamor-32 {
   box-sizing: border-box;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -142,7 +116,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-34:last-child {
+.glamor-32:last-child {
   border: 0;
 }
 
@@ -203,72 +177,74 @@ exports[`OrganizationApiKeysList renders 1`] = `
           New API Key
         </Button>
       }
-      label="API Keys"
+      title="API Keys"
     >
       <Styled(div)>
         <div
-          className="glamor-8 glamor-9"
+          className="glamor-6 glamor-7"
         >
-          <Styled(div)>
-            <div
-              className="glamor-4 glamor-5"
+          <Flex
+            align="center"
+          >
+            <Base
+              align="center"
+              className="glamor-4"
             >
-              <Styled(div)>
-                <div
-                  className="glamor-2 glamor-3"
-                >
-                  <Styled(span)>
-                    <span
-                      className="glamor-0 glamor-1"
-                    >
-                      API Keys
-                    </span>
-                  </Styled(span)>
-                </div>
-              </Styled(div)>
-            </div>
-          </Styled(div)>
-          <div>
-            <Button
-              disabled={false}
-              priority="link"
-            >
-              <button
-                className="button button-link"
-                disabled={false}
-                onClick={[Function]}
-                role="button"
+              <div
+                className="glamor-4"
+                is={null}
               >
-                <FlowLayout
-                  truncate={false}
-                >
+                <Styled(div)>
                   <div
-                    className="flow-layout"
+                    className="glamor-0 glamor-1"
                   >
-                    <span
-                      className="button-label"
-                    >
-                      <Styled(span)
-                        className="icon-plus"
-                      >
-                        <span
-                          className="icon-plus glamor-6 glamor-7"
-                        />
-                      </Styled(span)>
-                       
-                      New API Key
-                    </span>
+                    API Keys
                   </div>
-                </FlowLayout>
-              </button>
-            </Button>
-          </div>
+                </Styled(div)>
+                <div>
+                  <Button
+                    disabled={false}
+                    priority="link"
+                  >
+                    <button
+                      className="button button-link"
+                      disabled={false}
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      <FlowLayout
+                        truncate={false}
+                      >
+                        <div
+                          className="flow-layout"
+                        >
+                          <span
+                            className="button-label"
+                          >
+                            <Styled(span)
+                              className="icon-plus"
+                            >
+                              <span
+                                className="icon-plus glamor-2 glamor-3"
+                              />
+                            </Styled(span)>
+                             
+                            New API Key
+                          </span>
+                        </div>
+                      </FlowLayout>
+                    </button>
+                  </Button>
+                </div>
+              </div>
+            </Base>
+          </Flex>
         </div>
       </Styled(div)>
     </SettingsPageHeading>
     <Styled(p)>
       <p
-        className="glamor-10 glamor-11"
+        className="glamor-8 glamor-9"
       >
         <span
           key="5"
@@ -340,7 +316,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
     </div>
     <Styled(div)>
       <div
-        className="glamor-40 glamor-41"
+        className="glamor-38 glamor-39"
       >
         <PanelHeader
           disablePadding={true}
@@ -349,21 +325,21 @@ exports[`OrganizationApiKeysList renders 1`] = `
             disablePadding={true}
           >
             <div
-              className="glamor-24 glamor-25"
+              className="glamor-22 glamor-23"
             >
               <Styled(div)>
                 <div
-                  className="glamor-22 glamor-23"
+                  className="glamor-20 glamor-21"
                 >
                   <Flex
                     align="center"
                   >
                     <Base
                       align="center"
-                      className="glamor-20"
+                      className="glamor-4"
                     >
                       <div
-                        className="glamor-20"
+                        className="glamor-4"
                         is={null}
                       >
                         <Flex
@@ -372,11 +348,11 @@ exports[`OrganizationApiKeysList renders 1`] = `
                         >
                           <Base
                             align="center"
-                            className="glamor-16"
+                            className="glamor-14"
                             flex="1"
                           >
                             <div
-                              className="glamor-16"
+                              className="glamor-14"
                               is={null}
                             >
                               <Box
@@ -384,12 +360,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                 px={2}
                               >
                                 <Base
-                                  className="glamor-12"
+                                  className="glamor-10"
                                   flex="1"
                                   px={2}
                                 >
                                   <div
-                                    className="glamor-12"
+                                    className="glamor-10"
                                     is={null}
                                   >
                                     Name
@@ -401,12 +377,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                 px={2}
                               >
                                 <Base
-                                  className="glamor-14"
+                                  className="glamor-12"
                                   flex="2"
                                   px={2}
                                 >
                                   <div
-                                    className="glamor-14"
+                                    className="glamor-12"
                                     is={null}
                                   >
                                     Key
@@ -421,12 +397,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                           w={100}
                         >
                           <Base
-                            className="glamor-18"
+                            className="glamor-16"
                             px={2}
                             w={100}
                           >
                             <div
-                              className="glamor-18"
+                              className="glamor-16"
                               is={null}
                             >
                               Actions
@@ -443,7 +419,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
         </PanelHeader>
         <Styled(div)>
           <div
-            className="glamor-38 glamor-39"
+            className="glamor-36 glamor-37"
           >
             <Styled(Base)
               align="center"
@@ -452,11 +428,11 @@ exports[`OrganizationApiKeysList renders 1`] = `
             >
               <Base
                 align="center"
-                className="glamor-34 glamor-35"
+                className="glamor-32 glamor-33"
                 py={1}
               >
                 <div
-                  className="glamor-34 glamor-35"
+                  className="glamor-32 glamor-33"
                   is={null}
                 >
                   <Flex
@@ -465,11 +441,11 @@ exports[`OrganizationApiKeysList renders 1`] = `
                   >
                     <Base
                       align="center"
-                      className="glamor-16"
+                      className="glamor-14"
                       flex="1"
                     >
                       <div
-                        className="glamor-16"
+                        className="glamor-14"
                         is={null}
                       >
                         <Box
@@ -479,12 +455,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                         >
                           <Base
                             align="center"
-                            className="glamor-12"
+                            className="glamor-10"
                             flex="1"
                             px={2}
                           >
                             <div
-                              className="glamor-12"
+                              className="glamor-10"
                               is={null}
                             >
                               <Link
@@ -504,12 +480,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                           px={2}
                         >
                           <Base
-                            className="glamor-14"
+                            className="glamor-12"
                             flex="2"
                             px={2}
                           >
                             <div
-                              className="glamor-14"
+                              className="glamor-12"
                               is={null}
                             >
                               <div
@@ -528,12 +504,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                     w={100}
                   >
                     <Base
-                      className="glamor-18"
+                      className="glamor-16"
                       px={2}
                       w={100}
                     >
                       <div
-                        className="glamor-18"
+                        className="glamor-16"
                         is={null}
                       >
                         <LinkWithConfirmation

--- a/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
@@ -1,31 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OrganizationMembersView No Require Link does not have 2fa warning if user has 2fa 1`] = `
-.glamor-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: top;
-  -webkit-box-align: top;
-  -ms-flex-align: top;
-  align-items: top;
+.glamor-4 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
-  margin-bottom: 30px;
-}
-
-.glamor-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
+  margin: -20px 0 30px;
 }
 
 .glamor-2 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,22 +17,25 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  font-weight: bold;
-  border-bottom: 3px solid;
 }
 
 .glamor-0 {
-  padding: 0 0 15px;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 20px 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
-.glamor-84 {
+.glamor-82 {
   background: #fff;
   border: 1px solid;
   margin-bottom: 30px;
   position: relative;
 }
 
-.glamor-20 {
+.glamor-18 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   background: padding:15px 0;
@@ -57,7 +43,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   font-size: 13px;
 }
 
-.glamor-18 {
+.glamor-16 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -67,19 +53,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   margin: 0;
 }
 
-.glamor-16 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.glamor-8 {
+.glamor-6 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -88,21 +62,21 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-10 {
+.glamor-8 {
   box-sizing: border-box;
   width: 180px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-12 {
+.glamor-10 {
   box-sizing: border-box;
   width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-38 {
+.glamor-36 {
   box-sizing: border-box;
   padding-top: 16px;
   padding-bottom: 16px;
@@ -117,16 +91,16 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   border-bottom: 1px solid;
 }
 
-.glamor-38:last-child {
+.glamor-36:last-child {
   border: 0;
 }
 
-.glamor-22 {
+.glamor-20 {
   box-sizing: border-box;
   padding-left: 16px;
 }
 
-.glamor-30 {
+.glamor-28 {
   box-sizing: border-box;
   padding-left: 8px;
   padding-right: 16px;
@@ -135,11 +109,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-24 {
+.glamor-22 {
   font-size: 16px;
 }
 
-.glamor-28 {
+.glamor-26 {
   font-size: 14px;
 }
 
@@ -188,7 +162,8 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
         action={
           <Button
             disabled={false}
-            priority="link"
+            priority="primary"
+            size="small"
             title={undefined}
             to="new"
           >
@@ -199,74 +174,77 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
             Invite Member
           </Button>
         }
-        label="Members"
+        title="Members"
       >
         <Styled(div)>
           <div
-            className="glamor-6 glamor-7"
+            className="glamor-4 glamor-5"
           >
-            <Styled(div)>
-              <div
-                className="glamor-4 glamor-5"
+            <Flex
+              align="center"
+            >
+              <Base
+                align="center"
+                className="glamor-2"
               >
-                <Styled(div)>
-                  <div
-                    className="glamor-2 glamor-3"
-                  >
-                    <Styled(span)>
-                      <span
-                        className="glamor-0 glamor-1"
-                      >
-                        Members
-                      </span>
-                    </Styled(span)>
-                  </div>
-                </Styled(div)>
-              </div>
-            </Styled(div)>
-            <div>
-              <Button
-                disabled={false}
-                priority="link"
-                to="new"
-              >
-                <Link
-                  className="button button-link"
-                  disabled={false}
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  role="button"
-                  style={Object {}}
-                  to="new"
+                <div
+                  className="glamor-2"
+                  is={null}
                 >
-                  <a
-                    className="button button-link"
-                    disabled={false}
-                    onClick={[Function]}
-                    role="button"
-                    style={Object {}}
-                  >
-                    <FlowLayout
-                      truncate={false}
+                  <Styled(div)>
+                    <div
+                      className="glamor-0 glamor-1"
                     >
-                      <div
-                        className="flow-layout"
+                      Members
+                    </div>
+                  </Styled(div)>
+                  <div>
+                    <Button
+                      disabled={false}
+                      priority="primary"
+                      size="small"
+                      to="new"
+                    >
+                      <Link
+                        className="button button-primary button-sm"
+                        disabled={false}
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        role="button"
+                        style={Object {}}
+                        to="new"
                       >
-                        <span
-                          className="button-label"
+                        <a
+                          className="button button-primary button-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          role="button"
+                          style={Object {}}
                         >
-                          <span
-                            className="icon-plus"
-                          />
-                           
-                          Invite Member
-                        </span>
-                      </div>
-                    </FlowLayout>
-                  </a>
-                </Link>
-              </Button>
-            </div>
+                          <FlowLayout
+                            truncate={false}
+                          >
+                            <div
+                              className="flow-layout"
+                            >
+                              <span
+                                className="button-label"
+                              >
+                                <span
+                                  className="icon-plus"
+                                />
+                                 
+                                Invite Member
+                              </span>
+                            </div>
+                          </FlowLayout>
+                        </a>
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              </Base>
+            </Flex>
           </div>
         </Styled(div)>
       </SettingsPageHeading>
@@ -278,7 +256,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
       />
       <Styled(div)>
         <div
-          className="glamor-84 glamor-85"
+          className="glamor-82 glamor-83"
         >
           <PanelHeader
             disablePadding={true}
@@ -287,21 +265,21 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
               disablePadding={true}
             >
               <div
-                className="glamor-20 glamor-21"
+                className="glamor-18 glamor-19"
               >
                 <Styled(div)>
                   <div
-                    className="glamor-18 glamor-19"
+                    className="glamor-16 glamor-17"
                   >
                     <Flex
                       align="center"
                     >
                       <Base
                         align="center"
-                        className="glamor-16"
+                        className="glamor-2"
                       >
                         <div
-                          className="glamor-16"
+                          className="glamor-2"
                           is={null}
                         >
                           <Box
@@ -309,12 +287,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             px={2}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-6"
                               flex="1"
                               px={2}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-6"
                                 is={null}
                               >
                                 Member
@@ -326,12 +304,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-8"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-8"
                                 is={null}
                               >
                                 Status
@@ -343,12 +321,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-10"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-10"
                                 is={null}
                               >
                                 Role
@@ -360,12 +338,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-10"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-10"
                                 is={null}
                               >
                                 Actions
@@ -382,7 +360,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
           </PanelHeader>
           <Styled(div)>
             <div
-              className="glamor-82 glamor-83"
+              className="glamor-80 glamor-81"
             >
               <OrganizationMemberRow
                 canAddMembers={true}
@@ -446,22 +424,22 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                 >
                   <Base
                     align="center"
-                    className="glamor-38 glamor-39"
+                    className="glamor-36 glamor-37"
                     py={2}
                   >
                     <div
-                      className="glamor-38 glamor-39"
+                      className="glamor-36 glamor-37"
                       is={null}
                     >
                       <Box
                         pl={2}
                       >
                         <Base
-                          className="glamor-22"
+                          className="glamor-20"
                           pl={2}
                         >
                           <div
-                            className="glamor-22"
+                            className="glamor-20"
                             is={null}
                           >
                             <Avatar
@@ -509,13 +487,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         pr={2}
                       >
                         <Base
-                          className="glamor-30"
+                          className="glamor-28"
                           flex="1"
                           pl={1}
                           pr={2}
                         >
                           <div
-                            className="glamor-30"
+                            className="glamor-28"
                             is={null}
                           >
                             <h5
@@ -529,11 +507,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 to="1"
                               >
                                 <Link
-                                  className="glamor-24 glamor-25"
+                                  className="glamor-22 glamor-23"
                                   to="1"
                                 >
                                   <a
-                                    className="glamor-24 glamor-25"
+                                    className="glamor-22 glamor-23"
                                     href="1"
                                   />
                                 </Link>
@@ -541,7 +519,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             </h5>
                             <Styled(div)>
                               <div
-                                className="glamor-28 glamor-29"
+                                className="glamor-26 glamor-27"
                               />
                             </Styled(div)>
                           </div>
@@ -552,12 +530,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={180}
                       >
                         <Base
-                          className="glamor-10"
+                          className="glamor-8"
                           px={2}
                           w={180}
                         >
                           <div
-                            className="glamor-10"
+                            className="glamor-8"
                             is={null}
                           >
                             <div>
@@ -583,12 +561,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           />
                         </Base>
@@ -598,12 +576,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           >
                             <Button
@@ -705,22 +683,22 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                 >
                   <Base
                     align="center"
-                    className="glamor-38 glamor-39"
+                    className="glamor-36 glamor-37"
                     py={2}
                   >
                     <div
-                      className="glamor-38 glamor-39"
+                      className="glamor-36 glamor-37"
                       is={null}
                     >
                       <Box
                         pl={2}
                       >
                         <Base
-                          className="glamor-22"
+                          className="glamor-20"
                           pl={2}
                         >
                           <div
-                            className="glamor-22"
+                            className="glamor-20"
                             is={null}
                           >
                             <Avatar
@@ -768,13 +746,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         pr={2}
                       >
                         <Base
-                          className="glamor-30"
+                          className="glamor-28"
                           flex="1"
                           pl={1}
                           pr={2}
                         >
                           <div
-                            className="glamor-30"
+                            className="glamor-28"
                             is={null}
                           >
                             <h5
@@ -788,11 +766,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 to="2"
                               >
                                 <Link
-                                  className="glamor-24 glamor-25"
+                                  className="glamor-22 glamor-23"
                                   to="2"
                                 >
                                   <a
-                                    className="glamor-24 glamor-25"
+                                    className="glamor-22 glamor-23"
                                     href="2"
                                   />
                                 </Link>
@@ -800,7 +778,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             </h5>
                             <Styled(div)>
                               <div
-                                className="glamor-28 glamor-29"
+                                className="glamor-26 glamor-27"
                               />
                             </Styled(div)>
                           </div>
@@ -811,12 +789,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={180}
                       >
                         <Base
-                          className="glamor-10"
+                          className="glamor-8"
                           px={2}
                           w={180}
                         >
                           <div
-                            className="glamor-10"
+                            className="glamor-8"
                             is={null}
                           >
                             <div>
@@ -837,12 +815,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           />
                         </Base>
@@ -852,12 +830,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           >
                             <Button
@@ -959,22 +937,22 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                 >
                   <Base
                     align="center"
-                    className="glamor-38 glamor-39"
+                    className="glamor-36 glamor-37"
                     py={2}
                   >
                     <div
-                      className="glamor-38 glamor-39"
+                      className="glamor-36 glamor-37"
                       is={null}
                     >
                       <Box
                         pl={2}
                       >
                         <Base
-                          className="glamor-22"
+                          className="glamor-20"
                           pl={2}
                         >
                           <div
-                            className="glamor-22"
+                            className="glamor-20"
                             is={null}
                           >
                             <Avatar
@@ -1022,13 +1000,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         pr={2}
                       >
                         <Base
-                          className="glamor-30"
+                          className="glamor-28"
                           flex="1"
                           pl={1}
                           pr={2}
                         >
                           <div
-                            className="glamor-30"
+                            className="glamor-28"
                             is={null}
                           >
                             <h5
@@ -1042,11 +1020,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 to="3"
                               >
                                 <Link
-                                  className="glamor-24 glamor-25"
+                                  className="glamor-22 glamor-23"
                                   to="3"
                                 >
                                   <a
-                                    className="glamor-24 glamor-25"
+                                    className="glamor-22 glamor-23"
                                     href="3"
                                   />
                                 </Link>
@@ -1054,7 +1032,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             </h5>
                             <Styled(div)>
                               <div
-                                className="glamor-28 glamor-29"
+                                className="glamor-26 glamor-27"
                               />
                             </Styled(div)>
                           </div>
@@ -1065,12 +1043,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={180}
                       >
                         <Base
-                          className="glamor-10"
+                          className="glamor-8"
                           px={2}
                           w={180}
                         >
                           <div
-                            className="glamor-10"
+                            className="glamor-8"
                             is={null}
                           >
                             <div>
@@ -1091,12 +1069,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           />
                         </Base>
@@ -1106,12 +1084,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           >
                             <Button
@@ -1161,31 +1139,14 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
 `;
 
 exports[`OrganizationMembersView Require Link does not have 2fa warning if user has 2fa 1`] = `
-.glamor-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: top;
-  -webkit-box-align: top;
-  -ms-flex-align: top;
-  align-items: top;
+.glamor-4 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
-  margin-bottom: 30px;
-}
-
-.glamor-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
+  margin: -20px 0 30px;
 }
 
 .glamor-2 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1194,22 +1155,25 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  font-weight: bold;
-  border-bottom: 3px solid;
 }
 
 .glamor-0 {
-  padding: 0 0 15px;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 20px 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
-.glamor-84 {
+.glamor-82 {
   background: #fff;
   border: 1px solid;
   margin-bottom: 30px;
   position: relative;
 }
 
-.glamor-20 {
+.glamor-18 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   background: padding:15px 0;
@@ -1217,7 +1181,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   font-size: 13px;
 }
 
-.glamor-18 {
+.glamor-16 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -1227,19 +1191,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   margin: 0;
 }
 
-.glamor-16 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.glamor-8 {
+.glamor-6 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -1248,21 +1200,21 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-10 {
+.glamor-8 {
   box-sizing: border-box;
   width: 180px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-12 {
+.glamor-10 {
   box-sizing: border-box;
   width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-38 {
+.glamor-36 {
   box-sizing: border-box;
   padding-top: 16px;
   padding-bottom: 16px;
@@ -1277,16 +1229,16 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   border-bottom: 1px solid;
 }
 
-.glamor-38:last-child {
+.glamor-36:last-child {
   border: 0;
 }
 
-.glamor-22 {
+.glamor-20 {
   box-sizing: border-box;
   padding-left: 16px;
 }
 
-.glamor-30 {
+.glamor-28 {
   box-sizing: border-box;
   padding-left: 8px;
   padding-right: 16px;
@@ -1295,11 +1247,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-24 {
+.glamor-22 {
   font-size: 16px;
 }
 
-.glamor-28 {
+.glamor-26 {
   font-size: 14px;
 }
 
@@ -1348,7 +1300,8 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
         action={
           <Button
             disabled={false}
-            priority="link"
+            priority="primary"
+            size="small"
             title={undefined}
             to="new"
           >
@@ -1359,74 +1312,77 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
             Invite Member
           </Button>
         }
-        label="Members"
+        title="Members"
       >
         <Styled(div)>
           <div
-            className="glamor-6 glamor-7"
+            className="glamor-4 glamor-5"
           >
-            <Styled(div)>
-              <div
-                className="glamor-4 glamor-5"
+            <Flex
+              align="center"
+            >
+              <Base
+                align="center"
+                className="glamor-2"
               >
-                <Styled(div)>
-                  <div
-                    className="glamor-2 glamor-3"
-                  >
-                    <Styled(span)>
-                      <span
-                        className="glamor-0 glamor-1"
-                      >
-                        Members
-                      </span>
-                    </Styled(span)>
-                  </div>
-                </Styled(div)>
-              </div>
-            </Styled(div)>
-            <div>
-              <Button
-                disabled={false}
-                priority="link"
-                to="new"
-              >
-                <Link
-                  className="button button-link"
-                  disabled={false}
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  role="button"
-                  style={Object {}}
-                  to="new"
+                <div
+                  className="glamor-2"
+                  is={null}
                 >
-                  <a
-                    className="button button-link"
-                    disabled={false}
-                    onClick={[Function]}
-                    role="button"
-                    style={Object {}}
-                  >
-                    <FlowLayout
-                      truncate={false}
+                  <Styled(div)>
+                    <div
+                      className="glamor-0 glamor-1"
                     >
-                      <div
-                        className="flow-layout"
+                      Members
+                    </div>
+                  </Styled(div)>
+                  <div>
+                    <Button
+                      disabled={false}
+                      priority="primary"
+                      size="small"
+                      to="new"
+                    >
+                      <Link
+                        className="button button-primary button-sm"
+                        disabled={false}
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        role="button"
+                        style={Object {}}
+                        to="new"
                       >
-                        <span
-                          className="button-label"
+                        <a
+                          className="button button-primary button-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          role="button"
+                          style={Object {}}
                         >
-                          <span
-                            className="icon-plus"
-                          />
-                           
-                          Invite Member
-                        </span>
-                      </div>
-                    </FlowLayout>
-                  </a>
-                </Link>
-              </Button>
-            </div>
+                          <FlowLayout
+                            truncate={false}
+                          >
+                            <div
+                              className="flow-layout"
+                            >
+                              <span
+                                className="button-label"
+                              >
+                                <span
+                                  className="icon-plus"
+                                />
+                                 
+                                Invite Member
+                              </span>
+                            </div>
+                          </FlowLayout>
+                        </a>
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              </Base>
+            </Flex>
           </div>
         </Styled(div)>
       </SettingsPageHeading>
@@ -1438,7 +1394,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
       />
       <Styled(div)>
         <div
-          className="glamor-84 glamor-85"
+          className="glamor-82 glamor-83"
         >
           <PanelHeader
             disablePadding={true}
@@ -1447,21 +1403,21 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
               disablePadding={true}
             >
               <div
-                className="glamor-20 glamor-21"
+                className="glamor-18 glamor-19"
               >
                 <Styled(div)>
                   <div
-                    className="glamor-18 glamor-19"
+                    className="glamor-16 glamor-17"
                   >
                     <Flex
                       align="center"
                     >
                       <Base
                         align="center"
-                        className="glamor-16"
+                        className="glamor-2"
                       >
                         <div
-                          className="glamor-16"
+                          className="glamor-2"
                           is={null}
                         >
                           <Box
@@ -1469,12 +1425,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             px={2}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-6"
                               flex="1"
                               px={2}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-6"
                                 is={null}
                               >
                                 Member
@@ -1486,12 +1442,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-8"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-8"
                                 is={null}
                               >
                                 Status
@@ -1503,12 +1459,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-10"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-10"
                                 is={null}
                               >
                                 Role
@@ -1520,12 +1476,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-10"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-10"
                                 is={null}
                               >
                                 Actions
@@ -1542,7 +1498,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
           </PanelHeader>
           <Styled(div)>
             <div
-              className="glamor-82 glamor-83"
+              className="glamor-80 glamor-81"
             >
               <OrganizationMemberRow
                 canAddMembers={true}
@@ -1606,22 +1562,22 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                 >
                   <Base
                     align="center"
-                    className="glamor-38 glamor-39"
+                    className="glamor-36 glamor-37"
                     py={2}
                   >
                     <div
-                      className="glamor-38 glamor-39"
+                      className="glamor-36 glamor-37"
                       is={null}
                     >
                       <Box
                         pl={2}
                       >
                         <Base
-                          className="glamor-22"
+                          className="glamor-20"
                           pl={2}
                         >
                           <div
-                            className="glamor-22"
+                            className="glamor-20"
                             is={null}
                           >
                             <Avatar
@@ -1669,13 +1625,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         pr={2}
                       >
                         <Base
-                          className="glamor-30"
+                          className="glamor-28"
                           flex="1"
                           pl={1}
                           pr={2}
                         >
                           <div
-                            className="glamor-30"
+                            className="glamor-28"
                             is={null}
                           >
                             <h5
@@ -1689,11 +1645,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 to="1"
                               >
                                 <Link
-                                  className="glamor-24 glamor-25"
+                                  className="glamor-22 glamor-23"
                                   to="1"
                                 >
                                   <a
-                                    className="glamor-24 glamor-25"
+                                    className="glamor-22 glamor-23"
                                     href="1"
                                   />
                                 </Link>
@@ -1701,7 +1657,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             </h5>
                             <Styled(div)>
                               <div
-                                className="glamor-28 glamor-29"
+                                className="glamor-26 glamor-27"
                               />
                             </Styled(div)>
                           </div>
@@ -1712,12 +1668,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={180}
                       >
                         <Base
-                          className="glamor-10"
+                          className="glamor-8"
                           px={2}
                           w={180}
                         >
                           <div
-                            className="glamor-10"
+                            className="glamor-8"
                             is={null}
                           >
                             <div>
@@ -1774,12 +1730,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           />
                         </Base>
@@ -1789,12 +1745,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           >
                             <Button
@@ -1896,22 +1852,22 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                 >
                   <Base
                     align="center"
-                    className="glamor-38 glamor-39"
+                    className="glamor-36 glamor-37"
                     py={2}
                   >
                     <div
-                      className="glamor-38 glamor-39"
+                      className="glamor-36 glamor-37"
                       is={null}
                     >
                       <Box
                         pl={2}
                       >
                         <Base
-                          className="glamor-22"
+                          className="glamor-20"
                           pl={2}
                         >
                           <div
-                            className="glamor-22"
+                            className="glamor-20"
                             is={null}
                           >
                             <Avatar
@@ -1959,13 +1915,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         pr={2}
                       >
                         <Base
-                          className="glamor-30"
+                          className="glamor-28"
                           flex="1"
                           pl={1}
                           pr={2}
                         >
                           <div
-                            className="glamor-30"
+                            className="glamor-28"
                             is={null}
                           >
                             <h5
@@ -1979,11 +1935,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 to="2"
                               >
                                 <Link
-                                  className="glamor-24 glamor-25"
+                                  className="glamor-22 glamor-23"
                                   to="2"
                                 >
                                   <a
-                                    className="glamor-24 glamor-25"
+                                    className="glamor-22 glamor-23"
                                     href="2"
                                   />
                                 </Link>
@@ -1991,7 +1947,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             </h5>
                             <Styled(div)>
                               <div
-                                className="glamor-28 glamor-29"
+                                className="glamor-26 glamor-27"
                               />
                             </Styled(div)>
                           </div>
@@ -2002,12 +1958,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={180}
                       >
                         <Base
-                          className="glamor-10"
+                          className="glamor-8"
                           px={2}
                           w={180}
                         >
                           <div
-                            className="glamor-10"
+                            className="glamor-8"
                             is={null}
                           >
                             <div>
@@ -2064,12 +2020,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           />
                         </Base>
@@ -2079,12 +2035,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           >
                             <Button
@@ -2186,22 +2142,22 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                 >
                   <Base
                     align="center"
-                    className="glamor-38 glamor-39"
+                    className="glamor-36 glamor-37"
                     py={2}
                   >
                     <div
-                      className="glamor-38 glamor-39"
+                      className="glamor-36 glamor-37"
                       is={null}
                     >
                       <Box
                         pl={2}
                       >
                         <Base
-                          className="glamor-22"
+                          className="glamor-20"
                           pl={2}
                         >
                           <div
-                            className="glamor-22"
+                            className="glamor-20"
                             is={null}
                           >
                             <Avatar
@@ -2249,13 +2205,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         pr={2}
                       >
                         <Base
-                          className="glamor-30"
+                          className="glamor-28"
                           flex="1"
                           pl={1}
                           pr={2}
                         >
                           <div
-                            className="glamor-30"
+                            className="glamor-28"
                             is={null}
                           >
                             <h5
@@ -2269,11 +2225,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 to="3"
                               >
                                 <Link
-                                  className="glamor-24 glamor-25"
+                                  className="glamor-22 glamor-23"
                                   to="3"
                                 >
                                   <a
-                                    className="glamor-24 glamor-25"
+                                    className="glamor-22 glamor-23"
                                     href="3"
                                   />
                                 </Link>
@@ -2281,7 +2237,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             </h5>
                             <Styled(div)>
                               <div
-                                className="glamor-28 glamor-29"
+                                className="glamor-26 glamor-27"
                               />
                             </Styled(div)>
                           </div>
@@ -2292,12 +2248,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={180}
                       >
                         <Base
-                          className="glamor-10"
+                          className="glamor-8"
                           px={2}
                           w={180}
                         >
                           <div
-                            className="glamor-10"
+                            className="glamor-8"
                             is={null}
                           >
                             <div>
@@ -2318,12 +2274,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           />
                         </Base>
@@ -2333,12 +2289,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                         w={140}
                       >
                         <Base
-                          className="glamor-12"
+                          className="glamor-10"
                           px={2}
                           w={140}
                         >
                           <div
-                            className="glamor-12"
+                            className="glamor-10"
                             is={null}
                           >
                             <Button

--- a/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -38,7 +38,7 @@ exports[`OrganizationRepositories renders with a repository 1`] = `
         </MenuItem>
       </DropdownLink>
     }
-    label="Repositories"
+    title="Repositories"
   />
   <Styled(div)>
     <PanelHeader
@@ -151,7 +151,7 @@ exports[`OrganizationRepositories renders with github provider 1`] = `
         </MenuItem>
       </DropdownLink>
     }
-    label="Repositories"
+    title="Repositories"
   />
   <div
     className="m-b-2"
@@ -224,7 +224,7 @@ exports[`OrganizationRepositories renders without providers 1`] = `
         title="Add Repository"
       />
     }
-    label="Repositories"
+    title="Repositories"
   />
   <div
     className="m-b-2"


### PR DESCRIPTION
This makes the SettingsPageHeader a little more consistent and flexible:

It supports 3 props: title, action, and tabs

All present:

<img width="1181" alt="screen shot 2018-01-08 at 4 32 22 pm" src="https://user-images.githubusercontent.com/30713/34699563-dc4459ba-f492-11e7-830a-1c179c7bd0d3.png">

No tabs:

<img width="1145" alt="screen shot 2018-01-08 at 4 32 05 pm" src="https://user-images.githubusercontent.com/30713/34699571-eee2ce6c-f492-11e7-9511-182808902ec1.png">

Title-only:

<img width="1142" alt="screen shot 2018-01-08 at 4 42 56 pm" src="https://user-images.githubusercontent.com/30713/34699584-0b588082-f493-11e7-8fc5-421bd0c8c456.png">



  