### PR TITLE
ref(rules): Allow rules to be disabled (hiding them)

### DIFF
--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -69,6 +69,9 @@ class RuleBase(object):
         self.had_data = data is not None
         self.rule = rule
 
+    def is_enabled(self):
+        return True
+
     def get_option(self, key):
         return self.data.get(key)
 

--- a/src/sentry/web/frontend/project_rule_edit.py
+++ b/src/sentry/web/frontend/project_rule_edit.py
@@ -36,6 +36,9 @@ class ProjectRuleEditView(ProjectView):
                 'html': node.render_form(),
             }
 
+            if not node.is_enabled():
+                continue
+
             if rule_type.startswith('condition/'):
                 condition_list.append(context)
             elif rule_type.startswith('action/'):


### PR DESCRIPTION
This does *not* disable functionality of the rule, it only removes it from being enabled.

This will be required for the upcoming slack integration alerts.