### PR TITLE
feat: Disable legacy rate limits when unused

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -15,12 +15,13 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
     DetailedOrganizationSerializer)
 from sentry.api.serializers.rest_framework import ListField
-from sentry.constants import RESERVED_ORGANIZATION_SLUGS
+from sentry.constants import LEGACY_RATE_LIMIT_OPTIONS, RESERVED_ORGANIZATION_SLUGS
 from sentry.models import (
     AuditLogEntryEvent, Authenticator, Organization, OrganizationAvatar, OrganizationOption, OrganizationStatus
 )
 from sentry.tasks.deletion import delete_organization
 from sentry.utils.apidocs import scenario, attach_scenarios
+from sentry.utils.cache import memoize
 
 ERR_DEFAULT_ORG = 'You cannot remove the default organization.'
 
@@ -86,6 +87,14 @@ class OrganizationSerializer(serializers.Serializer):
     isEarlyAdopter = serializers.BooleanField(required=False)
     require2FA = serializers.BooleanField(required=False)
 
+    @memoize
+    def _has_legacy_rate_limits(self):
+        org = self.context['organization']
+        return OrganizationOption.objects.filter(
+            organization=org,
+            key__in=LEGACY_RATE_LIMIT_OPTIONS,
+        ).exists()
+
     def validate_slug(self, attrs, source):
         value = attrs[source]
         # Historically, the only check just made sure there was more than 1
@@ -126,6 +135,18 @@ class OrganizationSerializer(serializers.Serializer):
         if value and not has_2fa:
             raise serializers.ValidationError(
                 'Cannot require two-factor authentication without personal two-factor enabled.')
+        return attrs
+
+    def validate_accountRateLimit(self, attrs, source):
+        if not self._has_legacy_rate_limits:
+            raise serializers.ValidationError(
+                'The accountRateLimit option cannot be configured for this organization')
+        return attrs
+
+    def validate_projectRateLimit(self, attrs, source):
+        if not self._has_legacy_rate_limits:
+            raise serializers.ValidationError(
+                'The accountRateLimit option cannot be configured for this organization')
         return attrs
 
     def validate(self, attrs):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -6,6 +6,7 @@ from sentry import roles
 from sentry.app import quotas
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.auth import access
+from sentry.constants import LEGACY_RATE_LIMIT_OPTIONS
 from sentry.models import (
     ApiKey, Organization, OrganizationAccessRequest, OrganizationAvatar, OrganizationOnboardingTask,
     OrganizationOption, OrganizationStatus, Project, ProjectStatus, Team, TeamStatus
@@ -130,7 +131,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             feature_list.append('relay')
         if features.has('organizations:health', obj, actor=user):
             feature_list.append('health')
-
+        if OrganizationOption.objects.filter(
+                organization=obj, key__in=LEGACY_RATE_LIMIT_OPTIONS).exists():
+            feature_list.append('legacy-rate-limits')
         if getattr(obj.flags, 'allow_joinleave'):
             feature_list.append('open-membership')
         if not getattr(obj.flags, 'disable_shared_issues'):

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -359,3 +359,5 @@ class ObjectStatus(object):
 
 
 StatsPeriod = namedtuple('StatsPeriod', ('segments', 'interval'))
+
+LEGACY_RATE_LIMIT_OPTIONS = frozenset(('sentry:project-rate-limit', 'sentry:account-rate-limit'))

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
@@ -56,7 +56,8 @@ const organizationNavigation = [
       {
         path: `${pathPrefix}/rate-limits/`,
         title: t('Rate Limits'),
-        show: ({access}) => access.has('org:write'),
+        show: ({access, features}) =>
+          features.has('legacy-rate-limits') && access.has('org:write'),
         description: t('Configure rate limits for all projects in the organization'),
       },
       {

--- a/src/sentry/templates/sentry/bases/organization.html
+++ b/src/sentry/templates/sentry/bases/organization.html
@@ -73,7 +73,6 @@
     {% endif %}
     {% if ACCESS.org_write %}
       <li><a href="{% absolute_uri '/organizations/{}/audit-log/' organization.slug %}">{% trans "Audit Log" %}</a></li>
-      <li><a href="{% absolute_uri '/organizations/{}/rate-limits/' organization.slug %}">{% trans "Rate Limits" %}</li></a>
       <li><a href="{% absolute_uri '/organizations/{}/repos/' organization.slug %}">{% trans "Repositories" %}</li></a>
       <li class="{% block org_settings_nav %}{% endblock %}">
         <a href="{% absolute_uri '/organizations/{}/settings/' organization.slug %}">

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.core import mail
 from mock import patch
 from exam import fixture
+from pprint import pprint
 
 from sentry.constants import RESERVED_ORGANIZATION_SLUGS
 from sentry.models import (
@@ -45,10 +46,10 @@ class OrganizationDetailsTest(APITestCase):
         )
         # TODO(dcramer): we need to pare this down -- lots of duplicate queries
         # for membership data
-        with self.assertNumQueries(27, using='default'):
+        with self.assertNumQueries(28, using='default'):
             from django.db import connections
             response = self.client.get(url, format='json')
-            print(connections['default'].queries)
+            pprint(connections['default'].queries)
         assert len(response.data['projects']) == 5
 
     def test_onboarding_tasks(self):
@@ -143,23 +144,6 @@ class OrganizationUpdateTest(APITestCase):
         )
         assert response.status_code == 400, response.content
 
-    def test_setting_rate_limit(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse(
-            'sentry-api-0-organization-details', kwargs={
-                'organization_slug': org.slug,
-            }
-        )
-        response = self.client.put(
-            url, data={
-                'projectRateLimit': '80',
-            }
-        )
-        assert response.status_code == 200, response.content
-        result = OrganizationOption.objects.get_value(org, 'sentry:project-rate-limit')
-        assert result == 80
-
     def test_upload_avatar(self):
         org = self.create_organization(owner=self.user)
         self.login_as(user=self.user)
@@ -226,6 +210,52 @@ class OrganizationUpdateTest(APITestCase):
         assert options.get('sentry:require_scrub_ip_address')
         assert options.get('sentry:sensitive_fields') == ['password']
         assert options.get('sentry:safe_fields') == ['email']
+
+    def test_setting_legacy_rate_limits(self):
+        org = self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-organization-details', kwargs={
+                'organization_slug': org.slug,
+            }
+        )
+        response = self.client.put(
+            url,
+            data={
+                'accountRateLimit': 1000,
+            }
+        )
+        assert response.status_code == 400, response.content
+
+        response = self.client.put(
+            url,
+            data={
+                'projectRateLimit': 1000,
+            }
+        )
+        assert response.status_code == 400, response.content
+
+        OrganizationOption.objects.set_value(org, 'sentry:project-rate-limit', 1)
+
+        response = self.client.put(
+            url,
+            data={
+                'projectRateLimit': 100,
+            }
+        )
+        assert response.status_code == 200, response.content
+
+        assert OrganizationOption.objects.get_value(org, 'sentry:project-rate-limit') == 100
+
+        response = self.client.put(
+            url,
+            data={
+                'accountRateLimit': 50,
+            }
+        )
+        assert response.status_code == 200, response.content
+
+        assert OrganizationOption.objects.get_value(org, 'sentry:account-rate-limit') == 50
 
     def test_safe_fields_as_string_regression(self):
         org = self.create_organization(owner=self.user)


### PR DESCRIPTION
These have been superceded by per-key rate limits.