### PR TITLE
fix(slack): Do not mask the integration setup issues

### DIFF
--- a/src/sentry/web/frontend/integration_setup.py
+++ b/src/sentry/web/frontend/integration_setup.py
@@ -25,8 +25,4 @@ class IntegrationSetupView(BaseView):
             logging.error('integration.setup-error')
             return self.redirect('/')
 
-        try:
-            return pipeline.current_step()
-        except Exception:
-            logging.exception('integration.setup-error')
-            return pipeline.error('an internal error occurred')
+        return pipeline.current_step()


### PR DESCRIPTION
I'm seeing a few issues like this in sentry. The pipeline.eror is not yet implemented for the integration setup piepline, so I'd rather make this quick change to start knowing *what* is breaking in the pipeline, and then later implement the error page.