### PR TITLE
feat(search): Include issues assigned to teams in search results

### DIFF
--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -62,6 +62,7 @@ class DjangoSearchBackendTest(TestCase):
             last_seen=datetime(2013, 7, 14, 3, 8, 24, 880386),
             first_seen=datetime(2013, 7, 14, 3, 8, 24, 880386),
         )
+
         self.event2 = self.create_event(
             event_id='b' * 32,
             group=self.group2,
@@ -286,6 +287,24 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project1, assigned_to=self.user)
         assert len(results) == 1
         assert results[0] == self.group2
+
+        # test team assignee
+        ga = GroupAssignee.objects.get(
+            user=self.user,
+            group=self.group2,
+            project=self.group2.project,
+        )
+        ga.update(team=self.team, user=None)
+        assert GroupAssignee.objects.get(id=ga.id).user is None
+
+        results = self.backend.query(self.project1, assigned_to=self.user)
+        assert len(results) == 1
+        assert results[0] == self.group2
+
+        # test when there should be no results
+        other_user = self.create_user()
+        results = self.backend.query(self.project1, assigned_to=other_user)
+        assert len(results) == 0
 
     def test_subscribed_by(self):
         results = self.backend.query(


### PR DESCRIPTION
basically just copied the query from here https://github.com/getsentry/sentry/pull/7434

kind of expected this to be more complicated, so is there something i'm missing?

<img width="1187" alt="screenshot 2018-03-06 18 39 58" src="https://user-images.githubusercontent.com/5026776/37070879-afbfb250-216e-11e8-9fb2-2fc5a19cf404.png">
