### PR TITLE
fix: Extranious margin on group detail event annotation

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -57,7 +57,7 @@
 
   .event-annotation {
     display: inline-block;
-    margin: 0 0 5px 9px;
+    margin-left: 9px;
     font-size: 13px;
     line-height: 1;
     border-left: 1px solid lighten(@trim, 6);


### PR DESCRIPTION
Fixes the issue pointed out here: https://github.com/getsentry/sentry/pull/7456#issuecomment-370555323

As far as I can tell this change won't affect anything else, lets see what percy says.
![image](https://user-images.githubusercontent.com/1421724/37010685-8a6b7e3a-20a1-11e8-99bf-273bc4bec69e.png)
