### PR TITLE
fix(note): displaying codes in preview

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/noteInput.jsx
+++ b/src/sentry/static/sentry/app/components/activity/noteInput.jsx
@@ -331,7 +331,7 @@ const NoteInput = createReactClass({
           {preview ? (
             <div
               className="note-preview"
-              dangerouslySetInnerHTML={{__html: marked(value)}}
+              dangerouslySetInnerHTML={{__html: marked(this.cleanMarkdown(value))}}
             />
           ) : (
             <MentionsInput


### PR DESCRIPTION
prevents: 
<img width="869" alt="screenshot 2018-02-16 14 38 14" src="https://user-images.githubusercontent.com/5915546/36332448-0af53dbc-1327-11e8-9c44-3215d87faceb.png">
