### PR TITLE
feat(ui): Allow teams to be created with slugs instead of names

### DIFF
--- a/src/sentry/static/sentry/app/views/teamCreate.jsx
+++ b/src/sentry/static/sentry/app/views/teamCreate.jsx
@@ -29,6 +29,25 @@ export default class TeamCreate extends AsyncView {
     return 'Create Team';
   }
 
+  renderField() {
+    let features = new Set(this.context.organization.features);
+    return features.has('internal-catchall') ? (
+      <TextField
+        name="slug"
+        label={t('Team Slug')}
+        placeholder={t('e.g. operations, web, desktop')}
+        required={true}
+      />
+    ) : (
+      <TextField
+        name="name"
+        label={t('Team Name')}
+        placeholder={t('e.g. Operations, Web, Desktop')}
+        required={true}
+      />
+    );
+  }
+
   renderBody() {
     let {orgId} = this.props.params;
     return (
@@ -48,12 +67,7 @@ export default class TeamCreate extends AsyncView {
           onSubmitSuccess={this.onSubmitSuccess}
           requireChanges={true}
         >
-          <TextField
-            name="name"
-            label={t('Team Name')}
-            placeholder={t('e.g. Operations, Web, Desktop')}
-            required={true}
-          />
+          {this.renderField()}
         </ApiForm>
       </NarrowLayout>
     );

--- a/src/sentry/static/sentry/app/views/teamCreate.jsx
+++ b/src/sentry/static/sentry/app/views/teamCreate.jsx
@@ -35,7 +35,8 @@ export default class TeamCreate extends AsyncView {
       <TextField
         name="slug"
         label={t('Team Slug')}
-        placeholder={t('e.g. operations, web, desktop')}
+        placeholder={t('e.g. operations, web-frontend, desktop')}
+        help={t('May contain letters, numbers, dashes and underscores.')}
         required={true}
       />
     ) : (

--- a/tests/js/spec/views/teamCreate.spec.jsx
+++ b/tests/js/spec/views/teamCreate.spec.jsx
@@ -13,7 +13,7 @@ describe('TeamCreate', function() {
           }}
         />,
         {
-          context: {router: TestStubs.router()},
+          context: {router: TestStubs.router(), organization: TestStubs.Organization()},
         }
       );
       expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
depends on https://github.com/getsentry/sentry/pull/7507