### PR TITLE
remove uses of sentry_project.team_id, update tests to set column to null

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -258,7 +258,12 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                         'detail': ['The new team is not found.']
                     }, status=400
                 )
-            old_team_id = project.team_id
+            # TODO(jess): update / deprecate this functionality
+            try:
+                old_team_id = project.teams.values_list('id', flat=True)[0]
+            except IndexError:
+                pass
+
             project.team = team_list[0]
             changed = True
 

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -314,7 +314,6 @@ class MailPlugin(NotificationPlugin):
         ))
 
         headers = {
-            'X-Sentry-Team': project.team.slug,
             'X-Sentry-Project': project.slug,
         }
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -286,28 +286,15 @@ class Fixtures(object):
     def create_project(self, **kwargs):
         teams = kwargs.pop('teams', None)
 
-        # TOOD(jess): this is just to keep backwards compat
-        # for sentry-plugins and getsentry. Remove once those
-        # are updated
-        team = kwargs.pop('team', None)
-        assert team is None or teams is None
-        if team is not None:
-            teams = [team]
-
         if teams is None:
             teams = [self.team]
-        # TODO(jess): remove when deprecated
-        try:
-            kwargs['team'] = teams[0]
-        except IndexError:
-            pass
 
         if not kwargs.get('name'):
             kwargs['name'] = petname.Generate(2, ' ', letters=10).title()
         if not kwargs.get('slug'):
             kwargs['slug'] = slugify(six.text_type(kwargs['name']))
         if not kwargs.get('organization'):
-            kwargs['organization'] = kwargs['team'].organization
+            kwargs['organization'] = teams[0].organization
 
         project = Project.objects.create(**kwargs)
         for team in teams:

--- a/tests/sentry/api/endpoints/test_organization_issues_new.py
+++ b/tests/sentry/api/endpoints/test_organization_issues_new.py
@@ -26,7 +26,7 @@ class OrganizationIssuesNewTest(APITestCase):
         )
         OrganizationMemberTeam.objects.create(
             organizationmember=member,
-            team=project1.team,
+            team=project1.teams.first(),
         )
 
         self.login_as(user=user)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -91,7 +91,6 @@ class ProjectUpdateTest(APITestCase):
         )
         assert resp.status_code == 200, resp.content
         project = Project.objects.get(id=project.id)
-        assert project.team == team
         assert project.teams.first() == team
 
     def test_team_changes_not_found(self):
@@ -113,7 +112,7 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data['detail'][0] == 'The new team is not found.'
         project = Project.objects.get(id=project.id)
 
-        assert project.team == self.team
+        assert project.teams.first() == self.team
 
     def test_simple_member_restriction(self):
         project = self.create_project()
@@ -121,7 +120,7 @@ class ProjectUpdateTest(APITestCase):
         self.create_member(
             user=user,
             organization=project.organization,
-            teams=[project.team],
+            teams=[project.teams.first()],
             role='member',
         )
         self.login_as(user)
@@ -141,7 +140,7 @@ class ProjectUpdateTest(APITestCase):
         self.create_member(
             user=user,
             organization=project.organization,
-            teams=[project.team],
+            teams=[project.teams.first()],
             role='member',
         )
         self.login_as(user=user)

--- a/tests/sentry/api/endpoints/test_project_search_details.py
+++ b/tests/sentry/api/endpoints/test_project_search_details.py
@@ -146,7 +146,7 @@ class UpdateProjectSearchDetailsTest(APITestCase):
             user=member,
             role='member',
             organization=project.organization,
-            teams=[project.team],
+            teams=[project.teams.first()],
         )
 
         search = SavedSearch.objects.create(

--- a/tests/sentry/api/endpoints/test_project_user_details.py
+++ b/tests/sentry/api/endpoints/test_project_user_details.py
@@ -15,7 +15,11 @@ class ProjectUserDetailsTest(APITestCase):
         self.org = self.create_organization(owner=None)
         self.team = self.create_team(organization=self.org)
         self.project = self.create_project(organization=self.org, teams=[self.team])
-        self.create_member(user=self.user, organization=self.org, teams=[self.project.team])
+        self.create_member(
+            user=self.user,
+            organization=self.org,
+            teams=[
+                self.project.teams.first()])
         self.euser = EventUser.objects.create(email='foo@example.com', project_id=self.project.id)
 
         self.login_as(user=self.user)

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -99,7 +99,7 @@ class OrganizationTest(TestCase):
         from_project_two = Project.objects.get(id=from_project_two.id)
         assert from_project_two.slug != 'bizzy'
         assert from_project_two.organization == to_org
-        assert from_project_two.team == from_team_two
+        assert from_project_two.teams.first() == from_team_two
 
         to_team_two = Team.objects.get(id=to_team_two.id)
         assert to_team_two.slug == 'bizzy'
@@ -108,7 +108,7 @@ class OrganizationTest(TestCase):
         to_project_two = Project.objects.get(id=to_project_two.id)
         assert to_project_two.slug == 'bizzy'
         assert to_project_two.organization == to_org
-        assert to_project_two.team == to_team_two
+        assert to_project_two.teams.first() == to_team_two
 
         assert not Release.objects.filter(id=from_release.id).exists()
         assert ReleaseFile.objects.get(id=from_release_file.id).organization == to_org

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -340,7 +340,7 @@ class MailPluginTest(TestCase):
             },
         )
 
-        self.project.team.organization.member_set.create(user=user_foo)
+        self.project.teams.first().organization.member_set.create(user=user_foo)
 
         with self.tasks():
             self.plugin.notify_about_activity(activity)
@@ -368,7 +368,7 @@ class MailPluginSignalsTest(TestCase):
             email='homer.simpson@example.com'
         )
 
-        self.project.team.organization.member_set.create(user=user_foo)
+        self.project.teams.first().organization.member_set.create(user=user_foo)
 
         with self.tasks():
             self.plugin.handle_signal(

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -282,7 +282,7 @@ class ReportTestCase(TestCase):
             now - timedelta(days=1),
         )
 
-        member_set = set(project.team.member_set.all())
+        member_set = set(project.teams.first().member_set.all())
 
         with self.tasks(), \
                 mock.patch.object(tsdb, 'get_earliest_timestamp') as get_earliest_timestamp:

--- a/tests/sentry/web/frontend/test_account_notifications.py
+++ b/tests/sentry/web/frontend/test_account_notifications.py
@@ -37,7 +37,7 @@ class NotificationSettingsTest(TestCase):
             organization=organization, teams=[team], status=ProjectStatus.PENDING_DELETION
         )
         self.create_project(organization=organization, teams=[team2])
-        self.create_member(organization=organization, user=user, teams=[project.team])
+        self.create_member(organization=organization, user=user, teams=[project.teams.first()])
         self.login_as(user)
         resp = self.client.get(self.path)
         assert resp.status_code == 200


### PR DESCRIPTION
This fixes a few small bugs/places where I was still using the old team relation and updates the tests to leave the column as null.