### PR TITLE
fix(tagstore): Fix v2 TagKey deletes when not using Postgres of MySQL

### DIFF
--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -82,10 +82,15 @@ class V2TagStorage(TagStorage):
             def get_child_relations(self, instance):
                 # in bulk
                 model_list = (GroupTagValue, GroupTagKey, TagValue)
+
+                # required to deal with custom SQL queries and the ORM
+                # in `bulk_delete_objects`
+                key_id_field_name = 'key_id' if (db.is_postgres() or db.is_mysql()) else '_key_id'
+
                 relations = [
                     ModelRelation(m, {
                         'project_id': instance.project_id,
-                        'key_id': instance.id,
+                        key_id_field_name: instance.id,
                     }) for m in model_list
                 ]
                 return relations


### PR DESCRIPTION
Been testing with Postgres. This fixes TagKey deletes for sqlite and whatever else isn't Postgres/MySQL.