### PR TITLE
feat: Add native retention concept

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -29,6 +29,7 @@ register('system.security-email', flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register('system.databases', type=Dict, flags=FLAG_NOSTORE)
 # register('system.debug', default=False, flags=FLAG_NOSTORE)
 register('system.rate-limit', default=0, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register('system.event-retention-days', default=0, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register('system.secret-key', flags=FLAG_NOSTORE)
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 register('system.url-prefix', ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -46,7 +46,7 @@ class Quota(Service):
     """
     __all__ = (
         'get_maximum_quota', 'get_organization_quota', 'get_project_quota', 'is_rate_limited',
-        'translate_quota', 'validate', 'refund',
+        'translate_quota', 'validate', 'refund', 'get_event_retention',
     )
 
     def __init__(self, **options):
@@ -137,3 +137,6 @@ class Quota(Service):
         Return the maximum capable rate for an organization.
         """
         return (options.get('system.rate-limit'), 60)
+
+    def get_event_retention(self, organization):
+        return options.get('system.event-retention-days') or None

--- a/tests/sentry/api/endpoints/test_project_events.py
+++ b/tests/sentry/api/endpoints/test_project_events.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import six
 
+from datetime import timedelta
+from django.utils import timezone
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
@@ -30,6 +32,37 @@ class ProjectEventsTest(APITestCase):
         assert sorted(map(lambda x: x['id'], response.data)) == sorted(
             [
                 six.text_type(event_1.id),
+                six.text_type(event_2.id),
+            ]
+        )
+
+    def test_filters_based_on_retention(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        group = self.create_group(project=project)
+        self.create_event(
+            'a' *
+            32,
+            group=group,
+            datetime=timezone.now() - timedelta(days=2),
+        )
+        event_2 = self.create_event('b' * 32, group=group)
+
+        with self.options({'system.event-retention-days': 1}):
+            url = reverse(
+                'sentry-api-0-project-events',
+                kwargs={
+                    'organization_slug': project.organization.slug,
+                    'project_slug': project.slug,
+                }
+            )
+            response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert sorted(map(lambda x: x['id'], response.data)) == sorted(
+            [
                 six.text_type(event_2.id),
             ]
         )

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -298,6 +298,17 @@ class GroupListTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]['id'] == six.text_type(group.id)
 
+    def test_filters_based_on_retention(self):
+        self.login_as(user=self.user)
+
+        self.create_group(last_seen=timezone.now() - timedelta(days=2))
+
+        with self.options({'system.event-retention-days': 1}):
+            response = self.client.get(self.path)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
 
 class GroupUpdateTest(APITestCase):
     @fixture


### PR DESCRIPTION
- Add option `system.event-retention-days`.
- Add `Quota.get_event_retention(organization)` API.
- Limit search and event endpoint queries to retention days.