### PR TITLE
fix(environments): Only keep environment parameter on stream transition

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -518,9 +518,11 @@ const Stream = createReactClass({
   },
 
   transitionTo() {
-    let queryParams = {
-      ...this.props.location.query,
-    };
+    let queryParams = {};
+
+    if (this.props.location.query.environment) {
+      queryParams.environment = this.props.location.query.environment;
+    }
 
     if (!this.state.searchId) {
       queryParams.query = this.state.query;


### PR DESCRIPTION
We don't want to keep any of the the query parameters around like cursor or stats period