### PR TITLE
feat(ownership): Add grammar parser

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -26,6 +26,7 @@ lxml>=3.4.1
 mock>=0.8.0,<1.1
 mmh3>=2.3.1,<2.4
 oauth2>=1.5.167
+parsimonious==0.8.0
 percy>=0.4.5
 petname>=2.0,<2.1
 Pillow>=3.2.0,<=4.2.1

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -4,8 +4,10 @@ from jsonfield import JSONField
 
 from django.db import models
 from django.utils import timezone
+
 from sentry.db.models import Model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey
+from sentry.ownership.grammar import dump_schema, parse_rules
 
 
 class ProjectOwnership(Model):
@@ -24,3 +26,10 @@ class ProjectOwnership(Model):
         db_table = 'sentry_projectownership'
 
     __repr__ = sane_repr('project_id', 'is_active')
+
+    def save(self, *args, **kwargs):
+        if self.raw is None:
+            self.schema = None
+        else:
+            self.schema = dump_schema(parse_rules(self.raw))
+        return super(ProjectOwnership, self).save(*args, **kwargs)

--- a/src/sentry/ownership/__init__.py
+++ b/src/sentry/ownership/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -1,0 +1,178 @@
+from __future__ import absolute_import
+
+from collections import namedtuple
+from parsimonious.grammar import Grammar, NodeVisitor
+
+__all__ = ('parse_rules', 'dump_schema', 'load_schema')
+
+VERSION = 1
+
+# Grammar is defined in EBNF syntax.
+ownership_grammar = Grammar(r"""
+
+ownership = line+
+
+line = _ (comment / rule / empty) newline?
+
+rule = _ matcher owners
+
+matcher      = _ matcher_tag identifier
+matcher_tag  = (matcher_type sep)?
+matcher_type = "url" / "path"
+
+owners       = _ owner+
+owner        = _ team_prefix identifier
+team_prefix  = "#"?
+
+comment = ~r"#[^\r\n]*"
+
+# TODO: make more specific
+identifier = ~r"\S+"
+
+sep     = ":"
+space   = " "
+empty   = ""
+newline = ~r"[\r\n]"
+_       = space*
+
+""")
+
+
+class Rule(namedtuple('Rule', 'matcher owners')):
+    """
+    A Rule represents a single line in an Ownership file.
+    This line contains a Matcher and a list of Owners.
+    """
+
+    def dump(self):
+        return {
+            'matcher': self.matcher.dump(),
+            'owners': [o.dump() for o in self.owners],
+        }
+
+    @classmethod
+    def load(cls, data):
+        return cls(
+            Matcher.load(data['matcher']),
+            [Owner.load(o) for o in data['owners']],
+        )
+
+
+class Matcher(namedtuple('Matcher', 'type pattern')):
+    """
+    A Matcher represents a type:pattern pairing for use in
+    comparing with an Event.
+
+    type is either `path` or `url` at this point.
+
+    TODO(mattrobenolt): pattern needs to be parsed into a regex
+
+    Examples:
+        url:example.com
+        path:src/*
+        src/*
+    """
+
+    def dump(self):
+        return {
+            'type': self.type,
+            'pattern': self.pattern,
+        }
+
+    @classmethod
+    def load(cls, data):
+        return cls(
+            data['type'],
+            data['pattern'],
+        )
+
+
+class Owner(namedtuple('Owner', 'type identifier')):
+    """
+    An Owner represents a User or Team who owns this Rule.
+
+    type is either `user` or `team`.
+
+    Examples:
+        foo@example.com
+        #team
+    """
+
+    def dump(self):
+        return {
+            'type': self.type,
+            'identifier': self.identifier,
+        }
+
+    @classmethod
+    def load(cls, data):
+        return cls(
+            data['type'],
+            data['identifier'],
+        )
+
+
+class OwnershipVisitor(NodeVisitor):
+    visit_comment = visit_empty = lambda *a: None
+
+    def visit_ownership(self, node, children):
+        return filter(None, children)
+
+    def visit_line(self, node, children):
+        _, line, _ = children
+        comment_or_rule_or_empty = line[0]
+        if comment_or_rule_or_empty:
+            return comment_or_rule_or_empty
+
+    def visit_rule(self, node, children):
+        _, matcher, owners = children
+        return Rule(matcher, owners)
+
+    def visit_matcher(self, node, children):
+        _, tag, identifier = children
+        return Matcher(tag, identifier)
+
+    def visit_matcher_tag(self, node, children):
+        if not children:
+            return 'path'
+        tag, = children
+        type, _ = tag
+        return type[0].text
+
+    def visit_owners(self, node, children):
+        _, owners = children
+        return owners
+
+    def visit_owner(self, node, children):
+        _, is_team, pattern = children
+        return Owner('team' if is_team else 'user', pattern)
+
+    def visit_team_prefix(self, node, children):
+        return bool(children)
+
+    def visit_identifier(self, node, children):
+        return node.text
+
+    def generic_visit(self, node, children):
+        return children or node
+
+
+def parse_rules(data):
+    """Convert a raw text input into a Rule tree"""
+    tree = ownership_grammar.parse(data)
+    return OwnershipVisitor().visit(tree)
+
+
+def dump_schema(rules):
+    """Convert a Rule tree into a JSON schema"""
+    return {
+        '$version': VERSION,
+        'rules': [r.dump() for r in rules],
+    }
+
+
+def load_schema(schema):
+    """Convert a JSON schema into a Rule tree"""
+    if schema['$version'] != VERSION:
+        raise RuntimeError('Invalid schema $version: %r' % schema['$version'])
+    return [Rule.load(r) for r in schema['rules']]

--- a/tests/sentry/ownership/__init__.py
+++ b/tests/sentry/ownership/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+
+from sentry.ownership.grammar import (
+    Rule, Matcher, Owner,
+    parse_rules, dump_schema, load_schema,
+)
+
+fixture_data = """
+# cool stuff comment
+*.js                    #frontend m@robenolt.com
+# good comment
+
+
+  url:http://google.com/* #backend
+path:src/sentry/*       david@sentry.io
+"""
+
+
+def test_parse_rules():
+    assert parse_rules(fixture_data) == [
+        Rule(Matcher('path', '*.js'), [Owner('team', 'frontend'), Owner('user', 'm@robenolt.com')]),
+        Rule(Matcher('url', 'http://google.com/*'), [Owner('team', 'backend')]),
+        Rule(Matcher('path', 'src/sentry/*'), [Owner('user', 'david@sentry.io')]),
+    ]
+
+
+def test_dump_schema():
+    assert dump_schema([Rule(
+        Matcher('path', '*.js'),
+        [Owner('team', 'frontend')]
+    )]) == {
+        '$version': 1,
+        'rules': [{
+            'matcher': {
+                'type': 'path',
+                'pattern': '*.js',
+            },
+            'owners': [{
+                'type': 'team',
+                'identifier': 'frontend',
+            }]
+        }]
+    }
+
+
+def test_load_schema():
+    assert load_schema({
+        '$version': 1,
+        'rules': [{
+            'matcher': {
+                'type': 'path',
+                'pattern': '*.js',
+            },
+            'owners': [{
+                'type': 'team',
+                'identifier': 'frontend',
+            }]
+        }]
+    }) == [Rule(
+        Matcher('path', '*.js'),
+        [Owner('team', 'frontend')]
+    )]


### PR DESCRIPTION
Hopefully the tests here will be self explanatory, but I'm happy to fill in some gaps.

The tl;dr is that this is handling the raw input from the UI/API for our crude ownership file format. The grammar is pretty loose right now and has gaps, so this grammar will be expanded and evolve once we get some tangible examples.