### PR TITLE
fix(environments): Display actual env name in environment management

### DIFF
--- a/src/sentry/static/sentry/app/views/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/projectEnvironments.jsx
@@ -132,7 +132,9 @@ const ProjectEnvironments = createReactClass({
     const buttonText = isHidden ? t('Show') : t('Hide');
     return envs.map(env => (
       <PanelItem key={env.id} align="center" justify="space-between">
-        <span>{env.displayName}</span>
+        <span>
+          {env.displayName} {env.name && <code>{env.name}</code>}
+        </span>
         <Button size="xsmall" onClick={() => this.toggleEnv(env, !isHidden)}>
           {buttonText}
         </Button>

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -589,6 +589,10 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                   >
                     <span>
                       Production
+                       
+                      <code>
+                        production
+                      </code>
                     </span>
                     <Button
                       disabled={false}
@@ -643,6 +647,10 @@ exports[`ProjectEnvironments render active renders environment list 1`] = `
                   >
                     <span>
                       Staging
+                       
+                      <code>
+                        staging
+                      </code>
                     </span>
                     <Button
                       disabled={false}
@@ -1271,6 +1279,10 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                   >
                     <span>
                       Zzz
+                       
+                      <code>
+                        zzz
+                      </code>
                     </span>
                     <Button
                       disabled={false}


### PR DESCRIPTION
Since environments are not case sensitive we should show the actual name on the environment management page in addition to the display name.