### PR TITLE
chore(environments): Add empty environment to mock data

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -57,6 +57,7 @@ ENVIRONMENTS = itertools.cycle([
     'staging',
     'alpha',
     'beta',
+    ''
 ])
 
 
@@ -75,6 +76,7 @@ def create_sample_event(*args, **kwargs):
         if event is not None:
             features.record([event])
             return event
+
 
 def generate_commits(user):
     commits = []


### PR DESCRIPTION
It's helpful to have the empty environment in mock data as this is a default value when no environment is set and often needs to be handled differently