### PR TITLE
feat: Prevent environment tag delete button from being shown

### DIFF
--- a/src/sentry/static/sentry/app/views/projectTags.jsx
+++ b/src/sentry/static/sentry/app/views/projectTags.jsx
@@ -6,6 +6,7 @@ import ExternalLink from '../components/externalLink';
 import LinkWithConfirmation from '../components/linkWithConfirmation';
 import SettingsPageHeader from './settings/components/settingsPageHeader';
 import TextBlock from './settings/components/text/textBlock';
+import Tooltip from '../components/tooltip';
 
 export default class ProjectTags extends AsyncView {
   getEndpoints() {
@@ -32,6 +33,20 @@ export default class ProjectTags extends AsyncView {
     });
   }
 
+  renderLink(key, canDelete, idx) {
+    return (
+      <LinkWithConfirmation
+        className={'btn btn-sm btn-default'}
+        title={'Remove tag?'}
+        message={'Are you sure you want to remove this tag?'}
+        onConfirm={() => this.onDelete(key, idx)}
+        disabled={!canDelete}
+      >
+        <span className="icon icon-trash" />
+      </LinkWithConfirmation>
+    );
+  }
+
   renderBody() {
     return (
       <div>
@@ -49,12 +64,12 @@ export default class ProjectTags extends AsyncView {
           <table className="table">
             <thead>
               <tr>
-                <th>Tags</th>
+                <th>{t('Tags')}</th>
                 <th style={{width: 20}} />
               </tr>
             </thead>
             <tbody>
-              {this.state.tags.map(({key, name}, idx) => {
+              {this.state.tags.map(({key, name, canDelete}, idx) => {
                 return (
                   <tr key={key}>
                     <td>
@@ -65,14 +80,13 @@ export default class ProjectTags extends AsyncView {
                       </h5>
                     </td>
                     <td>
-                      <LinkWithConfirmation
-                        className="btn btn-sm btn-default"
-                        title={'Remove tag?'}
-                        message={'Are you sure you want to remove this tag?'}
-                        onConfirm={() => this.onDelete(key, idx)}
-                      >
-                        <span className="icon icon-trash" />
-                      </LinkWithConfirmation>
+                      {canDelete ? (
+                        this.renderLink(key, canDelete, idx)
+                      ) : (
+                        <Tooltip title={t('This tag cannot be deleted.')}>
+                          <span>{this.renderLink(key, canDelete, idx)}</span>
+                        </Tooltip>
+                      )}
                     </td>
                   </tr>
                 );

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -258,7 +258,11 @@ window.TestStubs = {
     };
   },
   Tags: () => {
-    return [{key: 'browser', name: 'Browser'}, {key: 'device', name: 'Device'}];
+    return [
+      {key: 'browser', name: 'Browser', canDelete: true},
+      {key: 'device', name: 'Device', canDelete: true},
+      {key: 'environment', name: 'Environment', canDelete: false},
+    ];
   },
   Plugin: params => {
     return {

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -139,6 +139,7 @@ exports[`ProjectTags renders 1`] = `
                 <td>
                   <LinkWithConfirmation
                     className="btn btn-sm btn-default"
+                    disabled={false}
                     message="Are you sure you want to remove this tag?"
                     onConfirm={[Function]}
                     title="Remove tag?"
@@ -146,12 +147,14 @@ exports[`ProjectTags renders 1`] = `
                     <Confirm
                       cancelText="Cancel"
                       confirmText="Confirm"
+                      disabled={false}
                       message="Are you sure you want to remove this tag?"
                       onConfirm={[Function]}
                       priority="primary"
                     >
                       <a
                         className="btn btn-sm btn-default"
+                        disabled={false}
                         onClick={[Function]}
                         title="Remove tag?"
                       >
@@ -233,6 +236,7 @@ exports[`ProjectTags renders 1`] = `
                 <td>
                   <LinkWithConfirmation
                     className="btn btn-sm btn-default"
+                    disabled={false}
                     message="Are you sure you want to remove this tag?"
                     onConfirm={[Function]}
                     title="Remove tag?"
@@ -240,12 +244,14 @@ exports[`ProjectTags renders 1`] = `
                     <Confirm
                       cancelText="Cancel"
                       confirmText="Confirm"
+                      disabled={false}
                       message="Are you sure you want to remove this tag?"
                       onConfirm={[Function]}
                       priority="primary"
                     >
                       <a
                         className="btn btn-sm btn-default"
+                        disabled={false}
                         onClick={[Function]}
                         title="Remove tag?"
                       >
@@ -308,6 +314,112 @@ exports[`ProjectTags renders 1`] = `
                       </a>
                     </Confirm>
                   </LinkWithConfirmation>
+                </td>
+              </tr>
+              <tr
+                key="environment"
+              >
+                <td>
+                  <h5>
+                    Environment
+                     
+                    <small>
+                      (
+                      environment
+                      )
+                    </small>
+                  </h5>
+                </td>
+                <td>
+                  <Tooltip
+                    title="This tag cannot be deleted."
+                  >
+                    <span
+                      className="tip"
+                      title="This tag cannot be deleted."
+                    >
+                      <LinkWithConfirmation
+                        className="btn btn-sm btn-default"
+                        disabled={true}
+                        message="Are you sure you want to remove this tag?"
+                        onConfirm={[Function]}
+                        title="Remove tag?"
+                      >
+                        <Confirm
+                          cancelText="Cancel"
+                          confirmText="Confirm"
+                          disabled={true}
+                          message="Are you sure you want to remove this tag?"
+                          onConfirm={[Function]}
+                          priority="primary"
+                        >
+                          <a
+                            className="btn btn-sm btn-default disabled"
+                            disabled={true}
+                            onClick={[Function]}
+                            title="Remove tag?"
+                          >
+                            <span
+                              className="icon icon-trash"
+                            />
+                            <Modal
+                              animation={false}
+                              autoFocus={true}
+                              backdrop={true}
+                              bsClass="modal"
+                              dialogComponentClass={[Function]}
+                              enforceFocus={true}
+                              key="confirm"
+                              keyboard={true}
+                              manager={
+                                ModalManager {
+                                  "add": [Function],
+                                  "containers": Array [],
+                                  "data": Array [],
+                                  "handleContainerOverflow": true,
+                                  "hideSiblingNodes": true,
+                                  "isTopModal": [Function],
+                                  "modals": Array [],
+                                  "remove": [Function],
+                                }
+                              }
+                              onHide={[Function]}
+                              renderBackdrop={[Function]}
+                              restoreFocus={true}
+                              show={false}
+                            >
+                              <Modal
+                                autoFocus={true}
+                                backdrop={true}
+                                backdropClassName="modal-backdrop"
+                                containerClassName="modal-open"
+                                enforceFocus={true}
+                                keyboard={true}
+                                manager={
+                                  ModalManager {
+                                    "add": [Function],
+                                    "containers": Array [],
+                                    "data": Array [],
+                                    "handleContainerOverflow": true,
+                                    "hideSiblingNodes": true,
+                                    "isTopModal": [Function],
+                                    "modals": Array [],
+                                    "remove": [Function],
+                                  }
+                                }
+                                onEntering={[Function]}
+                                onExited={[Function]}
+                                onHide={[Function]}
+                                renderBackdrop={[Function]}
+                                restoreFocus={true}
+                                show={false}
+                              />
+                            </Modal>
+                          </a>
+                        </Confirm>
+                      </LinkWithConfirmation>
+                    </span>
+                  </Tooltip>
                 </td>
               </tr>
             </tbody>

--- a/tests/js/spec/views/projectTags.spec.jsx
+++ b/tests/js/spec/views/projectTags.spec.jsx
@@ -47,6 +47,6 @@ describe('ProjectTags', function() {
 
     wrapper.update();
 
-    expect(wrapper.find('tbody tr').length).toBe(1);
+    expect(wrapper.find('tbody tr').length).toBe(2);
   });
 });


### PR DESCRIPTION
Just hiding this in the UI for now if the tag key is `environment`!

@tkaemming Not sure if you'd prefer to add a `canDelete` prop to the tags endpoint instead, which I guess would be a bit nicer

<img width="1047" alt="screen shot 2018-01-19 at 1 51 26 pm" src="https://user-images.githubusercontent.com/1779792/35173320-e41e4354-fd1f-11e7-9c05-6b15b83b6340.png">
