### PR TITLE
feat(ui): Add "- Sentry" to AsyncView document title

### DIFF
--- a/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
+++ b/src/sentry/static/sentry/app/views/accountAuthorizations.jsx
@@ -92,7 +92,7 @@ class AccountAuthorizations extends AsyncView {
   }
 
   getTitle() {
-    return 'Approved Applications - Sentry';
+    return 'Approved Applications';
   }
 
   onRevoke(authorization) {

--- a/src/sentry/static/sentry/app/views/apiApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/apiApplicationDetails.jsx
@@ -126,7 +126,7 @@ const ApiApplicationDetails = createReactClass({
   onRemoveApplication(app) {},
 
   getTitle() {
-    return 'Application Details - Sentry';
+    return 'Application Details';
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/apiApplications.jsx
@@ -177,7 +177,7 @@ const ApiApplications = createReactClass({
   },
 
   getTitle() {
-    return 'API Applications - Sentry';
+    return 'API Applications';
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/apiTokens.jsx
@@ -177,7 +177,7 @@ const ApiTokens = createReactClass({
   },
 
   getTitle() {
-    return 'API Tokens - Sentry';
+    return 'API Tokens';
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/asyncView.jsx
+++ b/src/sentry/static/sentry/app/views/asyncView.jsx
@@ -9,11 +9,14 @@ class AsyncView extends AsyncComponent {
   }
 
   getTitle() {
-    return 'Sentry';
+    return '';
   }
   render() {
+    let title = this.getTitle();
     return (
-      <DocumentTitle title={this.getTitle()}>{this.renderComponent()}</DocumentTitle>
+      <DocumentTitle title={`${title ? `${title} - ` : ''}Sentry`}>
+        {this.renderComponent()}
+      </DocumentTitle>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/account/accountAuthorizations.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountAuthorizations.jsx
@@ -66,7 +66,7 @@ class AccountAuthorizations extends AsyncView {
   }
 
   getTitle() {
-    return 'Approved Applications - Sentry';
+    return 'Approved Applications';
   }
 
   handleRevoke = authorization => {

--- a/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
@@ -80,6 +80,10 @@ class AccountEmails extends AsyncView {
     return [['emails', ENDPOINT]];
   }
 
+  getTitle() {
+    return 'Emails';
+  }
+
   handleSubmitSuccess = (change, model, id) => {
     model.setValue(id, '');
     this.remountComponent();

--- a/src/sentry/static/sentry/app/views/settings/account/accountIdentities.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountIdentities.jsx
@@ -19,6 +19,10 @@ class AccountIdentities extends AsyncView {
     return [['identities', ENDPOINT]];
   }
 
+  getTitle() {
+    return 'Identities';
+  }
+
   getDefaultState() {
     return {
       identities: [],

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
@@ -23,6 +23,10 @@ export default class AccountNotifications extends AsyncView {
     return [['data', '/users/me/notifications/']];
   }
 
+  getTitle() {
+    return 'Notifications';
+  }
+
   renderBody() {
     return (
       <div>

--- a/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
@@ -34,6 +34,10 @@ class AccountSubscriptions extends AsyncView {
     return [['subscriptions', ENDPOINT]];
   }
 
+  getTitle() {
+    return 'Subscriptions';
+  }
+
   handleToggle = (subscription, index, e) => {
     let subscribed = !subscription.subscribed;
     let oldSubscriptions = this.state.subscriptions;

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
@@ -37,7 +37,7 @@ class ApiApplicationDetails extends AsyncView {
   }
 
   getTitle() {
-    return 'Application Details - Sentry';
+    return 'Application Details';
   }
 
   handleSubmitSuccess = (change, model, id) => {

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
@@ -107,7 +107,7 @@ class ApiApplications extends AsyncView {
   }
 
   getTitle() {
-    return 'API Applications - Sentry';
+    return 'API Applications';
   }
 
   handleCreateApplication = () => {

--- a/src/sentry/static/sentry/app/views/settings/account/apiNewToken.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiNewToken.jsx
@@ -28,7 +28,7 @@ export default class ApiNewToken extends React.Component {
 
   render() {
     return (
-      <DocumentTitle title="Create API Token">
+      <DocumentTitle title="Create API Token - Sentry">
         <div>
           <SettingsPageHeader title={t('Create New Token')} />
           <TextBlock>

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -15,7 +15,7 @@ import TextBlock from '../components/text/textBlock';
 
 class ApiTokens extends AsyncView {
   getTitle() {
-    return 'API Tokens - Sentry';
+    return 'API Tokens';
   }
 
   getDefaultState() {

--- a/tests/js/spec/views/__snapshots__/accountEmails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountEmails.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AccountEmails renders with emails 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Emails - Sentry"
 >
   <div>
     <SettingsPageHeading

--- a/tests/js/spec/views/__snapshots__/accountIdentities.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountIdentities.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AccountIdentities renders empty 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Identities - Sentry"
 >
   <div>
     <SettingsPageHeading
@@ -34,7 +34,7 @@ exports[`AccountIdentities renders empty 1`] = `
 
 exports[`AccountIdentities renders list 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Identities - Sentry"
 >
   <div>
     <SettingsPageHeading

--- a/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AccountSubscriptions renders empty 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Subscriptions - Sentry"
 >
   <div>
     <SettingsPageHeading
@@ -193,10 +193,10 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
 
 <AccountSubscriptions>
   <SideEffect(DocumentTitle)
-    title="Sentry"
+    title="Subscriptions - Sentry"
   >
     <DocumentTitle
-      title="Sentry"
+      title="Subscriptions - Sentry"
     >
       <div>
         <SettingsPageHeading

--- a/tests/js/spec/views/__snapshots__/apiNewToken.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiNewToken.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ApiNewToken render() renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Create API Token"
+  title="Create API Token - Sentry"
 >
   <NarryLayout>
     <h3>

--- a/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OrganizationCreate render() renders correctly 1`] = `
 <SideEffect(DocumentTitle)
-  title="Create Organization"
+  title="Create Organization - Sentry"
 >
   <NarryLayout>
     <h3>

--- a/tests/js/spec/views/__snapshots__/organizationIntegrations.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationIntegrations.spec.jsx.snap
@@ -9,10 +9,10 @@ exports[`OrganizationIntegrations render() with a provider renders 1`] = `
   }
 >
   <SideEffect(DocumentTitle)
-    title="Integrations"
+    title="Integrations - Sentry"
   >
     <DocumentTitle
-      title="Integrations"
+      title="Integrations - Sentry"
     >
       <div
         className="ref-organization-integrations"
@@ -135,10 +135,10 @@ exports[`OrganizationIntegrations render() with a provider renders with a reposi
   }
 >
   <SideEffect(DocumentTitle)
-    title="Integrations"
+    title="Integrations - Sentry"
   >
     <DocumentTitle
-      title="Integrations"
+      title="Integrations - Sentry"
     >
       <div
         className="ref-organization-integrations"
@@ -340,7 +340,7 @@ exports[`OrganizationIntegrations render() with a provider renders with a reposi
 
 exports[`OrganizationIntegrations render() without any providers is loading when initially rendering 1`] = `
 <SideEffect(DocumentTitle)
-  title="Integrations"
+  title="Integrations - Sentry"
 >
   <div
     className="ref-organization-integrations"
@@ -398,10 +398,10 @@ exports[`OrganizationIntegrations render() without any providers renders 1`] = `
   }
 >
   <SideEffect(DocumentTitle)
-    title="Integrations"
+    title="Integrations - Sentry"
   >
     <DocumentTitle
-      title="Integrations"
+      title="Integrations - Sentry"
     >
       <div
         className="ref-organization-integrations"

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectAlertSettings render() renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Project Alert Settings"
+  title="Project Alert Settings - Sentry"
 >
   <div>
     <SettingsPageHeading

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -236,10 +236,10 @@ exports[`ProjectPluginDetails renders 1`] = `
     }
   >
     <SideEffect(DocumentTitle)
-      title="Sentry"
+      title="Sentry - Sentry"
     >
       <DocumentTitle
-        title="Sentry"
+        title="Sentry - Sentry"
       >
         <div>
           <SettingsPageHeading

--- a/tests/js/spec/views/__snapshots__/teamCreate.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamCreate.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TeamCreate render() renders correctly 1`] = `
 <SideEffect(DocumentTitle)
-  title="Create Team"
+  title="Create Team - Sentry"
 >
   <NarryLayout>
     <h3>

--- a/tests/js/spec/views/__snapshots__/teamSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamSettings.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TeamSettings render() renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Team Settings"
+  title="Team Settings - Sentry"
 >
   <div
     className="box"


### PR DESCRIPTION
This adds "- Sentry" to document title when using AsyncView and `getTitle` is defined,
otherwise defaults to "Sentry"