### PR TITLE
feat(ui): System alerts

### DIFF
--- a/docs-ui/components/alertMessage.stories.js
+++ b/docs-ui/components/alertMessage.stories.js
@@ -5,35 +5,91 @@ import {withInfo} from '@storybook/addon-info';
 
 import AlertMessage from 'sentry-ui/alertMessage';
 
-storiesOf('AlertMessage', module).add(
-  'all',
-  withInfo('All of the different alert messages')(() => (
-    <div>
-      <AlertMessage
-        alert={{
-          id: 'id',
-          message: 'Alert Message',
-          type: 'success',
-          url: 'url',
-        }}
-      />
+storiesOf('AlertMessage', module)
+  .add(
+    'Default',
+    withInfo('Inline alert messages')(() => (
+      <div>
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: 'Info message with a url',
+            type: 'info',
+            url: 'url',
+          }}
+        />
 
-      <AlertMessage
-        alert={{
-          id: 'id',
-          message: 'Alert Message',
-          type: 'error',
-          url: 'url',
-        }}
-      />
-      <AlertMessage
-        alert={{
-          id: 'id',
-          message: 'Alert Message',
-          type: 'warning',
-          url: 'url',
-        }}
-      />
-    </div>
-  ))
-);
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: 'Success message without a url',
+            type: 'success',
+          }}
+        />
+
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: 'Warning Message',
+            type: 'warning',
+            url: 'url',
+          }}
+        />
+
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: 'Error Message',
+            type: 'error',
+            url: 'url',
+          }}
+        />
+      </div>
+    ))
+  )
+  .add(
+    'System',
+    withInfo('System-level alert messages that appear at the top of the viewport')(() => (
+      <div>
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: 'Info message with a url',
+            type: 'info',
+            url: 'url',
+          }}
+          system
+        />
+
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: 'Success message without a url',
+            type: 'success',
+          }}
+          system
+        />
+
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: 'Warning Message',
+            type: 'warning',
+            url: 'url',
+          }}
+          system
+        />
+
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message:
+              "Background workers haven't checked in recently. This can mean an issue with your configuration or a serious backlog in tasks.",
+            type: 'error',
+            url: 'url',
+          }}
+          system
+        />
+      </div>
+    ))
+  );

--- a/src/sentry/static/sentry/app/components/alert.jsx
+++ b/src/sentry/static/sentry/app/components/alert.jsx
@@ -5,11 +5,43 @@ import styled from 'react-emotion';
 import TextBlock from '../views/settings/components/text/textBlock';
 import InlineSvg from './inlineSvg';
 
-const getAlertColorStyles = ({backgroundLight, border, iconColor}) => `
+const StyledInlineSvg = styled(InlineSvg)`
+  margin-right: 12px;
+`;
+
+const getAlertColorStyles = ({backgroundLight, border, iconColor}, textColor) => `
   background: ${backgroundLight};
   border: 1px solid ${border};
+
   svg {
     color: ${iconColor};
+  }
+
+  a {
+    color: ${textColor};
+    border-bottom: 1px dotted ${textColor};
+  }
+`;
+
+const getSystemAlertColorStyles = ({background}) => `
+  background: ${background};
+  border: 0;
+  border-radius: 0;
+  color: #fff;
+  font-weight: bold;
+  text-shadow: 0 1px 1px rgba(0,0,0, .15);
+
+  ${StyledInlineSvg} {
+    color: #fff;
+  }
+
+  a {
+    color: #fff;
+    border-bottom: 1px dotted rgba(255,255,255, .8);
+
+    &:hover {
+      border-bottom: 1px dotted rgba(255,255,255, 1);
+    }
   }
 `;
 
@@ -23,7 +55,10 @@ const AlertWrapper = styled.div`
   background: ${p => p.theme.whiteDark};
   border: 1px solid ${p => p.theme.borderDark};
 
-  ${p => p.type && getAlertColorStyles(p.theme.alert[p.type])};
+  ${p =>
+    p.system
+      ? p.type && getSystemAlertColorStyles(p.theme.alert[p.type])
+      : p.type && getAlertColorStyles(p.theme.alert[p.type], p.theme.gray5)};
 `;
 
 const StyledTextBlock = styled(TextBlock)`
@@ -31,10 +66,6 @@ const StyledTextBlock = styled(TextBlock)`
   margin-bottom: 0;
   flex: 1;
   align-self: center;
-`;
-
-const StyledInlineSvg = styled(InlineSvg)`
-  margin-right: 12px;
 `;
 
 const Alert = ({type, icon, children, className, ...props}) => {

--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -41,9 +41,10 @@ export default class AlertMessage extends React.PureComponent {
     alert: PropTypes.shape({
       id: PropTypes.string,
       message: PropTypes.string.isRequired,
-      type: PropTypes.oneOf(['success', 'error', 'warning']),
+      type: PropTypes.oneOf(['success', 'error', 'warning', 'info']),
       url: PropTypes.string,
     }),
+    system: PropTypes.bool,
   };
 
   closeAlert = () => {
@@ -51,16 +52,16 @@ export default class AlertMessage extends React.PureComponent {
   };
 
   render = () => {
-    let alert = this.props.alert;
+    let {alert, system} = this.props;
     let icon;
 
     if (alert.type == 'success') {
       icon = 'icon-circle-check';
-    } else if (alert.type == 'error' || alert.type == 'warning') {
+    } else {
       icon = 'icon-circle-exclamation';
     }
     return (
-      <StyledAlert type={this.props.alert.type} icon={icon}>
+      <StyledAlert type={this.props.alert.type} icon={icon} system={system}>
         <StyledCloseButton
           type="button"
           aria-label={t('Close')}

--- a/src/sentry/static/sentry/app/components/alerts.jsx
+++ b/src/sentry/static/sentry/app/components/alerts.jsx
@@ -23,7 +23,7 @@ const Alerts = createReactClass({
       <ThemeProvider theme={theme}>
         <div {...this.props}>
           {this.state.alerts.map(function(alert) {
-            return <AlertMessage alert={alert} key={alert.key} />;
+            return <AlertMessage alert={alert} key={alert.key} system />;
           })}
         </div>
       </ThemeProvider>

--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -16,10 +16,10 @@ const theme = {
   greenLight: '#71D8A6',
   greenDark: '#3EA573',
 
-  yellow: '#ECD744',
+  yellow: '#ecc844',
   yellowLightest: '#FFFDF7',
   yellowLight: '#FFF15E',
-  yellowDark: '#D3BE2B',
+  yellowDark: '#e6bc23',
 
   yellowOrange: '#f9a66d',
   yellowOrangeLight: '#FFC087',

--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -62,7 +62,6 @@ const theme = {
   alert: {
     info: {
       backgroundLight: '#F5FAFE',
-      background: '#2D5BB1',
       border: '#B5D6ED',
     },
     warning: {
@@ -77,7 +76,7 @@ const theme = {
       border: '#BBD6B3',
     },
     error: {
-      background: '#FDF6F5',
+      backgroundLight: '#FDF6F5',
       border: '#E7C0BC',
       textLight: '#92635f',
       textDark: '#5d3e3b',
@@ -111,9 +110,16 @@ theme.success = theme.green;
 theme.error = theme.red;
 
 theme.alert.info.iconColor = theme.blue;
+theme.alert.info.background = theme.blue;
+
 theme.alert.warning.iconColor = theme.yellowDark;
+theme.alert.warning.background = theme.yellow;
+
 theme.alert.success.iconColor = theme.greenDark;
+theme.alert.success.background = theme.green;
+
 theme.alert.error.iconColor = theme.redDark;
+theme.alert.error.background = theme.red;
 
 //alias warn to warning
 theme.alert.warn = theme.alert.warning;


### PR DESCRIPTION
This adds a `system` prop to `AlertMessage` that are to be shown at the top of the viewport. It should look pretty familiar:

<img width="1099" alt="screen shot 2018-03-05 at 3 12 23 pm" src="https://user-images.githubusercontent.com/30713/37005096-aafe30e4-2087-11e8-9c3a-d8817b64d0d4.png">

This also cleans up default `AlertMessages` where the `system` prop is not present. They aren't used anywhere at the moment, but are designed to eventually replace the various inline alerts that exist throughout the app. They look like this and will be utilized in a future PR:

<img width="1100" alt="screen shot 2018-03-05 at 3 14 05 pm" src="https://user-images.githubusercontent.com/30713/37005178-fc482554-2087-11e8-8ef8-362f58c8301e.png">

Check them out in [Storybook](http://localhost:9001/?selectedKind=AlertMessage&selectedStory=Default&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs).