### PR TITLE
Passed flag to 'dynamic' plugin forms to complete desired behavior sans required field errors

### DIFF
--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -80,7 +80,7 @@ class PluginWithConfigSerializer(PluginSerializer):
         d = super(PluginWithConfigSerializer, self).serialize(obj, attrs, user)
         d['config'] = [
             serialize_field(self.project, obj, c)
-            for c in obj.get_config(project=self.project, user=user)
+            for c in obj.get_config(project=self.project, user=user, add_additial_fields=True)
         ]
         return d
 


### PR DESCRIPTION
This change will allow the plugins to know when to surface new fields for the first time without having to accept values that bypass all validations the very first time information is entered. This allows the plugins to check all values, but still be able to add required fields, surfacing the new fields to the serializer only for the first time and then validation after that. See https://github.com/getsentry/sentry-trello/pull/7 as an example.