### PR TITLE
feat(ui): Fix Projects breadcrumb in new settings

### DIFF
--- a/src/sentry/static/sentry/app/utils/withProjects.jsx
+++ b/src/sentry/static/sentry/app/utils/withProjects.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import Reflux from 'reflux';
+
+import ProjectsStore from '../stores/projectsStore';
+import SentryTypes from '../proptypes';
+
+/**
+ * Higher order component that uses ProjectsStore and provides a list of projects
+ */
+const withProjects = WrappedComponent =>
+  createReactClass({
+    displayName: 'withProjects',
+    propTypes: {
+      organization: SentryTypes.Organization,
+      project: SentryTypes.Project,
+    },
+    mixins: [Reflux.listenTo(ProjectsStore, 'onProjectUpdate')],
+    getInitialState() {
+      return {
+        projects: ProjectsStore.getAll(),
+      };
+    },
+
+    onProjectUpdate() {
+      this.setState({
+        // TODO(billy): Needs to be updated after max's PR
+        projects: Array.from(ProjectsStore.getAll()),
+      });
+    },
+    render() {
+      return <WrappedComponent {...this.props} projects={this.state.projects} />;
+    },
+  });
+
+export default withProjects;

--- a/src/sentry/static/sentry/app/utils/withProjects.jsx
+++ b/src/sentry/static/sentry/app/utils/withProjects.jsx
@@ -24,8 +24,7 @@ const withProjects = WrappedComponent =>
 
     onProjectUpdate() {
       this.setState({
-        // TODO(billy): Needs to be updated after max's PR
-        projects: Array.from(ProjectsStore.getAll()),
+        projects: ProjectsStore.getAll(),
       });
     },
     render() {

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
@@ -12,6 +12,7 @@ import SettingsBreadcrumbDropdown from './settingsBreadcrumbDropdown';
 import recreateRoute from '../../../utils/recreateRoute';
 import replaceRouterParams from '../../../utils/replaceRouterParams';
 import withLatestContext from '../../../utils/withLatestContext';
+import withProjects from '../../../utils/withProjects';
 
 const Breadcrumbs = styled.div`
   display: flex;
@@ -53,68 +54,68 @@ const ProjectName = styled.div`
 
 // `organizationDetails` to differeniate from the organization that comes from `OrganizationsStore` which only has
 // a fraction of an org's properties
-const ProjectCrumb = withLatestContext(
-  ({
-    team,
-    organization: latestOrganization,
-    project: latestProject,
-    params,
-    routes,
-    route,
-    ...props
-  }) => {
-    if (!latestOrganization) return null;
+const ProjectCrumb = withProjects(
+  withLatestContext(
+    ({
+      organization: latestOrganization,
+      project: latestProject,
+      projects,
+      params,
+      routes,
+      route,
+      ...props
+    }) => {
+      if (!latestOrganization) return null;
 
-    let {teams} = latestOrganization;
-    let teamFromOrg = (teams && teams.find(({slug}) => slug === team.slug)) || {};
-    let {projects} = teamFromOrg;
+      // let {projects} = teamFromOrg;
 
-    if (!projects) return null;
+      if (!projects) return null;
 
-    let hasMenu = projects && projects.length > 1;
+      let hasMenu = projects && projects.length > 1;
 
-    return (
-      <SettingsBreadcrumbDropdown
-        hasMenu={hasMenu}
-        route={route}
-        name={
-          <ProjectName>
-            {!latestProject ? (
-              <LoadingIndicator mini />
-            ) : (
-              <div>
-                <StyledLink
-                  to={replaceRouterParams(
-                    '/settings/organization/:orgId/project/:projectId/',
-                    {
-                      orgId: latestOrganization.slug,
-                      projectId: latestProject.slug,
-                    }
-                  )}
-                >
-                  {`${teamFromOrg.name} / ${latestProject.name}`}
-                </StyledLink>
-              </div>
-            )}
-          </ProjectName>
-        }
-        {...props}
-      >
-        {projects.map(project => (
-          <MenuItem
-            to={recreateRoute(route, {
-              routes,
-              params: {...params, projectId: project.slug},
-            })}
-            active={project.slug === params.projectId}
-            key={project.slug}
-          >
-            {project.name}
-          </MenuItem>
-        ))}
-      </SettingsBreadcrumbDropdown>
-    );
-  }
+      return (
+        <SettingsBreadcrumbDropdown
+          hasMenu={hasMenu}
+          route={route}
+          name={
+            <ProjectName>
+              {!latestProject ? (
+                <LoadingIndicator mini />
+              ) : (
+                <div>
+                  <StyledLink
+                    to={replaceRouterParams(
+                      '/settings/organization/:orgId/project/:projectId/',
+                      {
+                        orgId: latestOrganization.slug,
+                        projectId: latestProject.slug,
+                      }
+                    )}
+                  >
+                    {`${latestProject.name}`}
+                  </StyledLink>
+                </div>
+              )}
+            </ProjectName>
+          }
+          {...props}
+        >
+          {projects.map(project => (
+            <MenuItem
+              to={recreateRoute(route, {
+                routes,
+                params: {...params, projectId: project.slug},
+              })}
+              active={project.slug === params.projectId}
+              key={project.slug}
+            >
+              {project.name}
+            </MenuItem>
+          ))}
+        </SettingsBreadcrumbDropdown>
+      );
+    }
+  )
 );
 
 ProjectCrumb.displayName = 'ProjectCrumb';

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb.jsx
@@ -66,9 +66,6 @@ const ProjectCrumb = withProjects(
       ...props
     }) => {
       if (!latestOrganization) return null;
-
-      // let {projects} = teamFromOrg;
-
       if (!projects) return null;
 
       let hasMenu = projects && projects.length > 1;

--- a/tests/js/spec/utils/withProjects.spec.jsx
+++ b/tests/js/spec/utils/withProjects.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import ProjectsStore from 'app/stores/projectsStore';
+import withProjects from 'app/utils/withProjects';
+
+describe('withProjects HoC', function() {
+  beforeEach(() => {
+    ProjectsStore.reset();
+  });
+
+  it('works', function() {
+    const MyComponent = () => null;
+    let Container = withProjects(MyComponent);
+    let wrapper = mount(<Container />);
+
+    expect(wrapper.find('MyComponent').prop('projects')).toEqual([]);
+
+    // Insert into projects store
+    let project = TestStubs.Project();
+    ProjectsStore.loadInitialData([project]);
+
+    wrapper.update();
+    let props = wrapper.find('MyComponent').prop('projects');
+    expect(props.length).toBe(1);
+    expect(props[0].id).toBe(project.id);
+  });
+});


### PR DESCRIPTION
This changes the new settings breadcrumb for projects to:
* Not list Team -> Project
* List all projects in org

I've added a `withProjects` HoC @MaxBittker, will update after #7034 lands