### PR TITLE
ref(slack): Add alerting rule names to footer

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -71,7 +71,8 @@ class SlackNotifyServiceAction(EventAction):
         )
 
         def send_notification(event, futures):
-            attachment = build_attachment(event.group, event=event)
+            rules = [f.rule for f in futures]
+            attachment = build_attachment(event.group, event=event, rules=rules)
 
             payload = {
                 'token': integration.metadata['access_token'],

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -195,11 +195,10 @@ def build_attachment(group, event=None, identity=None, actions=None, rules=None)
     footer = u'{}'.format(group.qualified_short_id)
 
     if rules:
-        rule = rules.pop(0)
-        footer += u' via {}'.format(rule.label)
+        footer += u' via {}'.format(rules[0].label)
 
-    if rules:
-        footer += u' (+{} other)'.format(len(rules))
+        if len(rules) > 1:
+            footer += u' (+{} other)'.format(len(rules) - 1)
 
     return {
         'fallback': u'[{}] {}'.format(group.project.slug, group.title),

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -115,7 +115,7 @@ def build_action_text(identity, action):
     )
 
 
-def build_attachment(group, event=None, identity=None, actions=None):
+def build_attachment(group, event=None, identity=None, actions=None, rules=None):
     # XXX(dcramer): options are limited to 100 choices, even when nested
     status = group.get_status()
     assignees = get_assignees(group)
@@ -192,6 +192,15 @@ def build_attachment(group, event=None, identity=None, actions=None):
         event_ts = event.datetime
         ts = max(ts, event_ts)
 
+    footer = u'{}'.format(group.qualified_short_id)
+
+    if rules:
+        rule = rules.pop(0)
+        footer += u' via {}'.format(rule.label)
+
+    if rules:
+        footer += u' (+{} other)'.format(len(rules))
+
     return {
         'fallback': u'[{}] {}'.format(group.project.slug, group.title),
         'title': build_attachment_title(group, event),
@@ -200,10 +209,7 @@ def build_attachment(group, event=None, identity=None, actions=None):
         'mrkdwn_in': ['text'],
         'callback_id': json.dumps({'issue': group.id}),
         'footer_icon': logo_url,
-        'footer': u'{} / {}'.format(
-            group.organization.slug,
-            group.project.slug,
-        ),
+        'footer': footer,
         'ts': to_timestamp(ts),
         'color': color,
         'actions': payload_actions,


### PR DESCRIPTION
Adds the name of the rule which triggered a slack alert in the format `Rule name (+n others)`