### PR TITLE
fix(teams): Limit query correctly in Team.objects.get_for_user

### DIFF
--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -82,6 +82,7 @@ class TeamManager(BaseManager):
             teams_by_project = defaultdict(set)
             for project_id, team_id in ProjectTeam.objects.filter(
                 project__in=project_list,
+                team__in=team_list,
             ).values_list('project_id', 'team_id'):
                 teams_by_project[project_id].add(team_id)
 


### PR DESCRIPTION
this was errors locally once we started adding multiple teams per project because we were pulling back more ProjectTeam relations than we needed (it was including other teams that also had permission to the selected projects). 