### PR TITLE
feat(workflow): Clickable "Select a Project"

### DIFF
--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -333,7 +333,11 @@ const ProjectSelector = createReactClass({
           {this.state.activeProject ? (
             this.getLinkNode(this.state.activeTeam, this.state.activeProject)
           ) : (
-            <span onClick={() => (this.state.isOpen ? this.onClose() : this.onOpen())}>
+            <span
+              role="button"
+              style={{cursor: 'pointer'}}
+              onClick={() => (this.state.isOpen ? this.onClose() : this.onOpen())}
+            >
               {t('Select a project')}
             </span>
           )}

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -330,9 +330,13 @@ const ProjectSelector = createReactClass({
           <Link to={`/${org.slug}/`} className="home-crumb">
             <span className="icon-home" />
           </Link>
-          {this.state.activeProject
-            ? this.getLinkNode(this.state.activeTeam, this.state.activeProject)
-            : t('Select a project')}
+          {this.state.activeProject ? (
+            this.getLinkNode(this.state.activeTeam, this.state.activeProject)
+          ) : (
+            <span onClick={() => (this.state.isOpen ? this.onClose() : this.onOpen())}>
+              {t('Select a project')}
+            </span>
+          )}
           <DropdownLink
             title=""
             topLevelClasses={dropdownClassNames}

--- a/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
+++ b/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
@@ -45,7 +45,11 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
           />
         </a>
       </Link>
-      Select a project
+      <span
+        onClick={[Function]}
+      >
+        Select a project
+      </span>
       <DropdownLink
         alwaysRenderMenu={false}
         anchorRight={false}
@@ -184,7 +188,11 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
           />
         </a>
       </Link>
-      Select a project
+      <span
+        onClick={[Function]}
+      >
+        Select a project
+      </span>
       <DropdownLink
         alwaysRenderMenu={false}
         anchorRight={false}
@@ -313,7 +321,11 @@ exports[`ProjectSelector render() lists projects and has filter 1`] = `
         className="icon-home"
       />
     </Link>
-    Select a project
+    <span
+      onClick={[Function]}
+    >
+      Select a project
+    </span>
     <DropdownLink
       alwaysRenderMenu={false}
       anchorRight={false}
@@ -378,7 +390,11 @@ exports[`ProjectSelector render() should show empty message and create project b
         className="icon-home"
       />
     </Link>
-    Select a project
+    <span
+      onClick={[Function]}
+    >
+      Select a project
+    </span>
     <DropdownLink
       alwaysRenderMenu={false}
       anchorRight={false}
@@ -435,7 +451,11 @@ exports[`ProjectSelector render() should show empty message with no projects but
         className="icon-home"
       />
     </Link>
-    Select a project
+    <span
+      onClick={[Function]}
+    >
+      Select a project
+    </span>
     <DropdownLink
       alwaysRenderMenu={false}
       anchorRight={false}
@@ -508,7 +528,11 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
           />
         </a>
       </Link>
-      Select a project
+      <span
+        onClick={[Function]}
+      >
+        Select a project
+      </span>
       <DropdownLink
         alwaysRenderMenu={false}
         anchorRight={false}

--- a/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
+++ b/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
@@ -47,6 +47,12 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
       </Link>
       <span
         onClick={[Function]}
+        role="button"
+        style={
+          Object {
+            "cursor": "pointer",
+          }
+        }
       >
         Select a project
       </span>
@@ -190,6 +196,12 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
       </Link>
       <span
         onClick={[Function]}
+        role="button"
+        style={
+          Object {
+            "cursor": "pointer",
+          }
+        }
       >
         Select a project
       </span>
@@ -323,6 +335,12 @@ exports[`ProjectSelector render() lists projects and has filter 1`] = `
     </Link>
     <span
       onClick={[Function]}
+      role="button"
+      style={
+        Object {
+          "cursor": "pointer",
+        }
+      }
     >
       Select a project
     </span>
@@ -392,6 +410,12 @@ exports[`ProjectSelector render() should show empty message and create project b
     </Link>
     <span
       onClick={[Function]}
+      role="button"
+      style={
+        Object {
+          "cursor": "pointer",
+        }
+      }
     >
       Select a project
     </span>
@@ -453,6 +477,12 @@ exports[`ProjectSelector render() should show empty message with no projects but
     </Link>
     <span
       onClick={[Function]}
+      role="button"
+      style={
+        Object {
+          "cursor": "pointer",
+        }
+      }
     >
       Select a project
     </span>
@@ -530,6 +560,12 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
       </Link>
       <span
         onClick={[Function]}
+        role="button"
+        style={
+          Object {
+            "cursor": "pointer",
+          }
+        }
       >
         Select a project
       </span>


### PR DESCRIPTION
make entire select a project button clickable when it displays this default message (not just the caret)
<img width="221" alt="screenshot 2018-01-11 13 42 56" src="https://user-images.githubusercontent.com/5915546/34849131-327e3644-f6d6-11e7-85ba-da899860a654.png">
