### PR TITLE
Relax generic bot regex to also match Yandex bots.

### DIFF
--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -31,7 +31,7 @@ CRAWLERS = re.compile(
             # Alexa
             r'ia_archiver',
             # Generic bot
-            r'bot[\/\s\)\;]',
+            r'bots?[\/\s\)\;]',
             # Generic spider
             r'spider[\/\s\)\;]',
             # Slack - see https://api.slack.com/robots


### PR DESCRIPTION
This should match all Yandex bots by allowing a match on the plural, since they all have a user agent that ends with `+http://yandex.com/bots)`.  There's an [official list of Yandex bots](https://yandex.com/support/webmaster/robot-workings/check-yandex-robots.html) but it doesn't appear to be up to date; [this list](http://www.botopedia.org/user-agent-list/search-bots/yandex-bot) has some other variants.  They should all be covered by this change, though.