### PR TITLE
fix(environments): Fix query string generation

### DIFF
--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -370,7 +370,7 @@ const Stream = createReactClass({
     let url = this.getGroupListEndpoint();
 
     // Remove leading and trailing whitespace
-    let query = this.state.query.replace(/^\s+|\s+$/g, '');
+    let query = streamUtils.formatQueryString(this.state.query);
 
     let activeEnvironment = this.state.activeEnvironment;
     let activeEnvName = activeEnvironment ? activeEnvironment.name : null;

--- a/src/sentry/static/sentry/app/views/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream.jsx
@@ -25,11 +25,10 @@ import StreamFilters from './stream/filters';
 import StreamSidebar from './stream/sidebar';
 import TimeSince from '../components/timeSince';
 import utils from '../utils';
+import streamUtils from './stream/utils';
 import {logAjaxError} from '../utils/logging';
 import parseLinkHeader from '../utils/parseLinkHeader';
 import {t, tn, tct} from '../locale';
-
-import {objToQuery, queryToObj} from '../utils/stream';
 
 import {setActiveEnvironment} from '../actionCreators/environments';
 
@@ -386,20 +385,18 @@ const Stream = createReactClass({
 
     // Always keep the global active environment in sync with the queried environment
     // The global environment wins unless there one is specified by the saved search
-    let queryObj = queryToObj(query);
-    if ('environment' in queryObj) {
+    const queryEnvironment = streamUtils.getQueryEnvironment(query);
+
+    if (queryEnvironment !== null) {
       // Set the global environment to the one specified by the saved search
-      if (queryObj.environment !== activeEnvName) {
-        let env = EnvironmentStore.getByName(queryObj.environment);
+      if (queryEnvironment !== activeEnvName) {
+        let env = EnvironmentStore.getByName(queryEnvironment);
         setActiveEnvironment(env);
       }
-      requestParams.environment = queryObj.environment;
+      requestParams.environment = queryEnvironment;
     } else if (activeEnvironment) {
       // Set the environment of the query to match the global settings
-      query = objToQuery({
-        ...queryObj,
-        environment: activeEnvironment.name,
-      });
+      query = streamUtils.getQueryStringWithEnvironment(query, activeEnvironment.name);
       requestParams.query = query;
       requestParams.environment = activeEnvironment.name;
     }
@@ -539,22 +536,10 @@ const Stream = createReactClass({
       // the environment parameter is part of the saved search
       let environment = context.environment;
 
-      let query = this.state.query;
-
-      if (environment) {
-        // Environment has changed: append the new environment to the query
-        query = objToQuery({
-          ...queryToObj(this.state.query),
-          environment: environment.name,
-        });
-      } else {
-        // Environment is null, remove it from the query
-        let queryObj = queryToObj(this.state.query);
-        delete queryObj.environment;
-        query = objToQuery({
-          ...queryObj,
-        });
-      }
+      let query = streamUtils.getQueryStringWithEnvironment(
+        this.state.query,
+        environment.name
+      );
 
       this.setState(
         {

--- a/src/sentry/static/sentry/app/views/stream/utils.js
+++ b/src/sentry/static/sentry/app/views/stream/utils.js
@@ -1,3 +1,8 @@
+// remove leading and trailing whitespace and remove double spaces
+function formatQueryString(qs) {
+  return qs.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
+}
+
 // returns environment name from query or null if not specified
 function getQueryEnvironment(qs) {
   const match = qs.match(/environment:(\w*)/);
@@ -5,11 +10,14 @@ function getQueryEnvironment(qs) {
 }
 
 function getQueryStringWithEnvironment(qs, env) {
-  let qsWithoutEnv = qs.replace(/environment:\w+/g, '');
-  return env === null ? qsWithoutEnv : qsWithoutEnv + ` environment:${env}`;
+  const qsWithoutEnv = qs.replace(/environment:\w+/g, '');
+  return formatQueryString(
+    env === null ? qsWithoutEnv : qsWithoutEnv + ` environment:${env}`
+  );
 }
 
 export default {
+  formatQueryString,
   getQueryEnvironment,
   getQueryStringWithEnvironment,
 };

--- a/src/sentry/static/sentry/app/views/stream/utils.js
+++ b/src/sentry/static/sentry/app/views/stream/utils.js
@@ -1,0 +1,15 @@
+// returns environment name from query or null if not specified
+function getQueryEnvironment(qs) {
+  const match = qs.match(/environment:(\w*)/);
+  return match ? match[1] : null;
+}
+
+function getQueryStringWithEnvironment(qs, env) {
+  let qsWithoutEnv = qs.replace(/environment:\w+/g, '');
+  return env === null ? qsWithoutEnv : qsWithoutEnv + ` environment:${env}`;
+}
+
+export default {
+  getQueryEnvironment,
+  getQueryStringWithEnvironment,
+};

--- a/src/sentry/static/sentry/app/views/stream/utils.js
+++ b/src/sentry/static/sentry/app/views/stream/utils.js
@@ -1,6 +1,6 @@
 // remove leading and trailing whitespace and remove double spaces
 function formatQueryString(qs) {
-  return qs.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
+  return qs.trim().replace(/\s+/g, ' ');
 }
 
 // returns environment name from query or null if not specified

--- a/tests/js/spec/views/stream/utils.spec.js
+++ b/tests/js/spec/views/stream/utils.spec.js
@@ -1,0 +1,42 @@
+import utils from 'app/views/stream/utils';
+
+describe('getQueryEnvironment()', function() {
+  it('returns environment name', function() {
+    const qs = 'is:unresolved is:unassigned environment:production';
+    expect(utils.getQueryEnvironment(qs)).toBe('production');
+  });
+
+  // empty environment aka. (No environment) has '' as a name
+  it('returns empty string environment (the empty environment case)', function() {
+    const qs = 'is:unresolved is:unassigned environment:';
+    expect(utils.getQueryEnvironment(qs)).toBe('');
+  });
+
+  it('returns null if no environment specified in query', function() {
+    const qs = 'is:unresolved is:unassigned';
+    expect(utils.getQueryEnvironment(qs)).toBe(null);
+  });
+});
+
+describe('getQueryStringWithEnvironment', function() {
+  it('replaces environment in query string', function() {
+    const qs = 'is:unresolved environment:development is:unassigned';
+    expect(utils.getQueryStringWithEnvironment(qs, 'staging')).toBe(
+      'is:unresolved is:unassigned environment:staging'
+    );
+  });
+
+  it('handles empty string environment', function() {
+    const qs = 'is:unresolved environment:development is:unassigned';
+    expect(utils.getQueryStringWithEnvironment(qs, '')).toBe(
+      'is:unresolved is:unassigned environment:'
+    );
+  });
+
+  it('handles null environment', function() {
+    const qs = 'is:unresolved environment:development is:unassigned';
+    expect(utils.getQueryStringWithEnvironment(qs, null)).toBe(
+      'is:unresolved is:unassigned'
+    );
+  });
+});


### PR DESCRIPTION
We shouldn't use objToQuery/queryToObj since there can be duplicate keys
e.g. is:unresolved is:unassigned