### PR TITLE
fix: Remove recursive calls from Stacktrace hash calculation

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -750,9 +750,20 @@ class Stacktrace(Interface):
             if len(frames) / float(total_frames) < 0.10:
                 return []
 
+        if not frames:
+            return []
+
         output = []
-        for frame in frames:
-            output.extend(frame.get_hash(platform))
+
+        # stacktraces that only differ by the number of recursive calls should
+        # hash the same, so we squash recursive calls by comparing each frame
+        # to the previous frame
+        output.extend(frames[0].get_hash(platform))
+        prev_frame = frames[0]
+        for frame in frames[1:]:
+            if not frame == prev_frame:
+                output.extend(frame.get_hash(platform))
+            prev_frame = frame
         return output
 
     def to_string(self, event, is_public=False, **kwargs):

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -761,7 +761,7 @@ class Stacktrace(Interface):
         output.extend(frames[0].get_hash(platform))
         prev_frame = frames[0]
         for frame in frames[1:]:
-            if not frame == prev_frame:
+            if frame != prev_frame:
                 output.extend(frame.get_hash(platform))
             prev_frame = frame
         return output

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -500,6 +500,81 @@ class StacktraceTest(TestCase):
         result = interface.get_hash()
         assert result == []
 
+    def test_collapse_recursion(self):
+        interface = Stacktrace.to_python(
+            {
+                'frames': [
+                    {
+                        'abs_path': 'Application.java',
+                        'filename': 'Application.java',
+                        'function': 'main',
+                        'in_app': False,
+                        'lineno': 13,
+                        'module': 'io.sentry.example.Application'
+                    },
+                    {
+                        'abs_path': 'Application.java',
+                        'filename': 'Application.java',
+                        'function': 'normalFunc',
+                        'in_app': False,
+                        'lineno': 20,
+                        'module': 'io.sentry.example.Application'
+                    },
+                    {
+                        'abs_path': 'Application.java',
+                        'filename': 'Application.java',
+                        'function': 'recurFunc',
+                        'in_app': False,
+                        'lineno': 27,
+                        'module': 'io.sentry.example.Application'
+                    },
+                    {
+                        'abs_path': 'Application.java',
+                        'filename': 'Application.java',
+                        'function': 'recurFunc',
+                        'in_app': False,
+                        'lineno': 27,
+                        'module': 'io.sentry.example.Application'
+                    },
+                    {
+                        'abs_path': 'Application.java',
+                        'filename': 'Application.java',
+                        'function': 'recurFunc',
+                        'in_app': False,
+                        'lineno': 27,
+                        'module': 'io.sentry.example.Application'
+                    },
+                    {
+                        'abs_path': 'Application.java',
+                        'filename': 'Application.java',
+                        'function': 'recurFunc',
+                        'in_app': False,
+                        'lineno': 25,
+                        'module': 'io.sentry.example.Application'
+                    },
+                    {
+                        'abs_path': 'Application.java',
+                        'filename': 'Application.java',
+                        'function': 'throwError',
+                        'in_app': False,
+                        'lineno': 32,
+                        'module': 'io.sentry.example.Application'
+                    }
+                ]
+            }
+        )
+        result = interface.get_hash()
+        self.assertEquals(result, [
+            'io.sentry.example.Application', 'main',
+            'io.sentry.example.Application', 'normalFunc',
+            # first call to recursive function
+            'io.sentry.example.Application', 'recurFunc',
+            # (exact) recursive frames omitted here
+            # call from *different location* in recursive function
+            'io.sentry.example.Application', 'recurFunc',
+            'io.sentry.example.Application', 'throwError'
+        ])
+
     def test_get_hash_ignores_safari_native_code(self):
         interface = Frame.to_python(
             {


### PR DESCRIPTION
Fixes GH-5816

This came up again so I'm taking care of it. Note that this will effect issue grouping. We discussed previously and couldn't come up with a single example of why someone would want recursive calls to group differently.