### PR TITLE
feat(environments): Add environment to query string on group pages

### DIFF
--- a/src/sentry/static/sentry/app/views/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupEventDetails.jsx
@@ -9,6 +9,7 @@ import MutedBox from '../components/mutedBox';
 import GroupEventDetailsLoadingError from '../components/errors/groupEventDetailsLoadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import ResolutionBox from '../components/resolutionBox';
+import withEnvironmentInQueryString from '../utils/withEnvironmentInQueryString';
 
 const GroupEventDetails = createReactClass({
   displayName: 'GroupEventDetails',
@@ -121,4 +122,4 @@ const GroupEventDetails = createReactClass({
   },
 });
 
-export default GroupEventDetails;
+export default withEnvironmentInQueryString(GroupEventDetails);

--- a/src/sentry/static/sentry/app/views/groupTags.jsx
+++ b/src/sentry/static/sentry/app/views/groupTags.jsx
@@ -9,7 +9,7 @@ import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import {percent, deviceNameMapper} from '../utils';
 import {t} from '../locale';
-import withEnvironment from '../utils/withEnvironment';
+import withEnvironmentInQueryString from '../utils/withEnvironmentInQueryString';
 
 const GroupTags = createReactClass({
   displayName: 'GroupTags',
@@ -148,4 +148,4 @@ const GroupTags = createReactClass({
   },
 });
 
-export default withEnvironment(GroupTags);
+export default withEnvironmentInQueryString(GroupTags);

--- a/src/sentry/static/sentry/app/views/groupUserReports.jsx
+++ b/src/sentry/static/sentry/app/views/groupUserReports.jsx
@@ -8,7 +8,7 @@ import EventUserReport from '../components/events/userReport';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
 import {t, tct} from '../locale';
-import withEnvironment from '../utils/withEnvironment';
+import withEnvironmentInQueryString from '../utils/withEnvironmentInQueryString';
 
 const GroupUserReports = createReactClass({
   displayName: 'GroupUserReports',
@@ -128,4 +128,4 @@ const GroupUserReports = createReactClass({
   },
 });
 
-export default withEnvironment(GroupUserReports);
+export default withEnvironmentInQueryString(GroupUserReports);


### PR DESCRIPTION
Add to group details and user report and tag pages since they contain environment specific information