### PR TITLE
ref: Only pass environment to search backend when `organizations:environments` switch enabled

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -230,10 +230,11 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             query_kwargs.update(extra_query_kwargs)
 
         try:
-            query_kwargs['environment'] = self._get_environment_from_request(
-                request,
-                project.organization_id,
-            )
+            if features.has('organizations:environments', project, actor=request.user):
+                query_kwargs['environment'] = self._get_environment_from_request(
+                    request,
+                    project.organization_id,
+                )
         except Environment.DoesNotExist:
             # XXX: The 1000 magic number for `max_hits` is an abstraction leak
             # from `sentry.api.paginator.BasePaginator.get_result`.


### PR DESCRIPTION
The frontend is passing this regardless of switch status which would cause the backend to use the new environment-aware search path in GH-7565 unexpectedly.