### PR TITLE
Add BingPreview crawler

### DIFF
--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -19,6 +19,7 @@ CRAWLERS = re.compile(
             r'Google',
             # Bing search
             r'BingBot',
+            r'BingPreview',
             # Baidu search
             r'Baiduspider',
             # Yahoo


### PR DESCRIPTION
The BingPreview UA appears to be specific to Bing's search app, as documented here: https://blogs.bing.com/webmaster/2012/10/26/page-snapshots-in-bing-windows-8-app-to-bring-new-crawl-traffic-to-sites.