### PR TITLE
fix: Bump responses to 0.8.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,4 +10,4 @@ msgpack-python<0.5.0
 pytest-cov>=2.5.1,<2.6.0
 pytest-timeout>=0.5.0,<0.6.0
 pytest-xdist>=1.18.0,<1.19.0
-responses>=0.8.0,<0.9.0
+responses>=0.8.1,<0.9.0


### PR DESCRIPTION
Brings things in line with https://github.com/getsentry/getsentry/pull/1679