### PR TITLE
feat(ui): Add Confirm to "require 2fa" option

### DIFF
--- a/src/sentry/static/sentry/app/components/confirm.jsx
+++ b/src/sentry/static/sentry/app/components/confirm.jsx
@@ -33,6 +33,35 @@ class Confirm extends React.PureComponent {
     this.confirming = false;
   }
 
+  openModal = () => {
+    let {onConfirming} = this.props;
+    if (typeof onConfirming === 'function') {
+      onConfirming();
+    }
+
+    this.setState(state => ({
+      isModalOpen: true,
+      disableConfirmButton: false,
+    }));
+
+    // always reset `confirming` when modal visibility changes
+    this.confirming = false;
+  };
+
+  closeModal = () => {
+    let {onCancel} = this.props;
+    if (typeof onCancel === 'function') {
+      onCancel();
+    }
+    this.setState(state => ({
+      isModalOpen: false,
+      disableConfirmButton: false,
+    }));
+
+    // always reset `confirming` when modal visibility changes
+    this.confirming = false;
+  };
+
   handleConfirm = e => {
     // `confirming` is used to make sure `onConfirm` is only called once
     if (!this.confirming) {
@@ -48,28 +77,15 @@ class Confirm extends React.PureComponent {
   };
 
   handleToggle = e => {
-    let {onConfirming, onCancel, disabled} = this.props;
+    let {disabled} = this.props;
     if (disabled) return;
 
     // Current state is closed, means it will toggle open
     if (!this.state.isModalOpen) {
-      if (typeof onConfirming === 'function') {
-        onConfirming();
-      }
+      this.openModal();
     } else {
-      if (typeof onCancel === 'function') {
-        onCancel();
-      }
+      this.closeModal();
     }
-
-    // Toggle modal display state
-    // Also always reset `confirming` when modal visibility changes
-    this.setState(state => ({
-      isModalOpen: !state.isModalOpen,
-      disableConfirmButton: false,
-    }));
-
-    this.confirming = false;
   };
 
   render() {
@@ -85,7 +101,12 @@ class Confirm extends React.PureComponent {
 
     return (
       <React.Fragment>
-        {React.cloneElement(children, {disabled, onClick: this.handleToggle})}
+        {typeof children === 'function'
+          ? children({
+              close: this.closeModal,
+              open: this.openModal,
+            })
+          : React.cloneElement(children, {disabled, onClick: this.handleToggle})}
         <Modal show={this.state.isModalOpen} animation={false} onHide={this.handleToggle}>
           <div className="modal-body">{confirmMessage}</div>
           <div className="modal-footer">

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -65,6 +65,16 @@ const formGroups = [
     title: t('Security & Privacy'),
     fields: [
       {
+        name: 'require2FA',
+        type: 'boolean',
+        label: t('Require Two-Factor Authentication'),
+        help: t('Require two-factor authentication for all members.'),
+        confirm: t(
+          'Enabling this feature will disable all accounts without two-factor authentication. It will also send an email to all users to enable two-factor authentication. Do you want to continue?'
+        ),
+        visible: ({features}) => features.has('require-2fa'),
+      },
+      {
         name: 'allowSharedIssues',
         type: 'boolean',
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
@@ -27,6 +27,7 @@ export default class BooleanField extends InputField {
     return (
       <InputField
         {...fieldProps}
+        resetOnError
         field={({onChange, onBlur, value, disabled, ...props}) => {
           // Create a function with required args bound
           let handleChange = this.handleChange.bind(this, value, onChange, onBlur);

--- a/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
@@ -51,7 +51,8 @@ export default class BooleanField extends InputField {
                       // Then show confirm dialog, otherwise propagate change as normal
                       //
                       // TODO(billy): We will probably want a way to control if it happens on enable or disable
-                      if (!!confirm && !value) {
+                      if (!value) {
+                        // Open confirm modal
                         open();
                         return;
                       }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
@@ -1,14 +1,20 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import InputField from './inputField';
 import Switch from '../../../../components/switch';
+import Confirm from '../../../../components/confirm';
 
 export default class BooleanField extends InputField {
+  static propTypes = {
+    ...InputField.propTypes,
+    confirm: PropTypes.node,
+  };
   coerceValue(value) {
     return value ? true : false;
   }
 
-  onChange = (value, onChange, onBlur, e) => {
+  handleChange = (value, onChange, onBlur, e) => {
     // We need to toggle current value because Switch is not an input
     let newValue = this.coerceValue(!value);
     onChange(newValue, e);
@@ -16,17 +22,35 @@ export default class BooleanField extends InputField {
   };
 
   render() {
+    let {confirm, ...fieldProps} = this.props;
+
     return (
       <InputField
-        {...this.props}
+        {...fieldProps}
         field={({onChange, onBlur, value, disabled, ...props}) => (
-          <Switch
-            size="lg"
-            {...props}
-            isActive={!!value}
-            isDisabled={disabled}
-            toggle={this.onChange.bind(this, value, onChange, onBlur)}
-          />
+          <Confirm
+            message={confirm}
+            onConfirm={this.handleChange.bind(this, value, onChange, onBlur, {})}
+          >
+            {({open}) => (
+              <Switch
+                size="lg"
+                {...props}
+                isActive={!!value}
+                isDisabled={disabled}
+                toggle={e => {
+                  // If we have a `confirm` prop and enabling switch
+                  // Then show confirm dialog, otherwise propagate change as normal
+                  if (!!confirm && !value) {
+                    open();
+                    return;
+                  }
+
+                  this.handleChange(value, onChange, onBlur, e);
+                }}
+              />
+            )}
+          </Confirm>
         )}
       />
     );

--- a/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
@@ -27,31 +27,44 @@ export default class BooleanField extends InputField {
     return (
       <InputField
         {...fieldProps}
-        field={({onChange, onBlur, value, disabled, ...props}) => (
-          <Confirm
-            message={confirm}
-            onConfirm={this.handleChange.bind(this, value, onChange, onBlur, {})}
-          >
-            {({open}) => (
-              <Switch
-                size="lg"
-                {...props}
-                isActive={!!value}
-                isDisabled={disabled}
-                toggle={e => {
-                  // If we have a `confirm` prop and enabling switch
-                  // Then show confirm dialog, otherwise propagate change as normal
-                  if (!!confirm && !value) {
-                    open();
-                    return;
-                  }
+        field={({onChange, onBlur, value, disabled, ...props}) => {
+          // Create a function with required args bound
+          let handleChange = this.handleChange.bind(this, value, onChange, onBlur);
 
-                  this.handleChange(value, onChange, onBlur, e);
-                }}
-              />
-            )}
-          </Confirm>
-        )}
+          let switchProps = {
+            size: 'lg',
+            ...props,
+            isActive: !!value,
+            isDisabled: disabled,
+            toggle: handleChange,
+          };
+
+          if (confirm) {
+            return (
+              <Confirm message={confirm} onConfirm={() => handleChange({})}>
+                {({open}) => (
+                  <Switch
+                    {...switchProps}
+                    toggle={e => {
+                      // If we have a `confirm` prop and enabling switch
+                      // Then show confirm dialog, otherwise propagate change as normal
+                      //
+                      // TODO(billy): We will probably want a way to control if it happens on enable or disable
+                      if (!!confirm && !value) {
+                        open();
+                        return;
+                      }
+
+                      handleChange(e);
+                    }}
+                  />
+                )}
+              </Confirm>
+            );
+          }
+
+          return <Switch {...switchProps} />;
+        }}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -333,12 +333,11 @@ class FormModel {
    */
   @action
   saveField(id, currentValue) {
+    let initialValue = this.initialData[id];
+
     // Don't save if field hasn't changed
     // Don't need to check for error state since initialData wouldn't have updated since last error
-    if (
-      currentValue === this.initialData[id] ||
-      (currentValue === '' && !defined(this.initialData[id]))
-    )
+    if (currentValue === initialValue || (currentValue === '' && !defined(initialValue)))
       return null;
 
     // Check for error first
@@ -381,6 +380,13 @@ class FormModel {
       .catch(resp => {
         // should we revert field value to last known state?
         saveSnapshot = null;
+
+        // Field can be configured to reset on error
+        // e.g. BooleanFields
+        let shouldReset = this.getDescriptor(id, 'resetOnError');
+        if (shouldReset) {
+          this.setValue(id, initialValue);
+        }
 
         // API can return a JSON object with either:
         // 1) map of {[fieldName] => Array<ErrorMessages>}
@@ -444,13 +450,6 @@ class FormModel {
         return resp;
       })
       .catch(error => {
-        // Field can be configured to reset on error
-        // e.g. BooleanFields
-        let shouldReset = this.getDescriptor(id, 'resetOnError');
-        if (shouldReset) {
-          this.setValue(id, oldValue);
-        }
-
         if (this.options.onSubmitError) {
           this.options.onSubmitError(error, this, id);
         }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -444,6 +444,13 @@ class FormModel {
         return resp;
       })
       .catch(error => {
+        // Field can be configured to reset on error
+        // e.g. BooleanFields
+        let shouldReset = this.getDescriptor(id, 'resetOnError');
+        if (shouldReset) {
+          this.setValue(id, oldValue);
+        }
+
         if (this.options.onSubmitError) {
           this.options.onSubmitError(error, this, id);
         }

--- a/src/sentry/static/sentry/app/views/settings/organization/general/organizationSettingsForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/general/organizationSettingsForm.jsx
@@ -27,20 +27,6 @@ const NewOrganizationSettingsForm = createReactClass({
   render() {
     let {initialData, orgId, onSave, access} = this.props;
 
-    //Only for adding the Flag to 2FA Enforcement.
-    if (this.getFeatures().has('require-2fa')) {
-      let security_panel = organizationSettingsFields.find(
-        panel => panel.title == 'Security & Privacy'
-      );
-      if (!security_panel.fields.find(field => field.name == 'require2FA'))
-        security_panel.fields.unshift({
-          name: 'require2FA',
-          type: 'boolean',
-          label: 'Require Two-Factor Authentication',
-          help: 'Require two-factor authentication for all members.',
-        });
-    }
-
     return (
       <Form
         className="ref-organization-settings"
@@ -66,6 +52,7 @@ const NewOrganizationSettingsForm = createReactClass({
       >
         <Box>
           <JsonForm
+            features={this.getFeatures()}
             access={access}
             location={this.props.location}
             forms={organizationSettingsFields}

--- a/tests/acceptance/test_organization_settings.py
+++ b/tests/acceptance/test_organization_settings.py
@@ -84,5 +84,8 @@ class OrganizationSettingsTest(AcceptanceTestCase):
             self.browser.wait_until_not('.loading-indicator')
             assert not self.browser.element_exists('.ref-organization-settings .error')
             self.browser.click('#require2FA')
+            self.browser.wait_until('.modal')
+            self.browser.click('.modal .button-primary')
+            self.browser.wait_until_not('.modal')
             self.load_organization_helper("setting 2fa without 2fa enabled")
             self.browser.wait_until('.ref-toast.ref-error')


### PR DESCRIPTION
* move require2fa into data/forms + add confirm
* add `confirm` prop to BooleanField to open a Confirm modal
* refactor Confirm component to overload `children` and accept a render function
  * allow rendered child to control confirm state

Soft dependency on https://github.com/getsentry/sentry/pull/7303