### PR TITLE
ref(rules): Remove `is_sample` as an argument to `RuleProcessor`

### DIFF
--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -110,7 +110,6 @@ class RuleBase(object):
 
 
 class EventState(object):
-    def __init__(self, is_new, is_regression, is_sample):
+    def __init__(self, is_new, is_regression):
         self.is_new = is_new
         self.is_regression = is_regression
-        self.is_sample = is_sample,

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -36,15 +36,13 @@ class EventCompatibilityProxy(object):
 class RuleProcessor(object):
     logger = logging.getLogger('sentry.rules')
 
-    def __init__(self, event, is_new, is_regression, is_sample):
+    def __init__(self, event, is_new, is_regression):
         self.event = EventCompatibilityProxy(event)
         self.group = event.group
         self.project = event.project
 
         self.is_new = is_new
         self.is_regression = is_regression
-        # TODO(dcramer): lets remove is_sample
-        self.is_sample = is_sample
 
         self.futures_by_cb = defaultdict(list)
 
@@ -75,7 +73,6 @@ class RuleProcessor(object):
         return EventState(
             is_new=self.is_new,
             is_regression=self.is_regression,
-            is_sample=self.is_sample,
         )
 
     def apply_rule(self, rule):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -83,7 +83,7 @@ def post_process_group(event, is_new, is_regression, is_sample, **kwargs):
     # we process snoozes before rules as it might create a regression
     process_snoozes(event.group)
 
-    rp = RuleProcessor(event, is_new, is_regression, is_sample)
+    rp = RuleProcessor(event, is_new, is_regression)
     has_alert = False
     # TODO(dcramer): ideally this would fanout, but serializing giant
     # objects back and forth isn't super efficient

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -342,7 +342,6 @@ class RuleTestCase(TestCase):
     def get_state(self, **kwargs):
         kwargs.setdefault('is_new', True)
         kwargs.setdefault('is_regression', True)
-        kwargs.setdefault('is_sample', True)
         return EventState(**kwargs)
 
     def assertPasses(self, rule, event=None, **kwargs):

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -32,7 +32,7 @@ class RuleProcessorTest(TestCase):
             }
         )
 
-        rp = RuleProcessor(event, is_new=True, is_regression=True, is_sample=False)
+        rp = RuleProcessor(event, is_new=True, is_regression=True)
         results = list(rp.apply())
         assert len(results) == 1
         callback, futures = results[0]

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -34,7 +34,7 @@ class PostProcessGroupTest(TestCase):
             is_sample=False,
         )
 
-        mock_processor.assert_called_once_with(event, True, False, False)
+        mock_processor.assert_called_once_with(event, True, False)
         mock_processor.return_value.apply.assert_called_once_with()
 
         mock_callback.assert_called_once_with(event, mock_futures)


### PR DESCRIPTION
This is/was unused.