### PR TITLE
fix(native): Windows support

### DIFF
--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import posixpath
+import re
 
 from sentry.utils.compat import implements_to_string
 from sentry.constants import NATIVE_UNKNOWN_STRING
@@ -8,6 +9,12 @@ from sentry.constants import NATIVE_UNKNOWN_STRING
 from symbolic import parse_addr
 
 REPORT_VERSION = '104'
+WINDOWS_PATH_RE = re.compile(r'^[a-z]:\\', re.IGNORECASE)
+
+
+def package_name(pkg):
+    split = '\\' if WINDOWS_PATH_RE.match(pkg) else '/'
+    return pkg.rsplit(split, 1)[-1]
 
 
 @implements_to_string
@@ -145,8 +152,7 @@ class AppleCrashReport(object):
                 symbol = '[inlined] ' + symbol
         return '%s%s%s%s%s' % (
             str(number).ljust(4, ' '),
-            (frame.get('package') or NATIVE_UNKNOWN_STRING).rsplit(
-                '/', 1)[-1].ljust(32, ' '),
+            package_name(frame.get('package') or NATIVE_UNKNOWN_STRING).ljust(32, ' '),
             hex(instruction_addr).ljust(20, ' '), symbol, offset
         )
 
@@ -174,7 +180,6 @@ class AppleCrashReport(object):
         image_addr = parse_addr(debug_image['image_addr']) + slide_value
         return '%s - %s %s %s  <%s> %s' % (
             hex(image_addr), hex(image_addr + debug_image['image_size'] - 1),
-            debug_image['name'].rsplit(
-                '/', 1)[-1], self.context['device']['arch'],
+            package_name(debug_image['name']), self.context['device']['arch'],
             debug_image['uuid'].replace('-', '').lower(), debug_image['name']
         )

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -36,6 +36,7 @@ LINUX_SYS_PATHS = (
     '/usr/lib/',
     'linux-gate.so',
 )
+WINDOWS_SYS_PATH = re.compile(r'^[a-z]:\\windows', re.IGNORECASE)
 
 _internal_function_re = re.compile(
     r'(kscm_|kscrash_|KSCrash |SentryClient |RNSentry )')
@@ -159,6 +160,8 @@ class Symbolizer(object):
         if sdk_name == 'macos' and MAC_OS_PATH in obj_path:
             return True
         if sdk_name == 'linux' and not obj_path.startswith(LINUX_SYS_PATHS):
+            return True
+        if sdk_name == 'windows' and not WINDOWS_SYS_PATH.match(obj_path):
             return True
 
         return False

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -25,6 +25,7 @@ VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)\s+(.*)')
 # Mapping of well-known minidump OS constants to our internal names
 MINIDUMP_OS_TYPES = {
     'Mac OS X': 'macOS',
+    'Windows NT': 'Windows',
 }
 
 AppInfo = namedtuple('AppInfo', ['id', 'version', 'build', 'name'])

--- a/src/sentry/static/sentry/app/components/events/errorItem.jsx
+++ b/src/sentry/static/sentry/app/components/events/errorItem.jsx
@@ -34,9 +34,10 @@ class EventErrorItem extends React.Component {
 
     if (typeof data.image_path === 'string') {
       // Separate the image name for readability
-      let path = data.image_path.split('/');
+      let separator = /^[a-z]:\\/i.test(data.image_path) ? '\\' : '/';
+      let path = data.image_path.split(separator);
       data.image_name = path.splice(-1, 1)[0];
-      data.image_path = path.length ? path.join('/') + '/' : '';
+      data.image_path = path.length ? path.join(separator) + separator : '';
     }
 
     return _.mapKeys(data, (value, key) => _.startCase(key));

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -13,14 +13,13 @@ class DebugMetaInterface extends React.Component {
     data: PropTypes.object.isRequired,
   };
 
-  getImageDetail = (img, evt) => {
+  getImageDetail(img, evt) {
     // in particular proguard images do not have a name, skip them
     if (img.name === null || img.type === 'proguard') {
       return null;
     }
 
-    let name = img.name.split('/').pop();
-
+    let name = img.name.split(/^[a-z]:\\/i.test(img.name) ? '\\' : '/').pop();
     if (name == 'dyld_sim') return null; // this is only for simulator builds
 
     let version = null;
@@ -39,7 +38,7 @@ class DebugMetaInterface extends React.Component {
     if (version) return [name, version];
 
     return null;
-  };
+  }
 
   render() {
     let data = this.props.data;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -15,10 +15,9 @@ import ContextLine from './contextLine';
 import FrameVariables from './frameVariables';
 
 export function trimPackage(pkg) {
-  let pieces = pkg.split(/\//g);
-  let rv = pieces[pieces.length - 1] || pieces[pieces.length - 2] || pkg;
-  let match = rv.match(/^(.*?)\.(dylib|so|a)$/);
-  return (match && match[1]) || rv;
+  let pieces = pkg.split(/^[a-z]:\\/i.test(pkg) ? '\\' : '/');
+  let filename = pieces[pieces.length - 1] || pieces[pieces.length - 2] || pkg;
+  return filename.replace(/\.(dylib|so|a|dll|exe)$/, '');
 }
 
 const Frame = createReactClass({


### PR DESCRIPTION
This PR adds support for native crashes from a Windows host:

 - In-app symbol detection for `sdk_name == 'windows'`. Symbols are in-app iff they are located outside of `C:\Windows`.
 - Mapping of the breakpad name `Windows NT` to `Windows`, which is required by the platform logic and UI
 - Support for splitting Windows paths in the UI and AppleCrashReport renderer
 - Special handling for `.exe` and `.dll` extensions in the native frame component

![localhost_8000_sentry_minidump_issues_136_](https://user-images.githubusercontent.com/1433023/35633142-d4abd278-06a8-11e8-8bbb-3cb66d8c174e.png)
