### PR TITLE
ref: Switch to slugs in numerous areas

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item.jsx
@@ -328,7 +328,7 @@ class ActivityItem extends React.Component {
             />
             <div className="activity-meta">
               <Link className="project" to={`/${orgId}/${item.project.slug}/`}>
-                {item.project.name}
+                {item.project.slug}
               </Link>
               <span className="bullet" />
               <TimeSince date={item.dateCreated} />
@@ -352,7 +352,7 @@ class ActivityItem extends React.Component {
             </div>
             <div className="activity-meta">
               <Link className="project" to={`/${orgId}/${item.project.slug}/`}>
-                {item.project.name}
+                {item.project.slug}
               </Link>
               <span className="bullet" />
               <TimeSince date={item.dateCreated} />
@@ -373,7 +373,7 @@ class ActivityItem extends React.Component {
             )}
             <div className="activity-meta">
               <Link className="project" to={`/${orgId}/${item.project.slug}/`}>
-                {item.project.name}
+                {item.project.slug}
               </Link>
               <span className="bullet" />
               <TimeSince date={item.dateCreated} />

--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -78,7 +78,7 @@ class CompactIssueHeader extends React.Component {
         </h3>
         <div className="event-extra">
           <span className="project-name">
-            <Link to={`/${orgId}/${projectId}/`}>{data.project.name}</Link>
+            <Link to={`/${orgId}/${projectId}/`}>{data.project.slug}</Link>
           </span>
           {data.numComments !== 0 && (
             <span>

--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -89,7 +89,7 @@ const ReleaseProjectStatSparkline = createReactClass({
           </Sparklines>
         </div>
         <Link to={`/${orgId}/${project.slug}/releases/${encodeURIComponent(version)}/`}>
-          <h6 className="m-b-0">{project.name}</h6>
+          <h6 className="m-b-0">{project.slug}</h6>
           <p className="m-b-0 text-muted">
             <small>
               {newIssueCount > 0

--- a/src/sentry/static/sentry/app/views/projectChooser.jsx
+++ b/src/sentry/static/sentry/app/views/projectChooser.jsx
@@ -42,6 +42,7 @@ const ProjectChooser = createReactClass({
     let task = TodoList.TASKS.filter(
       task_inst => task_inst.task == this.props.location.query.task
     )[0];
+    let features = new Set(org.features);
 
     // Expect onboarding=1 and task=<task id> parameters and task.featureLocation == 'project'
     // TODO throw up report dialog if not true
@@ -56,7 +57,7 @@ const ProjectChooser = createReactClass({
             <td>
               <h4>
                 <a href={`/${org.slug}/${project.slug}/${task.location}`}>
-                  {project.name}
+                  {features.has('internal-catchall') ? project.slug : project.name}
                 </a>
               </h4>
             </td>
@@ -68,7 +69,7 @@ const ProjectChooser = createReactClass({
         <div className="box" key={i}>
           <div key={team.id}>
             <div className="box-header" key={team.id}>
-              <h2>{team.name}</h2>
+              <h2>{features.has('internal-catchall') ? team.slug : team.name}</h2>
             </div>
             <div className="box-content">
               <table className="table">

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -53,7 +53,7 @@ const ReleaseDetails = createReactClass({
   getTitle() {
     let project = this.getProject();
     let params = this.props.params;
-    return 'Release ' + params.version + ' | ' + project.name;
+    return 'Release ' + params.version + ' | ' + project.slug;
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
@@ -100,7 +100,7 @@ class AccountNotificationsByProject extends React.Component {
             // `name` key refers to field name
             // we use project.id because slugs are not unique across orgs
             name: project.id,
-            label: project.name,
+            label: project.slug,
           };
         }),
       };

--- a/src/sentry/static/sentry/app/views/settings/organization/stats/projectTable.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/stats/projectTable.jsx
@@ -28,6 +28,7 @@ class ProjectTable extends React.PureComponent {
     let projectTotals = this.props.projectTotals;
     let orgTotal = this.props.orgTotal;
     let org = this.props.organization;
+    let features = new Set(org.features);
 
     if (!projectTotals) {
       return <div />;
@@ -69,7 +70,9 @@ class ProjectTable extends React.PureComponent {
               <tr key={item.id}>
                 <td>
                   <Link to={`/${org.slug}/${project.slug}/`}>
-                    {project.team.name} / {project.name}
+                    {features.has('internal-catchall')
+                      ? project.slug
+                      : `${project.team.name} / ${project.name}`}
                   </Link>
                 </td>
                 <td className="align-right">

--- a/src/sentry/templates/sentry/accept-organization-invite.html
+++ b/src/sentry/templates/sentry/accept-organization-invite.html
@@ -32,7 +32,7 @@
           <ul>
             {% for project in project_list|slice:"5" %}
               <li>
-                {{ project.name }}
+                {{ project.slug }}
               </li>
             {% endfor %}
           </ul>

--- a/src/sentry/templates/sentry/account/email_unsubscribe_project.html
+++ b/src/sentry/templates/sentry/account/email_unsubscribe_project.html
@@ -13,7 +13,7 @@
         <p>
           {% trans "You are about to unsubscribe from project notifications for the following project:" %}
         </p>
-        <p><strong>{{ project.organization.name }} / {{ project.name }}</strong></p>
+        <p><strong>{{ project.organization.slug }} / {{ project.slug }}</strong></p>
         <p>
           {% trans "You can subscribe to it again by going to your account settings." %}
         </p>

--- a/src/sentry/templates/sentry/admin/users/edit.html
+++ b/src/sentry/templates/sentry/admin/users/edit.html
@@ -44,7 +44,7 @@
                     {% for project, avg_events in project_list|with_event_counts %}
                         <tr>
                             <td>
-                                {{ project.name }} <a href="{% absolute_uri '/{}/{}/' project.organization.slug project.slug %}">[view]</a>
+                                {{ project.slug }} <a href="{% absolute_uri '/{}/{}/' project.organization.slug project.slug %}">[view]</a>
                                 </a>
                             </td>
                             <td style="text-align:center; vertical-align:middle;">

--- a/src/sentry/templates/sentry/bases/stream.html
+++ b/src/sentry/templates/sentry/bases/stream.html
@@ -1,3 +1,3 @@
 {% extends "sentry/bases/modal.html" %}
 
-{% block title %} {{ project.name }} | {{ block.super }}{% endblock %}
+{% block title %} {{ project.slug }} | {{ block.super }}{% endblock %}

--- a/src/sentry/templates/sentry/emails/activity/new_processing_issues.html
+++ b/src/sentry/templates/sentry/emails/activity/new_processing_issues.html
@@ -12,7 +12,7 @@
     </h2>
 
     <p class="muted">
-      Some events failed to process in your project "<a href="{{ project.get_absolute_url }}">{{ project.name }}</a>".
+      Some events failed to process in your project "<a href="{{ project.get_absolute_url }}">{{ project.slug }}</a>".
       {% if reprocessing_active %}
         Since reprocessing is enabled, these events will not show up in Sentry until the processing issues are resolved.
       {% endif %}
@@ -33,7 +33,7 @@
           <tr>
             <td>
               <h5 style="margin-bottom: 0">
-                <a href="{{ project.get_absolute_url }}">{{ project.name }}</a>
+                <a href="{{ project.get_absolute_url }}">{{ project.slug }}</a>
               </h5>
               <p class="muted" style="margin-bottom: 0">
                 {% if issues|length == 1 %}1 issue{% else %}{{ issues|length }} issues{% endif %}

--- a/src/sentry/templates/sentry/emails/activity/new_processing_issues.txt
+++ b/src/sentry/templates/sentry/emails/activity/new_processing_issues.txt
@@ -1,4 +1,4 @@
-Some events failed to process in your project "{{ project.name }}".
+Some events failed to process in your project "{{ project.slug }}".
 
 {% if reprocessing_active %}Since reprocessing is enabled, these events
 will not show up in Sentry until the processing issues are resolved.

--- a/src/sentry/templates/sentry/emails/activity/release.html
+++ b/src/sentry/templates/sentry/emails/activity/release.html
@@ -22,7 +22,7 @@
             <tr>
               <td>
                 <h5 style="margin-bottom: 0">
-                  <a href="{{ release_link }}">{{ project.name }}</a>
+                  <a href="{{ release_link }}">{{ project.slug }}</a>
                 </h5>
                 <p class="muted" style="margin-bottom: 0">
                   {% if resolved_issue_count %}

--- a/src/sentry/templates/sentry/emails/alert.txt
+++ b/src/sentry/templates/sentry/emails/alert.txt
@@ -10,6 +10,6 @@ Details
 {{ link }}
 
 Date: {{ alert.datetime }}
-Project: {{ alert.project.name }}
+Project: {{ alert.project.slug }}
 {% endautoescape %}
 {% endspaceless %}

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 <div class="container" style="padding-top: 30px;">
-  <h2>{{ counts|length }} new alert{{ counts|pluralize }} from <a href="{{ project.get_absolute_url }}">{{ project.name }}</a></h2>
+  <h2>{{ counts|length }} new alert{{ counts|pluralize }} from <a href="{{ project.get_absolute_url }}">{{ project.slug }}</a></h2>
   {% with start=start|date:"N j, Y, P e" end=end|date:"N j, Y, P e" %}
     <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
   {% endwith %}

--- a/src/sentry/templates/sentry/emails/digests/body.txt
+++ b/src/sentry/templates/sentry/emails/digests/body.txt
@@ -1,4 +1,4 @@
-{% load sentry_helpers %}Notifications for {{ project.name }}
+{% load sentry_helpers %}Notifications for {{ project.slug }}
 {{ start|date:"N j, Y, P e" }} to {{ end|date:"N j, Y, P e" }}
 
 {% for rule, groups in digest.iteritems %}{{ rule.label }}

--- a/src/sentry/templates/sentry/projects/accept_project_transfer.html
+++ b/src/sentry/templates/sentry/projects/accept_project_transfer.html
@@ -15,7 +15,7 @@
     {% csrf_token %}
     {{ form|as_crispy_errors }}
     <p>Projects must be transferred to a specific <strong>Team</strong> in order to be moved over to another <strong>Organization</strong>. You can always change the team later under the <strong>Project Settings</strong>.</p>
-    <p>{% trans "Please select which" %} <strong>{% trans "Team" %}</strong> {% trans "you want for the project" %} <strong>{{ project.name }}</strong>.</p>
+    <p>Please select which <strong>Team</strong> you want for the project <strong>{{ project.slug }}</strong>.</p>
     <div class="box">
       <div class="box-content with-padding">
           {{ form.team|as_crispy_field }}

--- a/src/sentry/templates/sentry/projects/remove.html
+++ b/src/sentry/templates/sentry/projects/remove.html
@@ -9,7 +9,7 @@
   <div class="page-header">
     <h2>
       {% trans "Remove Project" %}
-      <small>{{ project.name }}</small>
+      <small>{{ project.slug }}</small>
     </h2>
   </div>
   <form action="" method="post">

--- a/src/sentry/templates/sentry/projects/transfer.html
+++ b/src/sentry/templates/sentry/projects/transfer.html
@@ -9,7 +9,7 @@
   <div class="page-header">
     <h2>
       {% trans "Transfer Project" %}
-      <small>{{ project.name }}</small>
+      <small>{{ project.slug }}</small>
     </h2>
   </div>
   <form action="" method="post">
@@ -25,7 +25,7 @@
         {{ field|as_crispy_field }}
     {% endfor %}
 
-    <p>{% trans "A request will be emailed to the Owner in order to transfer" %} <strong> {{ project.name }} </strong> {%trans "to a new organization." %}</p>
+    <p>{% trans "A request will be emailed to the Owner in order to transfer" %} <strong> {{ project.slug }} </strong> {%trans "to a new organization." %}</p>
 
     <fieldset class="form-actions">
       <button type="submit" class="btn btn-danger">{% trans "Send Transfer Project Request" %}</button>

--- a/src/sentry/templates/sentry/reprocessing-script.sh
+++ b/src/sentry/templates/sentry/reprocessing-script.sh
@@ -58,6 +58,6 @@ export SENTRY_PROJECT="{{ project.slug }}"
 echo
 echo $'\033[32mSuccessfully found all symbols!\033[0m'
 {% else %}
-echo 'There are currently no missing debug symbols for {{ project.name }} ({{ project.slug }})'
+echo 'There are currently no missing debug symbols for ``{{ project.slug }}``'
 {% endif %}
 {% endautoescape %}


### PR DESCRIPTION
Update numerous uses of project name to be project slug, and when possible do so behind feature switch.