### PR TITLE
fix(ui): Fix membership judgement for nonmembers visiting a project

### DIFF
--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -198,7 +198,7 @@ const ProjectContext = createReactClass({
       this.setState({
         loading: false,
       });
-    } else if (activeTeam && activeTeam.isMember) {
+    } else if (activeTeam && !activeTeam.isMember) {
       this.setState({
         loading: false,
         error: true,


### PR DESCRIPTION
Member of a team should already get `has_access` be `true`. I assume `MISSING_MEMBERSHIP` error should be triggered when a nonmember is visiting the project, not for an existing member.