### PR TITLE
ref(rules): Render descriptive validation errors for rules

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from rest_framework import serializers
 
 from sentry.rules import rules
@@ -41,7 +43,7 @@ class RuleNodeField(serializers.WritableField):
             # XXX(epurkhiser): Very hacky, but we really just want validation
             # errors that are more specific, not just 'this wasn't filled out',
             # give a more generic error for those.
-            first_error = form.errors.values()[0][0]
+            first_error = next(six.itervalues(form.errors))[0]
 
             if first_error != 'This field is required.':
                 raise ValidationError(first_error)

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -30,8 +30,25 @@ class RuleNodeField(serializers.WritableField):
             msg = "Invalid node. Could not find '%s'"
             raise ValidationError(msg % data['id'])
 
-        if not cls(self.context['project'], data).validate_form():
-            raise ValidationError('Node did not pass validation')
+        node = cls(self.context['project'], data)
+
+        if not node.form_cls:
+            return data
+
+        form = node.get_form_instance()
+
+        if not form.is_valid():
+            # XXX(epurkhiser): Very hacky, but we really just want validation
+            # errors that are more specific, not just 'this wasn't filled out',
+            # give a more generic error for those.
+            first_error = form.errors.values()[0][0]
+
+            if first_error != 'This field is required.':
+                raise ValidationError(first_error)
+
+            raise ValidationError(
+                'Ensure at least one action is enabled and all required fields are filled in.'
+            )
 
         return data
 

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -158,9 +158,7 @@ const RuleEditor = createReactClass({
 
             {this.hasError('conditions') && (
               <p className="error">
-                {t(
-                  'Ensure at least one condition is enabled and all required fields are filled in.'
-                )}
+                {this.state.error['conditions'][0]}
               </p>
             )}
 
@@ -177,9 +175,7 @@ const RuleEditor = createReactClass({
 
             {this.hasError('actions') && (
               <p className="error">
-                {t(
-                  'Ensure at least one action is enabled and all required fields are filled in.'
-                )}
+                {this.state.error['actions'][0]}
               </p>
             )}
 

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -157,9 +157,7 @@ const RuleEditor = createReactClass({
             </div>
 
             {this.hasError('conditions') && (
-              <p className="error">
-                {this.state.error['conditions'][0]}
-              </p>
+              <p className="error">{this.state.error.conditions[0]}</p>
             )}
 
             <RuleNodeList
@@ -174,9 +172,7 @@ const RuleEditor = createReactClass({
             <h6>{t('Take these actions:')}</h6>
 
             {this.hasError('actions') && (
-              <p className="error">
-                {this.state.error['actions'][0]}
-              </p>
+              <p className="error">{this.state.error.actions[0]}</p>
             )}
 
             <RuleNodeList


### PR DESCRIPTION
Most rule condition and action forms simply contain fields with required
validation. However, for fields that need some extra validation [1] the
static error message does not provide enough clarity.

This change includes a kludge to generate the old validation error when
the rule node validation is simple 'is required'.

[1]: Specifically for the upcoming enhanced slack integration alerts
     that require validation on the slack channel name.