### PR TITLE
fix(reprocessing): Clean up reprocessing reports correctly

### DIFF
--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -109,6 +109,7 @@ class StoreTasksTest(PluginTestCase):
 
         mock_save_event.delay.assert_called_once_with(
             cache_key='e:1', data=None, start_time=1, event_id=None,
+            project_id=project.id
         )
 
     @mock.patch('sentry.tasks.store.save_event')
@@ -134,6 +135,7 @@ class StoreTasksTest(PluginTestCase):
 
         mock_save_event.delay.assert_called_once_with(
             cache_key='e:1', data=None, start_time=1, event_id=None,
+            project_id=project.id
         )
 
     @mock.patch('sentry.tasks.store.save_event')
@@ -168,6 +170,7 @@ class StoreTasksTest(PluginTestCase):
 
         mock_save_event.delay.assert_called_once_with(
             cache_key='e:1', data=None, start_time=1, event_id=None,
+            project_id=project.id
         )
 
     @mock.patch.object(tsdb, 'incr')


### PR DESCRIPTION
This commit changes the cleanup logic for reprocessing reports to delete them
reliably even if concurrency issues happen.  Additionally it now also expires
them after the cleanup time.