### PR TITLE
fix(identity): Redirect to account settings for now

### DIFF
--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -57,4 +57,7 @@ class IdentityProviderPipeline(Pipeline):
 
         self.state.clear()
 
-        return HttpResponseRedirect(reverse('sentry-account-settings-identities'))
+        # TODO(epurkhiser): When we have more identities and have built out an
+        # idententity managment page that supports these new identities (not
+        # social-auth ones), redirect to the identities page.
+        return HttpResponseRedirect(reverse('sentry-account-settings'))

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -58,6 +58,6 @@ class IdentityProviderPipeline(Pipeline):
         self.state.clear()
 
         # TODO(epurkhiser): When we have more identities and have built out an
-        # idententity managment page that supports these new identities (not
+        # identity management page that supports these new identities (not
         # social-auth ones), redirect to the identities page.
         return HttpResponseRedirect(reverse('sentry-account-settings'))


### PR DESCRIPTION
This is the outcome of a discussion with @saragilford, since we don't have a identities management page for these newer identities, just redirect to the accounts page instead.