### PR TITLE
fix(tooltip): Refine Tooltip component

### DIFF
--- a/docs-ui/components/tooltip.stories.js
+++ b/docs-ui/components/tooltip.stories.js
@@ -1,31 +1,39 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
+import {text, boolean} from '@storybook/addon-knobs';
 
 import Tooltip from 'sentry-ui/tooltip';
 import Button from 'sentry-ui/buttons/button';
 
 storiesOf('Tooltip', module).add(
   'default',
-  withInfo('Description')(() => (
-    <div>
-      <h1>Test</h1>
-      <div>
-        <Tooltip title="My tooltip">
-          <Button>Custom React Component</Button>
-        </Tooltip>
-      </div>
+  withInfo('Description')(() => {
+    let title = text('My tooltip', 'My tooltip');
+    let disabled = boolean('Disabled', false);
 
+    return (
       <div>
-        <Tooltip
-          title="My tooltip with options"
-          tooltipOptions={{
-            placement: 'bottom',
-          }}
-        >
-          <button>Native button</button>
-        </Tooltip>
+        <p>Test</p>
+        <div>
+          <Tooltip title={title} disabled={disabled}>
+            <Button>Custom React Component</Button>
+          </Tooltip>
+        </div>
+        <p>Test with options</p>
+
+        <div>
+          <Tooltip
+            title={title}
+            disabled={disabled}
+            tooltipOptions={{
+              placement: 'bottom',
+            }}
+          >
+            <button>Native button</button>
+          </Tooltip>
+        </div>
       </div>
-    </div>
-  ))
+    );
+  })
 );

--- a/src/sentry/static/sentry/app/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip.jsx
@@ -17,53 +17,56 @@ class Tooltip extends React.Component {
   componentWillReceiveProps(newProps) {
     let {disabled} = this.props;
     if (newProps.disabled && !disabled) {
-      this.removeTooltips(this.$ref);
+      this.removeTooltips(this.ref);
+    } else if (!newProps.disabled && disabled) {
+      this.attachTooltips(this.ref);
     }
   }
 
   componentDidUpdate = prevProps => {
     if (prevProps.title != this.props.title) {
-      this.removeTooltips(this.$ref);
+      this.removeTooltips(this.ref);
+      this.attachTooltips(this.ref);
     }
   };
 
   handleMount = ref => {
     if (ref && !this.ref) {
       // eslint-disable-next-line react/no-find-dom-node
-      this.$ref = $(ReactDOM.findDOMNode(ref));
-      this.attachTooltips(this.$ref);
+      this.attachTooltips(ref);
     } else if (!ref && this.ref) {
-      this.removeTooltips(this.$ref);
-      this.$ref = null;
+      this.removeTooltips(ref);
     }
 
     this.ref = ref;
   };
 
-  attachTooltips = $el => {
+  attachTooltips = ref => {
+    this.$ref = $(ReactDOM.findDOMNode(ref));
+
     let {title, tooltipOptions} = this.props;
     let options =
       typeof tooltipOptions === 'function'
         ? tooltipOptions.call(this)
         : tooltipOptions || {};
 
-    $el &&
-      $el.tooltip({
-        title,
-        ...options,
-      });
+    this.$ref.tooltip({
+      title,
+      ...options,
+    });
   };
 
-  removeTooltips = $el => {
+  removeTooltips = ref => {
+    this.$ref = $(ReactDOM.findDOMNode(ref));
+
     let {tooltipOptions} = this.props;
-    let tooltipEl = $el;
-    if (!tooltipEl) {
-      return;
-    }
-    tooltipEl
+
+    this.$ref
       .tooltip('destroy') // destroy tooltips on parent ...
       .find(tooltipOptions && tooltipOptions.selector)
       .tooltip('destroy'); // ... and descendents
+
+    this.$ref = null;
   };
 
   render() {

--- a/src/sentry/static/sentry/app/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip.jsx
@@ -14,10 +14,16 @@ class Tooltip extends React.Component {
     title: PropTypes.node,
   };
 
-  componentDidUpdate = prevProps => {
-    if ( prevProps.title != this.props.title ) {
+  componentWillReceiveProps(newProps) {
+    let {disabled} = this.props;
+    if (newProps.disabled && !disabled) {
       this.removeTooltips(this.$ref);
-      this.attachTooltips(this.$ref);
+    }
+  }
+
+  componentDidUpdate = prevProps => {
+    if (prevProps.title != this.props.title) {
+      this.removeTooltips(this.$ref);
     }
   };
 
@@ -40,15 +46,21 @@ class Tooltip extends React.Component {
       typeof tooltipOptions === 'function'
         ? tooltipOptions.call(this)
         : tooltipOptions || {};
-    $el.tooltip({
-      title,
-      ...options,
-    });
+
+    $el &&
+      $el.tooltip({
+        title,
+        ...options,
+      });
   };
 
   removeTooltips = $el => {
     let {tooltipOptions} = this.props;
-    $el
+    let tooltipEl = $el;
+    if (!tooltipEl) {
+      return;
+    }
+    tooltipEl
       .tooltip('destroy') // destroy tooltips on parent ...
       .find(tooltipOptions && tooltipOptions.selector)
       .tooltip('destroy'); // ... and descendents

--- a/src/sentry/static/sentry/app/views/settings/components/settingsProjectItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsProjectItem.jsx
@@ -56,6 +56,8 @@ const ProjectItem = createReactClass({
         },
       })
     );
+    //needed to dismiss tooltip
+    document.activeElement.blur();
   },
 
   render() {

--- a/tests/js/spec/components/tooltip.spec.jsx
+++ b/tests/js/spec/components/tooltip.spec.jsx
@@ -11,4 +11,50 @@ describe('Tooltip', function() {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('updates title', function() {
+    let wrapper = mount(
+      <Tooltip title="test">
+        <span>My Button</span>
+      </Tooltip>
+    );
+
+    wrapper.setProps({title: 'bar'});
+    let tip = wrapper.find('.tip');
+    expect(tip.props().title).toBe('bar');
+    wrapper.setProps({title: 'baz'});
+    tip = wrapper.find('.tip');
+    expect(tip.props().title).toBe('baz');
+  });
+
+  it('disables and re-enables', function() {
+    let wrapper = mount(
+      <Tooltip title="test">
+        <span>My Button</span>
+      </Tooltip>
+    );
+
+    wrapper.setProps({disabled: true});
+    let tip = wrapper.find('span');
+
+    expect(tip.props().title).toBeUndefined();
+    wrapper.setProps({disabled: false});
+
+    tip = wrapper.find('.tip');
+    expect(tip.props().title).toBe('test');
+  });
+
+  it('simultaneous enable and text change', function() {
+    let wrapper = mount(
+      <Tooltip title="test">
+        <span>My Button</span>
+      </Tooltip>
+    );
+
+    wrapper.setProps({disabled: true, title: 'bar'});
+    let tip = wrapper.find('span');
+
+    expect(tip.props().title).toBeUndefined();
+    wrapper.setProps({disabled: false});
+  });
 });


### PR DESCRIPTION
trying to fix behavior of this component regarding changing titles
(if a new title prop is provided, the tooltip should reflect it)
and respecting the disabled prop
(the tooltip should disapear when disabled is truthy, come back when it's falsey)

as well as testing old behavior to make sure it's retained