### PR TITLE
feat(slack): Switch to workspace tokens

### DIFF
--- a/src/sentry/identity/slack/provider.py
+++ b/src/sentry/identity/slack/provider.py
@@ -13,7 +13,10 @@ class SlackIdentityProvider(OAuth2Provider):
     key = 'slack'
     name = 'Slack'
 
-    oauth_access_token_url = 'https://slack.com/api/oauth.access'
+    # TODO(epurkhiser): This identity provider is actually used for authorizing
+    # the Slack application through their Workspace Token OAuth flow, not a
+    # standard user access token flow.
+    oauth_access_token_url = 'https://slack.com/api/oauth.token'
     oauth_authorize_url = 'https://slack.com/oauth/authorize'
 
     oauth_scopes = (

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -214,7 +214,12 @@ class SlackActionEndpoint(Endpoint):
                 idp=IdentityProvider.objects.get(organization=group.organization),
             )
         except Identity.DoesNotExist:
-            associate_url = build_linking_url(integration, group.organization, user_id)
+            associate_url = build_linking_url(
+                integration,
+                group.organization,
+                user_id,
+                channel_id
+            )
 
             return self.respond({
                 'response_type': 'ephemeral',

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -1,15 +1,13 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
-
 from sentry import analytics
 from sentry import http, options
 from sentry.api import client
 from sentry.api.base import Endpoint
 from sentry.models import Group, Integration, Project, IdentityProvider, Identity, ApiKey
 from sentry.utils import json
-from sentry.utils.http import absolute_uri
 
+from .link_identity import build_linking_url
 from .utils import build_attachment, logger
 
 LINK_IDENTITY_MESSAGE = "Looks like you haven't linked your Sentry account with your Slack identity yet! <{associate_url}|Link your identity now> to perform actions in Sentry through Slack."
@@ -111,7 +109,7 @@ class SlackActionEndpoint(Endpoint):
         payload = {
             'dialog': json.dumps(dialog),
             'trigger_id': data['trigger_id'],
-            'token': integration.metadata['bot_access_token'],
+            'token': integration.metadata['access_token'],
         }
 
         session = http.build_session()
@@ -216,10 +214,7 @@ class SlackActionEndpoint(Endpoint):
                 idp=IdentityProvider.objects.get(organization=group.organization),
             )
         except Identity.DoesNotExist:
-            associate_url = absolute_uri(reverse('sentry-account-associate-identity', kwargs={
-                'organization_slug': group.organization.slug,
-                'provider_key': 'slack',
-            }))
+            associate_url = build_linking_url(integration, group.organization, user_id)
 
             return self.respond({
                 'response_type': 'ephemeral',

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -38,13 +38,12 @@ class SlackIntegration(Integration):
     metadata = metadata
 
     identity_oauth_scopes = frozenset([
-        'bot',
         'channels:read',
-        'chat:write:bot',
         'commands',
         'links:read',
         'links:write',
         'team:read',
+        'chat:write'
     ])
 
     setup_dialog_config = {
@@ -83,7 +82,7 @@ class SlackIntegration(Integration):
         data = state['identity']['data']
         assert data['ok']
 
-        scopes = sorted(data['scope'].split(','))
+        scopes = sorted(self.identity_oauth_scopes)
         team_data = self.get_team_info(data['access_token'])
 
         return {
@@ -91,18 +90,14 @@ class SlackIntegration(Integration):
             'external_id': data['team_id'],
             'metadata': {
                 'access_token': data['access_token'],
-                'bot_access_token': data['bot']['bot_access_token'],
-                'bot_user_id': data['bot']['bot_user_id'],
                 'scopes': scopes,
                 'icon': team_data['icon']['image_132'],
                 'domain_name': team_data['domain'] + '.slack.com',
             },
             'user_identity': {
                 'type': 'slack',
-                'external_id': data['user_id'],
-                'scopes': scopes,
-                'data': {
-                    'access_token': data['access_token'],
-                },
+                'external_id': data['installer_user_id'],
+                'scopes': [],
+                'data': {},
             },
         }

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import, print_function
+
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect, Http404
+from django.views.decorators.cache import never_cache
+from django.utils.translation import ugettext_lazy as _
+
+from sentry.models import Integration, Identity, IdentityProvider, IdentityStatus, Organization
+from sentry.utils.http import absolute_uri
+from sentry.utils.signing import sign, unsign
+from sentry.web.frontend.base import BaseView
+from sentry.web.helpers import render_to_response
+
+SLACK_IDENTITY_LINKED = _("Your Slack identity has been associated with your Sentry account")
+
+
+def build_linking_url(integration, organization, slack_id):
+    signed_params = sign(
+        integration_id=integration.id,
+        organization_id=organization.id,
+        slack_id=slack_id,
+    )
+
+    return absolute_uri(reverse('sentry-integration-slack-link-identity', kwargs={
+        'signed_params': signed_params,
+    }))
+
+
+class SlackLinkIdentitiyView(BaseView):
+    @never_cache
+    def handle(self, request, signed_params):
+        params = unsign(signed_params.encode('ascii', errors='ignore'))
+
+        try:
+            organization = Organization.objects.get(
+                id__in=request.user.get_orgs(),
+                id=params['organization_id'],
+            )
+        except Organization.DoesNotExist:
+            raise Http404
+
+        try:
+            integration = Integration.objects.get(
+                id=params['integration_id'],
+                organizations=organization,
+            )
+        except Integration.DoesNotExist:
+            raise Http404
+
+        try:
+            idp = IdentityProvider.objects.get(
+                type='slack',
+                organization=organization,
+            )
+        except Integration.DoesNotExist:
+            raise Http404
+
+        if request.method != 'POST':
+            return render_to_response('sentry/auth-link-identity.html', request=request, context={
+                'organization': organization,
+                'provider': integration.get_provider(),
+            })
+
+        # TODO(epurkhiser): We could do some fancy slack querying here to
+        # render a nice linking page with info about the user their linking.
+
+        Identity.objects.get_or_create(
+            external_id=params['slack_id'],
+            user=request.user,
+            idp=idp,
+            status=IdentityStatus.VALID,
+        )
+
+        messages.add_message(self.request, messages.SUCCESS, SLACK_IDENTITY_LINKED)
+
+        return HttpResponseRedirect('/')

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import, print_function
 
-from django.contrib import messages
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, Http404
+from django.http import Http404
 from django.views.decorators.cache import never_cache
-from django.utils.translation import ugettext_lazy as _
 
 from sentry import http
 from sentry.models import Integration, Identity, IdentityProvider, IdentityStatus, Organization
@@ -14,8 +12,6 @@ from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
 from .utils import logger
-
-SLACK_IDENTITY_LINKED = _("Your Slack identity has been associated with your Sentry account")
 
 
 def build_linking_url(integration, organization, slack_id, notify_channel_id):
@@ -92,6 +88,7 @@ class SlackLinkIdentitiyView(BaseView):
                 'error': resp.get('error'),
             })
 
-        messages.add_message(self.request, messages.SUCCESS, SLACK_IDENTITY_LINKED)
-
-        return HttpResponseRedirect('/')
+        return render_to_response('sentry/slack-linked.html', request=request, context={
+            'channel_id': params['notify_channel_id'],
+            'team_id': integration.external_id,
+        })

--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -4,10 +4,16 @@ from django.conf.urls import patterns, url
 
 from .action_endpoint import SlackActionEndpoint
 from .event_endpoint import SlackEventEndpoint
+from .link_identity import SlackLinkIdentitiyView
 
 
 urlpatterns = patterns(
     '',
     url(r'^action/$', SlackActionEndpoint.as_view()),
     url(r'^event/$', SlackEventEndpoint.as_view()),
+    url(
+        r'^link-identity/(?P<signed_params>[^\/]+)/$',
+        SlackLinkIdentitiyView.as_view(),
+        name='sentry-integration-slack-link-identity'
+    ),
 )

--- a/src/sentry/templates/sentry/auth-link-identity.html
+++ b/src/sentry/templates/sentry/auth-link-identity.html
@@ -17,7 +17,7 @@
   </div>
 
   <div class="align-center">
-    <p>Confirm that you'd like to link your {{ provider.name }} account identity to your Sentry account.</p>
+    <p>Confirm that you'd like to link your {{ provider.name }} identity to your Sentry account.</p>
 
     <p>
       <button type="submit" class="btn btn-default btn-login-{{ provider.key }}">

--- a/src/sentry/templates/sentry/auth-link-identity.html
+++ b/src/sentry/templates/sentry/auth-link-identity.html
@@ -17,7 +17,7 @@
   </div>
 
   <div class="align-center">
-    <p>Login with your {{ provider.name }} account to link the identity to your Sentry account.</p>
+    <p>Confirm that you'd like to link your {{ provider.name }} account identity to your Sentry account.</p>
 
     <p>
       <button type="submit" class="btn btn-default btn-login-{{ provider.key }}">

--- a/src/sentry/templates/sentry/slack-linked.html
+++ b/src/sentry/templates/sentry/slack-linked.html
@@ -8,7 +8,7 @@
 {% block main %}
   <div class="align-center">
     <p>
-      {% trans "Your slack identity has been associated with your Sentry account. You may now take actions through slack!" %}
+      {% trans "Your Slack identity has been associated with your Sentry account. You may now take actions through Slack!" %}
     </p>
     <p>
       <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">

--- a/src/sentry/templates/sentry/slack-linked.html
+++ b/src/sentry/templates/sentry/slack-linked.html
@@ -12,7 +12,7 @@
     </p>
     <p>
       <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">
-        <span class="provider-logo slack"></span> Go back to slack
+        <span class="provider-logo slack"></span> Go back to Slack
       </a>
     </p>
   </div>

--- a/src/sentry/templates/sentry/slack-linked.html
+++ b/src/sentry/templates/sentry/slack-linked.html
@@ -1,0 +1,19 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Slack Linked" %} | {{ block.super }}{% endblock %}
+{% block wrapperclass %}narrow auth{% endblock %}
+
+{% block main %}
+  <div class="align-center">
+    <p>
+      {% trans "Your slack identity has been associated with your Sentry account. You may now take actions through slack!" %}
+    </p>
+    <p>
+      <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">
+        <span class="provider-logo slack"></span> Go back to slack
+      </a>
+    </p>
+  </div>
+{% endblock %}

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import responses
 
-from django.core.urlresolvers import reverse
 from six.moves.urllib.parse import parse_qs
 
 from sentry import options
@@ -13,8 +12,8 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.utils import json
-from sentry.utils.http import absolute_uri
 from sentry.integrations.slack.action_endpoint import LINK_IDENTITY_MESSAGE
+from sentry.integrations.slack.link_identity import build_linking_url
 
 
 class BaseEventTest(APITestCase):
@@ -28,8 +27,7 @@ class BaseEventTest(APITestCase):
             provider='slack',
             external_id='TXXXXXXX1',
             metadata={
-                'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
-                'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
+                'access_token': 'xoxa-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
             }
         )
         OrganizationIntegration.objects.create(
@@ -106,10 +104,7 @@ class StatusActionTest(BaseEventTest):
             'domain': 'example',
         })
 
-        associate_url = absolute_uri(reverse('sentry-account-associate-identity', kwargs={
-            'organization_slug': self.org.slug,
-            'provider_key': 'slack',
-        }))
+        associate_url = build_linking_url(self.integration, self.org, 'invalid-id')
 
         assert resp.status_code == 200, resp.content
         assert resp.data['response_type'] == 'ephemeral'
@@ -269,7 +264,7 @@ class StatusActionTest(BaseEventTest):
         assert resp.content == ''
 
         data = parse_qs(responses.calls[0].request.body)
-        assert data['token'][0] == self.integration.metadata['bot_access_token']
+        assert data['token'][0] == self.integration.metadata['access_token']
         assert data['trigger_id'][0] == self.trigger_id
         assert 'dialog' in data
 

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -104,7 +104,7 @@ class StatusActionTest(BaseEventTest):
             'domain': 'example',
         })
 
-        associate_url = build_linking_url(self.integration, self.org, 'invalid-id')
+        associate_url = build_linking_url(self.integration, self.org, 'invalid-id', 'C065W1189')
 
         assert resp.status_code == 200, resp.content
         assert resp.data['response_type'] == 'ephemeral'

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -32,18 +32,14 @@ class SlackIntegrationTest(IntegrationTestCase):
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
         responses.add(
-            responses.POST, 'https://slack.com/api/oauth.access',
+            responses.POST, 'https://slack.com/api/oauth.token',
             json={
                 'ok': True,
                 'user_id': 'UXXXXXXX1',
                 'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
                 'team_id': 'TXXXXXXX1',
                 'team_name': 'Example',
-                'bot': {
-                    'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
-                    'bot_user_id': 'UXXXXXXX2',
-                },
-                'scope': ','.join(authorize_params['scope'].split(' ')),
+                'installer_user_id': 'UXXXXXXX1',
             }
         )
 
@@ -82,8 +78,6 @@ class SlackIntegrationTest(IntegrationTestCase):
         assert integration.name == 'Example'
         assert integration.metadata == {
             'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
-            'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
-            'bot_user_id': 'UXXXXXXX2',
             'scopes': sorted(self.provider.identity_oauth_scopes),
             'icon': 'http://example.com/ws_icon.jpg',
             'domain_name': 'test-slack-workspace.slack.com',
@@ -104,7 +98,3 @@ class SlackIntegrationTest(IntegrationTestCase):
             external_id='UXXXXXXX1',
         )
         assert identity.status == IdentityStatus.VALID
-        assert identity.scopes == sorted(self.provider.identity_oauth_scopes)
-        assert identity.data == {
-            'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
-        }

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration, OrganizationIntegration
+from sentry.testutils import TestCase
+from sentry.integrations.slack.link_identity import build_linking_url
+
+
+class SlackIntegrationLinkIdentityTest(TestCase):
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.user = self.create_user(is_superuser=False)
+        self.org = self.create_organization(owner=None)
+        self.team = self.create_team(organization=self.org, members=[self.user])
+
+        self.login_as(self.user)
+
+        self.integration = Integration.objects.create(
+            provider='slack',
+            external_id='TXXXXXXX1',
+            metadata={
+                'access_token': 'xoxa-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
+            }
+        )
+        OrganizationIntegration.objects.create(
+            organization=self.org,
+            integration=self.integration,
+        )
+
+        self.idp = IdentityProvider.objects.create(
+            type='slack',
+            organization=self.org,
+            config={},
+        )
+
+    def test_basic_flow(self):
+        linking_url = build_linking_url(
+            self.integration,
+            self.org,
+            'new-slack-id'
+        )
+
+        resp = self.client.get(linking_url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/auth-link-identity.html')
+
+        # Link identity of user
+        resp = self.client.post(linking_url)
+
+        identity = Identity.objects.filter(
+            external_id='new-slack-id',
+            user=self.user,
+        )
+
+        assert len(identity) == 1
+        assert identity[0].idp == self.idp
+        assert identity[0].status == IdentityStatus.VALID


### PR DESCRIPTION
This switches the slack integration to using Workspace tokens, which are tokens that are granted to an entire slack workspace, *not* just a single user.

This changes the linking flow, as Workspace tokens do not provide a way for users to authenticate with slack. Instead we now generate a signed link which includes the slack user ID who is intiating the linking from within slack.