### PR TITLE
fix(forms): Invalidate pending LostPasswordHash on account changes

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.db.models import BaseManager, BaseModel, BoundedAutoField
+from sentry.models import LostPasswordHash
 from sentry.utils.http import absolute_uri
 
 audit_logger = logging.getLogger('sentry.audit.user')
@@ -278,3 +279,6 @@ class User(BaseModel, AbstractBaseUser):
                 user=self,
             ).values('organization'),
         )
+
+    def clear_lost_passwords(self):
+        LostPasswordHash.objects.filter(user=self).delete()

--- a/src/sentry/receivers/auth.py
+++ b/src/sentry/receivers/auth.py
@@ -6,7 +6,7 @@ import six
 from django.contrib.auth.models import update_last_login
 from django.contrib.auth.signals import user_logged_in
 from django.db.utils import DatabaseError
-from sentry.models import UserOption, LostPasswordHash
+from sentry.models import UserOption
 
 
 # Set user language if set
@@ -34,7 +34,7 @@ def safe_update_last_login(sender, user, **kwargs):
 
 def remove_lost_password_hashes(sender, user, **kwargs):
     # Remove pending password recovery hashes; user was able to login
-    LostPasswordHash.objects.filter(user=user).delete()
+    user.clear_lost_passwords()
 
 user_logged_in.disconnect(update_last_login)
 user_logged_in.connect(

--- a/src/sentry/receivers/auth.py
+++ b/src/sentry/receivers/auth.py
@@ -6,7 +6,6 @@ import six
 from django.contrib.auth.models import update_last_login
 from django.contrib.auth.signals import user_logged_in
 from django.db.utils import DatabaseError
-
 from sentry.models import UserOption, LostPasswordHash
 
 

--- a/src/sentry/receivers/email.py
+++ b/src/sentry/receivers/email.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import IntegrityError, transaction
 from django.db.models.signals import post_delete, post_save
 
-from sentry.models import Email, UserEmail
+from sentry.models import Email, UserEmail, User, LostPasswordHash
 
 
 def create_email(instance, created, **kwargs):
@@ -22,5 +22,21 @@ def delete_email(instance, **kwargs):
     Email.objects.filter(email=instance.email).delete()
 
 
+def remove_lost_password_hashes_by_user(instance, **kwargs):
+    LostPasswordHash.objects.filter(user=instance).delete()
+
+
+def remove_lost_password_hashes_by_useremail(instance, **kwargs):
+    LostPasswordHash.objects.filter(user=instance.user).delete()
+
 post_save.connect(create_email, sender=UserEmail, dispatch_uid="create_email", weak=False)
 post_delete.connect(delete_email, sender=UserEmail, dispatch_uid="delete_email", weak=False)
+
+post_save.connect(remove_lost_password_hashes_by_user,
+                  sender=User,
+                  dispatch_uid='remove_lost_password_hashes_by_user',
+                  weak=False)
+post_save.connect(remove_lost_password_hashes_by_useremail,
+                  sender=UserEmail,
+                  dispatch_uid='remove_lost_password_hashes_by_useremail',
+                  weak=False)

--- a/src/sentry/receivers/email.py
+++ b/src/sentry/receivers/email.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import IntegrityError, transaction
 from django.db.models.signals import post_delete, post_save
 
-from sentry.models import Email, UserEmail, User, LostPasswordHash
+from sentry.models import Email, UserEmail
 
 
 def create_email(instance, created, **kwargs):
@@ -22,21 +22,5 @@ def delete_email(instance, **kwargs):
     Email.objects.filter(email=instance.email).delete()
 
 
-def remove_lost_password_hashes_by_user(instance, **kwargs):
-    LostPasswordHash.objects.filter(user=instance).delete()
-
-
-def remove_lost_password_hashes_by_useremail(instance, **kwargs):
-    LostPasswordHash.objects.filter(user=instance.user).delete()
-
 post_save.connect(create_email, sender=UserEmail, dispatch_uid="create_email", weak=False)
 post_delete.connect(delete_email, sender=UserEmail, dispatch_uid="delete_email", weak=False)
-
-post_save.connect(remove_lost_password_hashes_by_user,
-                  sender=User,
-                  dispatch_uid='remove_lost_password_hashes_by_user',
-                  weak=False)
-post_save.connect(remove_lost_password_hashes_by_useremail,
-                  sender=UserEmail,
-                  dispatch_uid='remove_lost_password_hashes_by_useremail',
-                  weak=False)

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -296,6 +296,8 @@ def account_settings(request):
                 msg = _('A confirmation email has been sent to %s.') % user_email.email
                 messages.add_message(request, messages.SUCCESS, msg)
 
+        user.clear_lost_passwords()
+
         messages.add_message(request, messages.SUCCESS, _('Your settings were saved.'))
         return HttpResponseRedirect(request.path)
 
@@ -509,7 +511,7 @@ def show_emails(request):
                 'email': email,
             }
         )
-
+        user.clear_lost_passwords()
         return HttpResponseRedirect(request.path)
 
     if 'primary' in request.POST:
@@ -545,6 +547,7 @@ def show_emails(request):
             if has_new_username and not User.objects.filter(username__iexact=new_primary).exists():
                 user.username = user.email
             user.save()
+        user.clear_lost_passwords()
         return HttpResponseRedirect(request.path)
 
     if email_form.is_valid():
@@ -581,6 +584,8 @@ def show_emails(request):
                 )
                 msg = _('A confirmation email has been sent to %s.') % new_email.email
                 messages.add_message(request, messages.SUCCESS, msg)
+
+        user.clear_lost_passwords()
 
         messages.add_message(request, messages.SUCCESS, _('Your settings were saved.'))
         return HttpResponseRedirect(request.path)

--- a/src/sentry/web/frontend/accounts_twofactor.py
+++ b/src/sentry/web/frontend/accounts_twofactor.py
@@ -46,6 +46,7 @@ class TwoFactorSettingsView(BaseView):
             interface = Authenticator.objects.get_interface(request.user, self.interface_id)
         except LookupError:
             raise Http404
+        request.user.clear_lost_passwords()
         return self.configure(request, interface)
 
     def make_context(self, request, interface):

--- a/tests/sentry/web/frontend/test_2fa.py
+++ b/tests/sentry/web/frontend/test_2fa.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import TestCase
-from sentry.models import TotpInterface
+from sentry.models import TotpInterface, LostPasswordHash
 
 
 class TwoFactorAuthTest(TestCase):
@@ -110,3 +110,30 @@ class TwoFactorAuthTest(TestCase):
         self.assertTemplateUsed('sentry/account/twofactor/remove.html')
         self.assertContains(resp, 'Do you want to remove the method?')
         self.assertContains(resp, 'Sentry account password')
+
+    def test_add_2fa_password_deletes_lost_password(self):
+        user = self.create_user('foo@example.com')
+        path = reverse('sentry-account-settings-2fa-totp')
+        self.login_as(user)
+        LostPasswordHash.objects.create(user=user)
+        resp = self.client.post(path, data={'enroll': ''})
+        self.assertContains(resp, 'Scan the below QR code')
+        self.assertContains(resp, 'Sentry account password')
+        self.assertNotContains(resp, 'Method is currently not enabled')
+        assert not LostPasswordHash.objects.filter(user=user).exists()
+
+    def test_add_2fa_SSO_deletes_lost_passswords(self):
+        user = self.create_user('foo@example.com')
+        user.set_unusable_password()
+        user.save()
+        path = reverse('sentry-account-settings-2fa-totp')
+        self.login_as(user)
+        LostPasswordHash.objects.create(user=user)
+        resp = self.client.post(path, data={'enroll': ''})
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/twofactor/enroll_totp.html')
+        assert 'otp_form' in resp.context
+        self.assertContains(resp, 'One-time password')
+        self.assertContains(resp, 'Authenticator App')
+        self.assertNotContains(resp, 'Sentry account password')
+        assert not LostPasswordHash.objects.filter(user=user).exists()


### PR DESCRIPTION
Lost password hashes are now invalidated when a user changes email address, password, two-factor settings, and after logging in successfully via the frontend.

FIXES #6939