### PR TITLE
Bump pytest-timeout

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,6 +8,6 @@ cqlsh
 datadog
 msgpack-python<0.5.0
 pytest-cov>=2.5.1,<2.6.0
-pytest-timeout>=0.5.0,<0.6.0
+pytest-timeout==1.2.1
 pytest-xdist>=1.18.0,<1.19.0
 responses>=0.8.1,<0.9.0


### PR DESCRIPTION
Is anyone else really sick of that `__multicall__` deprecation warning?  This should fix it.
