### PR TITLE
feat(slack): Add icon / team name

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -13,6 +13,8 @@ class IntegrationSerializer(Serializer):
         return {
             'id': six.text_type(obj.id),
             'name': obj.name,
+            'icon': obj.metadata.get('icon'),
+            'domain_name': obj.metadata.get('domain_name'),
             'provider': {
                 'key': provider.key,
                 'name': provider.name,

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -60,7 +60,7 @@ class SlackIntegration(Integration):
         }
 
         session = http.build_session()
-        resp = session.post('https://slack.com/api/team.info', data=payload)
+        resp = session.get('https://slack.com/api/team.info', data=payload)
         resp.raise_for_status()
         resp = resp.json()
 

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry import http
 from sentry.integrations import Integration, IntegrationMetadata
 from sentry.utils.pipeline import NestedPipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
@@ -53,11 +54,24 @@ class SlackIntegration(Integration):
 
         return [identity_pipeline_view]
 
+    def get_team_info(self, access_token):
+        payload = {
+            'token': access_token,
+        }
+
+        session = http.build_session()
+        resp = session.post('https://slack.com/api/team.info', data=payload)
+        resp.raise_for_status()
+        resp = resp.json()
+
+        return resp['team']
+
     def build_integration(self, state):
         data = state['identity']['data']
         assert data['ok']
 
         scopes = sorted(data['scope'].split(','))
+        team_data = self.get_team_info(data['access_token'])
 
         return {
             'name': data['team_name'],
@@ -67,6 +81,8 @@ class SlackIntegration(Integration):
                 'bot_access_token': data['bot']['bot_access_token'],
                 'bot_user_id': data['bot']['bot_user_id'],
                 'scopes': scopes,
+                'icon': team_data['icon']['image_132'],
+                'domain_name': team_data['domain'] + '.slack.com',
             },
             'user_identity': {
                 'type': 'slack',

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -48,7 +48,7 @@ class SlackIntegrationTest(IntegrationTestCase):
         )
 
         responses.add(
-            responses.POST, 'https://slack.com/api/team.info',
+            responses.GET, 'https://slack.com/api/team.info',
             json={
                 'ok': True,
                 'team': {

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -44,7 +44,19 @@ class SlackIntegrationTest(IntegrationTestCase):
                     'bot_user_id': 'UXXXXXXX2',
                 },
                 'scope': ','.join(authorize_params['scope'].split(' ')),
-            })
+            }
+        )
+
+        responses.add(
+            responses.POST, 'https://slack.com/api/team.info',
+            json={
+                'ok': True,
+                'team': {
+                    'domain': 'test-slack-workspace',
+                    'icon': {'image_132': 'http://example.com/ws_icon.jpg'},
+                },
+            }
+        )
 
         resp = self.client.get('{}?{}'.format(
             self.path,
@@ -54,7 +66,7 @@ class SlackIntegrationTest(IntegrationTestCase):
             })
         ))
 
-        mock_request = responses.calls[-1].request
+        mock_request = responses.calls[0].request
         req_params = parse_qs(mock_request.body)
         assert req_params['grant_type'] == ['authorization_code']
         assert req_params['code'] == ['oauth-code']
@@ -73,6 +85,8 @@ class SlackIntegrationTest(IntegrationTestCase):
             'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
             'bot_user_id': 'UXXXXXXX2',
             'scopes': sorted(self.provider.identity_oauth_scopes),
+            'icon': 'http://example.com/ws_icon.jpg',
+            'domain_name': 'test-slack-workspace.slack.com',
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration,


### PR DESCRIPTION
This Implementation doesn't do anything to refresh the icon, so if there's no icon (slack sends back a default iocn) initially then there will never be an icon unless they re-add the integration.