### PR TITLE
fix(slack): Mock timestamp signer sign/unsign

### DIFF
--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import responses
 
 from six.moves.urllib.parse import parse_qs
+from mock import patch
 
 from sentry import options
 from sentry.models import (
@@ -98,7 +99,10 @@ class BaseEventTest(APITestCase):
 
 
 class StatusActionTest(BaseEventTest):
-    def test_ask_linking(self):
+    @patch('sentry.integrations.slack.link_identity.sign')
+    def test_ask_linking(self, sign):
+        sign.return_value = 'signed_parameters'
+
         resp = self.post_webhook(slack_user={
             'id': 'invalid-id',
             'domain': 'example',

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import responses
 
+from mock import patch
+
 from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration, OrganizationIntegration
 from sentry.testutils import TestCase
 from sentry.integrations.slack.link_identity import build_linking_url
@@ -35,7 +37,15 @@ class SlackIntegrationLinkIdentityTest(TestCase):
         )
 
     @responses.activate
-    def test_basic_flow(self):
+    @patch('sentry.integrations.slack.link_identity.unsign')
+    def test_basic_flow(self, unsign):
+        unsign.return_value = {
+            'integration_id': self.integration.id,
+            'organization_id': self.org.id,
+            'slack_id': 'new-slack-id',
+            'notify_channel_id': 'my-channel',
+        }
+
         linking_url = build_linking_url(
             self.integration,
             self.org,


### PR DESCRIPTION
Intermitently fails, lets just stub it out.