### PR TITLE
feat(api): Add "close account" API endpoint

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -3,17 +3,25 @@ from __future__ import absolute_import
 from datetime import datetime
 
 import pytz
+import logging
+
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
+from django.contrib.auth import logout
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
+from sentry import roles
+from sentry.api import client
 from sentry.api.bases.user import UserEndpoint
+from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import DetailedUserSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import LANGUAGES
-from sentry.models import User, UserOption
+from sentry.models import Organization, OrganizationMember, OrganizationStatus, User, UserOption
+
+delete_logger = logging.getLogger('sentry.deletions.ui')
 
 
 def _get_timezone_choices():
@@ -153,3 +161,69 @@ class UserDetailsEndpoint(UserEndpoint):
         user = serializer.save()
 
         return Response(serialize(user, request.user, DetailedUserSerializer()))
+
+    @sudo_required
+    def delete(self, request, user):
+        """
+        Delete User Account
+
+        Also removes organizations if they are an owner
+        :pparam string user_id: user id
+        :param list organizations: List of organization ids to remove
+        :auth required:
+        """
+
+        # from `frontend/remove_account.py`
+        org_list = Organization.objects.filter(
+            member_set__role=roles.get_top_dog().id,
+            member_set__user=user,
+            status=OrganizationStatus.VISIBLE,
+        )
+        org_results = []
+        for org in sorted(org_list, key=lambda x: x.name):
+            # O(N) query
+            org_results.append({
+                'organization': org,
+                'single_owner': org.has_single_owner(),
+            })
+
+        avail_org_slugs = set([o['organization'].slug for o in org_results])
+        orgs_to_remove = set(request.DATA.get('organizations')).intersection(avail_org_slugs)
+
+        for result in org_results:
+            if result['single_owner']:
+                orgs_to_remove.add(result['organization'].slug)
+
+        delete_logger.info(
+            'user.deactivate',
+            extra={
+                'actor_id': request.user.id,
+                'ip_address': request.META['REMOTE_ADDR'],
+            }
+        )
+
+        for org_slug in orgs_to_remove:
+            client.delete(
+                path='/organizations/{}/'.format(org_slug),
+                request=request,
+                is_sudo=True)
+
+        remaining_org_ids = [
+            o.id for o in org_list if o.slug in avail_org_slugs.difference(orgs_to_remove)
+        ]
+
+        if remaining_org_ids:
+            OrganizationMember.objects.filter(
+                organization__in=remaining_org_ids,
+                user=request.user,
+            ).delete()
+
+        User.objects.filter(
+            id=request.user.id,
+        ).update(
+            is_active=False,
+        )
+
+        logout(request)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -213,6 +213,16 @@ class UserUpdateTest(APITestCase):
             }
         )
 
+        # test validations
+        response = self.client.delete(url, data={
+        })
+        assert response.status_code == 400
+        response = self.client.delete(url, data={
+            'organizations': None
+        })
+        assert response.status_code == 400
+
+        # test actual delete
         response = self.client.delete(url, data={
             'organizations': [org_with_other_owner.slug, org_as_other_owner.slug, not_owned_org.slug]
         })

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -4,7 +4,7 @@ import six
 
 from django.core.urlresolvers import reverse
 
-from sentry.models import User, UserOption
+from sentry.models import Organization, OrganizationStatus, User, UserOption
 from sentry.testutils import APITestCase
 
 
@@ -186,3 +186,47 @@ class UserUpdateTest(APITestCase):
 
         assert user.email == 'new@example.com'
         assert user.username == 'new@example.com'
+
+    def test_close_account(self):
+        self.login_as(user=self.user)
+        org_single_owner = self.create_organization(name="A", owner=self.user)
+        user2 = self.create_user(email="user2@example.com")
+        org_with_other_owner = self.create_organization(name="B", owner=self.user)
+        org_as_other_owner = self.create_organization(name="C", owner=user2)
+        not_owned_org = self.create_organization(name="D", owner=user2)
+
+        self.create_member(
+            user=user2,
+            organization=org_with_other_owner,
+            role='owner',
+        )
+
+        self.create_member(
+            user=self.user,
+            organization=org_as_other_owner,
+            role='owner',
+        )
+
+        url = reverse(
+            'sentry-api-0-user-details', kwargs={
+                'user_id': self.user.id,
+            }
+        )
+
+        response = self.client.delete(url, data={
+            'organizations': [org_with_other_owner.slug, org_as_other_owner.slug, not_owned_org.slug]
+        })
+
+        # deletes org_single_owner even though it wasn't specified in array
+        # because it has a single owner
+        assert Organization.objects.get(
+            id=org_single_owner.id).status == OrganizationStatus.PENDING_DELETION
+        # should delete org_with_other_owner, and org_as_other_owner
+        assert Organization.objects.get(
+            id=org_with_other_owner.id).status == OrganizationStatus.PENDING_DELETION
+        assert Organization.objects.get(
+            id=org_as_other_owner.id).status == OrganizationStatus.PENDING_DELETION
+        # should NOT delete `not_owned_org`
+        assert Organization.objects.get(id=not_owned_org.id).status == OrganizationStatus.ACTIVE
+
+        assert response.status_code == 204


### PR DESCRIPTION
Mostly existing code from `remove_account.py`:

Takes a list of organization slugs and removes the orgs if they are an owner, also removes ALL orgs of which user is the sole owner of.