### PR TITLE
fix: sort ANY tag searches last.

### DIFF
--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -528,7 +528,7 @@ class LegacyTagStorage(TagStorage):
             key='sentry:user',
         ).order_by('-last_seen')[:limit])
 
-    def get_group_ids_for_search_filter(self, project_id, environment_id, tags):
+    def get_group_ids_for_search_filter(self, project_id, environment_id, tags, limit=1000):
         from sentry.search.base import ANY, EMPTY
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -565,7 +565,7 @@ class LegacyTagStorage(TagStorage):
                 # restrict matches to only the most recently seen issues
                 base_qs = base_qs.order_by('-last_seen')
 
-            matches = list(base_qs.values_list('group_id', flat=True)[:1000])
+            matches = list(base_qs.values_list('group_id', flat=True)[:limit])
 
             if not matches:
                 return None

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -535,7 +535,7 @@ class LegacyTagStorage(TagStorage):
 
         # ANY matches should come last since they're the least specific and
         # will provide the largest range of matches
-        tag_lookups = sorted(six.iteritems(tags), key=lambda x: x != ANY)
+        tag_lookups = sorted(six.iteritems(tags), key=lambda (k, v): v == ANY)
 
         # get initial matches to start the filter
         matches = None

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -650,7 +650,7 @@ class V2TagStorage(TagStorage):
 
         # ANY matches should come last since they're the least specific and
         # will provide the largest range of matches
-        tag_lookups = sorted(six.iteritems(tags), key=lambda x: x != ANY)
+        tag_lookups = sorted(six.iteritems(tags), key=lambda (k, v): v == ANY)
 
         # get initial matches to start the filter
         matches = None

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -643,7 +643,7 @@ class V2TagStorage(TagStorage):
             _key__key='sentry:user',
         ).order_by('-last_seen')[:limit])
 
-    def get_group_ids_for_search_filter(self, project_id, environment_id, tags):
+    def get_group_ids_for_search_filter(self, project_id, environment_id, tags, limit=1000):
         from sentry.search.base import ANY, EMPTY
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -682,7 +682,7 @@ class V2TagStorage(TagStorage):
                 # restrict matches to only the most recently seen issues
                 base_qs = base_qs.order_by('-last_seen')
 
-            matches = list(base_qs.values_list('group_id', flat=True)[:1000])
+            matches = list(base_qs.values_list('group_id', flat=True)[:limit])
 
             if not matches:
                 return None

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -632,16 +632,16 @@ class TagStorage(TestCase):
 
     def test_get_group_ids_for_search_filter_predicate_order(self):
         """
-            Since each tag-matching filter is capped at 1000 results, and each
+            Since each tag-matching filter returns limited results, and each
             filter returns a subset of the previous filter's matches, we
             attempt to match more selective predicates first.
 
             This tests that we filter by a more selective "divides == even"
             predicate before filtering by an ANY predicate and therefore return
-            all 501 matching groups instead of the 500 that would be returned
-            if we had filtered by the ANY predicate first.
+            all matching groups instead of the partial set that would be returned
+            if we had filtered and limited using the ANY predicate first.
         """
-        for i in range(1002):
+        for i in range(3):
             self.ts.get_or_create_group_tag_value(
                 self.proj1.id, i, self.proj1env1.id,
                 'foo', 'bar'
@@ -655,7 +655,9 @@ class TagStorage(TestCase):
         assert len(self.ts.get_group_ids_for_search_filter(
             self.proj1.id,
             self.proj1env1.id,
-            OrderedDict([('foo', ANY), ('divides', 'even')]))) == 501
+            OrderedDict([('foo', ANY), ('divides', 'even')]),
+            limit=2
+        )) == 2
 
     def test_update_group_for_events(self):
         v1, _ = self.ts.get_or_create_tag_value(self.proj1.id, self.proj1env1.id, 'k1', 'v1')

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import
 
 import pytest
 
+from collections import OrderedDict
 from datetime import datetime
 
+from sentry.search.base import ANY
 from sentry.testutils import TestCase
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.v2.backend import V2TagStorage
@@ -627,6 +629,33 @@ class TagStorage(TestCase):
 
         assert self.ts.get_group_ids_for_search_filter(
             self.proj1.id, self.proj1env1.id, tags) == [self.proj1group1.id]
+
+    def test_get_group_ids_for_search_filter_predicate_order(self):
+        """
+            Since each tag-matching filter is capped at 1000 results, and each
+            filter returns a subset of the previous filter's matches, we
+            attempt to match more selective predicates first.
+
+            This tests that we filter by a more selective "divides == even"
+            predicate before filtering by an ANY predicate and therefore return
+            all 501 matching groups instead of the 500 that would be returned
+            if we had filtered by the ANY predicate first.
+        """
+        for i in range(1002):
+            self.ts.get_or_create_group_tag_value(
+                self.proj1.id, i, self.proj1env1.id,
+                'foo', 'bar'
+            )
+
+            self.ts.get_or_create_group_tag_value(
+                self.proj1.id, i, self.proj1env1.id,
+                'divides', 'even' if i % 2 == 0 else 'odd'
+            )
+
+        assert len(self.ts.get_group_ids_for_search_filter(
+            self.proj1.id,
+            self.proj1env1.id,
+            OrderedDict([('foo', ANY), ('divides', 'even')]))) == 501
 
     def test_update_group_for_events(self):
         v1, _ = self.ts.get_or_create_tag_value(self.proj1.id, self.proj1env1.id, 'k1', 'v1')


### PR DESCRIPTION
The existing code did not appear to do what the comment said, which is
to put {'tag': ANY} values at the end of the list.