### PR TITLE
feat(projects): Use project slug and omit team name on org dashboard

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -10,6 +10,7 @@ import {loadStats} from '../actionCreators/projects';
 
 import GroupStore from '../stores/groupStore';
 import HookStore from '../stores/hookStore';
+import ProjectStore from '../stores/projectsStore';
 import TeamStore from '../stores/teamStore';
 
 import ActivityFeed from '../components/activity/feed';
@@ -144,7 +145,7 @@ ProjectSparkline.propTypes = {
   data: PropTypes.array.isRequired,
 };
 
-const ProjectList = createReactClass({
+const ProjectListOld = createReactClass({
   displayName: 'ProjectList',
 
   propTypes: {
@@ -227,6 +228,83 @@ const ProjectList = createReactClass({
   },
 });
 
+const ProjectList = createReactClass({
+  displayName: 'ProjectList',
+
+  propTypes: {
+    projects: PropTypes.array,
+    maxProjects: PropTypes.number,
+  },
+
+  mixins: [OrganizationState],
+
+  getDefaultProps() {
+    return {
+      maxProjects: 8,
+    };
+  },
+
+  render() {
+    let org = this.getOrganization();
+    let {maxProjects} = this.props;
+
+    let projects = this.props.projects.filter(p => {
+      return p.isMember;
+    });
+    projects = sortArray(projects, item => {
+      return [!item.isBookmarked, item.name];
+    });
+
+    // project list is
+    // a) all bookmarked projects
+    // b) if bookmarked projcets < maxProjects, then fill with sorted projects until maxProjects
+
+    let bookmarkedProjects = projects.filter(p => p.isBookmarked);
+    if (bookmarkedProjects.length < maxProjects) {
+      projects = bookmarkedProjects.concat(
+        projects.slice(bookmarkedProjects.length, maxProjects)
+      );
+    } else {
+      projects = bookmarkedProjects;
+    }
+
+    return (
+      <div className="organization-dashboard-projects">
+        <Link className="btn-sidebar-header" to={`/organizations/${org.slug}/teams/`}>
+          {t('View All')}
+        </Link>
+        <h6 className="nav-header">{t('Projects')}</h6>
+        {bookmarkedProjects.length === 0 && (
+          <div className="alert alert-info" style={{marginBottom: 10}}>
+            {tct('Bookmark your most used [projects:projects] to have them appear here', {
+              projects: <Link to={`/organizations/${org.slug}/teams/`} />,
+            })}
+          </div>
+        )}
+        <ul className="nav nav-stacked">
+          {projects.map(project => {
+            return (
+              <li key={project.id} style={{clear: 'both'}}>
+                <div className="pull-right sparkline">
+                  {project.stats && <ProjectSparkline data={project.stats} />}
+                </div>
+                <Link to={`/${org.slug}/${project.slug}/`}>
+                  <h4 style={{margin: '25px 0px'}}>
+                    {project.isBookmarked && (
+                      <span className="bookmark icon-star-solid" />
+                    )}
+                    {project.slug}
+                  </h4>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  },
+});
+
 class Activity extends React.Component {
   getEndpoint = () => {
     return `/organizations/${this.props.params.orgId}/activity/`;
@@ -265,7 +343,12 @@ class Activity extends React.Component {
 
 const OrganizationDashboard = createReactClass({
   displayName: 'OrganizationDashboard',
-  mixins: [ApiMixin, Reflux.listenTo(TeamStore, 'onTeamListChange')],
+  mixins: [
+    ApiMixin,
+    Reflux.listenTo(TeamStore, 'onTeamListChange'),
+    Reflux.listenTo(ProjectStore, 'onProjectListChange'),
+    OrganizationState,
+  ],
 
   getDefaultProps() {
     return {
@@ -284,6 +367,7 @@ const OrganizationDashboard = createReactClass({
 
     return {
       teams: TeamStore.getAll(),
+      projects: ProjectStore.getAll(),
       hooks,
     };
   },
@@ -309,7 +393,16 @@ const OrganizationDashboard = createReactClass({
     });
   },
 
+  onProjectListChange() {
+    this.setState({
+      projects: ProjectStore.getAll(),
+    });
+  },
+
   render() {
+    let org = this.getOrganization();
+    let features = new Set(org.features);
+
     return (
       <OrganizationHomeContainer>
         <div className="row">
@@ -321,7 +414,11 @@ const OrganizationDashboard = createReactClass({
           <div className="col-md-4">
             {this.state.hooks}
             <EventsPerHour {...this.props} />
-            <ProjectList {...this.props} teams={this.state.teams} />
+            {features.has('internal-catchall') ? (
+              <ProjectList {...this.props} projects={this.state.projects} />
+            ) : (
+              <ProjectListOld {...this.props} teams={this.state.teams} />
+            )}
           </div>
         </div>
       </OrganizationHomeContainer>

--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -228,7 +228,7 @@ const ProjectListOld = createReactClass({
   },
 });
 
-const ProjectList = createReactClass({
+export const ProjectList = createReactClass({
   displayName: 'ProjectList',
 
   propTypes: {

--- a/tests/js/spec/views/__snapshots__/organizationDashboard.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationDashboard.spec.jsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectList render() renders 1`] = `
+<div
+  className="organization-dashboard-projects"
+>
+  <Link
+    className="btn-sidebar-header"
+    onlyActiveOnIndex={false}
+    style={Object {}}
+    to="/organizations/org-slug/teams/"
+  >
+    View All
+  </Link>
+  <h6
+    className="nav-header"
+  >
+    Projects
+  </h6>
+  <div
+    className="alert alert-info"
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  >
+    <span
+      key="5"
+    >
+      <span
+        key="0"
+      >
+        Bookmark your most used 
+      </span>
+      <Link
+        key="2"
+        onlyActiveOnIndex={false}
+        style={Object {}}
+        to="/organizations/org-slug/teams/"
+      >
+        <span
+          key="1"
+        >
+          projects
+        </span>
+      </Link>
+      <span
+        key="3"
+      >
+         to have them appear here
+      </span>
+    </span>
+  </div>
+  <ul
+    className="nav nav-stacked"
+  >
+    <li
+      key="2"
+      style={
+        Object {
+          "clear": "both",
+        }
+      }
+    >
+      <div
+        className="pull-right sparkline"
+      />
+      <Link
+        onlyActiveOnIndex={false}
+        style={Object {}}
+        to="/org-slug/project-slug/"
+      >
+        <h4
+          style={
+            Object {
+              "margin": "25px 0px",
+            }
+          }
+        >
+          project-slug
+        </h4>
+      </Link>
+    </li>
+  </ul>
+</div>
+`;

--- a/tests/js/spec/views/organizationDashboard.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard.spec.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {ProjectList} from 'app/views/organizationDashboard';
+
+describe('ProjectList', function() {
+  describe('render()', function() {
+    it('renders', function() {
+      let wrapper = shallow(
+        <ProjectList projects={[TestStubs.Project({isMember: true})]} />,
+        {
+          context: {
+            router: TestStubs.router(),
+            organization: TestStubs.Organization(),
+          },
+        }
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
This is internal only. 

The sparklines are a little squished cc @ckj @Chrissy -- not sure if you have any quick suggestions or I should just merge as is and one of you can update as you see fit when one of you has time.

internal version:
<img width="348" alt="screenshot 2018-02-21 22 21 47" src="https://user-images.githubusercontent.com/5026776/36523339-e947e4ac-1755-11e8-90b2-b59938684475.png">

external version (unchanged):
<img width="344" alt="screenshot 2018-02-21 22 21 10" src="https://user-images.githubusercontent.com/5026776/36523347-f5eaf7da-1755-11e8-8659-9a1139b992ab.png">
