### PR TITLE
ref: Improve compatibility of paginator APIs

### DIFF
--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -400,4 +400,4 @@ class SequencePaginatorTestCase(SimpleTestCase):
     def test_hits(self):
         n = 10
         paginator = SequencePaginator([(i, i) for i in range(n)])
-        assert paginator.get_result(5).hits == n
+        assert paginator.get_result(5, count_hits=True).hits == n


### PR DESCRIPTION
This change is intended to increase the substitutability of different paginator classes (to be) used in search (see GH-7509) with these changes:

- Adds `max_limit` to the `SequencePaginator` constructor (passed as `paginator_options` to the search backend `query` method),
- Adds `count_hits` to the `SequencePaginator.get_results` method (also passed to the search backend `query` method.)