### PR TITLE
fix(plugins): Make request data avaliable to plugins.get_config

### DIFF
--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -100,6 +100,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
             for c in plugin.get_config(
                 project=project,
                 user=request.user,
+                initial=request.DATA,
             )
         ]
 


### PR DESCRIPTION
The plugins are broken from the change to react. Plugins with a "dynamic" django form have been broken and require request data at the get_config stage in order to behave as intended until they can be converted to react.This change should put the new data into the **kwargs that is already part of the method.