### PR TITLE
feat(servicehooks): Expand event.created hook

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -95,9 +95,7 @@ def post_process_group(event, is_new, is_regression, is_sample, **kwargs):
         'projects:servicehooks',
         project=event.project,
     ):
-        allowed_events = set()
-        if is_new:
-            allowed_events.add('event.created')
+        allowed_events = set(['event.created'])
         if has_alert:
             allowed_events.add('event.alert')
 

--- a/src/sentry/tasks/servicehooks.py
+++ b/src/sentry/tasks/servicehooks.py
@@ -46,12 +46,15 @@ def get_payload_v0(servicehook, event):
     name='sentry.tasks.process_service_hook', default_retry_delay=60 * 5, max_retries=5
 )
 def process_service_hook(servicehook_id, event, **kwargs):
+    from sentry import tsdb
     from sentry.models import ServiceHook
 
     try:
         servicehook = ServiceHook.objects.get(id=servicehook_id)
     except ServiceHook.DoesNotExist:
         return
+
+    tsdb.incr(tsdb.models.servicehook_fired, servicehook.id)
 
     if servicehook.version == 0:
         payload = get_payload_v0(event)

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -97,6 +97,8 @@ class TSDBModel(Enum):
     # the number of events filtered because their group was discarded
     project_total_received_discarded = 610
 
+    servicehook_fired = 700
+
 
 class BaseTSDB(Service):
     __all__ = (

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -124,7 +124,7 @@ class PostProcessGroupTest(TestCase):
         with self.feature('projects:servicehooks'):
             post_process_group(
                 event=event,
-                is_new=True,
+                is_new=False,
                 is_regression=False,
                 is_sample=False,
             )
@@ -165,6 +165,31 @@ class PostProcessGroupTest(TestCase):
             hook_id=hook.id,
             event=event,
         )
+
+    @patch('sentry.tasks.servicehooks.process_service_hook')
+    @patch('sentry.rules.processor.RuleProcessor')
+    def test_service_hook_does_not_fire_without_alert(
+            self, mock_processor, mock_process_service_hook):
+        group = self.create_group(project=self.project)
+        event = self.create_event(group=group)
+
+        mock_processor.return_value.apply.return_value = []
+
+        ServiceHook.objects.create(
+            project_id=self.project.id,
+            actor_id=self.user.id,
+            events=['event.alert'],
+        )
+
+        with self.feature('projects:servicehooks'):
+            post_process_group(
+                event=event,
+                is_new=False,
+                is_regression=False,
+                is_sample=False,
+            )
+
+        assert not mock_process_service_hook.delay.mock_calls
 
     @patch('sentry.tasks.servicehooks.process_service_hook')
     def test_service_hook_does_not_fire_without_event(self, mock_process_service_hook):


### PR DESCRIPTION
This fires a hook for event.created on *every* single event, not just new issues.

It also creates a metric to track events per service hook.