### PR TITLE
feat(api): Rework user details/appearance endpoints

### DIFF
--- a/src/sentry/api/endpoints/sudo.py
+++ b/src/sentry/api/endpoints/sudo.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.contrib import auth
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from sudo.utils import grant_sudo_privileges
@@ -37,6 +38,7 @@ class SudoEndpoint(Endpoint):
 
         if authenticated:
             grant_sudo_privileges(request._request)
-            return Response(status=200)
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
-        return Response({'allowFail': True}, content_type="application/json", status=401)
+        return Response({'allowFail': True}, content_type="application/json",
+                        status=status.HTTP_401_UNAUTHORIZED)

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -57,7 +57,7 @@ class AdminUserSerializer(BaseUserSerializer):
         model = User
         # no idea wtf is up with django rest framework, but we need is_active
         # and isActive
-        fields = ('name', 'isActive', 'username', 'email')
+        fields = ('name', 'isActive')
         # write_only_fields = ('password',)
 
 

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -1,17 +1,47 @@
 from __future__ import absolute_import
 
+from datetime import datetime
+
+import pytz
 from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import DetailedUserSerializer
-from sentry.auth import password_validation
 from sentry.auth.superuser import is_active_superuser
+from sentry.constants import LANGUAGES
 from sentry.models import User, UserOption
-from sentry.security import capture_security_activity
+
+
+def _get_timezone_choices():
+    results = []
+    for tz in pytz.common_timezones:
+        now = datetime.now(pytz.timezone(tz))
+        offset = now.strftime('%z')
+        results.append((int(offset), tz, '(UTC%s) %s' % (offset, tz)))
+    results.sort()
+
+    for i in range(len(results)):
+        results[i] = results[i][1:]
+    return results
+
+
+TIMEZONE_CHOICES = _get_timezone_choices()
+
+
+class UserOptionsSerializer(serializers.Serializer):
+    language = serializers.ChoiceField(choices=LANGUAGES, required=False)
+    stacktraceOrder = serializers.ChoiceField(choices=(
+        ('-1', _('Default (let Sentry decide)')),
+        ('1', _('Most recent call last')),
+        ('2', _('Most recent call first')),
+    ), required=False)
+    timezone = serializers.ChoiceField(choices=TIMEZONE_CHOICES, required=False)
+    clock24Hours = serializers.BooleanField(required=False)
+    seenReleaseBroadcast = serializers.BooleanField(required=False)
 
 
 class BaseUserSerializer(serializers.ModelSerializer):
@@ -26,6 +56,7 @@ class BaseUserSerializer(serializers.ModelSerializer):
 
         if self.object.email == self.object.username:
             if attrs.get('username', self.object.email) != self.object.email:
+                # ... this probably needs to handle newsletters and such?
                 attrs.setdefault('email', attrs['username'])
 
         return attrs
@@ -39,15 +70,13 @@ class BaseUserSerializer(serializers.ModelSerializer):
 class UserSerializer(BaseUserSerializer):
     class Meta:
         model = User
-        fields = ('name', )
+        fields = ('name', 'username')
 
     def validate(self, attrs):
         for field in settings.SENTRY_MANAGED_USER_FIELDS:
             attrs.pop(field, None)
 
-        attrs = super(UserSerializer, self).validate(attrs)
-
-        return attrs
+        return super(UserSerializer, self).validate(attrs)
 
 
 class AdminUserSerializer(BaseUserSerializer):
@@ -57,99 +86,70 @@ class AdminUserSerializer(BaseUserSerializer):
         model = User
         # no idea wtf is up with django rest framework, but we need is_active
         # and isActive
-        fields = ('name', 'isActive')
+        fields = ('name', 'username', 'isActive')
         # write_only_fields = ('password',)
-
-
-class UserSudoSerializer(BaseUserSerializer):
-    # Required because this serializer only handles password changes
-    passwordVerify = serializers.CharField(max_length=128, required=False)
-    password = serializers.CharField(max_length=128, required=False)
-
-    class Meta:
-        model = User
-        fields = ('password', 'passwordVerify')
-
-    def validate_password(self, attrs, source):
-        # this will raise a ValidationError if password is invalid
-        password_validation.validate_password(attrs[source])
-
-        if self.context['is_managed'] or not self.context['has_usable_password']:
-            raise serializers.ValidationError('Not allowed to change password')
-
-        return attrs
-
-    def validate(self, attrs):
-        # make sure `password` matches `passwordVerify`
-        if 'password' in attrs and attrs.get('password') != attrs.get('passwordVerify'):
-            raise serializers.ValidationError('New password does not match verified password.')
-
-        attrs = super(UserSudoSerializer, self).validate(attrs)
-        return attrs
 
 
 class UserDetailsEndpoint(UserEndpoint):
     def get(self, request, user):
-        data = serialize(user, request.user, DetailedUserSerializer())
-        return Response(data)
+        """
+        Retrieve User Details
+        `````````````````````
 
-    @sudo_required
-    def protected_put(self, request, user):
-        # pass some context to serializer otherwise when we create a new serializer instance,
-        # user.password gets set to new plaintext password from request and
-        # `user.has_usable_password` becomes False
-        serializer = UserSudoSerializer(user, data=request.DATA, partial=True, context={
-            'is_managed': user.is_managed,
-            'has_usable_password': user.has_usable_password(),
-        })
+        Return details for an account's details and options such as: full name, timezone, 24hr times, language,
+        stacktrace_order.
 
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        result = serializer.object
-
-        if result.password:
-            user.set_password(result.password)
-            user.refresh_session_nonce(request._request)
-
-            user = serializer.save()
-
-            capture_security_activity(
-                account=user,
-                type='password-changed',
-                actor=request.user,
-                ip_address=request.META['REMOTE_ADDR'],
-                send_email=True,
-            )
-
-        # Proceed to update unprivileged fields
-        return self.update_unprivileged_details(request, user)
+        :auth: required
+        """
+        return Response(serialize(user, request.user, DetailedUserSerializer()))
 
     def put(self, request, user):
-        # Changing `password` requires sudo
-        if request.DATA.get('password'):
-            return self.protected_put(request, user)
-        else:
-            return self.update_unprivileged_details(request, user)
+        """
+        Update Account Appearance options
+        `````````````````````````````````
 
-    def update_unprivileged_details(self, request, user):
+        Update account appearance options. Only supplied values are updated.
+
+        :pparam string user_id: user id
+        :param string language: language preference
+        :param string stacktrace_order: One of -1 (default), 1 (most recent call last), 2 (most recent call first).
+        :param string timezone: timezone option
+        :param clock_24_hours boolean: use 24 hour clock
+        :auth: required
+        """
+
         if is_active_superuser(request):
             serializer_cls = AdminUserSerializer
         else:
             serializer_cls = UserSerializer
         serializer = serializer_cls(user, data=request.DATA, partial=True)
 
-        # This serializer should NOT include privileged fields e.g. password
-        if serializer.is_valid():
-            user = serializer.save()
+        serializer_options = UserOptionsSerializer(
+            data=request.DATA.get('options', {}), partial=True)
 
-            options = request.DATA.get('options', {})
-            if options.get('seenReleaseBroadcast'):
+        # This serializer should NOT include privileged fields e.g. password
+        if not serializer.is_valid() or not serializer_options.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # map API keys to keys in model
+        key_map = {
+            'language': 'language',
+            'timezone': 'timezone',
+            'stacktraceOrder': 'stacktrace_order',
+            'clock24Hours': 'clock_24_hours',
+            'seenReleaseBroadcast': 'seen_release_broadcast',
+        }
+
+        options_result = serializer_options.object
+
+        for key in key_map:
+            if key in options_result:
                 UserOption.objects.set_value(
                     user=user,
-                    key='seen_release_broadcast',
-                    value=options.get('seenReleaseBroadcast'),
+                    key=key_map.get(key, key),
+                    value=options_result.get(key),
                 )
-            return Response(serialize(user, request.user))
 
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        user = serializer.save()
+
+        return Response(serialize(user, request.user, DetailedUserSerializer()))

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -85,12 +85,6 @@ class UserSerializer(Serializer):
                 )
             }
             stacktrace_order = int(options.get('stacktrace_order', -1) or -1)
-            if stacktrace_order == -1:
-                stacktrace_order = 'default'
-            elif stacktrace_order == 2:
-                stacktrace_order = 'newestFirst'
-            elif stacktrace_order == 1:
-                stacktrace_order = 'newestLast'
 
             d['options'] = {
                 'language': options.get('language') or 'en',

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktrace.jsx
@@ -12,11 +12,11 @@ export function isStacktraceNewestFirst() {
   // user may not be authenticated
   let options = user ? user.options : {};
   switch (options.stacktraceOrder) {
-    case 'newestFirst':
+    case 2:
       return true;
-    case 'newestLast':
+    case 1:
       return false;
-    case 'default': // is "default" a valid value? or bad case statement
+    case -1:
     default:
       return true;
   }
@@ -28,7 +28,6 @@ class StacktraceInterface extends React.Component {
     event: SentryTypes.Event.isRequired,
     type: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
-    platform: PropTypes.string,
   };
 
   constructor(...args) {

--- a/tests/sentry/api/endpoints/test_sudo.py
+++ b/tests/sentry/api/endpoints/test_sudo.py
@@ -37,7 +37,7 @@ class SudoTest(APITestCase):
                 'username': 'foo@example.com',
                 'password': 'admin',
             })
-            assert response.status_code == 200
+            assert response.status_code == 204
 
             # This should now work
             response = self.client.delete(url, is_sudo=False)

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -194,6 +194,7 @@ class UserUpdateTest(APITestCase):
 
         user = User.objects.get(id=self.user.id)
         assert user.password != old_password
+        assert user.password != 'newpassword'
         assert user.name == 'new name'
 
 

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -41,6 +41,7 @@ class UserDetailsTest(APITestCase):
         assert resp.data['id'] == six.text_type(user.id)
         assert resp.data['options']['timezone'] == 'UTC'
         assert resp.data['options']['language'] == 'en'
+        assert resp.data['options']['stacktraceOrder'] == -1
         assert not resp.data['options']['clock24Hours']
 
     def test_superuser(self):

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import six
 
 from django.core.urlresolvers import reverse
-from django.conf import settings
 
 from sentry.models import User, UserOption
 from sentry.testutils import APITestCase
@@ -40,6 +39,9 @@ class UserDetailsTest(APITestCase):
 
         assert resp.status_code == 200, resp.content
         assert resp.data['id'] == six.text_type(user.id)
+        assert resp.data['options']['timezone'] == 'UTC'
+        assert resp.data['options']['language'] == 'en'
+        assert not resp.data['options']['clock24Hours']
 
     def test_superuser(self):
         user = self.create_user(email='a@example.com')
@@ -75,9 +77,13 @@ class UserUpdateTest(APITestCase):
             self.url,
             data={
                 'name': 'hello world',
-                'username': 'b@example.com',
                 'options': {
-                    'seenReleaseBroadcast': True
+                    'timezone': 'UTC',
+                    'stacktraceOrder': '2',
+                    'language': 'fr',
+                    'clock24Hours': True,
+                    'extra': True,
+                    'seenReleaseBroadcast': True,
                 }
             }
         )
@@ -88,11 +94,16 @@ class UserUpdateTest(APITestCase):
         assert user.name == 'hello world'
         # note: email should not change, removed support for email changing from this endpoint
         assert user.email == 'a@example.com'
-        assert user.username == user.email
+        assert user.username == 'a@example.com'
         assert UserOption.objects.get_value(
             user=user,
             key='seen_release_broadcast',
         ) is True
+        assert UserOption.objects.get_value(user=self.user, key='timezone') == 'UTC'
+        assert UserOption.objects.get_value(user=self.user, key='stacktrace_order') == '2'
+        assert UserOption.objects.get_value(user=self.user, key='language') == 'fr'
+        assert UserOption.objects.get_value(user=self.user, key='clock_24_hours')
+        assert not UserOption.objects.get_value(user=self.user, key='extra')
 
     def test_superuser(self):
         # superuser should be able to change self.user's name
@@ -110,7 +121,6 @@ class UserUpdateTest(APITestCase):
             data={
                 'name': 'hello world',
                 'email': 'c@example.com',
-                'username': 'foo',
                 'isActive': 'false',
             }
         )
@@ -137,109 +147,41 @@ class UserUpdateTest(APITestCase):
 
             # name remains unchanged
             user = User.objects.get(id=self.user.id)
-            assert user.name == 'example name'
+            assert user
 
-    def test_verifies_mismatch_password(self):
-        # Password mismatch
-        response = self.client.put(self.url, data={
-            'password': 'testpassword',
-            'passwordVerify': 'passworddoesntmatch',
-        })
-        assert response.status_code == 400
+    def test_change_username_when_different(self):
+        # if email != username and we change username, only username should change
+        user = self.create_user(email="c@example.com", username="diff@example.com")
+        self.login_as(user=user, superuser=False)
 
-    def test_managed_unable_change_password(self):
-        user = self.create_user(email='new@example.com', is_managed=True)
-        self.login_as(user)
-        url = reverse(
-            'sentry-api-0-user-details', kwargs={
-                'user_id': user.id,
+        resp = self.client.put(
+            self.url,
+            data={
+                'username': 'new@example.com',
             }
         )
+        assert resp.status_code == 200, resp.content
 
-        response = self.client.put(url, data={
-            'password': 'newpassword',
-            'passwordVerify': 'newpassword',
-        })
-        assert response.status_code == 400
+        user = User.objects.get(id=user.id)
 
-    def test_unusable_password_unable_change_password(self):
-        user = self.create_user(email='new@example.com')
-        user.set_unusable_password()
-        user.save()
-        self.login_as(user)
+        assert user.email == 'c@example.com'
+        assert user.username == 'new@example.com'
 
-        url = reverse(
-            'sentry-api-0-user-details', kwargs={
-                'user_id': user.id,
+    def test_change_username_when_same(self):
+        # if email == username and we change username,
+        # keep email in sync
+        user = self.create_user(email="c@example.com", username="c@example.com")
+        self.login_as(user=user)
+
+        resp = self.client.put(
+            self.url,
+            data={
+                'username': 'new@example.com',
             }
         )
+        assert resp.status_code == 200, resp.content
 
-        response = self.client.put(url, data={
-            'password': 'newpassword',
-            'passwordVerify': 'newpassword',
-        })
-        assert response.status_code == 400
+        user = User.objects.get(id=user.id)
 
-    def test_change_privileged_and_unprivileged(self):
-        self.login_as(self.user)
-        user = User.objects.get(id=self.user.id)
-        old_password = user.password
-
-        response = self.client.put(self.url, data={
-            'password': 'newpassword',
-            'passwordVerify': 'newpassword',
-            'name': 'new name',
-        })
-        assert response.status_code == 200
-
-        user = User.objects.get(id=self.user.id)
-        assert user.password != old_password
-        assert user.password != 'newpassword'
-        assert user.name == 'new name'
-
-
-class UserSudoUpdateTest(APITestCase):
-    def setUp(self):
-        self.user = self.create_user(email='a@example.com')
-        self.login_as(user=self.user)
-
-        self.url = reverse(
-            'sentry-api-0-user-details', kwargs={
-                'user_id': self.user.id,
-            }
-        )
-
-        middleware = list(settings.MIDDLEWARE_CLASSES)
-        index = middleware.index('sentry.testutils.middleware.SudoMiddleware')
-        middleware[index] = 'sentry.middleware.sudo.SudoMiddleware'
-        self.sudo_middleware = tuple(middleware)
-
-        self.sudo_url = reverse('sentry-api-0-sudo', kwargs={})
-
-    def test_change_password_requires_sudo(self):
-        user = User.objects.get(id=self.user.id)
-        old_password = user.password
-        with self.settings(MIDDLEWARE_CLASSES=tuple(self.sudo_middleware)):
-            response = self.client.put(self.url, data={
-                'password': 'testpassword',
-                'passwordVerify': 'testpassword',
-            })
-
-            assert response.status_code == 401
-            assert response.data['sudoRequired']
-
-            # Now try to gain sudo access
-            response = self.client.post(self.sudo_url, {
-                'username': 'foo@example.com',
-                'password': 'admin',
-            })
-            assert response.status_code == 204
-
-            # correct password change
-            response = self.client.put(self.url, data={
-                'password': 'testpassword',
-                'passwordVerify': 'testpassword',
-            })
-            assert response.status_code == 200
-            user = User.objects.get(id=self.user.id)
-            assert user.password != old_password
+        assert user.email == 'new@example.com'
+        assert user.username == 'new@example.com'


### PR DESCRIPTION
I've merged the `user_appearance` endpoint into `user_details` and removed password and emails as fields that can be updated by this endpoint. There is a separate endpoint for adding emails and there will be a follow up PRs to:

* https://github.com/getsentry/sentry/pull/7133 - change password (will be a new endpoint but I think should be merged into the users/security endpoint introduced in #7113)
* remove user_appearance endpoint and update JSX accordingly