### PR TITLE
fix(tasks): Add sentry.tagstore.tasks.delete_tag_key to celery imports

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -434,7 +434,7 @@ CELERY_IMPORTS = (
     'sentry.tasks.process_buffer', 'sentry.tasks.reports', 'sentry.tasks.reprocessing',
     'sentry.tasks.scheduler', 'sentry.tasks.signals', 'sentry.tasks.store', 'sentry.tasks.unmerge',
     'sentry.tasks.symcache_update', 'sentry.tasks.servicehooks',
-    'sentry.tagstore.tasks.delete_tag_key',
+    'sentry.tagstore.tasks',
 )
 CELERY_QUEUES = [
     Queue('alerts', routing_key='alerts'),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -434,6 +434,7 @@ CELERY_IMPORTS = (
     'sentry.tasks.process_buffer', 'sentry.tasks.reports', 'sentry.tasks.reprocessing',
     'sentry.tasks.scheduler', 'sentry.tasks.signals', 'sentry.tasks.store', 'sentry.tasks.unmerge',
     'sentry.tasks.symcache_update', 'sentry.tasks.servicehooks',
+    'sentry.tagstore.tasks.delete_tag_key',
 )
 CELERY_QUEUES = [
     Queue('alerts', routing_key='alerts'),


### PR DESCRIPTION
fixes SENTRY-588

This was grouped with a separate issue of mine and I didn't notice the regression email so this has been happening for a month. Not sure if there's any cleanup that needs to happen as a result :-/