### PR TITLE
test: Fix confirm modal test

### DIFF
--- a/tests/js/spec/components/confirm.spec.jsx
+++ b/tests/js/spec/components/confirm.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import Confirm from 'app/components/confirm';
 
 describe('Confirm', function() {
@@ -43,7 +43,7 @@ describe('Confirm', function() {
 
   it('clicks Confirm in modal and calls `onConfirm` callback', function() {
     let mock = jest.fn();
-    let wrapper = shallow(
+    let wrapper = mount(
       <Confirm message="Are you sure?" onConfirm={mock}>
         <button>Confirm?</button>
       </Confirm>
@@ -56,12 +56,17 @@ describe('Confirm', function() {
 
     // Click "Confirm" button, should be last button
     wrapper
-      .find('Modal')
       .find('Button')
       .last()
       .simulate('click');
 
-    expect(wrapper.find('Modal').prop('show')).toBe(false);
+    expect(
+      wrapper
+        .find('Modal')
+        .first()
+        .prop('show')
+    ).toBe(false);
     expect(mock).toHaveBeenCalled();
+    expect(mock.mock.calls).toHaveLength(1);
   });
 });

--- a/tests/js/spec/components/confirm.spec.jsx
+++ b/tests/js/spec/components/confirm.spec.jsx
@@ -64,30 +64,4 @@ describe('Confirm', function() {
     expect(wrapper.find('Modal').prop('show')).toBe(false);
     expect(mock).toHaveBeenCalled();
   });
-
-  it('clicks Confirm in modal and calls `onConfirm` callback', function() {
-    let mock = jest.fn();
-    let wrapper = shallow(
-      <Confirm message="Are you sure?" onConfirm={mock}>
-        <button>Confirm?</button>
-      </Confirm>
-    );
-
-    expect(mock).not.toHaveBeenCalled();
-
-    wrapper.find('button').simulate('click');
-    wrapper.update();
-
-    // Click "Confirm" button, should be last button
-    let confirm = wrapper
-      .find('Modal')
-      .find('Button')
-      .last();
-
-    confirm.simulate('click');
-    confirm.simulate('click');
-
-    expect(wrapper.find('Modal').prop('show')).toBe(false);
-    expect(mock.mock.calls).toHaveLength(1);
-  });
 });


### PR DESCRIPTION
Needed `mount()` instead of `shallow()` as well as `.first()` since there the modal generates 2 nested elements that match "Modal"