### PR TITLE
feat(environments): Added ReleaseProjectEnvironment to team and project transfer_to, project delete, and release merge.

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -43,7 +43,7 @@ class ProjectDeletionTask(ModelDeletionTask):
         # in bulk
         # Release needs to handle deletes after Group is cleaned up as the foreign
         # key is protected
-        model_list = (models.Group, models.ReleaseProject, models.ProjectDSymFile,
+        model_list = (models.Group, models.ReleaseProject, models.ReleaseProjectEnvironment, models.ProjectDSymFile,
                       models.ProjectSymCacheFile)
         relations.extend(
             [ModelRelation(m, {'project_id': instance.id}, ModelDeletionTask) for m in model_list]

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -293,6 +293,7 @@ class Project(Model):
             EnvironmentProject,
             ProjectTeam,
             ReleaseProject,
+            ReleaseProjectEnvironment,
             Rule,
         )
 
@@ -327,7 +328,7 @@ class Project(Model):
         # to this however, such as rules, which should maintain their
         # configuration when moved across organizations.
         if org_changed:
-            for model in ReleaseProject, EnvironmentProject:
+            for model in ReleaseProject, ReleaseProjectEnvironment, EnvironmentProject:
                 model.objects.filter(
                     project_id=self.id,
                 ).delete()

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -186,12 +186,12 @@ class Release(Model):
         # ReleaseFile.release
 
         from sentry.models import (
-            ReleaseCommit, ReleaseEnvironment, ReleaseFile, ReleaseProject, Group, GroupRelease,
+            ReleaseCommit, ReleaseEnvironment, ReleaseFile, ReleaseProject, ReleaseProjectEnvironment, Group, GroupRelease,
             GroupResolution
         )
 
         model_list = (
-            ReleaseCommit, ReleaseEnvironment, ReleaseFile, ReleaseProject, GroupRelease,
+            ReleaseCommit, ReleaseEnvironment, ReleaseFile, ReleaseProject, ReleaseProjectEnvironment, GroupRelease,
             GroupResolution
         )
         for release in from_releases:

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -185,7 +185,7 @@ class Team(Model):
         """
         from sentry.models import (
             OrganizationAccessRequest, OrganizationMember, OrganizationMemberTeam, Project,
-            ProjectTeam, ReleaseProject
+            ProjectTeam, ReleaseProject, ReleaseProjectEnvironment
         )
 
         try:
@@ -212,6 +212,9 @@ class Team(Model):
         # remove associations with releases from other org
         ReleaseProject.objects.filter(
             project_id__in=project_ids,
+        ).delete()
+        ReleaseProjectEnvironment.objects.filter(
+            project__id__in=project_ids,
         ).delete()
 
         Project.objects.filter(

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -214,7 +214,7 @@ class Team(Model):
             project_id__in=project_ids,
         ).delete()
         ReleaseProjectEnvironment.objects.filter(
-            project__id__in=project_ids,
+            project_id__in=project_ids,
         ).delete()
 
         Project.objects.filter(

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -5,7 +5,7 @@ import six
 
 from sentry.models import (
     Commit, CommitAuthor, Group, GroupRelease, GroupResolution, GroupLink, GroupStatus,
-    Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject, Repository
+    Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject, ReleaseProjectEnvironment, Repository
 )
 
 from sentry.testutils import TestCase
@@ -27,6 +27,9 @@ class MergeReleasesTest(TestCase):
         release_environment = ReleaseEnvironment.objects.create(
             organization_id=org.id, project_id=project.id, release_id=release.id, environment_id=2
         )
+        release_project_environment = ReleaseProjectEnvironment.objects.create(
+            release_id=release.id, project_id=project.id, environment_id=2
+        )
         group_release = GroupRelease.objects.create(
             project_id=project.id, release_id=release.id, group_id=1
         )
@@ -46,6 +49,9 @@ class MergeReleasesTest(TestCase):
             release_id=release2.id,
             environment_id=3,
         )
+        release_project_environment2 = ReleaseProjectEnvironment.objects.create(
+            release_id=release2.id, project_id=project2.id, environment_id=3
+        )
         group_release2 = GroupRelease.objects.create(
             project_id=project2.id, release_id=release2.id, group_id=2
         )
@@ -64,6 +70,9 @@ class MergeReleasesTest(TestCase):
             project_id=project3.id,
             release_id=release3.id,
             environment_id=4,
+        )
+        release_project_environment3 = ReleaseProjectEnvironment.objects.create(
+            release_id=release3.id, project_id=project3.id, environment_id=4
         )
         group_release3 = GroupRelease.objects.create(
             project_id=project3.id, release_id=release3.id, group_id=3
@@ -89,6 +98,14 @@ class MergeReleasesTest(TestCase):
         assert ReleaseProject.objects.filter(release=release, project=project).exists()
         assert ReleaseProject.objects.filter(release=release, project=project2).exists()
         assert ReleaseProject.objects.filter(release=release, project=project3).exists()
+
+        # ReleaseProjectEnvironment.release
+        assert ReleaseProjectEnvironment.objects.get(
+            id=release_project_environment.id).release_id == release.id
+        assert ReleaseProjectEnvironment.objects.get(
+            id=release_project_environment2.id).release_id == release.id
+        assert ReleaseProjectEnvironment.objects.get(
+            id=release_project_environment3.id).release_id == release.id
 
         # GroupRelease.release_id
         assert GroupRelease.objects.get(id=group_release.id).release_id == release.id

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -4,7 +4,7 @@ import datetime
 import six
 
 from sentry.models import (
-    Commit, CommitAuthor, Group, GroupRelease, GroupResolution, GroupLink, GroupStatus,
+    Commit, CommitAuthor, Environment, Group, GroupRelease, GroupResolution, GroupLink, GroupStatus,
     Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject, ReleaseProjectEnvironment, Repository
 )
 
@@ -19,16 +19,17 @@ class MergeReleasesTest(TestCase):
 
         # merge to
         project = self.create_project(organization=org, name='foo')
+        environment = Environment.get_or_create(project=project, name='env1')
         release = Release.objects.create(version='abcdabc', organization=org)
         release.add_project(project)
         release_commit = ReleaseCommit.objects.create(
             organization_id=org.id, release=release, commit=commit, order=1
         )
         release_environment = ReleaseEnvironment.objects.create(
-            organization_id=org.id, project_id=project.id, release_id=release.id, environment_id=2
+            organization_id=org.id, project_id=project.id, release_id=release.id, environment_id=environment.id
         )
         release_project_environment = ReleaseProjectEnvironment.objects.create(
-            release_id=release.id, project_id=project.id, environment_id=2
+            release_id=release.id, project_id=project.id, environment_id=environment.id
         )
         group_release = GroupRelease.objects.create(
             project_id=project.id, release_id=release.id, group_id=1
@@ -38,6 +39,7 @@ class MergeReleasesTest(TestCase):
 
         # merge from #1
         project2 = self.create_project(organization=org, name='bar')
+        environment2 = Environment.get_or_create(project=project2, name='env2')
         release2 = Release.objects.create(version='bbbbbbb', organization=org)
         release2.add_project(project2)
         release_commit2 = ReleaseCommit.objects.create(
@@ -47,10 +49,10 @@ class MergeReleasesTest(TestCase):
             organization_id=org.id,
             project_id=project2.id,
             release_id=release2.id,
-            environment_id=3,
+            environment_id=environment2.id,
         )
         release_project_environment2 = ReleaseProjectEnvironment.objects.create(
-            release_id=release2.id, project_id=project2.id, environment_id=3
+            release_id=release2.id, project_id=project2.id, environment_id=environment2.id
         )
         group_release2 = GroupRelease.objects.create(
             project_id=project2.id, release_id=release2.id, group_id=2
@@ -60,6 +62,7 @@ class MergeReleasesTest(TestCase):
 
         # merge from #2
         project3 = self.create_project(organization=org, name='baz')
+        environment3 = Environment.get_or_create(project=project3, name='env3')
         release3 = Release.objects.create(version='cccccc', organization=org)
         release3.add_project(project3)
         release_commit3 = ReleaseCommit.objects.create(
@@ -69,10 +72,10 @@ class MergeReleasesTest(TestCase):
             organization_id=org.id,
             project_id=project3.id,
             release_id=release3.id,
-            environment_id=4,
+            environment_id=environment3.id,
         )
         release_project_environment3 = ReleaseProjectEnvironment.objects.create(
-            release_id=release3.id, project_id=project3.id, environment_id=4
+            release_id=release3.id, project_id=project3.id, environment_id=environment3.id
         )
         group_release3 = GroupRelease.objects.create(
             project_id=project3.id, release_id=release3.id, group_id=3

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from sentry.models import (
     OrganizationMember, OrganizationMemberTeam, Project, ProjectTeam,
-    Release, ReleaseProject, Team
+    Release, ReleaseProject, ReleaseProjectEnvironment, Team
 )
 from sentry.testutils import TestCase
 
@@ -159,4 +159,43 @@ class TransferTest(TestCase):
         assert not ReleaseProject.objects.filter(
             release=release,
             project=project,
+        ).exists()
+
+    def test_release_project_envs(self):
+        user = self.create_user()
+        org = self.create_organization(name='foo', owner=user)
+        org2 = self.create_organization(name='bar', owner=None)
+        team = self.create_team(organization=org)
+        project = self.create_project(teams=[team])
+
+        release = Release.objects.create(
+            version='a' * 7,
+            organization=org,
+        )
+
+        release.add_project(project)
+        env = self.create_environment(
+            name='prod',
+            project=project,
+        )
+        ReleaseProjectEnvironment.objects.create(
+            release=release,
+            project=project,
+            environment=env,
+        )
+
+        assert ReleaseProjectEnvironment.objects.filter(
+            release=release,
+            project=project,
+            environment=env,
+        ).exists()
+
+        team.transfer_to(org2)
+
+        assert Release.objects.filter(id=release.id).exists()
+
+        assert not ReleaseProjectEnvironment.objects.filter(
+            release=release,
+            project=project,
+            environment=env,
         ).exists()


### PR DESCRIPTION
The ReleaseProjectEnvironment model relationship needs to be handled during the transfer process for teams and projects, project deletions, and release merges. 