### PR TITLE
chore(js): upgrade raven version to 3.23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "po-catalog-loader": "^1.2.0",
     "prop-types": "^15.6.0",
     "query-string": "2.4.2",
-    "raven-js": "3.19.1",
+    "raven-js": "3.23.2",
     "react": "16.2.0",
     "react-addons-css-transition-group": "15.6.2",
     "react-bootstrap": "^0.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7359,9 +7359,9 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@3.19.1:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.19.1.tgz#a5d25646556fc2c86d2b188ae4f425c144c08dd8"
+raven-js@3.23.2:
+  version "3.23.2"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.23.2.tgz#b71df14a066e450326b5356cc7fcc035510fdb26"
 
 raw-body@2.3.2:
   version "2.3.2"


### PR DESCRIPTION
https://github.com/getsentry/raven-js/releases

among other bugfixes, we'll benefit from https://github.com/getsentry/raven-js/pull/1253