### PR TITLE
Revert "fix(style): justify-content: center dropdown-actor-title"

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2541,7 +2541,6 @@ header + .alert {
 }
 
 .dropdown-actor-title {
-  justify-content: center;
   display: flex;
   align-items: center;
   height: 100%;


### PR DESCRIPTION
This reverts commit 200fbbf9ef439ef7c73bdcd4ccb18d228b5caa13.

this turned out to make other dropdown a bit wonky and I fixed my problem in a more robust way since. 