### PR TITLE
ref: Improvements to `DjangoSearchBackendTest`

### DIFF
--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -41,7 +41,7 @@ class DjangoSearchBackendTest(TestCase):
             datetime=datetime(2013, 7, 13, 3, 8, 24, 880386),
             tags={
                 'server': 'example.com',
-                'env': 'production',
+                'environment': 'production',
             }
         )
         self.event3 = self.create_event(
@@ -50,7 +50,7 @@ class DjangoSearchBackendTest(TestCase):
             datetime=datetime(2013, 8, 13, 3, 8, 24, 880386),
             tags={
                 'server': 'example.com',
-                'env': 'production',
+                'environment': 'production',
             }
         )
 
@@ -74,7 +74,7 @@ class DjangoSearchBackendTest(TestCase):
             datetime=datetime(2013, 7, 14, 3, 8, 24, 880386),
             tags={
                 'server': 'example.com',
-                'env': 'staging',
+                'environment': 'staging',
                 'url': 'http://example.com',
             }
         )
@@ -152,27 +152,34 @@ class DjangoSearchBackendTest(TestCase):
     def test_tags(self):
         results = self.backend.query(
             self.project,
-            tags={'env': 'staging'})
+            tags={'environment': 'staging'})
         assert set(results) == set([self.group2])
 
-        results = self.backend.query(self.project, tags={'env': 'example.com'})
+        results = self.backend.query(
+            self.project,
+            tags={'environment': 'example.com'})
         assert set(results) == set([])
 
-        results = self.backend.query(self.project, tags={'env': ANY})
+        results = self.backend.query(
+            self.project,
+            tags={'environment': ANY})
         assert set(results) == set([self.group2, self.group1])
 
         results = self.backend.query(
             self.project,
-            tags={'env': 'staging',
+            tags={'environment': 'staging',
                   'server': 'example.com'})
-        assert set(results) == set([self.group2])
-
-        results = self.backend.query(self.project, tags={'env': 'staging', 'server': ANY})
         assert set(results) == set([self.group2])
 
         results = self.backend.query(
             self.project,
-            tags={'env': 'staging',
+            tags={'environment': 'staging',
+                  'server': ANY})
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            tags={'environment': 'staging',
                   'server': 'bar.example.com'})
         assert set(results) == set([])
 

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -114,174 +114,143 @@ class DjangoSearchBackendTest(TestCase):
 
     def test_query(self):
         results = self.backend.query(self.project, query='foo')
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
         results = self.backend.query(self.project, query='bar')
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
     def test_sort(self):
         results = self.backend.query(self.project, sort_by='date')
-        assert len(results) == 2
-        assert results[0] == self.group1
-        assert results[1] == self.group2
+        assert list(results) == [self.group1, self.group2]
 
         results = self.backend.query(self.project, sort_by='new')
-        assert len(results) == 2
-        assert results[0] == self.group2
-        assert results[1] == self.group1
+        assert list(results) == [self.group2, self.group1]
 
         results = self.backend.query(self.project, sort_by='freq')
-        assert len(results) == 2
-        assert results[0] == self.group2
-        assert results[1] == self.group1
+        assert list(results) == [self.group2, self.group1]
 
     def test_status(self):
         results = self.backend.query(self.project, status=GroupStatus.UNRESOLVED)
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
         results = self.backend.query(self.project, status=GroupStatus.RESOLVED)
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
     def test_tags(self):
         results = self.backend.query(
             self.project,
-            tags={
-                'env': 'staging'})
-        assert len(results) == 1
-        assert results[0] == self.group2
+            tags={'env': 'staging'})
+        assert set(results) == set([self.group2])
 
         results = self.backend.query(self.project, tags={'env': 'example.com'})
-        assert len(results) == 0
+        assert set(results) == set([])
 
         results = self.backend.query(self.project, tags={'env': ANY})
-        assert len(results) == 2
+        assert set(results) == set([self.group2, self.group1])
 
         results = self.backend.query(
-            self.project, tags={'env': 'staging',
-                                'server': 'example.com'}
-        )
-        assert len(results) == 1
-        assert results[0] == self.group2
+            self.project,
+            tags={'env': 'staging',
+                  'server': 'example.com'})
+        assert set(results) == set([self.group2])
 
         results = self.backend.query(self.project, tags={'env': 'staging', 'server': ANY})
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
         results = self.backend.query(
-            self.project, tags={'env': 'staging',
-                                'server': 'bar.example.com'}
-        )
-        assert len(results) == 0
+            self.project,
+            tags={'env': 'staging',
+                  'server': 'bar.example.com'})
+        assert set(results) == set([])
 
     def test_bookmarked_by(self):
         results = self.backend.query(self.project, bookmarked_by=self.user)
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
     def test_project(self):
         results = self.backend.query(self.create_project(name='other'))
-        assert len(results) == 0
+        assert set(results) == set([])
 
     def test_pagination(self):
         results = self.backend.query(self.project, limit=1, sort_by='date')
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
         results = self.backend.query(self.project, cursor=results.next, limit=1, sort_by='date')
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
         results = self.backend.query(self.project, cursor=results.next, limit=1, sort_by='date')
-        assert len(results) == 0
+        assert set(results) == set([])
 
     def test_age_filter(self):
         results = self.backend.query(
             self.project,
             age_from=self.group2.first_seen,
         )
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
         results = self.backend.query(
             self.project,
             age_to=self.group1.first_seen + timedelta(minutes=1),
         )
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
         results = self.backend.query(
             self.project,
             age_from=self.group1.first_seen,
             age_to=self.group1.first_seen + timedelta(minutes=1),
         )
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
     def test_last_seen_filter(self):
         results = self.backend.query(
             self.project,
             last_seen_from=self.group1.last_seen,
         )
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
         results = self.backend.query(
             self.project,
             last_seen_to=self.group2.last_seen + timedelta(minutes=1),
         )
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
         results = self.backend.query(
             self.project,
             last_seen_from=self.group1.last_seen,
             last_seen_to=self.group1.last_seen + timedelta(minutes=1),
         )
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
     def test_date_filter(self):
         results = self.backend.query(
             self.project,
             date_from=self.event2.datetime,
         )
-        assert len(results) == 2
-        assert results[0] == self.group1
-        assert results[1] == self.group2
+        assert set(results) == set([self.group1, self.group2])
 
         results = self.backend.query(
             self.project,
             date_to=self.event1.datetime + timedelta(minutes=1),
         )
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
         results = self.backend.query(
             self.project,
             date_from=self.event1.datetime,
             date_to=self.event2.datetime + timedelta(minutes=1),
         )
-        assert len(results) == 2
-        assert results[0] == self.group1
-        assert results[1] == self.group2
+        assert set(results) == set([self.group1, self.group2])
 
     def test_unassigned(self):
         results = self.backend.query(self.project, unassigned=True)
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])
 
         results = self.backend.query(self.project, unassigned=False)
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
     def test_assigned_to(self):
         results = self.backend.query(self.project, assigned_to=self.user)
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
         # test team assignee
         ga = GroupAssignee.objects.get(
@@ -293,18 +262,16 @@ class DjangoSearchBackendTest(TestCase):
         assert GroupAssignee.objects.get(id=ga.id).user is None
 
         results = self.backend.query(self.project, assigned_to=self.user)
-        assert len(results) == 1
-        assert results[0] == self.group2
+        assert set(results) == set([self.group2])
 
         # test when there should be no results
         other_user = self.create_user()
         results = self.backend.query(self.project, assigned_to=other_user)
-        assert len(results) == 0
+        assert set(results) == set([])
 
     def test_subscribed_by(self):
         results = self.backend.query(
             self.group1.project,
             subscribed_by=self.user,
         )
-        assert len(results) == 1
-        assert results[0] == self.group1
+        assert set(results) == set([self.group1])


### PR DESCRIPTION
These are several improvements extracted from GH-7509 that should make reviewing that change (when resubmitted) easier to understand in isolation. These don't change the behavior of the tests in any meaningful way (they do remove some implicit assumptions around sort order of results that were only passing by coincidence and not intentionally.) The basic changes are:

- Removes some unused fixtures,
- Adds a test for `priority` sort order,
- Uses the `environment` tag instead of `env`,
- Changes independent assertions on sequence length and indexed item checks to a single assertion on `set` or `list` contents, depending on whether or not the sort order is relevant to the test scope.

