### PR TITLE
feat(ui): Add a generic global Modal

### DIFF
--- a/docs-ui/components/globalModal.stories.js
+++ b/docs-ui/components/globalModal.stories.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import GlobalModal from 'sentry-ui/globalModal';
+import Button from 'sentry-ui/buttons/button';
+import {openModal} from 'application-root/actionCreators/modal';
+
+storiesOf('GlobalModal', module).add(
+  'default',
+  withInfo(
+    `
+    This is the onClick handler to open the modal:
+
+    ~~~js
+    openModal(({closeModal, Header, Body}) => (
+      <div>
+        \<Header\>Modal Header\</Header\>
+        \<Body\>
+          <div>Test Modal Body</div>
+          <Button onClick={closeModal}>Close</Button>
+        </Body>
+      </div>
+    ))
+    ~~~
+
+  `,
+    {propTablesExclude: ['Button']}
+  )(() => (
+    <div>
+      <Button
+        onClick={() =>
+          openModal(({closeModal, Header, Body}) => (
+            <div>
+              <Header>Modal Header</Header>
+              <Body>
+                <div>Test Modal Body</div>
+                <Button onClick={closeModal}>Close</Button>
+              </Body>
+            </div>
+          ))}
+      >
+        Open
+      </Button>
+      <GlobalModal />
+    </div>
+  ))
+);

--- a/src/sentry/static/sentry/app/actionCreators/modal.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.jsx
@@ -1,0 +1,16 @@
+import ModalActions from '../actions/modalActions';
+
+/**
+ * Show a modal
+ */
+export function openModal(renderer, options) {
+  ModalActions.openModal(renderer, options);
+}
+
+/**
+ * Close modal
+ */
+export function closeModal() {
+  ModalActions.closeModal();
+}
+

--- a/src/sentry/static/sentry/app/actions/modalActions.jsx
+++ b/src/sentry/static/sentry/app/actions/modalActions.jsx
@@ -1,0 +1,3 @@
+import Reflux from 'reflux';
+
+export default Reflux.createActions(['openModal', 'closeModal']);

--- a/src/sentry/static/sentry/app/components/globalModal.jsx
+++ b/src/sentry/static/sentry/app/components/globalModal.jsx
@@ -1,0 +1,94 @@
+import {Modal} from 'react-bootstrap';
+import {browserHistory} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+
+import {closeModal} from '../actionCreators/modal';
+import Confirm from './confirm';
+import ModalStore from '../stores/modalStore';
+
+class GlobalModal extends React.Component {
+  static propTypes = {
+    /**
+     * Needs to be a function that returns a React Element
+     * Function is injected with:
+     * Modal `Header`, `Body`, and `Footer,
+     * `closeModal`
+     *
+     */
+    children: PropTypes.func.isRequired,
+    options: PropTypes.shape({
+      modalClassName: PropTypes.string,
+    }),
+    visible: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    visible: false,
+    options: {},
+  };
+
+  render() {
+    let {visible, children, options} = this.props;
+    let Component = Modal;
+
+    if (options && options.type === 'confirm') {
+      Component = Confirm;
+    }
+
+    return (
+      <Component
+        className={options && options.modalClassName}
+        show={visible}
+        animation={false}
+        onHide={closeModal}
+      >
+        {children &&
+          children({
+            closeModal,
+            Header: Modal.Header,
+            Body: Modal.Body,
+            Footer: Modal.Footer,
+          })}
+      </Component>
+    );
+  }
+}
+
+const GlobalModalContainer = createReactClass({
+  displayName: 'GlobalModalContainer',
+  mixins: [Reflux.connect(ModalStore, 'modalStore')],
+
+  getInitialState() {
+    return {
+      modalStore: {},
+      error: false,
+      busy: false,
+    };
+  },
+
+  componentDidMount() {
+    // Listen for route changes so we can dismiss modal
+    this.unlisten = browserHistory.listen(() => closeModal());
+  },
+
+  componentWillUnmount() {
+    if (this.unlisten) {
+      this.unlisten();
+    }
+  },
+
+  render() {
+    let {modalStore} = this.state;
+    let visible = !!modalStore && typeof modalStore.renderer === 'function';
+
+    return (
+      <GlobalModal {...this.props} {...modalStore} visible={visible}>
+        {visible && modalStore.renderer}
+      </GlobalModal>
+    );
+  },
+});
+export default GlobalModalContainer;

--- a/src/sentry/static/sentry/app/stores/modalStore.jsx
+++ b/src/sentry/static/sentry/app/stores/modalStore.jsx
@@ -1,0 +1,30 @@
+import Reflux from 'reflux';
+
+import ModalActions from '../actions/modalActions';
+
+const ModalStore = Reflux.createStore({
+  init() {
+    this.reset();
+    this.listenTo(ModalActions.closeModal, this.onCloseModal);
+    this.listenTo(ModalActions.openModal, this.onOpenModal);
+  },
+
+  reset() {
+    this.state = {
+      renderer: null,
+      options: {},
+    };
+  },
+
+  onCloseModal() {
+    this.reset();
+    this.trigger(this.state);
+  },
+
+  onOpenModal(renderer, options) {
+    this.state = {renderer, options};
+    this.trigger(this.state);
+  },
+});
+
+export default ModalStore;

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -18,6 +18,7 @@ import LoadingIndicator from '../components/loadingIndicator';
 import OrganizationsLoader from '../components/organizations/organizationsLoader';
 import OrganizationsStore from '../stores/organizationsStore';
 import SudoModal from '../components/modals/sudoModal';
+import GlobalModal from '../components/globalModal';
 import theme from '../utils/theme';
 
 if (window.globalStaticUrl) __webpack_public_path__ = window.globalStaticUrl; // defined in layout.html
@@ -148,6 +149,7 @@ const App = createReactClass({
       <ThemeProvider theme={theme}>
         <OrganizationsLoader>
           <SudoModal />
+          <GlobalModal />
           <Alerts className="messages-container" />
           <Indicators className="indicators-container" />
           {this.props.children}

--- a/tests/js/spec/components/__snapshots__/globalModal.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/globalModal.spec.jsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlobalModal renders 1`] = `
+<GlobalModal
+  options={Object {}}
+  visible={false}
+/>
+`;

--- a/tests/js/spec/components/globalModal.spec.jsx
+++ b/tests/js/spec/components/globalModal.spec.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import GlobalModal from 'app/components/globalModal';
+import {openModal, closeModal} from 'app/actionCreators/modal';
+
+describe('GlobalModal', function() {
+  it('renders', function() {
+    let wrapper = shallow(<GlobalModal />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('uses actionCreators to open and close Modal', function(done) {
+    let wrapper = mount(<GlobalModal />);
+
+    openModal(() => <div id="modal-test">Hi</div>);
+
+    // async :<
+    setTimeout(() => {
+      wrapper.update();
+      let modal = $(document.body).find('.modal');
+      expect(modal.text()).toBe('Hi');
+      expect(wrapper.find('GlobalModal').prop('visible')).toBe(true);
+
+      closeModal();
+      setTimeout(() => {
+        wrapper.update();
+        expect(wrapper.find('GlobalModal').prop('visible')).toBe(false);
+        done();
+      }, 1);
+    }, 1);
+  });
+});


### PR DESCRIPTION
Add a modal component to App root. Use via `openModal` action creator (preferably create a new actionCreator that calls `openModal`).

e.x:
```
openModal(({closeModal, Header, Body}) => (
     <div>
        <Header>Modal Header</Header>
        <Body>
          <div>Test Modal Body</div>
          <Button onClick={closeModal}>Close</Button>
        </Body>
      </div>
))
```