### PR TITLE
feat(sourcemaps): Cache Sourcemaps based on Cache-Control header with set Min and Max

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -56,6 +56,9 @@ CLEAN_MODULE_RE = re.compile(
 VERSION_RE = re.compile(r'^[a-f0-9]{32}|[a-f0-9]{40}$', re.I)
 NODE_MODULES_RE = re.compile(r'\bnode_modules/')
 SOURCE_MAPPING_URL_RE = re.compile(r'\/\/# sourceMappingURL=(.*)$')
+CACHE_CONTROL_RE = re.compile(r'max-age=(\d+)')
+CACHE_CONTROL_MAX = 7200
+CACHE_CONTROL_MIN = 60
 # the maximum number of remote resources (i.e. source files) that should be
 # fetched
 MAX_RESOURCE_FETCHES = 100
@@ -331,7 +334,14 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
         with metrics.timer('sourcemaps.fetch'):
             result = http.fetch_file(url, headers=headers, verify_ssl=verify_ssl)
             z_body = zlib.compress(result.body)
-            cache.set(cache_key, (url, result.headers, z_body, result.status, result.encoding), 60)
+            cache.set(
+                cache_key,
+                (url,
+                 result.headers,
+                 z_body,
+                 result.status,
+                 result.encoding),
+                get_max_age(headers))
 
     # If we did not get a 200 OK we just raise a cannot fetch here.
     if result.status != 200:
@@ -379,6 +389,21 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
             raise http.CannotFetch(error)
 
     return result
+
+
+def get_max_age(headers):
+    cache_control = 'cache-control'
+    max_age = CACHE_CONTROL_MIN
+
+    if has_header(headers, cache_control):
+        match = re.search(CACHE_CONTROL_RE, headers[cache_control])
+        if match:
+            max_age = max(CACHE_CONTROL_MIN, int(match.group(1)))
+    return min(max_age, CACHE_CONTROL_MAX)
+
+
+def has_header(headers, header_name):
+    return header_name.lower() in {header.lower() for header in headers}
 
 
 def fetch_sourcemap(url, project=None, release=None, dist=None, allow_scraping=True):

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -341,7 +341,7 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
                  z_body,
                  result.status,
                  result.encoding),
-                get_max_age(headers))
+                get_max_age(result.headers))
 
     # If we did not get a 200 OK we just raise a cannot fetch here.
     if result.status != 200:
@@ -395,15 +395,11 @@ def get_max_age(headers):
     cache_control = 'cache-control'
     max_age = CACHE_CONTROL_MIN
 
-    if has_header(headers, cache_control):
-        match = re.search(CACHE_CONTROL_RE, headers[cache_control])
+    if cache_control in headers:
+        match = CACHE_CONTROL_RE.search(headers[cache_control])
         if match:
             max_age = max(CACHE_CONTROL_MIN, int(match.group(1)))
     return min(max_age, CACHE_CONTROL_MAX)
-
-
-def has_header(headers, header_name):
-    return header_name.lower() in {header.lower() for header in headers}
 
 
 def fetch_sourcemap(url, project=None, release=None, dist=None, allow_scraping=True):

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -392,11 +392,11 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
 
 
 def get_max_age(headers):
-    cache_control = 'cache-control'
+    cache_control = headers.get('cache-control')
     max_age = CACHE_CONTROL_MIN
 
-    if cache_control in headers:
-        match = CACHE_CONTROL_RE.search(headers[cache_control])
+    if cache_control:
+        match = CACHE_CONTROL_RE.search(cache_control)
         if match:
             max_age = max(CACHE_CONTROL_MIN, int(match.group(1)))
     return min(max_age, CACHE_CONTROL_MAX)


### PR DESCRIPTION
The sourcemap is cached with the http cache-control header's max-age. There is, however a set minimum (60s) the original value that was hardcoded previously for performance reasons, and a maximum (2hrs). In order to avoid breaking the linter, various changes were made to test containing utf-8. 