### PR TITLE
fix: Return all DIFs when uploading fat objects

### DIFF
--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -274,7 +274,7 @@ class DifAssembleEndpoint(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data[total_checksum]['dif']['cpuName'] == 'x86_64'
+        assert response.data[total_checksum]['difs'][0]['cpuName'] == 'x86_64'
 
     def test_dif_error_reponse(self):
         sym_file = 'fail'
@@ -312,4 +312,4 @@ class DifAssembleEndpoint(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data[total_checksum]['error'] == 'Invalid object file'
+        assert response.data[total_checksum]['errors'][0] == 'Invalid object file'


### PR DESCRIPTION
This fixes a bug where the DIF assemble endpoint only returns a single created `ProjectDsymFile` for an uploaded DIF with multiple architectures. The models were created correctly in the database but the endpoint only returned the first file found. 

This is solved by three steps:
1. Resolve all `File` models that match the provided checksum within the organization+project scope
2. If at least one of them contained an error, set the `state` to `ERROR`
3. Always return a list of `errors` and `difs` instead of single values.

In the case that a fat object contained partially breaking architectures, this will render the entire file as ERROR in the CLI and not show the successful objects to the user. I think this should be expected behavior.