### PR TITLE
feat(slack): Support DMing users

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -53,6 +53,9 @@ class RuleNodeField(serializers.WritableField):
                 'Ensure at least one action is enabled and all required fields are filled in.'
             )
 
+        # Update data from cleaned form values
+        data.update(form.cleaned_data)
+
         return data
 
 

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -20,7 +20,7 @@ class SlackNotifyServiceForm(forms.Form):
         attrs={'style': 'width:150px'},
     ))
     channel = forms.CharField(widget=forms.TextInput(
-        attrs={'placeholder': 'i.e #critical or @evan'},
+        attrs={'placeholder': 'i.e #critical'},
     ))
     channel_id = forms.HiddenInput()
 

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -35,7 +35,7 @@ class SlackNotifyActionTest(RuleTestCase):
         event = self.get_event()
 
         rule = self.get_rule(data={
-            'team': self.integration.id,
+            'workspace': self.integration.id,
             'channel': '#my-channel',
         })
 
@@ -62,27 +62,27 @@ class SlackNotifyActionTest(RuleTestCase):
 
     def test_render_label(self):
         rule = self.get_rule(data={
-            'team': self.integration.id,
+            'workspace': self.integration.id,
             'channel': '#my-channel',
         })
 
-        assert rule.render_label() == 'Send a notification to the Slack Awesome Team team in #my-channel'
+        assert rule.render_label() == 'Send a notification to the Slack Awesome Team workspace to #my-channel'
 
     def test_render_label_without_integration(self):
         self.integration.delete()
 
         rule = self.get_rule(data={
-            'team': self.integration.id,
+            'workspace': self.integration.id,
             'channel': '#my-channel',
         })
 
         label = rule.render_label()
-        assert label == 'Send a notification to the Slack [removed] team in #my-channel'
+        assert label == 'Send a notification to the Slack [removed] workspace to #my-channel'
 
     @responses.activate
     def test_valid_channel_selected(self):
         rule = self.get_rule(data={
-            'team': self.integration.id,
+            'workspace': self.integration.id,
             'channel': '#my-channel',
         })
 
@@ -108,7 +108,7 @@ class SlackNotifyActionTest(RuleTestCase):
     @responses.activate
     def test_valid_member_selected(self):
         rule = self.get_rule(data={
-            'team': self.integration.id,
+            'workspace': self.integration.id,
             'channel': '@morty',
         })
 
@@ -150,7 +150,7 @@ class SlackNotifyActionTest(RuleTestCase):
     @responses.activate
     def test_invalid_channel_selected(self):
         rule = self.get_rule(data={
-            'team': self.integration.id,
+            'workspace': self.integration.id,
             'channel': '#my-channel',
         })
 


### PR DESCRIPTION
Adds support to the slack integration for sending alerts directly to users

⚠️ Landing this will break the integration for current beta testers.
⚠️ Note for self: Verify that configuration of alerts _will not completely break_ leaving the users unable to update their alerts when this is merged.