### PR TITLE
fix(minidump): Use correct return address for symbolication

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -50,7 +50,7 @@ statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=2.0.3,<3.0.0
+symbolic>=2.0.4,<3.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -189,7 +189,7 @@ def merge_minidump_event(data, minidump):
         'crashed': False,
         'stacktrace': {
             'frames': [{
-                'instruction_addr': '0x%x' % frame.instruction,
+                'instruction_addr': '0x%x' % frame.return_address,
                 'function': '<unknown>',  # Required by interface
                 'package': frame.module.name if frame.module else None,
             } for frame in reversed(list(thread.frames()))],


### PR DESCRIPTION
Uses the original return address obtained from stackwalking minidumps for symbolication. The previous `instruction` field contains a value that has been "cleaned" by breakpad already during stackwalking. However, we apply our own heuristics during frame preprocessing, so we must not apply this correction twice.

Also, the upgrade to symbolic 2.0.4 includes a number of bug fixes and stability improvements in symbolicating inlined frames, dealing linux symbols and the aforementioned instruction heuristics.

**NOTE:** Travis is currently not running the macOS job, so symbolic 2.0.4 is not yet available on pypi. I will update this once the release has gone through.