### PR TITLE
feat(api): Filter Organization and Project Releases by Environment

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError, transaction
 from rest_framework.response import Response
 
 from .project_releases import ReleaseSerializer
-from sentry.api.base import DocSection
+from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import InvalidRepository
 from sentry.api.paginator import OffsetPaginator
@@ -13,7 +13,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializer, ReleaseHeadCommitSerializerDeprecated, ListField
 )
-from sentry.models import Activity, Release
+from sentry.models import Activity, Environment, Release, ReleaseEnvironment
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -49,7 +49,7 @@ class ReleaseSerializerWithProjects(ReleaseSerializer):
     )
 
 
-class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint):
+class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
     doc_section = DocSection.RELEASES
 
     @attach_scenarios([list_org_releases_scenario])
@@ -64,11 +64,23 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint):
                               "starts with" filter for the version.
         """
         query = request.GET.get('query')
+        try:
+            environment = self._get_environment_from_request(
+                request,
+                organization.id,
+            )
+        except Environment.DoesNotExist:
+            queryset = Release.objects.none()
+        else:
+            queryset = Release.objects.filter(
+                organization=organization,
+                projects__in=self.get_allowed_projects(request, organization)
+            ).select_related('owner')
 
-        queryset = Release.objects.filter(
-            organization=organization,
-            projects__in=self.get_allowed_projects(request, organization)
-        ).select_related('owner')
+            if environment is not None:
+                # should I put this in a try-catch?
+                queryset = queryset.filter(id__in=ReleaseEnvironment.objects.filter(
+                    environment_id=environment.id).values_list('release_id', flat=True))
 
         if query:
             queryset = queryset.filter(

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -78,9 +78,10 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
             ).select_related('owner')
 
             if environment is not None:
-                # should I put this in a try-catch?
                 queryset = queryset.filter(id__in=ReleaseEnvironment.objects.filter(
-                    environment_id=environment.id).values_list('release_id', flat=True))
+                    organization_id=organization.id,
+                    environment_id=environment.id,
+                ).values_list('release_id', flat=True))
 
         if query:
             queryset = queryset.filter(

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -54,7 +54,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
         try:
             environment = self._get_environment_from_request(
                 request,
-                project.organization.id,
+                project.organization_id,
             )
         except Environment.DoesNotExist:
             queryset = Release.objects.none()
@@ -64,7 +64,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
             ).select_related('owner')
             if environment is not None:
                 queryset = queryset.filter(id__in=ReleaseEnvironment.objects.filter(
-                    organization_id=project.organization.id,
+                    organization_id=project.organization_id,
                     environment_id=environment.id,
                 ).values_list('release_id', flat=True))
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1028,3 +1028,13 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         )
         response = self.client.get(url, format='json')
         self.assert_releases(response, [self.release1, self.release2, self.release3, self.release4])
+
+    def test_invalid_environment(self):
+        url = reverse(
+            'sentry-api-0-organization-releases',
+            kwargs={
+                'organization_slug': self.org.slug,
+            }
+        )
+        response = self.client.get(url + '?environment=' + 'invalid_environment', format='json')
+        self.assert_releases(response, [])

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -992,16 +992,6 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         response = self.client.get(url + '?environment=' + self.env2.name, format='json')
         self.assert_releases(response, [self.release2, self.release3])
 
-    def test_no_environment(self):
-        url = reverse(
-            'sentry-api-0-organization-releases',
-            kwargs={
-                'organization_slug': self.org.slug,
-            }
-        )
-        response = self.client.get(url + '?environment=', format='json')
-        self.assert_releases(response, [])
-
     def test_empty_environment(self):
         url = reverse(
             'sentry-api-0-organization-releases',

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -205,17 +205,6 @@ class ProjectReleaseListEnvironmentsTest(APITestCase):
         response = self.client.get(url + '?environment=' + self.env2.name, format='json')
         self.assert_releases(response, [self.release2])
 
-    def test_no_environment(self):
-        url = reverse(
-            'sentry-api-0-project-releases',
-            kwargs={
-                'organization_slug': self.project2.organization.slug,
-                'project_slug': self.project2.slug,
-            }
-        )
-        response = self.client.get(url + '?environment=', format='json')
-        self.assert_releases(response, [])
-
     def test_empty_environment(self):
         url = reverse(
             'sentry-api-0-project-releases',

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from datetime import datetime
 from django.core.urlresolvers import reverse
 
-from sentry.models import Release, ReleaseCommit, ReleaseProject
+from sentry.models import Environment, Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject
 from sentry.testutils import APITestCase
 
 
@@ -90,6 +90,160 @@ class ProjectReleaseListTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
+
+
+class ProjectReleaseListEnvironmentsTest(APITestCase):
+    def setUp(self):
+        self.login_as(user=self.user)
+
+        team = self.create_team()
+        project1 = self.create_project(teams=[team], name='foo')
+        project2 = self.create_project(teams=[team], name='bar')
+
+        env1 = self.make_environment('prod', project1)
+        env2 = self.make_environment('staging', project2)
+        env3 = self.make_environment('test', project1)
+
+        release1 = Release.objects.create(
+            organization_id=project1.organization_id,
+            version='1',
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
+        )
+        release1.add_project(project1)
+        ReleaseEnvironment.objects.create(
+            organization_id=project1.organization_id,
+            project_id=project1.id,
+            release_id=release1.id,
+            environment_id=env1.id,
+        )
+
+        release2 = Release.objects.create(
+            organization_id=project2.organization_id,
+            version='2',
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
+        )
+        release2.add_project(project2)
+        ReleaseEnvironment.objects.create(
+            organization_id=project2.organization_id,
+            project_id=project2.id,
+            release_id=release2.id,
+            environment_id=env2.id,
+        )
+
+        release3 = Release.objects.create(
+            organization_id=project1.organization_id,
+            version='3',
+            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386),
+            date_released=datetime(2013, 8, 15, 3, 8, 24, 880386),
+        )
+        release3.add_project(project1)
+        ReleaseEnvironment.objects.create(
+            organization_id=project1.organization_id,
+            project_id=project1.id,
+            release_id=release3.id,
+            environment_id=env3.id,
+        )
+
+        release4 = Release.objects.create(
+            organization_id=project2.organization_id,
+            version='4',
+        )
+        release4.add_project(project2)
+
+        self.project1 = project1
+        self.project2 = project2
+
+        self.release1 = release1
+        self.release2 = release2
+        self.release3 = release3
+        self.release4 = release4
+
+        self.env1 = env1
+        self.env2 = env2
+        self.env3 = env3
+
+    def make_environment(self, name, project):
+        env = Environment.objects.create(
+            project_id=project.id,
+            organization_id=project.organization_id,
+            name=name,
+        )
+        env.add_project(project)
+        return env
+
+    def assert_releases(self, response, releases):
+        assert response.status_code == 200, response.content
+        assert len(response.data) == len(releases)
+
+        response_versions = sorted([r['version'] for r in response.data])
+        releases_versions = sorted([r.version for r in releases])
+        assert response_versions == releases_versions
+
+    def test_environments_filter(self):
+        url = reverse(
+            'sentry-api-0-project-releases',
+            kwargs={
+                'organization_slug': self.project1.organization.slug,
+                'project_slug': self.project1.slug,
+            }
+        )
+        response = self.client.get(url + '?environment=' + self.env1.name, format='json')
+        self.assert_releases(response, [self.release1])
+
+        response = self.client.get(url + '?environment=' + self.env2.name, format='json')
+        self.assert_releases(response, [])
+
+        response = self.client.get(url + '?environment=' + self.env3.name, format='json')
+        self.assert_releases(response, [self.release3])
+        url = reverse(
+            'sentry-api-0-project-releases',
+            kwargs={
+                'organization_slug': self.project2.organization.slug,
+                'project_slug': self.project2.slug,
+            }
+        )
+        response = self.client.get(url + '?environment=' + self.env2.name, format='json')
+        self.assert_releases(response, [self.release2])
+
+    def test_no_environment(self):
+        url = reverse(
+            'sentry-api-0-project-releases',
+            kwargs={
+                'organization_slug': self.project2.organization.slug,
+                'project_slug': self.project2.slug,
+            }
+        )
+        response = self.client.get(url + '?environment=', format='json')
+        self.assert_releases(response, [])
+
+    def test_empty_environment(self):
+        url = reverse(
+            'sentry-api-0-project-releases',
+            kwargs={
+                'organization_slug': self.project2.organization.slug,
+                'project_slug': self.project2.slug,
+            }
+        )
+        env = self.make_environment('', self.project2)
+        ReleaseEnvironment.objects.create(
+            organization_id=self.project2.organization_id,
+            project_id=self.project2.id,
+            release_id=self.release4.id,
+            environment_id=env.id,
+        )
+        response = self.client.get(url + '?environment=', format='json')
+        self.assert_releases(response, [self.release4])
+
+    def test_all_environments(self):
+        url = reverse(
+            'sentry-api-0-project-releases',
+            kwargs={
+                'organization_slug': self.project1.organization.slug,
+                'project_slug': self.project1.slug,
+            }
+        )
+        response = self.client.get(url, format='json')
+        self.assert_releases(response, [self.release1, self.release3])
 
 
 class ProjectReleaseCreateTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -245,6 +245,17 @@ class ProjectReleaseListEnvironmentsTest(APITestCase):
         response = self.client.get(url, format='json')
         self.assert_releases(response, [self.release1, self.release3])
 
+    def test_invalid_environment(self):
+        url = reverse(
+            'sentry-api-0-project-releases',
+            kwargs={
+                'organization_slug': self.project1.organization.slug,
+                'project_slug': self.project1.slug,
+            }
+        )
+        response = self.client.get(url + '?environment=' + 'invalid_environment', format='json')
+        self.assert_releases(response, [])
+
 
 class ProjectReleaseCreateTest(APITestCase):
     def test_minimal(self):


### PR DESCRIPTION
As part of the Sentry 9 Environments features, ProjectReleases and OrganizationReleases API Endpoints are now able to filter by environments. Note that this PR has not changed the behavior of "New Issues" or "Last Event" columns on the releases page. It simply filters the releases by the ReleaseEnvironment it is associated with.