### PR TITLE
fix(db): Remove null values in string literals

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,5 +52,6 @@
     "python.unitTest.pyTestEnabled": false,
     "python.unitTest.unittestEnabled": false,
     "python.unitTest.nosetestsEnabled": false,
-    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js"
+    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js",
+    "restructuredtext.confPath": "/Users/laurynbrown/Documents/sentry"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,5 @@
     "python.unitTest.pyTestEnabled": false,
     "python.unitTest.unittestEnabled": false,
     "python.unitTest.nosetestsEnabled": false,
-    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js",
-    "restructuredtext.confPath": "/Users/laurynbrown/Documents/sentry"
+    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js"
 }

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -19,7 +19,7 @@ __all__ = ('DatabaseWrapper', )
 def escape_null(value):
     if not isinstance(value, string_types):
         return value
-    return value.replace('\x00', '\\x00')
+    return value.replace('\x00', '')
 
 
 class CursorWrapper(object):

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -16,7 +16,7 @@ from .operations import DatabaseOperations
 __all__ = ('DatabaseWrapper', )
 
 
-def escape_null(value):
+def remove_null(value):
     if not isinstance(value, string_types):
         return value
     return value.replace('\x00', '')
@@ -60,7 +60,7 @@ class CursorWrapper(object):
                 # address that later rather than potentially catch incorrect behavior.
                 if e.message != 'A string literal cannot contain NUL (0x00) characters.':
                     raise
-                return self.cursor.execute(sql, [escape_null(param) for param in params])
+                return self.cursor.execute(sql, [remove_null(param) for param in params])
         return self.cursor.execute(sql)
 
     @capture_transaction_exceptions

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -50,7 +50,7 @@ class CursorWrapper(object):
                 # NULL byte in a parameter would start raising a ValueError.
                 # psycopg2 chose to do this rather than let Postgres silently
                 # truncate the data, which is it's behavior when it sees a
-                # NULL byte. But for us, we'd rather munge the value so it's
+                # NULL byte. But for us, we'd rather remove the null value so it's
                 # somewhat legible rather than error. Considering this is better
                 # behavior than the database truncating, seems good to do this
                 # rather than attempting to sanitize all data inputs now manually.

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -21,18 +21,30 @@ class CursorWrapperTestCase(TestCase):
         from django.db import connection
         cursor = connection.cursor()
         cursor.execute('SELECT %s', [b'Ma\x00tt'])
-        assert cursor.fetchone()[0] == b'Ma\\x00tt'
+        assert cursor.fetchone()[0] == b'Matt'
         cursor.execute('SELECT %s', [u'Ma\x00tt'])
-        assert cursor.fetchone()[0] == u'Ma\\x00tt'
+        assert cursor.fetchone()[0] == u'Matt'
 
-    def test_null_bytes_at_max_len(self):
+    def test_null_bytes_at_max_len_bytes(self):
         from django.db import connection
         cursor = connection.cursor()
 
-        long_str = (b"a" * MAX_CULPRIT_LENGTH - 1) + b'\x00'
+        long_str = (b'a' * (MAX_CULPRIT_LENGTH - 1)) + b'\x00'
         assert len(long_str) <= MAX_CULPRIT_LENGTH
 
         cursor.execute('SELECT %s', [long_str])
         long_str_from_db = cursor.fetchone()[0]
-        assert long_str_from_db == (b'a' * MAX_CULPRIT_LENGTH - 1) + b'\\x00'
+        assert long_str_from_db == (b'a' * (MAX_CULPRIT_LENGTH - 1))
+        assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH
+
+    def test_null_bytes_at_max_len_unicode(self):
+        from django.db import connection
+        cursor = connection.cursor()
+
+        long_str = (u'a' * (MAX_CULPRIT_LENGTH - 1)) + u'\x00'
+        assert len(long_str) <= MAX_CULPRIT_LENGTH
+
+        cursor.execute('SELECT %s', [long_str])
+        long_str_from_db = cursor.fetchone()[0]
+        assert long_str_from_db == (u'a' * (MAX_CULPRIT_LENGTH - 1))
         assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH


### PR DESCRIPTION
Changed the behavior of a function in ```CursorWrapper``` to replace the null character with an empty string rather than escaping it. This is to ensure that the database's max length is not exceeded inadvertently.