### PR TITLE
fix(slack): Correctly pass token to team.info request

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -60,7 +60,7 @@ class SlackIntegration(Integration):
         }
 
         session = http.build_session()
-        resp = session.get('https://slack.com/api/team.info', data=payload)
+        resp = session.get('https://slack.com/api/team.info', params=payload)
         resp.raise_for_status()
         resp = resp.json()
 


### PR DESCRIPTION
Missed this in https://github.com/getsentry/sentry/pull/7381/commits/2480fb0c74138ffc0b78056b629c3a15154784aa