### PR TITLE
feat(slack): Implement issue actions via slack

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Version 8.23 (Unreleased)
 -------------------------
+- Experiemental implementation of slack actions via a new Integrations and Identity API.
 
 Schema Changes
 ~~~~~~~~~~~~~~

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -1,0 +1,116 @@
+from __future__ import absolute_import
+
+from sentry import http, options
+from sentry.api.base import Endpoint
+from sentry.models import Activity, Group, Integration, Project
+from sentry.utils import json
+
+from .utils import build_attachment, build_workflow_message, logger
+
+
+# https://api.slack.com/docs/message-threading
+class SlackActionEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    def on_status(self, request, integration, group, action, data):
+        activity = Activity(type=Activity.SET_RESOLVED, group=group, project=group.project)
+
+        payload = build_workflow_message(activity)
+        payload.update({
+            'thread_ts': data['message_ts'],
+            'source_team': data['team']['id'],
+            'channel': data['channel']['id'],
+            'user': integration.metadata['bot_user_id'],
+            'token': integration.metadata['bot_access_token'],
+            'type': 'message',
+            'as_user': True,
+            'unfurl_links': False,
+            'unfurl_media': False,
+        })
+        session = http.build_session()
+        req = session.post('https://slack.com/api/chat.postMessage', data=payload)
+        req.raise_for_status()
+        resp = req.json()
+        if not resp.get('ok'):
+            logger.error('slack.action.response-error', extra={
+                'error': resp.get('error'),
+            })
+
+    def post(self, request):
+        logging_data = {}
+
+        try:
+            data = request.DATA
+        except (ValueError, TypeError):
+            logger.error('slack.action.invalid-json', extra=logging_data, exc_info=True)
+            return self.respond(status=400)
+
+        try:
+            data = json.loads(data['payload'])
+        except (KeyError, IndexError, TypeError, ValueError):
+            logger.error('slack.action.invalid-payload', extra=logging_data, exc_info=True)
+            return self.respond(status=400)
+
+        event_id = data.get('event_id')
+        team_id = data.get('team', {}).get('id')
+        channel_id = data.get('channel', {}).get('id')
+        user_id = data.get('user', {}).get('id')
+        callback_id = data.get('callback_id')
+        # TODO(dcramer): should we verify this here?
+        # authed_users = data.get('authed_users')
+
+        logging_data.update({
+            'team_id': team_id,
+            'channel_id': channel_id,
+            'user_id': user_id,
+            'event_id': event_id,
+            'callback_id': callback_id,
+        })
+
+        token = data.get('token')
+        if token != options.get('slack.verification-token'):
+            logger.error('slack.action.invalid-token', extra=logging_data)
+            return self.respond(status=401)
+
+        logger.info('slack.action', extra=logging_data)
+
+        try:
+            integration = Integration.objects.get(
+                provider='slack',
+                external_id=team_id,
+            )
+        except Integration.DoesNotExist:
+            logger.error('slack.action.invalid-team-id', extra=logging_data)
+            return self.respond(status=403)
+
+        logging_data['integration_id'] = integration.id
+
+        # TODO
+        # When your Action URL is triggered, you'll receive the user ID and team
+        # ID for the invoker. If they do not yet exist in your system, send them
+        # an ephemeral message containing a link they can follow to link accounts
+        # on your website.
+        action_list = data.get('actions')
+        if not action_list:
+            logger.error('slack.action.missing-actions', extra=logging_data)
+            return self.respond(status=400)
+
+        assert callback_id.startswith('issue:')
+        group_id = callback_id.split('issue:', 1)[-1]
+
+        try:
+            group = Group.objects.get(
+                project__in=Project.objects.filter(
+                    organization__in=integration.organizations.all(),
+                ),
+                id=group_id,
+            )
+        except Group.DoesNotExist:
+            logger.error('slack.action.invalid-issue', extra=logging_data)
+            return self.respond(status=403)
+
+        for action in action_list:
+            if action['name'] == 'status':
+                self.on_status(request, integration, group, action, data)
+        return self.respond(build_attachment(group))

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -17,7 +17,7 @@ RESOLVE_SELECTOR = {
     'label': 'Resolve issue',
     'type': 'select',
     'name': 'resolve_type',
-    'placeholder': 'Select when to expect this issue resolved',
+    'placeholder': 'Select the resolution target',
     'value': 'resolved',
     'options': [
         {

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -11,7 +11,7 @@ from sentry.utils.http import absolute_uri
 
 from .utils import build_attachment, logger
 
-LINK_IDENTITY_MESSAGE = "Looks like you haven't linked your Sentry account with your Slack identity yet! <{link_url}|Link your identity now> to perform actions in Sentry through Slack."
+LINK_IDENTITY_MESSAGE = "Looks like you haven't linked your Sentry account with your Slack identity yet! <{associate_url}|Link your identity now> to perform actions in Sentry through Slack."
 
 RESOLVE_SELECTOR = {
     'label': 'Resolve issue',
@@ -192,7 +192,7 @@ class SlackActionEndpoint(Endpoint):
             return self.respond({
                 'response_type': 'ephemeral',
                 'replace_original': False,
-                'text': LINK_IDENTITY_MESSAGE.format(link_url=associate_url)
+                'text': LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
             })
 
         # Handle status dialog submission

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -167,11 +167,7 @@ class SlackActionEndpoint(Endpoint):
 
         logging_data['integration_id'] = integration.id
 
-        try:
-            callback_data = json.loads(callback_id)
-        except (KeyError, IndexError, TypeError, ValueError):
-            logger.error('slack.action.invalid-callback-id', extra=logging_data, exc_info=True)
-            return self.respond(status=400)
+        callback_data = json.loads(callback_id)
 
         # Determine the issue group action is being taken on
         group_id = callback_data['issue']

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -60,7 +60,6 @@ class SlackActionEndpoint(Endpoint):
         callback_id = json.dumps({
             'issue': group.id,
             'orig_response_url': data['response_url'],
-
         })
 
         dialog = {

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -86,10 +86,6 @@ class SlackActionEndpoint(Endpoint):
     def on_status(self, request, identity, group, action, data, integration):
         status = action['value']
 
-        if status == 'resolve_dialog':
-            self.open_resolve_dialog(data, group, integration)
-            return
-
         status_data = status.split(':', 1)
         status = {'status': status_data[0]}
 
@@ -227,15 +223,16 @@ class SlackActionEndpoint(Endpoint):
         for action in action_list:
             if action['name'] == 'status':
                 self.on_status(request, identity, group, action, data, integration)
-
-            if action['name'] == 'assign':
+            elif action['name'] == 'assign':
                 self.on_assign(request, identity, group, action)
+            elif action['name'] == 'resolve_dialog':
+                self.open_resolve_dialog(data, group, integration)
 
         # Usually we'll want to respond with the updated attachment including
         # the list of actions taken. However, when opening a dialog we do not
         # have anything to update the message with and will use the
         # response_url later to update it.
-        if len(action_list) > 0 and action_list[0].get('value') == 'resolve_dialog':
+        if len(action_list) > 0 and action_list[0].get('name') == 'resolve_dialog':
             return self.respond()
 
         # Reload group as it may have been mutated by the action

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -57,11 +57,11 @@ class SlackActionEndpoint(Endpoint):
         status_data = status.split(':', 1)
         status = {'status': status_data[0]}
 
-        # Additional status details
-        if status_data[-1] == 'inNextRelease':
-            status.update({'statusDetails': {'inNextRelease': True}})
+        resolve_type = status_data[-1]
 
-        if status_data[-1] == 'inCurrentRelease':
+        if resolve_type == 'inNextRelease':
+            status.update({'statusDetails': {'inNextRelease': True}})
+        elif resolve_type == 'inCurrentRelease':
             status.update({'statusDetails': {'inRelease': 'latest'}})
 
         try:

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -68,6 +68,8 @@ class SlackActionEndpoint(Endpoint):
             self.update_group(group, identity, status)
         except client.ApiError as e:
             logger.error('slack.action.sentry-client-error', extra={'error': e.body})
+            # TODO(epurkhiser): Do we need to make it clear that if the user
+            # isn't on the team for this that hey can't do anything?
 
     def update_group(self, group, identity, data):
         return client.put(

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -161,8 +161,13 @@ class SlackActionEndpoint(Endpoint):
 
         logging_data['integration_id'] = integration.id
 
+        try:
+            callback_data = json.loads(callback_id)
+        except (KeyError, IndexError, TypeError, ValueError):
+            logger.error('slack.action.invalid-callback-id', extra=logging_data, exc_info=True)
+            return self.respond(status=400)
+
         # Determine the issue group action is being taken on
-        callback_data = json.loads(callback_id)
         group_id = callback_data['issue']
 
         # Actions list may be empty when receiving a dialog response

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -1,27 +1,18 @@
 from __future__ import absolute_import
 
-import logging
 import json
 import re
 import six
-
-from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from sentry import http, options
 from sentry.api.base import Endpoint
 from sentry.models import Group, Integration, Project
 
-logger = logging.getLogger('sentry.integrations.slack')
+from .utils import build_attachment, logger
 
+# XXX(dcramer): this could be more tightly bound to our configured domain,
+# but slack limits what we can unfurl anyways so its probably safe
 _link_regexp = re.compile(r'^https?\://[^/]+/[^/]+/[^/]+/issues/(\d+)/')
-
-LEVEL_TO_COLOR = {
-    'debug': 'cfd3da',
-    'info': '2788ce',
-    'warning': 'f18500',
-    'error': 'f43f20',
-    'fatal': 'd20f2a',
-}
 
 
 # XXX(dcramer): a lot of this is copied from sentry-plugins right now, and will
@@ -38,22 +29,6 @@ class SlackEventEndpoint(Endpoint):
             return int(match.group(1))
         except (TypeError, ValueError):
             return
-
-    def _attachment_for(self, group):
-        return {
-            'fallback': u'[{}] {}'.format(group.project.slug, group.title),
-            'title': group.title,
-            'title_link': self._add_notification_referrer_param(group.get_absolute_url()),
-        }
-
-    def _add_notification_referrer_param(self, url):
-        parsed_url = urlparse(url)
-        query = parse_qs(parsed_url.query)
-        query['referrer'] = 'slack'
-
-        url_list = list(parsed_url)
-        url_list[4] = urlencode(query, doseq=True)
-        return urlunparse(url_list)
 
     def on_url_verification(self, request, data):
         return self.respond({
@@ -87,7 +62,7 @@ class SlackEventEndpoint(Endpoint):
             'channel': data['channel'],
             'ts': data['message_ts'],
             'unfurls': json.dumps({
-                v: self._attachment_for(results[k])
+                v: build_attachment(results[k])
                 for k, v in six.iteritems(issue_map)
                 if k in results
             }),

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -12,7 +12,7 @@ from .utils import build_attachment, logger
 
 # XXX(dcramer): this could be more tightly bound to our configured domain,
 # but slack limits what we can unfurl anyways so its probably safe
-_link_regexp = re.compile(r'^https?\://[^/]+/[^/]+/[^/]+/issues/(\d+)/')
+_link_regexp = re.compile(r'^https?\://[^/]+/[^/]+/[^/]+/issues/(\d+)')
 
 
 # XXX(dcramer): a lot of this is copied from sentry-plugins right now, and will

--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import, print_function
 
 from django.conf.urls import patterns, url
 
+from .action_endpoint import SlackActionEndpoint
 from .event_endpoint import SlackEventEndpoint
 
 
 urlpatterns = patterns(
     '',
+    url(r'^action/$', SlackActionEndpoint.as_view()),
     url(r'^event/$', SlackEventEndpoint.as_view()),
 )

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -1,0 +1,122 @@
+from __future__ import absolute_import
+
+import logging
+
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from sentry.models import GroupStatus
+
+
+logger = logging.getLogger('sentry.integrations.slack')
+
+
+def add_notification_referrer_param(url, provider):
+    parsed_url = urlparse(url)
+    query = parse_qs(parsed_url.query)
+    query['referrer'] = provider
+    url_list = list(parsed_url)
+    url_list[4] = urlencode(query, doseq=True)
+    return urlunparse(url_list)
+
+
+def build_workflow_message(activity):
+    from sentry.plugins.sentry_mail.activity import emails
+
+    cls = emails.get(activity.type)
+    if cls is None:
+        return
+
+    email = cls(activity)
+
+    context = email.get_context()
+
+    return {
+        'text': context['text_description'],
+    }
+
+
+def build_attachment_title(group, event=None):
+    ev_metadata = group.get_event_metadata()
+    ev_type = group.get_event_type()
+    if ev_type == 'error':
+        if group.culprit:
+            return '{} - {}'.format(ev_metadata['type'][:40], group.culprit)
+        return ev_metadata['type']
+    elif ev_type == 'csp':
+        return '{} - {}'.format(ev_metadata['directive'], ev_metadata['uri'])
+    else:
+        if group.culprit:
+            return '{} - {}'.format(group.title[:40], group.culprit)
+        return group.title
+
+
+def build_attachment_pretext(group, event=None):
+    ev_metadata = group.get_event_metadata()
+    ev_type = group.get_event_type()
+    if ev_type == 'error':
+        return ev_metadata['value']
+    else:
+        return None
+
+
+def build_attachment(group, event=None):
+    # XXX(dcramer): options are limited to 100 choices, even when nested
+    status = group.get_status()
+    if status == GroupStatus.UNRESOLVED:
+        status_label = 'Unresolved'
+    elif status == GroupStatus.RESOLVED:
+        status_label = 'Resolved'
+    elif status == GroupStatus.IGNORED:
+        status_label = 'Ignored'
+    else:
+        status_label = 'n/a'
+
+    return {
+        'fallback': '[{}] {}'.format(group.project.slug, group.title),
+        'title': build_attachment_title(group, event),
+        'title_link': add_notification_referrer_param(group.get_absolute_url(), 'slack'),
+        'text': build_attachment_pretext(group, event),
+        'callback_id': 'issue:{}'.format(group.id),
+        'footer': '{} / {}'.format(
+            group.organization.slug,
+            group.project.slug,
+        ),
+        'color': '#6C5FC7',
+        'actions': [
+            {
+                'name': 'assignedTo',
+                'text': 'Assign ..',
+                'type': 'select',
+                'options': [
+                    {'text': 'David Cramer', 'value': 'dcramer'},
+                    {'text': 'George Castanza', 'value': 'george'},
+                ],
+                "selected_options": [
+                    {
+                        "text": "Assigned to: David Cramer",
+                        "value": "dcramer"
+                    }
+                ]
+            },
+            {
+                'name': 'status',
+                'text': 'Status: {}'.format(status_label),
+                'type': 'select',
+                'option_groups': [
+                    {
+                        'text': 'Ignore until ..',
+                        'options': [
+                            {'text': 'Forever', 'value': 'ignore'},
+                        ]
+                    },
+                    {
+                        'text': 'Resolve in ..',
+                        'options': [
+                            {'text': 'The next release', 'value': 'resolve:inNextRelease'},
+                            {'text': 'The current release', 'value': 'resolve:inCurrentRelease'},
+                        ]
+                    }
+                ]
+            }
+        ],
+    }

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -115,15 +115,13 @@ def build_attachment(group, event=None, identity=None, actions=None):
     status = group.get_status()
     assignees = get_assignees(group)
 
-    text = build_attachment_text(group, event) or ''
+    logo_url = absolute_uri(get_asset_url('sentry', 'images/sentry-email-avatar.png'))
     color = NEW_ISSUE_COLOR
+
+    text = build_attachment_text(group, event) or ''
 
     if actions is None:
         actions = []
-
-    if len(actions) > 0:
-        action_texts = filter(None, [build_action_text(identity, a) for a in actions])
-        text += '\n' + '\n'.join(action_texts)
 
     try:
         assignee = GroupAssignee.objects.get(group=group).user
@@ -176,11 +174,12 @@ def build_attachment(group, event=None, identity=None, actions=None):
         },
     ]
 
-    if len(actions) > 0:
+    if actions:
+        action_texts = filter(None, [build_action_text(identity, a) for a in actions])
+        text += '\n' + '\n'.join(action_texts)
+
         color = ACTIONED_ISSUE_COLOR
         payload_actions = []
-
-    logo_url = absolute_uri(get_asset_url('sentry', 'images/sentry-email-avatar.png'))
 
     return {
         'fallback': '[{}] {}'.format(group.project.slug, group.title),

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -76,10 +76,15 @@ def build_assigned_text(identity, assignee):
         )
 
     try:
-        assignee_ident = Identity.objects.get(user=User.objects.get(email=assignee))
+        assignee_user = User.objects.get(email=assignee)
+    except User.DoesNotExist:
+        return
+
+    try:
+        assignee_ident = Identity.objects.get(user=assignee_user)
         assignee_text = u'<@{}>'.format(assignee_ident.external_id)
     except Identity.DoesNotExist:
-        assignee_text = assignee
+        assignee_text = assignee_user.get_display_name()
 
     return u'*Issue assigned to {assignee_text} by <@{user_id}>*'.format(
         assignee_text=assignee_text,

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -182,14 +182,14 @@ def build_attachment(group, event=None, identity=None, actions=None):
         payload_actions = []
 
     return {
-        'fallback': '[{}] {}'.format(group.project.slug, group.title),
+        'fallback': u'[{}] {}'.format(group.project.slug, group.title),
         'title': build_attachment_title(group, event),
         'title_link': add_notification_referrer_param(group.get_absolute_url(), 'slack'),
         'text': text,
         'mrkdwn_in': ['text'],
         'callback_id': json.dumps({'issue': group.id}),
         'footer_icon': logo_url,
-        'footer': '{} / {}'.format(
+        'footer': u'{} / {}'.format(
             group.organization.slug,
             group.project.slug,
         ),

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -27,7 +27,7 @@ def get_assignees(group):
     queryset = OrganizationMember.objects.filter(
         Q(user__is_active=True) | Q(user__isnull=True),
         organization=group.organization,
-        teams=group.team,
+        teams__in=group.project.teams.all(),
     ).select_related('user')
 
     members = sorted(queryset, key=lambda x: x.user.get_display_name() if x.user_id else x.email)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -138,21 +138,22 @@ def build_attachment(group, event=None, identity=None, actions=None):
         assignee = None
 
     resolve_button = {
-        'name': 'status',
+        'name': 'resolve_dialog',
+        'value': 'resolve_dialog',
         'type': 'button',
         'text': 'Resolve',
-        'value': 'resolve_dialog',
     }
 
     ignore_button = {
         'name': 'status',
+        'value': 'ignored',
         'type': 'button',
         'text': 'Ignore',
-        'value': 'ignored',
     }
 
     if status == GroupStatus.RESOLVED:
         resolve_button.update({
+            'name': 'status',
             'text': 'Unresolve Issue',
             'value': 'unresolved',
         })

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import
+
+import responses
+
+from sentry import options
+from sentry.models import Integration, OrganizationIntegration
+from sentry.testutils import APITestCase
+
+UNSET = object()
+
+
+class BaseEventTest(APITestCase):
+    def setUp(self):
+        super(BaseEventTest, self).setUp()
+        self.user = self.create_user(is_superuser=False)
+        self.org = self.create_organization(owner=None)
+        self.integration = Integration.objects.create(
+            provider='slack',
+            external_id='TXXXXXXX1',
+            metadata={
+                'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
+                'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
+            }
+        )
+        OrganizationIntegration.objects.create(
+            organization=self.org,
+            integration=self.integration,
+        )
+
+    def post_webhook(self, action_data=None, type='event_callback', data=None,
+                     token=UNSET, team_id='TXXXXXXX1', callback_id='comic_1234_xyz'):
+        if token is UNSET:
+            token = options.get('slack.verification-token')
+        payload = {
+            'token': token,
+            'team': {
+                'id': team_id,
+                'domain': 'example.com',
+            },
+            'channel': {
+                'id': 'C065W1189',
+                'domain': 'forgotten-works',
+            },
+            'user': {
+                'id': 'U045VRZFT',
+                'domain': 'example',
+            },
+            'callback_id': callback_id,
+            'action_ts': '1458170917.164398',
+            'message_ts': '1458170866.000004',
+            'original_message': {},  # unused
+            'trigger_id': '13345224609.738474920.8088930838d88f008e0',
+            'response_url': 'https://hooks.slack.com/actions/T47563693/6204672533/x7ZLaiVMoECAW50Gw1ZYAXEM',
+            'attachment_id': '1',
+            'actions': action_data or [],
+        }
+        if data:
+            payload.update(data)
+        return self.client.post(
+            '/extensions/slack/action/',
+            payload,
+        )
+
+
+class StatusActionTest(BaseEventTest):
+    @responses.activate
+    def test_valid_token(self):
+        responses.add(responses.POST, 'https://slack.com/api/chat.unfurl',
+                      json={'ok': True})
+        project1 = self.create_project(organization=self.org)
+        group1 = self.create_group(project=project1)
+        resp = self.post_webhook(action_data=[
+            {
+                'name': 'status',
+                'value': 'ignore',
+                'type': 'button'
+            }
+        ], callback_id='issue:{}'.format(group1.id))
+        assert resp.status_code == 200, resp.content

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -210,9 +210,7 @@ class StatusActionTest(BaseEventTest):
 
         status_action = {
             'name': 'assign',
-            'selected_options': [
-                {'value': user2.username},
-            ],
+            'selected_options': [{'value': user2.username}],
         }
 
         resp = self.post_webhook(action_data=[status_action])
@@ -312,3 +310,16 @@ class StatusActionTest(BaseEventTest):
         assert resp.data['response_type'] == 'ephemeral'
         assert not resp.data['replace_original']
         assert resp.data['text'] == 'Action failed: You do not have permission to perform this action.'
+
+    def test_invalid_token(self):
+        resp = self.post_webhook(token='invalid')
+        assert resp.status_code == 401
+
+    def test_no_integration(self):
+        self.integration.delete()
+        resp = self.post_webhook()
+        assert resp.status_code == 403
+
+    def test_slack_bad_payload(self):
+        resp = self.client.post('/extensions/slack/action/', data={'nopayload': 0})
+        assert resp.status_code == 400

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -2,11 +2,18 @@ from __future__ import absolute_import
 
 import responses
 
-from sentry import options
-from sentry.models import Integration, OrganizationIntegration
-from sentry.testutils import APITestCase
+from django.core.urlresolvers import reverse
+from six.moves.urllib.parse import parse_qs
 
-UNSET = object()
+from sentry import options
+from sentry.models import (
+    Integration, OrganizationIntegration, Identity, IdentityProvider,
+    IdentityStatus, Group, GroupStatus, GroupAssignee
+)
+from sentry.testutils import APITestCase
+from sentry.utils import json
+from sentry.utils.http import absolute_uri
+from sentry.integrations.slack.action_endpoint import LINK_IDENTITY_MESSAGE
 
 
 class BaseEventTest(APITestCase):
@@ -14,6 +21,8 @@ class BaseEventTest(APITestCase):
         super(BaseEventTest, self).setUp()
         self.user = self.create_user(is_superuser=False)
         self.org = self.create_organization(owner=None)
+        self.team = self.create_team(organization=self.org, members=[self.user])
+
         self.integration = Integration.objects.create(
             provider='slack',
             external_id='TXXXXXXX1',
@@ -27,10 +36,36 @@ class BaseEventTest(APITestCase):
             integration=self.integration,
         )
 
+        self.idp = IdentityProvider.objects.create(
+            type='slack',
+            organization=self.org,
+            config={},
+        )
+        self.identity = Identity.objects.create(
+            external_id='slack_id',
+            idp=self.idp,
+            user=self.user,
+            status=IdentityStatus.VALID,
+            scopes=[],
+        )
+
+        self.project1 = self.create_project(organization=self.org)
+        self.group1 = self.create_group(project=self.project1)
+
+        self.trigger_id = '13345224609.738474920.8088930838d88f008e0'
+        self.response_url = 'https://hooks.slack.com/actions/T47563693/6204672533/x7ZLaiVMoECAW50Gw1ZYAXEM'
+
     def post_webhook(self, action_data=None, type='event_callback', data=None,
-                     token=UNSET, team_id='TXXXXXXX1', callback_id='comic_1234_xyz'):
-        if token is UNSET:
+                     token=None, team_id='TXXXXXXX1', callback_id=None, slack_user=None):
+        if token is None:
             token = options.get('slack.verification-token')
+
+        if slack_user is None:
+            slack_user = {'id': self.identity.external_id, 'domain': 'example'}
+
+        if callback_id is None:
+            callback_id = json.dumps({'issue': self.group1.id})
+
         payload = {
             'token': token,
             'team': {
@@ -41,39 +76,165 @@ class BaseEventTest(APITestCase):
                 'id': 'C065W1189',
                 'domain': 'forgotten-works',
             },
-            'user': {
-                'id': 'U045VRZFT',
-                'domain': 'example',
-            },
+            'user': slack_user,
             'callback_id': callback_id,
             'action_ts': '1458170917.164398',
             'message_ts': '1458170866.000004',
             'original_message': {},  # unused
-            'trigger_id': '13345224609.738474920.8088930838d88f008e0',
-            'response_url': 'https://hooks.slack.com/actions/T47563693/6204672533/x7ZLaiVMoECAW50Gw1ZYAXEM',
+            'trigger_id': self.trigger_id,
+            'response_url': self.response_url,
             'attachment_id': '1',
             'actions': action_data or [],
+            'type': type,
         }
         if data:
             payload.update(data)
-        return self.client.post(
-            '/extensions/slack/action/',
-            payload,
-        )
+
+        payload = {'payload': json.dumps(payload)}
+
+        return self.client.post('/extensions/slack/action/', data=payload)
 
 
 class StatusActionTest(BaseEventTest):
-    @responses.activate
-    def test_valid_token(self):
-        responses.add(responses.POST, 'https://slack.com/api/chat.unfurl',
-                      json={'ok': True})
-        project1 = self.create_project(organization=self.org)
-        group1 = self.create_group(project=project1)
-        resp = self.post_webhook(action_data=[
-            {
-                'name': 'status',
-                'value': 'ignore',
-                'type': 'button'
-            }
-        ], callback_id='issue:{}'.format(group1.id))
+    def test_ask_linking(self):
+        resp = self.post_webhook(slack_user={
+            'id': 'invalid-id',
+            'domain': 'example',
+        })
+
+        associate_url = absolute_uri(reverse('sentry-account-associate-identity', kwargs={
+            'organization_slug': self.org.slug,
+            'provider_key': 'slack',
+        }))
+
         assert resp.status_code == 200, resp.content
+        assert resp.data['response_type'] == 'ephemeral'
+        assert resp.data['text'] == LINK_IDENTITY_MESSAGE.format(
+            associate_url=associate_url,
+        )
+
+    def test_ignore_issue(self):
+        status_action = {
+            'name': 'status',
+            'value': 'ignored',
+            'type': 'button'
+        }
+
+        resp = self.post_webhook(action_data=[status_action])
+        self.group1 = Group.objects.get(id=self.group1.id)
+
+        assert resp.status_code == 200, resp.content
+        assert self.group1.get_status() == GroupStatus.IGNORED
+
+        expect_status = u'*Issue ignored by <@{}>*'.format(self.identity.external_id)
+        assert resp.data['text'].endswith(expect_status), resp.data['text']
+
+    def test_assign_issue(self):
+        user2 = self.create_user(is_superuser=False)
+        self.create_member(user=user2, organization=self.org, teams=[self.team])
+
+        status_action = {
+            'name': 'assign',
+            'selected_options': [
+                {'value': user2.username},
+            ],
+        }
+
+        resp = self.post_webhook(action_data=[status_action])
+
+        assert resp.status_code == 200, resp.content
+        assert GroupAssignee.objects.filter(group=self.group1, user=user2).exists()
+
+        expect_status = u'*Issue assigned to {assignee} by <@{assigner}>*'.format(
+            assignee=user2.get_display_name(),
+            assigner=self.identity.external_id,
+        )
+
+        assert resp.data['text'].endswith(expect_status), resp.data['text']
+
+    def test_assign_issue_user_has_identity(self):
+        user2 = self.create_user(is_superuser=False)
+        self.create_member(user=user2, organization=self.org, teams=[self.team])
+
+        user2_identity = Identity.objects.create(
+            external_id='slack_id2',
+            idp=self.idp,
+            user=user2,
+            status=IdentityStatus.VALID,
+            scopes=[],
+        )
+
+        status_action = {
+            'name': 'assign',
+            'selected_options': [
+                {'value': user2.username},
+            ],
+        }
+
+        resp = self.post_webhook(action_data=[status_action])
+
+        assert resp.status_code == 200, resp.content
+        assert GroupAssignee.objects.filter(group=self.group1, user=user2).exists()
+
+        expect_status = u'*Issue assigned to <@{assignee}> by <@{assigner}>*'.format(
+            assignee=user2_identity.external_id,
+            assigner=self.identity.external_id,
+        )
+
+        assert resp.data['text'].endswith(expect_status), resp.data['text']
+
+    @responses.activate
+    def test_resolve_issue(self):
+        status_action = {
+            'name': 'resolve_dialog',
+            'value': 'resolve_dialog',
+        }
+
+        # Expect request to open dialog on slack
+        responses.add(
+            method=responses.POST,
+            url='https://slack.com/api/dialog.open',
+            body='{"ok": true}',
+            status=200,
+            content_type='application/json',
+        )
+
+        resp = self.post_webhook(action_data=[status_action])
+        assert resp.status_code == 200, resp.content
+
+        # Opening dialog should *not* cause the current message to be updated
+        assert resp.content == ''
+
+        data = parse_qs(responses.calls[0].request.body)
+        assert data['token'][0] == self.integration.metadata['bot_access_token']
+        assert data['trigger_id'][0] == self.trigger_id
+        assert 'dialog' in data
+
+        dialog = json.loads(data['dialog'][0])
+        callback_data = json.loads(dialog['callback_id'])
+        assert int(callback_data['issue']) == self.group1.id
+        assert callback_data['orig_response_url'] == self.response_url
+
+        # Completing the dialog will update the message
+        responses.add(
+            method=responses.POST,
+            url=self.response_url,
+            body='{"ok": true}',
+            status=200,
+            content_type='application/json',
+        )
+
+        resp = self.post_webhook(
+            type='dialog_submission',
+            callback_id=dialog['callback_id'],
+            data={'submission': {'resolve_type': 'resolved'}}
+        )
+        self.group1 = Group.objects.get(id=self.group1.id)
+
+        assert resp.status_code == 200, resp.content
+        assert self.group1.get_status() == GroupStatus.RESOLVED
+
+        update_data = json.loads(responses.calls[1].request.body)
+
+        expect_status = u'*Issue resolved by <@{}>*'.format(self.identity.external_id)
+        assert update_data['text'].endswith(expect_status)


### PR DESCRIPTION
This includes the inital work from @dcramer in adding slack actions, but then makes additional refactors to bring the interactions in line with the current design. 

 * Implements Assign, Ignore, and Resolve (via dialog).

 * Refactor attachment generation to remove buttons when an action is completed on the issue from within slack.

Tests incoming