### PR TITLE
fix(environments): Fix parsing of environment from query string

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/utils.js
+++ b/src/sentry/static/sentry/app/views/stream/utils.js
@@ -4,13 +4,14 @@ function formatQueryString(qs) {
 }
 
 // returns environment name from query or null if not specified
+// Any charater can be valid in an environment name
 function getQueryEnvironment(qs) {
-  const match = qs.match(/environment:(\w*)/);
+  const match = qs.match(/environment:([^\s]*)/);
   return match ? match[1] : null;
 }
 
 function getQueryStringWithEnvironment(qs, env) {
-  const qsWithoutEnv = qs.replace(/environment:\w*/g, '');
+  const qsWithoutEnv = qs.replace(/environment:[^\s]*/g, '');
   return formatQueryString(
     env === null ? qsWithoutEnv : qsWithoutEnv + ` environment:${env}`
   );

--- a/tests/js/spec/views/stream/utils.spec.js
+++ b/tests/js/spec/views/stream/utils.spec.js
@@ -16,6 +16,11 @@ describe('getQueryEnvironment()', function() {
     const qs = 'is:unresolved is:unassigned';
     expect(utils.getQueryEnvironment(qs)).toBe(null);
   });
+
+  it('handles environment with non word characters', function() {
+    const qs = 'is:unresolved is:unassigned environment:something.com';
+    expect(utils.getQueryEnvironment(qs)).toBe('something.com');
+  });
 });
 
 describe('getQueryStringWithEnvironment', function() {
@@ -37,6 +42,13 @@ describe('getQueryStringWithEnvironment', function() {
     const qs = 'is:unresolved environment:development is:unassigned';
     expect(utils.getQueryStringWithEnvironment(qs, null)).toBe(
       'is:unresolved is:unassigned'
+    );
+  });
+
+  it('handles environment with non word characters', function() {
+    const qs = 'is:unresolved environment:something.com is:unassigned';
+    expect(utils.getQueryStringWithEnvironment(qs, 'test.com')).toBe(
+      'is:unresolved is:unassigned environment:test.com'
     );
   });
 });


### PR DESCRIPTION
Any character should be valid, not just word characters.
However space character won't currently work because of the way we parse the query string