### PR TITLE
fix(owners): Fix ordering of related releases

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -215,34 +215,6 @@ class Release(Model):
 
             release.delete()
 
-    @classmethod
-    def get_closest_releases(cls, project, start_version, limit=5):
-        # given a release version + project, return next
-        # `limit` releases (includes the release specified by `version`)
-        try:
-            release_dates = cls.objects.filter(
-                organization_id=project.organization_id,
-                version=start_version,
-                projects=project,
-            ).values('date_released', 'date_added').get()
-        except cls.DoesNotExist:
-            return []
-
-        start_date = release_dates['date_released'] or release_dates['date_added']
-
-        return list(Release.objects.filter(
-            projects=project,
-            organization_id=project.organization_id,
-        ).extra(select={
-                'date': 'COALESCE(date_released, date_added)',
-                }
-                ).extra(
-            where=["COALESCE(date_released, date_added) >= %s"],
-            params=[start_date]
-        ).extra(
-            order_by=['date']
-        )[:limit])
-
     @property
     def short_version(self):
         return Release.get_display_version(self.version)

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import datetime
 import six
 
 from sentry.models import (
@@ -457,43 +456,3 @@ class SetCommitsTestCase(TestCase):
         assert resolution.actor_id is None
 
         assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
-
-
-class GetClosestReleasesTestCase(TestCase):
-    def test_simple(self):
-
-        date = datetime.datetime.utcnow()
-
-        org = self.create_organization()
-        project = self.create_project(organization=org, name='foo')
-
-        # this shouldn't be included
-        release1 = Release.objects.create(
-            organization=org,
-            version='a' * 40,
-            date_released=date - datetime.timedelta(days=2),
-        )
-
-        release1.add_project(project)
-
-        release2 = Release.objects.create(
-            organization=org,
-            version='b' * 40,
-            date_released=date - datetime.timedelta(days=1),
-        )
-
-        release2.add_project(project)
-
-        release3 = Release.objects.create(
-            organization=org,
-            version='c' * 40,
-            date_released=date,
-        )
-
-        release3.add_project(project)
-
-        releases = list(Release.get_closest_releases(project, release2.version))
-
-        assert len(releases) == 2
-        assert releases[0] == release2
-        assert releases[1] == release3

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
 
-from sentry.utils.committers import score_path_match_length, tokenize_path
+from datetime import timedelta
+from django.utils import timezone
+
+from sentry.models import Release
+from sentry.testutils import TestCase
+from sentry.utils.committers import get_previous_releases, score_path_match_length, tokenize_path
 
 
 def test_score_path_match_length():
@@ -15,3 +20,42 @@ def test_tokenize_path():
     assert list(tokenize_path('foo/bar')) == ['bar', 'foo']
     assert list(tokenize_path('foo\\bar')) == ['bar', 'foo']
     assert list(tokenize_path('foo.bar')) == ['foo.bar']
+
+
+class GetPreviousReleasesTestCase(TestCase):
+    def test_simple(self):
+        current_datetime = timezone.now()
+
+        org = self.create_organization()
+        project = self.create_project(organization=org, name='foo')
+
+        release1 = Release.objects.create(
+            organization=org,
+            version='a' * 40,
+            date_released=current_datetime - timedelta(days=2),
+        )
+
+        release1.add_project(project)
+
+        release2 = Release.objects.create(
+            organization=org,
+            version='b' * 40,
+            date_released=current_datetime - timedelta(days=1),
+        )
+
+        release2.add_project(project)
+
+        # this shouldn't be included
+        release3 = Release.objects.create(
+            organization=org,
+            version='c' * 40,
+            date_released=current_datetime,
+        )
+
+        release3.add_project(project)
+
+        releases = list(get_previous_releases(project, release2.version))
+
+        assert len(releases) == 2
+        assert releases[0] == release2
+        assert releases[1] == release1


### PR DESCRIPTION
This adjusts the "recent releases" behavior to use releases that are **at or before** the first release, as newer releases certainly **cannot** be responsible for the issue.

It also moves the ``get_closest_releases`` into the committers utils as its not used by any other party.