### PR TITLE
fix(auditlog): Handle org flag audit log entries

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -158,7 +158,11 @@ class OrganizationSerializer(serializers.Serializer):
                     key=option,
                     value=type_(self.init_data[key]),
                 )
-                changed_data[key] = self.init_data[key]
+                # TODO(kelly): This will not work if new ORG_OPTIONS are added and their
+                # default value evaluates as truthy, but this should work for now with the
+                # current ORG_OPTIONS (assumes ORG_OPTIONS are falsy)
+                if type_(self.init_data[key]):
+                    changed_data[key] = self.init_data[key]
             else:
                 option_inst.value = self.init_data[key]
                 # check if ORG_OPTIONS changed


### PR DESCRIPTION
When creating a new organization, handle ORG_OPTIONS properly when an organization flag is toggled for the first time.

FIXES GH-#7129

cc @ehfeng 