### PR TITLE
fix(tagstore): Fix object delete in merge code for tagstore v2

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -334,7 +334,12 @@ def merge_objects(models, group, new_group, limit=1000, logger=None, transaction
                     obj.merge_counts(new_group)
 
                 obj_id = obj.id
-                obj.delete()
+
+                if hasattr(model, 'delete_for_merge'):
+                    obj.delete_for_merge()
+                else:
+                    obj.delete()
+
                 if logger is not None:
                     delete_logger.debug(
                         'object.delete.executed',


### PR DESCRIPTION
Fixes SENTRY-630

---

I could override `delete` on the v2 models but this felt cleaner/safer.