### PR TITLE
fix(environments): Fix environment display name

### DIFF
--- a/src/sentry/static/sentry/app/components/projectHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/index.jsx
@@ -41,7 +41,7 @@ class ProjectHeader extends React.Component {
     let showEnvironmentsToggle = hasEnvironmentsFeature && navSection !== 'settings';
 
     let activeEnvironmentTitle = activeEnvironment
-      ? activeEnvironment.name
+      ? activeEnvironment.displayName
       : allEnvironmentsLabel;
 
     return (
@@ -97,7 +97,7 @@ class ProjectHeader extends React.Component {
                 </MenuItem>
                 {environments.map(env => (
                   <MenuItem key={env.id} onClick={() => setActiveEnvironment(env)}>
-                    {env.name}
+                    {env.displayName}
                   </MenuItem>
                 ))}
               </DropdownLink>

--- a/src/sentry/static/sentry/app/stores/environmentStore.jsx
+++ b/src/sentry/static/sentry/app/stores/environmentStore.jsx
@@ -14,8 +14,8 @@ const PRODUCTION_ENV_NAMES = new Set([
   'trunk',
 ]);
 
-const DEFAULT_ENV_NAME = '(Default Environment)';
-const DEFAULT_ROUTING_NAME = 'none';
+const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
+const DEFAULT_EMPTY_ROUTING_NAME = 'none';
 
 const EnvironmentStore = Reflux.createStore({
   init() {
@@ -30,10 +30,10 @@ const EnvironmentStore = Reflux.createStore({
       id: item.id,
       name: item.name,
       get displayName() {
-        return toTitleCase(item.name) || DEFAULT_ENV_NAME;
+        return toTitleCase(item.name) || DEFAULT_EMPTY_ENV_NAME;
       },
       get urlRoutingName() {
-        return item.name || DEFAULT_ROUTING_NAME;
+        return item.name || DEFAULT_EMPTY_ROUTING_NAME;
       },
     }));
     this.trigger(this.items, 'initial');


### PR DESCRIPTION
Change the default empty environment name to (No environment) since it's actually represents empty environment data.

Use the correct display name in the dropdown toggle