### PR TITLE
ref: Use `environment` request parameter as implicit tag condition for search

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -65,8 +65,6 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             else:
                 query = query_kwargs.pop('query', None)
                 tags = query_kwargs.pop('tags', {})
-                assert not query_kwargs, 'unexpected query parameters arguments: {!r}'.format(
-                    query_kwargs.keys())
         else:
             query = None
             tags = {}


### PR DESCRIPTION
This causes the `environment:production` search token to no longer need to be provided when specifying that environment as a query string parameter (`/api/0/endpoint?environment=production`.)