### PR TITLE
ref(tagstore): Add `date_added` to `create_event_tags`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -845,6 +845,7 @@ class EventManager(object):
                 environment_id=environment.id,
                 event_id=event.id,
                 tags=tags,
+                date_added=event.datetime,
             )
 
         if event_user:

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -248,7 +248,8 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def create_event_tags(self, project_id, group_id, environment_id, event_id, tags):
+    def create_event_tags(self, project_id, group_id, environment_id,
+                          event_id, tags, date_added=None):
         """
         >>> create_event_tags(1, 2, 3, 4, [('foo', 'bar'), ('baz', 'qux')])
         """

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -193,15 +193,17 @@ class LegacyTagStorage(TagStorage):
         return GroupTagValue.objects.get_or_create(
             project_id=project_id, group_id=group_id, key=key, value=value, **kwargs)
 
-    def create_event_tags(self, project_id, group_id, environment_id, event_id, tags):
+    def create_event_tags(self, project_id, group_id, environment_id,
+                          event_id, tags, date_added=None):
+        if date_added is None:
+            date_added = timezone.now()
+
         tag_ids = []
         for key, value in tags:
             tagkey, _ = self.get_or_create_tag_key(project_id, environment_id, key)
             tagvalue, _ = self.get_or_create_tag_value(
                 project_id, environment_id, key, value)
             tag_ids.append((tagkey.id, tagvalue.id))
-
-        date_added = timezone.now()
 
         try:
             # don't let a duplicate break the outer transaction

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -280,8 +280,12 @@ class V2TagStorage(TagStorage):
         gtv.value = value
         return (gtv, created)
 
-    def create_event_tags(self, project_id, group_id, environment_id, event_id, tags):
+    def create_event_tags(self, project_id, group_id, environment_id,
+                          event_id, tags, date_added=None):
         assert environment_id is not None
+
+        if date_added is None:
+            date_added = timezone.now()
 
         tag_ids = []
         for key, value in tags:
@@ -289,8 +293,6 @@ class V2TagStorage(TagStorage):
             tagvalue, _ = self.get_or_create_tag_value(
                 project_id, environment_id, key, value, key_id=tagkey.id)
             tag_ids.append((tagkey.id, tagvalue.id))
-
-        date_added = timezone.now()
 
         try:
             # don't let a duplicate break the outer transaction

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -159,12 +159,16 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
     name='sentry.tasks.index_event_tags', default_retry_delay=60 * 5, max_retries=None
 )
 def index_event_tags(organization_id, project_id, event_id, tags,
-                     group_id, environment_id, **kwargs):
+                     group_id, environment_id, date_added=None, **kwargs):
     from sentry import tagstore
 
     Raven.tags_context({
         'project': project_id,
     })
+
+    create_event_tags_kwargs = {}
+    if date_added is not None:
+        create_event_tags_kwargs['date_added'] = date_added
 
     tagstore.create_event_tags(
         project_id=project_id,
@@ -172,4 +176,5 @@ def index_event_tags(organization_id, project_id, event_id, tags,
         environment_id=environment_id,
         event_id=event_id,
         tags=tags,
+        **create_event_tags_kwargs
     )


### PR DESCRIPTION
This ensures that the `EventTag` timestamp mirrors the accompanying `Event`.

References GH-7565.