### PR TITLE
fix(events): Validation of special tags

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -37,7 +37,7 @@ def get_all_languages():
 MODULE_ROOT = os.path.dirname(__import__('sentry').__file__)
 DATA_ROOT = os.path.join(MODULE_ROOT, 'data')
 
-VERSION_LENGTH = 250
+VERSION_LENGTH = 200
 
 SORT_OPTIONS = OrderedDict(
     (

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -20,7 +20,6 @@ from sentry.constants import (
     MAX_TAG_KEY_LENGTH,
     MAX_TAG_VALUE_LENGTH,
     VALID_PLATFORMS,
-    VERSION_LENGTH,
 )
 from sentry.interfaces.base import InterfaceValidationError
 from sentry.models import EventError
@@ -43,6 +42,13 @@ PAIRS = {
         'maxItems': 2,
         'items': {'type': 'string'}
     }
+}
+
+TAG_VALUE = {
+    'type': 'string',
+    'pattern': '^[^\n]*\Z',  # \Z because $ matches before a trailing newline
+    'minLength': 1,
+    'maxLength': MAX_TAG_VALUE_LENGTH,
 }
 
 HTTP_INTERFACE_SCHEMA = {
@@ -220,12 +226,7 @@ TAGS_DICT_SCHEMA = {
             'type': 'object',
             # TODO with draft 6 support, we can just use propertyNames/maxLength
             'patternProperties': {
-                '^[a-zA-Z0-9_\.:-]{1,%d}$' % MAX_TAG_KEY_LENGTH: {
-                    'type': 'string',
-                    'minLength': 1,
-                    'maxLength': MAX_TAG_VALUE_LENGTH,
-                    'pattern': '^[^\n]+\Z',  # \Z because $ matches before trailing newline
-                }
+                '^[a-zA-Z0-9_\.:-]{1,%d}$' % MAX_TAG_KEY_LENGTH: TAG_VALUE,
             },
             'additionalProperties': False,
         },
@@ -329,11 +330,8 @@ EVENT_SCHEMA = {
             # 'maxLength': MAX_CULPRIT_LENGTH,
             'default': lambda: apierror('Invalid value for culprit'),
         },
-        'server_name': {'type': 'string'},
-        'release': {
-            'type': 'string',
-            'maxLength': VERSION_LENGTH,
-        },
+        'server_name': TAG_VALUE,
+        'release': TAG_VALUE,
         'dist': {
             'type': 'string',
             'pattern': '^[a-zA-Z0-9_.-]+$',
@@ -387,7 +385,7 @@ EVENT_SCHEMA = {
         'key_id': {},
         'errors': {'type': 'array'},
         'checksum': {},
-        'site': {},
+        'site': TAG_VALUE,
         'received': {},
     },
     'required': ['platform', 'event_id'],

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -24,7 +24,6 @@ from sentry.db.models import (
 
 from sentry.models import CommitFileChange
 
-from sentry.constants import VERSION_LENGTH
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 from sentry.utils.retries import TimedRetryPolicy
@@ -34,6 +33,7 @@ logger = logging.getLogger(__name__)
 _sha1_re = re.compile(r'^[a-f0-9]{40}$')
 _dotted_path_prefix_re = re.compile(r'^([a-zA-Z][a-zA-Z0-9-]+)(\.[a-zA-Z][a-zA-Z0-9-]+)+-')
 BAD_RELEASE_CHARS = '\n\f\t/'
+DB_VERSION_LENGTH = 250
 
 
 class ReleaseProject(Model):
@@ -62,9 +62,9 @@ class Release(Model):
     )
     # DEPRECATED
     project_id = BoundedPositiveIntegerField(null=True)
-    version = models.CharField(max_length=VERSION_LENGTH)
+    version = models.CharField(max_length=DB_VERSION_LENGTH)
     # ref might be the branch name being released
-    ref = models.CharField(max_length=VERSION_LENGTH, null=True, blank=True)
+    ref = models.CharField(max_length=DB_VERSION_LENGTH, null=True, blank=True)
     url = models.URLField(null=True, blank=True)
     date_added = models.DateTimeField(default=timezone.now)
     # DEPRECATED - not available in UI or editable from API
@@ -137,7 +137,7 @@ class Release(Model):
         if release in (None, -1):
             # TODO(dcramer): if the cache result is -1 we could attempt a
             # default create here instead of default get
-            project_version = ('%s-%s' % (project.slug, version))[:VERSION_LENGTH]
+            project_version = ('%s-%s' % (project.slug, version))[:DB_VERSION_LENGTH]
             releases = list(
                 cls.objects.filter(
                     organization_id=project.organization_id,

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -7,7 +7,7 @@ import mock
 import pytest
 
 from django.core.exceptions import SuspiciousOperation
-from sentry.constants import VERSION_LENGTH
+from sentry.constants import VERSION_LENGTH, MAX_CULPRIT_LENGTH
 from uuid import UUID
 
 from sentry.coreapi import (
@@ -295,6 +295,30 @@ class ValidateDataTest(BaseAPITest):
         })
         assert not data['errors']
         assert data['tags'] == [(release_key, release_value)]
+
+    def test_server_name_too_long(self):
+        key = u'server_name'
+        value = ('a' * (MAX_CULPRIT_LENGTH + 1))
+        data = self.validate_and_normalize({
+            key: value,
+        })
+        assert not data.get(key)
+        assert len(data['errors']) == 1
+        assert data['errors'][0]['type'] == 'value_too_long'
+        assert data['errors'][0]['name'] == key
+        assert data['errors'][0]['value'] == value
+
+    def test_site_too_long(self):
+        key = u'site'
+        value = ('a' * (MAX_CULPRIT_LENGTH + 1))
+        data = self.validate_and_normalize({
+            key: value,
+        })
+        assert not data.get(key)
+        assert len(data['errors']) == 1
+        assert data['errors'][0]['type'] == 'value_too_long'
+        assert data['errors'][0]['name'] == key
+        assert data['errors'][0]['value'] == value
 
     def test_release_too_long(self):
         data = self.validate_and_normalize({

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -284,6 +284,18 @@ class ValidateDataTest(BaseAPITest):
         })
         assert data['extra'] == {}
 
+    def test_release_tag_max_len(self):
+        release_key = u'sentry:release'
+        release_value = ('a' * VERSION_LENGTH)
+        data = self.validate_and_normalize({
+            'message': 'foo',
+            'tags': [
+                [release_key, release_value],
+            ],
+        })
+        assert not data['errors']
+        assert data['tags'] == [(release_key, release_value)]
+
     def test_release_too_long(self):
         data = self.validate_and_normalize({
             'release': 'a' * (VERSION_LENGTH + 1),


### PR DESCRIPTION
There are special event tags that are created in the system during event ingestion, of those generated tags `site`,` release`, and `server_name` were lacking general tag validation. The tags are now checked using the event schema. In addition there was a mismatch between the `release` tag's max length `VERSION_LENGTH`that was fixed and the max length for tags, release is now checked via the schema to be the max tag length instead.

