### PR TITLE
fix(router): Async Component works without the location prop passed

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -11,6 +11,10 @@ import LoadingIndicator from '../components/loadingIndicator';
 import RouteError from './../views/routeError';
 
 class AsyncComponent extends React.Component {
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+
   constructor(props, context) {
     super(props, context);
 
@@ -25,11 +29,11 @@ class AsyncComponent extends React.Component {
     this.fetchData();
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps, nextContext) {
     // re-fetch data when router params change
     if (
       !isEqual(this.props.params, nextProps.params) ||
-      this.props.location.search !== nextProps.location.search
+      this.context.router.location.search !== nextContext.router.location.search
     ) {
       this.remountComponent();
     }
@@ -208,10 +212,6 @@ AsyncComponent.errorHandler = (component, fn) => {
       return null;
     }
   };
-};
-
-AsyncComponent.contextTypes = {
-  router: PropTypes.object.isRequired,
 };
 
 export default AsyncComponent;

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -31,6 +31,7 @@ class CreateProjectTest(AcceptanceTestCase):
 
         self.browser.click('.new-project-submit')
         self.browser.wait_until(title='Java')
+        self.browser.wait_until_not('.loading')
 
         project = Project.objects.get(organization=self.org)
         assert project.name == 'Java'

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -34,6 +34,7 @@ window.TestStubs = {
     setRouteLeaveHook: sinon.spy(),
     isActive: sinon.spy(),
     createHref: sinon.spy(),
+    location: sinon.spy(),
   }),
 
   location: () => ({


### PR DESCRIPTION
`this.props.location` isn't passed down to child components. Probably changed in React Router 3.

Fixes #7245