### PR TITLE
ref(ui): form search

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/formSearch.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/formSearch.jsx
@@ -1,0 +1,18 @@
+import FormSearchActions from '../actions/formSearchActions';
+import addForm from '../utils/addForm';
+
+export function addSearchMap(searchMap) {
+  FormSearchActions.addSearchMap(searchMap);
+}
+
+export function loadSearchMap() {
+  // Load search map by directory via webpack
+  let context = require.context('../data/forms', true, /\.jsx$/);
+  context.keys().forEach(function(key) {
+    let mod = context(key);
+
+    if (!mod) return;
+
+    addForm({formGroups: mod.default || mod.formGroups, route: mod.route});
+  });
+}

--- a/src/sentry/static/sentry/app/actions/formSearchActions.jsx
+++ b/src/sentry/static/sentry/app/actions/formSearchActions.jsx
@@ -1,0 +1,3 @@
+import Reflux from 'reflux';
+
+export default Reflux.createActions(['addSearchMap']);

--- a/src/sentry/static/sentry/app/data/forms/accountAppearance.jsx
+++ b/src/sentry/static/sentry/app/data/forms/accountAppearance.jsx
@@ -1,8 +1,10 @@
-import {createSearchMap} from './util';
 import timezones from '../timezones';
 import languages from '../languages';
 
-const forms = [
+// Export route to make these forms searchable by label/help
+export const route = '/settings/account/appearance/';
+
+const formGroups = [
   {
     // Form "section"/"panel"
     title: 'Events',
@@ -49,16 +51,4 @@ const forms = [
   },
 ];
 
-export default forms;
-
-// generate search index from form fields
-export const searchIndex = createSearchMap({
-  route: '/settings/account/appearance/',
-  formGroups: forms,
-});
-
-// need to associate index -> form group -> route
-// so when we search for a term we need to find:
-//   * what field(s) it matches:
-//     * what form group it belongs to
-//     * what route that belongs to
+export default formGroups;

--- a/src/sentry/static/sentry/app/data/forms/accountEmails.jsx
+++ b/src/sentry/static/sentry/app/data/forms/accountEmails.jsx
@@ -1,6 +1,7 @@
-import {createSearchMap} from './util';
+// Export route to make these forms searchable by label/help
+export const route = '/settings/account/emails/';
 
-const forms = [
+const formGroups = [
   {
     // Form "section"/"panel"
     title: 'Add Secondary Emails',
@@ -18,16 +19,4 @@ const forms = [
   },
 ];
 
-export default forms;
-
-// generate search index from form fields
-export const searchIndex = createSearchMap({
-  route: '/settings/account/emails/',
-  formGroups: forms,
-});
-
-// need to associate index -> form group -> route
-// so when we search for a term we need to find:
-//   * what field(s) it matches:
-//     * what form group it belongs to
-//     * what route that belongs to
+export default formGroups;

--- a/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
@@ -1,4 +1,7 @@
-const forms = [
+// Export route to make these forms searchable by label/help
+export const route = '/settings/account/notifications/';
+
+const formGroups = [
   {
     title: 'Alerts',
     fields: [
@@ -85,4 +88,4 @@ const forms = [
   },
 ];
 
-export default forms;
+export default formGroups;

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -1,7 +1,9 @@
-import {createSearchMap} from './util';
 import {extractMultilineFields} from '../../utils';
 
-const forms = [
+// Export route to make these forms searchable by label/help
+export const route = '/settings/organization/:orgId/settings/';
+
+const formGroups = [
   {
     // Form "section"/"panel"
     title: 'General',
@@ -126,17 +128,4 @@ const forms = [
   },
 ];
 
-export default forms;
-
-// generate search index from form fields
-export const searchIndex = createSearchMap({
-  route: '/settings/organization/:orgId/settings/',
-  requireParams: ['orgId'],
-  formGroups: forms,
-});
-
-// need to associate index -> form group -> route
-// so when we search for a term we need to find:
-//   * what field(s) it matches:
-//     * what form group it belongs to
-//     * what route that belongs to
+export default formGroups;

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -1,0 +1,168 @@
+import {extractMultilineFields} from '../../utils';
+
+// Export route to make these forms searchable by label/help
+export const route = '/settings/organization/:orgId/project/:projectId/settings/';
+
+const formGroups = [
+  {
+    // Form "section"/"panel"
+    title: 'Project Details',
+    fields: [
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+
+        // additional data/props that is related to rendering of form field rather than data
+        label: 'Project Name',
+        placeholder: 'My Service Name',
+        help: 'The name of your project',
+      },
+      {
+        name: 'slug',
+        type: 'string',
+        required: true,
+        label: 'Short Name',
+        placeholder: 'my-service-name',
+        help: 'A unique ID used to identify this project',
+      },
+      {
+        name: 'team',
+        type: 'array',
+        label: 'Team',
+        choices: ({organization}) =>
+          organization.teams.filter(o => o.isMember).map(o => [o.id, o.slug]),
+        help: "Opt-in to new features before they're released to the public.",
+      },
+    ],
+  },
+
+  {
+    title: 'Email',
+    fields: [
+      {
+        name: 'subjectPrefix',
+        type: 'string',
+        label: 'Subject Prefix',
+        help: 'Choose a custom prefix for emails from this project',
+      },
+    ],
+  },
+
+  {
+    title: 'Event Settings',
+    fields: [
+      {
+        name: 'defaultEnvironment',
+        type: 'string',
+        label: 'Default Environment',
+        placeholder: 'production',
+        help: 'The default selected environment when viewing issues',
+      },
+      {
+        name: 'resolveAge',
+        type: 'number',
+
+        min: 0,
+        max: 168,
+        step: 1,
+        label: 'Auto Resolve',
+        help:
+          "Automatically resolve an issue if it hasn't been seen for this amount of time",
+      },
+    ],
+  },
+
+  {
+    title: 'Data Privacy',
+    fields: [
+      {
+        name: 'dataScrubber',
+        type: 'boolean',
+        label: 'Data Scrubber',
+        help: 'Enable server-side data scrubbing',
+      },
+      {
+        name: 'dataScrubberDefaults',
+        type: 'boolean',
+
+        label: 'Use Default Scrubbers',
+        help:
+          'Apply default scrubbers to prevent things like passwords and credit cards from being stored',
+      },
+      {
+        name: 'sensitiveFields',
+        type: 'string',
+        multiline: true,
+        placeholder: 'email',
+        label: 'Additional Sensitive Fields',
+        help:
+          'Additional field names to match against when scrubbing data. Separate multiple entries with a newline',
+        getValue: val => extractMultilineFields(val),
+        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+      },
+      {
+        name: 'safeFields',
+        type: 'string',
+        multiline: true,
+        placeholder: 'business-email',
+        label: 'Safe Fields',
+        help:
+          'Field names which data scrubbers should ignore. Separate multiple entries with a newline',
+        getValue: val => extractMultilineFields(val),
+        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+      },
+      {
+        name: 'scrubIPAddresses',
+        type: 'boolean',
+        label: "Don't Store IP Addresses",
+        help: 'Preventing IP addresses from being stored for new events',
+      },
+    ],
+  },
+
+  {
+    title: 'Client Security',
+    fields: [
+      {
+        name: 'allowedDomains',
+        type: 'string',
+        multiline: true,
+        placeholder: 'https://example.com or example.com',
+        label: 'Allowed Domains',
+        help: 'Separate multiple entries with a newline',
+        getValue: val => extractMultilineFields(val),
+        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+      },
+      {
+        name: 'scrapeJavaScript',
+        type: 'boolean',
+        label: 'Enable JavaScript source fetching',
+        help: 'Allow Sentry to scrape missing JavaScript source context when possible',
+      },
+      {
+        name: 'securityToken',
+        type: 'string',
+        label: 'Security Token',
+        help:
+          'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended',
+      },
+      {
+        name: 'securityTokenHeader',
+        type: 'string',
+        placeholder: 'X-Sentry-Token',
+        label: 'Security Token Header',
+        help:
+          'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended.',
+      },
+      {
+        name: 'verifySSL',
+        type: 'boolean',
+        label: 'Verify TLS/SSL',
+        help: 'Outbound requests will verify TLS (sometimes known as SSL) connections.',
+      },
+    ],
+  },
+];
+
+export default formGroups;

--- a/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
+++ b/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
@@ -1,6 +1,7 @@
-import {createSearchMap} from './util';
+// Export route to make these forms searchable by label/help
+export const route = '/settings/organization/:orgId/teams/:teamId/settings/';
 
-const forms = [
+const formGroups = [
   {
     // Form "section"/"panel"
     title: 'Team Settings',
@@ -27,17 +28,4 @@ const forms = [
   },
 ];
 
-export default forms;
-
-// generate search index from form fields
-export const searchIndex = createSearchMap({
-  route: '/settings/organization/:orgId/teams/:teamId/settings/',
-  requireParams: ['orgId', 'teamId'],
-  formGroups: forms,
-});
-
-// need to associate index -> form group -> route
-// so when we search for a term we need to find:
-//   * what field(s) it matches:
-//     * what form group it belongs to
-//     * what route that belongs to
+export default formGroups;

--- a/src/sentry/static/sentry/app/data/forms/userFeedback.jsx
+++ b/src/sentry/static/sentry/app/data/forms/userFeedback.jsx
@@ -1,0 +1,23 @@
+// Export route to make these forms searchable by label/help
+export const route = '/settings/organization/:orgId/project/:projectId/user-feedback/';
+
+const formGroups = [
+  {
+    // Form "section"/"panel"
+    title: 'Settings',
+    fields: [
+      {
+        name: 'feedback:branding',
+        type: 'boolean',
+
+        // additional data/props that is related to rendering of form field rather than data
+        label: 'Show Sentry Branding',
+        placeholder: 'e.g. secondary@example.com',
+        help:
+          'Show "powered by Sentry within the feedback dialog. We appreciate you helping get the word out about Sentry! <3',
+      },
+    ],
+  },
+];
+
+export default formGroups;

--- a/src/sentry/static/sentry/app/stores/formSearchStore.jsx
+++ b/src/sentry/static/sentry/app/stores/formSearchStore.jsx
@@ -1,0 +1,36 @@
+import Reflux from 'reflux';
+import FormSearchActions from '../actions/formSearchActions';
+
+/**
+ * Store for "form" searches, but probably will include more
+ */
+const FormSearchStore = Reflux.createStore({
+  init() {
+    this.reset();
+    this.listenTo(FormSearchActions.addSearchMap, this.onAddSearchMap);
+  },
+
+  reset() {
+    this.searchMap = {};
+  },
+
+  /**
+   * Adds to search map
+   *
+   * @param Object searchIndex Map of search index -> object that includes route + field object
+   */
+  onAddSearchMap(searchMap) {
+    Object.keys(searchMap).forEach(searchIndex => {
+      this.searchMap[searchIndex] = searchMap[searchIndex];
+    });
+    this.trigger(this.searchMap);
+  },
+
+  get() {
+    return this.searchMap;
+  },
+});
+
+export default FormSearchStore;
+
+window.test = FormSearchStore;

--- a/src/sentry/static/sentry/app/stores/formSearchStore.jsx
+++ b/src/sentry/static/sentry/app/stores/formSearchStore.jsx
@@ -20,17 +20,13 @@ const FormSearchStore = Reflux.createStore({
    * @param Object searchIndex Map of search index -> object that includes route + field object
    */
   onAddSearchMap(searchMap) {
-    Object.keys(searchMap).forEach(searchIndex => {
-      this.searchMap[searchIndex] = searchMap[searchIndex];
-    });
-    this.trigger(this.searchMap);
-  },
+    this.searchMap = {
+      ...this.searchMap,
+      ...searchMap,
+    };
 
-  get() {
-    return this.searchMap;
+    this.trigger(this.searchMap);
   },
 });
 
 export default FormSearchStore;
-
-window.test = FormSearchStore;

--- a/src/sentry/static/sentry/app/utils/addForm.jsx
+++ b/src/sentry/static/sentry/app/utils/addForm.jsx
@@ -1,7 +1,9 @@
 import {fromPairs, flatMap} from 'lodash';
 
+import {addSearchMap} from '../actionCreators/formSearch';
+
 // Create a simple search index for a field
-export const createSearchIndex = field => {
+const createSearchIndex = field => {
   let fields = [field.name, field.label, field.help];
 
   return fields
@@ -15,7 +17,7 @@ export const createSearchIndex = field => {
 //   * what field(s) it matches:
 //     * what form group it belongs to
 //     * what route that belongs to
-export const createSearchMap = ({route, formGroups, ...other}) => {
+const createSearchMap = ({route, formGroups, ...other}) => {
   return fromPairs(
     flatMap(formGroups, ({title, fields}) =>
       fields.map(field => [
@@ -30,3 +32,18 @@ export const createSearchMap = ({route, formGroups, ...other}) => {
     )
   );
 };
+
+/**
+ * Given a formGroup ({ title: string, fields: Array<FormField> }) and route where form exists,
+ * create a search index for fields. Adds to a global search store.
+ *
+ * returns formGroup
+ */
+export default function addForm({formGroups, route, ...other}) {
+  if (route) {
+    // Only create searchMap if route is defined
+    addSearchMap(createSearchMap({route, formGroups, ...other}));
+  }
+
+  return formGroups;
+}


### PR DESCRIPTION
Refactor form search where we have an action creator that loads form
search map using webpack to load `data/forms/*.jsx`.

Form groups that export a `route` will be used in search.