### PR TITLE
Add tags to sample event

### DIFF
--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -174,9 +174,9 @@ def load_data(platform, default=None, timestamp=None, sample_name=None):
     }
     data.setdefault('tags', [
         ['environment', 'prod'],
-        ['release', '897a3d8'],
         ['level', 'error'],
         ['browser', 'Firefox 58.0'],
+        ['logger', 'sentry.billing'],
     ])
 
     start = datetime.utcnow()

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -172,6 +172,12 @@ def load_data(platform, default=None, timestamp=None, sample_name=None):
         "data": '{"hello": "world"}',
         "method": "GET"
     }
+    data.setdefault('tags', [
+        ['environment', 'prod'],
+        ['release', '897a3d8'],
+        ['level', 'error'],
+        ['browser', 'Firefox 58.0'],
+    ])
 
     start = datetime.utcnow()
     if timestamp:


### PR DESCRIPTION
Most sample events don't have tags, so the guide would point to nothing if we don't pre-populate it