### PR TITLE
fix(settings): Implement text block for blocks of text

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -28,7 +28,6 @@ const FormFieldControlErrorWrapper = styled(Box)`
 const FormFieldControlStyled = styled(FormFieldControl)`
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
 `;
 
 const FormFieldControlWrapper = styled(Flex)``;

--- a/src/sentry/static/sentry/app/views/settings/components/text/textBlock.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/text/textBlock.jsx
@@ -1,0 +1,8 @@
+import styled from 'react-emotion';
+
+const TextBlock = styled.div`
+  line-height: 1.5;
+  margin-bottom: 30px;
+`;
+
+export default TextBlock;

--- a/src/sentry/static/sentry/app/views/settings/organization/auditLog/auditLogList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/auditLog/auditLogList.jsx
@@ -13,7 +13,6 @@ import PanelBody from '../../components/panelBody';
 import PanelHeader from '../../components/panelHeader';
 import SelectInput from '../../../../components/selectInput';
 import SettingsPageHeader from '../../components/settingsPageHeader';
-import SpreadLayout from '../../../../components/spreadLayout';
 
 const UserInfo = styled(Box)`
   display: flex;
@@ -65,33 +64,27 @@ class AuditLogList extends React.Component {
     let {pageLinks, entries, eventType, eventTypes, onEventSelect} = this.props;
     let hasEntries = entries && entries.length > 0;
 
+    let action = (
+      <form>
+        <SelectInput
+          name="event"
+          onChange={onEventSelect}
+          value={eventType}
+          style={{width: 250}}
+        >
+          <option key="any" value="">
+            {t('Any action')}
+          </option>
+          {eventTypes.map(type => {
+            return <option key={type}>{type}</option>;
+          })}
+        </SelectInput>
+      </form>
+    );
+
     return (
       <div>
-        <SettingsPageHeader title={t('Audit Log')} />
-
-        <SpreadLayout>
-          <p>{t('Sentry keeps track of important events within your organization.')}</p>
-
-          <form className="form-horizontal" style={{marginBottom: 20}}>
-            <div className="control-group">
-              <div className="controls">
-                <SelectInput
-                  name="event"
-                  onChange={onEventSelect}
-                  value={eventType}
-                  style={{width: 250}}
-                >
-                  <option key="any" value="">
-                    {t('Any')}
-                  </option>
-                  {eventTypes.map(type => {
-                    return <option key={type}>{type}</option>;
-                  })}
-                </SelectInput>
-              </div>
-            </div>
-          </form>
-        </SpreadLayout>
+        <SettingsPageHeader title={t('Audit Log')} action={action} />
 
         <Panel>
           <PanelHeader disablePadding>

--- a/src/sentry/static/sentry/app/views/settings/organization/rateLimit/rateLimitView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/rateLimit/rateLimitView.jsx
@@ -12,6 +12,7 @@ import Panel from '../../components/panel';
 import PanelBody from '../../components/panelBody';
 import PanelHeader from '../../components/panelHeader';
 import SettingsPageHeader from '../../components/settingsPageHeader';
+import TextBlock from '../../components/text/textBlock';
 import {t} from '../../../../locale';
 
 class AccountLimit extends React.Component {
@@ -55,6 +56,10 @@ class AccountLimit extends React.Component {
     );
   }
 }
+
+const TextBlockStyled = styled(TextBlock)`
+  margin-bottom: 20px;
+`;
 
 const OldFooter = withTheme(styled.div`
   bordertop: 1px solid ${p => p.theme.borderLight};
@@ -163,11 +168,11 @@ const RateLimitView = createReactClass({
           <PanelBody>
             <form onSubmit={this.onSubmit} className="ref-rate-limit-editor">
               <Box p={2}>
-                <p>
+                <TextBlockStyled>
                   Rate limits allow you to control how much data is stored for this
                   organization. When a rate is exceeded the system will begin discarding
                   data until the next interval.
-                </p>
+                </TextBlockStyled>
 
                 <h5>Account Limit</h5>
 

--- a/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
@@ -166,7 +166,7 @@ class OrganizationRepositories extends React.Component {
             </PanelBody>
           </Panel>
         ) : (
-          <div className="well blankslate align-center p-x-2 p-y-1">
+          <Panel className="blankslate align-center p-x-2 p-y-1">
             <div className="icon icon-lg icon-git-commit" />
             <h3>{t('Sentry is better with commit data')}</h3>
             <TextBlock>
@@ -182,7 +182,7 @@ class OrganizationRepositories extends React.Component {
                 Learn more
               </a>
             </p>
-          </div>
+          </Panel>
         )}
       </div>
     );

--- a/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
@@ -14,6 +14,7 @@ import Panel from '../../components/panel';
 import PanelBody from '../../components/panelBody';
 import PanelHeader from '../../components/panelHeader';
 import SettingsPageHeader from '../../components/settingsPageHeader';
+import TextBlock from '../../components/text/textBlock';
 import AddRepositoryLink from './addRepositoryLink';
 
 const RepoRow = withTheme(styled(SpreadLayout)`
@@ -92,7 +93,7 @@ class OrganizationRepositories extends React.Component {
 
         {!hasItemList && (
           <div className="m-b-2">
-            <p>
+            <TextBlock>
               {t(
                 'Connecting a repository allows Sentry to capture commit data via webhooks. ' +
                   'This enables features like suggested assignees and resolving issues via commit message. ' +
@@ -102,7 +103,7 @@ class OrganizationRepositories extends React.Component {
               {tct('See our [link:documentation] for more details.', {
                 link: <a href="https://docs.sentry.io/learn/releases/" />,
               })}
-            </p>
+            </TextBlock>
           </div>
         )}
 
@@ -168,11 +169,11 @@ class OrganizationRepositories extends React.Component {
           <div className="well blankslate align-center p-x-2 p-y-1">
             <div className="icon icon-lg icon-git-commit" />
             <h3>{t('Sentry is better with commit data')}</h3>
-            <p>
+            <TextBlock>
               {t(
                 'Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.'
               )}
-            </p>
+            </TextBlock>
             <p className="m-b-1">
               <a
                 className="btn btn-default"

--- a/src/sentry/static/sentry/app/views/settings/organization/stats/organizationStats.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/stats/organizationStats.jsx
@@ -9,6 +9,7 @@ import Panel from '../../components/panel';
 import PanelBody from '../../components/panelBody';
 import PanelHeader from '../../components/panelHeader';
 import SettingsPageHeader from '../../components/settingsPageHeader';
+import TextBlock from '../../components/text/textBlock';
 
 import ProjectTable from './projectTable';
 import {t} from '../../../../locale';
@@ -67,7 +68,7 @@ class OrganizationStats extends React.Component {
         <SettingsPageHeader title={t('Organization Stats')} />
         <div className="row">
           <div className="col-md-9">
-            <p>
+            <TextBlock>
               {t(
                 `The chart below reflects events the system has received
             across your entire organization. Events are broken down into
@@ -76,7 +77,7 @@ class OrganizationStats extends React.Component {
             being hit, and Filtered events are events that were blocked
             due to your inbound data filter rules.`
               )}
-            </p>
+            </TextBlock>
           </div>
           {!statsLoading && (
             <div className="col-md-3 stats-column">

--- a/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -185,8 +185,8 @@ exports[`OrganizationRepositories renders with github provider 1`] = `
       </span>
     </Styled(div)>
   </div>
-  <div
-    className="well blankslate align-center p-x-2 p-y-1"
+  <Styled(div)
+    className="blankslate align-center p-x-2 p-y-1"
   >
     <div
       className="icon icon-lg icon-git-commit"
@@ -207,7 +207,7 @@ exports[`OrganizationRepositories renders with github provider 1`] = `
         Learn more
       </a>
     </p>
-  </div>
+  </Styled(div)>
 </div>
 `;
 
@@ -258,8 +258,8 @@ exports[`OrganizationRepositories renders without providers 1`] = `
       </span>
     </Styled(div)>
   </div>
-  <div
-    className="well blankslate align-center p-x-2 p-y-1"
+  <Styled(div)
+    className="blankslate align-center p-x-2 p-y-1"
   >
     <div
       className="icon icon-lg icon-git-commit"
@@ -280,6 +280,6 @@ exports[`OrganizationRepositories renders without providers 1`] = `
         Learn more
       </a>
     </p>
-  </div>
+  </Styled(div)>
 </div>
 `;

--- a/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -156,7 +156,7 @@ exports[`OrganizationRepositories renders with github provider 1`] = `
   <div
     className="m-b-2"
   >
-    <p>
+    <Styled(div)>
       Connecting a repository allows Sentry to capture commit data via webhooks. This enables features like suggested assignees and resolving issues via commit message. Once you've connected a repository, you can associate commits with releases via the API.
        
       <span
@@ -183,7 +183,7 @@ exports[`OrganizationRepositories renders with github provider 1`] = `
            for more details.
         </span>
       </span>
-    </p>
+    </Styled(div)>
   </div>
   <div
     className="well blankslate align-center p-x-2 p-y-1"
@@ -194,9 +194,9 @@ exports[`OrganizationRepositories renders with github provider 1`] = `
     <h3>
       Sentry is better with commit data
     </h3>
-    <p>
+    <Styled(div)>
       Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
-    </p>
+    </Styled(div)>
     <p
       className="m-b-1"
     >
@@ -229,7 +229,7 @@ exports[`OrganizationRepositories renders without providers 1`] = `
   <div
     className="m-b-2"
   >
-    <p>
+    <Styled(div)>
       Connecting a repository allows Sentry to capture commit data via webhooks. This enables features like suggested assignees and resolving issues via commit message. Once you've connected a repository, you can associate commits with releases via the API.
        
       <span
@@ -256,7 +256,7 @@ exports[`OrganizationRepositories renders without providers 1`] = `
            for more details.
         </span>
       </span>
-    </p>
+    </Styled(div)>
   </div>
   <div
     className="well blankslate align-center p-x-2 p-y-1"
@@ -267,9 +267,9 @@ exports[`OrganizationRepositories renders without providers 1`] = `
     <h3>
       Sentry is better with commit data
     </h3>
-    <p>
+    <Styled(div)>
       Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.
-    </p>
+    </Styled(div)>
     <p
       className="m-b-1"
     >


### PR DESCRIPTION
K, text in settings is a bit better now:

<img width="1135" alt="screen shot 2018-01-09 at 3 36 39 pm" src="https://user-images.githubusercontent.com/30713/34748757-f0ba2210-f552-11e7-9c74-c82d7400fd5b.png">

I also went ahead and cleaned up the Audit log header and reverted the `flex-end` issue that was improperly aligning the switch component.