### PR TITLE
ref: Add SequencePaginator

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -294,16 +294,13 @@ class SequencePaginator(object):
             hi = min(position, len(self.scores))
             lo = max(hi - limit, 0)
 
-        if lo > 0:
-            prev_score = self.scores[min(lo, len(self.scores) - 1)]
-            prev_cursor = Cursor(
-                prev_score,
-                lo - self.search(prev_score, hi=lo),
-                True,
-                True,
-            )
-        else:
-            prev_cursor = None  # XXX
+        prev_score = self.scores[min(lo, len(self.scores) - 1)]
+        prev_cursor = Cursor(
+            prev_score,
+            lo - self.search(prev_score, hi=lo),
+            True,
+            True if lo > 0 else False,
+        )
 
         next_score = self.scores[min(hi, len(self.scores) - 1)]
         next_cursor = Cursor(

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -223,11 +223,14 @@ class OffsetPaginator(BasePaginator):
         )
 
 
-def search(haystack, needle, reverse=False):
+def search(haystack, needle, reverse=False, lo=0, hi=None):
     # TODO: Replace this with binary search!
-    position = 0
+    if hi is None:
+        hi = len(haystack)
+
+    position = lo
     predicate = operator.ge if not reverse else operator.le
-    while position < len(haystack):
+    while position < hi:
         value, _ = haystack[position]
         if predicate(value, needle):
             break
@@ -279,13 +282,13 @@ class SequencePaginator(object):
         prev_cursor = None
         if lo > 0:
             prev_score = self.data[lo][0]
-            prev_offset = lo - search(self.data, prev_score, self.reverse)
+            prev_offset = lo - search(self.data, prev_score, self.reverse, hi=lo)
             prev_cursor = Cursor(prev_score, prev_offset, True, True)
 
         next_cursor = None
         if hi < len(self.data):
             next_score = self.data[hi][0]
-            next_offset = hi - search(self.data, next_score, self.reverse)
+            next_offset = hi - search(self.data, next_score, self.reverse, hi=hi)
             next_cursor = Cursor(next_score, next_offset, False, True)
 
         max_hits = 1000

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -296,14 +296,22 @@ class SequencePaginator(object):
         prev_cursor = None
         if lo > 0:
             prev_score = self.scores[min(lo, len(self.scores) - 1)]
-            prev_offset = lo - self.search(prev_score, hi=lo)
-            prev_cursor = Cursor(prev_score, prev_offset, True, True)
+            prev_cursor = Cursor(
+                prev_score,
+                lo - self.search(prev_score, hi=lo),
+                True,
+                True,
+            )
 
         next_cursor = None
         if hi < len(self.scores):
             next_score = self.scores[hi]
-            next_offset = hi - self.search(next_score, hi=hi + 1)
-            next_cursor = Cursor(next_score, next_offset, False, True)
+            next_cursor = Cursor(
+                next_score,
+                hi - self.search(next_score, hi=hi + 1),
+                False,
+                True,
+            )
 
         max_hits = 1000
 

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -21,6 +21,9 @@ from sentry.utils.cursors import build_cursor, Cursor, CursorResult
 quote_name = connections['default'].ops.quote_name
 
 
+MAX_HITS_LIMIT = 1000
+
+
 class BasePaginator(object):
     def __init__(self, queryset, order_by=None, max_limit=100):
         if order_by:
@@ -115,8 +118,7 @@ class BasePaginator(object):
         # TODO(dcramer): this does not yet work correctly for ``is_prev`` when
         # the key is not unique
         if count_hits:
-            max_hits = 1000
-            hits = self.count_hits(max_hits)
+            hits = self.count_hits(MAX_HITS_LIMIT)
         else:
             hits = None
             max_hits = None
@@ -313,15 +315,10 @@ class SequencePaginator(object):
                 True,
             )
 
-        max_hits = 1000
-
         return CursorResult(
             self.values[lo:hi],
             prev=prev_cursor,
             next=next_cursor,
-            hits=min(
-                len(self.scores),
-                max_hits,
-            ),
-            max_hits=max_hits,
+            hits=min(len(self.scores), MAX_HITS_LIMIT),
+            max_hits=MAX_HITS_LIMIT,
         )

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -295,7 +295,7 @@ class SequencePaginator(object):
 
         prev_cursor = None
         if lo > 0:
-            prev_score = self.scores[lo]
+            prev_score = self.scores[min(lo, len(self.scores) - 1)]
             prev_offset = lo - self.search(prev_score, hi=lo)
             prev_cursor = Cursor(prev_score, prev_offset, True, True)
 

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -121,7 +121,6 @@ class BasePaginator(object):
             hits = self.count_hits(MAX_HITS_LIMIT)
         else:
             hits = None
-            max_hits = None
 
         offset = cursor.offset
         # this effectively gets us the before row, and the current (after) row
@@ -141,7 +140,7 @@ class BasePaginator(object):
             results=results,
             limit=limit,
             hits=hits,
-            max_hits=max_hits,
+            max_hits=MAX_HITS_LIMIT if count_hits else None,
             cursor=cursor,
             is_desc=self.desc,
             key=self.get_item_key,

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -260,7 +260,7 @@ class SequencePaginator(object):
         ) if data else ([], [])
         self.reverse = reverse
         self.search = functools.partial(
-            bisect.bisect_left if not reverse else reverse_bisect_left,
+            reverse_bisect_left if reverse else bisect.bisect_left,
             self.scores,
         )
 
@@ -271,22 +271,22 @@ class SequencePaginator(object):
         assert cursor.offset > -1
 
         if cursor.value == 0:
-            position = 0 if not cursor.is_prev else len(self.scores)
+            position = len(self.scores) if cursor.is_prev else 0
         else:
             position = self.search(cursor.value)
 
         position = position + cursor.offset
 
-        if not cursor.is_prev:
-            lo = max(position, 0)
-            hi = min(lo + limit, len(self.scores))
-        else:
+        if cursor.is_prev:
             # TODO: It might make sense to ensure that this hi value is at
             # least the length of the page + 1 if we want to ensure we return a
             # full page of results when paginating backwards while data is
             # being mutated.
             hi = min(position, len(self.scores))
             lo = max(hi - limit, 0)
+        else:
+            lo = max(position, 0)
+            hi = min(lo + limit, len(self.scores))
 
         if self.scores:
             prev_score = self.scores[min(lo, len(self.scores) - 1)]

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -294,7 +294,6 @@ class SequencePaginator(object):
             hi = min(position, len(self.scores))
             lo = max(hi - limit, 0)
 
-        prev_cursor = None
         if lo > 0:
             prev_score = self.scores[min(lo, len(self.scores) - 1)]
             prev_cursor = Cursor(
@@ -303,16 +302,16 @@ class SequencePaginator(object):
                 True,
                 True,
             )
+        else:
+            prev_cursor = None  # XXX
 
-        next_cursor = None
-        if hi < len(self.scores):
-            next_score = self.scores[hi]
-            next_cursor = Cursor(
-                next_score,
-                hi - self.search(next_score, hi=hi + 1),
-                False,
-                True,
-            )
+        next_score = self.scores[min(hi, len(self.scores) - 1)]
+        next_cursor = Cursor(
+            next_score,
+            hi - self.search(next_score, hi=hi),
+            False,
+            True if hi < len(self.scores) else False,
+        )
 
         return CursorResult(
             self.values[lo:hi],

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -293,8 +293,6 @@ class SequencePaginator(object):
             hi = min(position, len(self.scores))
             lo = max(hi - limit, 0)
 
-        results = self.values[lo:hi]
-
         prev_cursor = None
         if lo > 0:
             prev_score = self.scores[lo]
@@ -310,7 +308,7 @@ class SequencePaginator(object):
         max_hits = 1000
 
         return CursorResult(
-            results,
+            self.values[lo:hi],
             prev=prev_cursor,
             next=next_cursor,
             hits=min(

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -279,19 +279,13 @@ class SequencePaginator(object):
         prev_cursor = None
         if lo > 0:
             prev_score = self.data[lo][0]
-            prev_offset = 0
-            # TODO: This point could be identified with binary search.
-            while lo - prev_offset - 1 > -1 and prev_score == self.data[lo - prev_offset - 1][0]:
-                prev_offset = prev_offset + 1
+            prev_offset = lo - search(self.data, prev_score, self.reverse)
             prev_cursor = Cursor(prev_score, prev_offset, True, True)
 
         next_cursor = None
         if hi < len(self.data):
             next_score = self.data[hi][0]
-            # TODO: This point could be identified with binary search.
-            next_offset = 0
-            while hi - next_offset - 1 > -1 and next_score == self.data[hi - next_offset - 1][0]:
-                next_offset = next_offset + 1
+            next_offset = hi - search(self.data, next_score, self.reverse)
             next_cursor = Cursor(next_score, next_offset, False, True)
 
         max_hits = 1000

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -22,6 +22,13 @@ class Cursor(object):
     def __str__(self):
         return '%s:%s:%s' % (self.value, self.offset, int(self.is_prev))
 
+    def __eq__(self, other):
+        return all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in
+            ('value', 'offset', 'is_prev', 'has_results')
+        )
+
     def __repr__(self):
         return '<%s: value=%s offset=%s is_prev=%s>' % (
             type(self), self.value, self.offset, int(self.is_prev)

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -297,7 +297,12 @@ class SequencePaginatorTestCase(SimpleTestCase):
 
         result = paginator.get_result(5)
         assert list(result) == [0, 1, 2, 3, 4]
-        assert result.prev is None
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 0
+        assert prev_cursor.offset == 0
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is False
 
         next_cursor = result.next
         assert next_cursor.value == 5
@@ -340,7 +345,12 @@ class SequencePaginatorTestCase(SimpleTestCase):
 
         result = paginator.get_result(5)
         assert list(result) == [9, 8, 7, 6, 5]
-        assert result.prev is None
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 9
+        assert prev_cursor.offset == 0
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is False
 
         next_cursor = result.next
         assert next_cursor.value == 4
@@ -361,6 +371,7 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert prev_cursor.value == 4
         assert prev_cursor.offset == 0
         assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
         result = paginator.get_result(5, Cursor(-10, 0, False))
         assert list(result) == []
@@ -375,13 +386,19 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert prev_cursor.value == 0
         assert prev_cursor.offset == 1
         assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
     def test_ascending_repeated_scores(self):
         paginator = SequencePaginator([(1, i) for i in range(10)], reverse=False)
 
         result = paginator.get_result(5)
         assert list(result) == [0, 1, 2, 3, 4]
-        assert result.prev is None
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 1
+        assert prev_cursor.offset == 0
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is False
 
         next_cursor = result.next
         assert next_cursor.value == 1
@@ -424,7 +441,12 @@ class SequencePaginatorTestCase(SimpleTestCase):
 
         result = paginator.get_result(5)
         assert list(result) == [9, 8, 7, 6, 5]
-        assert result.prev is None
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 1
+        assert prev_cursor.offset == 0
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is False
 
         next_cursor = result.next
         assert next_cursor.value == 1

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -411,3 +411,8 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert cursor.value == 1
         assert cursor.offset == 10
         assert cursor.is_prev is True
+
+    def test_hits(self):
+        n = 10
+        paginator = SequencePaginator([(i, i) for i in range(n)])
+        assert paginator.get_result(5).hits == n

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -294,10 +294,16 @@ def test_reverse_bisect_left():
 class SequencePaginatorTestCase(SimpleTestCase):
     def test_empty_results(self):
         paginator = SequencePaginator([])
-        assert list(paginator.get_result(5)) == []
+        result = paginator.get_result(5)
+        assert list(result) == []
+        assert result.prev == Cursor(0, 0, True, False)
+        assert result.next == Cursor(0, 0, False, False)
 
         paginator = SequencePaginator([], reverse=True)
-        assert list(paginator.get_result(5)) == []
+        result = paginator.get_result(5)
+        assert list(result) == []
+        assert result.prev == Cursor(0, 0, True, False)
+        assert result.next == Cursor(0, 0, False, False)
 
     def test_ascending_simple(self):
         paginator = SequencePaginator([(i, i) for i in range(10)], reverse=False)

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -292,6 +292,13 @@ def test_reverse_bisect_left():
 
 
 class SequencePaginatorTestCase(SimpleTestCase):
+    def test_empty_results(self):
+        paginator = SequencePaginator([])
+        assert list(paginator.get_result(5)) == []
+
+        paginator = SequencePaginator([], reverse=True)
+        assert list(paginator.get_result(5)) == []
+
     def test_ascending_simple(self):
         paginator = SequencePaginator([(i, i) for i in range(10)], reverse=False)
 

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -351,3 +351,63 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert cursor.value == 0
         assert cursor.offset == 1
         assert cursor.is_prev is True
+
+    def test_ascending_repeated_scores(self):
+        paginator = SequencePaginator([(1, i) for i in range(10)], reverse=False)
+
+        result = paginator.get_result(5)
+        assert list(result) == [0, 1, 2, 3, 4]
+        assert result.prev is None
+
+        cursor = result.next
+        assert cursor.value == 1
+        assert cursor.offset == 5
+        assert cursor.is_prev is False
+
+        result = paginator.get_result(5, cursor)
+        assert list(result) == [5, 6, 7, 8, 9]
+        assert result.next is None
+
+        cursor = result.prev
+        assert cursor.value == 1
+        assert cursor.offset == 5
+        assert cursor.is_prev is True
+
+        result = paginator.get_result(5, Cursor(100, 0, False))
+        assert list(result) == []
+        assert result.next is None
+
+        cursor = result.prev
+        assert cursor.value == 1
+        assert cursor.offset == 10
+        assert cursor.is_prev is True
+
+    def test_descending_repeated_scores(self):
+        paginator = SequencePaginator([(1, i) for i in range(10)], reverse=True)
+
+        result = paginator.get_result(5)
+        assert list(result) == [9, 8, 7, 6, 5]
+        assert result.prev is None
+
+        cursor = result.next
+        assert cursor.value == 1
+        assert cursor.offset == 5
+        assert cursor.is_prev is False
+
+        result = paginator.get_result(5, cursor)
+        assert list(result) == [4, 3, 2, 1, 0]
+        assert result.next is None
+
+        cursor = result.prev
+        assert cursor.value == 1
+        assert cursor.offset == 5
+        assert cursor.is_prev is True
+
+        result = paginator.get_result(5, Cursor(-10, 0, False))
+        assert list(result) == []
+        assert result.next is None
+
+        cursor = result.prev
+        assert cursor.value == 1
+        assert cursor.offset == 10
+        assert cursor.is_prev is True

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -4,7 +4,11 @@ import pytest
 from datetime import timedelta
 from django.utils import timezone
 
-from sentry.api.paginator import (Paginator, DateTimePaginator, OffsetPaginator)
+from sentry.api.paginator import (
+    Paginator,
+    DateTimePaginator,
+    OffsetPaginator,
+    reverse_bisect_left)
 from sentry.models import User
 from sentry.testutils import TestCase
 from sentry.utils.db import is_mysql
@@ -240,3 +244,45 @@ class DateTimePaginatorTest(TestCase):
 
         result5 = paginator.get_result(limit=10, cursor=result4.prev)
         assert len(result5) == 0, list(result5)
+
+
+def test_reverse_bisect_left():
+    assert reverse_bisect_left([], 0) == 0
+
+    assert reverse_bisect_left([1], -1) == 1
+    assert reverse_bisect_left([1], 0) == 1
+    assert reverse_bisect_left([1], 1) == 0
+    assert reverse_bisect_left([1], 2) == 0
+
+    assert reverse_bisect_left([2, 1], -1) == 2
+    assert reverse_bisect_left([2, 1], 0) == 2
+    assert reverse_bisect_left([2, 1], 1) == 1
+    assert reverse_bisect_left([2, 1], 2) == 0
+    assert reverse_bisect_left([2, 1], 3) == 0
+
+    assert reverse_bisect_left([3, 2, 1], -1) == 3
+    assert reverse_bisect_left([3, 2, 1], 0) == 3
+    assert reverse_bisect_left([3, 2, 1], 1) == 2
+    assert reverse_bisect_left([3, 2, 1], 2) == 1
+    assert reverse_bisect_left([3, 2, 1], 3) == 0
+    assert reverse_bisect_left([3, 2, 1], 4) == 0
+
+    assert reverse_bisect_left([4, 3, 2, 1], -1) == 4
+    assert reverse_bisect_left([4, 3, 2, 1], 0) == 4
+    assert reverse_bisect_left([4, 3, 2, 1], 1) == 3
+    assert reverse_bisect_left([4, 3, 2, 1], 2) == 2
+    assert reverse_bisect_left([4, 3, 2, 1], 3) == 1
+    assert reverse_bisect_left([4, 3, 2, 1], 4) == 0
+    assert reverse_bisect_left([4, 3, 2, 1], 5) == 0
+
+    assert reverse_bisect_left([1, 1], 0) == 2
+    assert reverse_bisect_left([1, 1], 1) == 0
+    assert reverse_bisect_left([1, 1], 2) == 0
+
+    assert reverse_bisect_left([2, 1, 1], 0) == 3
+    assert reverse_bisect_left([2, 1, 1], 1) == 1
+    assert reverse_bisect_left([2, 1, 1], 2) == 0
+
+    assert reverse_bisect_left([2, 2, 1], 0) == 3
+    assert reverse_bisect_left([2, 2, 1], 1) == 2
+    assert reverse_bisect_left([2, 2, 1], 2) == 0

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -299,28 +299,41 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert list(result) == [0, 1, 2, 3, 4]
         assert result.prev is None
 
-        cursor = result.next
-        assert cursor.value == 5
-        assert cursor.offset == 0
-        assert cursor.is_prev is False
+        next_cursor = result.next
+        assert next_cursor.value == 5
+        assert next_cursor.offset == 0
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is True
 
-        result = paginator.get_result(5, cursor)
+        result = paginator.get_result(5, next_cursor)
         assert list(result) == [5, 6, 7, 8, 9]
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 5
-        assert cursor.offset == 0
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 9
+        assert next_cursor.offset == 1
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 5
+        assert prev_cursor.offset == 0
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
         result = paginator.get_result(5, Cursor(100, 0, False))
         assert list(result) == []
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 9
-        assert cursor.offset == 1
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 9
+        assert next_cursor.offset == 1
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 9
+        assert prev_cursor.offset == 1
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
     def test_descending_simple(self):
         paginator = SequencePaginator([(i, i) for i in range(10)], reverse=True)
@@ -329,28 +342,39 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert list(result) == [9, 8, 7, 6, 5]
         assert result.prev is None
 
-        cursor = result.next
-        assert cursor.value == 4
-        assert cursor.offset == 0
-        assert cursor.is_prev is False
+        next_cursor = result.next
+        assert next_cursor.value == 4
+        assert next_cursor.offset == 0
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is True
 
-        result = paginator.get_result(5, cursor)
+        result = paginator.get_result(5, next_cursor)
         assert list(result) == [4, 3, 2, 1, 0]
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 4
-        assert cursor.offset == 0
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 0
+        assert next_cursor.offset == 1
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 4
+        assert prev_cursor.offset == 0
+        assert prev_cursor.is_prev is True
 
         result = paginator.get_result(5, Cursor(-10, 0, False))
         assert list(result) == []
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 0
-        assert cursor.offset == 1
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 0
+        assert next_cursor.offset == 1
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 0
+        assert prev_cursor.offset == 1
+        assert prev_cursor.is_prev is True
 
     def test_ascending_repeated_scores(self):
         paginator = SequencePaginator([(1, i) for i in range(10)], reverse=False)
@@ -359,28 +383,41 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert list(result) == [0, 1, 2, 3, 4]
         assert result.prev is None
 
-        cursor = result.next
-        assert cursor.value == 1
-        assert cursor.offset == 5
-        assert cursor.is_prev is False
+        next_cursor = result.next
+        assert next_cursor.value == 1
+        assert next_cursor.offset == 5
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is True
 
-        result = paginator.get_result(5, cursor)
+        result = paginator.get_result(5, next_cursor)
         assert list(result) == [5, 6, 7, 8, 9]
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 1
-        assert cursor.offset == 5
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 1
+        assert next_cursor.offset == 10
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 1
+        assert prev_cursor.offset == 5
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
         result = paginator.get_result(5, Cursor(100, 0, False))
         assert list(result) == []
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 1
-        assert cursor.offset == 10
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 1
+        assert next_cursor.offset == 10
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 1
+        assert prev_cursor.offset == 10
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
     def test_descending_repeated_scores(self):
         paginator = SequencePaginator([(1, i) for i in range(10)], reverse=True)
@@ -389,28 +426,41 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert list(result) == [9, 8, 7, 6, 5]
         assert result.prev is None
 
-        cursor = result.next
-        assert cursor.value == 1
-        assert cursor.offset == 5
-        assert cursor.is_prev is False
+        next_cursor = result.next
+        assert next_cursor.value == 1
+        assert next_cursor.offset == 5
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is True
 
-        result = paginator.get_result(5, cursor)
+        result = paginator.get_result(5, next_cursor)
         assert list(result) == [4, 3, 2, 1, 0]
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 1
-        assert cursor.offset == 5
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 1
+        assert next_cursor.offset == 10
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 1
+        assert prev_cursor.offset == 5
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
         result = paginator.get_result(5, Cursor(-10, 0, False))
         assert list(result) == []
-        assert result.next is None
 
-        cursor = result.prev
-        assert cursor.value == 1
-        assert cursor.offset == 10
-        assert cursor.is_prev is True
+        next_cursor = result.next
+        assert next_cursor.value == 1
+        assert next_cursor.offset == 10
+        assert next_cursor.is_prev is False
+        assert next_cursor.has_results is False
+
+        prev_cursor = result.prev
+        assert prev_cursor.value == 1
+        assert prev_cursor.offset == 10
+        assert prev_cursor.is_prev is True
+        assert prev_cursor.has_results is True
 
     def test_hits(self):
         n = 10

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -297,192 +297,72 @@ class SequencePaginatorTestCase(SimpleTestCase):
 
         result = paginator.get_result(5)
         assert list(result) == [0, 1, 2, 3, 4]
+        assert result.prev == Cursor(0, 0, True, False)
+        assert result.next == Cursor(5, 0, False, True)
 
-        prev_cursor = result.prev
-        assert prev_cursor.value == 0
-        assert prev_cursor.offset == 0
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is False
-
-        next_cursor = result.next
-        assert next_cursor.value == 5
-        assert next_cursor.offset == 0
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is True
-
-        result = paginator.get_result(5, next_cursor)
+        result = paginator.get_result(5, result.next)
         assert list(result) == [5, 6, 7, 8, 9]
-
-        next_cursor = result.next
-        assert next_cursor.value == 9
-        assert next_cursor.offset == 1
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 5
-        assert prev_cursor.offset == 0
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(5, 0, True, True)
+        assert result.next == Cursor(9, 1, False, False)
 
         result = paginator.get_result(5, Cursor(100, 0, False))
         assert list(result) == []
-
-        next_cursor = result.next
-        assert next_cursor.value == 9
-        assert next_cursor.offset == 1
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 9
-        assert prev_cursor.offset == 1
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(9, 1, True, True)
+        assert result.next == Cursor(9, 1, False, False)
 
     def test_descending_simple(self):
         paginator = SequencePaginator([(i, i) for i in range(10)], reverse=True)
 
         result = paginator.get_result(5)
         assert list(result) == [9, 8, 7, 6, 5]
+        assert result.prev == Cursor(9, 0, True, False)
+        assert result.next == Cursor(4, 0, False, True)
 
-        prev_cursor = result.prev
-        assert prev_cursor.value == 9
-        assert prev_cursor.offset == 0
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is False
-
-        next_cursor = result.next
-        assert next_cursor.value == 4
-        assert next_cursor.offset == 0
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is True
-
-        result = paginator.get_result(5, next_cursor)
+        result = paginator.get_result(5, result.next)
         assert list(result) == [4, 3, 2, 1, 0]
-
-        next_cursor = result.next
-        assert next_cursor.value == 0
-        assert next_cursor.offset == 1
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 4
-        assert prev_cursor.offset == 0
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(4, 0, True, True)
+        assert result.next == Cursor(0, 1, False, False)
 
         result = paginator.get_result(5, Cursor(-10, 0, False))
         assert list(result) == []
-
-        next_cursor = result.next
-        assert next_cursor.value == 0
-        assert next_cursor.offset == 1
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 0
-        assert prev_cursor.offset == 1
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(0, 1, True, True)
+        assert result.next == Cursor(0, 1, False, False)
 
     def test_ascending_repeated_scores(self):
         paginator = SequencePaginator([(1, i) for i in range(10)], reverse=False)
 
         result = paginator.get_result(5)
         assert list(result) == [0, 1, 2, 3, 4]
+        assert result.prev == Cursor(1, 0, True, False)
+        assert result.next == Cursor(1, 5, False, True)
 
-        prev_cursor = result.prev
-        assert prev_cursor.value == 1
-        assert prev_cursor.offset == 0
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is False
-
-        next_cursor = result.next
-        assert next_cursor.value == 1
-        assert next_cursor.offset == 5
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is True
-
-        result = paginator.get_result(5, next_cursor)
+        result = paginator.get_result(5, result.next)
         assert list(result) == [5, 6, 7, 8, 9]
-
-        next_cursor = result.next
-        assert next_cursor.value == 1
-        assert next_cursor.offset == 10
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 1
-        assert prev_cursor.offset == 5
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(1, 5, True, True)
+        assert result.next == Cursor(1, 10, False, False)
 
         result = paginator.get_result(5, Cursor(100, 0, False))
         assert list(result) == []
-
-        next_cursor = result.next
-        assert next_cursor.value == 1
-        assert next_cursor.offset == 10
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 1
-        assert prev_cursor.offset == 10
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(1, 10, True, True)
+        assert result.next == Cursor(1, 10, False, False)
 
     def test_descending_repeated_scores(self):
         paginator = SequencePaginator([(1, i) for i in range(10)], reverse=True)
 
         result = paginator.get_result(5)
         assert list(result) == [9, 8, 7, 6, 5]
+        assert result.prev == Cursor(1, 0, True, False)
+        assert result.next == Cursor(1, 5, False, True)
 
-        prev_cursor = result.prev
-        assert prev_cursor.value == 1
-        assert prev_cursor.offset == 0
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is False
-
-        next_cursor = result.next
-        assert next_cursor.value == 1
-        assert next_cursor.offset == 5
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is True
-
-        result = paginator.get_result(5, next_cursor)
+        result = paginator.get_result(5, result.next)
         assert list(result) == [4, 3, 2, 1, 0]
-
-        next_cursor = result.next
-        assert next_cursor.value == 1
-        assert next_cursor.offset == 10
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 1
-        assert prev_cursor.offset == 5
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(1, 5, True, True)
+        assert result.next == Cursor(1, 10, False, False)
 
         result = paginator.get_result(5, Cursor(-10, 0, False))
         assert list(result) == []
-
-        next_cursor = result.next
-        assert next_cursor.value == 1
-        assert next_cursor.offset == 10
-        assert next_cursor.is_prev is False
-        assert next_cursor.has_results is False
-
-        prev_cursor = result.prev
-        assert prev_cursor.value == 1
-        assert prev_cursor.offset == 10
-        assert prev_cursor.is_prev is True
-        assert prev_cursor.has_results is True
+        assert result.prev == Cursor(1, 10, True, True)
+        assert result.next == Cursor(1, 10, False, False)
 
     def test_hits(self):
         n = 10

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -305,6 +305,11 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert result.prev == Cursor(5, 0, True, True)
         assert result.next == Cursor(9, 1, False, False)
 
+        result = paginator.get_result(5, result.prev)
+        assert list(result) == [0, 1, 2, 3, 4]
+        assert result.prev == Cursor(0, 0, True, False)
+        assert result.next == Cursor(5, 0, False, True)
+
         result = paginator.get_result(5, Cursor(100, 0, False))
         assert list(result) == []
         assert result.prev == Cursor(9, 1, True, True)
@@ -322,6 +327,11 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert list(result) == [4, 3, 2, 1, 0]
         assert result.prev == Cursor(4, 0, True, True)
         assert result.next == Cursor(0, 1, False, False)
+
+        result = paginator.get_result(5, result.prev)
+        assert list(result) == [9, 8, 7, 6, 5]
+        assert result.prev == Cursor(9, 0, True, False)
+        assert result.next == Cursor(4, 0, False, True)
 
         result = paginator.get_result(5, Cursor(-10, 0, False))
         assert list(result) == []
@@ -341,6 +351,11 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert result.prev == Cursor(1, 5, True, True)
         assert result.next == Cursor(1, 10, False, False)
 
+        result = paginator.get_result(5, result.prev)
+        assert list(result) == [0, 1, 2, 3, 4]
+        assert result.prev == Cursor(1, 0, True, False)
+        assert result.next == Cursor(1, 5, False, True)
+
         result = paginator.get_result(5, Cursor(100, 0, False))
         assert list(result) == []
         assert result.prev == Cursor(1, 10, True, True)
@@ -358,6 +373,11 @@ class SequencePaginatorTestCase(SimpleTestCase):
         assert list(result) == [4, 3, 2, 1, 0]
         assert result.prev == Cursor(1, 5, True, True)
         assert result.next == Cursor(1, 10, False, False)
+
+        result = paginator.get_result(5, result.prev)
+        assert list(result) == [9, 8, 7, 6, 5]
+        assert result.prev == Cursor(1, 0, True, False)
+        assert result.next == Cursor(1, 5, False, True)
 
         result = paginator.get_result(5, Cursor(-10, 0, False))
         assert list(result) == []


### PR DESCRIPTION
This is an independent unit of work from the environment searching and sorting project.

This implements a cursor-based paginator (similar to the [`BasePaginator`](https://github.com/getsentry/sentry/blob/ba5c4cf70eac19e441cf301afd8c0fca1c3eb7e3/src/sentry/api/paginator.py#L22-L162)) that instead of being paginating through a `QuerySet`, paginates through an in-memory sequence of `(score, item)` pairs in either ascending (`reverse=False`) or descending (`reverse=True`) order.
