### PR TITLE
fix(asynccomponent): Get location from props if no router context

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -30,10 +30,19 @@ class AsyncComponent extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
+    const isRouterInContext = !!this.context.router;
+
+    const currentLocation = isRouterInContext
+      ? this.context.router.location
+      : this.props.location;
+    const nextLocation = isRouterInContext
+      ? nextContext.router.location
+      : this.context.router.location;
+
     // re-fetch data when router params change
     if (
       !isEqual(this.props.params, nextProps.params) ||
-      this.context.router.location.search !== nextContext.router.location.search
+      currentLocation.search !== nextLocation.search
     ) {
       this.remountComponent();
     }

--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -12,7 +12,7 @@ import RouteError from './../views/routeError';
 
 class AsyncComponent extends React.Component {
   static contextTypes = {
-    router: PropTypes.object.isRequired,
+    router: PropTypes.object,
   };
 
   constructor(props, context) {
@@ -37,7 +37,7 @@ class AsyncComponent extends React.Component {
       : this.props.location;
     const nextLocation = isRouterInContext
       ? nextContext.router.location
-      : this.context.router.location;
+      : nextProps.location;
 
     // re-fetch data when router params change
     if (


### PR DESCRIPTION
Router might not always be in context wherever the AsyncComponent is used.

Get the location from props if that's the case