### PR TITLE
feat(ui): Add org/project context modal for settings search

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -1,8 +1,11 @@
 import {browserHistory} from 'react-router';
 
+import {Client} from '../api';
 import IndicatorStore from '../stores/indicatorStore';
-import OrganizationsStore from '../stores/organizationsStore';
 import OrganizationsActions from '../actions/organizationsActions';
+import OrganizationsStore from '../stores/organizationsStore';
+import ProjectsStore from '../stores/projectsStore';
+import TeamStore from '../stores/teamStore';
 
 export function redirectToRemainingOrganization({orgId}) {
   // Remove queued, should redirect
@@ -53,4 +56,25 @@ export function changeOrganizationSlug(prev, next) {
 
 export function updateOrganization(org) {
   OrganizationsActions.update(org);
+}
+
+export function fetchOrganizationDetails(orgId, {setActive, loadProjects, loadTeam}) {
+  let api = new Client();
+  let request = api.requestPromise(`/organizations/${orgId}/`);
+
+  request.then(data => {
+    if (setActive) {
+      setActiveOrganization(data);
+    }
+
+    if (loadTeam) {
+      TeamStore.loadInitialData(data.teams);
+    }
+
+    if (loadProjects) {
+      ProjectsStore.loadInitialData(data.projects || []);
+    }
+  });
+
+  return request;
 }

--- a/src/sentry/static/sentry/app/components/contextPickerModal.jsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.jsx
@@ -161,9 +161,13 @@ class ContextPickerModal extends React.Component {
   };
 
   handleSelectOrganization = value => {
+    // If we do not need to select a project, we can early return after selecting an org
+    // No need to fetch org details
     if (!this.props.needProject) {
       this.navigateIfFinish([{slug: value}], []);
+      return;
     }
+
     this.setState(
       {
         loading: true,
@@ -190,6 +194,10 @@ class ContextPickerModal extends React.Component {
 
     if (!shouldShowPicker) return null;
 
+    // Org select should be empty except if we need a project and there's an org in context
+    // (otherwise they need to select an org before we can fetch projects)
+    let shouldHaveEmptyOrgSelector = !needProject || !latestContext.organization;
+
     // We're inserting a blank el for `select2` so that we can have the placeholder :(
     let orgChoices = organizations
       .filter(({status}) => status.id !== 'pending_deletion')
@@ -211,7 +219,7 @@ class ContextPickerModal extends React.Component {
                   name="organization"
                   choices={[['', ''], ...orgChoices]}
                   value={
-                    latestContext.organization ? latestContext.organization.slug : ''
+                    shouldHaveEmptyOrgSelector ? '' : latestContext.organization.slug
                   }
                   onChange={this.handleSelectOrganization}
                 />

--- a/src/sentry/static/sentry/app/components/contextPickerModal.jsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.jsx
@@ -63,6 +63,8 @@ class ContextPickerModal extends React.Component {
     super(props);
 
     this.state = {
+      // Initialize loading to true if there is only 1 organization because component will immediately
+      // attempt to fetch org details for that org. Otherwise we'd have to change state in `DidMount`
       loading: props.organizations.length === 1,
     };
   }
@@ -123,36 +125,39 @@ class ContextPickerModal extends React.Component {
   ) => {
     let {needProject, onFinish, nextPath} = this.props;
 
+    // If no project is needed and theres only 1 org OR
+    // if we need a project and there's only 1 project
+    // then return because we can't navigate anywhere yet
+    if (
+      (!needProject && organizations.length !== 1) ||
+      (needProject && projects.length !== 1)
+    ) {
+      this.setState({loading: false});
+      return;
+    }
+
     // If there is only one org and we dont need a project slug, then call finish callback
     if (!needProject) {
-      if (organizations.length !== 1) {
-        this.setState({loading: false});
-        return;
-      }
-
       onFinish(
         replaceRouterParams(nextPath, {
           orgId: organizations[0].slug,
         })
       );
-    } else {
-      if (projects.length !== 1) {
-        this.setState({loading: false});
-        return;
-      }
-
-      let org = latestOrg;
-      if (!org && organizations.length === 1) {
-        org = organizations[0];
-      }
-
-      onFinish(
-        replaceRouterParams(nextPath, {
-          orgId: org.slug,
-          projectId: projects[0].slug,
-        })
-      );
+      return;
     }
+
+    // Use latest org or if only 1 org, use that
+    let org = latestOrg;
+    if (!org && organizations.length === 1) {
+      org = organizations[0];
+    }
+
+    onFinish(
+      replaceRouterParams(nextPath, {
+        orgId: org.slug,
+        projectId: projects[0].slug,
+      })
+    );
   };
 
   handleSelectOrganization = value => {

--- a/src/sentry/static/sentry/app/components/contextPickerModal.jsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.jsx
@@ -79,7 +79,7 @@ class ContextPickerModal extends React.Component {
     // attempt to see if we need more info from user and redirect otherwise
     if (latestContext.organization) {
       // This will handle if we can intelligently move the user forward
-      this.checkShouldFinish(
+      this.navigateIfFinish(
         [latestContext.organization],
         latestContext.organization.projects
       );
@@ -105,7 +105,7 @@ class ContextPickerModal extends React.Component {
         latestContext.organization.slug !== nextProps.latestContext.organization.slug)
     ) {
       // Check if we can push the user forward w/o needing them to select anything
-      this.checkShouldFinish(
+      this.navigateIfFinish(
         this.props.organizations,
         nextProps.latestContext.organization.projects,
         nextProps.latestContext.organization
@@ -116,7 +116,7 @@ class ContextPickerModal extends React.Component {
   // Performs checks to see if we need to prompt user
   // i.e. When there is only 1 org and no project is needed or
   // there is only 1 org and only 1 project (which should be rare)
-  checkShouldFinish = (
+  navigateIfFinish = (
     organizations,
     projects,
     latestOrg = this.props.latestContext && this.props.latestContext.organization
@@ -157,7 +157,7 @@ class ContextPickerModal extends React.Component {
 
   handleSelectOrganization = value => {
     if (!this.props.needProject) {
-      this.checkShouldFinish([{slug: value}], []);
+      this.navigateIfFinish([{slug: value}], []);
     }
     this.setState(
       {
@@ -172,7 +172,7 @@ class ContextPickerModal extends React.Component {
 
     if (!projectId || !latestContext.organization) return;
 
-    this.checkShouldFinish([latestContext.organization], [{slug: projectId}]);
+    this.navigateIfFinish([latestContext.organization], [{slug: projectId}]);
   };
 
   render() {

--- a/src/sentry/static/sentry/app/components/contextPickerModal.jsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.jsx
@@ -1,0 +1,255 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+
+import {fetchOrganizationDetails} from '../actionCreators/organizations';
+import {t} from '../locale';
+import LatestContextStore from '../stores/latestContextStore';
+import LoadingIndicator from './loadingIndicator';
+import OrganizationsStore from '../stores/organizationsStore';
+import Select2Field from './forms/select2Field';
+import SentryTypes from '../proptypes';
+import replaceRouterParams from '../utils/replaceRouterParams';
+import withProjects from '../utils/withProjects';
+
+class ContextPickerModal extends React.Component {
+  static propTypes = {
+    /**
+     * The destination route
+     */
+    nextPath: PropTypes.string.isRequired,
+
+    /**
+     * Finish callback
+     */
+    onFinish: PropTypes.func.isRequired,
+
+    /**
+     * Container for modal header
+     */
+    Header: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string]),
+
+    /**
+     * Container for modal body
+     */
+    Body: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string]),
+
+    /**
+     * List of available organizations
+     */
+    organizations: PropTypes.arrayOf(SentryTypes.Organization),
+
+    /**
+     * LatestContext store
+     */
+    latestContext: PropTypes.shape({
+      organization: SentryTypes.Organization,
+    }),
+
+    /**
+     * Does modal need to prompt for organization.
+     * TODO(billy): This can be derived from `nextPath`
+     */
+    needOrg: PropTypes.bool,
+
+    /**
+     * Does modal need to prompt for project
+     */
+    needProject: PropTypes.bool,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: props.organizations.length === 1,
+    };
+  }
+
+  componentDidMount() {
+    let {latestContext, organizations} = this.props;
+
+    // Don't make any assumptions if there are multiple organizations
+    if (organizations.length !== 1) {
+      return;
+    }
+
+    // If there is an org in context (and there's only 1 org available),
+    // attempt to see if we need more info from user and redirect otherwise
+    if (latestContext.organization) {
+      // This will handle if we can intelligently move the user forward
+      this.checkShouldFinish(
+        [latestContext.organization],
+        latestContext.organization.projects
+      );
+      return;
+    }
+
+    // Since user belongs to only 1 org, we can set it as active and componentWillReceiveProps handle the rest
+    fetchOrganizationDetails(organizations[0].slug, {
+      setActive: true,
+      loadProjects: true,
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Should only check the case where there is no latestContext.organization and we're waiting
+    // for it to be set (after fetch in DidMount)
+    let {latestContext} = this.props;
+    if (
+      (!latestContext.organization &&
+        latestContext.organization !== nextProps.latestContext.organization) ||
+      (latestContext.organization &&
+        nextProps.latestContext.organization &&
+        latestContext.organization.slug !== nextProps.latestContext.organization.slug)
+    ) {
+      // Check if we can push the user forward w/o needing them to select anything
+      this.checkShouldFinish(
+        this.props.organizations,
+        nextProps.latestContext.organization.projects,
+        nextProps.latestContext.organization
+      );
+    }
+  }
+
+  // Performs checks to see if we need to prompt user
+  // i.e. When there is only 1 org and no project is needed or
+  // there is only 1 org and only 1 project (which should be rare)
+  checkShouldFinish = (
+    organizations,
+    projects,
+    latestOrg = this.props.latestContext && this.props.latestContext.organization
+  ) => {
+    let {needProject, onFinish, nextPath} = this.props;
+
+    // If there is only one org and we dont need a project slug, then call finish callback
+    if (!needProject) {
+      if (organizations.length !== 1) {
+        this.setState({loading: false});
+        return;
+      }
+
+      onFinish(
+        replaceRouterParams(nextPath, {
+          orgId: organizations[0].slug,
+        })
+      );
+    } else {
+      if (projects.length !== 1) {
+        this.setState({loading: false});
+        return;
+      }
+
+      let org = latestOrg;
+      if (!org && organizations.length === 1) {
+        org = organizations[0];
+      }
+
+      onFinish(
+        replaceRouterParams(nextPath, {
+          orgId: org.slug,
+          projectId: projects[0].slug,
+        })
+      );
+    }
+  };
+
+  handleSelectOrganization = value => {
+    if (!this.props.needProject) {
+      this.checkShouldFinish([{slug: value}], []);
+    }
+    this.setState(
+      {
+        loading: true,
+      },
+      () => fetchOrganizationDetails(value, {setActive: true, loadProjects: true})
+    );
+  };
+
+  handleSelectProject = projectId => {
+    let {latestContext} = this.props;
+
+    if (!projectId || !latestContext.organization) return;
+
+    this.checkShouldFinish([latestContext.organization], [{slug: projectId}]);
+  };
+
+  render() {
+    let {latestContext, needOrg, needProject, organizations, Header, Body} = this.props;
+    let {loading} = this.state;
+
+    let shouldShowPicker = needOrg || needProject;
+
+    let projects = latestContext.organization && latestContext.organization.projects;
+
+    if (!shouldShowPicker) return null;
+
+    // We're inserting a blank el for `select2` so that we can have the placeholder :(
+    let orgChoices = organizations
+      .filter(({status}) => status.id !== 'pending_deletion')
+      .map(({slug}) => [slug, slug]);
+
+    return (
+      <div>
+        {loading && <LoadingIndicator />}
+        {!loading && (
+          <React.Fragment>
+            <Header closeButton>{t('Select...')}</Header>
+            <Body>
+              <div css={{marginBottom: 12}}>
+                {t('Select an organization/project to continue')}
+              </div>
+              {needOrg && (
+                <Select2Field
+                  placeholder="Select an Organization"
+                  name="organization"
+                  choices={[['', ''], ...orgChoices]}
+                  value={
+                    latestContext.organization ? latestContext.organization.slug : ''
+                  }
+                  onChange={this.handleSelectOrganization}
+                />
+              )}
+
+              {latestContext.organization &&
+                needProject &&
+                projects && (
+                  <Select2Field
+                    placeholder="Select a Project"
+                    name="project"
+                    allowEmpty
+                    value=""
+                    choices={[['', ''], ...projects.map(({slug}) => [slug, slug])]}
+                    onChange={this.handleSelectProject}
+                  />
+                )}
+            </Body>
+          </React.Fragment>
+        )}
+      </div>
+    );
+  }
+}
+
+const ContextPickerModalContainer = withProjects(
+  createReactClass({
+    displayName: 'ContextPickerModalContainer',
+    mixins: [
+      Reflux.connect(LatestContextStore, 'latestContext'),
+      Reflux.connect(OrganizationsStore, 'organizations'),
+    ],
+    render() {
+      return (
+        <ContextPickerModal
+          {...this.props}
+          latestContext={this.state.latestContext}
+          organizations={this.state.organizations}
+        />
+      );
+    },
+  })
+);
+
+export default ContextPickerModalContainer;
+export {ContextPickerModal};

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
@@ -1,4 +1,5 @@
 import {Flex, Box} from 'grid-emotion';
+import DocumentTitle from 'react-document-title';
 import React from 'react';
 import styled from 'react-emotion';
 
@@ -104,203 +105,205 @@ class SettingsIndex extends React.Component {
     let SupportLinkComponent = isOnPremise ? ExternalHomeLink : HomeLink;
 
     return (
-      <SettingsLayout {...this.props}>
-        <Flex mx={-2} wrap>
-          <Box w={1 / 3} px={2}>
-            <Panel>
-              <HomePanelHeader>
-                <HomeLink to="/settings/account/">
-                  <HomeIcon color="blue">
-                    <InlineSvg src="icon-user" size="44px" />
-                  </HomeIcon>
-                  {t('My Account')}
-                </HomeLink>
-              </HomePanelHeader>
-
-              <HomePanelBody>
-                <h3>{t('Quick links')}:</h3>
-                <ul>
-                  <li>
-                    <HomeLink href="/settings/account/security/">
-                      {t('Change my password')}
-                    </HomeLink>
-                  </li>
-                  <li>
-                    <HomeLink to="/settings/account/notifications/">
-                      {t('Notification Preferences')}
-                    </HomeLink>
-                  </li>
-                  <li>
-                    <HomeLink to="/settings/account/avatar/">
-                      {t('Change my avatar')}
-                    </HomeLink>
-                  </li>
-                </ul>
-              </HomePanelBody>
-            </Panel>
-          </Box>
-
-          <Box w={1 / 3} px={2}>
-            {/* if admin */}
-            <Panel>
-              {!organization && <LoadingIndicator overlay />}
-              <HomePanelHeader>
-                <HomeLink to={organizationSettingsUrl}>
-                  <HomeIcon color="green">
-                    <InlineSvg src="icon-stack" size="44px" />
-                  </HomeIcon>
-                  <TextOverflow css={{lineHeight: '1.1em'}}>
-                    {organization ? organization.slug : t('Organization')}
-                  </TextOverflow>
-                </HomeLink>
-              </HomePanelHeader>
-              <HomePanelBody>
-                <h3>{t('Quick links')}:</h3>
-                <ul>
-                  <li>
-                    <HomeLink to={`${organizationSettingsUrl}teams/`}>
-                      {t('Projects & Teams')}
-                    </HomeLink>
-                  </li>
-                  <li>
-                    <HomeLink to={`${organizationSettingsUrl}members/`}>
-                      {t('Members')}
-                    </HomeLink>
-                  </li>
-                  <li>
-                    <HomeLink to={`${organizationSettingsUrl}stats/`}>
-                      {t('Stats')}
-                    </HomeLink>
-                  </li>
-                </ul>
-              </HomePanelBody>
-            </Panel>
-          </Box>
-
-          <Box w={1 / 3} px={2}>
-            <Panel>
-              <HomePanelHeader>
-                <ExternalHomeLink href={LINKS.DOCUMENTATION}>
-                  <HomeIcon color="orange">
-                    <InlineSvg src="icon-docs" size="48px" />
-                  </HomeIcon>
-                </ExternalHomeLink>
-                <ExternalHomeLink href={LINKS.DOCUMENTATION}>
-                  {t('Documentation')}
-                </ExternalHomeLink>
-              </HomePanelHeader>
-
-              <HomePanelBody>
-                <h3>{t('Quick links')}:</h3>
-                <ul>
-                  <li>
-                    <ExternalHomeLink href={LINKS.DOCUMENATATION_QUICKSTART}>
-                      {t('Quickstart Guide')}
-                    </ExternalHomeLink>
-                  </li>
-                  <li>
-                    <ExternalHomeLink href={LINKS.DOCUMENTATION_PLATFORMS}>
-                      {t('Platforms & Frameworks')}
-                    </ExternalHomeLink>
-                  </li>
-                  <li>
-                    <ExternalHomeLink href={LINKS.DOCUMENTATION_CLI}>
-                      {t('Sentry CLI')}
-                    </ExternalHomeLink>
-                  </li>
-                </ul>
-              </HomePanelBody>
-            </Panel>
-          </Box>
-
-          <Box w={1 / 3} px={2}>
-            <Panel>
-              <HomePanelHeader>
-                <SupportLinkComponent {...supportLinkProps}>
-                  <HomeIcon color="purple">
-                    <InlineSvg src="icon-support" size="48px" />
-                  </HomeIcon>
-                  {t('Support')}
-                </SupportLinkComponent>
-              </HomePanelHeader>
-
-              <HomePanelBody>
-                <h3>{t('Quick links')}:</h3>
-                <ul>
-                  <li>
-                    <SupportLinkComponent {...supportLinkProps}>
-                      {supportText}
-                    </SupportLinkComponent>
-                  </li>
-                  <li>
-                    <ExternalHomeLink href={LINKS.GITHUB_ISSUES}>
-                      {t('Sentry on GitHub')}
-                    </ExternalHomeLink>
-                  </li>
-                  <li>
-                    <ExternalHomeLink href={LINKS.SERVICE_STATUS}>
-                      {t('Service Status')}
-                    </ExternalHomeLink>
-                  </li>
-                </ul>
-              </HomePanelBody>
-            </Panel>
-          </Box>
-
-          <Box w={1 / 3} px={2}>
-            <Panel>
-              <HomePanelHeader>
-                <HomeLink to={LINKS.API}>
-                  <HomeIcon>
-                    <InlineSvg src="icon-lock" size="48px" />
-                  </HomeIcon>
-                  {t('API Keys')}
-                </HomeLink>
-              </HomePanelHeader>
-
-              <HomePanelBody>
-                <h3>{t('Quick links')}:</h3>
-                <ul>
-                  <li>
-                    <HomeLink to={LINKS.API}>{t('Auth Tokens')}</HomeLink>
-                  </li>
-                  <li>
-                    <HomeLink to={LINKS.API_APPLICATION}>{t('Applications')}</HomeLink>
-                  </li>
-                  <li>
-                    <ExternalHomeLink href={LINKS.DOCUMENTATION_API}>
-                      {t('Documentation')}
-                    </ExternalHomeLink>
-                  </li>
-                </ul>
-              </HomePanelBody>
-            </Panel>
-          </Box>
-
-          {isSuperuser && (
+      <DocumentTitle title={organization ? `${organization.slug} Settings` : 'Settings'}>
+        <SettingsLayout {...this.props}>
+          <Flex mx={-2} wrap>
             <Box w={1 / 3} px={2}>
               <Panel>
                 <HomePanelHeader>
-                  <HomeLink href={LINKS.MANAGE}>
-                    <HomeIcon color="red">
-                      <InlineSvg src="icon-laptop" size="48px" />
+                  <HomeLink to="/settings/account/">
+                    <HomeIcon color="blue">
+                      <InlineSvg src="icon-user" size="44px" />
                     </HomeIcon>
-                    {t('Server Admin')}
+                    {t('My Account')}
+                  </HomeLink>
+                </HomePanelHeader>
+
+                <HomePanelBody>
+                  <h3>{t('Quick links')}:</h3>
+                  <ul>
+                    <li>
+                      <HomeLink href="/settings/account/security/">
+                        {t('Change my password')}
+                      </HomeLink>
+                    </li>
+                    <li>
+                      <HomeLink to="/settings/account/notifications/">
+                        {t('Notification Preferences')}
+                      </HomeLink>
+                    </li>
+                    <li>
+                      <HomeLink to="/settings/account/avatar/">
+                        {t('Change my avatar')}
+                      </HomeLink>
+                    </li>
+                  </ul>
+                </HomePanelBody>
+              </Panel>
+            </Box>
+
+            <Box w={1 / 3} px={2}>
+              {/* if admin */}
+              <Panel>
+                {!organization && <LoadingIndicator overlay />}
+                <HomePanelHeader>
+                  <HomeLink to={organizationSettingsUrl}>
+                    <HomeIcon color="green">
+                      <InlineSvg src="icon-stack" size="44px" />
+                    </HomeIcon>
+                    <TextOverflow css={{lineHeight: '1.1em'}}>
+                      {organization ? organization.slug : t('Organization')}
+                    </TextOverflow>
                   </HomeLink>
                 </HomePanelHeader>
                 <HomePanelBody>
                   <h3>{t('Quick links')}:</h3>
                   <ul>
-                    <li />
-                    <li />
-                    <li />
+                    <li>
+                      <HomeLink to={`${organizationSettingsUrl}teams/`}>
+                        {t('Projects & Teams')}
+                      </HomeLink>
+                    </li>
+                    <li>
+                      <HomeLink to={`${organizationSettingsUrl}members/`}>
+                        {t('Members')}
+                      </HomeLink>
+                    </li>
+                    <li>
+                      <HomeLink to={`${organizationSettingsUrl}stats/`}>
+                        {t('Stats')}
+                      </HomeLink>
+                    </li>
                   </ul>
                 </HomePanelBody>
               </Panel>
             </Box>
-          )}
-        </Flex>
-      </SettingsLayout>
+
+            <Box w={1 / 3} px={2}>
+              <Panel>
+                <HomePanelHeader>
+                  <ExternalHomeLink href={LINKS.DOCUMENTATION}>
+                    <HomeIcon color="orange">
+                      <InlineSvg src="icon-docs" size="48px" />
+                    </HomeIcon>
+                  </ExternalHomeLink>
+                  <ExternalHomeLink href={LINKS.DOCUMENTATION}>
+                    {t('Documentation')}
+                  </ExternalHomeLink>
+                </HomePanelHeader>
+
+                <HomePanelBody>
+                  <h3>{t('Quick links')}:</h3>
+                  <ul>
+                    <li>
+                      <ExternalHomeLink href={LINKS.DOCUMENATATION_QUICKSTART}>
+                        {t('Quickstart Guide')}
+                      </ExternalHomeLink>
+                    </li>
+                    <li>
+                      <ExternalHomeLink href={LINKS.DOCUMENTATION_PLATFORMS}>
+                        {t('Platforms & Frameworks')}
+                      </ExternalHomeLink>
+                    </li>
+                    <li>
+                      <ExternalHomeLink href={LINKS.DOCUMENTATION_CLI}>
+                        {t('Sentry CLI')}
+                      </ExternalHomeLink>
+                    </li>
+                  </ul>
+                </HomePanelBody>
+              </Panel>
+            </Box>
+
+            <Box w={1 / 3} px={2}>
+              <Panel>
+                <HomePanelHeader>
+                  <SupportLinkComponent {...supportLinkProps}>
+                    <HomeIcon color="purple">
+                      <InlineSvg src="icon-support" size="48px" />
+                    </HomeIcon>
+                    {t('Support')}
+                  </SupportLinkComponent>
+                </HomePanelHeader>
+
+                <HomePanelBody>
+                  <h3>{t('Quick links')}:</h3>
+                  <ul>
+                    <li>
+                      <SupportLinkComponent {...supportLinkProps}>
+                        {supportText}
+                      </SupportLinkComponent>
+                    </li>
+                    <li>
+                      <ExternalHomeLink href={LINKS.GITHUB_ISSUES}>
+                        {t('Sentry on GitHub')}
+                      </ExternalHomeLink>
+                    </li>
+                    <li>
+                      <ExternalHomeLink href={LINKS.SERVICE_STATUS}>
+                        {t('Service Status')}
+                      </ExternalHomeLink>
+                    </li>
+                  </ul>
+                </HomePanelBody>
+              </Panel>
+            </Box>
+
+            <Box w={1 / 3} px={2}>
+              <Panel>
+                <HomePanelHeader>
+                  <HomeLink to={LINKS.API}>
+                    <HomeIcon>
+                      <InlineSvg src="icon-lock" size="48px" />
+                    </HomeIcon>
+                    {t('API Keys')}
+                  </HomeLink>
+                </HomePanelHeader>
+
+                <HomePanelBody>
+                  <h3>{t('Quick links')}:</h3>
+                  <ul>
+                    <li>
+                      <HomeLink to={LINKS.API}>{t('Auth Tokens')}</HomeLink>
+                    </li>
+                    <li>
+                      <HomeLink to={LINKS.API_APPLICATION}>{t('Applications')}</HomeLink>
+                    </li>
+                    <li>
+                      <ExternalHomeLink href={LINKS.DOCUMENTATION_API}>
+                        {t('Documentation')}
+                      </ExternalHomeLink>
+                    </li>
+                  </ul>
+                </HomePanelBody>
+              </Panel>
+            </Box>
+
+            {isSuperuser && (
+              <Box w={1 / 3} px={2}>
+                <Panel>
+                  <HomePanelHeader>
+                    <HomeLink href={LINKS.MANAGE}>
+                      <HomeIcon color="red">
+                        <InlineSvg src="icon-laptop" size="48px" />
+                      </HomeIcon>
+                      {t('Server Admin')}
+                    </HomeLink>
+                  </HomePanelHeader>
+                  <HomePanelBody>
+                    <h3>{t('Quick links')}:</h3>
+                    <ul>
+                      <li />
+                      <li />
+                      <li />
+                    </ul>
+                  </HomePanelBody>
+                </Panel>
+              </Box>
+            )}
+          </Flex>
+        </SettingsLayout>
+      </DocumentTitle>
     );
   }
 }

--- a/tests/js/setupFramework.js
+++ b/tests/js/setupFramework.js
@@ -1,5 +1,10 @@
+/* global process */
 // jest snapshot serializer for emotion
 import {sheet} from 'emotion';
 import serializer from 'jest-glamor-react';
 
 expect.addSnapshotSerializer(serializer(sheet));
+process.on('unhandledRejection', (reason, promise) => {
+  // eslint-disable-next-line no-console
+  console.error(reason);
+});

--- a/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`SettingsLayout renders 1`] = `
         routes={Array []}
       />
     </Box>
-    <SettingsSearchContainer />
+    <withRouter(SettingsSearchContainer) />
   </SettingsHeader>
   <Flex>
     <Content>

--- a/tests/js/spec/components/contextPickerModal.spec.jsx
+++ b/tests/js/spec/components/contextPickerModal.spec.jsx
@@ -107,7 +107,8 @@ describe('ContextPickerModal', function() {
       .instance()
       .onChange({target: {value: org.slug}});
     expect(onFinish).toHaveBeenCalledWith('/test/org-slug/path/');
-    expect(mock).toHaveBeenCalled();
+    // Is not called because we don't need to fetch org details
+    expect(mock).not.toHaveBeenCalled();
   });
 
   it('renders with project selector and org selector selected when org is in latest context', function() {

--- a/tests/js/spec/components/contextPickerModal.spec.jsx
+++ b/tests/js/spec/components/contextPickerModal.spec.jsx
@@ -1,0 +1,196 @@
+import React from 'react';
+
+import * as OrgActions from 'app/actionCreators/organizations';
+import {mount, shallow} from 'enzyme';
+import {ContextPickerModal} from 'app/components/contextPickerModal';
+
+jest.mock('jquery');
+
+describe('ContextPickerModal', function() {
+  let project = TestStubs.Project();
+  let org = TestStubs.Organization({projects: [project]});
+  let org2 = {slug: 'org2', id: '21', status: {id: 'active'}};
+  let project2 = {slug: 'project2'};
+  let onFinish = jest.fn();
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    onFinish.mockReset();
+  });
+
+  const getComponent = props => (
+    <ContextPickerModal
+      Header={() => <div />}
+      Body="div"
+      nextPath="/test/:orgId/path/"
+      organizations={[org, org2]}
+      needOrg
+      latestContext={{}}
+      onFinish={onFinish}
+      {...props}
+    />
+  );
+
+  it('renders with only org selector when no org in latest context', function() {
+    let wrapper = shallow(getComponent());
+
+    expect(wrapper.find('Select2Field[name="organization"]').exists()).toBe(true);
+    expect(wrapper.find('Select2Field[name="project"]').exists()).toBe(false);
+  });
+
+  it('fetches org details and sets as active org if there is only one org', function() {
+    let spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
+    let api = MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/`,
+    });
+    let wrapper = mount(getComponent({organizations: [org2]}));
+
+    wrapper.update();
+    expect(spy).toHaveBeenCalledWith('org2', {
+      setActive: true,
+      loadProjects: true,
+    });
+    expect(api).toHaveBeenCalled();
+  });
+
+  it('calls onFinish after latestContext is set, if project id is not needed, and only 1 org', function() {
+    let spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
+    let api = MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/`,
+    });
+    let wrapper = mount(getComponent({organizations: [org2]}));
+
+    expect(spy).toHaveBeenCalledWith('org2', {
+      setActive: true,
+      loadProjects: true,
+    });
+    expect(api).toHaveBeenCalled();
+
+    wrapper.setProps({latestContext: {organization: org2}});
+    wrapper.update();
+    expect(onFinish).toHaveBeenCalledWith('/test/org2/path/');
+  });
+
+  it('calls onFinish if there is only 1 org and 1 project', function() {
+    let spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
+    let api = MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/`,
+    });
+    let wrapper = mount(
+      getComponent({
+        needOrg: true,
+        needProject: true,
+        nextPath: '/test/:orgId/path/:projectId/',
+        organizations: [org2],
+      })
+    );
+
+    expect(spy).toHaveBeenCalledWith('org2', {
+      setActive: true,
+      loadProjects: true,
+    });
+    expect(api).toHaveBeenCalled();
+
+    wrapper.setProps({latestContext: {organization: {...org2, projects: [project2]}}});
+    wrapper.update();
+    expect(onFinish).toHaveBeenCalledWith('/test/org2/path/project2/');
+  });
+
+  it('selects an org and calls `onFinish` with URL with organization slug', function() {
+    let wrapper = mount(getComponent({}));
+    let mock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/`,
+    });
+
+    wrapper
+      .find('Select2Field[name="organization"]')
+      .instance()
+      .onChange({target: {value: org.slug}});
+    expect(onFinish).toHaveBeenCalledWith('/test/org-slug/path/');
+    expect(mock).toHaveBeenCalled();
+  });
+
+  it('renders with project selector and org selector selected when org is in latest context', function() {
+    let wrapper = shallow(
+      getComponent({
+        needOrg: true,
+        needProject: true,
+        latestContext: {
+          organization: {
+            ...org,
+            projects: [project, project2],
+          },
+        },
+      })
+    );
+
+    // Default to org in latest context
+    expect(wrapper.find('Select2Field[name="organization"]').prop('value')).toBe(
+      org.slug
+    );
+    expect(wrapper.find('Select2Field[name="project"]').prop('choices')).toEqual([
+      ['', ''],
+      [project.slug, project.slug],
+      [project2.slug, project2.slug],
+    ]);
+  });
+
+  it('can select org and project', function() {
+    let spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
+    let api = MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/`,
+    });
+    let wrapper = mount(
+      getComponent({
+        needOrg: true,
+        needProject: true,
+        nextPath: '/test/:orgId/path/:projectId/',
+        organizations: [
+          {
+            ...org,
+            projects: [project],
+          },
+          {
+            ...org2,
+            projects: [project2],
+          },
+        ],
+      })
+    );
+
+    // Should not have anything selected
+    expect(wrapper.find('Select2Field[name="organization"]').prop('value')).toBe('');
+
+    // Select org2
+    wrapper
+      .find('Select2Field[name="organization"]')
+      .instance()
+      .onChange({target: {value: org2.slug}});
+
+    expect(spy).toHaveBeenCalledWith('org2', {
+      setActive: true,
+      loadProjects: true,
+    });
+    expect(api).toHaveBeenCalled();
+
+    // org2 should have 2 projects, project2 and project3
+    wrapper.setProps({
+      latestContext: {organization: {...org2, projects: [project2, {slug: 'project3'}]}},
+    });
+    wrapper.update();
+
+    expect(wrapper.find('Select2Field[name="project"]').prop('choices')).toEqual([
+      ['', ''],
+      [project2.slug, project2.slug],
+      ['project3', 'project3'],
+    ]);
+
+    // Select org3
+    wrapper
+      .find('Select2Field[name="project"]')
+      .instance()
+      .onChange({target: {value: 'project3'}});
+
+    expect(onFinish).toHaveBeenCalledWith('/test/org2/path/project3/');
+  });
+});


### PR DESCRIPTION
When using settings search, if you are at a page with no org/project context, this will open a modal to select org/project. In the rare case that there is 1 org or project, it will auto select and redirect.

![projectpicker](https://user-images.githubusercontent.com/79684/36623020-f6ef061a-18b5-11e8-8405-be0e8af061af.gif)
