### PR TITLE
feat(ui): Add "Close Account" ui

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import AccountAuthorizations from './views/accountAuthorizations';
 import AccountLayout from './views/accountLayout';
-
 import AdminBuffer from './views/adminBuffer';
 import AdminLayout from './views/adminLayout';
 import AdminOrganizations from './views/adminOrganizations';
@@ -220,6 +219,15 @@ const accountSettingsRoutes = [
       />
     </Route>
   </Route>,
+
+  <Route
+    key="close-account/"
+    path="close-account/"
+    name="Close Account"
+    componentPromise={() =>
+      import(/*webpackChunkName: "AccountClose"*/ './views/settings/account/accountClose')}
+    component={errorHandler(LazyLoad)}
+  />,
 ];
 
 const projectSettingsRoutes = [

--- a/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
@@ -1,0 +1,176 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import {addMessage, addErrorMessage} from '../../../actionCreators/settingsIndicator';
+import {openModal} from '../../../actionCreators/modal';
+import {t} from '../../../locale';
+import AsyncView from '../../asyncView';
+import Button from '../../../components/buttons/button';
+import Confirm from '../../../components/confirm';
+import SettingsPageHeader from '../components/settingsPageHeader';
+import TextBlock from '../components/text/textBlock';
+
+const BYE_URL = '/';
+const leaveRedirect = () => (window.location.href = BYE_URL);
+
+const Important = styled.div`
+  font-weight: bold;
+  font-size: 1.2em;
+`;
+
+const GoodbyeModalContent = ({Header, Body, Footer}) => (
+  <div>
+    <Header>{t('Closing Account')}</Header>
+    <Body>
+      <TextBlock>
+        {t('Your account has been deactivated and scheduled for removal.')}
+      </TextBlock>
+      <TextBlock>
+        {t('Thanks for using Sentry! We hope to see you again soon!')}
+      </TextBlock>
+    </Body>
+    <Footer>
+      <Button href={BYE_URL}>{t('Goodbye')}</Button>
+    </Footer>
+  </div>
+);
+
+GoodbyeModalContent.propTypes = {
+  Header: PropTypes.node,
+  Body: PropTypes.node,
+  Footer: PropTypes.node,
+};
+
+class AccountClose extends AsyncView {
+  getEndpoints() {
+    return [['organizations', '/organizations/?owner=1']];
+  }
+
+  constructor(...args) {
+    super(...args);
+    this.state.orgsToRemove = null;
+  }
+
+  // Returns an array of single owners
+  getSingleOwners = () => {
+    return this.state.organizations
+      .filter(({singleOwner}) => singleOwner)
+      .map(({organization}) => organization.slug);
+  };
+
+  handleChange = ({slug}, isSingle, event) => {
+    let checked = event.target.checked;
+
+    // Can't unselect an org where you are the single owner
+    if (isSingle) return;
+
+    this.setState(state => {
+      let set = state.orgsToRemove || new Set(this.getSingleOwners());
+      if (checked) {
+        set.add(slug);
+      } else {
+        set.delete(slug);
+      }
+
+      return {
+        orgsToRemove: set,
+      };
+    });
+  };
+
+  handleRemoveAccount = () => {
+    let {orgsToRemove} = this.state;
+    let orgs = orgsToRemove === null ? this.getSingleOwners() : Array.from(orgsToRemove);
+
+    addMessage('Closing account...');
+
+    this.api
+      .requestPromise('/users/me/', {
+        method: 'DELETE',
+        data: {organizations: orgs},
+      })
+      .then(
+        () => {
+          openModal(GoodbyeModalContent, {
+            onClose: leaveRedirect,
+          });
+
+          // Redirect after 10 seconds
+          setTimeout(leaveRedirect, 10000);
+        },
+        () => {
+          addErrorMessage('Error closing account');
+        }
+      );
+  };
+
+  renderBody() {
+    let {organizations, orgsToRemove} = this.state;
+
+    return (
+      <div>
+        <SettingsPageHeader title="Close Account" />
+
+        <TextBlock>
+          {t('This will permanently remove all associated data for your user')}.
+        </TextBlock>
+
+        <TextBlock>
+          <Important>
+            {t('Closing your account is permanent and cannot be undone')}!
+          </Important>
+        </TextBlock>
+
+        {!!organizations.length && (
+          <TextBlock>
+            {t('If you continue, the following organizations will be removed')}:
+          </TextBlock>
+        )}
+
+        <ul>
+          {organizations.map(({organization, singleOwner}) => {
+            return (
+              <li key={organization.slug}>
+                <label>
+                  <input
+                    style={{marginRight: 6}}
+                    type="checkbox"
+                    value={organization.slug}
+                    onChange={this.handleChange.bind(this, organization, singleOwner)}
+                    name="organizations"
+                    checked={
+                      orgsToRemove === null
+                        ? singleOwner
+                        : orgsToRemove.has(organization.slug)
+                    }
+                    disabled={singleOwner}
+                  />
+                  {organization.name} ({organization.slug})
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+
+        <TextBlock>
+          Ownership will remain with other members if an organization is not deleted.<br />
+          Disabled boxes mean that there is no other owner within the organization so no
+          one else can take ownership.
+        </TextBlock>
+
+        <Confirm
+          priority="danger"
+          message={t(
+            'This is permanent and cannot be undone, are you really sure you want to do this?'
+          )}
+          onConfirm={this.handleRemoveAccount}
+        >
+          <Button priority="danger">{t('Close Account')}</Button>
+        </Confirm>
+      </div>
+    );
+  }
+}
+
+export default AccountClose;

--- a/src/sentry/static/sentry/app/views/settings/account/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/navigationConfiguration.jsx
@@ -34,6 +34,10 @@ const accountNavigation = [
         path: `${pathPrefix}/identities/`,
         title: t('Identities'),
       },
+      {
+        path: `${pathPrefix}/close-account/`,
+        title: t('Close Account'),
+      },
     ],
   },
   {

--- a/tests/js/spec/views/accountClose.spec.jsx
+++ b/tests/js/spec/views/accountClose.spec.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import AccountClose from 'app/views/settings/account/accountClose';
+
+describe('AccountClose', function() {
+  let deleteMock;
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/?owner=1',
+      body: [
+        {
+          organization: TestStubs.Organization(),
+          singleOwner: true,
+        },
+        {
+          organization: TestStubs.Organization({
+            id: '4',
+            slug: 'non-single-owner',
+          }),
+          singleOwner: false,
+        },
+      ],
+    });
+
+    deleteMock = MockApiClient.addMockResponse({
+      url: '/users/me/',
+      method: 'DELETE',
+    });
+  });
+
+  it('lists all orgs user is an owner of', function() {
+    let wrapper = mount(<AccountClose />, TestStubs.routerContext());
+
+    // Input for single owner org
+    expect(
+      wrapper
+        .find('input')
+        .first()
+        .prop('checked')
+    ).toBe(true);
+    expect(
+      wrapper
+        .find('input')
+        .first()
+        .prop('disabled')
+    ).toBe(true);
+
+    // Input for non-single-owner org
+    expect(
+      wrapper
+        .find('input')
+        .at(1)
+        .prop('checked')
+    ).toBe(false);
+    expect(
+      wrapper
+        .find('input')
+        .at(1)
+        .prop('disabled')
+    ).toBe(false);
+
+    // Can check 2nd org
+    wrapper
+      .find('input')
+      .at(1)
+      .simulate('change', {target: {checked: true}});
+
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find('input')
+        .at(1)
+        .prop('checked')
+    ).toBe(true);
+
+    // Delete
+    wrapper.find('Confirm Button').simulate('click');
+
+    // First button is cancel, target Button at index 2
+    wrapper
+      .find('Modal Button')
+      .at(1)
+      .simulate('click');
+
+    expect(deleteMock).toHaveBeenCalledWith(
+      '/users/me/',
+      expect.objectContaining({
+        data: {
+          organizations: ['org-slug', 'non-single-owner'],
+        },
+      })
+    );
+  });
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/79684/35711785-860e84d2-0773-11e8-806d-e706fbdc9ca8.png)

This will open a confirm modal, followed by a good bye modal which then redirects you to `/` when you close or click "bye"