### PR TITLE
fix(minidump): Linux support

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ setproctitle>=1.1.7,<1.2.0
 statsd>=3.1.0,<3.2.0
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=2.0.2,<3.0.0
+symbolic>=2.0.3,<3.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -143,14 +143,23 @@ class Symbolizer(object):
         fn = obj.name
         if not fn:
             return False
-        is_mac_platform = (
-            sdk_info is not None and sdk_info['sdk_name'].lower() == 'macos')
-        if not (
-            fn.startswith(APP_BUNDLE_PATHS) or (SIM_PATH in fn and SIM_APP_PATH in fn) or
-            (is_mac_platform and MAC_OS_PATH in fn)
-        ):
-            return False
-        return True
+
+        if fn.startswith(APP_BUNDLE_PATHS):
+            return True
+
+        if SIM_PATH in fn and SIM_APP_PATH in fn:
+            return True
+
+        sdk_name = sdk_info['sdk_name'].lower() if sdk_info else ''
+        if sdk_name == 'macos' and MAC_OS_PATH in fn:
+            return True
+
+        # For now, consider all linux objects in_app
+        # TODO(ja): Fix in_app using file paths
+        if sdk_name == 'linux':
+            return True
+
+        return False
 
     def _is_support_framework(self, obj):
         """True if the frame is from a framework that is known and app

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -77,7 +77,8 @@ def get_sdk_from_os(data):
     if 'name' not in data or 'version' not in data:
         return
     try:
-        system_version = tuple(int(x) for x in (data['version'] + '.0' * 3).split('.')[:3])
+        version = data['version'].split('-', 1)[0] + '.0' * 3
+        system_version = tuple(int(x) for x in version.split('.')[:3])
     except ValueError:
         return
 
@@ -174,15 +175,9 @@ def merge_minidump_event(data, minidump):
     device = context.setdefault('device', {})
     os['type'] = 'os'  # Required by "get_sdk_from_event"
     os['name'] = MINIDUMP_OS_TYPES.get(info.os_name, info.os_name)
+    os['version'] = info.os_version
+    os['build'] = info.os_build
     device['arch'] = arch_from_breakpad(info.cpu_family)
-
-    # Breakpad reports the version and build number always in one string,
-    # but a version number is guaranteed even on certain linux distros.
-    match = VERSION_RE.search(info.os_version)
-    if match is not None:
-        version, build = match.groups()
-        os['version'] = version
-        os['build'] = build
 
     # We can extract stack traces here already but since CFI is not
     # available yet (without debug symbols), the stackwalker will

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -196,7 +196,8 @@ def merge_minidump_event(data, minidump):
             'frames': [{
                 'instruction_addr': '0x%x' % frame.instruction,
                 'function': '<unknown>',  # Required by interface
-            } for frame in thread.frames()],
+                'package': frame.module.name if frame.module else None,
+            } for frame in reversed(list(thread.frames()))],
         },
     } for thread in state.threads()]
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -4,6 +4,7 @@ import base64
 import logging
 import six
 import traceback
+import uuid
 
 from time import time
 
@@ -591,9 +592,12 @@ class MinidumpView(StoreView):
         if isinstance(response_or_event_id, HttpResponse):
             return response_or_event_id
 
+        # Return the formatted UUID of the generated event. This is
+        # expected by the Electron http uploader on Linux and doesn't
+        # break the default Breakpad client library.
         return HttpResponse(
-            json.dumps({'id': response_or_event_id}),
-            content_type='application/json'
+            six.text_type(uuid.UUID(response_or_event_id)),
+            content_type='text/plain'
         )
 
 


### PR DESCRIPTION
This PR fixes some issues to support Linux crash reports:

- The Linux breakpad client (and apparently also the Windows one) expect the response from the minidump POSt request to be a formatted UUID including dashes. We previously responded with JSON. Now the response is `text/plain`.
- White-list all images from linux in `is_image_from_app_bundle`. In fact, it should check for well-known symbol locations (e.g. /usr/local/lib)
- `merge_minidump_event` now reverses the stacktrace order. The UI reverses stacktraces again and minidumps already contain them in the correct order.
- Fix version numbers from Linux crash reports. The Breakpad client always sets `0.0.0` as version number and adds `uname -srvmo` as build. Symbolic `2.0.3` has been updated to parse this already.