### PR TITLE
ref: Remove ujson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ install-python-base:
 	$(PIP) install "setuptools>=0.9.8" "pip>=8.0.0"
 	# order matters here, base package must install first
 	$(PIP) install -e .
-	$(PIP) install ujson
 	$(PIP) install "file://`pwd`#egg=sentry[dev]"
 
 install-python-develop:

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -38,15 +38,6 @@ from sentry.utils.data_filters import is_valid_ip, \
     is_valid_release, is_valid_error_message, FilterStatKeys
 from sentry.utils.strings import decompress
 
-try:
-    # Attempt to load ujson if it's installed.
-    # It's advantageous to leverage here because this is
-    # our primary data ingestion endpoint, and it's a
-    # simple win. ujson differs from simplejson a bunch
-    # so it's not worth utilizing it anywhere else.
-    import ujson as json  # noqa
-except ImportError:
-    from sentry.utils import json
 
 _dist_re = re.compile(r'^[a-zA-Z0-9_.-]+$')
 


### PR DESCRIPTION
This test made it into production a long time ago with no tangible
performance gain, and caused slight regressions in parsing certain
values, so removing all the code.