### PR TITLE
fix(invites): Only show project name in accept org invite page

### DIFF
--- a/src/sentry/templates/sentry/accept-organization-invite.html
+++ b/src/sentry/templates/sentry/accept-organization-invite.html
@@ -30,9 +30,9 @@
         {% if project_count %}
           <p>{% blocktrans %}You have been invited to join this organization, which manages <strong>{{ project_count }}</strong> project(s), including:{% endblocktrans %}</p>
           <ul>
-            {% for project, team in project_team_list|slice:"5" %}
+            {% for project in project_list|slice:"5" %}
               <li>
-                {{ team.name }} &#47; {{ project.name }}
+                {{ project.name }}
               </li>
             {% endfor %}
           </ul>

--- a/src/sentry/web/frontend/accept_organization_invite.py
+++ b/src/sentry/web/frontend/accept_organization_invite.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import (AuditLogEntryEvent, OrganizationMember, Project, ProjectTeam)
+from sentry.models import AuditLogEntryEvent, OrganizationMember, Project
 from sentry.signals import member_joined
 from sentry.utils import auth
 from sentry.web.frontend.base import BaseView
@@ -63,19 +63,11 @@ class AcceptOrganizationInviteView(BaseView):
             organization=organization,
         )
         project_list = list(qs[:25])
-        project_teams = list(ProjectTeam.objects.filter(
-            project__in=project_list,
-        ).select_related('team'))
-        projects_by_id = {p.id: p for p in project_list}
-
-        project_team_context = [
-            (projects_by_id[pt.project_id], pt.team) for pt in project_teams
-        ]
         project_count = qs.count()
 
         context = {
             'organization': om.organization,
-            'project_team_list': project_team_context,
+            'project_list': project_list,
             'project_count': project_count,
             'needs_authentication': not request.user.is_authenticated(),
             'logout_url': '{}?next={}'.format(


### PR DESCRIPTION
I'm not feature gating this just cause it seems like a place where people won't really be confused by the missing team name since it's the very beginning of their use of Sentry.

before:
![screenshot 2018-02-08 13 37 09](https://user-images.githubusercontent.com/5026776/35999939-46a28c54-0cd6-11e8-85f4-e4b9499f03d0.png)

after:
![screenshot 2018-02-08 13 36 29](https://user-images.githubusercontent.com/5026776/35999961-509cbfea-0cd6-11e8-9924-0c21615aa02e.png)
