### PR TITLE
fix(api): Error page adds environment

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -46,6 +46,7 @@ from sentry.auth.providers.dummy import DummyProvider
 from sentry.auth.superuser import (
     Superuser, COOKIE_SALT as SU_COOKIE_SALT, COOKIE_NAME as SU_COOKIE_NAME
 )
+from sentry.event_manager import EventManager
 from sentry.constants import MODULE_ROOT
 from sentry.models import (
     GroupMeta, ProjectOption, DeletedOrganization, Environment, GroupStatus, Organization, TotpInterface, UserReport
@@ -396,7 +397,9 @@ class UserReportEnvironmentTestCase(APITestCase):
             'tags': [],
         }
         result.update(kwargs)
-        return result
+        manager = EventManager(result)
+        manager.normalize()
+        manager.save(self.project.id)
 
     def create_environment(self, project, name):
         env = Environment.objects.create(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -46,7 +46,6 @@ from sentry.auth.providers.dummy import DummyProvider
 from sentry.auth.superuser import (
     Superuser, COOKIE_SALT as SU_COOKIE_SALT, COOKIE_NAME as SU_COOKIE_NAME
 )
-from sentry.event_manager import EventManager
 from sentry.constants import MODULE_ROOT
 from sentry.models import (
     GroupMeta, ProjectOption, DeletedOrganization, Environment, GroupStatus, Organization, TotpInterface, UserReport
@@ -397,9 +396,7 @@ class UserReportEnvironmentTestCase(APITestCase):
             'tags': [],
         }
         result.update(kwargs)
-        manager = EventManager(result)
-        manager.normalize()
-        manager.save(self.project.id)
+        return result
 
     def create_environment(self, project, name):
         env = Environment.objects.create(

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -3,9 +3,11 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 from six.moves.urllib.parse import quote
 from uuid import uuid4
+import logging
 
-from sentry.models import UserReport
+from sentry.models import Environment, UserReport
 from sentry.testutils import TestCase
+from sentry.event_manager import EventManager
 
 
 class ErrorPageEmbedTest(TestCase):
@@ -91,3 +93,74 @@ class ErrorPageEmbedTest(TestCase):
             HTTP_REFERER='http://example.com'
         )
         assert resp.status_code == 400
+
+
+class ErrorPageEmbedEnvironmentTest(TestCase):
+
+    urls = 'sentry.conf.urls'
+
+    def setUp(self):
+        self.project = self.create_project()
+        self.project.update_option('sentry:origins', ['example.com'])
+        self.key = self.create_project_key(self.project)
+        self.event_id = uuid4().hex
+        self.path = '%s?eventId=%s&dsn=%s' % (
+            reverse('sentry-error-page-embed'), quote(self.event_id), quote(self.key.dsn_public),
+        )
+        self.environment = Environment.objects.create(
+            project_id=self.project.id,
+            organization_id=self.project.organization_id,
+            name='production',
+        )
+        self.environment.add_project(self.project)
+
+    def make_event(self, **kwargs):
+        result = {
+            'event_id': 'a' * 32,
+            'message': 'foo',
+            'timestamp': 1403007314.570599,
+            'level': logging.ERROR,
+            'logger': 'default',
+            'tags': [],
+        }
+        result.update(kwargs)
+        manager = EventManager(result)
+        manager.normalize()
+        manager.save(self.project.id)
+
+    def test_environment_gets_user_report(self):
+        self.make_event(
+            environment=self.environment.name,
+            event_id=self.event_id,
+            group=self.group,
+        )
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self.path, {
+                'name': 'Jane Doe',
+                'email': 'jane@example.com',
+                'comments': 'This is an example!',
+            },
+            HTTP_REFERER='http://example.com'
+        )
+
+        assert response.status_code == 200, response.content
+        assert UserReport.objects.get(event_id=self.event_id).environment == self.environment
+
+    def test_user_report_gets_environment(self):
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self.path, {
+                'name': 'Jane Doe',
+                'email': 'jane@example.com',
+                'comments': 'This is an example!',
+            },
+            HTTP_REFERER='http://example.com'
+        )
+        self.make_event(
+            environment=self.environment.name,
+            event_id=self.event_id,
+            group=self.group,
+        )
+        assert response.status_code == 200, response.content
+        assert UserReport.objects.get(event_id=self.event_id).environment == self.environment


### PR DESCRIPTION
A part of the environments sentry 9 changes, the embedded error page generates a lot of UserReports, but was missed during previous changes. This changes the embedded error page so that it fills in the UserReport's environment column.