### PR TITLE
fix(teams): team serializer hasAccess should include role level

### DIFF
--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -27,6 +27,106 @@ class TeamSerializerTest(TestCase):
             'id': six.text_type(team.id),
         }
 
+    def test_member_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization)
+        team = self.create_team(organization=organization)
+
+        result = serialize(team, user)
+        result.pop('dateCreated')
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(team, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is False
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(team, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
+    def test_admin_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization, role='admin')
+        team = self.create_team(organization=organization)
+
+        result = serialize(team, user)
+        result.pop('dateCreated')
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(team, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is False
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(team, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
+    def test_manager_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization, role='manager')
+        team = self.create_team(organization=organization)
+
+        result = serialize(team, user)
+        result.pop('dateCreated')
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(team, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(team, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
+    def test_owner_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization, role='owner')
+        team = self.create_team(organization=organization)
+
+        result = serialize(team, user)
+        result.pop('dateCreated')
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(team, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(team, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
 
 class TeamWithProjectsSerializerTest(TestCase):
     def test_simple(self):


### PR DESCRIPTION
The UI was hiding some things that people have access to via the api. This is an attempt to match what the team serializer is returning with the actual api permissions. I think the main thing that will change is that managers and owners will now be able to see project pages (settings, stream, etc) even if they are not part of a team that has access to that project. Those projects won't appear in their project dropdown though.

cc @benvinegar @saragilford in case anyone thinks this is a terrible idea