### PR TITLE
feat(api): Add environment filter to UserReport Endpoints

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -223,7 +223,7 @@ class Endpoint(APIView):
 
 class EnvironmentMixin(object):
     def _get_environment_func(self, request, organization_id):
-        """
+        """\
         Creates a function that when called returns the ``Environment``
         associated with a request object, or ``None`` if no environment was
         provided. If the environment doesn't exist, an ``Environment.DoesNotExist``

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -223,7 +223,7 @@ class Endpoint(APIView):
 
 class EnvironmentMixin(object):
     def _get_environment_func(self, request, organization_id):
-        """\
+        """
         Creates a function that when called returns the ``Environment``
         associated with a request object, or ``None`` if no environment was
         provided. If the environment doesn't exist, an ``Environment.DoesNotExist``

--- a/src/sentry/api/endpoints/group_user_reports.py
+++ b/src/sentry/api/endpoints/group_user_reports.py
@@ -26,13 +26,11 @@ class GroupUserReportsEndpoint(GroupEndpoint, EnvironmentMixin):
                 group.organization.id,
             )
         except Environment.DoesNotExist:
-            report_list = Environment.objects.none()
+            report_list = UserReport.objects.none()
         else:
+            report_list = UserReport.objects.filter(group=group)
             if environment is not None:
-                report_list = UserReport.objects.filter(group=group, environment=environment)
-            else:
-                report_list = UserReport.objects.filter(group=group)
-
+                report_list = report_list.filter(environment=environment)
         return self.paginate(
             request=request,
             queryset=report_list,

--- a/src/sentry/api/endpoints/group_user_reports.py
+++ b/src/sentry/api/endpoints/group_user_reports.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.paginator import DateTimePaginator
-from sentry.models import UserReport
+from sentry.models import UserReport, Environment
+from sentry.api.base import EnvironmentMixin
 
 
-class GroupUserReportsEndpoint(GroupEndpoint):
+class GroupUserReportsEndpoint(GroupEndpoint, EnvironmentMixin):
     def get(self, request, group):
         """
         List User Reports
@@ -19,7 +20,18 @@ class GroupUserReportsEndpoint(GroupEndpoint):
         :auth: required
         """
 
-        report_list = UserReport.objects.filter(group=group)
+        try:
+            environment = self._get_environment_from_request(
+                request,
+                group.organization.id,
+            )
+        except Environment.DoesNotExist:
+            report_list = Environment.objects.none()
+        else:
+            if environment is not None:
+                report_list = UserReport.objects.filter(group=group, environment=environment)
+            else:
+                report_list = UserReport.objects.filter(group=group)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -56,18 +56,15 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
                 project.organization_id,
             )
         except Environment.DoesNotExist:
-            queryset = Environment.objects.none()
+            queryset = UserReport.objects.none()
         else:
+            queryset = UserReport.objects.filter(
+                project=project,
+                group__isnull=False,
+            ).select_related('group')
             if environment is not None:
-                queryset = UserReport.objects.filter(
-                    project=project,
-                    group__isnull=False,
+                queryset = queryset.filter(
                     environment=environment,
-                ).select_related('group')
-            else:
-                queryset = UserReport.objects.filter(
-                    project=project,
-                    group__isnull=False,
                 ).select_related('group')
 
             status = request.GET.get('status', 'unresolved')

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -65,7 +65,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
             if environment is not None:
                 queryset = queryset.filter(
                     environment=environment,
-                ).select_related('group')
+                )
 
             status = request.GET.get('status', 'unresolved')
             if status == 'unresolved':

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -56,26 +56,27 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
                 project.organization_id,
             )
         except Environment.DoesNotExist:
-            return Response({'environment': 'Invalid environment'}, status=400)
-        if environment is not None:
-            queryset = UserReport.objects.filter(
-                project=project,
-                group__isnull=False,
-                environment=environment,
-            ).select_related('group')
+            queryset = Environment.objects.none()
         else:
-            queryset = UserReport.objects.filter(
-                project=project,
-                group__isnull=False,
-            ).select_related('group')
+            if environment is not None:
+                queryset = UserReport.objects.filter(
+                    project=project,
+                    group__isnull=False,
+                    environment=environment,
+                ).select_related('group')
+            else:
+                queryset = UserReport.objects.filter(
+                    project=project,
+                    group__isnull=False,
+                ).select_related('group')
 
-        status = request.GET.get('status', 'unresolved')
-        if status == 'unresolved':
-            queryset = queryset.filter(
-                group__status=GroupStatus.UNRESOLVED,
-            )
-        elif status:
-            return Response({'status': 'Invalid status choice'}, status=400)
+            status = request.GET.get('status', 'unresolved')
+            if status == 'unresolved':
+                queryset = queryset.filter(
+                    group__status=GroupStatus.UNRESOLVED,
+                )
+            elif status:
+                return Response({'status': 'Invalid status choice'}, status=400)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -126,10 +126,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
             except Group.DoesNotExist:
                 pass
         else:
-            try:
-                report.environment = event.get_environment()
-            except Environment.DoesNotExist:
-                pass
+            report.environment = event.get_environment()
             report.group = event.group
 
         try:

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -120,17 +120,19 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
             report.event_user_id = euser.id
 
         try:
-            event = Event.objects.filter(event_id=report.event_id).select_related('group')[0]
-            try:
-                report.environment = event.get_environment()
-            except Environment.DoesNotExist:
-                pass
-            report.group = event.group
+            event = Event.objects.filter(project_id=project.id,
+                                         event_id=report.event_id).select_related('group')[0]
         except IndexError:
             try:
                 report.group = Group.objects.from_event_id(project, report.event_id)
             except Group.DoesNotExist:
                 pass
+        else:
+            try:
+                report.environment = event.get_environment()
+            except Environment.DoesNotExist:
+                pass
+            report.group = event.group
 
         try:
             with transaction.atomic():

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -807,7 +807,9 @@ class EventManager(object):
         UserReport.objects.filter(
             project=project,
             event_id=event_id,
-        ).update(group=group)
+        ).update(
+            group=group,
+            environment=environment)
 
         # save the event unless its been sampled
         if not is_sample:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -809,7 +809,8 @@ class EventManager(object):
             event_id=event_id,
         ).update(
             group=group,
-            environment=environment)
+            environment=environment,
+        )
 
         # save the event unless its been sampled
         if not is_sample:

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+from sentry.testutils import UserReportEnvironmentTestCase
+from exam import fixture
+
+
+class GroupUserReport(UserReportEnvironmentTestCase):
+    @fixture
+    def path(self):
+        return '/api/0/groups/{}/user-feedback/'.format(
+            self.group.id,
+        )
+
+    def test_specified_enviroment(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.path + '?environment=' + self.env1.name)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(self.env1_events)
+        self.assert_same_userreports(response.data, self.env1_userreports)
+
+        response = self.client.get(self.path + '?environment=' + self.env2.name)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(self.env2_events)
+        self.assert_same_userreports(response.data, self.env2_userreports)
+
+    def test_no_environment_does_not_exists(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.path + '?environment=')
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_no_environment(self):
+        self.login_as(user=self.user)
+
+        empty_env = self.create_environment(self.project, u'')
+        empty_env_events = self.create_events_for_environment(self.group, empty_env, 5)
+        userreports = self.create_user_report_for_events(
+            self.project, self.group, empty_env_events, empty_env)
+        response = self.client.get(self.path + '?environment=')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(userreports)
+        self.assert_same_userreports(response.data, userreports)
+
+    def test_all_environments(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.path)
+        userreports = self.env1_userreports + self.env2_userreports
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(userreports)
+        self.assert_same_userreports(response.data, userreports)
+
+    def test_invalid_environment(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.path + '?environment=invalid_env')
+        assert response.status_code == 200
+        assert response.data == []

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -4,7 +4,7 @@ import six
 from exam import fixture
 
 from sentry.testutils import APITestCase, UserReportEnvironmentTestCase
-from sentry.models import EventUser, GroupStatus, UserReport
+from sentry.models import EventUser, Environment, GroupStatus, UserReport
 from sentry.event_manager import EventManager
 
 
@@ -89,12 +89,23 @@ class ProjectUserReportListTest(APITestCase):
 
 
 class CreateProjectUserReportTest(APITestCase):
+    def make_environment(self, project, name='production'):
+        environment = Environment.objects.create(
+            project_id=project.id,
+            organization_id=project.organization_id,
+            name=name,
+        )
+        environment.add_project(project)
+        return environment
+
     def test_simple(self):
         self.login_as(user=self.user)
 
         project = self.create_project()
         group = self.create_group(project=project)
-        event = self.create_event(group=group)
+        environment = self.make_environment(project)
+        event = self.create_event(group=group, tags={
+            'environment': environment.name})
 
         url = '/api/0/projects/{}/{}/user-feedback/'.format(
             project.organization.slug,
@@ -127,7 +138,10 @@ class CreateProjectUserReportTest(APITestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        event = self.create_event(group=group)
+        environment = self.make_environment(project)
+        event = self.create_event(group=group, tags={
+            'environment': environment.name})
+
         UserReport.objects.create(
             group=group,
             project=project,
@@ -168,9 +182,11 @@ class CreateProjectUserReportTest(APITestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
+        environment = self.make_environment(project)
         event = self.create_event(
             group=group, tags={
                 'sentry:user': 'email:foo@example.com',
+                'environment': environment.name,
             }
         )
         euser = EventUser.objects.create(
@@ -219,6 +235,21 @@ class CreateProjectUserReportTest(APITestCase):
 
 
 class ProjectUserReportByEnvironmentsTest(UserReportEnvironmentTestCase):
+
+    def setUp(self):
+        super(ProjectUserReportByEnvironmentsTest, self).setUp()
+        group_2 = self.create_group()
+        env1_events = self.create_events_for_environment(group_2, self.env1, 5)
+        env2_events = self.create_events_for_environment(group_2, self.env2, 5)
+
+        self.env1_userreports += self.create_user_report_for_events(
+            self.project, group_2, env1_events, self.env1)
+        self.env2_userreports += self.create_user_report_for_events(
+            self.project, group_2, env2_events, self.env2)
+
+        self.env1_events += env1_events
+        self.env2_events += env2_events
+
     @fixture
     def path(self):
         return '/api/0/projects/{}/{}/user-feedback/'.format(

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -345,10 +345,20 @@ class ProjectUserReportByEnvironmentsTest(APITestCase):
         assert len(response.data) == len(self.env2_events)
         self.assert_same_userreports(response.data, self.env2_userreports)
 
+    def test_no_environment_does_not_exists(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.path + '?environment=')
+        assert response.status_code == 400
+        assert response.data == {'environment': 'Invalid environment'}
+
     def test_no_environment(self):
         self.login_as(user=self.user)
-        response = self.client.get(self.path)
-        userreports = self.env1_userreports + self.env2_userreports
+
+        empty_env = self.create_environment(self.project, u'')
+        empty_env_events = self.create_events_for_environment(self.group, empty_env, 5)
+        userreports = self.create_user_report_for_events(
+            self.project, self.group, empty_env_events, empty_env)
+        response = self.client.get(self.path + '?environment=')
 
         assert response.status_code == 200, response.content
         assert len(response.data) == len(userreports)

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 
 import six
+import logging
 
 from sentry.testutils import APITestCase
-from sentry.models import EventUser, GroupStatus, UserReport
+from sentry.models import Environment, EventUser, GroupStatus, UserReport
+from sentry.event_manager import EventManager
 
 
 class ProjectUserReportListTest(APITestCase):
@@ -214,3 +216,160 @@ class CreateProjectUserReportTest(APITestCase):
 
         euser = EventUser.objects.get(id=euser.id)
         assert euser.name == 'Foo Bar'
+
+
+class ProjectUserReportByEnvironmentsTest(APITestCase):
+    def setUp(self):
+
+        self.project = self.create_project()
+        self.env1 = self.create_environment(self.project, 'production')
+        self.env2 = self.create_environment(self.project, 'staging')
+
+        self.group = self.create_group(project=self.project)
+
+        self.env1_events = self.create_events_for_environment(self.group, self.env1, 5)
+        self.env2_events = self.create_events_for_environment(self.group, self.env2, 5)
+
+        self.env1_userreports = self.create_user_report_for_events(
+            self.project, self.group, self.env1_events, self.env1)
+        self.env2_userreports = self.create_user_report_for_events(
+            self.project, self.group, self.env2_events, self.env2)
+
+        self.path = '/api/0/projects/{}/{}/user-feedback/'.format(
+            self.project.organization.slug,
+            self.project.slug,
+        )
+
+    def make_event(self, **kwargs):
+        result = {
+            'event_id': 'a' * 32,
+            'message': 'foo',
+            'timestamp': 1403007314.570599,
+            'level': logging.ERROR,
+            'logger': 'default',
+            'tags': [],
+        }
+        result.update(kwargs)
+        return result
+
+    def create_environment(self, project, name):
+        env = Environment.objects.create(
+            project_id=project.id,
+            organization_id=project.organization_id,
+            name=name,
+        )
+        env.add_project(project)
+        return env
+
+    def create_events_for_environment(self, group, environment, num_events):
+        return [self.create_event(group=group, tags={
+            'environment': environment.name}) for __i in range(num_events)]
+
+    def create_user_report_for_events(self, project, group, events, environment):
+        reports = []
+        for i, event in enumerate(events):
+            reports.append(UserReport.objects.create(
+                group=group,
+                project=project,
+                event_id=event.event_id,
+                name='foo%d' % i,
+                email='bar%d@example.com' % i,
+                comments='It Broke!!!',
+                environment=environment,
+            ))
+        return reports
+
+    def test_environment_gets_user_report(self):
+        event_id = 'a' * 32
+        manager = EventManager(
+            self.make_event(
+                environment=self.env1.name,
+                event_id=event_id,
+                group=self.group))
+        manager.normalize()
+        manager.save(self.project.id)
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self.path,
+            data={
+                'event_id': event_id,
+                'email': 'foo@example.com',
+                'name': 'Foo Bar',
+                'comments': 'It broke!',
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert UserReport.objects.get(event_id=event_id).environment == self.env1
+
+    def test_user_report_gets_environment(self):
+        event_id = 'a' * 32
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self.path,
+            data={
+                'event_id': event_id,
+                'email': 'foo@example.com',
+                'name': 'Foo Bar',
+                'comments': 'It broke!',
+            }
+        )
+
+        manager = EventManager(
+            self.make_event(
+                environment=self.env1.name,
+                event_id=event_id,
+                group=self.group))
+        manager.normalize()
+        manager.save(self.project.id)
+        assert response.status_code == 200, response.content
+        assert UserReport.objects.get(event_id=event_id).environment == self.env1
+
+    def test_specified_enviroment(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.path + '?environment=' + self.env1.name)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(self.env1_events)
+        assert sorted(
+            r.get('eventID') for r in response.data) == sorted(
+            r.event_id for r in self.env1_userreports)
+        assert sorted(int(r.get('id'))
+                      for r in response.data) == sorted(r.id for r in self.env1_userreports)
+
+        response = self.client.get(self.path + '?environment=' + self.env2.name)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(self.env2_events)
+        assert sorted(
+            r.get('eventID') for r in response.data) == sorted(
+            r.event_id for r in self.env2_userreports)
+        assert sorted(int(r.get('id'))
+                      for r in response.data) == sorted(r.id for r in self.env2_userreports)
+
+    def test_no_environment(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.path)
+        events = self.env1_events + self.env2_events
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(events)
+        assert response.data == events
+
+    def test_all_environments(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.path)
+        events = self.env1_events + self.env2_events
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(events)
+        assert response.data == events
+
+    def test_invalid_environment(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.path + '?environment=invalid_env')
+
+        assert response.status_code == 400
+        assert response.content == {'environment': 'Invalid environment'}
+        assert len(response.data) == 0
+        assert not response.data

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -850,7 +850,7 @@ class EventManagerTest(TransactionTestCase):
             'environment': environment}), event_id=event_id)
         manager.normalize()
         manager.save(project.id)
-        assert UserReport.objects.filter(event_id=event_id).environment_id == environment.id
+        assert UserReport.objects.filter(event_id=event_id).environment == environment
 
     def test_default_event_type(self):
         manager = EventManager(self.make_event(message='foo bar'))

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -862,33 +862,6 @@ class EventManagerTest(TransactionTestCase):
         manager.save(project.id)
         assert UserReport.objects.get(event_id=event_id).environment == environment
 
-    def test_environment_gets_user_report(self):
-        project = self.create_project()
-        environment = Environment.objects.create(
-            project_id=project.id,
-            organization_id=project.organization_id,
-            name='production',
-        )
-        environment.add_project(project)
-        group = self.create_group(project=project)
-        event_id = 'a' * 32
-        manager = EventManager(
-            self.make_event(
-                environment=environment.name,
-                event_id=event_id,
-                group=group))
-        manager.normalize()
-        manager.save(project.id)
-        UserReport.objects.create(
-            group=self.create_group(project=project),
-            project=project,
-            event_id=event_id,
-            name='foo',
-            email='bar@example.com',
-            comments='It Broke!!!',
-        )
-        assert UserReport.objects.get(event_id=event_id).environment == environment
-
     def test_default_event_type(self):
         manager = EventManager(self.make_event(message='foo bar'))
         data = manager.normalize()


### PR DESCRIPTION
As part of the new environments features in Sentry 9, the ProjectUserReport and the GroupUserReport endpoints will filter on environment. It was also necessary to change part of the event processing pipeline (as well as in the put method of the ProjectUserReportsEndpoint), so that it fills in the new environment field. UserReports created prior to this change will need to be backfilled in the database order to filter.