### PR TITLE
fix: Filter merge queries by project/project_id when possible

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -301,18 +301,31 @@ def merge_objects(models, group, new_group, limit=1000, logger=None, transaction
     has_more = False
     for model in models:
         all_fields = model._meta.get_all_field_names()
+
+        # not all models have a 'project' or 'project_id' field, but we make a best effort
+        # to filter on one if it is available
+        has_project = 'project' in all_fields
+        has_project_id = 'project_id' in all_fields
+        if has_project:
+            project_qs = model.objects.filter(project=group.project)
+        elif has_project_id:
+            project_qs = model.objects.filter(project_id=group.project_id)
+        else:
+            project_qs = model.objects.all()
+
         has_group = 'group' in all_fields
         if has_group:
-            queryset = model.objects.filter(group=group)
+            queryset = project_qs.filter(group=group)
         else:
-            queryset = model.objects.filter(group_id=group.id)
+            queryset = project_qs.filter(group_id=group.id)
+
         for obj in queryset[:limit]:
             try:
                 with transaction.atomic(using=router.db_for_write(model)):
                     if has_group:
-                        model.objects.filter(id=obj.id).update(group=new_group)
+                        project_qs.filter(id=obj.id).update(group=new_group)
                     else:
-                        model.objects.filter(id=obj.id).update(group_id=new_group.id)
+                        project_qs.filter(id=obj.id).update(group_id=new_group.id)
             except IntegrityError:
                 delete = True
             else:

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -304,11 +304,8 @@ def merge_objects(models, group, new_group, limit=1000, logger=None, transaction
 
         # not all models have a 'project' or 'project_id' field, but we make a best effort
         # to filter on one if it is available
-        has_project = 'project' in all_fields
-        has_project_id = 'project_id' in all_fields
+        has_project = 'project_id' in all_fields or 'project' in all_fields
         if has_project:
-            project_qs = model.objects.filter(project=group.project)
-        elif has_project_id:
             project_qs = model.objects.filter(project_id=group.project_id)
         else:
             project_qs = model.objects.all()


### PR DESCRIPTION
Fixes SENTRY-61R

Example of model without project:

https://github.com/getsentry/sentry/blob/f5aa883f3b0696b8350e144e3125c6a872d40177/src/sentry/models/groupredirect.py#L6-L18