### PR TITLE
ref(ui): Change `JsonForm` to accept a list of fields

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/formSearch.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/formSearch.jsx
@@ -13,6 +13,10 @@ export function loadSearchMap() {
 
     if (!mod) return;
 
-    addForm({formGroups: mod.default || mod.formGroups, route: mod.route});
+    addForm({
+      formGroups: mod.default || mod.formGroups,
+      fields: mod.fields,
+      route: mod.route,
+    });
   });
 }

--- a/src/sentry/static/sentry/app/utils/addForm.jsx
+++ b/src/sentry/static/sentry/app/utils/addForm.jsx
@@ -17,25 +17,28 @@ const createSearchIndex = field => {
 //   * what field(s) it matches:
 //     * what form group it belongs to
 //     * what route that belongs to
-const createSearchMap = ({route, formGroups, ...other}) => {
+const createSearchMap = ({route, formGroups, fields, ...other}) => {
+  let listOfFields = formGroups
+    ? flatMap(formGroups, formGroup => formGroup.fields)
+    : Object.keys(fields).map(fieldName => fields[fieldName]);
+
   return fromPairs(
-    flatMap(formGroups, ({title, fields}) =>
-      fields.map(field => [
-        createSearchIndex(field),
-        {
-          ...other,
-          route,
-          groupTitle: title,
-          field,
-        },
-      ])
-    )
+    listOfFields.map(field => [
+      createSearchIndex(field),
+      {
+        ...other,
+        route,
+        field,
+      },
+    ])
   );
 };
 
 /**
- * Given a formGroup ({ title: string, fields: Array<FormField> }) and route where form exists,
- * create a search index for fields. Adds to a global search store.
+ * Given a `formGroup` ({ title: string, fields: Array<FormField> }) (or just `fields`)
+ * and `route` where form exists, create a search index for fields.
+ *
+ * Adds to a global search store.
  *
  * returns formGroup
  */

--- a/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectAlertSettings.jsx
@@ -110,7 +110,7 @@ export default class ProjectAlertSettings extends AsyncView {
         >
           <JsonForm
             forms={alertsFormGroups}
-            renderBodyStart={({title}) => {
+            renderHeader={({title}) => {
               if (title === 'Digests') {
                 return (
                   <PanelAlert m={0} mb={0} type="info" icon="icon-circle-exclamation">

--- a/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
@@ -182,7 +182,7 @@ export default class ProjectGeneralSettings extends AsyncView {
             forms={projectFields}
             additionalFieldProps={{organization}}
             access={new Set(organization.access)}
-            renderBodyStart={({title}) => {
+            renderHeader={({title}) => {
               if (title === 'Client Security') {
                 return (
                   <Box p={2} pb={0}>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
@@ -36,6 +36,7 @@ class JsonForm extends React.Component {
     title: PropTypes.string,
 
     access: PropTypes.object,
+    features: PropTypes.object,
     additionalFieldProps: PropTypes.object,
     renderFooter: PropTypes.func,
     /**
@@ -91,6 +92,7 @@ class JsonForm extends React.Component {
       fields,
 
       access,
+      features,
       additionalFieldProps,
       renderFooter,
       renderHeader,
@@ -102,6 +104,7 @@ class JsonForm extends React.Component {
     let hasFormGroups = defined(forms);
     let formPanelProps = {
       access,
+      features,
       additionalFieldProps,
       renderFooter,
       renderHeader,

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -119,7 +119,7 @@ exports[`ProjectAlertSettings render() renders 1`] = `
             },
           ]
         }
-        renderBodyStart={[Function]}
+        renderHeader={[Function]}
       />
     </Form>
     <PluginList


### PR DESCRIPTION
Changes `JsonForm` to accept a simple list of fields instead of a field group title + fields list.

+ renames `renderBodyStart` to `renderHeader` for consistency with `renderFooter`

Follow-up to and depends on #7360 