### PR TITLE
feat(api): Add project_ownership endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+from rest_framework.response import Response
+from django.utils import timezone
+
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import ProjectOwnership
+from sentry.ownership.grammar import parse_rules, dump_schema, ParseError
+
+
+class ProjectOwnershipSerializer(serializers.Serializer):
+    raw = serializers.CharField()
+    fallthrough = serializers.BooleanField()
+
+    def validate_raw(self, attrs, source):
+        if not attrs[source].strip():
+            return attrs
+        try:
+            rules = parse_rules(attrs[source])
+        except ParseError as e:
+            raise serializers.ValidationError(
+                u'Parse error: %r (line %d, column %d)' % (
+                    e.expr.name, e.line(), e.column()
+                ))
+        attrs['schema'] = dump_schema(rules)
+        return attrs
+
+    def save(self):
+        ownership = self.context['ownership']
+
+        changed = False
+        if 'raw' in self.object:
+            raw = self.object['raw']
+            if not raw.strip():
+                raw = None
+
+            if ownership.raw != raw:
+                ownership.raw = raw
+                ownership.schema = self.object.get('schema')
+                changed = True
+
+        if 'fallthrough' in self.object:
+            fallthrough = self.object['fallthrough']
+            if ownership.fallthrough != fallthrough:
+                ownership.fallthrough = fallthrough
+                changed = True
+
+        if changed:
+            now = timezone.now()
+            if ownership.date_created is None:
+                ownership.date_created = now
+            ownership.last_updated = now
+            ownership.save()
+
+        return ownership
+
+
+class ProjectOwnershipEndpoint(ProjectEndpoint):
+    def get_ownership(self, project):
+        try:
+            return ProjectOwnership.objects.get(project=project)
+        except ProjectOwnership.DoesNotExist:
+            return ProjectOwnership(
+                project=project,
+                date_created=None,
+                last_updated=None,
+            )
+
+    def get(self, request, project):
+        """
+        Retrieve a Project's Ownership configuration
+        ````````````````````````````````````````````
+
+        Return details on a project's ownership configuration.
+
+        :auth: required
+        """
+        return Response(serialize(self.get_ownership(project), request.user))
+
+    def put(self, request, project):
+        """
+        Update a Project's Ownership configuration
+        ``````````````````````````````````````````
+
+        Updates a project's ownership configuration settings. Only the
+        attributes submitted are modified.
+
+        :param string raw: Raw input for ownership configuration.
+        :param boolean fallthrough: Indicate if there is no match on explicit rules,
+                                    to fall through and make everyone an implicit owner.
+        :auth: required
+        """
+        serializer = ProjectOwnershipSerializer(
+            data=request.DATA,
+            partial=True,
+            context={'ownership': self.get_ownership(project)}
+        )
+        if serializer.is_valid():
+            ownership = serializer.save()
+            return Response(serialize(ownership, request.user))
+        return Response(serializer.errors, status=400)

--- a/src/sentry/api/serializers/models/projectownership.py
+++ b/src/sentry/api/serializers/models/projectownership.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import ProjectOwnership
+
+
+@register(ProjectOwnership)
+class ProjectOwnershipSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            'raw': obj.raw,
+            # Should we expose this?
+            # 'schema': obj.schema,
+            'fallthrough': obj.fallthrough,
+            'dateCreated': obj.date_created,
+            'lastUpdated': obj.last_updated,
+            'isActive': obj.is_active,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -91,6 +91,7 @@ from .endpoints.project_keys import ProjectKeysEndpoint
 from .endpoints.project_key_details import ProjectKeyDetailsEndpoint
 from .endpoints.project_key_stats import ProjectKeyStatsEndpoint
 from .endpoints.project_member_index import ProjectMemberIndexEndpoint
+from .endpoints.project_ownership import ProjectOwnershipEndpoint
 from .endpoints.project_plugins import ProjectPluginsEndpoint
 from .endpoints.project_plugin_details import ProjectPluginDetailsEndpoint
 from .endpoints.project_release_details import ProjectReleaseDetailsEndpoint
@@ -768,6 +769,11 @@ urlpatterns = patterns(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/processingissues/discard$',
         ProjectProcessingIssuesDiscardEndpoint.as_view(),
         name='sentry-api-0-project-discard-processing-issues'
+    ),
+    url(
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/ownership/$',
+        ProjectOwnershipEndpoint.as_view(),
+        name='sentry-api-0-project-ownership'
     ),
 
     # Load plugin project urls

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 
 from sentry.db.models import Model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey
-from sentry.ownership.grammar import dump_schema, parse_rules
 
 
 class ProjectOwnership(Model):
@@ -26,10 +25,3 @@ class ProjectOwnership(Model):
         db_table = 'sentry_projectownership'
 
     __repr__ = sane_repr('project_id', 'is_active')
-
-    def save(self, *args, **kwargs):
-        if self.raw is None:
-            self.schema = None
-        else:
-            self.schema = dump_schema(parse_rules(self.raw))
-        return super(ProjectOwnership, self).save(*args, **kwargs)

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from collections import namedtuple
 from parsimonious.grammar import Grammar, NodeVisitor
+from parsimonious.exceptions import ParseError  # noqa
 
 __all__ = ('parse_rules', 'dump_schema', 'load_schema')
 

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+
+class ProjectOwnershipEndpointTestCase(APITestCase):
+    def setUp(self):
+        self.login_as(user=self.user)
+        self.path = reverse(
+            'sentry-api-0-project-ownership',
+            kwargs={
+                'organization_slug': self.organization.slug,
+                'project_slug': self.project.slug,
+            },
+        )
+
+    def test_empty_state(self):
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp.data == {
+            'raw': None,
+            'fallthrough': True,
+            'isActive': True,
+            'dateCreated': None,
+            'lastUpdated': None,
+        }
+
+    def test_update(self):
+        resp = self.client.put(self.path, {
+            'raw': '*.js foo@example.com #foo-team',
+        })
+        assert resp.status_code == 200
+        assert resp.data['fallthrough'] is True
+        assert resp.data['raw'] == '*.js foo@example.com #foo-team'
+        assert resp.data['dateCreated'] is not None
+        assert resp.data['lastUpdated'] is not None
+
+        resp = self.client.put(self.path, {
+            'fallthrough': False,
+        })
+        assert resp.status_code == 200
+        assert resp.data['fallthrough'] is False
+        assert resp.data['raw'] == '*.js foo@example.com #foo-team'
+        assert resp.data['dateCreated'] is not None
+        assert resp.data['lastUpdated'] is not None
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp.data['fallthrough'] is False
+        assert resp.data['raw'] == '*.js foo@example.com #foo-team'
+        assert resp.data['dateCreated'] is not None
+        assert resp.data['lastUpdated'] is not None
+
+        resp = self.client.put(self.path, {
+            'raw': '...',
+        })
+        assert resp.status_code == 400


### PR DESCRIPTION
This adds the ability to fetch and update the ProjectOwnership configuration for a project.

The rules parsing was moved into the serializer since this makes more sense here now than within the model's `save()`.