### PR TITLE
fix: SelectInput accepts number as well as string

### DIFF
--- a/src/sentry/static/sentry/app/components/selectInput.jsx
+++ b/src/sentry/static/sentry/app/components/selectInput.jsx
@@ -7,8 +7,8 @@ class SelectInput extends React.Component {
     disabled: PropTypes.bool,
     multiple: PropTypes.bool,
     required: PropTypes.bool,
-    placeholder: PropTypes.string,
-    value: PropTypes.string,
+    placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onChange: PropTypes.func,
   };
 


### PR DESCRIPTION
Needed for the alert rules page and possibly other places as well