### PR TITLE
ref: Remove unused `CursorResult.from_ids` method

### DIFF
--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -14,8 +14,6 @@ from collections import Sequence
 
 class Cursor(object):
     def __init__(self, value, offset=0, is_prev=False, has_results=None):
-        # XXX: ceil is not entirely correct here, but it's a simple hack
-        # that solves most problems
         self.value = int(value)
         self.offset = int(offset)
         self.is_prev = bool(is_prev)

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -64,26 +64,6 @@ class CursorResult(Sequence):
     def __repr__(self):
         return '<%s: results=%s>' % (type(self).__name__, len(self.results))
 
-    @classmethod
-    def from_ids(cls, id_list, key=None, limit=100, cursor=None):
-        from sentry.models import Group
-
-        group_map = Group.objects.in_bulk(id_list)
-
-        results = []
-        for g_id in id_list:
-            try:
-                results.append(group_map[g_id])
-            except KeyError:
-                pass
-
-        return build_cursor(
-            results=results,
-            key=key,
-            cursor=cursor,
-            limit=limit,
-        )
-
 
 def _build_next_values(cursor, results, key, limit, is_desc):
     value = cursor.value


### PR DESCRIPTION
The last usage of this was removed in 17b598f9719ec9ed71471b8ded288455f1e06e42.