### PR TITLE
fix(tagstore): Fix merge of tagstore v2 by adding project_id to queries

### DIFF
--- a/src/sentry/tagstore/v2/models/grouptagkey.py
+++ b/src/sentry/tagstore/v2/models/grouptagkey.py
@@ -63,10 +63,6 @@ class GroupTagKey(Model):
     def key(self, key):
         self._set_key = key
 
-    @staticmethod
-    def get_select_related_for_merge():
-        return ('_key', )
-
     def merge_counts(self, new_group):
         from sentry.tagstore.v2.models import GroupTagValue
 
@@ -74,10 +70,12 @@ class GroupTagKey(Model):
             with transaction.atomic(using=router.db_for_write(GroupTagKey)):
                 GroupTagKey.objects.filter(
                     group_id=new_group.id,
+                    project_id=new_group.project_id,
                     _key_id=self._key_id,
                 ).update(
                     values_seen=GroupTagValue.objects.filter(
                         group_id=new_group.id,
+                        project_id=new_group.project_id,
                         _key_id=self._key_id,
                     ).count()
                 )

--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -99,15 +99,12 @@ class GroupTagValue(Model):
             self.first_seen = self.last_seen
         super(GroupTagValue, self).save(*args, **kwargs)
 
-    @staticmethod
-    def get_select_related_for_merge():
-        return ('_key', '_value', )
-
     def merge_counts(self, new_group):
         try:
             with transaction.atomic(using=router.db_for_write(GroupTagValue)):
                 new_obj = GroupTagValue.objects.get(
                     group_id=new_group.id,
+                    project_id=new_group.project_id,
                     _key_id=self._key_id,
                     _value_id=self._value_id,
                 )

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -316,9 +316,6 @@ def merge_objects(models, group, new_group, limit=1000, logger=None, transaction
         else:
             queryset = project_qs.filter(group_id=group.id)
 
-        if hasattr(model, 'get_select_related_for_merge'):
-            queryset = queryset.select_related(*model.get_select_related_for_merge())
-
         for obj in queryset[:limit]:
             try:
                 with transaction.atomic(using=router.db_for_write(model)):


### PR DESCRIPTION
@mattrobenolt I have no idea what I was doing with `select_related` here. Think I was crossing streams between issues. The issue was `merge_counts` didn't even have `project_id` in the queries.