### PR TITLE
Revert "feat(api): Add "sudo" for user notifications endpoint (#7348)"

### DIFF
--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from sentry.api.bases.user import UserEndpoint
 from sentry.models import UserOption, UserOptionValue
 
-from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize, Serializer
 
 from rest_framework.response import Response
@@ -88,7 +87,6 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
         serialized = serialize(user, request.user, UserNotificationsSerializer())
         return Response(serialized)
 
-    @sudo_required
     def put(self, request, user):
         serializer = UserNotificationDetailsSerializer(data=request.DATA)
 

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -7,7 +7,6 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserNotificationsSerializer
 from sentry.models import OrganizationMember, OrganizationMemberTeam, OrganizationStatus, ProjectTeam, UserOption, UserEmail
@@ -56,7 +55,6 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
         )
         return Response(serialized)
 
-    @sudo_required
     def put(self, request, user, notification_type):
         """
         Update user notification options


### PR DESCRIPTION
This reverts commit 32aaec2d78197d0ca9abae9333fd6bf4d368f6cb.

I was intending to keep this behavior the same, but we don't need sudo for this per slack convos.