### PR TITLE
fix(slack): Be consistent about username lookup

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -76,7 +76,7 @@ def build_assigned_text(identity, assignee):
         )
 
     try:
-        assignee_user = User.objects.get(email=assignee)
+        assignee_user = User.objects.get(username=assignee)
     except User.DoesNotExist:
         return
 


### PR DESCRIPTION
Assigning works, but looking up who was assigned does not when they have a
different username than email (duh).