### PR TITLE
fix: Allow psycopg2 2.7.x

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -30,7 +30,7 @@ percy>=0.4.5
 petname>=2.0,<2.1
 Pillow>=3.2.0,<=4.2.1
 progressbar2>=3.10,<3.11
-psycopg2>=2.6.0,<2.7.0
+psycopg2>=2.6.0,<2.8.0
 pytest>=3.1.2,<3.2.0
 pytest-django>=2.9.1,<2.10.0
 pytest-html>=1.9.0,<1.10.0


### PR DESCRIPTION
Fixes GH-6461, GH-6611

Help us all.