### PR TITLE
fix(sso): Prompt for auth when an existing user exists

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -492,7 +492,7 @@ class AuthHelper(object):
             # the email matches we go ahead and let them merge it. This is the
             # only way to prevent them having duplicate accounts, and because
             # we trust identity providers, its considered safe.
-            if existing_user and (existing_user.is_managed or verified_email):
+            if existing_user and existing_user.is_managed and verified_email:
                 # we only allow this flow to happen if the existing user has
                 # membership, otherwise we short circuit because it might be
                 # an attempt to hijack membership of another organization

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -455,10 +455,7 @@ class AuthHelper(object):
 
     def _find_existing_user(self, email):
         return User.objects.filter(
-            id__in=UserEmail.objects.filter(
-                email__iexact=email,
-                is_verified=True,
-            ).values('user'),
+            id__in=UserEmail.objects.filter(email__iexact=email).values('user'),
             is_active=True,
         ).first()
 
@@ -486,11 +483,16 @@ class AuthHelper(object):
             except IndexError:
                 existing_user = None
 
+            verified_email = existing_user and existing_user.emails.filter(
+                is_verified=True,
+                email__iexact=identity['email'],
+            ).exists()
+
             # If they already have an SSO account and the identity provider says
             # the email matches we go ahead and let them merge it. This is the
             # only way to prevent them having duplicate accounts, and because
             # we trust identity providers, its considered safe.
-            if existing_user and existing_user.is_managed:
+            if existing_user and (existing_user.is_managed or verified_email):
                 # we only allow this flow to happen if the existing user has
                 # membership, otherwise we short circuit because it might be
                 # an attempt to hijack membership of another organization

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -205,6 +205,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         )
         user = self.create_user('bar@example.com')
 
+        email = user.emails.all()[:1].get()
+        email.is_verified = False
+        email.save()
+
         path = reverse('sentry-auth-organization', args=[organization.slug])
 
         resp = self.client.post(path, {'init': True})


### PR DESCRIPTION
This fixes an issue where accounts are not merged at all if a user does not have a verified email.

Because we'll now have an `existing_user` object (even without a valid email), the form here:

https://github.com/getsentry/sentry/blob/c6c79e222968e85810d18038d029b08db7d2c28b/src/sentry/templates/sentry/auth-confirm-identity.html#L10-L42

will be rendered, instead of forcing the user through the new account flow.