### PR TITLE
fix: Correct handling of null values passed to `RuleSerializer`

### DIFF
--- a/src/sentry/api/endpoints/group_environment_details.py
+++ b/src/sentry/api/endpoints/group_environment_details.py
@@ -18,8 +18,7 @@ class GroupEnvironmentDetailsEndpoint(GroupEndpoint):
             environment = Environment.objects.get(
                 projects=project,
                 organization_id=project.organization_id,
-                # XXX(dcramer): we have no great way to pass the empty env
-                name='' if environment == 'none' else environment,
+                name=Environment.get_name_from_path_segment(environment),
             )
         except Environment.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/project_environment_details.py
+++ b/src/sentry/api/endpoints/project_environment_details.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import EnvironmentProject
+from sentry.models import Environment, EnvironmentProject
 
 
 class ProjectEnvironmentSerializer(serializers.Serializer):
@@ -18,7 +18,7 @@ class ProjectEnvironmentDetailsEndpoint(ProjectEndpoint):
         try:
             instance = EnvironmentProject.objects.select_related('environment').get(
                 project=project,
-                environment__name='' if environment == 'none' else environment,
+                environment__name=Environment.get_name_from_path_segment(environment),
             )
         except EnvironmentProject.DoesNotExist:
             raise ResourceDoesNotExist
@@ -29,7 +29,7 @@ class ProjectEnvironmentDetailsEndpoint(ProjectEndpoint):
         try:
             instance = EnvironmentProject.objects.select_related('environment').get(
                 project=project,
-                environment__name='' if environment == 'none' else environment,
+                environment__name=Environment.get_name_from_path_segment(environment),
             )
         except EnvironmentProject.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -58,7 +58,7 @@ class RuleNodeField(serializers.WritableField):
 
 class RuleSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=64)
-    environment = serializers.CharField(max_length=64, required=False)
+    environment = serializers.CharField(max_length=64, required=False, allow_none=True)
     actionMatch = serializers.ChoiceField(
         choices=(('all', 'all'), ('any', 'any'), ('none', 'none'), )
     )

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -92,3 +92,12 @@ class Environment(Model):
                 EnvironmentProject.objects.create(project=project, environment=self)
         except IntegrityError:
             pass
+
+    @staticmethod
+    def get_name_from_path_segment(segment):
+        # In cases where the environment name is passed as a URL path segment,
+        # the (case-sensitive) string "none" represents the empty string
+        # environment name for historic reasons (see commit b09858f.) In all
+        # other contexts (incl. request query string parameters), the empty
+        # string should be used.
+        return segment if segment != 'none' else ''

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -61,6 +61,30 @@ class ProjectRuleDetailsTest(APITestCase):
         assert response.data['id'] == six.text_type(rule.id)
         assert response.data['environment'] == 'production'
 
+    def test_with_null_environment(self):
+        self.login_as(user=self.user)
+
+        team = self.create_team()
+        project1 = self.create_project(teams=[team], name='foo')
+        self.create_project(teams=[team], name='bar')
+
+        rule = project1.rule_set.all()[0]
+        rule.update(environment_id=None)
+
+        url = reverse(
+            'sentry-api-0-project-rule-details',
+            kwargs={
+                'organization_slug': project1.organization.slug,
+                'project_slug': project1.slug,
+                'rule_id': rule.id,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == six.text_type(rule.id)
+        assert response.data['environment'] is None
+
 
 class UpdateProjectRuleTest(APITestCase):
     def test_simple(self):

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -181,6 +181,41 @@ class UpdateProjectRuleTest(APITestCase):
             'production',
         ).id
 
+    def test_with_null_environment(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        rule = Rule.objects.create(project=project, label='foo')
+
+        url = reverse(
+            'sentry-api-0-project-rule-details',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'project_slug': project.slug,
+                'rule_id': rule.id,
+            }
+        )
+        response = self.client.put(
+            url,
+            data={
+                'name': 'hello world',
+                'environment': None,
+                'actionMatch': 'any',
+                'actions': [],
+                'conditions': []
+            },
+            format='json'
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == six.text_type(rule.id)
+        assert response.data['environment'] is None
+
+        rule = Rule.objects.get(id=rule.id)
+        assert rule.label == 'hello world'
+        assert rule.environment_id is None
+
     def test_invalid_rule_node_type(self):
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -172,6 +172,7 @@ class UpdateProjectRuleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data['id'] == six.text_type(rule.id)
+        assert response.data['environment'] == 'production'
 
         rule = Rule.objects.get(id=rule.id)
         assert rule.label == 'hello world'

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -127,6 +127,50 @@ class CreateProjectRuleTest(APITestCase):
             'production',
         ).id
 
+    def test_with_null_environment(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        conditions = [
+            {
+                'id': 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+                'key': 'foo',
+                'match': 'eq',
+                'value': 'bar',
+            }
+        ]
+
+        actions = [{'id': 'sentry.rules.actions.notify_event.NotifyEventAction'}]
+
+        url = reverse(
+            'sentry-api-0-project-rules',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'project_slug': project.slug,
+            }
+        )
+        response = self.client.post(
+            url,
+            data={
+                'name': 'hello world',
+                'environment': None,
+                'conditions': conditions,
+                'actions': actions,
+                'actionMatch': 'any',
+                'frequency': 30,
+            },
+            format='json'
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data['id']
+        assert response.data['environment'] is None
+
+        rule = Rule.objects.get(id=response.data['id'])
+        assert rule.label == 'hello world'
+        assert rule.environment_id is None
+
     def test_missing_name(self):
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -118,6 +118,7 @@ class CreateProjectRuleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data['id']
+        assert response.data['environment'] == 'production'
 
         rule = Rule.objects.get(id=response.data['id'])
         assert rule.label == 'hello world'


### PR DESCRIPTION
This also continues the pattern of rewriting empty string environment names to "none".

References GH-7010, GH-7265.