### PR TITLE
feat(ui): more robust empty message component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,5 +52,6 @@
     "python.unitTest.pyTestEnabled": false,
     "python.unitTest.unittestEnabled": false,
     "python.unitTest.nosetestsEnabled": false,
-    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js"
+    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js",
+    "restructuredtext.workspaceRoot": "/Users/ckj/src/sentry"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,5 @@
     "python.unitTest.pyTestEnabled": false,
     "python.unitTest.unittestEnabled": false,
     "python.unitTest.nosetestsEnabled": false,
-    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js",
-    "restructuredtext.workspaceRoot": "/Users/ckj/src/sentry"
+    "prettier-eslint.prettierPath": "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js"
 }

--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import Panel from 'settings-ui/panel';
+import PanelHeader from 'settings-ui/panelHeader';
+import EmptyMessage from 'settings-ui/emptyMessage';
+
+import Button from 'sentry-ui/buttons/button';
+
+storiesOf('EmptyMessage', module)
+  .add(
+    'default',
+    withInfo('Super Generic')(() => (
+      <div style={{background: '#fff'}}>
+        <EmptyMessage>Nothing to see here</EmptyMessage>
+      </div>
+    ))
+  )
+  .add(
+    'in panel',
+    withInfo('Put this in a panel for maximum effect')(() => (
+      <Panel>
+        <PanelHeader>Audit Log</PanelHeader>
+        <EmptyMessage>No critical actions taken in this period</EmptyMessage>
+      </Panel>
+    ))
+  )
+  .add(
+    'in panel with icon',
+    withInfo('Put this in a panel for maximum effect')(() => (
+      <Panel>
+        <PanelHeader>Members</PanelHeader>
+        <EmptyMessage icon="icon-user">Sentry is better with friends</EmptyMessage>
+      </Panel>
+    ))
+  )
+  .add(
+    'in panel with icon and action',
+    withInfo('Put this in a panel for maximum effect')(() => (
+      <Panel>
+        <PanelHeader>Members</PanelHeader>
+        <EmptyMessage
+          icon="icon-user"
+          action={<Button priority="primary">Invite Members</Button>}
+        >
+          Sentry is better with friends
+        </EmptyMessage>
+      </Panel>
+    ))
+  );

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -1,12 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
-const EmptyMessage = styled.div`
-  display: flex;
-  justify-content: center;
-  padding: 18px;
+import InlineSvg from '../../../components/inlineSvg';
+
+const Wrapper = styled.div`
+  color: ${p => p.theme.gray4};
+  text-align: center;
+  padding: ${p => p.theme.grid * 3}px;
   font-size: 1.5em;
-  opacity: 0.4;
   font-weight: bold;
 `;
+
+const Icon = styled.div`
+  display: block;
+  margin: 0 auto ${p => p.theme.grid * 2.5}px;
+  color: ${p => p.theme.gray1};
+`;
+
+const Action = styled.div`
+  display: block;
+  margin: ${p => p.theme.grid * 2.5}px auto 0;
+`;
+
+class EmptyMessage extends React.Component {
+  render() {
+    let {icon, children, action} = this.props;
+    return (
+      <Wrapper>
+        {icon && (
+          <Icon>
+            <InlineSvg src={icon} size="48px" />
+          </Icon>
+        )}
+        <div className="ref-message">{children}</div>
+        {action && <Action>{action}</Action>}
+      </Wrapper>
+    );
+  }
+}
+
+EmptyMessage.propTypes = {
+  icon: PropTypes.string,
+  action: PropTypes.element,
+};
 
 export default EmptyMessage;

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -23,22 +23,19 @@ const Action = styled.div`
   margin: ${p => p.theme.grid * 2.5}px auto 0;
 `;
 
-class EmptyMessage extends React.Component {
-  render() {
-    let {icon, children, action} = this.props;
-    return (
-      <Wrapper>
-        {icon && (
-          <Icon>
-            <InlineSvg src={icon} size="48px" />
-          </Icon>
-        )}
-        <div className="ref-message">{children}</div>
-        {action && <Action>{action}</Action>}
-      </Wrapper>
-    );
-  }
-}
+const EmptyMessage = ({icon, children, action}) => {
+  return (
+    <Wrapper>
+      {icon && (
+        <Icon>
+          <InlineSvg src={icon} size="48px" />
+        </Icon>
+      )}
+      <div className="ref-message">{children}</div>
+      {action && <Action>{action}</Action>}
+    </Wrapper>
+  );
+};
 
 EmptyMessage.propTypes = {
   icon: PropTypes.string,

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -5,8 +5,10 @@ import styled from 'react-emotion';
 import InlineSvg from '../../../components/inlineSvg';
 
 const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
   color: ${p => p.theme.gray4};
-  text-align: center;
   padding: ${p => p.theme.grid * 3}px;
   font-size: 1.5em;
   font-weight: bold;
@@ -14,13 +16,13 @@ const Wrapper = styled.div`
 
 const Icon = styled.div`
   display: block;
-  margin: 0 auto ${p => p.theme.grid * 2.5}px;
+  margin-bottom: ${p => p.theme.grid * 2.5}px;
   color: ${p => p.theme.gray1};
 `;
 
 const Action = styled.div`
   display: block;
-  margin: ${p => p.theme.grid * 2.5}px auto 0;
+  margin-top: ${p => p.theme.grid * 2.5}px;
 `;
 
 const EmptyMessage = ({icon, children, action}) => {

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -61,17 +61,9 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
 }
 
 .glamor-17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  padding: 18px;
+  text-align: center;
+  padding: NaNpx;
   font-size: 1.5em;
-  opacity: 0.4;
   font-weight: bold;
 }
 
@@ -266,11 +258,17 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
             className=""
           >
             <EmptyMessage>
-              <div
-                className="glamor-17 glamor-18"
-              >
-                You don't have any environments yet.
-              </div>
+              <Wrapper>
+                <div
+                  className="glamor-17 glamor-18"
+                >
+                  <div
+                    className="ref-message"
+                  >
+                    You don't have any environments yet.
+                  </div>
+                </div>
+              </Wrapper>
             </EmptyMessage>
           </div>
         </PanelBody>
@@ -749,17 +747,9 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
 }
 
 .glamor-17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  padding: 18px;
+  text-align: center;
+  padding: NaNpx;
   font-size: 1.5em;
-  opacity: 0.4;
   font-weight: bold;
 }
 
@@ -954,11 +944,17 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
             className=""
           >
             <EmptyMessage>
-              <div
-                className="glamor-17 glamor-18"
-              >
-                You don't have any hidden environments.
-              </div>
+              <Wrapper>
+                <div
+                  className="glamor-17 glamor-18"
+                >
+                  <div
+                    className="ref-message"
+                  >
+                    You don't have any hidden environments.
+                  </div>
+                </div>
+              </Wrapper>
             </EmptyMessage>
           </div>
         </PanelBody>

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -61,7 +61,17 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
 }
 
 .glamor-17 {
-  text-align: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   padding: NaNpx;
   font-size: 1.5em;
   font-weight: bold;
@@ -747,7 +757,17 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
 }
 
 .glamor-17 {
-  text-align: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   padding: NaNpx;
   font-size: 1.5em;
   font-weight: bold;

--- a/tests/js/spec/views/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/projectEnvironments.spec.jsx
@@ -30,7 +30,9 @@ describe('ProjectEnvironments', function() {
     it('renders empty message', function() {
       EnvironmentStore.loadInitialData([]);
       const wrapper = mountComponent(false);
-      expect(wrapper.text()).toContain("You don't have any environments yet");
+      let errorMessage = wrapper.find('div').first();
+
+      expect(errorMessage.text()).toContain("You don't have any environments yet");
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -46,8 +48,9 @@ describe('ProjectEnvironments', function() {
       EnvironmentStore.loadHiddenData([]);
 
       const wrapper = mountComponent(true);
+      let errorMessage = wrapper.find('div').first();
 
-      expect(wrapper.text()).toContain("You don't have any hidden environments");
+      expect(errorMessage.text()).toContain("You don't have any hidden environments");
 
       expect(wrapper).toMatchSnapshot();
     });


### PR DESCRIPTION
<img width="878" alt="screen shot 2018-02-16 at 4 01 35 pm" src="https://user-images.githubusercontent.com/30713/36335157-b83f9f52-1332-11e8-87a8-d202c81039e9.png">

This component now supports `icon` and `action` props.

Test in storybook:
http://localhost:9001/?selectedKind=EmptyMessage&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs