### PR TITLE
fix(tagstore): Add partition key to tagstore v2 updates

### DIFF
--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -99,7 +99,10 @@ class V2TagStorage(TagStorage):
             def mark_deletion_in_progress(self, instance_list):
                 for instance in instance_list:
                     if instance.status != TagKeyStatus.DELETION_IN_PROGRESS:
-                        instance.update(status=TagKeyStatus.DELETION_IN_PROGRESS)
+                        TagKey.objects.filter(
+                            id=instance.id,
+                            project_id=instance.project_id,
+                        ).update(status=TagKeyStatus.DELETION_IN_PROGRESS)
 
         deletion_manager.register(TagKey, TagKeyDeletionTask)
 
@@ -778,7 +781,10 @@ class V2TagStorage(TagStorage):
         )
 
         for instance in gtk_qs:
-            instance.update(
+            GroupTagKey.objects.filter(
+                id=instance.id,
+                project_id=project_id,
+            ).update(
                 values_seen=GroupTagValue.objects.filter(
                     project_id=instance.project_id,
                     group_id=instance.group_id,

--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -108,7 +108,11 @@ class GroupTagValue(Model):
                     _key_id=self._key_id,
                     _value_id=self._value_id,
                 )
-                new_obj.update(
+
+                GroupTagValue.objects.filter(
+                    id=new_obj.id,
+                    project_id=new_group.project_id,
+                ).update(
                     first_seen=min(new_obj.first_seen, self.first_seen),
                     last_seen=max(new_obj.last_seen, self.last_seen),
                     times_seen=new_obj.times_seen + self.times_seen,


### PR DESCRIPTION
Fixes SENTRY-62Y
Fixes SENTRY-632

---

In retrospect this is obvious, alas.