### PR TITLE
feat: Add primary_hash to event post processing tasks/signals

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -872,6 +872,7 @@ class EventManager(object):
                 is_sample=is_sample,
                 is_regression=is_regression,
                 is_new_group_environment=is_new_group_environment,
+                primary_hash=hashes[0],
             )
         else:
             self.logger.info('post_process.skip.raw_event', extra={'event_id': event.id})

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -121,6 +121,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         project=event.project,
         group=event.group,
         event=event,
+        primary_hash=kwargs.get('primary_hash'),
     )
 
 

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -822,6 +822,7 @@ class EventManagerTest(TransactionTestCase):
             is_sample=False,
             is_regression=False,
             is_new_group_environment=True,
+            primary_hash='acbd18db4cc2f85cedef654fccc4a4d8',
         )
 
         event = save_event()
@@ -835,6 +836,7 @@ class EventManagerTest(TransactionTestCase):
             is_sample=False,
             is_regression=None,  # XXX: wut
             is_new_group_environment=False,
+            primary_hash='acbd18db4cc2f85cedef654fccc4a4d8',
         )
 
     def test_default_fingerprint(self):


### PR DESCRIPTION
For Snuba we need the first value from `hashes` to link event rows to groups.