### PR TITLE
fix(suggested-owner): use newer and more frames

### DIFF
--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -166,8 +166,8 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
             return Response({'detail': 'No Commits found for Release'}, status=404)
 
         frames = self._get_frame_paths(event)
-        frame_limit = 15
-        app_frames = [frame for frame in frames if frame['in_app']][:frame_limit]
+        frame_limit = 25
+        app_frames = [frame for frame in frames if frame['in_app']][-frame_limit:]
 
         # TODO(maxbittker) return this set instead of annotated frames
         path_set = {frame['abs_path'] for frame in app_frames}


### PR DESCRIPTION
increase limit and take the newest frames, not the oldest

suggested owner was taking frames from the front of the list, which are the oldest frames per:

>The list of frames should be ordered by the oldest call first.
https://docs.sentry.io/clientdev/interfaces/stacktrace/

I also thought we should take more because why not. 

this should help get more suggested owners 