### PR TITLE
feat(api): Don't 403 on health check for non-superusers

### DIFF
--- a/src/sentry/api/endpoints/system_health.py
+++ b/src/sentry/api/endpoints/system_health.py
@@ -3,18 +3,22 @@ from __future__ import absolute_import
 import itertools
 
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 
 from sentry import status_checks
 from sentry.status_checks import sort_by_severity
 from sentry.api.base import Endpoint
-from sentry.api.permissions import SuperuserPermission
+from sentry.auth.superuser import is_active_superuser
 from sentry.utils.hashlib import md5_text
 
 
 class SystemHealthEndpoint(Endpoint):
-    permission_classes = (SuperuserPermission, )
+    permission_classes = (IsAuthenticated, )
 
     def get(self, request):
+        if not is_active_superuser(request):
+            return Response()
+
         results = status_checks.check_all()
         return Response(
             {


### PR DESCRIPTION
This is confusing when users see this in their debug consoles and tend
to think something is broken. So instead we just wall the actual data
behind superuser, but let the request succeed.