### PR TITLE
fix(ui): Fix and improve rendering of native processing errors

### DIFF
--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -253,13 +253,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                 # optional dsyms)
                 errors = []
                 if e.is_user_fixable or e.is_sdk_failure:
-                    errors.append({
-                        'type': e.type,
-                        'image_uuid': e.image_uuid,
-                        'image_path': e.image_path,
-                        'image_arch': e.image_arch,
-                        'message': e.message,
-                    })
+                    errors.append(e.get_data())
                 else:
                     logger.debug('Failed to symbolicate with native backend',
                                  exc_info=True)

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -79,7 +79,7 @@ class SymbolicationFailed(Exception):
 
     def get_data(self):
         """Returns the event data."""
-        rv = {'message': self.message}
+        rv = {'message': self.message, 'type': self.type}
         if self.image_path is not None:
             rv['image_path'] = self.image_path
         if self.image_uuid is not None:

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -91,7 +91,7 @@ class EventError(object):
         NATIVE_MISSING_SYSTEM_DSYM: u'A system debug symbol file was missing.',
         NATIVE_MISSING_SYMBOL: u'Unable to resolve a symbol.',
         NATIVE_SIMULATOR_FRAME: u'Encountered an unprocessable simulator frame.',
-        NATIVE_UNKNOWN_IMAGE: u'An binary image is referenced that is unknown.',
+        NATIVE_UNKNOWN_IMAGE: u'A binary image is referenced that is unknown.',
         PROGUARD_MISSING_MAPPING: u'A proguard mapping file was missing.',
         PROGUARD_MISSING_LINENO: u'A proguard mapping file does not contain line info.',
     }

--- a/src/sentry/static/sentry/app/components/events/errorItem.jsx
+++ b/src/sentry/static/sentry/app/components/events/errorItem.jsx
@@ -1,5 +1,7 @@
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import KeyValueList from './interfaces/keyValueList';
 import {t} from '../../locale';
 
 class EventErrorItem extends React.Component {
@@ -22,21 +24,40 @@ class EventErrorItem extends React.Component {
     this.setState({isOpen: !this.state.isOpen});
   };
 
+  cleanedData() {
+    let data = {...this.props.error.data};
+
+    if (data.message === 'None') {
+      // Python ensures a message string, but "None" doesn't make sense here
+      delete data.message;
+    }
+
+    if (typeof data.image_path === 'string') {
+      // Separate the image name for readability
+      let path = data.image_path.split('/');
+      data.image_name = path.splice(-1, 1)[0];
+      data.image_path = path.length ? path.join('/') + '/' : '';
+    }
+
+    return _.mapKeys(data, (value, key) => _.startCase(key));
+  }
+
   render() {
     let error = this.props.error;
     let isOpen = this.state.isOpen;
+    let data = this.cleanedData();
     return (
       <li>
         {error.message}
-        <small>
-          {' '}
-          <a style={{marginLeft: 10}} onClick={this.toggle}>
-            {isOpen ? t('Collapse') : t('Expand')}
-          </a>
-        </small>
-        <pre style={{display: isOpen ? 'block' : 'none'}}>
-          {JSON.stringify(error.data, null, 2)}
-        </pre>
+        {!_.isEmpty(data) && (
+          <small>
+            {' '}
+            <a style={{marginLeft: 10}} onClick={this.toggle}>
+              {isOpen ? t('Collapse') : t('Expand')}
+            </a>
+          </small>
+        )}
+        {isOpen && <KeyValueList data={data} isContextData />}
       </li>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -31,7 +31,7 @@ class EventErrors extends React.Component {
   };
 
   uniqueErrors = errors => {
-    return _.uniqBy(errors, _.isEqual);
+    return _.uniqWith(errors, _.isEqual);
   };
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -381,7 +381,7 @@ const Frame = createReactClass({
           )}
           <span className="address">{data.instructionAddr}</span>
           <span className="symbol">
-            <code>{data.function || '<unknown>'}</code>
+            <code>{data.function || '<unknown>'}</code>{' '}
             {data.filename && (
               <span className="filename">
                 {data.filename}

--- a/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/projectProcessingIssues.jsx
@@ -22,7 +22,7 @@ const MESSAGES = {
   native_missing_system_dsym: t('A system debug symbol file was missing.'),
   native_missing_symbol: t('Unable to resolve a symbol.'),
   native_simulator_frame: t('Encountered an unprocessable simulator frame.'),
-  native_unknown_image: t('An binary image is referenced that is unknown.'),
+  native_unknown_image: t('A binary image is referenced that is unknown.'),
   proguard_missing_mapping: t('A proguard mapping file was missing.'),
   proguard_missing_lineno: t('A proguard mapping file does not contain line info.'),
 };


### PR DESCRIPTION
This PR aims to improve the rendering of processing errors (not reprocessing!) for native crashes.

**Bug Fixes:**
 - The issues are grouped incorrectly. In fact, the current way (`_.uniqBy(errors, _.isEqual)`) will only ever create one group. This is fixed now (`_.uniqWith(errors, _.isEqual)`).
 - Fixed a typo in `"An binary image ..."`

**Improvements:**
 - The `NATIVE_UNKNOWN_IMAGE` error is raised if we do not find a debug image for a frame address. In that case we also don't have any information about the image. Still, we render a huge block of JSON with basically no information. To improve this, all `None` values are now omitted from the error data and subsequently not rendered.
 - The message string of `SymbolicationFailed` errors defaults to `"None"`, which also carries no information for the user. So the UI strips this now explicitly.
 - The `image_path` value contains both the path and the name of an image. I personally find it much easier if they are separated. The UI now detects this as a special case and separates them.
 - If there is no data for a processing error, we would still show the Collapse/Expand toggle and render an empty JSON object. Now, if there is no data on an object (after the cleaning steps above), the toggle will be hidden completely.
 - Finally, since we have such a nice `<KeyValueList>` component to render structured data, it is now used to render processing error data, too.

**Before:** *(note how one issue is missing)*
<img width="685" alt="screen shot 2018-01-17 at 17 40 58" src="https://user-images.githubusercontent.com/1433023/35054747-a69a5734-fbad-11e7-9d6e-97e34a5c30e7.png">

**After:**
<img width="678" alt="screen shot 2018-01-17 at 17 16 56" src="https://user-images.githubusercontent.com/1433023/35054612-411dfaf0-fbad-11e7-9c51-7a55d3c029dd.png">
