### PR TITLE
feat(owners): Owner UI followup

### DIFF
--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 
 import Avatar from '../avatar';
 import ActorAvatar from '../actorAvatar';
-import TooltipMixin from '../../mixins/tooltip';
+import Tooltip from '../tooltip';
 import ApiMixin from '../../mixins/apiMixin';
 import GroupState from '../../mixins/groupState';
 import {assignToUser, assignToActor} from '../../actionCreators/group';
@@ -19,17 +19,7 @@ const SuggestedOwners = createReactClass({
     event: PropTypes.object,
   },
 
-  mixins: [
-    ApiMixin,
-    GroupState,
-    TooltipMixin({
-      selector: '.tip',
-      html: true,
-      container: 'body',
-      template:
-        '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner tooltip-owners"></div></div>',
-    }),
-  ],
+  mixins: [ApiMixin, GroupState],
 
   getInitialState() {
     return {
@@ -52,14 +42,6 @@ const SuggestedOwners = createReactClass({
     } else if (nextProps.event) {
       //going from having no event to having an event
       this.fetchData(nextProps.event);
-    }
-  },
-
-  componentDidUpdate(_, nextState) {
-    //this shallow equality should be OK because it's being mutated fetchData as a new object
-    if (this.state.owners !== nextState.owners) {
-      this.removeTooltips();
-      this.attachTooltips();
     }
   },
 
@@ -117,44 +99,56 @@ const SuggestedOwners = createReactClass({
     return (
       <span
         key={author.id || author.email}
-        className="avatar-grid-item tip"
+        className="avatar-grid-item"
         onClick={() => this.assignTo(author)}
-        title={ReactDOMServer.renderToStaticMarkup(
-          <div>
-            {author.id ? (
-              <div className="tooltip-owners-name">{author.name}</div>
-            ) : (
-              <div className="tooltip-owners-unknown">
-                <p className="tooltip-owners-unknown-email">
-                  <span className="icon icon-circle-cross" />
-                  <strong>{author.email}</strong>
-                </p>
-                <p>
-                  Sorry, we don't recognize this member. Make sure to link alternative
-                  emails in Account Settings.
-                </p>
-                <hr />
-              </div>
-            )}
-            <ul className="tooltip-owners-commits">
-              {commits.slice(0, 6).map(c => {
-                return (
-                  <li key={c.id} className="tooltip-owners-commit">
-                    <div style={{whiteSpace: 'pre-line'}}>
-                      {c.message.replace(/\n\s*\n/g, '\n') /*repress repeated newlines*/}
-                    </div>
-                    <span className="tooltip-owners-date">
-                      {' '}
-                      - {moment(c.dateCreated).fromNow()}
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        )}
       >
-        <Avatar user={author} />
+        <Tooltip
+          tooltipOptions={{
+            html: true,
+            container: 'body',
+            template:
+              '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner tooltip-owners"></div></div>',
+          }}
+          title={ReactDOMServer.renderToStaticMarkup(
+            <div>
+              {author.id ? (
+                <div className="tooltip-owners-name">{author.name}</div>
+              ) : (
+                <div className="tooltip-owners-unknown">
+                  <p className="tooltip-owners-unknown-email">
+                    <span className="icon icon-circle-cross" />
+                    <strong>{author.email}</strong>
+                  </p>
+                  <p>
+                    Sorry, we don't recognize this member. Make sure to link alternative
+                    emails in Account Settings.
+                  </p>
+                  <hr />
+                </div>
+              )}
+              <ul className="tooltip-owners-commits">
+                {commits.slice(0, 6).map(c => {
+                  return (
+                    <li key={c.id} className="tooltip-owners-commit">
+                      <div style={{whiteSpace: 'pre-line'}}>
+                        {c.message.replace(
+                          /\n\s*\n/g,
+                          '\n'
+                        ) /*repress repeated newlines*/}
+                      </div>
+                      <span className="tooltip-owners-date">
+                        {' '}
+                        - {moment(c.dateCreated).fromNow()}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        >
+          <Avatar user={author} />
+        </Tooltip>
       </span>
     );
   },
@@ -166,19 +160,28 @@ const SuggestedOwners = createReactClass({
         key={`${owner.id}:${owner.type}`}
         className="avatar-grid-item tip"
         onClick={() => this.assignToActor(owner)}
-        title={ReactDOMServer.renderToStaticMarkup(
-          <div>
-            <div className="tooltip-owners-name">{owner.name}</div>
-            <ul className="tooltip-owners-commits">
-              {t("Assigned based on your Project's Issue Ownership settings")}
-            </ul>
-            <ul className="tooltip-owners-commits">
-              {rule[0] + t(' matched: ') + rule[1]}
-            </ul>
-          </div>
-        )}
       >
-        <ActorAvatar actor={owner} hasTooltip={false} />
+        <Tooltip
+          tooltipOptions={{
+            html: true,
+            container: 'body',
+            template:
+              '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner tooltip-owners"></div></div>',
+          }}
+          title={ReactDOMServer.renderToStaticMarkup(
+            <div>
+              <div className="tooltip-owners-name">{owner.name}</div>
+              <ul className="tooltip-owners-commits">
+                {t("Assigned based on your Project's Issue Ownership settings")}
+              </ul>
+              <ul className="tooltip-owners-commits">
+                {rule[0] + t(' matched: ') + rule[1]}
+              </ul>
+            </div>
+          )}
+        >
+          <ActorAvatar actor={owner} hasTooltip={false} />
+        </Tooltip>
       </span>
     );
   },
@@ -190,25 +193,19 @@ const SuggestedOwners = createReactClass({
     if (owners.length == 0 && committers.length == 0) {
       return null;
     }
+
     return (
       <div className="m-b-1">
-        {committers.length ? (
+        {committers.length || (showOwners && owners.length) ? (
           <React.Fragment>
             <h6>
-              <span>{t('Suggested Owners')}</span>
+              <span>{t('Suggested Assignees')}</span>
               <small style={{background: '#FFFFFF'}}>{t('Click to assign')}</small>
             </h6>
-            <div className="avatar-grid">{committers.map(this.renderCommitter)}</div>
-          </React.Fragment>
-        ) : null}
-
-        {showOwners && owners.length ? (
-          <React.Fragment>
-            <h6>
-              <span>{t('Owners')}</span>
-              <small style={{background: '#FFFFFF'}}>{t('Click to assign')}</small>
-            </h6>
-            <div className="avatar-grid">{owners.map(this.renderOwner)}</div>
+            <div className="avatar-grid">
+              {committers.map(this.renderCommitter)}
+              {showOwners && owners.map(this.renderOwner)}
+            </div>
           </React.Fragment>
         ) : null}
       </div>

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -100,6 +100,7 @@ const SuggestedOwners = createReactClass({
       <span
         key={author.id || author.email}
         className="avatar-grid-item"
+        style={{cursor: 'pointer'}}
         onClick={() => this.assignTo(author)}
       >
         <Tooltip
@@ -158,7 +159,8 @@ const SuggestedOwners = createReactClass({
     return (
       <span
         key={`${owner.id}:${owner.type}`}
-        className="avatar-grid-item tip"
+        className="avatar-grid-item"
+        style={{cursor: 'pointer'}}
         onClick={() => this.assignToActor(owner)}
       >
         <Tooltip
@@ -190,24 +192,20 @@ const SuggestedOwners = createReactClass({
     let {committers, owners} = this.state;
     let showOwners = new Set(this.getOrganization().features).has('internal-catchall');
 
-    if (owners.length == 0 && committers.length == 0) {
+    if (committers.length == 0 && (!showOwners || owners.length == 0)) {
       return null;
     }
 
     return (
       <div className="m-b-1">
-        {committers.length || (showOwners && owners.length) ? (
-          <React.Fragment>
-            <h6>
-              <span>{t('Suggested Assignees')}</span>
-              <small style={{background: '#FFFFFF'}}>{t('Click to assign')}</small>
-            </h6>
-            <div className="avatar-grid">
-              {committers.map(this.renderCommitter)}
-              {showOwners && owners.map(this.renderOwner)}
-            </div>
-          </React.Fragment>
-        ) : null}
+        <h6>
+          <span>{t('Suggested Assignees')}</span>
+          <small style={{background: '#FFFFFF'}}>{t('Click to assign')}</small>
+        </h6>
+        <div className="avatar-grid">
+          {committers.map(this.renderCommitter)}
+          {showOwners && owners.map(this.renderOwner)}
+        </div>
       </div>
     );
   },

--- a/tests/js/spec/components/group/__snapshots__/suggestedOwners.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/suggestedOwners.spec.jsx.snap
@@ -33,7 +33,7 @@ exports[`SuggestedOwners render() should show owners when enable 1`] = `
   >
     <h6>
       <span>
-        Owners
+        Suggested Assignees
       </span>
       <small
         style={
@@ -52,47 +52,61 @@ exports[`SuggestedOwners render() should show owners when enable 1`] = `
         className="avatar-grid-item tip"
         key="1:user"
         onClick={[Function]}
-        title="<div><div class=\\"tooltip-owners-name\\">Jane Doe</div><ul class=\\"tooltip-owners-commits\\">Assigned based on your Project&#x27;s Issue Ownership settings</ul><ul class=\\"tooltip-owners-commits\\">path matched: sentry/tagstore/*</ul></div>"
       >
-        <ActorAvatar
-          actor={
+        <Tooltip
+          title="<div><div class=\\"tooltip-owners-name\\">Jane Doe</div><ul class=\\"tooltip-owners-commits\\">Assigned based on your Project&#x27;s Issue Ownership settings</ul><ul class=\\"tooltip-owners-commits\\">path matched: sentry/tagstore/*</ul></div>"
+          tooltipOptions={
             Object {
-              "id": "1",
-              "name": "Jane Doe",
-              "type": "user",
+              "container": "body",
+              "html": true,
+              "template": "<div class=\\"tooltip\\" role=\\"tooltip\\"><div class=\\"tooltip-arrow\\"></div><div class=\\"tooltip-inner tooltip-owners\\"></div></div>",
             }
           }
-          hasTooltip={false}
         >
-          <Avatar
-            className="avatar"
-            gravatar={true}
-            hasTooltip={false}
-            size={64}
-            user={
+          <ActorAvatar
+            actor={
               Object {
-                "email": "janedoe@example.com",
                 "id": "1",
                 "name": "Jane Doe",
+                "type": "user",
               }
             }
+            className="tip"
+            hasTooltip={false}
+            title="<div><div class=\\"tooltip-owners-name\\">Jane Doe</div><ul class=\\"tooltip-owners-commits\\">Assigned based on your Project&#x27;s Issue Ownership settings</ul><ul class=\\"tooltip-owners-commits\\">path matched: sentry/tagstore/*</ul></div>"
           >
-            <Tooltip
-              disabled={true}
-              title="Jane Doe (janedoe@example.com)"
+            <Avatar
+              className="tip"
+              gravatar={true}
+              hasTooltip={false}
+              size={64}
+              title="<div><div class=\\"tooltip-owners-name\\">Jane Doe</div><ul class=\\"tooltip-owners-commits\\">Assigned based on your Project&#x27;s Issue Ownership settings</ul><ul class=\\"tooltip-owners-commits\\">path matched: sentry/tagstore/*</ul></div>"
+              user={
+                Object {
+                  "email": "janedoe@example.com",
+                  "id": "1",
+                  "name": "Jane Doe",
+                }
+              }
             >
-              <span
-                className="avatar"
+              <Tooltip
+                disabled={true}
+                title="Jane Doe (janedoe@example.com)"
               >
-                <img
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  src="undefined/avatar/e1f3994f2632af3d1c8c2dcc168a10e6?s=64&d=blank"
-                />
-              </span>
-            </Tooltip>
-          </Avatar>
-        </ActorAvatar>
+                <span
+                  className="tip"
+                >
+                  <img
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="undefined/avatar/e1f3994f2632af3d1c8c2dcc168a10e6?s=64&d=blank"
+                    title="<div><div class=\\"tooltip-owners-name\\">Jane Doe</div><ul class=\\"tooltip-owners-commits\\">Assigned based on your Project&#x27;s Issue Ownership settings</ul><ul class=\\"tooltip-owners-commits\\">path matched: sentry/tagstore/*</ul></div>"
+                  />
+                </span>
+              </Tooltip>
+            </Avatar>
+          </ActorAvatar>
+        </Tooltip>
       </span>
     </div>
   </div>

--- a/tests/js/spec/components/group/__snapshots__/suggestedOwners.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/suggestedOwners.spec.jsx.snap
@@ -10,11 +10,7 @@ exports[`SuggestedOwners render() should not show owners committers without feat
       "message": "ApiException",
     }
   }
->
-  <div
-    className="m-b-1"
-  />
-</SuggestedOwners>
+/>
 `;
 
 exports[`SuggestedOwners render() should show owners when enable 1`] = `
@@ -49,9 +45,14 @@ exports[`SuggestedOwners render() should show owners when enable 1`] = `
       className="avatar-grid"
     >
       <span
-        className="avatar-grid-item tip"
+        className="avatar-grid-item"
         key="1:user"
         onClick={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+          }
+        }
       >
         <Tooltip
           title="<div><div class=\\"tooltip-owners-name\\">Jane Doe</div><ul class=\\"tooltip-owners-commits\\">Assigned based on your Project&#x27;s Issue Ownership settings</ul><ul class=\\"tooltip-owners-commits\\">path matched: sentry/tagstore/*</ul></div>"


### PR DESCRIPTION
remove tooltip mixin (use <Tooltip>)
rename "suggested owners" to "suggested assignees"

put both types of suggestion inline