### PR TITLE
feat: Implement environment-aware search and sorting

### DIFF
--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -8,297 +8,453 @@ sentry.search.django.backend
 
 from __future__ import absolute_import
 
+import functools
 from datetime import timedelta
+
 from django.db import router
 from django.db.models import Q
 from django.utils import timezone
 
 from sentry import quotas, tagstore
-from sentry.api.paginator import DateTimePaginator, Paginator
-from sentry.search.base import EMPTY, SearchBackend
+from sentry.api.paginator import DateTimePaginator, Paginator, SequencePaginator
+from sentry.search.base import SearchBackend
 from sentry.search.django.constants import (
     MSSQL_ENGINES, MSSQL_SORT_CLAUSES, MYSQL_SORT_CLAUSES, ORACLE_SORT_CLAUSES, SORT_CLAUSES,
     SQLITE_SORT_CLAUSES
 )
+from sentry.utils.dates import to_timestamp
 from sentry.utils.db import get_db_engine
 
 
+class QuerySetBuilder(object):
+    """\
+    Adds filters to a ``QuerySet`` from a ``parameters`` mapping.
+
+    ``Condition`` objects are registered by their parameter name and used to
+    update the ``QuerySet`` instance provided to the ``build`` method if they
+    are present in the ``parameters`` mapping.
+    """
+
+    def __init__(self, conditions):
+        self.conditions = conditions
+
+    def build(self, queryset, parameters):
+        for name, condition in self.conditions.items():
+            if name in parameters:
+                queryset = condition.apply(queryset, name, parameters)
+        return queryset
+
+
+class Condition(object):
+    """\
+    Adds a single filter to a ``QuerySet`` object. Used with
+    ``QuerySetBuilder``.
+    """
+
+    def apply(self, queryset, name, parameters):
+        raise NotImplementedError
+
+
+class CallbackCondition(Condition):
+    def __init__(self, callback, destructive=True):
+        self.callback = callback
+        self.destructive = destructive
+
+    def apply(self, queryset, name, parameters):
+        accessor = parameters.pop if self.destructive else parameters.__getitem__
+        return self.callback(queryset, accessor(name))
+
+
+class ScalarCondition(Condition):
+    """\
+    Adds a scalar filter (less than or greater than are supported) to a
+    ``QuerySet`` object. Whether or not the filter is inclusive is defined by
+    the '{parameter_name}_inclusive' parameter.
+    """
+
+    def __init__(self, field, operator, destructive=True):
+        assert operator in ['lt', 'gt']
+        self.field = field
+        self.operator = operator
+        self.destructive = destructive
+
+    def apply(self, queryset, name, parameters):
+        accessor = parameters.pop if self.destructive else parameters.__getitem__
+        inclusive = accessor('{}_inclusive'.format(name))
+        return queryset.filter(**{
+            '{}__{}{}'.format(
+                self.field,
+                self.operator,
+                'e' if inclusive else ''
+            ): accessor(name)
+        })
+
+
+def get_sql_table(model):
+    return '{}'.format(model._meta.db_table)
+
+
+def get_sql_column(model, field):
+    "Convert a model class and field name to it's (unquoted!) SQL column representation."
+    return '{}.{}'.format(*[
+        get_sql_table(model),
+        model._meta.get_field_by_name(field)[0].column,
+    ])
+
+
+sort_strategies = {
+    # sort_by -> Tuple[
+    #   Paginator,
+    #   String: QuerySet order_by parameter
+    # ]
+    'priority': (Paginator, '-score'),
+    'date': (DateTimePaginator, '-last_seen'),
+    'new': (DateTimePaginator, '-first_seen'),
+    'freq': (Paginator, '-times_seen'),
+}
+
+
+def get_priority_sort_expression(model):
+    engine = get_db_engine(router.db_for_read(model))
+    table = get_sql_table(model)
+    if 'postgres' in engine:
+        return 'log({table}.times_seen) * 600 + {table}.last_seen::abstime::int'.format(table=table)
+    else:
+        # TODO: This should be improved on other databases where possible.
+        # (This doesn't work on some databases: SQLite for example doesn't
+        # have a built-in logarithm function.)
+        return '{}.times_seen'.format(table)
+
+
+environment_sort_strategies = {
+    # sort_by -> Tuple[
+    #   Function[Model] returning String: SQL expression to generate sort value (of type T, used below),
+    #   Function[T] -> int: function for converting sort value to cursor value),
+    # ]
+    'priority': (
+        get_priority_sort_expression,
+        int,
+    ),
+    'date': (
+        lambda model: '{}.last_seen'.format(get_sql_table(model)),
+        lambda score: int(to_timestamp(score) * 1000),
+    ),
+    'new': (
+        lambda model: '{}.first_seen'.format(get_sql_table(model)),
+        lambda score: int(to_timestamp(score) * 1000),
+    ),
+    'freq': (
+        lambda model: '{}.times_seen'.format(get_sql_table(model)),
+        int,
+    ),
+}
+
+
+def get_sort_clause(sort_by):
+    engine = get_db_engine('default')
+    if engine.startswith('sqlite'):
+        return SQLITE_SORT_CLAUSES[sort_by]
+    elif engine.startswith('mysql'):
+        return MYSQL_SORT_CLAUSES[sort_by]
+    elif engine.startswith('oracle'):
+        return ORACLE_SORT_CLAUSES[sort_by]
+    elif engine in MSSQL_ENGINES:
+        return MSSQL_SORT_CLAUSES[sort_by]
+    else:
+        return SORT_CLAUSES[sort_by]
+
+
+def assigned_to_filter(queryset, user, project):
+    from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
+
+    teams = Team.objects.filter(
+        id__in=OrganizationMemberTeam.objects.filter(
+            organizationmember__in=OrganizationMember.objects.filter(
+                user=user,
+                organization_id=project.organization_id,
+            ),
+            is_active=True,
+        ).values('team')
+    )
+
+    return queryset.filter(
+        Q(assignee_set__user=user, assignee_set__project=project) |
+        Q(assignee_set__team__in=teams)
+    )
+
+
 class DjangoSearchBackend(SearchBackend):
-    def _build_queryset(
-        self,
-        project,
-        query=None,
-        status=None,
-        tags=None,
-        bookmarked_by=None,
-        assigned_to=None,
-        first_release=None,
-        sort_by='date',
-        unassigned=None,
-        subscribed_by=None,
-        age_from=None,
-        age_from_inclusive=True,
-        age_to=None,
-        age_to_inclusive=True,
-        last_seen_from=None,
-        last_seen_from_inclusive=True,
-        last_seen_to=None,
-        last_seen_to_inclusive=True,
-        date_from=None,
-        date_from_inclusive=True,
-        date_to=None,
-        date_to_inclusive=True,
-        active_at_from=None,
-        active_at_from_inclusive=True,
-        active_at_to=None,
-        active_at_to_inclusive=True,
-        times_seen=None,
-        times_seen_lower=None,
-        times_seen_lower_inclusive=True,
-        times_seen_upper=None,
-        times_seen_upper_inclusive=True,
-        cursor=None,
-        limit=None,
-        environment=None,
-    ):
-        from sentry.models import (
-            Event, Group, GroupSubscription, GroupStatus, OrganizationMember,
-            OrganizationMemberTeam, Team
-        )
+    def query(self, project, tags=None, environment=None, sort_by='date', limit=100,
+              cursor=None, count_hits=False, paginator_options=None, **parameters):
+        from sentry.models import (Environment, Group, GroupEnvironment,
+                                   GroupStatus, GroupSubscription, Release)
+
+        if paginator_options is None:
+            paginator_options = {}
 
         if tags is None:
             tags = {}
 
-        engine = get_db_engine('default')
-
-        queryset = Group.objects.filter(project=project)
-
-        if query:
-            # TODO(dcramer): if we want to continue to support search on SQL
-            # we should at least optimize this in Postgres so that it does
-            # the query filter **after** the index filters, and restricts the
-            # result set
-            queryset = queryset.filter(
-                Q(message__icontains=query) | Q(culprit__icontains=query))
-
-        if status is None:
-            status_in = (
-                GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS,
+        group_queryset = QuerySetBuilder({
+            'query': CallbackCondition(
+                lambda queryset, query: queryset.filter(
+                    Q(message__icontains=query) | Q(culprit__icontains=query),
+                ) if query else queryset,
+            ),
+            'status': CallbackCondition(
+                lambda queryset, status: queryset.filter(status=status),
+            ),
+            'bookmarked_by': CallbackCondition(
+                lambda queryset, user: queryset.filter(
+                    bookmark_set__project=project,
+                    bookmark_set__user=user,
+                ),
+            ),
+            'assigned_to': CallbackCondition(
+                functools.partial(assigned_to_filter, project=project),
+            ),
+            'unassigned': CallbackCondition(
+                lambda queryset, unassigned: queryset.filter(
+                    assignee_set__isnull=unassigned,
+                ),
+            ),
+            'subscribed_by': CallbackCondition(
+                lambda queryset, user: queryset.filter(
+                    id__in=GroupSubscription.objects.filter(
+                        project=project,
+                        user=user,
+                        is_active=True,
+                    ).values_list('group'),
+                ),
+            ),
+            'active_at_from': ScalarCondition('active_at', 'gt'),
+            'active_at_to': ScalarCondition('active_at', 'lt'),
+        }).build(
+            Group.objects.filter(project=project).exclude(status__in=[
+                GroupStatus.PENDING_DELETION,
+                GroupStatus.DELETION_IN_PROGRESS,
                 GroupStatus.PENDING_MERGE,
-            )
-            queryset = queryset.exclude(status__in=status_in)
-        else:
-            queryset = queryset.filter(status=status)
-
-        if bookmarked_by:
-            queryset = queryset.filter(
-                bookmark_set__project=project,
-                bookmark_set__user=bookmarked_by,
-            )
-
-        if assigned_to:
-            teams = Team.objects.filter(
-                id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__in=OrganizationMember.objects.filter(
-                        user=assigned_to,
-                        organization_id=project.organization_id,
-                    ),
-                    is_active=True,
-                ).values('team')
-            )
-
-            queryset = queryset.filter(
-                Q(assignee_set__user=assigned_to, assignee_set__project=project) |
-                Q(assignee_set__team__in=teams)
-            )
-        elif unassigned in (True, False):
-            queryset = queryset.filter(
-                assignee_set__isnull=unassigned,
-            )
-
-        if subscribed_by is not None:
-            queryset = queryset.filter(
-                id__in=GroupSubscription.objects.filter(
-                    project=project,
-                    user=subscribed_by,
-                    is_active=True,
-                ).values_list('group'),
-            )
-
-        if first_release:
-            if first_release is EMPTY:
-                return queryset.none()
-            queryset = queryset.filter(
-                first_release__organization_id=project.organization_id,
-                first_release__version=first_release,
-            )
-
-        if environment is not None:
-            # XXX: This overwrites the ``environment`` tag, if present, to
-            # ensure that the result set is limited to groups that have been
-            # seen in this environment (there is no way to search for groups
-            # that match multiple values of a single tag without changes to the
-            # tagstore API.)
-            tags['environment'] = environment.name
-
-        if tags:
-            matches = tagstore.get_group_ids_for_search_filter(
-                project.id,
-                environment.id if environment is not None else None,
-                tags,
-            )
-            if not matches:
-                return queryset.none()
-            queryset = queryset.filter(
-                id__in=matches,
-            )
-
-        if age_from or age_to:
-            params = {}
-            if age_from:
-                if age_from_inclusive:
-                    params['first_seen__gte'] = age_from
-                else:
-                    params['first_seen__gt'] = age_from
-            if age_to:
-                if age_to_inclusive:
-                    params['first_seen__lte'] = age_to
-                else:
-                    params['first_seen__lt'] = age_to
-            queryset = queryset.filter(**params)
-
-        if last_seen_from or last_seen_to:
-            params = {}
-            if last_seen_from:
-                if last_seen_from_inclusive:
-                    params['last_seen__gte'] = last_seen_from
-                else:
-                    params['last_seen__gt'] = last_seen_from
-            if last_seen_to:
-                if last_seen_to_inclusive:
-                    params['last_seen__lte'] = last_seen_to
-                else:
-                    params['last_seen__lt'] = last_seen_to
-            queryset = queryset.filter(**params)
-
-        if active_at_from or active_at_to:
-            params = {}
-            if active_at_from:
-                if active_at_from_inclusive:
-                    params['active_at__gte'] = active_at_from
-                else:
-                    params['active_at__gt'] = active_at_from
-            if active_at_to:
-                if active_at_to_inclusive:
-                    params['active_at__lte'] = active_at_to
-                else:
-                    params['active_at__lt'] = active_at_to
-            queryset = queryset.filter(**params)
-
-        if times_seen is not None:
-            queryset = queryset.filter(times_seen=times_seen)
-
-        if times_seen_lower is not None or times_seen_upper is not None:
-            params = {}
-            if times_seen_lower is not None:
-                if times_seen_lower_inclusive:
-                    params['times_seen__gte'] = times_seen_lower
-                else:
-                    params['times_seen__gt'] = times_seen_lower
-            if times_seen_upper is not None:
-                if times_seen_upper_inclusive:
-                    params['times_seen__lte'] = times_seen_upper
-                else:
-                    params['times_seen__lt'] = times_seen_upper
-            queryset = queryset.filter(**params)
-
-        if date_from or date_to:
-            params = {
-                'project_id': project.id,
-            }
-            if date_from:
-                if date_from_inclusive:
-                    params['datetime__gte'] = date_from
-                else:
-                    params['datetime__gt'] = date_from
-            if date_to:
-                if date_to_inclusive:
-                    params['datetime__lte'] = date_to
-                else:
-                    params['datetime__lt'] = date_to
-
-            event_queryset = Event.objects.filter(**params)
-
-            if query:
-                event_queryset = event_queryset.filter(
-                    message__icontains=query)
-
-            # limit to the first 1000 results
-            group_ids = event_queryset.distinct().values_list(
-                'group_id', flat=True)[:1000]
-
-            # if Event is not on the primary database remove Django's
-            # implicit subquery by coercing to a list
-            base = router.db_for_read(Group)
-            using = router.db_for_read(Event)
-            # MySQL also cannot do a LIMIT inside of a subquery
-            if base != using or engine.startswith('mysql'):
-                group_ids = list(group_ids)
-
-            queryset = queryset.filter(
-                id__in=group_ids,
-            )
-
-        if engine.startswith('sqlite'):
-            score_clause = SQLITE_SORT_CLAUSES[sort_by]
-        elif engine.startswith('mysql'):
-            score_clause = MYSQL_SORT_CLAUSES[sort_by]
-        elif engine.startswith('oracle'):
-            score_clause = ORACLE_SORT_CLAUSES[sort_by]
-        elif engine in MSSQL_ENGINES:
-            score_clause = MSSQL_SORT_CLAUSES[sort_by]
-        else:
-            score_clause = SORT_CLAUSES[sort_by]
+            ]),
+            parameters,
+        )
 
         # filter out groups which are beyond the retention period
         retention = quotas.get_event_retention(organization=project.organization)
         if retention:
-            queryset = queryset.filter(
+            group_queryset = group_queryset.filter(
                 last_seen__gte=timezone.now() - timedelta(days=retention)
             )
 
-        queryset = queryset.extra(
-            select={'sort_value': score_clause},
-        )
-        return queryset
+        if environment is not None:
+            if 'environment' in tags:
+                # TODO: This should probably just overwrite the existing tag,
+                # rather than asserting on it, but...?
+                assert Environment.objects.get(
+                    projects=project,
+                    name=tags.pop('environment'),
+                ).id == environment.id
 
-    def query(self, project, count_hits=False, paginator_options=None, **kwargs):
-        if paginator_options is None:
-            paginator_options = {}
+            group_queryset = QuerySetBuilder({
+                'first_release': CallbackCondition(
+                    lambda queryset, version: queryset.extra(
+                        where=[
+                            '{} = {}'.format(
+                                get_sql_column(GroupEnvironment, 'first_release_id'),
+                                get_sql_column(Release, 'id'),
+                            ),
+                            '{} = %s'.format(
+                                get_sql_column(Release, 'organization'),
+                            ),
+                            '{} = %s'.format(
+                                get_sql_column(Release, 'version'),
+                            ),
+                        ],
+                        params=[project.organization_id, version],
+                        tables=[Release._meta.db_table],
+                    ),
+                ),
+                'times_seen': CallbackCondition(
+                    # This condition represents the exact number of times that
+                    # an issue has been seen in an environment. Since an issue
+                    # can't be seen in an environment more times than the issue
+                    # was seen overall, we can safely exclude any groups that
+                    # don't have at least that many events.
+                    lambda queryset, times_seen: queryset.exclude(
+                        times_seen__lt=times_seen,
+                    ),
+                    destructive=False,
+                ),
+                'times_seen_lower': CallbackCondition(
+                    # This condition represents the lower threshold for the
+                    # number of times an issue has been seen in an environment.
+                    # Since an issue can't be seen in an environment more times
+                    # than the issue was seen overall, we can safely exclude
+                    # any groups that haven't met that threshold.
+                    lambda queryset, times_seen: queryset.exclude(
+                        times_seen__lt=times_seen,
+                    ),
+                    destructive=False,
+                ),
+                # The following conditions make a few assertions that are are
+                # correct in an abstract sense but may not accurately reflect
+                # the existing implementation (see GH-5289). These assumptions
+                # are that 1. The first seen time for a Group is the minimum
+                # value of the first seen time for all of it's GroupEnvironment
+                # relations; 2. The last seen time for a Group is the maximum
+                # value of the last seen time for all of it's GroupEnvironment
+                # relations; 3. The first seen time is always less than or
+                # equal to the last seen time.
+                'age_from': CallbackCondition(
+                    # This condition represents the lower threshold for "first
+                    # seen" time for an environment. Due to assertions #1 and
+                    # #3, we can exclude any groups where the "last seen" time
+                    # is prior to this timestamp.
+                    lambda queryset, first_seen: queryset.exclude(
+                        last_seen__lt=first_seen,
+                    ),
+                    destructive=False,
+                ),
+                'age_to': CallbackCondition(
+                    # This condition represents the upper threshold for "first
+                    # seen" time for an environment. Due to assertions #1, we
+                    # can exclude any values where the group first seen is
+                    # greater than that threshold.
+                    lambda queryset, first_seen: queryset.exclude(
+                        first_seen__gt=first_seen,
+                    ),
+                    destructive=False,
+                ),
+                'last_seen_from': CallbackCondition(
+                    # This condition represents the lower threshold for "last
+                    # seen" time for an environment. Due to assertion #2, we
+                    # can exclude any values where the group last seen value is
+                    # less than that threshold.
+                    lambda queryset, last_seen: queryset.exclude(
+                        last_seen__lt=last_seen,
+                    ),
+                    destructive=False,
+                ),
+                'last_seen_to': CallbackCondition(
+                    # This condition represents the upper threshold for "last
+                    # seen" time for an environment. Due to assertions #2 and
+                    # #3, we can exclude any values where the group first seen
+                    # value is greater than that threshold.
+                    lambda queryset, last_seen: queryset.exclude(
+                        first_seen__gt=last_seen,
+                    ),
+                    destructive=False,
+                ),
+            }).build(
+                group_queryset.extra(
+                    where=[
+                        '{} = {}'.format(
+                            get_sql_column(Group, 'id'),
+                            get_sql_column(GroupEnvironment, 'group_id'),
+                        ),
+                        '{} = %s'.format(
+                            get_sql_column(GroupEnvironment, 'environment_id'),
+                        ),
+                    ],
+                    params=[environment.id],
+                    tables=[GroupEnvironment._meta.db_table],
+                ),
+                parameters,
+            )
 
-        queryset = self._build_queryset(project=project, **kwargs)
+            get_sort_expression, sort_value_to_cursor_value = environment_sort_strategies[sort_by]
 
-        sort_by = kwargs.get('sort_by', 'date')
-        limit = kwargs.get('limit', 100)
-        cursor = kwargs.get('cursor')
+            group_tag_value_queryset = tagstore.get_group_tag_value_qs(
+                project.id,
+                set(group_queryset.values_list('id', flat=True)),  # TODO: Limit?,
+                environment.id,
+                'environment',
+                environment.name,
+            )
 
-        # HACK: don't sort by the same column twice
-        if sort_by == 'date':
-            paginator_cls = DateTimePaginator
-            sort_clause = '-last_seen'
-        elif sort_by == 'priority':
-            paginator_cls = Paginator
-            sort_clause = '-score'
-        elif sort_by == 'new':
-            paginator_cls = DateTimePaginator
-            sort_clause = '-first_seen'
-        elif sort_by == 'freq':
-            paginator_cls = Paginator
-            sort_clause = '-times_seen'
+            candidates = dict(
+                QuerySetBuilder({
+                    'age_from': ScalarCondition('first_seen', 'gt'),
+                    'age_to': ScalarCondition('first_seen', 'lt'),
+                    'last_seen_from': ScalarCondition('last_seen', 'gt'),
+                    'last_seen_to': ScalarCondition('last_seen', 'lt'),
+                    'times_seen': CallbackCondition(
+                        lambda queryset, times_seen: queryset.filter(times_seen=times_seen),
+                    ),
+                    'times_seen_lower': ScalarCondition('times_seen', 'gt'),
+                    'times_seen_upper': ScalarCondition('times_seen', 'lt'),
+                }).build(
+                    group_tag_value_queryset,
+                    parameters,
+                ).extra(
+                    select={
+                        'sort_value': get_sort_expression(group_tag_value_queryset.model),
+                    },
+                ).values_list('group_id', 'sort_value')
+            )
+
+            if tags:
+                matches = tagstore.get_group_ids_for_search_filter(
+                    project.id,
+                    environment.id,
+                    tags,
+                    candidates.keys(),
+                    limit=len(candidates),
+                )
+                for key in set(candidates) - set(matches or []):
+                    del candidates[key]
+
+            result = SequencePaginator(
+                map(
+                    lambda (id, score): (sort_value_to_cursor_value(score), id),
+                    candidates.items(),
+                ),
+                reverse=True,
+                **paginator_options
+            ).get_result(limit, cursor, count_hits=count_hits)
+
+            result.results = filter(
+                None,
+                map(
+                    Group.objects.in_bulk(result.results).get,
+                    result.results,
+                ),
+            )
+
+            return result
         else:
-            paginator_cls = Paginator
-            sort_clause = '-sort_value'
+            group_queryset = QuerySetBuilder({
+                'first_release': CallbackCondition(
+                    lambda queryset, version: queryset.filter(
+                        first_release__organization_id=project.organization_id,
+                        first_release__version=version,
+                    ),
+                ),
+                'age_from': ScalarCondition('first_seen', 'gt'),
+                'age_to': ScalarCondition('first_seen', 'lt'),
+                'last_seen_from': ScalarCondition('last_seen', 'gt'),
+                'last_seen_to': ScalarCondition('last_seen', 'lt'),
+                'times_seen': CallbackCondition(
+                    lambda queryset, times_seen: queryset.filter(times_seen=times_seen),
+                ),
+                'times_seen_lower': ScalarCondition('times_seen', 'gt'),
+                'times_seen_upper': ScalarCondition('times_seen', 'lt'),
+            }).build(
+                group_queryset,
+                parameters,
+            ).extra(
+                select={
+                    'sort_value': get_sort_clause(sort_by),
+                },
+            )
 
-        queryset = queryset.order_by(sort_clause)
-        paginator = paginator_cls(queryset, sort_clause, **paginator_options)
-        return paginator.get_result(limit, cursor, count_hits=count_hits)
+            if tags:
+                matches = tagstore.get_group_ids_for_search_filter(project.id, None, tags)
+                if matches:
+                    group_queryset = group_queryset.filter(id__in=matches)
+                else:
+                    group_queryset = group_queryset.none()
+
+            paginator_cls, sort_clause = sort_strategies[sort_by]
+            group_queryset = group_queryset.order_by(sort_clause)
+            paginator = paginator_cls(group_queryset, sort_clause, **paginator_options)
+            return paginator.get_result(limit, cursor, count_hits=count_hits)

--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -56,13 +56,11 @@ class Condition(object):
 
 
 class CallbackCondition(Condition):
-    def __init__(self, callback, destructive=True):
+    def __init__(self, callback):
         self.callback = callback
-        self.destructive = destructive
 
     def apply(self, queryset, name, parameters):
-        accessor = parameters.pop if self.destructive else parameters.__getitem__
-        return self.callback(queryset, accessor(name))
+        return self.callback(queryset, parameters[name])
 
 
 class ScalarCondition(Condition):
@@ -72,21 +70,23 @@ class ScalarCondition(Condition):
     the '{parameter_name}_inclusive' parameter.
     """
 
-    def __init__(self, field, operator, destructive=True):
+    def __init__(self, field, operator, default_inclusivity=False):
         assert operator in ['lt', 'gt']
         self.field = field
         self.operator = operator
-        self.destructive = destructive
+        self.default_inclusivity = default_inclusivity
 
     def apply(self, queryset, name, parameters):
-        accessor = parameters.pop if self.destructive else parameters.__getitem__
-        inclusive = accessor('{}_inclusive'.format(name))
+        inclusive = parameters.get(
+            '{}_inclusive'.format(name),
+            self.default_inclusivity,
+        )
         return queryset.filter(**{
             '{}__{}{}'.format(
                 self.field,
                 self.operator,
                 'e' if inclusive else ''
-            ): accessor(name)
+            ): parameters[name]
         })
 
 
@@ -282,7 +282,6 @@ class DjangoSearchBackend(SearchBackend):
                     lambda queryset, times_seen: queryset.exclude(
                         times_seen__lt=times_seen,
                     ),
-                    destructive=False,
                 ),
                 'times_seen_lower': CallbackCondition(
                     # This condition represents the lower threshold for the
@@ -293,7 +292,6 @@ class DjangoSearchBackend(SearchBackend):
                     lambda queryset, times_seen: queryset.exclude(
                         times_seen__lt=times_seen,
                     ),
-                    destructive=False,
                 ),
                 # The following conditions make a few assertions that are are
                 # correct in an abstract sense but may not accurately reflect
@@ -312,7 +310,6 @@ class DjangoSearchBackend(SearchBackend):
                     lambda queryset, first_seen: queryset.exclude(
                         last_seen__lt=first_seen,
                     ),
-                    destructive=False,
                 ),
                 'age_to': CallbackCondition(
                     # This condition represents the upper threshold for "first
@@ -322,7 +319,6 @@ class DjangoSearchBackend(SearchBackend):
                     lambda queryset, first_seen: queryset.exclude(
                         first_seen__gt=first_seen,
                     ),
-                    destructive=False,
                 ),
                 'last_seen_from': CallbackCondition(
                     # This condition represents the lower threshold for "last
@@ -332,7 +328,6 @@ class DjangoSearchBackend(SearchBackend):
                     lambda queryset, last_seen: queryset.exclude(
                         last_seen__lt=last_seen,
                     ),
-                    destructive=False,
                 ),
                 'last_seen_to': CallbackCondition(
                     # This condition represents the upper threshold for "last
@@ -342,7 +337,6 @@ class DjangoSearchBackend(SearchBackend):
                     lambda queryset, last_seen: queryset.exclude(
                         first_seen__gt=last_seen,
                     ),
-                    destructive=False,
                 ),
             }).build(
                 group_queryset.extra(

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -2,12 +2,13 @@
 
 from __future__ import absolute_import
 
+import pytz
 from datetime import datetime, timedelta
 
 from sentry import tagstore
 from sentry.event_manager import ScoreClause
 from sentry.models import (
-    GroupAssignee, GroupBookmark, GroupStatus, GroupSubscription
+    Environment, Event, GroupAssignee, GroupBookmark, GroupEnvironment, GroupStatus, GroupSubscription
 )
 from sentry.search.base import ANY
 from sentry.search.django.backend import DjangoSearchBackend
@@ -27,18 +28,18 @@ class DjangoSearchBackendTest(TestCase):
             message='foo',
             times_seen=5,
             status=GroupStatus.UNRESOLVED,
-            last_seen=datetime(2013, 8, 13, 3, 8, 24, 880386),
-            first_seen=datetime(2013, 7, 13, 3, 8, 24, 880386),
+            last_seen=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
+            first_seen=datetime(2013, 7, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
             score=ScoreClause.calculate(
                 times_seen=5,
-                last_seen=datetime(2013, 8, 13, 3, 8, 24, 880386),
+                last_seen=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
             ),
         )
 
         self.event1 = self.create_event(
             event_id='a' * 32,
             group=self.group1,
-            datetime=datetime(2013, 7, 13, 3, 8, 24, 880386),
+            datetime=datetime(2013, 7, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
             tags={
                 'server': 'example.com',
                 'environment': 'production',
@@ -47,7 +48,7 @@ class DjangoSearchBackendTest(TestCase):
         self.event3 = self.create_event(
             event_id='c' * 32,
             group=self.group1,
-            datetime=datetime(2013, 8, 13, 3, 8, 24, 880386),
+            datetime=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
             tags={
                 'server': 'example.com',
                 'environment': 'production',
@@ -60,18 +61,18 @@ class DjangoSearchBackendTest(TestCase):
             message='bar',
             times_seen=10,
             status=GroupStatus.RESOLVED,
-            last_seen=datetime(2013, 7, 14, 3, 8, 24, 880386),
-            first_seen=datetime(2013, 7, 14, 3, 8, 24, 880386),
+            last_seen=datetime(2013, 7, 14, 3, 8, 24, 880386, tzinfo=pytz.utc),
+            first_seen=datetime(2013, 7, 14, 3, 8, 24, 880386, tzinfo=pytz.utc),
             score=ScoreClause.calculate(
                 times_seen=10,
-                last_seen=datetime(2013, 7, 14, 3, 8, 24, 880386),
+                last_seen=datetime(2013, 7, 14, 3, 8, 24, 880386, tzinfo=pytz.utc),
             ),
         )
 
         self.event2 = self.create_event(
             event_id='b' * 32,
             group=self.group2,
-            datetime=datetime(2013, 7, 14, 3, 8, 24, 880386),
+            datetime=datetime(2013, 7, 14, 3, 8, 24, 880386, tzinfo=pytz.utc),
             tags={
                 'server': 'example.com',
                 'environment': 'staging',
@@ -79,22 +80,10 @@ class DjangoSearchBackendTest(TestCase):
             }
         )
 
-        for key, value in self.event1.data['tags']:
-            tagstore.create_group_tag_value(
-                project_id=self.group1.project_id,
-                group_id=self.group1.id,
-                environment_id=None,
-                key=key,
-                value=value,
-            )
-        for key, value in self.event2.data['tags']:
-            tagstore.create_group_tag_value(
-                project_id=self.group2.project_id,
-                group_id=self.group2.id,
-                environment_id=None,
-                key=key,
-                value=value,
-            )
+        self.environments = {}
+
+        for event in Event.objects.filter(project_id=self.project.id):
+            self._setup_tags_for_event(event)
 
         GroupBookmark.objects.create(
             user=self.user,
@@ -122,11 +111,76 @@ class DjangoSearchBackendTest(TestCase):
             is_active=False,
         )
 
+    def _setup_tags_for_event(self, event):
+        tags = dict(event.data['tags'])
+
+        try:
+            environment = self.environments[tags['environment']]
+        except KeyError:
+            environment = self.environments[tags['environment']] = Environment.get_or_create(
+                event.project,
+                tags['environment'],
+            )
+
+        GroupEnvironment.objects.get_or_create(
+            environment_id=environment.id,
+            group_id=event.group_id,
+        )
+
+        for key, value in tags.items():
+            for environment_id in [None, environment.id]:
+                tag_value, created = tagstore.get_or_create_group_tag_value(
+                    project_id=event.project_id,
+                    group_id=event.group_id,
+                    environment_id=environment_id,
+                    key=key,
+                    value=value,
+                )
+
+                if created:  # XXX: Hack for tagstore compat
+                    tag_value.update(
+                        times_seen=1,
+                        first_seen=event.datetime,
+                        last_seen=event.datetime,
+                    )
+                else:
+                    updates = {
+                        'times_seen': tag_value.times_seen + 1,
+                    }
+
+                    if event.datetime < tag_value.first_seen:
+                        updates['first_seen'] = event.datetime
+
+                    if event.datetime > tag_value.last_seen:
+                        updates['last_seen'] = event.datetime
+
+                    if updates:
+                        tag_value.update(**updates)
+
     def test_query(self):
         results = self.backend.query(self.project, query='foo')
         assert set(results) == set([self.group1])
 
         results = self.backend.query(self.project, query='bar')
+        assert set(results) == set([self.group2])
+
+    def test_query_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            query='foo')
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            query='bar')
+        assert set(results) == set([])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            query='bar')
         assert set(results) == set([self.group2])
 
     def test_sort(self):
@@ -142,12 +196,71 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project, sort_by='priority')
         assert list(results) == [self.group1, self.group2]
 
+    def test_sort_with_environment(self):
+        for dt in [
+                self.group1.first_seen + timedelta(days=1),
+                self.group1.first_seen + timedelta(days=2),
+                self.group1.last_seen + timedelta(days=1)]:
+            event = self.create_event(
+                group=self.group2,
+                datetime=dt,
+                tags={'environment': 'production'}
+            )
+            self._setup_tags_for_event(event)
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            sort_by='date',
+        )
+        assert list(results) == [self.group2, self.group1]
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            sort_by='new',
+        )
+        assert list(results) == [self.group2, self.group1]
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            sort_by='freq',
+        )
+        assert list(results) == [self.group2, self.group1]
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            sort_by='priority',
+        )
+        assert list(results) == [self.group2, self.group1]
+
     def test_status(self):
         results = self.backend.query(self.project, status=GroupStatus.UNRESOLVED)
         assert set(results) == set([self.group1])
 
         results = self.backend.query(self.project, status=GroupStatus.RESOLVED)
         assert set(results) == set([self.group2])
+
+    def test_status_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            status=GroupStatus.UNRESOLVED)
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            status=GroupStatus.RESOLVED)
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            status=GroupStatus.RESOLVED)
+        assert set(results) == set([])
 
     def test_tags(self):
         results = self.backend.query(
@@ -183,9 +296,59 @@ class DjangoSearchBackendTest(TestCase):
                   'server': 'bar.example.com'})
         assert set(results) == set([])
 
+    def test_tags_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            tags={'server': 'example.com'})
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            tags={'server': 'example.com'})
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            tags={'server': ANY})
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            tags={'url': 'http://example.com'})
+        assert set(results) == set([])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            tags={'url': 'http://example.com'})
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            tags={'server': 'bar.example.com'})
+        assert set(results) == set([])
+
     def test_bookmarked_by(self):
         results = self.backend.query(self.project, bookmarked_by=self.user)
         assert set(results) == set([self.group2])
+
+    def test_bookmarked_by_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            bookmarked_by=self.user)
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            bookmarked_by=self.user)
+        assert set(results) == set([])
 
     def test_project(self):
         results = self.backend.query(self.create_project(name='other'))
@@ -201,23 +364,122 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project, cursor=results.next, limit=1, sort_by='date')
         assert set(results) == set([])
 
+    def test_pagination_with_environment(self):
+        for dt in [
+                self.group1.first_seen + timedelta(days=1),
+                self.group1.first_seen + timedelta(days=2),
+                self.group1.last_seen + timedelta(days=1)]:
+            event = self.create_event(
+                group=self.group2,
+                datetime=dt,
+                tags={'environment': 'production'}
+            )
+            self._setup_tags_for_event(event)
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            sort_by='date',
+            limit=1,
+            count_hits=True,
+        )
+        assert list(results) == [self.group2]
+        assert results.hits == 2
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            sort_by='date',
+            limit=1,
+            cursor=results.next,
+            count_hits=True,
+        )
+        assert list(results) == [self.group1]
+        assert results.hits == 2
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            sort_by='date',
+            limit=1,
+            cursor=results.next,
+            count_hits=True,
+        )
+        assert list(results) == []
+        assert results.hits == 2
+
     def test_age_filter(self):
         results = self.backend.query(
             self.project,
             age_from=self.group2.first_seen,
+            age_from_inclusive=True,
         )
         assert set(results) == set([self.group2])
 
         results = self.backend.query(
             self.project,
             age_to=self.group1.first_seen + timedelta(minutes=1),
+            age_to_inclusive=True,
         )
         assert set(results) == set([self.group1])
 
         results = self.backend.query(
             self.project,
             age_from=self.group1.first_seen,
+            age_from_inclusive=True,
             age_to=self.group1.first_seen + timedelta(minutes=1),
+            age_to_inclusive=True,
+        )
+        assert set(results) == set([self.group1])
+
+    def test_age_filter_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            age_from=self.group1.first_seen,
+            age_from_inclusive=True,
+        )
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            age_to=self.group1.first_seen,
+            age_to_inclusive=True,
+        )
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            age_from=self.group1.first_seen,
+            age_from_inclusive=False,
+        )
+        assert set(results) == set([])
+
+        event = self.create_event(
+            group=self.group1,
+            datetime=self.group1.first_seen + timedelta(days=1),
+            tags={
+                'environment': 'development',
+            }
+        )
+
+        self._setup_tags_for_event(event)
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            age_from=self.group1.first_seen,
+            age_from_inclusive=False,
+        )
+        assert set(results) == set([])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['development'],
+            age_from=self.group1.first_seen,
+            age_from_inclusive=False,
         )
         assert set(results) == set([self.group1])
 
@@ -225,19 +487,74 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(
             self.project,
             last_seen_from=self.group1.last_seen,
+            last_seen_from_inclusive=True,
         )
         assert set(results) == set([self.group1])
 
         results = self.backend.query(
             self.project,
             last_seen_to=self.group2.last_seen + timedelta(minutes=1),
+            last_seen_to_inclusive=True,
         )
         assert set(results) == set([self.group2])
 
         results = self.backend.query(
             self.project,
             last_seen_from=self.group1.last_seen,
+            last_seen_from_inclusive=True,
             last_seen_to=self.group1.last_seen + timedelta(minutes=1),
+            last_seen_to_inclusive=True,
+        )
+        assert set(results) == set([self.group1])
+
+    def test_last_seen_filter_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            last_seen_from=self.group1.last_seen,
+            last_seen_from_inclusive=True,
+        )
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            last_seen_to=self.group1.last_seen,
+            last_seen_to_inclusive=True,
+        )
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            last_seen_from=self.group1.last_seen,
+            last_seen_from_inclusive=False,
+        )
+        assert set(results) == set([])
+
+        event = self.create_event(
+            group=self.group1,
+            datetime=self.group1.last_seen + timedelta(days=1),
+            tags={
+                'environment': 'development',
+            }
+        )
+
+        self._setup_tags_for_event(event)
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            last_seen_from=self.group1.last_seen,
+            last_seen_from_inclusive=False,
+        )
+        assert set(results) == set([])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['development'],
+            last_seen_from=self.group1.last_seen,
+            last_seen_from_inclusive=False,
         )
         assert set(results) == set([self.group1])
 
@@ -261,12 +578,34 @@ class DjangoSearchBackendTest(TestCase):
         )
         assert set(results) == set([self.group1, self.group2])
 
+    def test_date_filter_with_environment(self):
+        raise NotImplementedError
+
     def test_unassigned(self):
         results = self.backend.query(self.project, unassigned=True)
         assert set(results) == set([self.group1])
 
         results = self.backend.query(self.project, unassigned=False)
         assert set(results) == set([self.group2])
+
+    def test_unassigned_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            unassigned=True)
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            unassigned=False)
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            unassigned=False)
+        assert set(results) == set([])
 
     def test_assigned_to(self):
         results = self.backend.query(self.project, assigned_to=self.user)
@@ -301,9 +640,37 @@ class DjangoSearchBackendTest(TestCase):
         results = self.backend.query(self.project, assigned_to=owner)
         assert set(results) == set([])
 
+    def test_assigned_to_with_environment(self):
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['staging'],
+            assigned_to=self.user)
+        assert set(results) == set([self.group2])
+
+        results = self.backend.query(
+            self.project,
+            environment=self.environments['production'],
+            assigned_to=self.user)
+        assert set(results) == set([])
+
     def test_subscribed_by(self):
         results = self.backend.query(
             self.group1.project,
             subscribed_by=self.user,
         )
         assert set(results) == set([self.group1])
+
+    def test_subscribed_by_with_environment(self):
+        results = self.backend.query(
+            self.group1.project,
+            environment=self.environments['production'],
+            subscribed_by=self.user,
+        )
+        assert set(results) == set([self.group1])
+
+        results = self.backend.query(
+            self.group1.project,
+            environment=self.environments['staging'],
+            subscribed_by=self.user,
+        )
+        assert set(results) == set([])

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -12,6 +12,7 @@ from sentry.models import (
 )
 from sentry.search.base import ANY
 from sentry.search.django.backend import DjangoSearchBackend
+from sentry.tagstore.v2.backend import AGGREGATE_ENVIRONMENT_ID
 from sentry.testutils import TestCase
 
 
@@ -128,7 +129,7 @@ class DjangoSearchBackendTest(TestCase):
         )
 
         for key, value in tags.items():
-            for environment_id in [None, environment.id]:
+            for environment_id in [AGGREGATE_ENVIRONMENT_ID, environment.id]:
                 tag_value, created = tagstore.get_or_create_group_tag_value(
                     project_id=event.project_id,
                     group_id=event.group_id,


### PR DESCRIPTION
This change implements environment-aware search and sorting when an `environment` is passed to the search backend. This causes any filters that are based on event data (fields such as first seen, last seen, times seen, as well as tag data) to utilize data sources that are environment-specific.

In practice, this means that each search query shares a common base `Group` queryset, to which conditions around issue-level attributes (assignment, resolution status, etc) are applied.

For environment-aware queries, the result set of this `Group` queryset is used as input to a query on `GroupTagValue`, which uses the tag data to implement the environment-specific conditions (first seen, last seen, times seen, etc) as well as sort criteria. (It would be cleaner to have implemented these aggregates on the `GroupEnvironment` model, but they already existed on `GroupTagValue`. For the non-environment-aware queries, these conditions are instead applied to the `Group` queryset, mirroring the existing behavior.)

When dealing with environment-aware queries, several exclusion filters are also applied to the initial `Group` queryset to rule out results that cannot possibly be included in the result set — for example, a group can't be seen more times in a specific environment than in the summation of all environments it's occurred in, so those groups can be excluded from the second stage query. The `Group` query is also joined to `GroupEnvironment` to limit the results to only groups that have been observed in that environment. (This join is a little clunky, since it is performed as an implicit join using the `queryset.extra` method due to the `GroupEnvironment.group_id` not being a `ForeignKey` field.)

In both the environment and non-environment-aware scenarios, the result sets of the `GroupTagValue` or `Group` queries respectively are used as inputs to further restrict the result set based on tag matches.

For the non-environment aware case, pagination happens at the database level using cursor positions and `LIMIT`/`OFFSET`, but the environment-aware queries, pagination is performed using the `SequencePaginator`.

Some other notable differences from the previous implementation:

- For the environment-aware queries, `priority` sorting is calculated from row data as an expression instead of a denormalized `score` field.
- Query building is encapsulated in a `QueryBuilder` and `Condition` class abstraction (see docstrings.) This removes a lot of the repetition and verbosity of building things like scalar conditions and makes it clear at a glance what variables are in scope when adding a filter to the underlying queryset.