### PR TITLE
fix: Force loading indicator to close on Alert rules page

### DIFF
--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -118,14 +118,13 @@ const RuleEditor = createReactClass({
         browserHistory.replace(
           `/${org.slug}/${project.slug}/settings/alerts/rules/${resp.id}/`
         );
+        IndicatorStore.remove(loadingIndicator);
       },
       error: response => {
         this.setState({
           error: response.responseJSON || {__all__: 'Unknown error'},
           loading: false,
         });
-      },
-      complete: () => {
         IndicatorStore.remove(loadingIndicator);
       },
     });


### PR DESCRIPTION
For some reason complete handler isn't fired if we use browser history API
Adding this to the success/error handlers as a quick fix