### PR TITLE
fix(environments): Use environment name for alert rule configuration

### DIFF
--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -176,7 +176,7 @@ const RuleEditor = createReactClass({
     const activeEnvs = EnvironmentStore.getActive() || [];
     const environmentChoices = [
       ['all', t('All Environments')],
-      ...activeEnvs.map(env => [env.urlRoutingName, env.displayName]),
+      ...activeEnvs.map(env => [env.name, env.displayName]),
     ];
 
     if (!this.state.rule) return <LoadingIndicator />;


### PR DESCRIPTION
We shouldn't use default routing name here as the empty environment case won't work correctly