### PR TITLE
feat(templatetags): Support `as` assignment in `absolute_uri`

### DIFF
--- a/src/sentry/templates/sentry/plugins/bases/issue/not_configured.html
+++ b/src/sentry/templates/sentry/plugins/bases/issue/not_configured.html
@@ -19,7 +19,8 @@
                 {% endfor %}
             </ul>
         {% else %}
-            <p>{% blocktrans %}You still need to<a href="{% absolute_uri '/{}/{}/settings/plugins/{}/' project.organization.slug project.slug p.slug %}">configure this plugin</a>
+            {% absolute_uri '/{}/{}/settings/plugins/{}/' project.organization.slug project.slug p.slug as link %}
+            <p>{% blocktrans %}You still need to <a href="{{ link }}">configure this plugin</a>
                 before you can use it.{% endblocktrans %}
             </p>
         {% endif %}

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -65,10 +65,58 @@ def multiply(x, y):
     return coerce(x) * coerce(y)
 
 
-@register.simple_tag
-def absolute_uri(path='', *args):
-    from sentry.utils.http import absolute_uri
-    return absolute_uri(path.format(*args))
+class AbsoluteUriNode(template.Node):
+    def __init__(self, args, target_var):
+        self.args = args
+        self.target_var = target_var
+
+    def render(self, context):
+        from sentry.utils.http import absolute_uri
+
+        # Attempt to resolve all arguments into actual variables.
+        # This converts a value such as `"foo"` into the string `foo`
+        # and will look up a value such as `foo` from the context as
+        # the variable `foo`. If the variable does not exist, silently
+        # resolve as an empty string, which matches the behavior
+        # `SimpleTagNode`
+        args = []
+        for arg in self.args:
+            try:
+                arg = template.Variable(arg).resolve(context)
+            except template.VariableDoesNotExist:
+                arg = ''
+            args.append(arg)
+
+        # No args is just fine
+        if not args:
+            rv = ''
+        # If there's only 1 argument, there's nothing to format
+        elif len(args) == 1:
+            rv = args[0]
+        else:
+            rv = args[0].format(*args[1:])
+
+        rv = absolute_uri(rv)
+
+        # We're doing an `as foo` and we want to assign the result
+        # to a variable instead of actually returning.
+        if self.target_var is not None:
+            context[self.target_var] = rv
+            rv = ''
+
+        return rv
+
+
+@register.tag
+def absolute_uri(parser, token):
+    bits = token.split_contents()[1:]
+    # Check if the last two bits are `as {var}`
+    if len(bits) >= 2 and bits[-2] == 'as':
+        target_var = bits[-1]
+        bits = bits[:-2]
+    else:
+        target_var = None
+    return AbsoluteUriNode(bits, target_var)
 
 
 @register.simple_tag


### PR DESCRIPTION
cc @lauryndbrown 