### PR TITLE
fix(tagstore): Don't update project_id on every GroupTagValue incr

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -165,7 +165,6 @@ class GroupManager(BaseManager):
             })
 
             tagstore.incr_group_tag_value_times_seen(project_id, group.id, environment.id, key, value, extra={
-                'project_id': project_id,
                 'last_seen': date,
             })
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -148,7 +148,9 @@ class LegacyTagStorage(TagStorage):
             if not created:
                 return
 
-            project_id = extra['project_id']
+            # TODO: the fallback to `extra` is here only temporary as we
+            #       migrate to filters after the deploy completes
+            project_id = filters.get('project_id', extra.get('project_id'))
             group_id = filters['group_id']
             key = filters['key']
 
@@ -371,6 +373,7 @@ class LegacyTagStorage(TagStorage):
                         'times_seen': count,
                     },
                     filters={
+                        'project_id': project_id,
                         'group_id': group_id,
                         'key': key,
                         'value': value,


### PR DESCRIPTION
Fixes issue where 'placements' were being modified during a query (even though they weren't being changed): 'could not modify any active placements'.

Fixes SENTRY-627