### PR TITLE
refactor serializers so access is by project rather than by team

### DIFF
--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -24,6 +24,107 @@ class ProjectSerializerTest(TestCase):
         assert result['name'] == project.name
         assert result['id'] == six.text_type(project.id)
 
+    def test_member_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization)
+        team = self.create_team(organization=organization)
+        project = self.create_project(teams=[team])
+
+        result = serialize(project, user)
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(project, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is False
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(project, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
+    def test_admin_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization, role='admin')
+        team = self.create_team(organization=organization)
+        project = self.create_project(teams=[team])
+
+        result = serialize(project, user)
+        result.pop('dateCreated')
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(project, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is False
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(project, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
+    def test_manager_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization, role='manager')
+        team = self.create_team(organization=organization)
+        project = self.create_project(teams=[team])
+
+        result = serialize(project, user)
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(project, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(project, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
+    def test_owner_access(self):
+        user = self.create_user(username='foo')
+        organization = self.create_organization()
+        self.create_member(user=user, organization=organization, role='owner')
+        team = self.create_team(organization=organization)
+        project = self.create_project(teams=[team])
+
+        result = serialize(project, user)
+
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        organization.flags.allow_joinleave = False
+        organization.save()
+        result = serialize(project, user)
+        # after changing to allow_joinleave=False
+        assert result['hasAccess'] is True
+        assert result['isMember'] is False
+
+        self.create_team_membership(user=user, team=team)
+        result = serialize(project, user)
+        # after giving them access to team
+        assert result['hasAccess'] is True
+        assert result['isMember'] is True
+
 
 class ProjectWithTeamSerializerTest(TestCase):
     def test_simple(self):


### PR DESCRIPTION
this is to support the case where a project doesn't have any teams, but the UI still needs to be aware of it/know who has access