### PR TITLE
fix: Allow disposition in CSP reports

### DIFF
--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -439,9 +439,12 @@ CSP_SCHEMA = {
                 'line-number': {'type': 'number'},
                 'column-number': {'type': 'number'},
                 'script-sample': {'type': 'number'},  # Firefox specific key.
+                'disposition': {'type': 'string'},
             },
             'required': ['effective-directive'],
-            'additionalProperties': False,  # Don't allow any other keys.
+            # Allow additional keys as browser vendors are still changing CSP
+            # implementations fairly frequently
+            'additionalProperties': True,
         }
     },
     'required': ['csp-report'],

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -68,6 +68,7 @@ class SecurityReportCspTest(TestCase):
                 'source-file': 'http://example.com',
                 'effective-directive': 'style-src',
                 'violated-directive': 'style-src',
+                'disposition': 'enforce',
             }
         )
         assert resp.status_code == 201, resp.content


### PR DESCRIPTION
Because the schema does not allow additional keys in CSP reports,
and at least Chrome has started adding a 'disposition' field to these
reports, causing them to be rejected.