### PR TITLE
fix(emails): Correct handling of primary email address

### DIFF
--- a/src/sentry/templates/sentry/account/emails.html
+++ b/src/sentry/templates/sentry/account/emails.html
@@ -46,7 +46,7 @@
             {% endif %}
           </td>
           <td style="text-align: right">
-            {% if email != primary_email and email.is_verified and not user.is_managed %}
+            {% if email != primary_email and email.is_verified %}
             <form action="" method="post">
               {% csrf_token %}
               <input type='hidden' name='new_primary_email' value='{{ email.email }}'>

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -524,7 +524,12 @@ def show_emails(request):
             )
 
         elif new_primary != user.email:
-
+            new_primary_email = UserEmail.objects.get(user=user, email__iexact=new_primary)
+            if not new_primary_email.is_verified:
+                messages.add_message(
+                    request, messages.ERROR, _("Cannot make an unverified address your primary email")
+                )
+                return HttpResponseRedirect(request.path)
             # update notification settings for those set to primary email with new primary email
             alert_email = UserOption.objects.get_value(user=user, key='alert_email')
 

--- a/tests/sentry/web/frontend/accounts/tests.py
+++ b/tests/sentry/web/frontend/accounts/tests.py
@@ -50,37 +50,6 @@ class AppearanceSettingsTest(TestCase):
         assert options.get('clock_24_hours') is True
 
 
-class SettingsEmailTest(TestCase):
-    @fixture
-    def path(self):
-        return reverse('sentry-account-settings-emails')
-
-    def test_change_primary_email(self):
-        self.login_as(self.user)
-        self.create_user('foo@example.com')
-
-        # setting primary email changes it
-        self.client.post(self.path, {
-            'new_primary_email': 'foo1@example.com',
-            'primary': 1
-        })
-        assert User.objects.get(id=self.user.id).email == 'foo1@example.com'
-
-        # setting primary email to an existing user's email leaves it unchanged
-        self.client.post(self.path, {
-            'new_primary_email': 'foo@example.com',
-            'primary': 1
-        })
-        assert User.objects.get(id=self.user.id).email == 'foo1@example.com'
-
-        # setting primary to existing email + whitespace leaves it unchanged
-        self.client.post(self.path, {
-            'new_primary_email': 'foo@example.com\n\n',
-            'primary': 1
-        })
-        assert User.objects.get(id=self.user.id).email == 'foo1@example.com'
-
-
 class SettingsTest(TestCase):
     @fixture
     def path(self):


### PR DESCRIPTION
- Allow primary email address to be changed on managed accounts (legacy page)
- Disallow primary email address for unverified emails (enforce backend constraints)