### PR TITLE
feat(2fa): Show phone number mask on SMS page

### DIFF
--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -441,10 +441,19 @@ class SmsInterface(OtpMixin, AuthenticatorInterface):
     del _get_phone_number, _set_phone_number
 
     def activate(self, request):
+        phone_number = self.config['phone_number']
+        if len(phone_number) == 10:
+            mask = '(***) ***-**%s' % (phone_number[-2:])
+        else:
+            mask = '%s%s' % ((len(phone_number) - 2) * '*', phone_number[-2:])
+
         if self.send_text(request=request):
             return ActivationMessageResult(
-                _('A confirmation code was sent to your phone. '
-                  'It is valid for %d seconds.') % self.code_ttl
+                _('A confirmation code was sent to %(phone_mask)s. '
+                  'It is valid for %(ttl)d seconds.') % {
+                    'phone_mask': '<strong>%s</strong>' % mask,
+                    'ttl': self.code_ttl,
+                }
             )
         return ActivationMessageResult(
             _(

--- a/src/sentry/templates/sentry/twofactor.html
+++ b/src/sentry/templates/sentry/twofactor.html
@@ -18,7 +18,7 @@
       </p>
       {% if activation %}
         {% if activation.type == 'error' or activation.type == 'warning' or activation.type == 'info' %}
-          <p class="{{ activation.type }}">{{ activation.message }}</p>
+          <p class="{{ activation.type }}">{{ activation.message|safe }}</p>
         {% endif %}
       {% endif %}
       <form class="form-stacked" action="" method="post" autocomplete="off">


### PR DESCRIPTION
Avoids confusion of "what phone was this sent to" modeled after what
Google does.

![image](https://user-images.githubusercontent.com/375744/37305618-4595079e-25f2-11e8-942c-1bf34f110fed.png)

It masks our a nice number if it's exactly 10 digits, otherwise, it just fills in asterisks to match length.