### PR TITLE
fix: Prefix slack logging keys

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -134,11 +134,11 @@ class SlackActionEndpoint(Endpoint):
         callback_id = data.get('callback_id')
 
         logging_data.update({
-            'team_id': team_id,
-            'channel_id': channel_id,
-            'user_id': user_id,
-            'event_id': event_id,
-            'callback_id': callback_id,
+            'slack_team_id': team_id,
+            'slack_channel_id': channel_id,
+            'slack_user_id': user_id,
+            'slack_event_id': event_id,
+            'slack_callback_id': callback_id,
         })
 
         token = data.get('token')

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -99,9 +99,9 @@ class SlackEventEndpoint(Endpoint):
         # authed_users = data.get('authed_users')
 
         logging_data.update({
-            'team_id': team_id,
-            'api_app_id': api_app_id,
-            'event_id': event_id,
+            'slack_team_id': team_id,
+            'slack_api_app_id': api_app_id,
+            'slack_event_id': event_id,
         })
 
         token = data.get('token')
@@ -134,7 +134,7 @@ class SlackEventEndpoint(Endpoint):
             logger.error('slack.event.invalid-event-type', extra=logging_data)
             return self.respond(status=400)
 
-        logging_data['event_type'] = event_type
+        logging_data['slack_event_type'] = event_type
         if event_type == 'link_shared':
             resp = self.on_link_shared(request, integration, token, event_data)
         else:


### PR DESCRIPTION
Some of these keys will already have been type-defined in kabana since
they're often used for sentry related data (event_id is a good example)
causing them to be rejected.