### PR TITLE
fix(releases): Handle long release versions when creating activity records

### DIFF
--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -182,7 +182,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
                 Activity.objects.create(
                     type=Activity.RELEASE,
                     project=project,
-                    ident=release.version,
+                    ident=Activity.get_version_ident(release.version),
                     data={'version': release.version},
                     datetime=release.date_released,
                 )

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -170,7 +170,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint):
                     Activity.objects.create(
                         type=Activity.RELEASE,
                         project=project,
-                        ident=result['version'],
+                        ident=Activity.get_version_ident(result['version']),
                         data={'version': result['version']},
                         datetime=release.date_released,
                     )

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -111,7 +111,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
             Activity.objects.create(
                 type=Activity.RELEASE,
                 project=project,
-                ident=release.version,
+                ident=Activity.get_version_ident(release.version),
                 data={'version': release.version},
                 datetime=release.date_released,
             )

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -141,7 +141,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
                 Activity.objects.create(
                     type=Activity.RELEASE,
                     project=project,
-                    ident=result['version'],
+                    ident=Activity.get_version_ident(result['version']),
                     data={'version': result['version']},
                     datetime=release.date_released,
                 )

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -85,6 +85,10 @@ class Activity(Model):
 
     __repr__ = sane_repr('project_id', 'group_id', 'event_id', 'user_id', 'type', 'ident')
 
+    @staticmethod
+    def get_version_ident(version):
+        return (version or '')[:64]
+
     def __init__(self, *args, **kwargs):
         super(Activity, self).__init__(*args, **kwargs)
         from sentry.models import Release

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -88,7 +88,7 @@ class ReleaseHook(object):
         Activity.objects.create(
             type=Activity.RELEASE,
             project=self.project,
-            ident=version,
+            ident=Activity.get_version_ident(version),
             data={'version': version},
             datetime=values['date_released'],
         )

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -329,7 +329,7 @@ class Fixtures(object):
         Activity.objects.create(
             type=Activity.RELEASE,
             project=project,
-            ident=version,
+            ident=Activity.get_version_ident(version),
             user=user,
             data={'version': version},
         )

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -317,7 +317,7 @@ class MockUtils(object):
         Activity.objects.create(
             type=Activity.RELEASE,
             project=project,
-            ident=version,
+            ident=Activity.get_version_ident(version),
             user=user,
             data={'version': version},
         )


### PR DESCRIPTION
fixes SENTRY-5QE