### PR TITLE
refactor(ui): Add Icon support to Button component

### DIFF
--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -101,4 +101,16 @@ storiesOf('Buttons', module)
         </Item>
       </div>
     ))
+  )
+  .add(
+    'icons',
+    withInfo('Buttons with Icons')(() => (
+      <div style={{display: 'flex', alignItems: 'center'}}>
+        <Item>
+          <Button priority="" icon="icon-github">
+            View on GitHub
+          </Button>
+        </Item>
+      </div>
+    ))
   );

--- a/src/sentry/static/sentry/app/components/buttons/button.jsx
+++ b/src/sentry/static/sentry/app/components/buttons/button.jsx
@@ -12,8 +12,7 @@ const Icon = styled(Box)`
   margin-right: ${p => (p.size ? '6px' : '8px')};
   margin-left: -2px;
 
-  /* Need this to get proper vertical alignment */
-  svg {
+  {InlineSvg} {
     display: block;
   }
 `;

--- a/src/sentry/static/sentry/app/components/buttons/button.jsx
+++ b/src/sentry/static/sentry/app/components/buttons/button.jsx
@@ -9,8 +9,13 @@ import InlineSvg from '../inlineSvg';
 import '../../../less/components/button.less';
 
 const Icon = styled(Box)`
-  margin-right: ${p => p.theme.grid}px;
+  margin-right: ${p => (p.size ? '6px' : '8px')};
   margin-left: -2px;
+
+  /* Need this to get proper vertical alignment */
+  svg {
+    display: block;
+  }
 `;
 
 class Button extends React.Component {
@@ -98,15 +103,13 @@ class Button extends React.Component {
     });
 
     let childContainer = (
-      <Flex>
-        <span className="button-label">
-          {icon && (
-            <Icon>
-              <InlineSvg src={icon} size={size === 'small' ? '14px' : '16px'} />
-            </Icon>
-          )}
-          {children}
-        </span>
+      <Flex align="center" className="button-label">
+        {icon && (
+          <Icon size={size}>
+            <InlineSvg src={icon} size={size === 'small' ? '12px' : '16px'} />
+          </Icon>
+        )}
+        {children}
       </Flex>
     );
 

--- a/src/sentry/static/sentry/app/components/buttons/button.jsx
+++ b/src/sentry/static/sentry/app/components/buttons/button.jsx
@@ -1,11 +1,17 @@
+import {Flex, Box} from 'grid-emotion';
 import {Link} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 import classNames from 'classnames';
 
-import FlowLayout from '../flowLayout';
-
+import InlineSvg from '../inlineSvg';
 import '../../../less/components/button.less';
+
+const Icon = styled(Box)`
+  margin-right: ${p => p.theme.grid}px;
+  margin-left: -2px;
+`;
 
 class Button extends React.Component {
   static propTypes = {
@@ -21,6 +27,7 @@ class Button extends React.Component {
      * Use this prop if button should use a normal (non-react-router) link
      */
     href: PropTypes.string,
+    icon: PropTypes.string,
     /**
      * Tooltip text
      */
@@ -63,6 +70,7 @@ class Button extends React.Component {
       busy,
       title,
       borderless,
+      icon,
 
       // destructure from `buttonProps`
       // not necessary, but just in case someone re-orders props
@@ -89,12 +97,17 @@ class Button extends React.Component {
       'button-disabled': disabled,
     });
 
-    // This container is useless now, but leaves room for when we need to add
-    // components (i.e. icons, busy indicator, etc)
     let childContainer = (
-      <FlowLayout truncate={false}>
-        <span className="button-label">{children}</span>
-      </FlowLayout>
+      <Flex>
+        <span className="button-label">
+          {icon && (
+            <Icon>
+              <InlineSvg src={icon} size={size === 'small' ? '14px' : '16px'} />
+            </Icon>
+          )}
+          {children}
+        </span>
+      </Flex>
     );
 
     // Buttons come in 3 flavors: Link, anchor, and regular buttons. Let's

--- a/src/sentry/static/sentry/app/views/projectAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertRules.jsx
@@ -231,9 +231,8 @@ const ProjectAlertRules = createReactClass({
               to={`/${orgId}/${projectId}/settings/alerts/rules/new/`}
               priority="primary"
               size="small"
-              className="pull-right"
+              icon="icon-circle-add"
             >
-              <span className="icon-plus" />
               {t('New Alert Rule')}
             </Button>
           }

--- a/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
@@ -192,9 +192,8 @@ export default class ProjectAlertSettings extends AsyncView {
               to={`/${orgId}/${projectId}/settings/alerts/rules/new/`}
               priority="primary"
               size="small"
-              className="pull-right"
+              icon="icon-circle-add"
             >
-              <span className="icon-plus" />
               {t('New Alert Rule')}
             </Button>
           }

--- a/src/sentry/static/sentry/app/views/projectKeys.jsx
+++ b/src/sentry/static/sentry/app/views/projectKeys.jsx
@@ -365,8 +365,13 @@ export default createReactClass({
             title={t('Client Keys')}
             action={
               access.has('project:write') ? (
-                <Button onClick={this.onCreateKey} size="small" priority="primary">
-                  <span className="icon-plus" />&nbsp;{t('Generate New Key')}
+                <Button
+                  onClick={this.onCreateKey}
+                  size="small"
+                  priority="primary"
+                  icon="icon-circle-add"
+                >
+                  {t('Generate New Key')}
                 </Button>
               ) : null
             }

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
@@ -138,6 +138,7 @@ class ApiApplications extends AsyncView {
         size="small"
         className="ref-create-application"
         onClick={this.handleCreateApplication}
+        icon="icon-circle-add"
       >
         {t('Create New Application')}
       </Button>

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -68,6 +68,7 @@ class ApiTokens extends AsyncView {
         size="small"
         to="/settings/account/api/auth-tokens/new-token/"
         className="ref-create-token"
+        icon="icon-circle-add"
       >
         {t('Create New Token')}
       </Button>

--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
@@ -232,8 +232,9 @@ class OrganizationMembersView extends OrganizationSettingsView {
             : undefined
         }
         to={recreateRoute('new', {routes, params})}
+        icon="icon-circle-add"
       >
-        <span className="icon-plus" /> {t('Invite Member')}
+        {t('Invite Member')}
       </Button>
     );
 

--- a/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
@@ -49,8 +49,9 @@ class OrganizationProjectsView extends OrganizationSettingsView {
             : undefined
         }
         to={`/organizations/${organization.slug}/projects/new/`}
+        icon="icon-circle-add"
       >
-        <span className="icon-plus" /> {t('Create Project')}
+        {t('Create Project')}
       </Button>
     );
 

--- a/src/sentry/static/sentry/app/views/settings/team/organizationTeamsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/organizationTeamsView.jsx
@@ -50,8 +50,9 @@ class OrganizationTeamsView extends React.Component {
           !canCreateTeams ? t('You do not have permission to create teams') : undefined
         }
         to={`/organizations/${organization.slug}/teams/new/`}
+        icon="icon-circle-add"
       >
-        <span className="icon-plus" /> {t('Create Team')}
+        {t('Create Team')}
       </Button>
     );
 

--- a/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
@@ -113,8 +113,9 @@ const TeamMembers = createReactClass({
               size="small"
               className="pull-right"
               to={`/settings/organization/${params.orgId}/members/new/`}
+              icon="icon-circle-add"
             >
-              <span className="icon-plus" /> {t('Invite Member')}
+              {t('Invite Member')}
             </Button>
           ) : (
             <a

--- a/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
@@ -7,15 +7,13 @@ exports[`Button renders 1`] = `
   onClick={[Function]}
   role="button"
 >
-  <FlowLayout
-    truncate={false}
-  >
+  <Flex>
     <span
       className="button-label"
     >
       Button
     </span>
-  </FlowLayout>
+  </Flex>
 </button>
 `;
 
@@ -27,15 +25,13 @@ exports[`Button renders normal link 1`] = `
   onClick={[Function]}
   role="button"
 >
-  <FlowLayout
-    truncate={false}
-  >
+  <Flex>
     <span
       className="button-label"
     >
       Normal Link
     </span>
-  </FlowLayout>
+  </Flex>
 </a>
 `;
 
@@ -49,14 +45,12 @@ exports[`Button renders react-router link 1`] = `
   style={Object {}}
   to="/some/route"
 >
-  <FlowLayout
-    truncate={false}
-  >
+  <Flex>
     <span
       className="button-label"
     >
       Router Link
     </span>
-  </FlowLayout>
+  </Flex>
 </Link>
 `;

--- a/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
@@ -7,12 +7,11 @@ exports[`Button renders 1`] = `
   onClick={[Function]}
   role="button"
 >
-  <Flex>
-    <span
-      className="button-label"
-    >
-      Button
-    </span>
+  <Flex
+    align="center"
+    className="button-label"
+  >
+    Button
   </Flex>
 </button>
 `;
@@ -25,12 +24,11 @@ exports[`Button renders normal link 1`] = `
   onClick={[Function]}
   role="button"
 >
-  <Flex>
-    <span
-      className="button-label"
-    >
-      Normal Link
-    </span>
+  <Flex
+    align="center"
+    className="button-label"
+  >
+    Normal Link
   </Flex>
 </a>
 `;
@@ -45,12 +43,11 @@ exports[`Button renders react-router link 1`] = `
   style={Object {}}
   to="/some/route"
 >
-  <Flex>
-    <span
-      className="button-label"
-    >
-      Router Link
-    </span>
+  <Flex
+    align="center"
+    className="button-label"
+  >
+    Router Link
   </Flex>
 </Link>
 `;

--- a/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
@@ -10,6 +10,7 @@ exports[`ApiTokens renders empty result 1`] = `
         <Button
           className="ref-create-token"
           disabled={false}
+          icon="icon-circle-add"
           priority="primary"
           size="small"
           to="/settings/account/api/auth-tokens/new-token/"
@@ -92,13 +93,13 @@ exports[`ApiTokens renders empty result 1`] = `
 `;
 
 exports[`ApiTokens renders with result 1`] = `
-.glamor-6 {
+.glamor-12 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-4 {
+.glamor-8 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -119,27 +120,33 @@ exports[`ApiTokens renders with result 1`] = `
   flex: 1;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  margin-right: 6px;
+  margin-left: -2px;
 }
 
-.glamor-8 {
+.glamor-4 svg {
+  display: block;
+}
+
+.glamor-2 {
+  vertical-align: middle;
+}
+
+.glamor-14 {
   line-height: 1.5;
   margin-bottom: 30px;
 }
 
-.glamor-53 {
+.glamor-59 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-25 {
+.glamor-31 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -148,13 +155,13 @@ exports[`ApiTokens renders with result 1`] = `
   padding: 15px 0;
 }
 
-.glamor-21 {
+.glamor-27 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-19 {
+.glamor-25 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -164,7 +171,7 @@ exports[`ApiTokens renders with result 1`] = `
   margin: 0;
 }
 
-.glamor-14 {
+.glamor-20 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -173,7 +180,7 @@ exports[`ApiTokens renders with result 1`] = `
   flex: 1;
 }
 
-.glamor-49 {
+.glamor-55 {
   box-sizing: border-box;
   padding: 16px;
   padding-left: 16px;
@@ -191,18 +198,26 @@ exports[`ApiTokens renders with result 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-49:last-child {
+.glamor-55:last-child {
   border: 0;
 }
 
-.glamor-41 {
+.glamor-47 {
   box-sizing: border-box;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.glamor-33 {
+.glamor-41 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-39 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -210,7 +225,7 @@ exports[`ApiTokens renders with result 1`] = `
   border: none;
 }
 
-.glamor-29 {
+.glamor-35 {
   display: block;
   width: 100%;
   background: #fff;
@@ -226,46 +241,46 @@ exports[`ApiTokens renders with result 1`] = `
   border-bottom-right-radius: 0;
 }
 
-.glamor-29:focus {
+.glamor-35:focus {
   outline: none;
 }
 
-.glamor-29:hover,
-.glamor-29:focus,
-.glamor-29:active {
+.glamor-35:hover,
+.glamor-35:focus,
+.glamor-35:active {
   border: 1px solid;
 }
 
-.glamor-29:hover,
-.glamor-29:focus {
+.glamor-35:hover,
+.glamor-35:focus {
   border-right-width: 0;
 }
 
-.glamor-29:hover,
-.glamor-29:focus {
+.glamor-35:hover,
+.glamor-35:focus {
   border-right-width: 0;
 }
 
-.glamor-29:hover,
-.glamor-29:focus {
+.glamor-35:hover,
+.glamor-35:focus {
   border-right-width: 0;
 }
 
-.glamor-29:hover,
-.glamor-29:focus {
+.glamor-35:hover,
+.glamor-35:focus {
   border-right-width: 0;
 }
 
-.glamor-37 {
+.glamor-43 {
   font-size: 0.9em;
 }
 
-.glamor-39 {
+.glamor-45 {
   font-size: 0.9em;
   color: #999;
 }
 
-.glamor-45 {
+.glamor-51 {
   box-sizing: border-box;
   padding-left: 16px;
 }
@@ -283,6 +298,7 @@ exports[`ApiTokens renders with result 1`] = `
             <Button
               className="ref-create-token"
               disabled={false}
+              icon="icon-circle-add"
               priority="primary"
               size="small"
               to="/settings/account/api/auth-tokens/new-token/"
@@ -294,17 +310,17 @@ exports[`ApiTokens renders with result 1`] = `
         >
           <Wrapper>
             <div
-              className="glamor-6 glamor-7"
+              className="glamor-12 glamor-13"
             >
               <Flex
                 align="center"
               >
                 <Base
                   align="center"
-                  className="glamor-4"
+                  className="glamor-8"
                 >
                   <div
-                    className="glamor-4"
+                    className="glamor-8"
                     is={null}
                   >
                     <Title>
@@ -318,6 +334,7 @@ exports[`ApiTokens renders with result 1`] = `
                       <Button
                         className="ref-create-token"
                         disabled={false}
+                        icon="icon-circle-add"
                         priority="primary"
                         size="small"
                         to="/settings/account/api/auth-tokens/new-token/"
@@ -338,19 +355,59 @@ exports[`ApiTokens renders with result 1`] = `
                             role="button"
                             style={Object {}}
                           >
-                            <Flex>
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
                               <Base
-                                className="glamor-2"
+                                align="center"
+                                className="button-label glamor-8"
                               >
                                 <div
-                                  className="glamor-2"
+                                  className="button-label glamor-8"
                                   is={null}
                                 >
-                                  <span
-                                    className="button-label"
+                                  <Icon
+                                    size="small"
                                   >
-                                    Create New Token
-                                  </span>
+                                    <Base
+                                      className="glamor-4 glamor-5"
+                                      size="small"
+                                    >
+                                      <div
+                                        className="glamor-4 glamor-5"
+                                        is={null}
+                                        size="small"
+                                      >
+                                        <InlineSvg
+                                          size="12px"
+                                          src="icon-circle-add"
+                                        >
+                                          <StyledSvg
+                                            className=""
+                                            height="12px"
+                                            style={Object {}}
+                                            viewBox={Object {}}
+                                            width="12px"
+                                          >
+                                            <svg
+                                              className="glamor-2 glamor-3"
+                                              height="12px"
+                                              style={Object {}}
+                                              viewBox={Object {}}
+                                              width="12px"
+                                            >
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </StyledSvg>
+                                        </InlineSvg>
+                                      </div>
+                                    </Base>
+                                  </Icon>
+                                  Create New Token
                                 </div>
                               </Base>
                             </Flex>
@@ -366,14 +423,14 @@ exports[`ApiTokens renders with result 1`] = `
         </SettingsPageHeading>
         <TextBlock>
           <div
-            className="glamor-8 glamor-9"
+            className="glamor-14 glamor-15"
           >
             Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
           </div>
         </TextBlock>
         <TextBlock>
           <div
-            className="glamor-8 glamor-9"
+            className="glamor-14 glamor-15"
           >
             <span
               key="5"
@@ -403,7 +460,7 @@ exports[`ApiTokens renders with result 1`] = `
         </TextBlock>
         <TextBlock>
           <div
-            className="glamor-8 glamor-9"
+            className="glamor-14 glamor-15"
           >
             <small>
               psst. Looking for the 
@@ -421,7 +478,7 @@ exports[`ApiTokens renders with result 1`] = `
         </TextBlock>
         <Panel>
           <div
-            className="glamor-53 glamor-54"
+            className="glamor-59 glamor-60"
           >
             <PanelHeader
               disablePadding={true}
@@ -430,31 +487,31 @@ exports[`ApiTokens renders with result 1`] = `
                 disablePadding={true}
               >
                 <Component
-                  className="glamor-25 glamor-26"
+                  className="glamor-31 glamor-32"
                   disablePadding={true}
                 >
                   <div
-                    className="glamor-25 glamor-26"
+                    className="glamor-31 glamor-32"
                   >
                     <StyledPanelHeading>
                       <Component
-                        className="glamor-21 glamor-18"
+                        className="glamor-27 glamor-24"
                       >
                         <PanelHeading
-                          className="glamor-21 glamor-18"
+                          className="glamor-27 glamor-24"
                         >
                           <div
-                            className="glamor-18 glamor-19 glamor-20"
+                            className="glamor-24 glamor-25 glamor-26"
                           >
                             <Flex
                               align="center"
                             >
                               <Base
                                 align="center"
-                                className="glamor-4"
+                                className="glamor-8"
                               >
                                 <div
-                                  className="glamor-4"
+                                  className="glamor-8"
                                   is={null}
                                 >
                                   <Box
@@ -462,12 +519,12 @@ exports[`ApiTokens renders with result 1`] = `
                                     px={2}
                                   >
                                     <Base
-                                      className="glamor-14"
+                                      className="glamor-20"
                                       flex="1"
                                       px={2}
                                     >
                                       <div
-                                        className="glamor-14"
+                                        className="glamor-20"
                                         is={null}
                                       >
                                         Auth Token
@@ -520,25 +577,25 @@ exports[`ApiTokens renders with result 1`] = `
                       py={2}
                     >
                       <Base
-                        className="glamor-49 glamor-50"
+                        className="glamor-55 glamor-56"
                         justify="space-between"
                         p={2}
                         px={2}
                         py={2}
                       >
                         <div
-                          className="glamor-49 glamor-50"
+                          className="glamor-55 glamor-56"
                           is={null}
                         >
                           <Box
                             flex="1"
                           >
                             <Base
-                              className="glamor-41"
+                              className="glamor-47"
                               flex="1"
                             >
                               <div
-                                className="glamor-41"
+                                className="glamor-47"
                                 is={null}
                               >
                                 <div
@@ -556,15 +613,15 @@ exports[`ApiTokens renders with result 1`] = `
                                     >
                                       <Flex>
                                         <Base
-                                          className="glamor-2"
+                                          className="glamor-41"
                                         >
                                           <div
-                                            className="glamor-2"
+                                            className="glamor-41"
                                             is={null}
                                           >
                                             <OverflowContainer>
                                               <div
-                                                className="glamor-33 glamor-34"
+                                                className="glamor-39 glamor-40"
                                               >
                                                 <StyledInput
                                                   onClick={[Function]}
@@ -572,13 +629,13 @@ exports[`ApiTokens renders with result 1`] = `
                                                   value="apitoken123"
                                                 >
                                                   <Component
-                                                    className="glamor-29 glamor-30"
+                                                    className="glamor-35 glamor-36"
                                                     onClick={[Function]}
                                                     readOnly={true}
                                                     value="apitoken123"
                                                   >
                                                     <input
-                                                      className="glamor-29 glamor-30"
+                                                      className="glamor-35 glamor-36"
                                                       onClick={[Function]}
                                                       readOnly={true}
                                                       value="apitoken123"
@@ -610,7 +667,7 @@ exports[`ApiTokens renders with result 1`] = `
                                 >
                                   <Created>
                                     <div
-                                      className="glamor-37 glamor-38"
+                                      className="glamor-43 glamor-44"
                                     >
                                       Created
                                        
@@ -628,7 +685,7 @@ exports[`ApiTokens renders with result 1`] = `
                                 <div>
                                   <ScopeList>
                                     <div
-                                      className="glamor-39 glamor-40"
+                                      className="glamor-45 glamor-46"
                                     >
                                       scope1, scope2
                                     </div>
@@ -642,21 +699,21 @@ exports[`ApiTokens renders with result 1`] = `
                           >
                             <Base
                               align="center"
-                              className="glamor-4"
+                              className="glamor-8"
                             >
                               <div
-                                className="glamor-4"
+                                className="glamor-8"
                                 is={null}
                               >
                                 <Box
                                   pl={2}
                                 >
                                   <Base
-                                    className="glamor-45"
+                                    className="glamor-51"
                                     pl={2}
                                   >
                                     <div
-                                      className="glamor-45"
+                                      className="glamor-51"
                                       is={null}
                                     >
                                       <Button
@@ -669,21 +726,21 @@ exports[`ApiTokens renders with result 1`] = `
                                           onClick={[Function]}
                                           role="button"
                                         >
-                                          <Flex>
+                                          <Flex
+                                            align="center"
+                                            className="button-label"
+                                          >
                                             <Base
-                                              className="glamor-2"
+                                              align="center"
+                                              className="button-label glamor-8"
                                             >
                                               <div
-                                                className="glamor-2"
+                                                className="button-label glamor-8"
                                                 is={null}
                                               >
                                                 <span
-                                                  className="button-label"
-                                                >
-                                                  <span
-                                                    className="icon icon-trash"
-                                                  />
-                                                </span>
+                                                  className="icon icon-trash"
+                                                />
                                               </div>
                                             </Base>
                                           </Flex>

--- a/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
@@ -92,13 +92,13 @@ exports[`ApiTokens renders empty result 1`] = `
 `;
 
 exports[`ApiTokens renders with result 1`] = `
-.glamor-4 {
+.glamor-6 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -119,19 +119,27 @@ exports[`ApiTokens renders with result 1`] = `
   flex: 1;
 }
 
-.glamor-6 {
+.glamor-2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-8 {
   line-height: 1.5;
   margin-bottom: 30px;
 }
 
-.glamor-49 {
+.glamor-53 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-23 {
+.glamor-25 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -140,13 +148,13 @@ exports[`ApiTokens renders with result 1`] = `
   padding: 15px 0;
 }
 
-.glamor-19 {
+.glamor-21 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-17 {
+.glamor-19 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -156,7 +164,7 @@ exports[`ApiTokens renders with result 1`] = `
   margin: 0;
 }
 
-.glamor-12 {
+.glamor-14 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -165,7 +173,7 @@ exports[`ApiTokens renders with result 1`] = `
   flex: 1;
 }
 
-.glamor-45 {
+.glamor-49 {
   box-sizing: border-box;
   padding: 16px;
   padding-left: 16px;
@@ -183,11 +191,11 @@ exports[`ApiTokens renders with result 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-45:last-child {
+.glamor-49:last-child {
   border: 0;
 }
 
-.glamor-39 {
+.glamor-41 {
   box-sizing: border-box;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -195,14 +203,6 @@ exports[`ApiTokens renders with result 1`] = `
 }
 
 .glamor-33 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.glamor-31 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -210,7 +210,7 @@ exports[`ApiTokens renders with result 1`] = `
   border: none;
 }
 
-.glamor-27 {
+.glamor-29 {
   display: block;
   width: 100%;
   background: #fff;
@@ -226,46 +226,46 @@ exports[`ApiTokens renders with result 1`] = `
   border-bottom-right-radius: 0;
 }
 
-.glamor-27:focus {
+.glamor-29:focus {
   outline: none;
 }
 
-.glamor-27:hover,
-.glamor-27:focus,
-.glamor-27:active {
+.glamor-29:hover,
+.glamor-29:focus,
+.glamor-29:active {
   border: 1px solid;
 }
 
-.glamor-27:hover,
-.glamor-27:focus {
+.glamor-29:hover,
+.glamor-29:focus {
   border-right-width: 0;
 }
 
-.glamor-27:hover,
-.glamor-27:focus {
+.glamor-29:hover,
+.glamor-29:focus {
   border-right-width: 0;
 }
 
-.glamor-27:hover,
-.glamor-27:focus {
+.glamor-29:hover,
+.glamor-29:focus {
   border-right-width: 0;
 }
 
-.glamor-27:hover,
-.glamor-27:focus {
+.glamor-29:hover,
+.glamor-29:focus {
   border-right-width: 0;
-}
-
-.glamor-35 {
-  font-size: 0.9em;
 }
 
 .glamor-37 {
   font-size: 0.9em;
+}
+
+.glamor-39 {
+  font-size: 0.9em;
   color: #999;
 }
 
-.glamor-41 {
+.glamor-45 {
   box-sizing: border-box;
   padding-left: 16px;
 }
@@ -294,17 +294,17 @@ exports[`ApiTokens renders with result 1`] = `
         >
           <Wrapper>
             <div
-              className="glamor-4 glamor-5"
+              className="glamor-6 glamor-7"
             >
               <Flex
                 align="center"
               >
                 <Base
                   align="center"
-                  className="glamor-2"
+                  className="glamor-4"
                 >
                   <div
-                    className="glamor-2"
+                    className="glamor-4"
                     is={null}
                   >
                     <Title>
@@ -338,19 +338,22 @@ exports[`ApiTokens renders with result 1`] = `
                             role="button"
                             style={Object {}}
                           >
-                            <FlowLayout
-                              truncate={false}
-                            >
-                              <div
-                                className="flow-layout"
+                            <Flex>
+                              <Base
+                                className="glamor-2"
                               >
-                                <span
-                                  className="button-label"
+                                <div
+                                  className="glamor-2"
+                                  is={null}
                                 >
-                                  Create New Token
-                                </span>
-                              </div>
-                            </FlowLayout>
+                                  <span
+                                    className="button-label"
+                                  >
+                                    Create New Token
+                                  </span>
+                                </div>
+                              </Base>
+                            </Flex>
                           </a>
                         </Link>
                       </Button>
@@ -363,14 +366,14 @@ exports[`ApiTokens renders with result 1`] = `
         </SettingsPageHeading>
         <TextBlock>
           <div
-            className="glamor-6 glamor-7"
+            className="glamor-8 glamor-9"
           >
             Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
           </div>
         </TextBlock>
         <TextBlock>
           <div
-            className="glamor-6 glamor-7"
+            className="glamor-8 glamor-9"
           >
             <span
               key="5"
@@ -400,7 +403,7 @@ exports[`ApiTokens renders with result 1`] = `
         </TextBlock>
         <TextBlock>
           <div
-            className="glamor-6 glamor-7"
+            className="glamor-8 glamor-9"
           >
             <small>
               psst. Looking for the 
@@ -418,7 +421,7 @@ exports[`ApiTokens renders with result 1`] = `
         </TextBlock>
         <Panel>
           <div
-            className="glamor-49 glamor-50"
+            className="glamor-53 glamor-54"
           >
             <PanelHeader
               disablePadding={true}
@@ -427,31 +430,31 @@ exports[`ApiTokens renders with result 1`] = `
                 disablePadding={true}
               >
                 <Component
-                  className="glamor-23 glamor-24"
+                  className="glamor-25 glamor-26"
                   disablePadding={true}
                 >
                   <div
-                    className="glamor-23 glamor-24"
+                    className="glamor-25 glamor-26"
                   >
                     <StyledPanelHeading>
                       <Component
-                        className="glamor-19 glamor-16"
+                        className="glamor-21 glamor-18"
                       >
                         <PanelHeading
-                          className="glamor-19 glamor-16"
+                          className="glamor-21 glamor-18"
                         >
                           <div
-                            className="glamor-16 glamor-17 glamor-18"
+                            className="glamor-18 glamor-19 glamor-20"
                           >
                             <Flex
                               align="center"
                             >
                               <Base
                                 align="center"
-                                className="glamor-2"
+                                className="glamor-4"
                               >
                                 <div
-                                  className="glamor-2"
+                                  className="glamor-4"
                                   is={null}
                                 >
                                   <Box
@@ -459,12 +462,12 @@ exports[`ApiTokens renders with result 1`] = `
                                     px={2}
                                   >
                                     <Base
-                                      className="glamor-12"
+                                      className="glamor-14"
                                       flex="1"
                                       px={2}
                                     >
                                       <div
-                                        className="glamor-12"
+                                        className="glamor-14"
                                         is={null}
                                       >
                                         Auth Token
@@ -517,25 +520,25 @@ exports[`ApiTokens renders with result 1`] = `
                       py={2}
                     >
                       <Base
-                        className="glamor-45 glamor-46"
+                        className="glamor-49 glamor-50"
                         justify="space-between"
                         p={2}
                         px={2}
                         py={2}
                       >
                         <div
-                          className="glamor-45 glamor-46"
+                          className="glamor-49 glamor-50"
                           is={null}
                         >
                           <Box
                             flex="1"
                           >
                             <Base
-                              className="glamor-39"
+                              className="glamor-41"
                               flex="1"
                             >
                               <div
-                                className="glamor-39"
+                                className="glamor-41"
                                 is={null}
                               >
                                 <div
@@ -553,15 +556,15 @@ exports[`ApiTokens renders with result 1`] = `
                                     >
                                       <Flex>
                                         <Base
-                                          className="glamor-33"
+                                          className="glamor-2"
                                         >
                                           <div
-                                            className="glamor-33"
+                                            className="glamor-2"
                                             is={null}
                                           >
                                             <OverflowContainer>
                                               <div
-                                                className="glamor-31 glamor-32"
+                                                className="glamor-33 glamor-34"
                                               >
                                                 <StyledInput
                                                   onClick={[Function]}
@@ -569,13 +572,13 @@ exports[`ApiTokens renders with result 1`] = `
                                                   value="apitoken123"
                                                 >
                                                   <Component
-                                                    className="glamor-27 glamor-28"
+                                                    className="glamor-29 glamor-30"
                                                     onClick={[Function]}
                                                     readOnly={true}
                                                     value="apitoken123"
                                                   >
                                                     <input
-                                                      className="glamor-27 glamor-28"
+                                                      className="glamor-29 glamor-30"
                                                       onClick={[Function]}
                                                       readOnly={true}
                                                       value="apitoken123"
@@ -607,7 +610,7 @@ exports[`ApiTokens renders with result 1`] = `
                                 >
                                   <Created>
                                     <div
-                                      className="glamor-35 glamor-36"
+                                      className="glamor-37 glamor-38"
                                     >
                                       Created
                                        
@@ -625,7 +628,7 @@ exports[`ApiTokens renders with result 1`] = `
                                 <div>
                                   <ScopeList>
                                     <div
-                                      className="glamor-37 glamor-38"
+                                      className="glamor-39 glamor-40"
                                     >
                                       scope1, scope2
                                     </div>
@@ -639,21 +642,21 @@ exports[`ApiTokens renders with result 1`] = `
                           >
                             <Base
                               align="center"
-                              className="glamor-2"
+                              className="glamor-4"
                             >
                               <div
-                                className="glamor-2"
+                                className="glamor-4"
                                 is={null}
                               >
                                 <Box
                                   pl={2}
                                 >
                                   <Base
-                                    className="glamor-41"
+                                    className="glamor-45"
                                     pl={2}
                                   >
                                     <div
-                                      className="glamor-41"
+                                      className="glamor-45"
                                       is={null}
                                     >
                                       <Button
@@ -666,21 +669,24 @@ exports[`ApiTokens renders with result 1`] = `
                                           onClick={[Function]}
                                           role="button"
                                         >
-                                          <FlowLayout
-                                            truncate={false}
-                                          >
-                                            <div
-                                              className="flow-layout"
+                                          <Flex>
+                                            <Base
+                                              className="glamor-2"
                                             >
-                                              <span
-                                                className="button-label"
+                                              <div
+                                                className="glamor-2"
+                                                is={null}
                                               >
                                                 <span
-                                                  className="icon icon-trash"
-                                                />
-                                              </span>
-                                            </div>
-                                          </FlowLayout>
+                                                  className="button-label"
+                                                >
+                                                  <span
+                                                    className="icon icon-trash"
+                                                  />
+                                                </span>
+                                              </div>
+                                            </Base>
+                                          </Flex>
                                         </button>
                                       </Button>
                                     </div>

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -23,6 +23,10 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <GroupMergedView
@@ -419,19 +423,19 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                               }
                             }
                           >
-                            <Flex>
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
                               <Base
-                                className="glamor-0"
+                                align="center"
+                                className="button-label glamor-0"
                               >
                                 <div
-                                  className="glamor-0"
+                                  className="button-label glamor-0"
                                   is={null}
                                 >
-                                  <span
-                                    className="button-label"
-                                  >
-                                    Compare
-                                  </span>
+                                  Compare
                                 </div>
                               </Base>
                             </Flex>
@@ -460,19 +464,19 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             onClick={[Function]}
                             role="button"
                           >
-                            <Flex>
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
                               <Base
-                                className="glamor-0"
+                                align="center"
+                                className="button-label glamor-0"
                               >
                                 <div
-                                  className="glamor-0"
+                                  className="button-label glamor-0"
                                   is={null}
                                 >
-                                  <span
-                                    className="button-label"
-                                  >
-                                    Collapse All
-                                  </span>
+                                  Collapse All
                                 </div>
                               </Base>
                             </Flex>
@@ -1364,6 +1368,10 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <GroupMergedView
@@ -1760,19 +1768,19 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                               }
                             }
                           >
-                            <Flex>
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
                               <Base
-                                className="glamor-0"
+                                align="center"
+                                className="button-label glamor-0"
                               >
                                 <div
-                                  className="glamor-0"
+                                  className="button-label glamor-0"
                                   is={null}
                                 >
-                                  <span
-                                    className="button-label"
-                                  >
-                                    Compare
-                                  </span>
+                                  Compare
                                 </div>
                               </Base>
                             </Flex>
@@ -1801,19 +1809,19 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             onClick={[Function]}
                             role="button"
                           >
-                            <Flex>
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
                               <Base
-                                className="glamor-0"
+                                align="center"
+                                className="button-label glamor-0"
                               >
                                 <div
-                                  className="glamor-0"
+                                  className="button-label glamor-0"
                                   is={null}
                                 >
-                                  <span
-                                    className="button-label"
-                                  >
-                                    Collapse All
-                                  </span>
+                                  Collapse All
                                 </div>
                               </Base>
                             </Flex>

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -17,6 +17,14 @@ exports[`Issues -> Merged View renders initially with loading component 1`] = `
 `;
 
 exports[`Issues -> Merged View renders with mocked data 1`] = `
+.glamor-0 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <GroupMergedView
   location={
     Object {
@@ -411,19 +419,22 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                               }
                             }
                           >
-                            <FlowLayout
-                              truncate={false}
-                            >
-                              <div
-                                className="flow-layout"
+                            <Flex>
+                              <Base
+                                className="glamor-0"
                               >
-                                <span
-                                  className="button-label"
+                                <div
+                                  className="glamor-0"
+                                  is={null}
                                 >
-                                  Compare
-                                </span>
-                              </div>
-                            </FlowLayout>
+                                  <span
+                                    className="button-label"
+                                  >
+                                    Compare
+                                  </span>
+                                </div>
+                              </Base>
+                            </Flex>
                           </button>
                         </Button>
                       </div>
@@ -449,19 +460,22 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             onClick={[Function]}
                             role="button"
                           >
-                            <FlowLayout
-                              truncate={false}
-                            >
-                              <div
-                                className="flow-layout"
+                            <Flex>
+                              <Base
+                                className="glamor-0"
                               >
-                                <span
-                                  className="button-label"
+                                <div
+                                  className="glamor-0"
+                                  is={null}
                                 >
-                                  Collapse All
-                                </span>
-                              </div>
-                            </FlowLayout>
+                                  <span
+                                    className="button-label"
+                                  >
+                                    Collapse All
+                                  </span>
+                                </div>
+                              </Base>
+                            </Flex>
                           </button>
                         </Button>
                       </div>
@@ -1344,6 +1358,14 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
 `;
 
 exports[`Issues -> Merged View renders with mocked data 2`] = `
+.glamor-0 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <GroupMergedView
   location={
     Object {
@@ -1738,19 +1760,22 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                               }
                             }
                           >
-                            <FlowLayout
-                              truncate={false}
-                            >
-                              <div
-                                className="flow-layout"
+                            <Flex>
+                              <Base
+                                className="glamor-0"
                               >
-                                <span
-                                  className="button-label"
+                                <div
+                                  className="glamor-0"
+                                  is={null}
                                 >
-                                  Compare
-                                </span>
-                              </div>
-                            </FlowLayout>
+                                  <span
+                                    className="button-label"
+                                  >
+                                    Compare
+                                  </span>
+                                </div>
+                              </Base>
+                            </Flex>
                           </button>
                         </Button>
                       </div>
@@ -1776,19 +1801,22 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             onClick={[Function]}
                             role="button"
                           >
-                            <FlowLayout
-                              truncate={false}
-                            >
-                              <div
-                                className="flow-layout"
+                            <Flex>
+                              <Base
+                                className="glamor-0"
                               >
-                                <span
-                                  className="button-label"
+                                <div
+                                  className="glamor-0"
+                                  is={null}
                                 >
-                                  Collapse All
-                                </span>
-                              </div>
-                            </FlowLayout>
+                                  <span
+                                    className="button-label"
+                                  >
+                                    Collapse All
+                                  </span>
+                                </div>
+                              </Base>
+                            </Flex>
                           </button>
                         </Button>
                       </div>

--- a/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OrganizationApiKeysList renders 1`] = `
-.glamor-6 {
+.glamor-8 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-4 {
+.glamor-6 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -28,22 +28,30 @@ exports[`OrganizationApiKeysList renders 1`] = `
   flex: 1;
 }
 
+.glamor-4 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 .glamor-2 {
   margin-right: 4px;
 }
 
-.glamor-8 {
+.glamor-10 {
   line-height: 1.8;
 }
 
-.glamor-43 {
+.glamor-45 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-27 {
+.glamor-29 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -52,13 +60,13 @@ exports[`OrganizationApiKeysList renders 1`] = `
   padding: 15px 0;
 }
 
-.glamor-23 {
+.glamor-25 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-21 {
+.glamor-23 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -68,7 +76,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   margin: 0;
 }
 
-.glamor-14 {
+.glamor-16 {
   box-sizing: border-box;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -83,7 +91,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   align-items: center;
 }
 
-.glamor-10 {
+.glamor-12 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -92,7 +100,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   flex: 1;
 }
 
-.glamor-12 {
+.glamor-14 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -101,14 +109,14 @@ exports[`OrganizationApiKeysList renders 1`] = `
   flex: 2;
 }
 
-.glamor-16 {
+.glamor-18 {
   box-sizing: border-box;
   width: 100px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-39 {
+.glamor-41 {
   box-sizing: border-box;
   padding: 0px;
   padding-top: 8px;
@@ -124,7 +132,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-39:last-child {
+.glamor-41:last-child {
   border: 0;
 }
 
@@ -189,17 +197,17 @@ exports[`OrganizationApiKeysList renders 1`] = `
     >
       <Wrapper>
         <div
-          className="glamor-6 glamor-7"
+          className="glamor-8 glamor-9"
         >
           <Flex
             align="center"
           >
             <Base
               align="center"
-              className="glamor-4"
+              className="glamor-6"
             >
               <div
-                className="glamor-4"
+                className="glamor-6"
                 is={null}
               >
                 <Title>
@@ -220,27 +228,30 @@ exports[`OrganizationApiKeysList renders 1`] = `
                       onClick={[Function]}
                       role="button"
                     >
-                      <FlowLayout
-                        truncate={false}
-                      >
-                        <div
-                          className="flow-layout"
+                      <Flex>
+                        <Base
+                          className="glamor-4"
                         >
-                          <span
-                            className="button-label"
+                          <div
+                            className="glamor-4"
+                            is={null}
                           >
-                            <PlusIcon
-                              className="icon-plus"
+                            <span
+                              className="button-label"
                             >
-                              <span
-                                className="icon-plus glamor-2 glamor-3"
-                              />
-                            </PlusIcon>
-                             
-                            New API Key
-                          </span>
-                        </div>
-                      </FlowLayout>
+                              <PlusIcon
+                                className="icon-plus"
+                              >
+                                <span
+                                  className="icon-plus glamor-2 glamor-3"
+                                />
+                              </PlusIcon>
+                               
+                              New API Key
+                            </span>
+                          </div>
+                        </Base>
+                      </Flex>
                     </button>
                   </Button>
                 </div>
@@ -252,7 +263,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
     </SettingsPageHeading>
     <TextBlock>
       <p
-        className="glamor-8 glamor-9"
+        className="glamor-10 glamor-11"
       >
         <span
           key="5"
@@ -324,7 +335,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
     </div>
     <Panel>
       <div
-        className="glamor-43 glamor-44"
+        className="glamor-45 glamor-46"
       >
         <PanelHeader
           disablePadding={true}
@@ -333,31 +344,31 @@ exports[`OrganizationApiKeysList renders 1`] = `
             disablePadding={true}
           >
             <Component
-              className="glamor-27 glamor-28"
+              className="glamor-29 glamor-30"
               disablePadding={true}
             >
               <div
-                className="glamor-27 glamor-28"
+                className="glamor-29 glamor-30"
               >
                 <StyledPanelHeading>
                   <Component
-                    className="glamor-23 glamor-20"
+                    className="glamor-25 glamor-22"
                   >
                     <PanelHeading
-                      className="glamor-23 glamor-20"
+                      className="glamor-25 glamor-22"
                     >
                       <div
-                        className="glamor-20 glamor-21 glamor-22"
+                        className="glamor-22 glamor-23 glamor-24"
                       >
                         <Flex
                           align="center"
                         >
                           <Base
                             align="center"
-                            className="glamor-4"
+                            className="glamor-6"
                           >
                             <div
-                              className="glamor-4"
+                              className="glamor-6"
                               is={null}
                             >
                               <Flex
@@ -366,11 +377,11 @@ exports[`OrganizationApiKeysList renders 1`] = `
                               >
                                 <Base
                                   align="center"
-                                  className="glamor-14"
+                                  className="glamor-16"
                                   flex="1"
                                 >
                                   <div
-                                    className="glamor-14"
+                                    className="glamor-16"
                                     is={null}
                                   >
                                     <Box
@@ -378,12 +389,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                       px={2}
                                     >
                                       <Base
-                                        className="glamor-10"
+                                        className="glamor-12"
                                         flex="1"
                                         px={2}
                                       >
                                         <div
-                                          className="glamor-10"
+                                          className="glamor-12"
                                           is={null}
                                         >
                                           Name
@@ -395,12 +406,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                       px={2}
                                     >
                                       <Base
-                                        className="glamor-12"
+                                        className="glamor-14"
                                         flex="2"
                                         px={2}
                                       >
                                         <div
-                                          className="glamor-12"
+                                          className="glamor-14"
                                           is={null}
                                         >
                                           Key
@@ -415,12 +426,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                 w={100}
                               >
                                 <Base
-                                  className="glamor-16"
+                                  className="glamor-18"
                                   px={2}
                                   w={100}
                                 >
                                   <div
-                                    className="glamor-16"
+                                    className="glamor-18"
                                     is={null}
                                   >
                                     Actions
@@ -459,12 +470,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
               >
                 <Base
                   align="center"
-                  className="glamor-39 glamor-40"
+                  className="glamor-41 glamor-42"
                   p={0}
                   py={1}
                 >
                   <div
-                    className="glamor-39 glamor-40"
+                    className="glamor-41 glamor-42"
                     is={null}
                   >
                     <Flex
@@ -473,11 +484,11 @@ exports[`OrganizationApiKeysList renders 1`] = `
                     >
                       <Base
                         align="center"
-                        className="glamor-14"
+                        className="glamor-16"
                         flex="1"
                       >
                         <div
-                          className="glamor-14"
+                          className="glamor-16"
                           is={null}
                         >
                           <Box
@@ -487,12 +498,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                           >
                             <Base
                               align="center"
-                              className="glamor-10"
+                              className="glamor-12"
                               flex="1"
                               px={2}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               >
                                 <Link
@@ -512,12 +523,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                             px={2}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-14"
                               flex="2"
                               px={2}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-14"
                                 is={null}
                               >
                                 <div
@@ -536,12 +547,12 @@ exports[`OrganizationApiKeysList renders 1`] = `
                       w={100}
                     >
                       <Base
-                        className="glamor-16"
+                        className="glamor-18"
                         px={2}
                         w={100}
                       >
                         <div
-                          className="glamor-16"
+                          className="glamor-18"
                           is={null}
                         >
                           <LinkWithConfirmation

--- a/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
   margin: -20px 0 30px;
 }
 
-.glamor-6 {
+.glamor-4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -26,14 +26,6 @@ exports[`OrganizationApiKeysList renders 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-}
-
-.glamor-4 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .glamor-2 {
@@ -204,10 +196,10 @@ exports[`OrganizationApiKeysList renders 1`] = `
           >
             <Base
               align="center"
-              className="glamor-6"
+              className="glamor-4"
             >
               <div
-                className="glamor-6"
+                className="glamor-4"
                 is={null}
               >
                 <Title>
@@ -228,27 +220,27 @@ exports[`OrganizationApiKeysList renders 1`] = `
                       onClick={[Function]}
                       role="button"
                     >
-                      <Flex>
+                      <Flex
+                        align="center"
+                        className="button-label"
+                      >
                         <Base
-                          className="glamor-4"
+                          align="center"
+                          className="button-label glamor-4"
                         >
                           <div
-                            className="glamor-4"
+                            className="button-label glamor-4"
                             is={null}
                           >
-                            <span
-                              className="button-label"
+                            <PlusIcon
+                              className="icon-plus"
                             >
-                              <PlusIcon
-                                className="icon-plus"
-                              >
-                                <span
-                                  className="icon-plus glamor-2 glamor-3"
-                                />
-                              </PlusIcon>
-                               
-                              New API Key
-                            </span>
+                              <span
+                                className="icon-plus glamor-2 glamor-3"
+                              />
+                            </PlusIcon>
+                             
+                            New API Key
                           </div>
                         </Base>
                       </Flex>
@@ -365,10 +357,10 @@ exports[`OrganizationApiKeysList renders 1`] = `
                         >
                           <Base
                             align="center"
-                            className="glamor-6"
+                            className="glamor-4"
                           >
                             <div
-                              className="glamor-6"
+                              className="glamor-4"
                               is={null}
                             >
                               <Flex

--- a/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OrganizationMembersView No Require Link does not have 2fa warning if user has 2fa 1`] = `
-.glamor-6 {
+.glamor-12 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-4 {
+.glamor-8 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -28,22 +28,28 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  margin-right: 6px;
+  margin-left: -2px;
 }
 
-.glamor-95 {
+.glamor-4 svg {
+  display: block;
+}
+
+.glamor-2 {
+  vertical-align: middle;
+}
+
+.glamor-101 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-25 {
+.glamor-31 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -52,13 +58,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   padding: 15px 0;
 }
 
-.glamor-21 {
+.glamor-27 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-19 {
+.glamor-25 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -68,7 +74,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   margin: 0;
 }
 
-.glamor-8 {
+.glamor-14 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -77,21 +83,21 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-10 {
+.glamor-16 {
   box-sizing: border-box;
   width: 180px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-12 {
+.glamor-18 {
   box-sizing: border-box;
   width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-47 {
+.glamor-53 {
   box-sizing: border-box;
   padding: 0px;
   padding-top: 16px;
@@ -107,16 +113,16 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   border-bottom: 1px solid;
 }
 
-.glamor-47:last-child {
+.glamor-53:last-child {
   border: 0;
 }
 
-.glamor-29 {
+.glamor-35 {
   box-sizing: border-box;
   padding-left: 16px;
 }
 
-.glamor-37 {
+.glamor-43 {
   box-sizing: border-box;
   padding-left: 8px;
   padding-right: 16px;
@@ -125,11 +131,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-31 {
+.glamor-37 {
   font-size: 16px;
 }
 
-.glamor-35 {
+.glamor-41 {
   font-size: 14px;
 }
 
@@ -181,15 +187,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
           action={
             <Button
               disabled={false}
+              icon="icon-circle-add"
               priority="primary"
               size="small"
               title={undefined}
               to="new"
             >
-              <span
-                className="icon-plus"
-              />
-               
               Invite Member
             </Button>
           }
@@ -197,17 +200,17 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
         >
           <Wrapper>
             <div
-              className="glamor-6 glamor-7"
+              className="glamor-12 glamor-13"
             >
               <Flex
                 align="center"
               >
                 <Base
                   align="center"
-                  className="glamor-4"
+                  className="glamor-8"
                 >
                   <div
-                    className="glamor-4"
+                    className="glamor-8"
                     is={null}
                   >
                     <Title>
@@ -220,6 +223,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                     <div>
                       <Button
                         disabled={false}
+                        icon="icon-circle-add"
                         priority="primary"
                         size="small"
                         to="new"
@@ -240,23 +244,59 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             role="button"
                             style={Object {}}
                           >
-                            <Flex>
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
                               <Base
-                                className="glamor-2"
+                                align="center"
+                                className="button-label glamor-8"
                               >
                                 <div
-                                  className="glamor-2"
+                                  className="button-label glamor-8"
                                   is={null}
                                 >
-                                  <span
-                                    className="button-label"
+                                  <Icon
+                                    size="small"
                                   >
-                                    <span
-                                      className="icon-plus"
-                                    />
-                                     
-                                    Invite Member
-                                  </span>
+                                    <Base
+                                      className="glamor-4 glamor-5"
+                                      size="small"
+                                    >
+                                      <div
+                                        className="glamor-4 glamor-5"
+                                        is={null}
+                                        size="small"
+                                      >
+                                        <InlineSvg
+                                          size="12px"
+                                          src="icon-circle-add"
+                                        >
+                                          <StyledSvg
+                                            className=""
+                                            height="12px"
+                                            style={Object {}}
+                                            viewBox={Object {}}
+                                            width="12px"
+                                          >
+                                            <svg
+                                              className="glamor-2 glamor-3"
+                                              height="12px"
+                                              style={Object {}}
+                                              viewBox={Object {}}
+                                              width="12px"
+                                            >
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </StyledSvg>
+                                        </InlineSvg>
+                                      </div>
+                                    </Base>
+                                  </Icon>
+                                  Invite Member
                                 </div>
                               </Base>
                             </Flex>
@@ -278,7 +318,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
         />
         <Panel>
           <div
-            className="glamor-95 glamor-96"
+            className="glamor-101 glamor-102"
           >
             <PanelHeader
               disablePadding={true}
@@ -287,31 +327,31 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                 disablePadding={true}
               >
                 <Component
-                  className="glamor-25 glamor-26"
+                  className="glamor-31 glamor-32"
                   disablePadding={true}
                 >
                   <div
-                    className="glamor-25 glamor-26"
+                    className="glamor-31 glamor-32"
                   >
                     <StyledPanelHeading>
                       <Component
-                        className="glamor-21 glamor-18"
+                        className="glamor-27 glamor-24"
                       >
                         <PanelHeading
-                          className="glamor-21 glamor-18"
+                          className="glamor-27 glamor-24"
                         >
                           <div
-                            className="glamor-18 glamor-19 glamor-20"
+                            className="glamor-24 glamor-25 glamor-26"
                           >
                             <Flex
                               align="center"
                             >
                               <Base
                                 align="center"
-                                className="glamor-4"
+                                className="glamor-8"
                               >
                                 <div
-                                  className="glamor-4"
+                                  className="glamor-8"
                                   is={null}
                                 >
                                   <Box
@@ -319,12 +359,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     px={2}
                                   >
                                     <Base
-                                      className="glamor-8"
+                                      className="glamor-14"
                                       flex="1"
                                       px={2}
                                     >
                                       <div
-                                        className="glamor-8"
+                                        className="glamor-14"
                                         is={null}
                                       >
                                         Member
@@ -336,12 +376,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     w={180}
                                   >
                                     <Base
-                                      className="glamor-10"
+                                      className="glamor-16"
                                       px={2}
                                       w={180}
                                     >
                                       <div
-                                        className="glamor-10"
+                                        className="glamor-16"
                                         is={null}
                                       >
                                         Status
@@ -353,12 +393,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-12"
+                                      className="glamor-18"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-12"
+                                        className="glamor-18"
                                         is={null}
                                       >
                                         Role
@@ -370,12 +410,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-12"
+                                      className="glamor-18"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-12"
+                                        className="glamor-18"
                                         is={null}
                                       >
                                         Actions
@@ -469,23 +509,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                     >
                       <Base
                         align="center"
-                        className="glamor-47 glamor-48"
+                        className="glamor-53 glamor-54"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-47 glamor-48"
+                          className="glamor-53 glamor-54"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-29"
+                              className="glamor-35"
                               pl={2}
                             >
                               <div
-                                className="glamor-29"
+                                className="glamor-35"
                                 is={null}
                               >
                                 <Avatar
@@ -533,13 +573,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             pr={2}
                           >
                             <Base
-                              className="glamor-37"
+                              className="glamor-43"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-37"
+                                className="glamor-43"
                                 is={null}
                               >
                                 <h5
@@ -553,11 +593,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     to="1"
                                   >
                                     <Link
-                                      className="glamor-31 glamor-32"
+                                      className="glamor-37 glamor-38"
                                       to="1"
                                     >
                                       <a
-                                        className="glamor-31 glamor-32"
+                                        className="glamor-37 glamor-38"
                                         href="1"
                                       />
                                     </Link>
@@ -565,7 +605,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-35 glamor-36"
+                                    className="glamor-41 glamor-42"
                                   />
                                 </Email>
                               </div>
@@ -576,12 +616,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-16"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-16"
                                 is={null}
                               >
                                 <div>
@@ -607,12 +647,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               />
                             </Base>
@@ -622,12 +662,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               >
                                 <Button
@@ -641,23 +681,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <Flex>
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
                                       <Base
-                                        className="glamor-2"
+                                        align="center"
+                                        className="button-label glamor-8"
                                       >
                                         <div
-                                          className="glamor-2"
+                                          className="button-label glamor-8"
                                           is={null}
                                         >
                                           <span
-                                            className="button-label"
-                                          >
-                                            <span
-                                              className="icon icon-exit"
-                                            />
-                                             
-                                            Leave
-                                          </span>
+                                            className="icon icon-exit"
+                                          />
+                                           
+                                          Leave
                                         </div>
                                       </Base>
                                     </Flex>
@@ -739,23 +779,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                     >
                       <Base
                         align="center"
-                        className="glamor-47 glamor-48"
+                        className="glamor-53 glamor-54"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-47 glamor-48"
+                          className="glamor-53 glamor-54"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-29"
+                              className="glamor-35"
                               pl={2}
                             >
                               <div
-                                className="glamor-29"
+                                className="glamor-35"
                                 is={null}
                               >
                                 <Avatar
@@ -803,13 +843,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             pr={2}
                           >
                             <Base
-                              className="glamor-37"
+                              className="glamor-43"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-37"
+                                className="glamor-43"
                                 is={null}
                               >
                                 <h5
@@ -823,11 +863,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     to="2"
                                   >
                                     <Link
-                                      className="glamor-31 glamor-32"
+                                      className="glamor-37 glamor-38"
                                       to="2"
                                     >
                                       <a
-                                        className="glamor-31 glamor-32"
+                                        className="glamor-37 glamor-38"
                                         href="2"
                                       />
                                     </Link>
@@ -835,7 +875,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-35 glamor-36"
+                                    className="glamor-41 glamor-42"
                                   />
                                 </Email>
                               </div>
@@ -846,12 +886,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-16"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-16"
                                 is={null}
                               >
                                 <div>
@@ -872,12 +912,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               />
                             </Base>
@@ -887,12 +927,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               >
                                 <Button
@@ -906,23 +946,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <Flex>
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
                                       <Base
-                                        className="glamor-2"
+                                        align="center"
+                                        className="button-label glamor-8"
                                       >
                                         <div
-                                          className="glamor-2"
+                                          className="button-label glamor-8"
                                           is={null}
                                         >
                                           <span
-                                            className="button-label"
-                                          >
-                                            <span
-                                              className="icon icon-exit"
-                                            />
-                                             
-                                            Leave
-                                          </span>
+                                            className="icon icon-exit"
+                                          />
+                                           
+                                          Leave
                                         </div>
                                       </Base>
                                     </Flex>
@@ -1004,23 +1044,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                     >
                       <Base
                         align="center"
-                        className="glamor-47 glamor-48"
+                        className="glamor-53 glamor-54"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-47 glamor-48"
+                          className="glamor-53 glamor-54"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-29"
+                              className="glamor-35"
                               pl={2}
                             >
                               <div
-                                className="glamor-29"
+                                className="glamor-35"
                                 is={null}
                               >
                                 <Avatar
@@ -1068,13 +1108,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             pr={2}
                           >
                             <Base
-                              className="glamor-37"
+                              className="glamor-43"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-37"
+                                className="glamor-43"
                                 is={null}
                               >
                                 <h5
@@ -1088,11 +1128,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     to="3"
                                   >
                                     <Link
-                                      className="glamor-31 glamor-32"
+                                      className="glamor-37 glamor-38"
                                       to="3"
                                     >
                                       <a
-                                        className="glamor-31 glamor-32"
+                                        className="glamor-37 glamor-38"
                                         href="3"
                                       />
                                     </Link>
@@ -1100,7 +1140,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-35 glamor-36"
+                                    className="glamor-41 glamor-42"
                                   />
                                 </Email>
                               </div>
@@ -1111,12 +1151,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-16"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-16"
                                 is={null}
                               >
                                 <div>
@@ -1137,12 +1177,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               />
                             </Base>
@@ -1152,12 +1192,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               >
                                 <Button
@@ -1171,23 +1211,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <Flex>
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
                                       <Base
-                                        className="glamor-2"
+                                        align="center"
+                                        className="button-label glamor-8"
                                       >
                                         <div
-                                          className="glamor-2"
+                                          className="button-label glamor-8"
                                           is={null}
                                         >
                                           <span
-                                            className="button-label"
-                                          >
-                                            <span
-                                              className="icon icon-exit"
-                                            />
-                                             
-                                            Leave
-                                          </span>
+                                            className="icon icon-exit"
+                                          />
+                                           
+                                          Leave
                                         </div>
                                       </Base>
                                     </Flex>
@@ -1215,13 +1255,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
 `;
 
 exports[`OrganizationMembersView Require Link does not have 2fa warning if user has 2fa 1`] = `
-.glamor-6 {
+.glamor-12 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-4 {
+.glamor-8 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1242,22 +1282,28 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  margin-right: 6px;
+  margin-left: -2px;
 }
 
-.glamor-99 {
+.glamor-4 svg {
+  display: block;
+}
+
+.glamor-2 {
+  vertical-align: middle;
+}
+
+.glamor-105 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-25 {
+.glamor-31 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -1266,13 +1312,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   padding: 15px 0;
 }
 
-.glamor-21 {
+.glamor-27 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-19 {
+.glamor-25 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -1282,7 +1328,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   margin: 0;
 }
 
-.glamor-8 {
+.glamor-14 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -1291,21 +1337,21 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-10 {
+.glamor-16 {
   box-sizing: border-box;
   width: 180px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-12 {
+.glamor-18 {
   box-sizing: border-box;
   width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-49 {
+.glamor-55 {
   box-sizing: border-box;
   padding: 0px;
   padding-top: 16px;
@@ -1321,16 +1367,16 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   border-bottom: 1px solid;
 }
 
-.glamor-49:last-child {
+.glamor-55:last-child {
   border: 0;
 }
 
-.glamor-29 {
+.glamor-35 {
   box-sizing: border-box;
   padding-left: 16px;
 }
 
-.glamor-37 {
+.glamor-43 {
   box-sizing: border-box;
   padding-left: 8px;
   padding-right: 16px;
@@ -1339,11 +1385,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-31 {
+.glamor-37 {
   font-size: 16px;
 }
 
-.glamor-35 {
+.glamor-41 {
   font-size: 14px;
 }
 
@@ -1395,15 +1441,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
           action={
             <Button
               disabled={false}
+              icon="icon-circle-add"
               priority="primary"
               size="small"
               title={undefined}
               to="new"
             >
-              <span
-                className="icon-plus"
-              />
-               
               Invite Member
             </Button>
           }
@@ -1411,17 +1454,17 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
         >
           <Wrapper>
             <div
-              className="glamor-6 glamor-7"
+              className="glamor-12 glamor-13"
             >
               <Flex
                 align="center"
               >
                 <Base
                   align="center"
-                  className="glamor-4"
+                  className="glamor-8"
                 >
                   <div
-                    className="glamor-4"
+                    className="glamor-8"
                     is={null}
                   >
                     <Title>
@@ -1434,6 +1477,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                     <div>
                       <Button
                         disabled={false}
+                        icon="icon-circle-add"
                         priority="primary"
                         size="small"
                         to="new"
@@ -1454,23 +1498,59 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             role="button"
                             style={Object {}}
                           >
-                            <Flex>
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
                               <Base
-                                className="glamor-2"
+                                align="center"
+                                className="button-label glamor-8"
                               >
                                 <div
-                                  className="glamor-2"
+                                  className="button-label glamor-8"
                                   is={null}
                                 >
-                                  <span
-                                    className="button-label"
+                                  <Icon
+                                    size="small"
                                   >
-                                    <span
-                                      className="icon-plus"
-                                    />
-                                     
-                                    Invite Member
-                                  </span>
+                                    <Base
+                                      className="glamor-4 glamor-5"
+                                      size="small"
+                                    >
+                                      <div
+                                        className="glamor-4 glamor-5"
+                                        is={null}
+                                        size="small"
+                                      >
+                                        <InlineSvg
+                                          size="12px"
+                                          src="icon-circle-add"
+                                        >
+                                          <StyledSvg
+                                            className=""
+                                            height="12px"
+                                            style={Object {}}
+                                            viewBox={Object {}}
+                                            width="12px"
+                                          >
+                                            <svg
+                                              className="glamor-2 glamor-3"
+                                              height="12px"
+                                              style={Object {}}
+                                              viewBox={Object {}}
+                                              width="12px"
+                                            >
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </StyledSvg>
+                                        </InlineSvg>
+                                      </div>
+                                    </Base>
+                                  </Icon>
+                                  Invite Member
                                 </div>
                               </Base>
                             </Flex>
@@ -1492,7 +1572,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
         />
         <Panel>
           <div
-            className="glamor-99 glamor-100"
+            className="glamor-105 glamor-106"
           >
             <PanelHeader
               disablePadding={true}
@@ -1501,31 +1581,31 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                 disablePadding={true}
               >
                 <Component
-                  className="glamor-25 glamor-26"
+                  className="glamor-31 glamor-32"
                   disablePadding={true}
                 >
                   <div
-                    className="glamor-25 glamor-26"
+                    className="glamor-31 glamor-32"
                   >
                     <StyledPanelHeading>
                       <Component
-                        className="glamor-21 glamor-18"
+                        className="glamor-27 glamor-24"
                       >
                         <PanelHeading
-                          className="glamor-21 glamor-18"
+                          className="glamor-27 glamor-24"
                         >
                           <div
-                            className="glamor-18 glamor-19 glamor-20"
+                            className="glamor-24 glamor-25 glamor-26"
                           >
                             <Flex
                               align="center"
                             >
                               <Base
                                 align="center"
-                                className="glamor-4"
+                                className="glamor-8"
                               >
                                 <div
-                                  className="glamor-4"
+                                  className="glamor-8"
                                   is={null}
                                 >
                                   <Box
@@ -1533,12 +1613,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     px={2}
                                   >
                                     <Base
-                                      className="glamor-8"
+                                      className="glamor-14"
                                       flex="1"
                                       px={2}
                                     >
                                       <div
-                                        className="glamor-8"
+                                        className="glamor-14"
                                         is={null}
                                       >
                                         Member
@@ -1550,12 +1630,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     w={180}
                                   >
                                     <Base
-                                      className="glamor-10"
+                                      className="glamor-16"
                                       px={2}
                                       w={180}
                                     >
                                       <div
-                                        className="glamor-10"
+                                        className="glamor-16"
                                         is={null}
                                       >
                                         Status
@@ -1567,12 +1647,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-12"
+                                      className="glamor-18"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-12"
+                                        className="glamor-18"
                                         is={null}
                                       >
                                         Role
@@ -1584,12 +1664,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-12"
+                                      className="glamor-18"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-12"
+                                        className="glamor-18"
                                         is={null}
                                       >
                                         Actions
@@ -1683,23 +1763,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                     >
                       <Base
                         align="center"
-                        className="glamor-49 glamor-50"
+                        className="glamor-55 glamor-56"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-49 glamor-50"
+                          className="glamor-55 glamor-56"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-29"
+                              className="glamor-35"
                               pl={2}
                             >
                               <div
-                                className="glamor-29"
+                                className="glamor-35"
                                 is={null}
                               >
                                 <Avatar
@@ -1747,13 +1827,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             pr={2}
                           >
                             <Base
-                              className="glamor-37"
+                              className="glamor-43"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-37"
+                                className="glamor-43"
                                 is={null}
                               >
                                 <h5
@@ -1767,11 +1847,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     to="1"
                                   >
                                     <Link
-                                      className="glamor-31 glamor-32"
+                                      className="glamor-37 glamor-38"
                                       to="1"
                                     >
                                       <a
-                                        className="glamor-31 glamor-32"
+                                        className="glamor-37 glamor-38"
                                         href="1"
                                       />
                                     </Link>
@@ -1779,7 +1859,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-35 glamor-36"
+                                    className="glamor-41 glamor-42"
                                   />
                                 </Email>
                               </div>
@@ -1790,12 +1870,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-16"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-16"
                                 is={null}
                               >
                                 <div>
@@ -1828,19 +1908,19 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                         }
                                       }
                                     >
-                                      <Flex>
+                                      <Flex
+                                        align="center"
+                                        className="button-label"
+                                      >
                                         <Base
-                                          className="glamor-2"
+                                          align="center"
+                                          className="button-label glamor-8"
                                         >
                                           <div
-                                            className="glamor-2"
+                                            className="button-label glamor-8"
                                             is={null}
                                           >
-                                            <span
-                                              className="button-label"
-                                            >
-                                              Resend invite
-                                            </span>
+                                            Resend invite
                                           </div>
                                         </Base>
                                       </Flex>
@@ -1855,12 +1935,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               />
                             </Base>
@@ -1870,12 +1950,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               >
                                 <Button
@@ -1889,23 +1969,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <Flex>
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
                                       <Base
-                                        className="glamor-2"
+                                        align="center"
+                                        className="button-label glamor-8"
                                       >
                                         <div
-                                          className="glamor-2"
+                                          className="button-label glamor-8"
                                           is={null}
                                         >
                                           <span
-                                            className="button-label"
-                                          >
-                                            <span
-                                              className="icon icon-exit"
-                                            />
-                                             
-                                            Leave
-                                          </span>
+                                            className="icon icon-exit"
+                                          />
+                                           
+                                          Leave
                                         </div>
                                       </Base>
                                     </Flex>
@@ -1987,23 +2067,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                     >
                       <Base
                         align="center"
-                        className="glamor-49 glamor-50"
+                        className="glamor-55 glamor-56"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-49 glamor-50"
+                          className="glamor-55 glamor-56"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-29"
+                              className="glamor-35"
                               pl={2}
                             >
                               <div
-                                className="glamor-29"
+                                className="glamor-35"
                                 is={null}
                               >
                                 <Avatar
@@ -2051,13 +2131,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             pr={2}
                           >
                             <Base
-                              className="glamor-37"
+                              className="glamor-43"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-37"
+                                className="glamor-43"
                                 is={null}
                               >
                                 <h5
@@ -2071,11 +2151,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     to="2"
                                   >
                                     <Link
-                                      className="glamor-31 glamor-32"
+                                      className="glamor-37 glamor-38"
                                       to="2"
                                     >
                                       <a
-                                        className="glamor-31 glamor-32"
+                                        className="glamor-37 glamor-38"
                                         href="2"
                                       />
                                     </Link>
@@ -2083,7 +2163,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-35 glamor-36"
+                                    className="glamor-41 glamor-42"
                                   />
                                 </Email>
                               </div>
@@ -2094,12 +2174,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-16"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-16"
                                 is={null}
                               >
                                 <div>
@@ -2132,19 +2212,19 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                         }
                                       }
                                     >
-                                      <Flex>
+                                      <Flex
+                                        align="center"
+                                        className="button-label"
+                                      >
                                         <Base
-                                          className="glamor-2"
+                                          align="center"
+                                          className="button-label glamor-8"
                                         >
                                           <div
-                                            className="glamor-2"
+                                            className="button-label glamor-8"
                                             is={null}
                                           >
-                                            <span
-                                              className="button-label"
-                                            >
-                                              Resend invite
-                                            </span>
+                                            Resend invite
                                           </div>
                                         </Base>
                                       </Flex>
@@ -2159,12 +2239,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               />
                             </Base>
@@ -2174,12 +2254,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               >
                                 <Button
@@ -2193,23 +2273,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <Flex>
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
                                       <Base
-                                        className="glamor-2"
+                                        align="center"
+                                        className="button-label glamor-8"
                                       >
                                         <div
-                                          className="glamor-2"
+                                          className="button-label glamor-8"
                                           is={null}
                                         >
                                           <span
-                                            className="button-label"
-                                          >
-                                            <span
-                                              className="icon icon-exit"
-                                            />
-                                             
-                                            Leave
-                                          </span>
+                                            className="icon icon-exit"
+                                          />
+                                           
+                                          Leave
                                         </div>
                                       </Base>
                                     </Flex>
@@ -2291,23 +2371,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                     >
                       <Base
                         align="center"
-                        className="glamor-49 glamor-50"
+                        className="glamor-55 glamor-56"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-49 glamor-50"
+                          className="glamor-55 glamor-56"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-29"
+                              className="glamor-35"
                               pl={2}
                             >
                               <div
-                                className="glamor-29"
+                                className="glamor-35"
                                 is={null}
                               >
                                 <Avatar
@@ -2355,13 +2435,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             pr={2}
                           >
                             <Base
-                              className="glamor-37"
+                              className="glamor-43"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-37"
+                                className="glamor-43"
                                 is={null}
                               >
                                 <h5
@@ -2375,11 +2455,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     to="3"
                                   >
                                     <Link
-                                      className="glamor-31 glamor-32"
+                                      className="glamor-37 glamor-38"
                                       to="3"
                                     >
                                       <a
-                                        className="glamor-31 glamor-32"
+                                        className="glamor-37 glamor-38"
                                         href="3"
                                       />
                                     </Link>
@@ -2387,7 +2467,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-35 glamor-36"
+                                    className="glamor-41 glamor-42"
                                   />
                                 </Email>
                               </div>
@@ -2398,12 +2478,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={180}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-16"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-16"
                                 is={null}
                               >
                                 <div>
@@ -2424,12 +2504,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               />
                             </Base>
@@ -2439,12 +2519,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-12"
+                              className="glamor-18"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-12"
+                                className="glamor-18"
                                 is={null}
                               >
                                 <Button
@@ -2458,23 +2538,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <Flex>
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
                                       <Base
-                                        className="glamor-2"
+                                        align="center"
+                                        className="button-label glamor-8"
                                       >
                                         <div
-                                          className="glamor-2"
+                                          className="button-label glamor-8"
                                           is={null}
                                         >
                                           <span
-                                            className="button-label"
-                                          >
-                                            <span
-                                              className="icon icon-exit"
-                                            />
-                                             
-                                            Leave
-                                          </span>
+                                            className="icon icon-exit"
+                                          />
+                                           
+                                          Leave
                                         </div>
                                       </Base>
                                     </Flex>

--- a/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationMembersView.spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OrganizationMembersView No Require Link does not have 2fa warning if user has 2fa 1`] = `
-.glamor-4 {
+.glamor-6 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -28,14 +28,22 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-87 {
+.glamor-2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-95 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-23 {
+.glamor-25 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -44,13 +52,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   padding: 15px 0;
 }
 
-.glamor-19 {
+.glamor-21 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-17 {
+.glamor-19 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -60,7 +68,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   margin: 0;
 }
 
-.glamor-6 {
+.glamor-8 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -69,21 +77,21 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-8 {
+.glamor-10 {
   box-sizing: border-box;
   width: 180px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-10 {
+.glamor-12 {
   box-sizing: border-box;
   width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-43 {
+.glamor-47 {
   box-sizing: border-box;
   padding: 0px;
   padding-top: 16px;
@@ -99,16 +107,16 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   border-bottom: 1px solid;
 }
 
-.glamor-43:last-child {
+.glamor-47:last-child {
   border: 0;
 }
 
-.glamor-27 {
+.glamor-29 {
   box-sizing: border-box;
   padding-left: 16px;
 }
 
-.glamor-35 {
+.glamor-37 {
   box-sizing: border-box;
   padding-left: 8px;
   padding-right: 16px;
@@ -117,11 +125,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
   flex: 1;
 }
 
-.glamor-29 {
+.glamor-31 {
   font-size: 16px;
 }
 
-.glamor-33 {
+.glamor-35 {
   font-size: 14px;
 }
 
@@ -189,17 +197,17 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
         >
           <Wrapper>
             <div
-              className="glamor-4 glamor-5"
+              className="glamor-6 glamor-7"
             >
               <Flex
                 align="center"
               >
                 <Base
                   align="center"
-                  className="glamor-2"
+                  className="glamor-4"
                 >
                   <div
-                    className="glamor-2"
+                    className="glamor-4"
                     is={null}
                   >
                     <Title>
@@ -232,23 +240,26 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             role="button"
                             style={Object {}}
                           >
-                            <FlowLayout
-                              truncate={false}
-                            >
-                              <div
-                                className="flow-layout"
+                            <Flex>
+                              <Base
+                                className="glamor-2"
                               >
-                                <span
-                                  className="button-label"
+                                <div
+                                  className="glamor-2"
+                                  is={null}
                                 >
                                   <span
-                                    className="icon-plus"
-                                  />
-                                   
-                                  Invite Member
-                                </span>
-                              </div>
-                            </FlowLayout>
+                                    className="button-label"
+                                  >
+                                    <span
+                                      className="icon-plus"
+                                    />
+                                     
+                                    Invite Member
+                                  </span>
+                                </div>
+                              </Base>
+                            </Flex>
                           </a>
                         </Link>
                       </Button>
@@ -267,7 +278,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
         />
         <Panel>
           <div
-            className="glamor-87 glamor-88"
+            className="glamor-95 glamor-96"
           >
             <PanelHeader
               disablePadding={true}
@@ -276,31 +287,31 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                 disablePadding={true}
               >
                 <Component
-                  className="glamor-23 glamor-24"
+                  className="glamor-25 glamor-26"
                   disablePadding={true}
                 >
                   <div
-                    className="glamor-23 glamor-24"
+                    className="glamor-25 glamor-26"
                   >
                     <StyledPanelHeading>
                       <Component
-                        className="glamor-19 glamor-16"
+                        className="glamor-21 glamor-18"
                       >
                         <PanelHeading
-                          className="glamor-19 glamor-16"
+                          className="glamor-21 glamor-18"
                         >
                           <div
-                            className="glamor-16 glamor-17 glamor-18"
+                            className="glamor-18 glamor-19 glamor-20"
                           >
                             <Flex
                               align="center"
                             >
                               <Base
                                 align="center"
-                                className="glamor-2"
+                                className="glamor-4"
                               >
                                 <div
-                                  className="glamor-2"
+                                  className="glamor-4"
                                   is={null}
                                 >
                                   <Box
@@ -308,12 +319,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     px={2}
                                   >
                                     <Base
-                                      className="glamor-6"
+                                      className="glamor-8"
                                       flex="1"
                                       px={2}
                                     >
                                       <div
-                                        className="glamor-6"
+                                        className="glamor-8"
                                         is={null}
                                       >
                                         Member
@@ -325,12 +336,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     w={180}
                                   >
                                     <Base
-                                      className="glamor-8"
+                                      className="glamor-10"
                                       px={2}
                                       w={180}
                                     >
                                       <div
-                                        className="glamor-8"
+                                        className="glamor-10"
                                         is={null}
                                       >
                                         Status
@@ -342,12 +353,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-10"
+                                      className="glamor-12"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-10"
+                                        className="glamor-12"
                                         is={null}
                                       >
                                         Role
@@ -359,12 +370,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-10"
+                                      className="glamor-12"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-10"
+                                        className="glamor-12"
                                         is={null}
                                       >
                                         Actions
@@ -458,23 +469,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                     >
                       <Base
                         align="center"
-                        className="glamor-43 glamor-44"
+                        className="glamor-47 glamor-48"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-43 glamor-44"
+                          className="glamor-47 glamor-48"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-27"
+                              className="glamor-29"
                               pl={2}
                             >
                               <div
-                                className="glamor-27"
+                                className="glamor-29"
                                 is={null}
                               >
                                 <Avatar
@@ -522,13 +533,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             pr={2}
                           >
                             <Base
-                              className="glamor-35"
+                              className="glamor-37"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-35"
+                                className="glamor-37"
                                 is={null}
                               >
                                 <h5
@@ -542,11 +553,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     to="1"
                                   >
                                     <Link
-                                      className="glamor-29 glamor-30"
+                                      className="glamor-31 glamor-32"
                                       to="1"
                                     >
                                       <a
-                                        className="glamor-29 glamor-30"
+                                        className="glamor-31 glamor-32"
                                         href="1"
                                       />
                                     </Link>
@@ -554,7 +565,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-33 glamor-34"
+                                    className="glamor-35 glamor-36"
                                   />
                                 </Email>
                               </div>
@@ -565,12 +576,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={180}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-10"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-10"
                                 is={null}
                               >
                                 <div>
@@ -596,12 +607,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               />
                             </Base>
@@ -611,12 +622,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               >
                                 <Button
@@ -630,23 +641,26 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <FlowLayout
-                                      truncate={false}
-                                    >
-                                      <div
-                                        className="flow-layout"
+                                    <Flex>
+                                      <Base
+                                        className="glamor-2"
                                       >
-                                        <span
-                                          className="button-label"
+                                        <div
+                                          className="glamor-2"
+                                          is={null}
                                         >
                                           <span
-                                            className="icon icon-exit"
-                                          />
-                                           
-                                          Leave
-                                        </span>
-                                      </div>
-                                    </FlowLayout>
+                                            className="button-label"
+                                          >
+                                            <span
+                                              className="icon icon-exit"
+                                            />
+                                             
+                                            Leave
+                                          </span>
+                                        </div>
+                                      </Base>
+                                    </Flex>
                                   </button>
                                 </Button>
                               </div>
@@ -725,23 +739,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                     >
                       <Base
                         align="center"
-                        className="glamor-43 glamor-44"
+                        className="glamor-47 glamor-48"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-43 glamor-44"
+                          className="glamor-47 glamor-48"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-27"
+                              className="glamor-29"
                               pl={2}
                             >
                               <div
-                                className="glamor-27"
+                                className="glamor-29"
                                 is={null}
                               >
                                 <Avatar
@@ -789,13 +803,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             pr={2}
                           >
                             <Base
-                              className="glamor-35"
+                              className="glamor-37"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-35"
+                                className="glamor-37"
                                 is={null}
                               >
                                 <h5
@@ -809,11 +823,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     to="2"
                                   >
                                     <Link
-                                      className="glamor-29 glamor-30"
+                                      className="glamor-31 glamor-32"
                                       to="2"
                                     >
                                       <a
-                                        className="glamor-29 glamor-30"
+                                        className="glamor-31 glamor-32"
                                         href="2"
                                       />
                                     </Link>
@@ -821,7 +835,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-33 glamor-34"
+                                    className="glamor-35 glamor-36"
                                   />
                                 </Email>
                               </div>
@@ -832,12 +846,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={180}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-10"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-10"
                                 is={null}
                               >
                                 <div>
@@ -858,12 +872,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               />
                             </Base>
@@ -873,12 +887,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               >
                                 <Button
@@ -892,23 +906,26 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <FlowLayout
-                                      truncate={false}
-                                    >
-                                      <div
-                                        className="flow-layout"
+                                    <Flex>
+                                      <Base
+                                        className="glamor-2"
                                       >
-                                        <span
-                                          className="button-label"
+                                        <div
+                                          className="glamor-2"
+                                          is={null}
                                         >
                                           <span
-                                            className="icon icon-exit"
-                                          />
-                                           
-                                          Leave
-                                        </span>
-                                      </div>
-                                    </FlowLayout>
+                                            className="button-label"
+                                          >
+                                            <span
+                                              className="icon icon-exit"
+                                            />
+                                             
+                                            Leave
+                                          </span>
+                                        </div>
+                                      </Base>
+                                    </Flex>
                                   </button>
                                 </Button>
                               </div>
@@ -987,23 +1004,23 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                     >
                       <Base
                         align="center"
-                        className="glamor-43 glamor-44"
+                        className="glamor-47 glamor-48"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-43 glamor-44"
+                          className="glamor-47 glamor-48"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-27"
+                              className="glamor-29"
                               pl={2}
                             >
                               <div
-                                className="glamor-27"
+                                className="glamor-29"
                                 is={null}
                               >
                                 <Avatar
@@ -1051,13 +1068,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             pr={2}
                           >
                             <Base
-                              className="glamor-35"
+                              className="glamor-37"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-35"
+                                className="glamor-37"
                                 is={null}
                               >
                                 <h5
@@ -1071,11 +1088,11 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     to="3"
                                   >
                                     <Link
-                                      className="glamor-29 glamor-30"
+                                      className="glamor-31 glamor-32"
                                       to="3"
                                     >
                                       <a
-                                        className="glamor-29 glamor-30"
+                                        className="glamor-31 glamor-32"
                                         href="3"
                                       />
                                     </Link>
@@ -1083,7 +1100,7 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-33 glamor-34"
+                                    className="glamor-35 glamor-36"
                                   />
                                 </Email>
                               </div>
@@ -1094,12 +1111,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={180}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-10"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-10"
                                 is={null}
                               >
                                 <div>
@@ -1120,12 +1137,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               />
                             </Base>
@@ -1135,12 +1152,12 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               >
                                 <Button
@@ -1154,23 +1171,26 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <FlowLayout
-                                      truncate={false}
-                                    >
-                                      <div
-                                        className="flow-layout"
+                                    <Flex>
+                                      <Base
+                                        className="glamor-2"
                                       >
-                                        <span
-                                          className="button-label"
+                                        <div
+                                          className="glamor-2"
+                                          is={null}
                                         >
                                           <span
-                                            className="icon icon-exit"
-                                          />
-                                           
-                                          Leave
-                                        </span>
-                                      </div>
-                                    </FlowLayout>
+                                            className="button-label"
+                                          >
+                                            <span
+                                              className="icon icon-exit"
+                                            />
+                                             
+                                            Leave
+                                          </span>
+                                        </div>
+                                      </Base>
+                                    </Flex>
                                   </button>
                                 </Button>
                               </div>
@@ -1195,13 +1215,13 @@ exports[`OrganizationMembersView No Require Link does not have 2fa warning if us
 `;
 
 exports[`OrganizationMembersView Require Link does not have 2fa warning if user has 2fa 1`] = `
-.glamor-4 {
+.glamor-6 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1222,14 +1242,22 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-87 {
+.glamor-2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-99 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-23 {
+.glamor-25 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -1238,13 +1266,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   padding: 15px 0;
 }
 
-.glamor-19 {
+.glamor-21 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-17 {
+.glamor-19 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -1254,7 +1282,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   margin: 0;
 }
 
-.glamor-6 {
+.glamor-8 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -1263,21 +1291,21 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-8 {
+.glamor-10 {
   box-sizing: border-box;
   width: 180px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-10 {
+.glamor-12 {
   box-sizing: border-box;
   width: 140px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.glamor-43 {
+.glamor-49 {
   box-sizing: border-box;
   padding: 0px;
   padding-top: 16px;
@@ -1293,16 +1321,16 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   border-bottom: 1px solid;
 }
 
-.glamor-43:last-child {
+.glamor-49:last-child {
   border: 0;
 }
 
-.glamor-27 {
+.glamor-29 {
   box-sizing: border-box;
   padding-left: 16px;
 }
 
-.glamor-35 {
+.glamor-37 {
   box-sizing: border-box;
   padding-left: 8px;
   padding-right: 16px;
@@ -1311,11 +1339,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
   flex: 1;
 }
 
-.glamor-29 {
+.glamor-31 {
   font-size: 16px;
 }
 
-.glamor-33 {
+.glamor-35 {
   font-size: 14px;
 }
 
@@ -1383,17 +1411,17 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
         >
           <Wrapper>
             <div
-              className="glamor-4 glamor-5"
+              className="glamor-6 glamor-7"
             >
               <Flex
                 align="center"
               >
                 <Base
                   align="center"
-                  className="glamor-2"
+                  className="glamor-4"
                 >
                   <div
-                    className="glamor-2"
+                    className="glamor-4"
                     is={null}
                   >
                     <Title>
@@ -1426,23 +1454,26 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             role="button"
                             style={Object {}}
                           >
-                            <FlowLayout
-                              truncate={false}
-                            >
-                              <div
-                                className="flow-layout"
+                            <Flex>
+                              <Base
+                                className="glamor-2"
                               >
-                                <span
-                                  className="button-label"
+                                <div
+                                  className="glamor-2"
+                                  is={null}
                                 >
                                   <span
-                                    className="icon-plus"
-                                  />
-                                   
-                                  Invite Member
-                                </span>
-                              </div>
-                            </FlowLayout>
+                                    className="button-label"
+                                  >
+                                    <span
+                                      className="icon-plus"
+                                    />
+                                     
+                                    Invite Member
+                                  </span>
+                                </div>
+                              </Base>
+                            </Flex>
                           </a>
                         </Link>
                       </Button>
@@ -1461,7 +1492,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
         />
         <Panel>
           <div
-            className="glamor-87 glamor-88"
+            className="glamor-99 glamor-100"
           >
             <PanelHeader
               disablePadding={true}
@@ -1470,31 +1501,31 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                 disablePadding={true}
               >
                 <Component
-                  className="glamor-23 glamor-24"
+                  className="glamor-25 glamor-26"
                   disablePadding={true}
                 >
                   <div
-                    className="glamor-23 glamor-24"
+                    className="glamor-25 glamor-26"
                   >
                     <StyledPanelHeading>
                       <Component
-                        className="glamor-19 glamor-16"
+                        className="glamor-21 glamor-18"
                       >
                         <PanelHeading
-                          className="glamor-19 glamor-16"
+                          className="glamor-21 glamor-18"
                         >
                           <div
-                            className="glamor-16 glamor-17 glamor-18"
+                            className="glamor-18 glamor-19 glamor-20"
                           >
                             <Flex
                               align="center"
                             >
                               <Base
                                 align="center"
-                                className="glamor-2"
+                                className="glamor-4"
                               >
                                 <div
-                                  className="glamor-2"
+                                  className="glamor-4"
                                   is={null}
                                 >
                                   <Box
@@ -1502,12 +1533,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     px={2}
                                   >
                                     <Base
-                                      className="glamor-6"
+                                      className="glamor-8"
                                       flex="1"
                                       px={2}
                                     >
                                       <div
-                                        className="glamor-6"
+                                        className="glamor-8"
                                         is={null}
                                       >
                                         Member
@@ -1519,12 +1550,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     w={180}
                                   >
                                     <Base
-                                      className="glamor-8"
+                                      className="glamor-10"
                                       px={2}
                                       w={180}
                                     >
                                       <div
-                                        className="glamor-8"
+                                        className="glamor-10"
                                         is={null}
                                       >
                                         Status
@@ -1536,12 +1567,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-10"
+                                      className="glamor-12"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-10"
+                                        className="glamor-12"
                                         is={null}
                                       >
                                         Role
@@ -1553,12 +1584,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     w={140}
                                   >
                                     <Base
-                                      className="glamor-10"
+                                      className="glamor-12"
                                       px={2}
                                       w={140}
                                     >
                                       <div
-                                        className="glamor-10"
+                                        className="glamor-12"
                                         is={null}
                                       >
                                         Actions
@@ -1652,23 +1683,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                     >
                       <Base
                         align="center"
-                        className="glamor-43 glamor-44"
+                        className="glamor-49 glamor-50"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-43 glamor-44"
+                          className="glamor-49 glamor-50"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-27"
+                              className="glamor-29"
                               pl={2}
                             >
                               <div
-                                className="glamor-27"
+                                className="glamor-29"
                                 is={null}
                               >
                                 <Avatar
@@ -1716,13 +1747,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             pr={2}
                           >
                             <Base
-                              className="glamor-35"
+                              className="glamor-37"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-35"
+                                className="glamor-37"
                                 is={null}
                               >
                                 <h5
@@ -1736,11 +1767,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     to="1"
                                   >
                                     <Link
-                                      className="glamor-29 glamor-30"
+                                      className="glamor-31 glamor-32"
                                       to="1"
                                     >
                                       <a
-                                        className="glamor-29 glamor-30"
+                                        className="glamor-31 glamor-32"
                                         href="1"
                                       />
                                     </Link>
@@ -1748,7 +1779,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-33 glamor-34"
+                                    className="glamor-35 glamor-36"
                                   />
                                 </Email>
                               </div>
@@ -1759,12 +1790,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={180}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-10"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-10"
                                 is={null}
                               >
                                 <div>
@@ -1797,19 +1828,22 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                         }
                                       }
                                     >
-                                      <FlowLayout
-                                        truncate={false}
-                                      >
-                                        <div
-                                          className="flow-layout"
+                                      <Flex>
+                                        <Base
+                                          className="glamor-2"
                                         >
-                                          <span
-                                            className="button-label"
+                                          <div
+                                            className="glamor-2"
+                                            is={null}
                                           >
-                                            Resend invite
-                                          </span>
-                                        </div>
-                                      </FlowLayout>
+                                            <span
+                                              className="button-label"
+                                            >
+                                              Resend invite
+                                            </span>
+                                          </div>
+                                        </Base>
+                                      </Flex>
                                     </button>
                                   </Button>
                                 </div>
@@ -1821,12 +1855,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               />
                             </Base>
@@ -1836,12 +1870,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               >
                                 <Button
@@ -1855,23 +1889,26 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <FlowLayout
-                                      truncate={false}
-                                    >
-                                      <div
-                                        className="flow-layout"
+                                    <Flex>
+                                      <Base
+                                        className="glamor-2"
                                       >
-                                        <span
-                                          className="button-label"
+                                        <div
+                                          className="glamor-2"
+                                          is={null}
                                         >
                                           <span
-                                            className="icon icon-exit"
-                                          />
-                                           
-                                          Leave
-                                        </span>
-                                      </div>
-                                    </FlowLayout>
+                                            className="button-label"
+                                          >
+                                            <span
+                                              className="icon icon-exit"
+                                            />
+                                             
+                                            Leave
+                                          </span>
+                                        </div>
+                                      </Base>
+                                    </Flex>
                                   </button>
                                 </Button>
                               </div>
@@ -1950,23 +1987,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                     >
                       <Base
                         align="center"
-                        className="glamor-43 glamor-44"
+                        className="glamor-49 glamor-50"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-43 glamor-44"
+                          className="glamor-49 glamor-50"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-27"
+                              className="glamor-29"
                               pl={2}
                             >
                               <div
-                                className="glamor-27"
+                                className="glamor-29"
                                 is={null}
                               >
                                 <Avatar
@@ -2014,13 +2051,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             pr={2}
                           >
                             <Base
-                              className="glamor-35"
+                              className="glamor-37"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-35"
+                                className="glamor-37"
                                 is={null}
                               >
                                 <h5
@@ -2034,11 +2071,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     to="2"
                                   >
                                     <Link
-                                      className="glamor-29 glamor-30"
+                                      className="glamor-31 glamor-32"
                                       to="2"
                                     >
                                       <a
-                                        className="glamor-29 glamor-30"
+                                        className="glamor-31 glamor-32"
                                         href="2"
                                       />
                                     </Link>
@@ -2046,7 +2083,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-33 glamor-34"
+                                    className="glamor-35 glamor-36"
                                   />
                                 </Email>
                               </div>
@@ -2057,12 +2094,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={180}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-10"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-10"
                                 is={null}
                               >
                                 <div>
@@ -2095,19 +2132,22 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                         }
                                       }
                                     >
-                                      <FlowLayout
-                                        truncate={false}
-                                      >
-                                        <div
-                                          className="flow-layout"
+                                      <Flex>
+                                        <Base
+                                          className="glamor-2"
                                         >
-                                          <span
-                                            className="button-label"
+                                          <div
+                                            className="glamor-2"
+                                            is={null}
                                           >
-                                            Resend invite
-                                          </span>
-                                        </div>
-                                      </FlowLayout>
+                                            <span
+                                              className="button-label"
+                                            >
+                                              Resend invite
+                                            </span>
+                                          </div>
+                                        </Base>
+                                      </Flex>
                                     </button>
                                   </Button>
                                 </div>
@@ -2119,12 +2159,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               />
                             </Base>
@@ -2134,12 +2174,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               >
                                 <Button
@@ -2153,23 +2193,26 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <FlowLayout
-                                      truncate={false}
-                                    >
-                                      <div
-                                        className="flow-layout"
+                                    <Flex>
+                                      <Base
+                                        className="glamor-2"
                                       >
-                                        <span
-                                          className="button-label"
+                                        <div
+                                          className="glamor-2"
+                                          is={null}
                                         >
                                           <span
-                                            className="icon icon-exit"
-                                          />
-                                           
-                                          Leave
-                                        </span>
-                                      </div>
-                                    </FlowLayout>
+                                            className="button-label"
+                                          >
+                                            <span
+                                              className="icon icon-exit"
+                                            />
+                                             
+                                            Leave
+                                          </span>
+                                        </div>
+                                      </Base>
+                                    </Flex>
                                   </button>
                                 </Button>
                               </div>
@@ -2248,23 +2291,23 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                     >
                       <Base
                         align="center"
-                        className="glamor-43 glamor-44"
+                        className="glamor-49 glamor-50"
                         p={0}
                         py={2}
                       >
                         <div
-                          className="glamor-43 glamor-44"
+                          className="glamor-49 glamor-50"
                           is={null}
                         >
                           <Box
                             pl={2}
                           >
                             <Base
-                              className="glamor-27"
+                              className="glamor-29"
                               pl={2}
                             >
                               <div
-                                className="glamor-27"
+                                className="glamor-29"
                                 is={null}
                               >
                                 <Avatar
@@ -2312,13 +2355,13 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             pr={2}
                           >
                             <Base
-                              className="glamor-35"
+                              className="glamor-37"
                               flex="1"
                               pl={1}
                               pr={2}
                             >
                               <div
-                                className="glamor-35"
+                                className="glamor-37"
                                 is={null}
                               >
                                 <h5
@@ -2332,11 +2375,11 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     to="3"
                                   >
                                     <Link
-                                      className="glamor-29 glamor-30"
+                                      className="glamor-31 glamor-32"
                                       to="3"
                                     >
                                       <a
-                                        className="glamor-29 glamor-30"
+                                        className="glamor-31 glamor-32"
                                         href="3"
                                       />
                                     </Link>
@@ -2344,7 +2387,7 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                 </h5>
                                 <Email>
                                   <div
-                                    className="glamor-33 glamor-34"
+                                    className="glamor-35 glamor-36"
                                   />
                                 </Email>
                               </div>
@@ -2355,12 +2398,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={180}
                           >
                             <Base
-                              className="glamor-8"
+                              className="glamor-10"
                               px={2}
                               w={180}
                             >
                               <div
-                                className="glamor-8"
+                                className="glamor-10"
                                 is={null}
                               >
                                 <div>
@@ -2381,12 +2424,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               />
                             </Base>
@@ -2396,12 +2439,12 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                             w={140}
                           >
                             <Base
-                              className="glamor-10"
+                              className="glamor-12"
                               px={2}
                               w={140}
                             >
                               <div
-                                className="glamor-10"
+                                className="glamor-12"
                                 is={null}
                               >
                                 <Button
@@ -2415,23 +2458,26 @@ exports[`OrganizationMembersView Require Link does not have 2fa warning if user 
                                     onClick={[Function]}
                                     role="button"
                                   >
-                                    <FlowLayout
-                                      truncate={false}
-                                    >
-                                      <div
-                                        className="flow-layout"
+                                    <Flex>
+                                      <Base
+                                        className="glamor-2"
                                       >
-                                        <span
-                                          className="button-label"
+                                        <div
+                                          className="glamor-2"
+                                          is={null}
                                         >
                                           <span
-                                            className="icon icon-exit"
-                                          />
-                                           
-                                          Leave
-                                        </span>
-                                      </div>
-                                    </FlowLayout>
+                                            className="button-label"
+                                          >
+                                            <span
+                                              className="icon icon-exit"
+                                            />
+                                             
+                                            Leave
+                                          </span>
+                                        </div>
+                                      </Base>
+                                    </Flex>
                                   </button>
                                 </Button>
                               </div>

--- a/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OrganizationProjectsView render() Should render the projects in the store 1`] = `
-.glamor-32 {
+.glamor-38 {
   width: 100%;
 }
 
-.glamor-6 {
+.glamor-12 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-4 {
+.glamor-8 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -32,22 +32,28 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   flex: 1;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  margin-right: 6px;
+  margin-left: -2px;
 }
 
-.glamor-34 {
+.glamor-4 svg {
+  display: block;
+}
+
+.glamor-2 {
+  vertical-align: middle;
+}
+
+.glamor-40 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-15 {
+.glamor-21 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -56,13 +62,13 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   padding: 15px 20px;
 }
 
-.glamor-11 {
+.glamor-17 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-9 {
+.glamor-15 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -72,7 +78,7 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   margin: 0;
 }
 
-.glamor-28 {
+.glamor-34 {
   box-sizing: border-box;
   padding: 0px;
   display: -webkit-box;
@@ -86,21 +92,21 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   border-bottom: 1px solid;
 }
 
-.glamor-28:last-child {
+.glamor-34:last-child {
   border: 0;
 }
 
-.glamor-24 {
+.glamor-30 {
   box-sizing: border-box;
   width: 50%;
   padding: 16px;
 }
 
-.glamor-21 {
+.glamor-27 {
   color: #645574;
 }
 
-.glamor-19 {
+.glamor-25 {
   border: none;
   background-color: inherit;
   padding: 0;
@@ -143,15 +149,12 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
             action={
               <Button
                 disabled={false}
+                icon="icon-circle-add"
                 priority="primary"
                 size="small"
                 title={undefined}
                 to="/organizations/org-slug/projects/new/"
               >
-                <span
-                  className="icon-plus"
-                />
-                 
                 Create Project
               </Button>
             }
@@ -159,17 +162,17 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
           >
             <Wrapper>
               <div
-                className="glamor-6 glamor-7"
+                className="glamor-12 glamor-13"
               >
                 <Flex
                   align="center"
                 >
                   <Base
                     align="center"
-                    className="glamor-4"
+                    className="glamor-8"
                   >
                     <div
-                      className="glamor-4"
+                      className="glamor-8"
                       is={null}
                     >
                       <Title>
@@ -182,6 +185,7 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                       <div>
                         <Button
                           disabled={false}
+                          icon="icon-circle-add"
                           priority="primary"
                           size="small"
                           to="/organizations/org-slug/projects/new/"
@@ -202,23 +206,59 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                               role="button"
                               style={Object {}}
                             >
-                              <Flex>
+                              <Flex
+                                align="center"
+                                className="button-label"
+                              >
                                 <Base
-                                  className="glamor-2"
+                                  align="center"
+                                  className="button-label glamor-8"
                                 >
                                   <div
-                                    className="glamor-2"
+                                    className="button-label glamor-8"
                                     is={null}
                                   >
-                                    <span
-                                      className="button-label"
+                                    <Icon
+                                      size="small"
                                     >
-                                      <span
-                                        className="icon-plus"
-                                      />
-                                       
-                                      Create Project
-                                    </span>
+                                      <Base
+                                        className="glamor-4 glamor-5"
+                                        size="small"
+                                      >
+                                        <div
+                                          className="glamor-4 glamor-5"
+                                          is={null}
+                                          size="small"
+                                        >
+                                          <InlineSvg
+                                            size="12px"
+                                            src="icon-circle-add"
+                                          >
+                                            <StyledSvg
+                                              className=""
+                                              height="12px"
+                                              style={Object {}}
+                                              viewBox={Object {}}
+                                              width="12px"
+                                            >
+                                              <svg
+                                                className="glamor-2 glamor-3"
+                                                height="12px"
+                                                style={Object {}}
+                                                viewBox={Object {}}
+                                                width="12px"
+                                              >
+                                                <use
+                                                  href="#test"
+                                                  xlinkHref="#test"
+                                                />
+                                              </svg>
+                                            </StyledSvg>
+                                          </InlineSvg>
+                                        </div>
+                                      </Base>
+                                    </Icon>
+                                    Create Project
                                   </div>
                                 </Base>
                               </Flex>
@@ -236,25 +276,25 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
             className="table table-no-top-border m-b-0"
           >
             <div
-              className="table table-no-top-border m-b-0 glamor-34 glamor-35"
+              className="table table-no-top-border m-b-0 glamor-40 glamor-41"
             >
               <PanelHeader>
                 <StyledPanelHeader>
                   <Component
-                    className="glamor-15 glamor-16"
+                    className="glamor-21 glamor-22"
                   >
                     <div
-                      className="glamor-15 glamor-16"
+                      className="glamor-21 glamor-22"
                     >
                       <StyledPanelHeading>
                         <Component
-                          className="glamor-11 glamor-8"
+                          className="glamor-17 glamor-14"
                         >
                           <PanelHeading
-                            className="glamor-11 glamor-8"
+                            className="glamor-17 glamor-14"
                           >
                             <div
-                              className="glamor-8 glamor-9 glamor-10"
+                              className="glamor-14 glamor-15 glamor-16"
                             >
                               Projects
                             </div>
@@ -266,13 +306,13 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                 </StyledPanelHeader>
               </PanelHeader>
               <PanelBody
-                className="glamor-32"
+                className="glamor-38"
                 direction="column"
                 disablePadding={true}
                 flex={false}
               >
                 <div
-                  className="glamor-32"
+                  className="glamor-38"
                 >
                   <PanelItem
                     align="center"
@@ -285,11 +325,11 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                     >
                       <Base
                         align="center"
-                        className="glamor-28 glamor-29"
+                        className="glamor-34 glamor-35"
                         p={0}
                       >
                         <div
-                          className="glamor-28 glamor-29"
+                          className="glamor-34 glamor-35"
                           is={null}
                         >
                           <Box
@@ -297,12 +337,12 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                             w={0.5}
                           >
                             <Base
-                              className="glamor-24"
+                              className="glamor-30"
                               p={2}
                               w={0.5}
                             >
                               <div
-                                className="glamor-24"
+                                className="glamor-30"
                                 is={null}
                               >
                                 <ProjectItem
@@ -355,7 +395,7 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                                         title="Add to bookmarks"
                                       >
                                         <button
-                                          className="tip glamor-19 glamor-20"
+                                          className="tip glamor-25 glamor-26"
                                           onClick={[Function]}
                                           title="Add to bookmarks"
                                         >
@@ -366,17 +406,17 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                                       </InlineButton>
                                     </Tooltip>
                                     <Link
-                                      className="glamor-21"
+                                      className="glamor-27"
                                       to="/settings/organization/org-slug/project/project-slug/"
                                     >
                                       <Link
-                                        className="glamor-21"
+                                        className="glamor-27"
                                         onlyActiveOnIndex={false}
                                         style={Object {}}
                                         to="/settings/organization/org-slug/project/project-slug/"
                                       >
                                         <a
-                                          className="glamor-21"
+                                          className="glamor-27"
                                           onClick={[Function]}
                                           style={Object {}}
                                         >
@@ -440,12 +480,12 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                             w={0.5}
                           >
                             <Base
-                              className="glamor-24"
+                              className="glamor-30"
                               p={2}
                               w={0.5}
                             >
                               <div
-                                className="glamor-24"
+                                className="glamor-30"
                                 is={null}
                               >
                                 <ProjectListItem

--- a/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OrganizationProjectsView render() Should render the projects in the store 1`] = `
-.glamor-30 {
+.glamor-32 {
   width: 100%;
 }
 
-.glamor-4 {
+.glamor-6 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-2 {
+.glamor-4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -32,14 +32,22 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   flex: 1;
 }
 
-.glamor-32 {
+.glamor-2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-34 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-13 {
+.glamor-15 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -48,13 +56,13 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   padding: 15px 20px;
 }
 
-.glamor-9 {
+.glamor-11 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-7 {
+.glamor-9 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -64,7 +72,7 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   margin: 0;
 }
 
-.glamor-26 {
+.glamor-28 {
   box-sizing: border-box;
   padding: 0px;
   display: -webkit-box;
@@ -78,21 +86,21 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
   border-bottom: 1px solid;
 }
 
-.glamor-26:last-child {
+.glamor-28:last-child {
   border: 0;
 }
 
-.glamor-22 {
+.glamor-24 {
   box-sizing: border-box;
   width: 50%;
   padding: 16px;
 }
 
-.glamor-19 {
+.glamor-21 {
   color: #645574;
 }
 
-.glamor-17 {
+.glamor-19 {
   border: none;
   background-color: inherit;
   padding: 0;
@@ -151,17 +159,17 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
           >
             <Wrapper>
               <div
-                className="glamor-4 glamor-5"
+                className="glamor-6 glamor-7"
               >
                 <Flex
                   align="center"
                 >
                   <Base
                     align="center"
-                    className="glamor-2"
+                    className="glamor-4"
                   >
                     <div
-                      className="glamor-2"
+                      className="glamor-4"
                       is={null}
                     >
                       <Title>
@@ -194,23 +202,26 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                               role="button"
                               style={Object {}}
                             >
-                              <FlowLayout
-                                truncate={false}
-                              >
-                                <div
-                                  className="flow-layout"
+                              <Flex>
+                                <Base
+                                  className="glamor-2"
                                 >
-                                  <span
-                                    className="button-label"
+                                  <div
+                                    className="glamor-2"
+                                    is={null}
                                   >
                                     <span
-                                      className="icon-plus"
-                                    />
-                                     
-                                    Create Project
-                                  </span>
-                                </div>
-                              </FlowLayout>
+                                      className="button-label"
+                                    >
+                                      <span
+                                        className="icon-plus"
+                                      />
+                                       
+                                      Create Project
+                                    </span>
+                                  </div>
+                                </Base>
+                              </Flex>
                             </a>
                           </Link>
                         </Button>
@@ -225,25 +236,25 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
             className="table table-no-top-border m-b-0"
           >
             <div
-              className="table table-no-top-border m-b-0 glamor-32 glamor-33"
+              className="table table-no-top-border m-b-0 glamor-34 glamor-35"
             >
               <PanelHeader>
                 <StyledPanelHeader>
                   <Component
-                    className="glamor-13 glamor-14"
+                    className="glamor-15 glamor-16"
                   >
                     <div
-                      className="glamor-13 glamor-14"
+                      className="glamor-15 glamor-16"
                     >
                       <StyledPanelHeading>
                         <Component
-                          className="glamor-9 glamor-6"
+                          className="glamor-11 glamor-8"
                         >
                           <PanelHeading
-                            className="glamor-9 glamor-6"
+                            className="glamor-11 glamor-8"
                           >
                             <div
-                              className="glamor-6 glamor-7 glamor-8"
+                              className="glamor-8 glamor-9 glamor-10"
                             >
                               Projects
                             </div>
@@ -255,13 +266,13 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                 </StyledPanelHeader>
               </PanelHeader>
               <PanelBody
-                className="glamor-30"
+                className="glamor-32"
                 direction="column"
                 disablePadding={true}
                 flex={false}
               >
                 <div
-                  className="glamor-30"
+                  className="glamor-32"
                 >
                   <PanelItem
                     align="center"
@@ -274,11 +285,11 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                     >
                       <Base
                         align="center"
-                        className="glamor-26 glamor-27"
+                        className="glamor-28 glamor-29"
                         p={0}
                       >
                         <div
-                          className="glamor-26 glamor-27"
+                          className="glamor-28 glamor-29"
                           is={null}
                         >
                           <Box
@@ -286,12 +297,12 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                             w={0.5}
                           >
                             <Base
-                              className="glamor-22"
+                              className="glamor-24"
                               p={2}
                               w={0.5}
                             >
                               <div
-                                className="glamor-22"
+                                className="glamor-24"
                                 is={null}
                               >
                                 <ProjectItem
@@ -344,7 +355,7 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                                         title="Add to bookmarks"
                                       >
                                         <button
-                                          className="tip glamor-17 glamor-18"
+                                          className="tip glamor-19 glamor-20"
                                           onClick={[Function]}
                                           title="Add to bookmarks"
                                         >
@@ -355,17 +366,17 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                                       </InlineButton>
                                     </Tooltip>
                                     <Link
-                                      className="glamor-19"
+                                      className="glamor-21"
                                       to="/settings/organization/org-slug/project/project-slug/"
                                     >
                                       <Link
-                                        className="glamor-19"
+                                        className="glamor-21"
                                         onlyActiveOnIndex={false}
                                         style={Object {}}
                                         to="/settings/organization/org-slug/project/project-slug/"
                                       >
                                         <a
-                                          className="glamor-19"
+                                          className="glamor-21"
                                           onClick={[Function]}
                                           style={Object {}}
                                         >
@@ -429,12 +440,12 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                             w={0.5}
                           >
                             <Base
-                              className="glamor-22"
+                              className="glamor-24"
                               p={2}
                               w={0.5}
                             >
                               <div
-                                className="glamor-22"
+                                className="glamor-24"
                                 is={null}
                               >
                                 <ProjectListItem

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -80,6 +80,10 @@ exports[`OrganizationTeamProjects Should render 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <TeamProjects
@@ -355,19 +359,19 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                               onClick={[Function]}
                               role="button"
                             >
-                              <Flex>
+                              <Flex
+                                align="center"
+                                className="button-label"
+                              >
                                 <Base
-                                  className="glamor-31"
+                                  align="center"
+                                  className="button-label glamor-31"
                                 >
                                   <div
-                                    className="glamor-31"
+                                    className="button-label glamor-31"
                                     is={null}
                                   >
-                                    <span
-                                      className="button-label"
-                                    >
-                                      Add
-                                    </span>
+                                    Add
                                   </div>
                                 </Base>
                               </Flex>

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -33,7 +33,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
   margin: 0;
 }
 
-.glamor-33 {
+.glamor-35 {
   box-sizing: border-box;
   padding: 0px;
   display: -webkit-box;
@@ -47,7 +47,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-33:last-child {
+.glamor-35:last-child {
   border: 0;
 }
 
@@ -69,9 +69,17 @@ exports[`OrganizationTeamProjects Should render 1`] = `
   padding: 0;
 }
 
-.glamor-31 {
+.glamor-33 {
   box-sizing: border-box;
   padding: 16px;
+}
+
+.glamor-31 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <TeamProjects
@@ -175,11 +183,11 @@ exports[`OrganizationTeamProjects Should render 1`] = `
               >
                 <Base
                   align="center"
-                  className="glamor-33 glamor-34"
+                  className="glamor-35 glamor-36"
                   p={0}
                 >
                   <div
-                    className="glamor-33 glamor-34"
+                    className="glamor-35 glamor-36"
                     is={null}
                   >
                     <Box
@@ -329,11 +337,11 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                       p={2}
                     >
                       <Base
-                        className="glamor-31"
+                        className="glamor-33"
                         p={2}
                       >
                         <div
-                          className="glamor-31"
+                          className="glamor-33"
                           is={null}
                         >
                           <Button
@@ -347,19 +355,22 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                               onClick={[Function]}
                               role="button"
                             >
-                              <FlowLayout
-                                truncate={false}
-                              >
-                                <div
-                                  className="flow-layout"
+                              <Flex>
+                                <Base
+                                  className="glamor-31"
                                 >
-                                  <span
-                                    className="button-label"
+                                  <div
+                                    className="glamor-31"
+                                    is={null}
                                   >
-                                    Add
-                                  </span>
-                                </div>
-                              </FlowLayout>
+                                    <span
+                                      className="button-label"
+                                    >
+                                      Add
+                                    </span>
+                                  </div>
+                                </Base>
+                              </Flex>
                             </button>
                           </Button>
                         </div>

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -83,6 +83,14 @@ exports[`OrganizationDetails render() deletion in progress should render a delet
 `;
 
 exports[`OrganizationDetails render() pending deletion should render a restoration prompt 1`] = `
+.glamor-0 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <div
   class="app"
 >
@@ -138,7 +146,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                 role="button"
               >
                 <div
-                  class="flow-layout"
+                  class="glamor-0"
                 >
                   <span
                     class="button-label"

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -89,6 +89,10 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <div
@@ -146,13 +150,9 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                 role="button"
               >
                 <div
-                  class="glamor-0"
+                  class="button-label glamor-0"
                 >
-                  <span
-                    class="button-label"
-                  >
-                    Restore Organization
-                  </span>
+                  Restore Organization
                 </div>
               </button>
             </p>

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -8,15 +8,12 @@ exports[`ProjectAlertSettings render() renders 1`] = `
     <SettingsPageHeading
       action={
         <Button
-          className="pull-right"
           disabled={false}
+          icon="icon-circle-add"
           priority="primary"
           size="small"
           to="/org-slug/project-slug/settings/alerts/rules/new/"
         >
-          <span
-            className="icon-plus"
-          />
           New Alert Rule
         </Button>
       }

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -315,7 +315,7 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
   flex: 1;
 }
 
-.glamor-25 {
+.glamor-29 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
@@ -347,7 +347,7 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
   margin: 0;
 }
 
-.glamor-17 {
+.glamor-19 {
   box-sizing: border-box;
   padding: 16px;
   display: -webkit-box;
@@ -357,8 +357,16 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-17:last-child {
+.glamor-19:last-child {
   border: 0;
+}
+
+.glamor-17 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <ProjectEnvironments
@@ -521,7 +529,7 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
     </SettingsPageHeading>
     <Panel>
       <div
-        className="glamor-25 glamor-26"
+        className="glamor-29 glamor-30"
       >
         <PanelHeader>
           <StyledPanelHeader>
@@ -576,7 +584,7 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                 }
               >
                 <Base
-                  className="glamor-17 glamor-18"
+                  className="glamor-19 glamor-20"
                   p={2}
                   style={
                     Object {
@@ -585,7 +593,7 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                   }
                 >
                   <div
-                    className="glamor-17 glamor-18"
+                    className="glamor-19 glamor-20"
                     is={null}
                     style={
                       Object {
@@ -607,19 +615,22 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                         onClick={[Function]}
                         role="button"
                       >
-                        <FlowLayout
-                          truncate={false}
-                        >
-                          <div
-                            className="flow-layout"
+                        <Flex>
+                          <Base
+                            className="glamor-17"
                           >
-                            <span
-                              className="button-label"
+                            <div
+                              className="glamor-17"
+                              is={null}
                             >
-                              Hide
-                            </span>
-                          </div>
-                        </FlowLayout>
+                              <span
+                                className="button-label"
+                              >
+                                Hide
+                              </span>
+                            </div>
+                          </Base>
+                        </Flex>
                       </button>
                     </Button>
                   </div>
@@ -644,7 +655,7 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                 }
               >
                 <Base
-                  className="glamor-17 glamor-18"
+                  className="glamor-19 glamor-20"
                   p={2}
                   style={
                     Object {
@@ -653,7 +664,7 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                   }
                 >
                   <div
-                    className="glamor-17 glamor-18"
+                    className="glamor-19 glamor-20"
                     is={null}
                     style={
                       Object {
@@ -675,19 +686,22 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                         onClick={[Function]}
                         role="button"
                       >
-                        <FlowLayout
-                          truncate={false}
-                        >
-                          <div
-                            className="flow-layout"
+                        <Flex>
+                          <Base
+                            className="glamor-17"
                           >
-                            <span
-                              className="button-label"
+                            <div
+                              className="glamor-17"
+                              is={null}
                             >
-                              Hide
-                            </span>
-                          </div>
-                        </FlowLayout>
+                              <span
+                                className="button-label"
+                              >
+                                Hide
+                              </span>
+                            </div>
+                          </Base>
+                        </Flex>
                       </button>
                     </Button>
                   </div>
@@ -1017,7 +1031,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
   flex: 1;
 }
 
-.glamor-21 {
+.glamor-23 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
@@ -1049,7 +1063,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
   margin: 0;
 }
 
-.glamor-17 {
+.glamor-19 {
   box-sizing: border-box;
   padding: 16px;
   display: -webkit-box;
@@ -1059,8 +1073,16 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-17:last-child {
+.glamor-19:last-child {
   border: 0;
+}
+
+.glamor-17 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <ProjectEnvironments
@@ -1223,7 +1245,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
     </SettingsPageHeading>
     <Panel>
       <div
-        className="glamor-21 glamor-22"
+        className="glamor-23 glamor-24"
       >
         <PanelHeader>
           <StyledPanelHeader>
@@ -1278,7 +1300,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                 }
               >
                 <Base
-                  className="glamor-17 glamor-18"
+                  className="glamor-19 glamor-20"
                   p={2}
                   style={
                     Object {
@@ -1287,7 +1309,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                   }
                 >
                   <div
-                    className="glamor-17 glamor-18"
+                    className="glamor-19 glamor-20"
                     is={null}
                     style={
                       Object {
@@ -1309,19 +1331,22 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                         onClick={[Function]}
                         role="button"
                       >
-                        <FlowLayout
-                          truncate={false}
-                        >
-                          <div
-                            className="flow-layout"
+                        <Flex>
+                          <Base
+                            className="glamor-17"
                           >
-                            <span
-                              className="button-label"
+                            <div
+                              className="glamor-17"
+                              is={null}
                             >
-                              Show
-                            </span>
-                          </div>
-                        </FlowLayout>
+                              <span
+                                className="button-label"
+                              >
+                                Show
+                              </span>
+                            </div>
+                          </Base>
+                        </Flex>
                       </button>
                     </Button>
                   </div>

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -361,14 +361,6 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
   border: 0;
 }
 
-.glamor-17 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 <ProjectEnvironments
   params={
     Object {
@@ -615,19 +607,19 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                         onClick={[Function]}
                         role="button"
                       >
-                        <Flex>
+                        <Flex
+                          align="center"
+                          className="button-label"
+                        >
                           <Base
-                            className="glamor-17"
+                            align="center"
+                            className="button-label glamor-2"
                           >
                             <div
-                              className="glamor-17"
+                              className="button-label glamor-2"
                               is={null}
                             >
-                              <span
-                                className="button-label"
-                              >
-                                Hide
-                              </span>
+                              Hide
                             </div>
                           </Base>
                         </Flex>
@@ -686,19 +678,19 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                         onClick={[Function]}
                         role="button"
                       >
-                        <Flex>
+                        <Flex
+                          align="center"
+                          className="button-label"
+                        >
                           <Base
-                            className="glamor-17"
+                            align="center"
+                            className="button-label glamor-2"
                           >
                             <div
-                              className="glamor-17"
+                              className="button-label glamor-2"
                               is={null}
                             >
-                              <span
-                                className="button-label"
-                              >
-                                Hide
-                              </span>
+                              Hide
                             </div>
                           </Base>
                         </Flex>
@@ -1077,14 +1069,6 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
   border: 0;
 }
 
-.glamor-17 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 <ProjectEnvironments
   params={
     Object {
@@ -1331,19 +1315,19 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                         onClick={[Function]}
                         role="button"
                       >
-                        <Flex>
+                        <Flex
+                          align="center"
+                          className="button-label"
+                        >
                           <Base
-                            className="glamor-17"
+                            align="center"
+                            className="button-label glamor-2"
                           >
                             <div
-                              className="glamor-17"
+                              className="button-label glamor-2"
                               is={null}
                             >
-                              <span
-                                className="button-label"
-                              >
-                                Show
-                              </span>
+                              Show
                             </div>
                           </Base>
                         </Flex>

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`ProjectPluginDetails renders 1`] = `
   margin: -20px 0 30px;
 }
 
-.glamor-6 {
+.glamor-2 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -26,14 +26,6 @@ exports[`ProjectPluginDetails renders 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-}
-
-.glamor-2 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .glamor-31 {
@@ -66,6 +58,14 @@ exports[`ProjectPluginDetails renders 1`] = `
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
+}
+
+.glamor-16 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .glamor-14 {
@@ -277,10 +277,10 @@ exports[`ProjectPluginDetails renders 1`] = `
                 >
                   <Base
                     align="center"
-                    className="glamor-6"
+                    className="glamor-2"
                   >
                     <div
-                      className="glamor-6"
+                      className="glamor-2"
                       is={null}
                     >
                       <Title>
@@ -314,19 +314,19 @@ exports[`ProjectPluginDetails renders 1`] = `
                                 }
                               }
                             >
-                              <Flex>
+                              <Flex
+                                align="center"
+                                className="button-label"
+                              >
                                 <Base
-                                  className="glamor-2"
+                                  align="center"
+                                  className="button-label glamor-2"
                                 >
                                   <div
-                                    className="glamor-2"
+                                    className="button-label glamor-2"
                                     is={null}
                                   >
-                                    <span
-                                      className="button-label"
-                                    >
-                                      Enable Plugin
-                                    </span>
+                                    Enable Plugin
                                   </div>
                                 </Base>
                               </Flex>
@@ -342,19 +342,19 @@ exports[`ProjectPluginDetails renders 1`] = `
                               onClick={[Function]}
                               role="button"
                             >
-                              <Flex>
+                              <Flex
+                                align="center"
+                                className="button-label"
+                              >
                                 <Base
-                                  className="glamor-2"
+                                  align="center"
+                                  className="button-label glamor-2"
                                 >
                                   <div
-                                    className="glamor-2"
+                                    className="button-label glamor-2"
                                     is={null}
                                   >
-                                    <span
-                                      className="button-label"
-                                    >
-                                      Reset Configuration
-                                    </span>
+                                    Reset Configuration
                                   </div>
                                 </Base>
                               </Flex>
@@ -461,10 +461,10 @@ exports[`ProjectPluginDetails renders 1`] = `
                                   >
                                     <Flex>
                                       <Base
-                                        className="glamor-2"
+                                        className="glamor-16"
                                       >
                                         <div
-                                          className="glamor-2"
+                                          className="glamor-16"
                                           is={null}
                                         >
                                           <Flex

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProjectPluginDetails renders 1`] = `
-.glamor-4 {
+.glamor-8 {
   font-size: 14px;
   box-shadow: inset 0 -1px 0;
   margin: -20px 0 30px;
 }
 
-.glamor-2 {
+.glamor-6 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -28,14 +28,22 @@ exports[`ProjectPluginDetails renders 1`] = `
   flex: 1;
 }
 
-.glamor-27 {
+.glamor-2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-31 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
   position: relative;
 }
 
-.glamor-21 {
+.glamor-25 {
   border-bottom: 1px solid;
   border-radius: 0 0;
   text-transform: uppercase;
@@ -44,13 +52,13 @@ exports[`ProjectPluginDetails renders 1`] = `
   padding: 8px 20px;
 }
 
-.glamor-17 {
+.glamor-21 {
   font-size: inherit;
   text-transform: inherit;
   margin: 0;
 }
 
-.glamor-15 {
+.glamor-19 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -60,15 +68,7 @@ exports[`ProjectPluginDetails renders 1`] = `
   margin: 0;
 }
 
-.glamor-12 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.glamor-10 {
+.glamor-14 {
   box-sizing: border-box;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -83,7 +83,7 @@ exports[`ProjectPluginDetails renders 1`] = `
   align-items: center;
 }
 
-.glamor-8 {
+.glamor-12 {
   box-sizing: border-box;
   margin-right: 8px;
   display: -webkit-box;
@@ -96,7 +96,7 @@ exports[`ProjectPluginDetails renders 1`] = `
   align-items: center;
 }
 
-.glamor-6 {
+.glamor-10 {
   position: relative;
   height: 20px;
   width: 20px;
@@ -110,7 +110,7 @@ exports[`ProjectPluginDetails renders 1`] = `
   background-image: url();
 }
 
-.glamor-25 {
+.glamor-29 {
   box-sizing: border-box;
   padding-top: 16px;
   padding-left: 16px;
@@ -270,17 +270,17 @@ exports[`ProjectPluginDetails renders 1`] = `
           >
             <Wrapper>
               <div
-                className="glamor-4 glamor-5"
+                className="glamor-8 glamor-9"
               >
                 <Flex
                   align="center"
                 >
                   <Base
                     align="center"
-                    className="glamor-2"
+                    className="glamor-6"
                   >
                     <div
-                      className="glamor-2"
+                      className="glamor-6"
                       is={null}
                     >
                       <Title>
@@ -314,19 +314,22 @@ exports[`ProjectPluginDetails renders 1`] = `
                                 }
                               }
                             >
-                              <FlowLayout
-                                truncate={false}
-                              >
-                                <div
-                                  className="flow-layout"
+                              <Flex>
+                                <Base
+                                  className="glamor-2"
                                 >
-                                  <span
-                                    className="button-label"
+                                  <div
+                                    className="glamor-2"
+                                    is={null}
                                   >
-                                    Enable Plugin
-                                  </span>
-                                </div>
-                              </FlowLayout>
+                                    <span
+                                      className="button-label"
+                                    >
+                                      Enable Plugin
+                                    </span>
+                                  </div>
+                                </Base>
+                              </Flex>
                             </button>
                           </Button>
                           <Button
@@ -339,19 +342,22 @@ exports[`ProjectPluginDetails renders 1`] = `
                               onClick={[Function]}
                               role="button"
                             >
-                              <FlowLayout
-                                truncate={false}
-                              >
-                                <div
-                                  className="flow-layout"
+                              <Flex>
+                                <Base
+                                  className="glamor-2"
                                 >
-                                  <span
-                                    className="button-label"
+                                  <div
+                                    className="glamor-2"
+                                    is={null}
                                   >
-                                    Reset Configuration
-                                  </span>
-                                </div>
-                              </FlowLayout>
+                                    <span
+                                      className="button-label"
+                                    >
+                                      Reset Configuration
+                                    </span>
+                                  </div>
+                                </Base>
+                              </Flex>
                             </button>
                           </Button>
                         </div>
@@ -427,7 +433,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                   className="plugin-config ref-plugin-config-amazon-sqs"
                 >
                   <div
-                    className="plugin-config ref-plugin-config-amazon-sqs glamor-27 glamor-28"
+                    className="plugin-config ref-plugin-config-amazon-sqs glamor-31 glamor-32"
                   >
                     <PanelHeader
                       hasButtons={true}
@@ -436,29 +442,29 @@ exports[`ProjectPluginDetails renders 1`] = `
                         hasButtons={true}
                       >
                         <Component
-                          className="glamor-21 glamor-22"
+                          className="glamor-25 glamor-26"
                           hasButtons={true}
                         >
                           <div
-                            className="glamor-21 glamor-22"
+                            className="glamor-25 glamor-26"
                             hasButtons={true}
                           >
                             <StyledPanelHeading>
                               <Component
-                                className="glamor-17 glamor-14"
+                                className="glamor-21 glamor-18"
                               >
                                 <PanelHeading
-                                  className="glamor-17 glamor-14"
+                                  className="glamor-21 glamor-18"
                                 >
                                   <div
-                                    className="glamor-14 glamor-15 glamor-16"
+                                    className="glamor-18 glamor-19 glamor-20"
                                   >
                                     <Flex>
                                       <Base
-                                        className="glamor-12"
+                                        className="glamor-2"
                                       >
                                         <div
-                                          className="glamor-12"
+                                          className="glamor-2"
                                           is={null}
                                         >
                                           <Flex
@@ -467,11 +473,11 @@ exports[`ProjectPluginDetails renders 1`] = `
                                           >
                                             <Base
                                               align="center"
-                                              className="glamor-10"
+                                              className="glamor-14"
                                               flex="1"
                                             >
                                               <div
-                                                className="glamor-10"
+                                                className="glamor-14"
                                                 is={null}
                                               >
                                                 <Flex
@@ -480,11 +486,11 @@ exports[`ProjectPluginDetails renders 1`] = `
                                                 >
                                                   <Base
                                                     align="center"
-                                                    className="glamor-8"
+                                                    className="glamor-12"
                                                     mr={1}
                                                   >
                                                     <div
-                                                      className="glamor-8"
+                                                      className="glamor-12"
                                                       is={null}
                                                     >
                                                       <PluginIcon
@@ -496,7 +502,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                                           size={20}
                                                         >
                                                           <div
-                                                            className="glamor-6 glamor-7"
+                                                            className="glamor-10 glamor-11"
                                                             size={20}
                                                           />
                                                         </IntegrationIcon>
@@ -537,14 +543,14 @@ exports[`ProjectPluginDetails renders 1`] = `
                         wrap="wrap"
                       >
                         <Base
-                          className="glamor-25"
+                          className="glamor-29"
                           direction="column"
                           pt={2}
                           px={2}
                           wrap="wrap"
                         >
                           <div
-                            className="glamor-25"
+                            className="glamor-29"
                             is={null}
                           >
                             <div

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -502,21 +502,21 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           onClick={[Function]}
                                           role="button"
                                         >
-                                          <Flex>
+                                          <Flex
+                                            align="center"
+                                            className="button-label"
+                                          >
                                             <Base
-                                              className="glamor-16"
+                                              align="center"
+                                              className="button-label glamor-2"
                                             >
                                               <div
-                                                className="glamor-16"
+                                                className="button-label glamor-2"
                                                 is={null}
                                               >
                                                 <span
-                                                  className="button-label"
-                                                >
-                                                  <span
-                                                    className="icon icon-trash"
-                                                  />
-                                                </span>
+                                                  className="icon icon-trash"
+                                                />
                                               </div>
                                             </Base>
                                           </Flex>
@@ -759,21 +759,21 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           onClick={[Function]}
                                           role="button"
                                         >
-                                          <Flex>
+                                          <Flex
+                                            align="center"
+                                            className="button-label"
+                                          >
                                             <Base
-                                              className="glamor-16"
+                                              align="center"
+                                              className="button-label glamor-2"
                                             >
                                               <div
-                                                className="glamor-16"
+                                                className="button-label glamor-2"
                                                 is={null}
                                               >
                                                 <span
-                                                  className="button-label"
-                                                >
-                                                  <span
-                                                    className="icon icon-trash"
-                                                  />
-                                                </span>
+                                                  className="icon icon-trash"
+                                                />
                                               </div>
                                             </Base>
                                           </Flex>

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -28,7 +28,7 @@ exports[`ProjectSavedSearches renders 1`] = `
   flex: 1;
 }
 
-.glamor-61 {
+.glamor-65 {
   background: #fff;
   border: 1px solid;
   margin-bottom: NaNpx;
@@ -107,7 +107,7 @@ exports[`ProjectSavedSearches renders 1`] = `
   justify-content: center;
 }
 
-.glamor-41 {
+.glamor-43 {
   box-sizing: border-box;
   padding: 0px;
   padding-top: 16px;
@@ -123,7 +123,7 @@ exports[`ProjectSavedSearches renders 1`] = `
   border-bottom: 1px solid;
 }
 
-.glamor-41:last-child {
+.glamor-43:last-child {
   border: 0;
 }
 
@@ -190,7 +190,7 @@ exports[`ProjectSavedSearches renders 1`] = `
     </SettingsPageHeading>
     <Panel>
       <div
-        className="glamor-61 glamor-62"
+        className="glamor-65 glamor-66"
       >
         <PanelHeader
           disablePadding={true}
@@ -375,12 +375,12 @@ exports[`ProjectSavedSearches renders 1`] = `
                 >
                   <Base
                     align="center"
-                    className="glamor-41 glamor-42"
+                    className="glamor-43 glamor-44"
                     p={0}
                     py={2}
                   >
                     <div
-                      className="glamor-41 glamor-42"
+                      className="glamor-43 glamor-44"
                       is={null}
                     >
                       <Flex
@@ -502,21 +502,24 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           onClick={[Function]}
                                           role="button"
                                         >
-                                          <FlowLayout
-                                            truncate={false}
-                                          >
-                                            <div
-                                              className="flow-layout"
+                                          <Flex>
+                                            <Base
+                                              className="glamor-16"
                                             >
-                                              <span
-                                                className="button-label"
+                                              <div
+                                                className="glamor-16"
+                                                is={null}
                                               >
                                                 <span
-                                                  className="icon icon-trash"
-                                                />
-                                              </span>
-                                            </div>
-                                          </FlowLayout>
+                                                  className="button-label"
+                                                >
+                                                  <span
+                                                    className="icon icon-trash"
+                                                  />
+                                                </span>
+                                              </div>
+                                            </Base>
+                                          </Flex>
                                         </button>
                                       </Button>
                                       <Modal
@@ -629,12 +632,12 @@ exports[`ProjectSavedSearches renders 1`] = `
                 >
                   <Base
                     align="center"
-                    className="glamor-41 glamor-42"
+                    className="glamor-43 glamor-44"
                     p={0}
                     py={2}
                   >
                     <div
-                      className="glamor-41 glamor-42"
+                      className="glamor-43 glamor-44"
                       is={null}
                     >
                       <Flex
@@ -756,21 +759,24 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           onClick={[Function]}
                                           role="button"
                                         >
-                                          <FlowLayout
-                                            truncate={false}
-                                          >
-                                            <div
-                                              className="flow-layout"
+                                          <Flex>
+                                            <Base
+                                              className="glamor-16"
                                             >
-                                              <span
-                                                className="button-label"
+                                              <div
+                                                className="glamor-16"
+                                                is={null}
                                               >
                                                 <span
-                                                  className="icon icon-trash"
-                                                />
-                                              </span>
-                                            </div>
-                                          </FlowLayout>
+                                                  className="button-label"
+                                                >
+                                                  <span
+                                                    className="icon icon-trash"
+                                                  />
+                                                </span>
+                                              </div>
+                                            </Base>
+                                          </Flex>
                                         </button>
                                       </Button>
                                       <Modal

--- a/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
@@ -13,14 +13,11 @@ exports[`TeamMembers render() renders 1`] = `
     <Button
       className="pull-right"
       disabled={false}
+      icon="icon-circle-add"
       priority="primary"
       size="small"
       to="/settings/organization/org-slug/members/new/"
     >
-      <span
-        className="icon-plus"
-      />
-       
       Invite Member
     </Button>
   </div>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -116,14 +116,6 @@ exports[`CreateProject render() should render roles when available and allowed, 
   margin-bottom: 0;
 }
 
-.glamor-66 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .glamor-62 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
@@ -635,19 +627,19 @@ exports[`CreateProject render() should render roles when available and allowed, 
           onClick={[Function]}
           role="button"
         >
-          <Flex>
+          <Flex
+            align="center"
+            className="button-label"
+          >
             <Base
-              className="glamor-66"
+              align="center"
+              className="button-label glamor-2"
             >
               <div
-                className="glamor-66"
+                className="button-label glamor-2"
                 is={null}
               >
-                <span
-                  className="button-label"
-                >
-                  Add Member
-                </span>
+                Add Member
               </div>
             </Base>
           </Flex>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -116,6 +116,14 @@ exports[`CreateProject render() should render roles when available and allowed, 
   margin-bottom: 0;
 }
 
+.glamor-66 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 .glamor-62 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
@@ -627,19 +635,22 @@ exports[`CreateProject render() should render roles when available and allowed, 
           onClick={[Function]}
           role="button"
         >
-          <FlowLayout
-            truncate={false}
-          >
-            <div
-              className="flow-layout"
+          <Flex>
+            <Base
+              className="glamor-66"
             >
-              <span
-                className="button-label"
+              <div
+                className="glamor-66"
+                is={null}
               >
-                Add Member
-              </span>
-            </div>
-          </FlowLayout>
+                <span
+                  className="button-label"
+                >
+                  Add Member
+                </span>
+              </div>
+            </Base>
+          </Flex>
         </button>
       </Button>
     </div>

--- a/tests/js/spec/views/organizationTeamProjects.spec.jsx
+++ b/tests/js/spec/views/organizationTeamProjects.spec.jsx
@@ -75,7 +75,6 @@ describe('OrganizationTeamProjects', function() {
     );
 
     let add = wrapper.find('div.button-label');
-    console.log(wrapper.debug());
     expect(add.length).toBe(1);
     expect(add.text()).toContain('Add');
     add.simulate('click');

--- a/tests/js/spec/views/organizationTeamProjects.spec.jsx
+++ b/tests/js/spec/views/organizationTeamProjects.spec.jsx
@@ -76,7 +76,7 @@ describe('OrganizationTeamProjects', function() {
 
     let add = wrapper.find('.button-label');
     expect(add.length).toBe(1);
-    expect(add.text()).toBe('Add');
+    expect(add.text()).toContain('Add');
     add.simulate('click');
 
     wrapper.update();
@@ -85,10 +85,10 @@ describe('OrganizationTeamProjects', function() {
 
     setTimeout(() => {
       wrapper.update();
-      let remove = wrapper.find('.flow-layout .button-label');
+      let remove = wrapper.find('.button-label');
       expect(remove.length).toBe(1);
 
-      expect(remove.text()).toBe('Remove');
+      expect(remove.text()).toContain('Remove');
       remove.simulate('click');
 
       expect(deleteMock).toHaveBeenCalledTimes(1);

--- a/tests/js/spec/views/organizationTeamProjects.spec.jsx
+++ b/tests/js/spec/views/organizationTeamProjects.spec.jsx
@@ -74,7 +74,8 @@ describe('OrganizationTeamProjects', function() {
       TestStubs.routerOrganizationContext()
     );
 
-    let add = wrapper.find('.button-label');
+    let add = wrapper.find('div.button-label');
+    console.log(wrapper.debug());
     expect(add.length).toBe(1);
     expect(add.text()).toContain('Add');
     add.simulate('click');
@@ -85,7 +86,7 @@ describe('OrganizationTeamProjects', function() {
 
     setTimeout(() => {
       wrapper.update();
-      let remove = wrapper.find('.button-label');
+      let remove = wrapper.find('div.button-label');
       expect(remove.length).toBe(1);
 
       expect(remove.text()).toContain('Remove');


### PR DESCRIPTION
This enables us to pass an `icon` prop to `Button`

Looks like:

<img width="1105" alt="screen shot 2018-02-20 at 2 39 57 pm" src="https://user-images.githubusercontent.com/30713/36453569-5b187268-164d-11e8-9744-b00ad43f6a83.png">

I've converted all of the 'Add/Create` buttons to utilize it as a first pass.
