### PR TITLE
feat(ui): Add polish to API Application Details + form fixes

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -41,6 +41,11 @@ class Client {
       return url === response.url && (options.method || 'GET') === response.method;
     });
   }
+
+  uniqueId() {
+    return '123';
+  }
+
   // In the real client, this clears in-flight responses. It's NOT clearMockResponses. You probably don't want to call this from a test.
   clear() {}
 

--- a/src/sentry/static/sentry/app/stores/teamStore.jsx
+++ b/src/sentry/static/sentry/app/stores/teamStore.jsx
@@ -35,6 +35,18 @@ const TeamStore = Reflux.createStore({
     if (!item) {
       this.items.push(response);
     } else {
+      // Slug was changed
+      // Note: This is the proper way to handle slug changes but unfortunately not all of our
+      // components use stores correctly. To be safe reload browser :((
+      if (response.slug !== itemId) {
+        // Remove old team
+        this.items = this.items.filter(({slug}) => slug !== itemId);
+        // Add team w/ updated slug
+        this.items.push(response);
+        this.trigger(new Set([response.slug]));
+        return;
+      }
+
       $.extend(true /*deep*/, item, response);
     }
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
@@ -147,6 +147,7 @@ class AccountEmails extends AsyncView {
           apiMethod="POST"
           apiEndpoint={ENDPOINT}
           saveOnBlur
+          allowUndo={false}
           onSubmitSuccess={this.handleSubmitSuccess}
         >
           <JsonForm location={this.props.location} forms={accountEmailsFields} />

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
@@ -12,6 +12,7 @@ import JsonForm from '../components/forms/jsonForm';
 import Panel from '../components/panel';
 import PanelBody from '../components/panelBody';
 import PanelHeader from '../components/panelHeader';
+import SettingsPageHeader from '../components/settingsPageHeader';
 import TextCopyInput from '../components/forms/textCopyInput';
 import apiApplication from '../../../data/forms/apiApplication';
 
@@ -60,6 +61,8 @@ class ApiApplicationDetails extends AsyncView {
 
     return (
       <div>
+        <SettingsPageHeader title={this.getTitle()} />
+
         <Form
           apiMethod="PUT"
           apiEndpoint={`/api-applications/${this.props.params.appId}/`}

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplicationDetails.jsx
@@ -2,7 +2,7 @@ import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {addErrorMessage, addSuccessMessage} from '../../../actionCreators/indicator';
+import {addErrorMessage} from '../../../actionCreators/indicator';
 import {t} from '../../../locale';
 import AsyncView from '../../asyncView';
 import ConfigStore from '../../../stores/configStore';
@@ -38,24 +38,6 @@ class ApiApplicationDetails extends AsyncView {
     return 'Application Details';
   }
 
-  handleSubmitSuccess = (change, model, id) => {
-    if (!model) return;
-
-    let label = model.getDescriptor(id, 'label');
-
-    if (!label) return;
-
-    addSuccessMessage(`Changed ${label} from "${change.old}" to "${change.new}"`, 2000, {
-      model,
-      id,
-    });
-
-    // Special case for slug, need to forward to new slug
-    if (typeof onSave === 'function') {
-      this.props.onSave(this.props.initialData, model.initialData);
-    }
-  };
-
   renderBody() {
     let urlPrefix = ConfigStore.get('urlPrefix');
 
@@ -69,7 +51,6 @@ class ApiApplicationDetails extends AsyncView {
           saveOnBlur
           allowUndo
           initialData={this.state.app}
-          onSubmitSuccess={this.handleSubmitSuccess}
           onSubmitError={err => addErrorMessage('Unable to save change')}
         >
           <Box>

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+  removeIndicator,
+} from '../../../actionCreators/indicator';
 import {t} from '../../../locale';
 import ApiMixin from '../../../mixins/apiMixin';
 import AsyncView from '../../asyncView';
@@ -111,16 +117,17 @@ class ApiApplications extends AsyncView {
   }
 
   handleCreateApplication = () => {
-    let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+    let indicator = addLoadingMessage();
     this.api.request('/api-applications/', {
       method: 'POST',
       success: app => {
-        IndicatorStore.remove(loadingIndicator);
+        addSuccessMessage(t('Created a new API Application'));
+        removeIndicator(indicator);
         this.context.router.push(`${ROUTE_PREFIX}applications/${app.id}/`);
       },
       error: error => {
-        IndicatorStore.remove(loadingIndicator);
-        IndicatorStore.add(t('Unable to remove application. Please try again.'), 'error');
+        removeIndicator(indicator);
+        addErrorMessage(t('Unable to remove application. Please try again.'));
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/settings/account/avatar.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/avatar.jsx
@@ -44,7 +44,9 @@ const AccountAvatar = createReactClass({
 
   componentWillReceiveProps(nextProps) {
     // Update local state if defined in props
-    this.setState({user: nextProps.user});
+    if (typeof nextProps.user !== 'undefined') {
+      this.setState({user: nextProps.user});
+    }
   },
 
   getEndpoint() {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -352,7 +352,7 @@ class FormModel {
 
     let fieldDescriptor = this.fieldDescriptor.get(id);
 
-    // Check if field needs to handle
+    // Check if field needs to handle transforming request object
     let getData =
       typeof fieldDescriptor.getData === 'function' ? fieldDescriptor.getData : a => a;
 
@@ -374,7 +374,7 @@ class FormModel {
         }
 
         // Update initialData after successfully saving a field as it will now be the baseline value
-        this.initialData[id] = newValue;
+        this.initialData[id] = this.getValue(id);
 
         return data;
       })

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -370,6 +370,9 @@ class FormModel {
           saveSnapshot = null;
         }
 
+        // Update initialData after successfully saving a field as it will now be the baseline value
+        this.initialData[id] = newValue;
+
         return data;
       })
       .catch(resp => {
@@ -422,7 +425,6 @@ class FormModel {
     return savePromise
       .then(change => {
         let newValue = this.getValue(id);
-        this.initialData[id] = newValue;
         let result = {old: oldValue, new: newValue};
 
         if (this.options.onSubmitSuccess) {

--- a/src/sentry/static/sentry/app/views/settings/organization/general/organizationSettingsForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/general/organizationSettingsForm.jsx
@@ -4,10 +4,7 @@ import React from 'react';
 
 import createReactClass from 'create-react-class';
 
-import {
-  addErrorMessage,
-  saveOnBlurUndoMessage,
-} from '../../../../actionCreators/indicator';
+import {addErrorMessage} from '../../../../actionCreators/indicator';
 import ApiMixin from '../../../../mixins/apiMixin';
 import Form from '../../components/forms/form';
 import JsonForm from '../../components/forms/jsonForm';
@@ -53,8 +50,7 @@ const NewOrganizationSettingsForm = createReactClass({
         saveOnBlur
         allowUndo
         initialData={initialData}
-        onSubmitSuccess={(change, model, fieldName) => {
-          saveOnBlurUndoMessage(change, model, fieldName);
+        onSubmitSuccess={(resp, model, fieldName, change) => {
           // Special case for slug, need to forward to new slug
           if (typeof onSave === 'function') {
             onSave(initialData, model.initialData);

--- a/src/sentry/static/sentry/app/views/settings/team/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/model.jsx
@@ -3,11 +3,20 @@ import FormModel from '../components/forms/model';
 
 class TeamFormModel extends FormModel {
   doApiRequest({data}) {
-    return updateTeam(this.api, {
-      orgId: this.orgId,
-      teamId: this.teamId,
-      data,
-    });
+    return new Promise((resolve, reject) =>
+      updateTeam(
+        this.api,
+        {
+          orgId: this.orgId,
+          teamId: this.teamId,
+          data,
+        },
+        {
+          success: resolve,
+          error: reject,
+        }
+      )
+    );
   }
 }
 

--- a/src/sentry/static/sentry/app/views/settings/team/teamSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamSettings.jsx
@@ -2,7 +2,7 @@ import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {addErrorMessage, saveOnBlurUndoMessage} from '../../../actionCreators/indicator';
+import {addErrorMessage} from '../../../actionCreators/indicator';
 import AsyncView from '../../asyncView';
 import Form from '../components/forms/form';
 import JsonForm from '../components/forms/jsonForm';
@@ -43,9 +43,6 @@ export default class TeamSettings extends AsyncView {
         apiMethod="PUT"
         saveOnBlur
         allowUndo
-        onSubmitSuccess={(change, model, id) => {
-          saveOnBlurUndoMessage(change, model, id);
-        }}
         onSubmitError={() => addErrorMessage('Unable to save change', TOAST_DURATION)}
         initialData={{
           name: team.name,

--- a/src/sentry/static/sentry/app/views/settings/team/teamSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamSettings.jsx
@@ -2,14 +2,13 @@ import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {addErrorMessage} from '../../../actionCreators/indicator';
+import {addErrorMessage, addLoadingMessage} from '../../../actionCreators/indicator';
+import {t} from '../../../locale';
 import AsyncView from '../../asyncView';
 import Form from '../components/forms/form';
 import JsonForm from '../components/forms/jsonForm';
-import teamSettingsFields from '../../../data/forms/teamSettingsFields';
 import TeamModel from './model';
-
-const TOAST_DURATION = 10000;
+import teamSettingsFields from '../../../data/forms/teamSettingsFields';
 
 export default class TeamSettings extends AsyncView {
   static propTypes = {
@@ -34,6 +33,23 @@ export default class TeamSettings extends AsyncView {
     return 'Team Settings';
   }
 
+  handleSubmitSuccess = (resp, model, id, change) => {
+    if (id === 'slug') {
+      addLoadingMessage(t('Slug changed, refreshing page...'));
+      window.location.assign(
+        `/settings/organization/${this.props.params.orgId}/teams/${model.getValue(
+          id
+        )}/settings/`
+      );
+      this.props.router.push(
+        `/settings/organization/${this.props.params.orgId}/teams/${model.getValue(
+          id
+        )}/settings/`
+      );
+      this.setState({loading: true});
+    }
+  };
+
   renderBody() {
     let team = this.props.team;
 
@@ -43,7 +59,8 @@ export default class TeamSettings extends AsyncView {
         apiMethod="PUT"
         saveOnBlur
         allowUndo
-        onSubmitError={() => addErrorMessage('Unable to save change', TOAST_DURATION)}
+        onSubmitSuccess={this.handleSubmitSuccess}
+        onSubmitError={() => addErrorMessage(t('Unable to save change'))}
         initialData={{
           name: team.name,
           slug: team.slug,

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 
 import TeamSettings from 'app/views/settings/team/teamSettings.old';
+import NewTeamSettings from 'app/views/settings/team/teamSettings';
 
 const childContextTypes = {
   organization: PropTypes.object,
@@ -10,6 +11,7 @@ const childContextTypes = {
   location: PropTypes.object,
 };
 
+// #NEW-SETTINGS
 describe('TeamSettings', function() {
   describe('render()', function() {
     it('renders', function() {
@@ -32,5 +34,71 @@ describe('TeamSettings', function() {
       wrapper.update();
       expect(wrapper).toMatchSnapshot();
     });
+  });
+});
+
+describe('NewTeamSettings', function() {
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    sinon.stub(window.location, 'assign');
+  });
+
+  afterEach(function() {
+    window.location.assign.restore();
+  });
+
+  it('can change name and slug', function(done) {
+    let team = TestStubs.Team();
+    let putMock = MockApiClient.addMockResponse({
+      url: `/teams/org/${team.slug}/`,
+      method: 'PUT',
+    });
+
+    let wrapper = mount(
+      <NewTeamSettings
+        routes={[]}
+        params={{orgId: 'org', teamId: team.slug}}
+        team={team}
+        onTeamChange={() => {}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    wrapper
+      .find('input[name="name"]')
+      .simulate('change', {target: {value: 'New Name'}})
+      .simulate('blur');
+
+    expect(putMock).toHaveBeenCalledWith(
+      `/teams/org/${team.slug}/`,
+      expect.objectContaining({
+        data: {
+          name: 'New Name',
+        },
+      })
+    );
+
+    wrapper
+      .find('input[name="slug"]')
+      .simulate('change', {target: {value: 'new-slug'}})
+      .simulate('blur');
+
+    expect(putMock).toHaveBeenCalledWith(
+      `/teams/org/${team.slug}/`,
+      expect.objectContaining({
+        data: {
+          slug: 'new-slug',
+        },
+      })
+    );
+
+    setTimeout(() => {
+      expect(
+        window.location.assign.calledWith(
+          '/settings/organization/org/teams/new-slug/settings/'
+        )
+      ).toBe(true);
+      done();
+    }, 1);
   });
 });


### PR DESCRIPTION
* Add success toast after creating a new API Application
* Change saveOnBlur forms to send saved + undo indicator by default
* Fix form undo + add test

Review this commit range: https://github.com/getsentry/sentry/pull/7274/files/e4edc3f54a309de86e4f16b4776d0de6eebde98f..b777ae809f6639a58746ef61a810802129c6606f