### PR TITLE
feat(buffers): Add partitioning to redis implementation

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -53,7 +53,7 @@ class Buffer(Service):
             }
         )
 
-    def process_pending(self):
+    def process_pending(self, *args, **kwargs):
         return []
 
     def process(self, model, columns, filters, extra=None):

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -53,7 +53,7 @@ class Buffer(Service):
             }
         )
 
-    def process_pending(self, *args, **kwargs):
+    def process_pending(self, partition=None):
         return []
 
     def process(self, model, columns, filters, extra=None):

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -132,7 +132,7 @@ class RedisBuffer(Buffer):
             # If we're using shards, this one task fans out into
             # N subtasks instead.
             for i in range(self.pending_shards):
-                process_pending.delay(shard=i)
+                process_pending.apply_async(kwargs={'shard': i})
             # Explicitly also run over the unsharded buffer as well
             # to ease in transition. In practice, this should just be
             # super fast and is fine to do redundantly.

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -17,25 +17,25 @@ logger = logging.getLogger(__name__)
 
 
 @instrumented_task(name='sentry.tasks.process_buffer.process_pending')
-def process_pending(shard=None):
+def process_pending(partition=None):
     """
     Process pending buffers.
     """
     from sentry import buffer
     from sentry.app import locks
 
-    if shard is None:
+    if partition is None:
         lock_key = 'buffer:process_pending'
     else:
-        lock_key = 'buffer:process_pending:%d' % shard
+        lock_key = 'buffer:process_pending:%d' % partition
 
     lock = locks.get(lock_key, duration=60)
 
     try:
         with lock.acquire():
-            buffer.process_pending(shard=shard)
+            buffer.process_pending(partition=partition)
     except UnableToAcquireLock as error:
-        logger.warning('process_pending.fail', extra={'error': error, 'shard': shard})
+        logger.warning('process_pending.fail', extra={'error': error, 'partition': partition})
 
 
 @instrumented_task(name='sentry.tasks.process_buffer.process_incr')

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -99,3 +99,55 @@ class RedisBufferTest(TestCase):
         }
         pending = client.zrange('b:p', 0, -1)
         assert pending == ['foo']
+
+    @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
+    @mock.patch('sentry.buffer.redis.process_incr')
+    @mock.patch('sentry.buffer.redis.process_pending')
+    def test_process_pending_shards_none(self, process_pending, process_incr):
+        self.buf.pending_shards = 2
+        with self.buf.cluster.map() as client:
+            client.zadd('b:p:0', 1, 'foo')
+            client.zadd('b:p:1', 1, 'bar')
+            client.zadd('b:p', 1, 'baz')
+
+        # On first pass, we are expecing to do:
+        # * process the buffer that doesn't have a shard (b:p)
+        # * queue up 2 jobs, one for each shard to process.
+        self.buf.process_pending()
+        assert len(process_incr.apply_async.mock_calls) == 1
+        process_incr.apply_async.assert_any_call(kwargs={
+            'batch_keys': ['baz'],
+        })
+        assert len(process_pending.apply_async.mock_calls) == 2
+        process_pending.apply_async.mock_calls == [
+            mock.call(kwargs={'shard': 0}),
+            mock.call(kwargs={'shard': 1}),
+        ]
+
+        # Confirm that we've only processed the unsharded buffer
+        client = self.buf.cluster.get_routing_client()
+        assert client.zrange('b:p', 0, -1) == []
+        assert client.zrange('b:p:0', 0, -1) != []
+        assert client.zrange('b:p:1', 0, -1) != []
+
+        # shard 0
+        self.buf.process_pending(shard=0)
+        assert len(process_incr.apply_async.mock_calls) == 2
+        process_incr.apply_async.assert_any_call(kwargs={
+            'batch_keys': ['foo'],
+        })
+        assert client.zrange('b:p:0', 0, -1) == []
+
+        # Make sure we didn't queue up more
+        assert len(process_pending.apply_async.mock_calls) == 2
+
+        # shard 1
+        self.buf.process_pending(shard=1)
+        assert len(process_incr.apply_async.mock_calls) == 3
+        process_incr.apply_async.assert_any_call(kwargs={
+            'batch_keys': ['bar'],
+        })
+        assert client.zrange('b:p:1', 0, -1) == []
+
+        # Make sure we didn't queue up more
+        assert len(process_pending.apply_async.mock_calls) == 2

--- a/tests/sentry/tasks/process_buffer/tests.py
+++ b/tests/sentry/tasks/process_buffer/tests.py
@@ -23,7 +23,9 @@ class ProcessPendingTest(TestCase):
     def test_nothing(self, mock_process_pending):
         # this effectively just says "does the code run"
         process_pending()
-        mock_process_pending.assert_called_once_with(shard=None)
+        assert len(mock_process_pending.mock_calls) == 1
+        mock_process_pending.assert_any_call(shard=None)
 
         process_pending(shard=1)
-        mock_process_pending.assert_called_once_with(shard=1)
+        assert len(mock_process_pending.mock_calls) == 2
+        mock_process_pending.assert_any_call(shard=1)

--- a/tests/sentry/tasks/process_buffer/tests.py
+++ b/tests/sentry/tasks/process_buffer/tests.py
@@ -23,4 +23,7 @@ class ProcessPendingTest(TestCase):
     def test_nothing(self, mock_process_pending):
         # this effectively just says "does the code run"
         process_pending()
-        mock_process_pending.assert_called_once_with()
+        mock_process_pending.assert_called_once_with(shard=None)
+
+        process_pending(shard=1)
+        mock_process_pending.assert_called_once_with(shard=1)

--- a/tests/sentry/tasks/process_buffer/tests.py
+++ b/tests/sentry/tasks/process_buffer/tests.py
@@ -24,8 +24,8 @@ class ProcessPendingTest(TestCase):
         # this effectively just says "does the code run"
         process_pending()
         assert len(mock_process_pending.mock_calls) == 1
-        mock_process_pending.assert_any_call(shard=None)
+        mock_process_pending.assert_any_call(partition=None)
 
-        process_pending(shard=1)
+        process_pending(partition=1)
         assert len(mock_process_pending.mock_calls) == 2
-        mock_process_pending.assert_any_call(shard=1)
+        mock_process_pending.assert_any_call(partition=1)


### PR DESCRIPTION
Right now, a single process_buffer job can become unbearably slow. This
single job contains all of the increments that need to be performed. In
practice, we are seeing this balloon upwards of 20,000 or more, and the
bottleneck is purely fetching all of these keys and fanning out the
additional jobs.

This changes process_buffer to accept a partition, and increments can be
splayed across N partitions so we can process this massive buffer in
parallel and keep processing times fast.