### PR TITLE
feat(ui): Replace "Team Settings" button w/ link to project

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -11,6 +11,7 @@ import Confirm from '../../../components/confirm';
 import DropdownLink from '../../../components/dropdownLink';
 import EmptyMessage from '../components/emptyMessage';
 import IndicatorStore from '../../../stores/indicatorStore';
+import Link from '../../../components/link';
 import MenuItem from '../../../components/menuItem';
 import Panel from '../components/panel';
 import PanelBody from '../components/panelBody';
@@ -60,11 +61,20 @@ const TeamRow = createReactClass({
   },
 
   render() {
-    let team = this.props.team;
+    let {team, access, orgId} = this.props;
+
     return (
       <PanelItem>
         <Box flex="1">
-          <h5 style={{margin: '10px 0px'}}>{team.name}</h5>
+          <h5 style={{margin: '10px 0px'}}>
+            {access.has('team:write') ? (
+              <Link to={`/settings/organization/${orgId}/teams/${team.slug}`}>
+                {team.name}
+              </Link>
+            ) : (
+              team.name
+            )}
+          </h5>
         </Box>
         {this.props.access.has('project:write') && (
           <Box pl={2}>

--- a/src/sentry/static/sentry/app/views/settings/team/allTeamsRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/allTeamsRow.jsx
@@ -101,7 +101,11 @@ const AllTeamsRow = createReactClass({
     return (
       <PanelItem p={0} align="center">
         <Box flex="1" p={2}>
-          {team.name}
+          {access.has('team:write') ? (
+            <Link to={`${urlPrefix}teams/${team.slug}/settings/`}>{team.name}</Link>
+          ) : (
+            team.name
+          )}
         </Box>
         <Box p={2}>
           {this.state.loading ? (
@@ -120,15 +124,6 @@ const AllTeamsRow = createReactClass({
             <a className="btn btn-default btn-sm" onClick={this.joinTeam}>
               {t('Request Access')}
             </a>
-          )}
-          {access.has('team:write') && (
-            <Link
-              className="btn btn-default btn-sm"
-              to={`${urlPrefix}teams/${team.slug}/settings/`}
-              style={{marginLeft: 5}}
-            >
-              {t('Team Settings')}
-            </Link>
           )}
         </Box>
       </PanelItem>


### PR DESCRIPTION
We've discussed internally that the "Team Settings" button doesn't match UI patterns of other pages. And it's dangerously close to "Remove Team", which could be misclicked. This changes it to just be a link.

This change should only affect new settings (there's a copy of `allTeamsRow.jsx` for the legacy page).

<img width="532" alt="image" src="https://user-images.githubusercontent.com/2153/36349155-3fe1c946-1435-11e8-96a4-bfac13559723.png">
