### PR TITLE
fix(environments): Do not update global environment on every search

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -445,8 +445,10 @@ const Stream = createReactClass({
       // and remove it from the query if someone does provide it this way
       if (this.props.hasEnvironmentsFeature) {
         const queryEnvironment = queryString.getQueryEnvironment(query);
-        const env = EnvironmentStore.getByName(queryEnvironment);
-        setActiveEnvironment(env);
+        if (queryEnvironment !== null) {
+          const env = EnvironmentStore.getByName(queryEnvironment);
+          setActiveEnvironment(env);
+        }
 
         query = queryString.getQueryStringWithoutEnvironment(query);
       }


### PR DESCRIPTION
We should only update the global environment if one is actually specified by the search
query, otherwise leave the environment unchanged and do not default to 'All Environments'