### PR TITLE
fix(environments): Ensure loading is false on release sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -139,6 +139,7 @@ const GroupReleaseStats = createReactClass({
 
     this.setState({
       data,
+      loading: false,
     });
   },
 


### PR DESCRIPTION
Loading might not be set to false correctly if no default env is available