### PR TITLE
fix: Change tagstore v2 'ForeignKey' columns to BigInt

### DIFF
--- a/src/sentry/tagstore/south_migrations/0007_auto__chg_field_tagkey_environment_id__chg_field_tagkey_project_id__ch.py
+++ b/src/sentry/tagstore/south_migrations/0007_auto__chg_field_tagkey_environment_id__chg_field_tagkey_project_id__ch.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = True
+
+    def forwards(self, orm):
+
+        # Changing field 'TagKey.environment_id'
+        db.alter_column(u'tagstore_tagkey', 'environment_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')(null=True))
+
+        # Changing field 'TagKey.project_id'
+        db.alter_column(u'tagstore_tagkey', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'TagValue.project_id'
+        db.alter_column(u'tagstore_tagvalue', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'GroupTagKey.project_id'
+        db.alter_column(u'tagstore_grouptagkey', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'GroupTagKey.group_id'
+        db.alter_column(u'tagstore_grouptagkey', 'group_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'EventTag.project_id'
+        db.alter_column(u'tagstore_eventtag', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'EventTag.event_id'
+        db.alter_column(u'tagstore_eventtag', 'event_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'EventTag.group_id'
+        db.alter_column(u'tagstore_eventtag', 'group_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'GroupTagValue.group_id'
+        db.alter_column(u'tagstore_grouptagvalue', 'group_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+        # Changing field 'GroupTagValue.project_id'
+        db.alter_column(u'tagstore_grouptagvalue', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedBigIntegerField')())
+
+    def backwards(self, orm):
+
+        # Changing field 'TagKey.environment_id'
+        db.alter_column(u'tagstore_tagkey', 'environment_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')(null=True))
+
+        # Changing field 'TagKey.project_id'
+        db.alter_column(u'tagstore_tagkey', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'TagValue.project_id'
+        db.alter_column(u'tagstore_tagvalue', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'GroupTagKey.project_id'
+        db.alter_column(u'tagstore_grouptagkey', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'GroupTagKey.group_id'
+        db.alter_column(u'tagstore_grouptagkey', 'group_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'EventTag.project_id'
+        db.alter_column(u'tagstore_eventtag', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'EventTag.event_id'
+        db.alter_column(u'tagstore_eventtag', 'event_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'EventTag.group_id'
+        db.alter_column(u'tagstore_eventtag', 'group_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'GroupTagValue.group_id'
+        db.alter_column(u'tagstore_grouptagvalue', 'group_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+        # Changing field 'GroupTagValue.project_id'
+        db.alter_column(u'tagstore_grouptagvalue', 'project_id', self.gf(
+            'sentry.db.models.fields.bounded.BoundedPositiveIntegerField')())
+
+    models = {
+        'tagstore.eventtag': {
+            'Meta': {'unique_together': "(('project_id', 'event_id', 'key', 'value'),)", 'object_name': 'EventTag', 'index_together': "(('project_id', 'key', 'value'), ('group_id', 'key', 'value'))"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'event_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'value': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagValue']", 'db_column': "'value_id'"})
+        },
+        'tagstore.grouptagkey': {
+            'Meta': {'unique_together': "(('project_id', 'group_id', '_key'),)", 'object_name': 'GroupTagKey'},
+            '_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'tagstore.grouptagvalue': {
+            'Meta': {'unique_together': "(('project_id', 'group_id', '_key', '_value'),)", 'object_name': 'GroupTagValue', 'index_together': "(('project_id', '_key', '_value', 'last_seen'),)"},
+            '_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            '_value': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagValue']", 'db_column': "'value_id'"}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'tagstore.tagkey': {
+            'Meta': {'unique_together': "(('project_id', 'environment_id', 'key'),)", 'object_name': 'TagKey'},
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'tagstore.tagvalue': {
+            'Meta': {'unique_together': "(('project_id', '_key', 'value'),)", 'object_name': 'TagValue', 'index_together': "(('project_id', '_key', 'last_seen'),)"},
+            '_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['tagstore.TagKey']", 'db_column': "'key_id'"}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True', 'blank': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['tagstore']

--- a/src/sentry/tagstore/v2/models/eventtag.py
+++ b/src/sentry/tagstore/v2/models/eventtag.py
@@ -10,15 +10,15 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils import timezone
 
-from sentry.db.models import (Model, BoundedPositiveIntegerField, FlexibleForeignKey, sane_repr)
+from sentry.db.models import (Model, BoundedBigIntegerField, FlexibleForeignKey, sane_repr)
 
 
 class EventTag(Model):
     __core__ = False
 
-    project_id = BoundedPositiveIntegerField()
-    group_id = BoundedPositiveIntegerField()
-    event_id = BoundedPositiveIntegerField()
+    project_id = BoundedBigIntegerField()
+    group_id = BoundedBigIntegerField()
+    event_id = BoundedBigIntegerField()
     key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
     value = FlexibleForeignKey('tagstore.TagValue', db_column='value_id')
     date_added = models.DateTimeField(default=timezone.now, db_index=True)

--- a/src/sentry/tagstore/v2/models/grouptagkey.py
+++ b/src/sentry/tagstore/v2/models/grouptagkey.py
@@ -13,7 +13,7 @@ from django.db import router, transaction, DataError
 
 from sentry.api.serializers import Serializer, register
 from sentry.db.models import (
-    Model, BoundedPositiveIntegerField, BaseManager, FlexibleForeignKey, sane_repr
+    Model, BoundedPositiveIntegerField, BoundedBigIntegerField, BaseManager, FlexibleForeignKey, sane_repr
 )
 
 
@@ -25,8 +25,8 @@ class GroupTagKey(Model):
     """
     __core__ = False
 
-    project_id = BoundedPositiveIntegerField(db_index=True)
-    group_id = BoundedPositiveIntegerField(db_index=True)
+    project_id = BoundedBigIntegerField(db_index=True)
+    group_id = BoundedBigIntegerField(db_index=True)
     _key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
     values_seen = BoundedPositiveIntegerField(default=0)
 

--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 
 from sentry.api.serializers import Serializer, register
 from sentry.db.models import (
-    Model, BoundedPositiveIntegerField, BaseManager, FlexibleForeignKey, sane_repr
+    Model, BoundedPositiveIntegerField, BoundedBigIntegerField, BaseManager, FlexibleForeignKey, sane_repr
 )
 
 
@@ -25,8 +25,8 @@ class GroupTagValue(Model):
     """
     __core__ = False
 
-    project_id = BoundedPositiveIntegerField(db_index=True)
-    group_id = BoundedPositiveIntegerField(db_index=True)
+    project_id = BoundedBigIntegerField(db_index=True)
+    group_id = BoundedBigIntegerField(db_index=True)
     times_seen = BoundedPositiveIntegerField(default=0)
     _key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
     _value = FlexibleForeignKey('tagstore.TagValue', db_column='value_id')

--- a/src/sentry/tagstore/v2/models/tagkey.py
+++ b/src/sentry/tagstore/v2/models/tagkey.py
@@ -16,7 +16,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.api.serializers import Serializer, register
 from sentry.tagstore import TagKeyStatus
 from sentry.constants import MAX_TAG_KEY_LENGTH
-from sentry.db.models import (Model, BoundedPositiveIntegerField, sane_repr)
+from sentry.db.models import (Model, BoundedPositiveIntegerField, BoundedBigIntegerField, sane_repr)
 
 
 class TagKey(Model):
@@ -25,8 +25,8 @@ class TagKey(Model):
     """
     __core__ = False
 
-    project_id = BoundedPositiveIntegerField(db_index=True)
-    environment_id = BoundedPositiveIntegerField(null=True)
+    project_id = BoundedBigIntegerField(db_index=True)
+    environment_id = BoundedBigIntegerField(null=True)
     key = models.CharField(max_length=MAX_TAG_KEY_LENGTH)
     values_seen = BoundedPositiveIntegerField(default=0)
     status = BoundedPositiveIntegerField(

--- a/src/sentry/tagstore/v2/models/tagvalue.py
+++ b/src/sentry/tagstore/v2/models/tagvalue.py
@@ -15,7 +15,8 @@ from django.utils import timezone
 from sentry.api.serializers import Serializer, register
 from sentry.constants import MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
-    Model, BoundedPositiveIntegerField, GzippedDictField, BaseManager, FlexibleForeignKey, sane_repr
+    Model, BoundedPositiveIntegerField, BoundedBigIntegerField, GzippedDictField,
+    BaseManager, FlexibleForeignKey, sane_repr
 )
 
 
@@ -25,7 +26,7 @@ class TagValue(Model):
     """
     __core__ = False
 
-    project_id = BoundedPositiveIntegerField(db_index=True)
+    project_id = BoundedBigIntegerField(db_index=True)
     _key = FlexibleForeignKey('tagstore.TagKey', db_column='key_id')
     value = models.CharField(max_length=MAX_TAG_VALUE_LENGTH)
     data = GzippedDictField(blank=True, null=True)


### PR DESCRIPTION
@mattrobenolt The migration was auto generated, I forget if I need to adjust it for you... `dangerous = True`?