### PR TITLE
fix(environments): Environment store trigger with this.items

### DIFF
--- a/src/sentry/static/sentry/app/stores/environmentStore.jsx
+++ b/src/sentry/static/sentry/app/stores/environmentStore.jsx
@@ -55,7 +55,7 @@ const EnvironmentStore = Reflux.createStore({
         return item.name || DEFAULT_EMPTY_ROUTING_NAME;
       },
     }));
-    this.trigger(this[key]);
+    this.trigger(this.items);
   },
 
   getByName(name) {


### PR DESCRIPTION
Environment store should only trigger with this.items (and never the hidden items) since many components are connected to this