### PR TITLE
test(js): Use jest mock fns in API Client mock

### DIFF
--- a/tests/js/spec/sudoModal.spec.jsx
+++ b/tests/js/spec/sudoModal.spec.jsx
@@ -41,6 +41,7 @@ describe('Sudo Modal', function() {
     let api = new Client();
     let successCb = jest.fn();
     let errorCb = jest.fn();
+    let orgDeleteMock;
 
     // No Modal
     expect($('.modal input').length).toBe(0);
@@ -53,51 +54,63 @@ describe('Sudo Modal', function() {
     });
 
     setTimeout(() => {
-      // SudoModal
-      const $input = $('.modal input');
-      expect($input.length).toBe(1);
+      try {
+        // SudoModal
+        const $input = $('.modal input');
+        expect($input.length).toBe(1);
 
-      // Original callbacks should not have been called
-      expect(successCb).not.toBeCalled();
-      expect(errorCb).not.toBeCalled();
+        // Original callbacks should not have been called
+        expect(successCb).not.toBeCalled();
+        expect(errorCb).not.toBeCalled();
 
-      // Clear mocks and allow DELETE
-      Client.clearMockResponses();
-      Client.addMockResponse({
-        url: '/organizations/org-slug/',
-        method: 'DELETE',
-        statusCode: 200,
-      });
-      Client.addMockResponse({
-        url: '/sudo/',
-        method: 'POST',
-        statusCode: 200,
-      });
+        // Clear mocks and allow DELETE
+        Client.clearMockResponses();
+        orgDeleteMock = Client.addMockResponse({
+          url: '/organizations/org-slug/',
+          method: 'DELETE',
+          statusCode: 200,
+        });
+        let sudoMock = Client.addMockResponse({
+          url: '/sudo/',
+          method: 'POST',
+          statusCode: 200,
+        });
 
-      // "Sudo" auth
-      $input.val('password');
-      $('.modal [type="submit"]').click();
+        expect(sudoMock).not.toHaveBeenCalled();
 
-      expect(
-        Client.getCallCount(
-          Client.findMockResponse('/sudo/', {
+        // "Sudo" auth
+        $input.val('password');
+        $('.modal [type="submit"]').click();
+
+        expect(sudoMock).toHaveBeenCalledWith(
+          '/sudo/',
+          expect.objectContaining({
             method: 'POST',
+            // XXX: This doesn't submit with password in tests because modal is rendered outside of
+            // react tree. So we can't simulate react events on input
+            // data: {
+            // password: 'password',
+            // },
           })
-        )
-      ).toBe(1);
-
+        );
+      } catch (err) {
+        done(err);
+      }
       setTimeout(() => {
-        // Modal can be around but should be "busy"
+        try {
+          // Modal can be around but should be "busy"
 
-        // Retry API request
-        expect(successCb).toHaveBeenCalled();
-        expect(
-          Client.getCallCount(
-            Client.findMockResponse('/organizations/org-slug/', {
+          // Retry API request
+          expect(successCb).toHaveBeenCalled();
+          expect(orgDeleteMock).toHaveBeenCalledWith(
+            '/organizations/org-slug/',
+            expect.objectContaining({
               method: 'DELETE',
             })
-          )
-        ).toBe(1);
+          );
+        } catch (err) {
+          done(err);
+        }
         done();
       }, 1);
     }, 1);

--- a/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
+++ b/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
@@ -138,7 +138,7 @@ describe('CreateProject', function() {
         body: {},
       };
 
-      Client.addMockResponse(inviteRequest);
+      let mock = Client.addMockResponse(inviteRequest);
 
       let wrapper = mount(<InviteMember {...baseProps} />, baseContext);
 
@@ -161,7 +161,7 @@ describe('CreateProject', function() {
       node.props().onClick({preventDefault: () => {}});
       expect(wrapper.state('busy')).toBe(true);
       expect(wrapper.state('error')).toBe(undefined);
-      expect(Client.getCallCount(inviteRequest)).toBe(3);
+      expect(mock).toHaveBeenCalledTimes(3);
     });
   });
 });


### PR DESCRIPTION
`addMockResponse` now returns a jest mock function that represents
`Client.request` calls. Now we can write assertions with jest matchers
for Client.request.