### PR TITLE
ref(native): Add a better check for linux app symbols

### DIFF
--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -158,8 +158,6 @@ class Symbolizer(object):
         sdk_name = sdk_info['sdk_name'].lower() if sdk_info else ''
         if sdk_name == 'macos' and MAC_OS_PATH in obj_path:
             return True
-
-        # For now, consider all linux objects in_app
         if sdk_name == 'linux' and not obj_path.startswith(LINUX_SYS_PATHS):
             return True
 

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -31,6 +31,11 @@ _support_framework = re.compile(
 SIM_PATH = '/Developer/CoreSimulator/Devices/'
 SIM_APP_PATH = '/Containers/Bundle/Application/'
 MAC_OS_PATH = '.app/Contents/'
+LINUX_SYS_PATHS = (
+    '/lib/',
+    '/usr/lib/',
+    'linux-gate.so',
+)
 
 _internal_function_re = re.compile(
     r'(kscm_|kscrash_|KSCrash |SentryClient |RNSentry )')
@@ -140,23 +145,22 @@ class Symbolizer(object):
         return frame
 
     def is_image_from_app_bundle(self, obj, sdk_info=None):
-        fn = obj.name
-        if not fn:
+        obj_path = obj.name
+        if not obj_path:
             return False
 
-        if fn.startswith(APP_BUNDLE_PATHS):
+        if obj_path.startswith(APP_BUNDLE_PATHS):
             return True
 
-        if SIM_PATH in fn and SIM_APP_PATH in fn:
+        if SIM_PATH in obj_path and SIM_APP_PATH in obj_path:
             return True
 
         sdk_name = sdk_info['sdk_name'].lower() if sdk_info else ''
-        if sdk_name == 'macos' and MAC_OS_PATH in fn:
+        if sdk_name == 'macos' and MAC_OS_PATH in obj_path:
             return True
 
         # For now, consider all linux objects in_app
-        # TODO(ja): Fix in_app using file paths
-        if sdk_name == 'linux':
+        if sdk_name == 'linux' and not obj_path.startswith(LINUX_SYS_PATHS):
             return True
 
         return False


### PR DESCRIPTION
This is probably not complete but should improve our detection of app frames for linux crashes. It assumes, that non-static dependencies are usually pulled into `/lib` (for system stuff), `/usr/lib` (via package manager) or we are dealing with the magic `linux-gate.so`. In all other cases, we just assume that it's an app symbol. For reference, I've seen paths like `/home/travis/...` etc there.

Obviously, our symbol server is not yet able to deal with these symbols but that is subject to change.