### PR TITLE
fix(reprocessing): Return correct revision if not cached

### DIFF
--- a/src/sentry/reprocessing.py
+++ b/src/sentry/reprocessing.py
@@ -17,7 +17,7 @@ def get_reprocessing_revision(project, cached=True):
         return ProjectOption.objects.get(
             project=project,
             key=REPROCESSING_OPTION
-        )
+        ).value
     except ProjectOption.DoesNotExist:
         pass
 


### PR DESCRIPTION
Fixes an endless loop in reprocessing. The path for resolving cached and not-cached reprocessing revisions was returning different values: 
 - **cached**: Returns the revision value
 - **not cached**: Returns the `ProjectOption` object

The check in `create_failed_event` subsequently failed and raised `RetryProcessing`. The rest is history.