### PR TITLE
fix(settings): re-add delete button for old team settings

### DIFF
--- a/src/sentry/static/sentry/app/views/teamDetails.jsx
+++ b/src/sentry/static/sentry/app/views/teamDetails.jsx
@@ -7,9 +7,11 @@ import Reflux from 'reflux';
 import {fetchTeamDetails} from '../actionCreators/teams';
 import {t} from '../locale';
 import ApiMixin from '../mixins/apiMixin';
+import DropdownLink from '../components/dropdownLink';
 import ListLink from '../components/listLink';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
+import MenuItem from '../components/menuItem';
 import OrganizationState from '../mixins/organizationState';
 import TeamStore from '../stores/teamStore';
 import recreateRoute from '../utils/recreateRoute';
@@ -87,20 +89,33 @@ const TeamDetails = createReactClass({
     else if (!team || this.state.error) return <LoadingError onRetry={this.fetchData} />;
 
     let routePrefix = recreateRoute('', {routes, params, stepBack: -1}); //`/organizations/${orgId}/teams/${teamId}`;
+    let access = this.getAccess();
 
     //TODO(maxbittker) remove hack to not show this page on old settings
     let onNewSettings = routePrefix.startsWith('/settings/');
 
+    const features = new Set(this.context.organization.features);
     return (
       <div>
         <h3>{team.name}</h3>
 
+        {!features.has('new-settings') &&
+          access.has('team:admin') && (
+            <DropdownLink anchorRight title={t('More')}>
+              <MenuItem
+                href={`/organizations/${params.orgId}/teams/${params.teamId}/remove/`}
+              >
+                {t('Remove Team')}
+              </MenuItem>
+            </DropdownLink>
+          )}
+
         <ul className="nav nav-tabs border-bottom">
+          <ListLink to={`${routePrefix}settings/`}>{t('Settings')}</ListLink>
           <ListLink to={`${routePrefix}members/`}>{t('Members')}</ListLink>
           {onNewSettings ? (
             <ListLink to={`${routePrefix}projects/`}>{t('Projects')}</ListLink>
           ) : null}
-          <ListLink to={`${routePrefix}settings/`}>{t('Settings')}</ListLink>
         </ul>
 
         {children &&

--- a/src/sentry/static/sentry/app/views/teamDetails.jsx
+++ b/src/sentry/static/sentry/app/views/teamDetails.jsx
@@ -111,11 +111,11 @@ const TeamDetails = createReactClass({
           )}
 
         <ul className="nav nav-tabs border-bottom">
-          <ListLink to={`${routePrefix}settings/`}>{t('Settings')}</ListLink>
           <ListLink to={`${routePrefix}members/`}>{t('Members')}</ListLink>
           {onNewSettings ? (
             <ListLink to={`${routePrefix}projects/`}>{t('Projects')}</ListLink>
           ) : null}
+          <ListLink to={`${routePrefix}settings/`}>{t('Settings')}</ListLink>
         </ul>
 
         {children &&


### PR DESCRIPTION
tldr; chrissy made a boo boo. 

This re-adds the delete dropdown for old (current for 99% of our users) team settings. I didn't realize it was part of that, mostly because I didn't have my `new-settings` feature flag enabled.

I'm leaving settings as the second tab for now. It's a bit weird, but I didn't think it was worth all the extra logic in the template. If people disagree we can discuss post fix. 

![image](https://user-images.githubusercontent.com/435981/36819223-69352eda-1c9d-11e8-8677-672306e38562.png)

![image](https://user-images.githubusercontent.com/435981/36819250-8650a6ca-1c9d-11e8-969d-543313b31e7a.png)
