### PR TITLE
fix: Handle NULL bytes due to psycopg2 upgrade

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from six import string_types
 import psycopg2 as Database
 
 # Some of these imports are unused, but they are inherited from other engines
@@ -13,6 +14,12 @@ from .decorators import (
 from .operations import DatabaseOperations
 
 __all__ = ('DatabaseWrapper', )
+
+
+def escape_null(value):
+    if not isinstance(value, string_types):
+        return value
+    return value.replace('\x00', '\\x00')
 
 
 class CursorWrapper(object):
@@ -36,7 +43,24 @@ class CursorWrapper(object):
     @less_shitty_error_messages
     def execute(self, sql, params=None):
         if params is not None:
-            return self.cursor.execute(sql, params)
+            try:
+                return self.cursor.execute(sql, params)
+            except ValueError as e:
+                # In psycopg2 2.7+, behavior was introduced where a
+                # NULL byte in a parameter would start raising a ValueError.
+                # psycopg2 chose to do this rather than let Postgres silently
+                # truncate the data, which is it's behavior when it sees a
+                # NULL byte. But for us, we'd rather munge the value so it's
+                # somewhat legible rather than error. Considering this is better
+                # behavior than the database truncating, seems good to do this
+                # rather than attempting to sanitize all data inputs now manually.
+
+                # Note: This message is brittle, but it's currently hardcoded into
+                # psycopg2 for this behavior. If anything changes, we're choosing to
+                # address that later rather than potentially catch incorrect behavior.
+                if e.message != 'A string literal cannot contain NUL (0x00) characters.':
+                    raise
+                return self.cursor.execute(sql, [escape_null(param) for param in params])
         return self.cursor.execute(sql)
 
     @capture_transaction_exceptions

--- a/tests/sentry/db/postgres/__init__.py
+++ b/tests/sentry/db/postgres/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+
+import pytest
+from sentry.utils.db import is_postgres
+from sentry.testutils import TestCase
+
+
+def psycopg2_version():
+    import psycopg2
+    version = psycopg2.__version__.split()[0].split('.')
+    return tuple(map(int, version))
+
+
+@pytest.mark.skipif(
+    not is_postgres() or psycopg2_version() < (2, 7),
+    reason='Test requires Postgres and psycopg 2.7+',
+)
+class CursorWrapperTestCase(TestCase):
+    def test_null_bytes(self):
+        from django.db import connection
+        cursor = connection.cursor()
+        cursor.execute('SELECT %s', [b'Ma\x00tt'])
+        assert cursor.fetchone()[0] == b'Ma\\x00tt'
+        cursor.execute('SELECT %s', [u'Ma\x00tt'])
+        assert cursor.fetchone()[0] == u'Ma\\x00tt'


### PR DESCRIPTION
See: https://github.com/psycopg/psycopg2/pull/459
Fixes SENTRY-5Q5