### PR TITLE
fix(http): Do not raise cannot fetch from http fetch for non 200 ok

### DIFF
--- a/src/sentry/http.py
+++ b/src/sentry/http.py
@@ -366,13 +366,4 @@ def fetch_file(
         if response is not None:
             response.close()
 
-    if result[2] != 200:
-        logger.debug('HTTP %s when fetching %r', result[2], url, exc_info=True)
-        error = {
-            'type': EventError.FETCH_INVALID_HTTP_CODE,
-            'value': result[2],
-            'url': expose_url(url),
-        }
-        raise CannotFetch(error)
-
     return UrlResult(url, result[0], result[1], result[2], result[3])

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -333,6 +333,16 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
             z_body = zlib.compress(result.body)
             cache.set(cache_key, (url, result.headers, z_body, result.status, result.encoding), 60)
 
+    # If we did not get a 200 OK we just raise a cannot fetch here.
+    if result.status != 200:
+        raise http.CannotFetch(
+            {
+                'type': EventError.FETCH_INVALID_HTTP_CODE,
+                'value': result.status,
+                'url': http.expose_url(url),
+            }
+        )
+
     # Make sure the file we're getting back is six.binary_type. The only
     # reason it'd not be binary would be from old cached blobs, so
     # for compatibility with current cached files, let's coerce back to


### PR DESCRIPTION
This makes the http fetch function return a normal result for non 200
as well.  This way we can properly handle these status codes now which
is what I think the code originally expected.  Now that also means that
we need to raise a cannot fetch at a higher level.  This seems to have a
similar effect but it means we properly cache the non 200 oks in the
javascript source cache.