### PR TITLE
feat(environments): Support ReleaseProjectEnvironment in event pipeline

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -865,10 +865,10 @@ class EventManager(object):
                 )
             if is_new_group_environment:
                 buffer.incr(
-                    ReleaseProjectEnvironment, columns={'new_issues_count': 1}, filters={
-                        'project': project,
-                        'release': release,
-                        'environment': environment,
+                    ReleaseProjectEnvironment, {'new_issues_count': 1}, {
+                        'project_id': project.id,
+                        'release_id': release.id,
+                        'environment_id': environment.id,
                     }
                 )
 


### PR DESCRIPTION
As part of the environments sentry 9 efforts, this will fill in the new ReleaseProjectEnvironment model in the event processing pipeline. This model will help us filter releases' new issues, first seen, last seen by environment.