### PR TITLE
fix: Align dropdown menu tooltip to open button

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -168,6 +168,11 @@ dl.flat dd {
   box-shadow: none;
 }
 
+// Align the dropdown menu tip to the center of the open button
+.btn-group > .dropdown.open > .dropdown-menu {
+  left: -5px;
+}
+
 // Disabled buttons
 
 .btn-primary.disabled,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/36820947-74dccec0-1ca5-11e8-81e8-ad137d27e67a.png)
