### PR TITLE
fix(schema): Validate transaction as string

### DIFF
--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -330,6 +330,7 @@ EVENT_SCHEMA = {
             # 'maxLength': MAX_CULPRIT_LENGTH,
             'default': lambda: apierror('Invalid value for culprit'),
         },
+        'transaction': {'type': 'string'},
         'server_name': TAG_VALUE,
         'release': TAG_VALUE,
         'dist': {

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -512,15 +512,14 @@ class EventManagerTest(TransactionTestCase):
         data = manager.normalize()
         assert len(data['culprit']) == MAX_CULPRIT_LENGTH
 
-    def test_handles_non_string_generated_culprit(self):
+    def test_invalid_transaction(self):
         dict_input = {'messages': 'foo'}
         manager = EventManager(self.make_event(
             transaction=dict_input,
         ))
         manager.normalize()
         event = manager.save(1)
-        assert event.transaction == dict_input
-        assert event.culprit == dict_input
+        assert event.transaction is None
 
     def test_long_transaction(self):
         manager = EventManager(self.make_event(


### PR DESCRIPTION
This is one approach, make sure transaction is always a string or discard it.