### PR TITLE
bug(stream): Remove .stream-filters from document flow when hidden

### DIFF
--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -1155,6 +1155,7 @@
     visibility: hidden;
     opacity: 0;
     padding-left: 20px;
+    position: absolute;
 
     .stream-tag-filter {
       margin-bottom: 1em;
@@ -1195,6 +1196,7 @@
       opacity: 1;
       height: auto;
       overflow: visible;
+      position: static;
     }
   }
 }


### PR DESCRIPTION
Removes the massive (`.stream-sidebar`-sized) bottom padding from the stream.

@ehfeng 

