### PR TITLE
fix(teams): Get rid of third confirmation on the remove teams page

### DIFF
--- a/src/sentry/templates/sentry/teams/remove.html
+++ b/src/sentry/templates/sentry/teams/remove.html
@@ -25,8 +25,7 @@
     {% endfor %}
 
     <fieldset class="form-actions">
-      <button type="submit" class="btn btn-danger"
-              onclick="return confirm('Are you sure you want to remove this team?')">{% trans "Remove Team" %}</button>
+      <button type="submit" class="btn btn-danger">{% trans "Remove Team" %}</button>
       <a href="{% absolute_uri '/organizations/{}/teams/{}/settings/' team.organization.slug team.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>
     </fieldset>
   </form>


### PR DESCRIPTION
probably also going to just add a confirm dialogue on the new settings remove team button, but this was faster and also fixes for people using old settings