### PR TITLE
feat(slack): Implement slack via an alert rule

### DIFF
--- a/src/sentry/integrations/slack/__init__.py
+++ b/src/sentry/integrations/slack/__init__.py
@@ -1,5 +1,10 @@
 from __future__ import absolute_import
 
 from sentry.utils.imports import import_submodules
+from sentry.rules import rules
+
+from .notify_action import SlackNotifyServiceAction
 
 import_submodules(globals(), __name__, __path__)
+
+rules.add(SlackNotifyServiceAction)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -17,6 +17,7 @@ class SlackIntegration(Integration):
         'links:read',
         'links:write',
         'team:read',
+        'channels:read',
     )
 
     def get_pipeline_views(self):

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -10,15 +10,15 @@ class SlackIntegration(Integration):
     key = 'slack'
     name = 'Slack'
 
-    identity_oauth_scopes = (
+    identity_oauth_scopes = frozenset([
         'bot',
+        'channels:read',
         'chat:write:bot',
         'commands',
         'links:read',
         'links:write',
         'team:read',
-        'channels:read',
-    )
+    ])
 
     def get_pipeline_views(self):
         identity_pipeline_config = {

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -1,0 +1,137 @@
+from __future__ import absolute_import
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from sentry import http
+from sentry.rules.actions.base import EventAction
+from sentry.utils import metrics, json
+from sentry.models import Integration
+
+from .utils import build_attachment
+
+
+class SlackNotifyServiceForm(forms.Form):
+    team = forms.ChoiceField(choices=(), widget=forms.Select(
+        attrs={'style': 'width:150px'},
+    ))
+    channel = forms.CharField(widget=forms.TextInput(
+        attrs={'placeholder': 'i.e #critical-errors'},
+    ))
+
+    def __init__(self, *args, **kwargs):
+        team_list = [(i.id, i.name) for i in kwargs.pop('integrations')]
+        self.channel_transformer = kwargs.pop('channel_transformer')
+
+        super(SlackNotifyServiceForm, self).__init__(*args, **kwargs)
+
+        self.fields['team'].choices = team_list
+        self.fields['team'].widget.choices = self.fields['team'].choices
+
+    def clean_channel(self):
+        channel = self.cleaned_data.get('channel', '').lstrip('#')
+        team = self.cleaned_data.get('team')
+
+        channel_id = self.channel_transformer(team, channel)
+
+        if channel_id is None and team is not None:
+            params = {
+                'channel': channel,
+                'team': dict(self.fields['team'].choices).get(int(team)),
+            }
+
+            raise forms.ValidationError(
+                _('The #%(channel)s channel does not exist in the %(team)s Slack team.'),
+                code='invalid',
+                params=params,
+            )
+
+        return channel
+
+
+class SlackNotifyServiceAction(EventAction):
+    form_cls = SlackNotifyServiceForm
+    label = 'Send a notification to the Slack {team} team in {channel}'
+
+    def is_enabled(self):
+        return self.get_integrations().exists()
+
+    def after(self, event, state):
+        channel = self.get_option('channel')
+        integration = Integration.objects.get(
+            provider='slack',
+            organizations=self.project.organization,
+        )
+
+        def send_notification(event, futures):
+            attachment = build_attachment(event.group, event=event)
+
+            payload = {
+                'token': integration.metadata['access_token'],
+                'channel': channel,
+                'attachments': json.dumps([attachment]),
+            }
+
+            session = http.build_session()
+            req = session.get('https://slack.com/api/chat.postMessage', params=payload)
+            req.raise_for_status()
+            resp = req.json()
+            if not resp.get('ok'):
+                self.logger.error('rule.fail.slack_post', error=resp.get('error'))
+
+        metrics.incr('notifications.sent')
+        yield self.future(send_notification)
+
+    def render_label(self):
+        try:
+            integration_name = Integration.objects.get(
+                provider='slack',
+                organizations=self.project.organization,
+                id=self.data['team'],
+            ).name
+        except Integration.DoesNotExist:
+            integration_name = '[removed]'
+
+        return self.label.format(
+            team=integration_name,
+            channel='#' + self.data['channel'],
+        )
+
+    def get_integrations(self):
+        return Integration.objects.filter(
+            provider='slack',
+            organizations=self.project.organization,
+        )
+
+    def get_channel_id(self, integration_id, value):
+        try:
+            integration = Integration.objects.get(
+                provider='slack',
+                organizations=self.project.organization,
+                id=integration_id,
+            )
+        except Integration.DoesNotExist:
+            return None
+
+        payload = {
+            'token': integration.metadata['access_token'],
+            'exclude_archived': False,
+            'exclude_members': True,
+        }
+
+        session = http.build_session()
+        req = session.get('https://slack.com/api/channels.list', params=payload)
+        req.raise_for_status()
+        resp = req.json()
+        if not resp.get('ok'):
+            self.logger.error('rule.slack.channel_list_failed', error=resp.get('error'))
+            return None
+
+        return {c['name']: c['id'] for c in resp['channels']}.get(value)
+
+    def get_form_instance(self):
+        return self.form_cls(
+            self.data,
+            integrations=self.get_integrations(),
+            channel_transformer=self.get_channel_id,
+        )

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -51,7 +51,7 @@ class SlackNotifyServiceForm(forms.Form):
 
 class SlackNotifyServiceAction(EventAction):
     form_cls = SlackNotifyServiceForm
-    label = 'Send a notification to the Slack {team} team in {channel}'
+    label = u'Send a notification to the Slack {team} team in {channel}'
 
     def is_enabled(self):
         return self.get_integrations().exists()

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -86,7 +86,7 @@ class SlackNotifyServiceAction(EventAction):
             if not resp.get('ok'):
                 self.logger.error('rule.fail.slack_post', extra={'error': resp.get('error')})
 
-        metrics.incr('notifications.sent')
+        metrics.incr('notifications.sent', instance='slack.notification')
         yield self.future(send_notification)
 
     def render_label(self):

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -128,7 +128,7 @@ class SlackNotifyServiceAction(EventAction):
         resp.raise_for_status()
         resp = resp.json()
         if not resp.get('ok'):
-            self.logger.error('rule.slack.channel_list_failed', extra={'error': resp.get('error')})
+            self.logger.info('rule.slack.channel_list_failed', extra={'error': resp.get('error')})
             return None
 
         return {c['name']: c['id'] for c in resp['channels']}.get(channel_name)

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -84,7 +84,7 @@ class SlackNotifyServiceAction(EventAction):
             resp.raise_for_status()
             resp = resp.json()
             if not resp.get('ok'):
-                self.logger.error('rule.fail.slack_post', extra={'error': resp.get('error')})
+                self.logger.info('rule.fail.slack_post', extra={'error': resp.get('error')})
 
         metrics.incr('notifications.sent', instance='slack.notification')
         yield self.future(send_notification)

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -110,7 +110,7 @@ class SlackNotifyServiceAction(EventAction):
             organizations=self.project.organization,
         )
 
-    def get_channel_id(self, integration_id, value):
+    def get_channel_id(self, integration_id, channel_name):
         try:
             integration = Integration.objects.get(
                 provider='slack',
@@ -134,7 +134,7 @@ class SlackNotifyServiceAction(EventAction):
             self.logger.error('rule.slack.channel_list_failed', extra={'error': resp.get('error')})
             return None
 
-        return {c['name']: c['id'] for c in resp['channels']}.get(value)
+        return {c['name']: c['id'] for c in resp['channels']}.get(channel_name)
 
     def get_form_instance(self):
         return self.form_cls(

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -60,15 +60,12 @@ class SlackNotifyServiceAction(EventAction):
     def after(self, event, state):
         integration_id = self.get_option('team')
         channel = self.get_option('channel')
-        try:
-            integration = Integration.objects.get(
-                provider='slack',
-                organizations=self.project.organization,
-                id=integration_id
-            )
-        except Integration.DoesNotExist:
-            self.logger.error('rule.fail.slack_notify.missing_integration')
-            return
+
+        integration = Integration.objects.get(
+            provider='slack',
+            organizations=self.project.organization,
+            id=integration_id
+        )
 
         def send_notification(event, futures):
             attachment = build_attachment(event.group, event=event)

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -72,7 +72,7 @@ class SlackIntegrationTest(IntegrationTestCase):
             'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
             'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
             'bot_user_id': 'UXXXXXXX2',
-            'scopes': list(self.provider.identity_oauth_scopes),
+            'scopes': sorted(self.provider.identity_oauth_scopes),
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration,
@@ -90,7 +90,7 @@ class SlackIntegrationTest(IntegrationTestCase):
             external_id='UXXXXXXX1',
         )
         assert identity.status == IdentityStatus.VALID
-        assert identity.scopes == list(self.provider.identity_oauth_scopes)
+        assert identity.scopes == sorted(self.provider.identity_oauth_scopes)
         assert identity.data == {
             'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
         }

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -1,0 +1,131 @@
+from __future__ import absolute_import
+
+import responses
+
+from six.moves.urllib.parse import parse_qs
+
+from sentry.utils import json
+from sentry.models import OrganizationIntegration, Integration
+from sentry.testutils.cases import RuleTestCase
+from sentry.integrations.slack import SlackNotifyServiceAction
+
+
+class SlackNotifyActionTest(RuleTestCase):
+    rule_cls = SlackNotifyServiceAction
+
+    def setUp(self):
+        event = self.get_event()
+
+        self.integration = Integration.objects.create(
+            provider='slack',
+            name='Awesome Team',
+            external_id='TXXXXXXX1',
+            metadata={
+                'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
+                'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
+            }
+        )
+        OrganizationIntegration.objects.create(
+            organization=event.project.organization,
+            integration=self.integration,
+        )
+
+    @responses.activate
+    def test_applies_correctly(self):
+        event = self.get_event()
+
+        rule = self.get_rule(data={
+            'team': self.integration.id,
+            'channel': 'my-channel',
+        })
+
+        results = list(rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+
+        responses.add(
+            method=responses.POST,
+            url='https://slack.com/api/chat.postMessage',
+            body='{"ok": true}',
+            status=200,
+            content_type='application/json',
+        )
+
+        # Trigger rule callback
+        results[0].callback(event, futures=[])
+        data = parse_qs(responses.calls[0].request.body)
+
+        assert 'attachments' in data
+        attachments = json.loads(data['attachments'][0])
+
+        assert len(attachments) == 1
+        assert attachments[0]['title'] == event.title
+
+    def test_render_label(self):
+        rule = self.get_rule(data={
+            'team': self.integration.id,
+            'channel': 'my-channel',
+        })
+
+        assert rule.render_label() == 'Send a notification to the Slack Awesome Team team in #my-channel'
+
+    def test_render_label_without_integration(self):
+        self.integration.delete()
+
+        rule = self.get_rule(data={
+            'team': self.integration.id,
+            'channel': 'my-channel',
+        })
+
+        label = rule.render_label()
+        assert label == 'Send a notification to the Slack [removed] team in #my-channel'
+
+    @responses.activate
+    def test_valid_channel_selected(self):
+        rule = self.get_rule(data={
+            'team': self.integration.id,
+            'channel': 'my-channel',
+        })
+
+        channels = {
+            'ok': 'true',
+            'channels': [
+                {'name': 'my-channel', 'id': 'chan-id'},
+                {'name': 'other-chann', 'id': 'chan-id'},
+            ],
+        }
+
+        responses.add(
+            method=responses.GET,
+            url='https://slack.com/api/channels.list',
+            status=200,
+            content_type='application/json',
+            body=json.dumps(channels),
+        )
+
+        form = rule.get_form_instance()
+        assert form.is_valid()
+
+    @responses.activate
+    def test_invalid_channel_selected(self):
+        rule = self.get_rule(data={
+            'team': self.integration.id,
+            'channel': 'my-channel',
+        })
+
+        channels = {
+            'ok': 'true',
+            'channels': [{'name': 'other-chann', 'id': 'chan-id'}],
+        }
+
+        responses.add(
+            method=responses.GET,
+            url='https://slack.com/api/channels.list',
+            status=200,
+            content_type='application/json',
+            body=json.dumps(channels),
+        )
+
+        form = rule.get_form_instance()
+
+        assert not form.is_valid()
+        assert len(form.errors) == 1


### PR DESCRIPTION
This implements a new registered rule `Action` that is enabled when any slack integrations are added to the organization. A notification is sent to the configured channel when the rule is applied.

Had originally discussed some ideas around a notification destination, I decided to punt on this for now since it would need to interface with rules anyway, and since we don't have a concrete use case for it yet it would be harder to come up with an API we think could work in the future.
