### PR TITLE
fix(ui): On Project Settings, rename "Configuration" label

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -7,11 +7,11 @@ export default function getConfiguration({project}) {
 
   return [
     {
-      name: t('Configuration'),
+      name: t('Project'),
       items: [
         {
           path: `${pathPrefix}/settings/`,
-          title: t('General'),
+          title: t('General Settings'),
         },
         {
           path: `${pathPrefix}/teams/`,


### PR DESCRIPTION
Now looks like:

<img width="457" alt="image" src="https://user-images.githubusercontent.com/2153/36706358-585ea17a-1b1e-11e8-986b-7b219d75585e.png">

To match the same convention used on "Organization Settings".

cc @saragilford 