### PR TITLE
Fix stream tests

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -22,7 +22,7 @@ class Client {
   // Returns a jest mock that represents Client.request calls
   static addMockResponse(response) {
     let mock = jest.fn();
-    Client.mockResponses.push([
+    Client.mockResponses.unshift([
       {
         statusCode: 200,
         body: '',

--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -29,6 +29,7 @@ class Client {
         method: 'GET',
         callCount: 0,
         ...response,
+        headers: response.headers || {},
       },
       mock,
     ]);
@@ -116,7 +117,9 @@ class Client {
           options.success,
           response.body,
           {},
-          {getResponseHeader: () => {}}
+          {
+            getResponseHeader: key => response.headers[key],
+          }
         );
       }
     }

--- a/tests/js/spec/views/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/stream.spec.jsx.snap
@@ -19,7 +19,15 @@ exports[`Stream render() displays the group list 1`] = `
         projectId="456"
         query="is:unresolved"
         queryCount={null}
-        savedSearchList={Array []}
+        savedSearchList={
+          Array [
+            Object {
+              "id": "789",
+              "name": "test",
+              "query": "is:unresolved",
+            },
+          ]
+        }
         searchId={null}
         sort="date"
         tags={
@@ -119,7 +127,7 @@ exports[`Stream render() displays the group list 1`] = `
       />
     </div>
     <StreamSidebar
-      loading={true}
+      loading={false}
       onQueryChange={[Function]}
       orgId="123"
       projectId="456"
@@ -219,7 +227,15 @@ exports[`Stream toggles environment select all environments 1`] = `
         projectId="456"
         query="is:unresolved"
         queryCount={null}
-        savedSearchList={Array []}
+        savedSearchList={
+          Array [
+            Object {
+              "id": "789",
+              "name": "test",
+              "query": "is:unresolved",
+            },
+          ]
+        }
         searchId={null}
         sort="date"
         tags={
@@ -319,7 +335,7 @@ exports[`Stream toggles environment select all environments 1`] = `
       />
     </div>
     <StreamSidebar
-      loading={true}
+      loading={false}
       onQueryChange={[Function]}
       orgId="123"
       projectId="456"

--- a/tests/js/spec/views/accountNotifications.spec.jsx
+++ b/tests/js/spec/views/accountNotifications.spec.jsx
@@ -7,7 +7,6 @@ describe('AccountNotifications', function() {
   let url = '/users/me/notifications/';
 
   beforeEach(function() {
-    MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url,
       method: 'GET',
@@ -20,15 +19,10 @@ describe('AccountNotifications', function() {
         subscribeByDefault: true,
       },
     });
+  });
 
-    MockApiClient.addMockResponse({
-      url,
-      method: 'GET',
-      body: {
-        webhookUrl: 'webhook-url',
-        token: 'token token token',
-      },
-    });
+  afterEach(function() {
+    MockApiClient.clearMockResponses();
   });
 
   it('renders with values from API', function() {


### PR DESCRIPTION
- Adds ability to mock jqxhr response headers
- Mock api client will always return the last added response, so single responses can be overridden without clearing all
- Update the stream tests to use the mock api client
