### PR TITLE
fix(ui): Fix ApiForm indicator

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/apiForm.jsx
+++ b/src/sentry/static/sentry/app/components/forms/apiForm.jsx
@@ -43,14 +43,13 @@ export default class ApiForm extends Form {
           method: this.props.apiMethod,
           data,
           success: result => {
+            IndicatorStore.remove(loadingIndicator);
             this.onSubmitSuccess(result);
           },
           error: error => {
+            IndicatorStore.remove(loadingIndicator);
             IndicatorStore.add(t('There was an error saving your changes.'), 'error');
             this.onSubmitError(error);
-          },
-          complete: () => {
-            IndicatorStore.remove(loadingIndicator);
           },
         });
       }


### PR DESCRIPTION
`complete` callback in api client should be avoided when you're
navigating away from route in success callback.

Navigation away from route will cause component to unmount and if you're
using ApiMixin will cause xhr cancel, and thus `complete` will never get
fired.