### PR TITLE
fix(tagstore): Do in-app deletes of v2 tagstore models since we can't…

### DIFF
--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -34,6 +34,7 @@ class LegacyTagStorage(TagStorage):
 
     def setup(self):
         self.setup_deletions(
+            tagkey_model=TagKey,
             tagvalue_model=TagValue,
             grouptagkey_model=GroupTagKey,
             grouptagvalue_model=GroupTagValue,
@@ -61,7 +62,6 @@ class LegacyTagStorage(TagStorage):
 
         from sentry.deletions import default_manager as deletion_manager
         from sentry.deletions.base import ModelRelation, ModelDeletionTask
-        from sentry.models import Project
 
         class TagKeyDeletionTask(ModelDeletionTask):
             def get_child_relations(self, instance):
@@ -81,12 +81,6 @@ class LegacyTagStorage(TagStorage):
                         instance.update(status=TagKeyStatus.DELETION_IN_PROGRESS)
 
         deletion_manager.register(TagKey, TagKeyDeletionTask)
-        deletion_manager.add_dependencies(Project, [
-            lambda instance: ModelRelation(TagKey, {'project_id': instance.id}),
-            lambda instance: ModelRelation(TagValue, {'project_id': instance.id}),
-            lambda instance: ModelRelation(GroupTagKey, {'project_id': instance.id}),
-            lambda instance: ModelRelation(GroupTagValue, {'project_id': instance.id}),
-        ])
 
     def setup_receivers(self, **kwargs):
         super(LegacyTagStorage, self).setup_receivers(**kwargs)

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -76,7 +76,7 @@ class V2TagStorage(TagStorage):
                 relations = [
                     ModelRelation(m, {
                         'project_id': instance.project_id,
-                        '_key_id': instance.id,
+                        'key_id': instance.id,
                     }) for m in model_list
                 ]
                 return relations

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -40,6 +40,7 @@ class V2TagStorage(TagStorage):
 
     def setup(self):
         self.setup_deletions(
+            tagkey_model=TagKey,
             tagvalue_model=TagValue,
             grouptagkey_model=GroupTagKey,
             grouptagvalue_model=GroupTagValue,
@@ -66,14 +67,26 @@ class V2TagStorage(TagStorage):
         super(V2TagStorage, self).setup_deletions(**kwargs)
 
         from sentry.deletions import default_manager as deletion_manager
-        from sentry.deletions.defaults import BulkModelDeletionTask
-        from sentry.deletions.base import ModelRelation
-        from sentry.models import Project
+        from sentry.deletions.base import ModelRelation, ModelDeletionTask
 
-        deletion_manager.register(TagKey, BulkModelDeletionTask)
-        deletion_manager.add_dependencies(Project, [
-            lambda instance: ModelRelation(TagKey, {'project_id': instance.id}),
-        ])
+        class TagKeyDeletionTask(ModelDeletionTask):
+            def get_child_relations(self, instance):
+                # in bulk
+                model_list = (GroupTagValue, GroupTagKey, TagValue)
+                relations = [
+                    ModelRelation(m, {
+                        'project_id': instance.project_id,
+                        '_key_id': instance.id,
+                    }) for m in model_list
+                ]
+                return relations
+
+            def mark_deletion_in_progress(self, instance_list):
+                for instance in instance_list:
+                    if instance.status != TagKeyStatus.DELETION_IN_PROGRESS:
+                        instance.update(status=TagKeyStatus.DELETION_IN_PROGRESS)
+
+        deletion_manager.register(TagKey, TagKeyDeletionTask)
 
     def setup_receivers(self, **kwargs):
         super(V2TagStorage, self).setup_receivers(**kwargs)


### PR DESCRIPTION
… cascade

We can't do FK constraints like we assumed, so this is just moving the legacy-only deletion code up into base, so that both legacy and v2 do in-app deletion again.