### PR TITLE
feat(rules): Add environment support to rule processor and relevant conditions

### DIFF
--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -15,4 +15,7 @@ class FirstSeenEventCondition(EventCondition):
     label = 'An event is first seen'
 
     def passes(self, event, state):
-        return state.is_new
+        if self.rule.environment_id is None:
+            return state.is_new
+        else:
+            return state.is_new_group_environment

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -87,6 +87,10 @@ class RuleProcessor(object):
         if not condition_list:
             return
 
+        if rule.environment_id is not None \
+                and self.event.get_environment().id != rule.environment_id:
+            return
+
         status = self.get_rule_status(rule)
 
         now = timezone.now()

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -384,11 +384,10 @@ class RuleTestCase(TestCase):
     def get_event(self):
         return self.event
 
-    def get_rule(self, data=None):
-        return self.rule_cls(
-            project=self.project,
-            data=data or {},
-        )
+    def get_rule(self, **kwargs):
+        kwargs.setdefault('project', self.project)
+        kwargs.setdefault('data', {})
+        return self.rule_cls(**kwargs)
 
     def get_state(self, **kwargs):
         kwargs.setdefault('is_new', True)

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -16,7 +16,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
         plugin.is_enabled.return_value = True
         plugin.should_notify.return_value = True
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'service': 'mail',
         })
 

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -53,7 +53,7 @@ class EventAttributeConditionTest(RuleTestCase):
         return event
 
     def test_render_label(self):
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': u'\xc3',
             'value': u'\xc4',
@@ -62,134 +62,110 @@ class EventAttributeConditionTest(RuleTestCase):
 
     def test_equals(self):
         event = self.get_event()
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': 'platform',
             'value': 'php',
         })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'platform',
-                'value': 'python',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'platform',
+            'value': 'python',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_does_not_equal(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_EQUAL,
-                'attribute': 'platform',
-                'value': 'php',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_EQUAL,
+            'attribute': 'platform',
+            'value': 'php',
+        })
         self.assertDoesNotPass(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_EQUAL,
-                'attribute': 'platform',
-                'value': 'python',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_EQUAL,
+            'attribute': 'platform',
+            'value': 'python',
+        })
         self.assertPasses(rule, event)
 
     def test_starts_with(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.STARTS_WITH,
-                'attribute': 'platform',
-                'value': 'ph',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.STARTS_WITH,
+            'attribute': 'platform',
+            'value': 'ph',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.STARTS_WITH,
-                'attribute': 'platform',
-                'value': 'py',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.STARTS_WITH,
+            'attribute': 'platform',
+            'value': 'py',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_ends_with(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.ENDS_WITH,
-                'attribute': 'platform',
-                'value': 'hp',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.ENDS_WITH,
+            'attribute': 'platform',
+            'value': 'hp',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.ENDS_WITH,
-                'attribute': 'platform',
-                'value': 'thon',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.ENDS_WITH,
+            'attribute': 'platform',
+            'value': 'thon',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_contains(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.CONTAINS,
-                'attribute': 'platform',
-                'value': 'p',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.CONTAINS,
+            'attribute': 'platform',
+            'value': 'p',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.CONTAINS,
-                'attribute': 'platform',
-                'value': 'z',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.CONTAINS,
+            'attribute': 'platform',
+            'value': 'z',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_does_not_contain(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_CONTAINS,
-                'attribute': 'platform',
-                'value': 'p',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_CONTAINS,
+            'attribute': 'platform',
+            'value': 'p',
+        })
         self.assertDoesNotPass(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_CONTAINS,
-                'attribute': 'platform',
-                'value': 'z',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_CONTAINS,
+            'attribute': 'platform',
+            'value': 'z',
+        })
         self.assertPasses(rule, event)
 
     def test_message(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'message',
-                'value': 'hello world',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'message',
+            'value': 'hello world',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': 'message',
             'value': 'php',
@@ -198,74 +174,62 @@ class EventAttributeConditionTest(RuleTestCase):
 
     def test_environment(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'environment',
-                'value': 'production',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'environment',
+            'value': 'production',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'environment',
-                'value': 'staging',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'environment',
+            'value': 'staging',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_http_method(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'http.method',
-                'value': 'get',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'http.method',
+            'value': 'get',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'http.method',
-                'value': 'post',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'http.method',
+            'value': 'post',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_http_url(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'http.url',
-                'value': 'http://example.com',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'http.url',
+            'value': 'http://example.com',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'http.url',
-                'value': 'http://foo.com',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'http.url',
+            'value': 'http://foo.com',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_user_id(self):
         event = self.get_event()
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': 'user.id',
             'value': '1',
         })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': 'user.id',
             'value': '2',
@@ -274,36 +238,30 @@ class EventAttributeConditionTest(RuleTestCase):
 
     def test_user_ip_address(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'user.ip_address',
-                'value': '127.0.0.1',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'user.ip_address',
+            'value': '127.0.0.1',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'user.ip_address',
-                'value': '2',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'user.ip_address',
+            'value': '2',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_user_email(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'user.email',
-                'value': 'foo@example.com',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'user.email',
+            'value': 'foo@example.com',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': 'user.email',
             'value': '2',
@@ -312,194 +270,158 @@ class EventAttributeConditionTest(RuleTestCase):
 
     def test_user_username(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'user.username',
-                'value': 'foo',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'user.username',
+            'value': 'foo',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'user.username',
-                'value': '2',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'user.username',
+            'value': '2',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_exception_type(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'exception.type',
-                'value': 'SyntaxError',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.type',
+            'value': 'SyntaxError',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'exception.type',
-                'value': 'TypeError',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.type',
+            'value': 'TypeError',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_exception_value(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'exception.value',
-                'value': 'hello world',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.value',
+            'value': 'hello world',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'exception.value',
-                'value': 'foo bar',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'exception.value',
+            'value': 'foo bar',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_stacktrace_filename(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'stacktrace.filename',
-                'value': 'example.php',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.filename',
+            'value': 'example.php',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'stacktrace.filename',
-                'value': 'foo.php',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.filename',
+            'value': 'foo.php',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_stacktrace_module(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'stacktrace.module',
-                'value': 'example',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.module',
+            'value': 'example',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'stacktrace.module',
-                'value': 'foo',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.module',
+            'value': 'foo',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_stacktrace_code(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'stacktrace.code',
-                'value': 'echo "hello";',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.code',
+            'value': 'echo "hello";',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'stacktrace.code',
-                'value': 'foo',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'stacktrace.code',
+            'value': 'foo',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_extra_simple_value(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'extra.bar',
-                'value': 'foo',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.bar',
+            'value': 'foo',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'extra.bar',
-                'value': 'bar',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.bar',
+            'value': 'bar',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_extra_nested_value(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'extra.foo.bar',
-                'value': 'baz',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.foo.bar',
+            'value': 'baz',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'extra.foo.bar',
-                'value': 'bar',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.foo.bar',
+            'value': 'bar',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_extra_nested_list(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'extra.biz',
-                'value': 'baz',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.biz',
+            'value': 'baz',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'attribute': 'extra.biz',
-                'value': 'bar',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'attribute': 'extra.biz',
+            'value': 'bar',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_event_type(self):
         event = self.get_event()
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': 'type',
             'value': 'error',
         })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'attribute': 'type',
             'value': 'csp',

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -25,7 +25,7 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'interval': '1m',
             'value': six.text_type(value),
         })
@@ -50,7 +50,7 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'interval': '1h',
             'value': six.text_type(value),
         })
@@ -75,7 +75,7 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'interval': '1d',
             'value': six.text_type(value),
         })
@@ -99,7 +99,7 @@ class FrequencyConditionMixin(object):
         now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
 
         event = self.get_event()
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'interval': '1m',
             'value': six.text_type('0'),
         })

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import mock
 import six
 
+from sentry.models import Rule
 from sentry.tsdb import backend as tsdb
 from sentry.rules.conditions.event_frequency import (
     EventFrequencyCondition, EventUniqueUserFrequencyCondition
@@ -25,10 +26,13 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
-        rule = self.get_rule(data={
-            'interval': '1m',
-            'value': six.text_type(value),
-        })
+        rule = self.get_rule(
+            data={
+                'interval': '1m',
+                'value': six.text_type(value),
+            },
+            rule=Rule(environment_id=None),
+        )
 
         self.increment(
             event,
@@ -50,10 +54,13 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
-        rule = self.get_rule(data={
-            'interval': '1h',
-            'value': six.text_type(value),
-        })
+        rule = self.get_rule(
+            data={
+                'interval': '1h',
+                'value': six.text_type(value),
+            },
+            rule=Rule(environment_id=None),
+        )
 
         self.increment(
             event,
@@ -75,10 +82,13 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
-        rule = self.get_rule(data={
-            'interval': '1d',
-            'value': six.text_type(value),
-        })
+        rule = self.get_rule(
+            data={
+                'interval': '1d',
+                'value': six.text_type(value),
+            },
+            rule=Rule(environment_id=None),
+        )
 
         self.increment(
             event,
@@ -99,10 +109,13 @@ class FrequencyConditionMixin(object):
         now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
 
         event = self.get_event()
-        rule = self.get_rule(data={
-            'interval': '1m',
-            'value': six.text_type('0'),
-        })
+        rule = self.get_rule(
+            data={
+                'interval': '1m',
+                'value': six.text_type('0'),
+            },
+            rule=Rule(environment_id=None),
+        )
 
         self.assertDoesNotPass(rule, event)
 

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -26,27 +26,45 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
+        data = {
+            'interval': '1m',
+            'value': six.text_type(value),
+        }
+
         rule = self.get_rule(
-            data={
-                'interval': '1m',
-                'value': six.text_type(value),
-            },
+            data=data,
             rule=Rule(environment_id=None),
+        )
+
+        environment_id = 1
+        environment_rule = self.get_rule(
+            data=data,
+            rule=Rule(environment_id=environment_id),
         )
 
         self.increment(
             event,
             value + 1,
+            environment_id=environment_id,
             timestamp=now() - timedelta(minutes=5),
         )
         self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(environment_rule, event)
 
-        self.increment(event, value)
+        self.increment(event, value, environment_id=environment_id)
         self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(environment_rule, event)
 
-        self.increment(event, 1)
-
+        self.increment(event, 1, environment_id=environment_id)
         self.assertPasses(rule, event)
+        self.assertPasses(environment_rule, event)
+        self.assertDoesNotPass(
+            self.get_rule(
+                data=data,
+                rule=Rule(environment_id=0),
+            ),
+            event,
+        )
 
     @mock.patch('django.utils.timezone.now')
     def test_one_hour(self, now):
@@ -54,27 +72,45 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
+        data = {
+            'interval': '1h',
+            'value': six.text_type(value),
+        }
+
         rule = self.get_rule(
-            data={
-                'interval': '1h',
-                'value': six.text_type(value),
-            },
+            data=data,
             rule=Rule(environment_id=None),
+        )
+
+        environment_id = 1
+        environment_rule = self.get_rule(
+            data=data,
+            rule=Rule(environment_id=environment_id),
         )
 
         self.increment(
             event,
             value + 1,
+            environment_id=environment_id,
             timestamp=now() - timedelta(minutes=90),
         )
         self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(environment_rule, event)
 
-        self.increment(event, value)
+        self.increment(event, value, environment_id=environment_id)
         self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(environment_rule, event)
 
-        self.increment(event, 1)
-
+        self.increment(event, 1, environment_id=environment_id)
         self.assertPasses(rule, event)
+        self.assertPasses(environment_rule, event)
+        self.assertDoesNotPass(
+            self.get_rule(
+                data=data,
+                rule=Rule(environment_id=0),
+            ),
+            event,
+        )
 
     @mock.patch('django.utils.timezone.now')
     def test_one_day(self, now):
@@ -82,53 +118,94 @@ class FrequencyConditionMixin(object):
 
         event = self.get_event()
         value = 10
+        data = {
+            'interval': '1d',
+            'value': six.text_type(value),
+        }
+
         rule = self.get_rule(
-            data={
-                'interval': '1d',
-                'value': six.text_type(value),
-            },
+            data=data,
             rule=Rule(environment_id=None),
+        )
+
+        environment_id = 1
+        environment_rule = self.get_rule(
+            data=data,
+            rule=Rule(environment_id=environment_id),
         )
 
         self.increment(
             event,
             value + 1,
+            environment_id=environment_id,
             timestamp=now() - timedelta(hours=36),
         )
         self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(environment_rule, event)
 
-        self.increment(event, value)
+        self.increment(event, value, environment_id=environment_id)
         self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(environment_rule, event)
 
-        self.increment(event, 1)
-
+        self.increment(event, 1, environment_id=environment_id)
         self.assertPasses(rule, event)
+        self.assertPasses(environment_rule, event)
+        self.assertDoesNotPass(
+            self.get_rule(
+                data=data,
+                rule=Rule(environment_id=0),
+            ),
+            event,
+        )
 
     @mock.patch('django.utils.timezone.now')
     def test_more_than_zero(self, now):
         now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
 
         event = self.get_event()
+        data = {
+            'interval': '1m',
+            'value': six.text_type('0'),
+        }
+
         rule = self.get_rule(
-            data={
-                'interval': '1m',
-                'value': six.text_type('0'),
-            },
+            data=data,
             rule=Rule(environment_id=None),
         )
 
-        self.assertDoesNotPass(rule, event)
+        environment_id = 1
+        environment_rule = self.get_rule(
+            data=data,
+            rule=Rule(environment_id=environment_id),
+        )
 
-        self.increment(event, 1)
+        self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(environment_rule, event)
+
+        self.increment(event, 1, environment_id=environment_id)
 
         self.assertPasses(rule, event)
+        self.assertPasses(environment_rule, event)
+        self.assertDoesNotPass(
+            self.get_rule(
+                data=data,
+                rule=Rule(environment_id=0),
+            ),
+            event,
+        )
 
 
 class EventFrequencyConditionTestCase(FrequencyConditionMixin, RuleTestCase):
     rule_cls = EventFrequencyCondition
 
-    def increment(self, event, count, timestamp=None):
-        tsdb.incr(tsdb.models.group, event.group_id, count=count, timestamp=timestamp)
+    def increment(self, event, count, environment_id, timestamp=None):
+        tsdb.incr(
+            tsdb.models.group,
+            event.group_id,
+            count=count,
+            environment_id=environment_id,
+            timestamp=timestamp,
+        )
 
 
 class EventUniqueUserFrequencyConditionTestCase(FrequencyConditionMixin, RuleTestCase):
@@ -136,9 +213,11 @@ class EventUniqueUserFrequencyConditionTestCase(FrequencyConditionMixin, RuleTes
 
     sequence = itertools.count()  # generates unique values, class scope doesn't matter
 
-    def increment(self, event, count, timestamp=None):
+    def increment(self, event, count, environment_id, timestamp=None):
         tsdb.record(
             tsdb.models.users_affected_by_group,
-            event.group_id, [next(self.sequence) for _ in xrange(0, count)],
+            event.group_id,
+            [next(self.sequence) for _ in xrange(0, count)],
+            environment_id=environment_id,
             timestamp=timestamp
         )

--- a/tests/sentry/rules/conditions/test_first_seen_event.py
+++ b/tests/sentry/rules/conditions/test_first_seen_event.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.models import Rule
 from sentry.testutils.cases import RuleTestCase
 from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
 
@@ -8,7 +9,9 @@ class FirstSeenEventConditionTest(RuleTestCase):
     rule_cls = FirstSeenEventCondition
 
     def test_applies_correctly(self):
-        rule = self.get_rule()
+        rule = self.get_rule(
+            rule=Rule(environment_id=None),
+        )
 
         self.assertPasses(rule, self.event, is_new=True)
 

--- a/tests/sentry/rules/conditions/test_first_seen_event.py
+++ b/tests/sentry/rules/conditions/test_first_seen_event.py
@@ -16,3 +16,14 @@ class FirstSeenEventConditionTest(RuleTestCase):
         self.assertPasses(rule, self.event, is_new=True)
 
         self.assertDoesNotPass(rule, self.event, is_new=False)
+
+    def test_applies_correctly_with_environment(self):
+        rule = self.get_rule(
+            rule=Rule(environment_id=1),
+        )
+
+        self.assertPasses(rule, self.event, is_new=True, is_new_group_environment=True)
+        self.assertPasses(rule, self.event, is_new=False, is_new_group_environment=True)
+
+        self.assertDoesNotPass(rule, self.event, is_new=True, is_new_group_environment=False)
+        self.assertDoesNotPass(rule, self.event, is_new=False, is_new_group_environment=False)

--- a/tests/sentry/rules/conditions/test_level_event.py
+++ b/tests/sentry/rules/conditions/test_level_event.py
@@ -10,7 +10,7 @@ class LevelConditionTest(RuleTestCase):
     rule_cls = LevelCondition
 
     def test_render_label(self):
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'level': '30',
         })
@@ -18,13 +18,13 @@ class LevelConditionTest(RuleTestCase):
 
     def test_equals(self):
         event = self.create_event(event_id='a' * 32, tags={'level': 'info'})
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'level': '20',
         })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'level': '30',
         })
@@ -32,13 +32,13 @@ class LevelConditionTest(RuleTestCase):
 
     def test_greater_than(self):
         event = self.create_event(event_id='a' * 32, tags={'level': 'info'})
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.GREATER_OR_EQUAL,
             'level': '40',
         })
         self.assertDoesNotPass(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.GREATER_OR_EQUAL,
             'level': '20',
         })
@@ -46,13 +46,13 @@ class LevelConditionTest(RuleTestCase):
 
     def test_less_than(self):
         event = self.create_event(event_id='a' * 32, tags={'level': 'info'})
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.LESS_OR_EQUAL,
             'level': '10',
         })
         self.assertDoesNotPass(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.LESS_OR_EQUAL,
             'level': '30',
         })
@@ -60,7 +60,7 @@ class LevelConditionTest(RuleTestCase):
 
     def test_without_tag(self):
         event = self.create_event(event_id='a' * 32, tags={})
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'level': '30',
         })
@@ -68,7 +68,7 @@ class LevelConditionTest(RuleTestCase):
 
     def test_errors_with_invalid_level(self):
         event = self.create_event(event_id='a' * 32, tags={'level': 'foobar'})
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'level': '30',
         })
@@ -94,7 +94,7 @@ class LevelConditionTest(RuleTestCase):
         assert wevent.level == logging.WARNING
         assert eevent.level == logging.WARNING
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.GREATER_OR_EQUAL,
             'level': '40',
         })

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -16,7 +16,7 @@ class TaggedEventConditionTest(RuleTestCase):
         return event
 
     def test_render_label(self):
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.EQUAL,
             'key': u'\xc3',
             'value': u'\xc4',
@@ -25,56 +25,46 @@ class TaggedEventConditionTest(RuleTestCase):
 
     def test_equals(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'key': 'LOGGER',
-                'value': 'sentry.example',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'key': 'LOGGER',
+            'value': 'sentry.example',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.EQUAL,
-                'key': 'logger',
-                'value': 'sentry.other.example',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.EQUAL,
+            'key': 'logger',
+            'value': 'sentry.other.example',
+        })
         self.assertDoesNotPass(rule, event)
 
     def test_does_not_equal(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_EQUAL,
-                'key': 'logger',
-                'value': 'sentry.example',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_EQUAL,
+            'key': 'logger',
+            'value': 'sentry.example',
+        })
         self.assertDoesNotPass(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_EQUAL,
-                'key': 'logger',
-                'value': 'sentry.other.example',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_EQUAL,
+            'key': 'logger',
+            'value': 'sentry.other.example',
+        })
         self.assertPasses(rule, event)
 
     def test_starts_with(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.STARTS_WITH,
-                'key': 'logger',
-                'value': 'sentry.',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.STARTS_WITH,
+            'key': 'logger',
+            'value': 'sentry.',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.STARTS_WITH,
             'key': 'logger',
             'value': 'bar.',
@@ -83,16 +73,14 @@ class TaggedEventConditionTest(RuleTestCase):
 
     def test_ends_with(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.ENDS_WITH,
-                'key': 'logger',
-                'value': '.example',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.ENDS_WITH,
+            'key': 'logger',
+            'value': '.example',
+        })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.ENDS_WITH,
             'key': 'logger',
             'value': '.foo',
@@ -101,14 +89,14 @@ class TaggedEventConditionTest(RuleTestCase):
 
     def test_contains(self):
         event = self.get_event()
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.CONTAINS,
             'key': 'logger',
             'value': 'sentry',
         })
         self.assertPasses(rule, event)
 
-        rule = self.get_rule({
+        rule = self.get_rule(data={
             'match': MatchType.CONTAINS,
             'key': 'logger',
             'value': 'bar.foo',
@@ -117,20 +105,16 @@ class TaggedEventConditionTest(RuleTestCase):
 
     def test_does_not_contain(self):
         event = self.get_event()
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_CONTAINS,
-                'key': 'logger',
-                'value': 'sentry',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_CONTAINS,
+            'key': 'logger',
+            'value': 'sentry',
+        })
         self.assertDoesNotPass(rule, event)
 
-        rule = self.get_rule(
-            {
-                'match': MatchType.NOT_CONTAINS,
-                'key': 'logger',
-                'value': 'bar.foo',
-            }
-        )
+        rule = self.get_rule(data={
+            'match': MatchType.NOT_CONTAINS,
+            'key': 'logger',
+            'value': 'bar.foo',
+        })
         self.assertPasses(rule, event)


### PR DESCRIPTION
This adds environment-awareness to the rule processor (only tests against events that match the rule environment, if set) as well as to conditions that use history that can be queried on a per-environment basis (first seen, event frequency, distinct user frequency.)