### PR TITLE
feat(environments): Include active environment in links

### DIFF
--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -10,6 +10,7 @@ import SnoozeAction from './issues/snoozeAction';
 import GroupChart from './stream/groupChart';
 import GroupStore from '../stores/groupStore';
 import Link from './link';
+import ProjectLink from './projectLink';
 import {t} from '../locale';
 
 class CompactIssueHeader extends React.Component {
@@ -70,15 +71,15 @@ class CompactIssueHeader extends React.Component {
       <div>
         <span className="error-level truncate" title={data.level} />
         <h3 className="truncate">
-          <Link to={`/${orgId}/${projectId}/issues/${data.id}/`}>
+          <ProjectLink to={`/${orgId}/${projectId}/issues/${data.id}/`}>
             <span className="icon icon-soundoff" />
             <span className="icon icon-star-solid" />
             {this.getTitle()}
-          </Link>
+          </ProjectLink>
         </h3>
         <div className="event-extra">
           <span className="project-name">
-            <Link to={`/${orgId}/${projectId}/`}>{data.project.slug}</Link>
+            <ProjectLink to={`/${orgId}/${projectId}/`}>{data.project.slug}</ProjectLink>
           </span>
           {data.numComments !== 0 && (
             <span>

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import {Link} from 'react-router';
 
+import ProjectLink from '../components/projectLink';
 import {Metadata} from '../proptypes';
 import EventOrGroupTitle from './eventOrGroupTitle';
 
@@ -61,7 +61,7 @@ class EventOrGroupHeader extends React.Component {
           : ''}`,
         search: `${this.props.query ? `?query=${this.props.query}` : ''}`,
       };
-      Wrapper = Link;
+      Wrapper = ProjectLink;
     } else {
       Wrapper = 'span';
     }

--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Link} from 'react-router';
 
+import ProjectLink from '../components/projectLink';
 import {getShortVersion} from '../utils';
 
 class Version extends React.Component {
@@ -24,9 +24,11 @@ class Version extends React.Component {
       return (
         // NOTE: version is encoded because it can contain slashes "/",
         //       which can interfere with URL construction
-        <Link to={`/${orgId}/${projectId}/releases/${encodeURIComponent(version)}/`}>
+        <ProjectLink
+          to={`/${orgId}/${projectId}/releases/${encodeURIComponent(version)}/`}
+        >
           <span title={version}>{shortVersion}</span>
-        </Link>
+        </ProjectLink>
       );
     }
     return <span title={version}>{shortVersion}</span>;

--- a/src/sentry/static/sentry/app/views/projectEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/index.jsx
@@ -2,7 +2,9 @@ import jQuery from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import {Link, browserHistory} from 'react-router';
+import {browserHistory} from 'react-router';
+
+import ProjectLink from '../../components/projectLink';
 import ApiMixin from '../../mixins/apiMixin';
 import DateTime from '../../components/dateTime';
 import Avatar from '../../components/avatar';
@@ -162,11 +164,11 @@ const ProjectEvents = createReactClass({
           </td>
           <td>
             <h5>
-              <Link
+              <ProjectLink
                 to={`/${orgId}/${projectId}/issues/${event.groupID}/events/${event.id}/`}
               >
                 {this.getEventTitle(event)}
-              </Link>
+              </ProjectLink>
             </h5>
           </td>
           <td className="event-user table-user-info" style={{textAlign: 'right'}}>

--- a/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
@@ -7,9 +7,7 @@ exports[`EventOrGroupHeader Event hides level tag 1`] = `
   <h3
     className="truncate"
   >
-    <Link
-      onlyActiveOnIndex={false}
-      style={Object {}}
+    <ProjectLink
       to={
         Object {
           "pathname": "/orgId/projectId/issues/groupID/events/id/",
@@ -46,7 +44,7 @@ exports[`EventOrGroupHeader Event hides level tag 1`] = `
         orgId="orgId"
         projectId="projectId"
       />
-    </Link>
+    </ProjectLink>
   </h3>
 </div>
 `;
@@ -58,9 +56,7 @@ exports[`EventOrGroupHeader Event renders with \`type = csp\` 1`] = `
   <h3
     className="truncate"
   >
-    <Link
-      onlyActiveOnIndex={false}
-      style={Object {}}
+    <ProjectLink
       to={
         Object {
           "pathname": "/orgId/projectId/issues/groupID/events/id/",
@@ -96,7 +92,7 @@ exports[`EventOrGroupHeader Event renders with \`type = csp\` 1`] = `
         orgId="orgId"
         projectId="projectId"
       />
-    </Link>
+    </ProjectLink>
   </h3>
   <div
     className="event-message truncate"
@@ -117,9 +113,7 @@ exports[`EventOrGroupHeader Event renders with \`type = default\` 1`] = `
   <h3
     className="truncate"
   >
-    <Link
-      onlyActiveOnIndex={false}
-      style={Object {}}
+    <ProjectLink
       to={
         Object {
           "pathname": "/orgId/projectId/issues/groupID/events/id/",
@@ -155,7 +149,7 @@ exports[`EventOrGroupHeader Event renders with \`type = default\` 1`] = `
         orgId="orgId"
         projectId="projectId"
       />
-    </Link>
+    </ProjectLink>
   </h3>
 </div>
 `;
@@ -167,9 +161,7 @@ exports[`EventOrGroupHeader Event renders with \`type = error\` 1`] = `
   <h3
     className="truncate"
   >
-    <Link
-      onlyActiveOnIndex={false}
-      style={Object {}}
+    <ProjectLink
       to={
         Object {
           "pathname": "/orgId/projectId/issues/groupID/events/id/",
@@ -205,7 +197,7 @@ exports[`EventOrGroupHeader Event renders with \`type = error\` 1`] = `
         orgId="orgId"
         projectId="projectId"
       />
-    </Link>
+    </ProjectLink>
   </h3>
   <div
     className="event-message truncate"
@@ -226,9 +218,7 @@ exports[`EventOrGroupHeader Group renders with \`type = csp\` 1`] = `
   <h3
     className="truncate"
   >
-    <Link
-      onlyActiveOnIndex={false}
-      style={Object {}}
+    <ProjectLink
       to={
         Object {
           "pathname": "/orgId/projectId/issues/id/",
@@ -268,7 +258,7 @@ exports[`EventOrGroupHeader Group renders with \`type = csp\` 1`] = `
         orgId="orgId"
         projectId="projectId"
       />
-    </Link>
+    </ProjectLink>
   </h3>
   <div
     className="event-message truncate"
@@ -289,9 +279,7 @@ exports[`EventOrGroupHeader Group renders with \`type = default\` 1`] = `
   <h3
     className="truncate"
   >
-    <Link
-      onlyActiveOnIndex={false}
-      style={Object {}}
+    <ProjectLink
       to={
         Object {
           "pathname": "/orgId/projectId/issues/id/",
@@ -331,7 +319,7 @@ exports[`EventOrGroupHeader Group renders with \`type = default\` 1`] = `
         orgId="orgId"
         projectId="projectId"
       />
-    </Link>
+    </ProjectLink>
   </h3>
   <div
     className="event-message truncate"
@@ -352,9 +340,7 @@ exports[`EventOrGroupHeader Group renders with \`type = error\` 1`] = `
   <h3
     className="truncate"
   >
-    <Link
-      onlyActiveOnIndex={false}
-      style={Object {}}
+    <ProjectLink
       to={
         Object {
           "pathname": "/orgId/projectId/issues/id/",
@@ -394,7 +380,7 @@ exports[`EventOrGroupHeader Group renders with \`type = error\` 1`] = `
         orgId="orgId"
         projectId="projectId"
       />
-    </Link>
+    </ProjectLink>
   </h3>
   <div
     className="event-message truncate"

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -784,9 +784,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             <h3
                               className="truncate"
                             >
-                              <Link
-                                onlyActiveOnIndex={false}
-                                style={Object {}}
+                              <ProjectLink
                                 to={
                                   Object {
                                     "pathname": "/orgId/projectId/issues/268/events/904/",
@@ -795,8 +793,12 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                 }
                               >
                                 <a
-                                  onClick={[Function]}
-                                  style={Object {}}
+                                  href={
+                                    Object {
+                                      "pathname": "/orgId/projectId/issues/268/events/904/",
+                                      "search": "",
+                                    }
+                                  }
                                 >
                                   <EventOrGroupTitle
                                     data={
@@ -907,7 +909,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                     </span>
                                   </EventOrGroupTitle>
                                 </a>
-                              </Link>
+                              </ProjectLink>
                             </h3>
                             <div
                               className="event-message truncate"
@@ -1218,9 +1220,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             <h3
                               className="truncate"
                             >
-                              <Link
-                                onlyActiveOnIndex={false}
-                                style={Object {}}
+                              <ProjectLink
                                 to={
                                   Object {
                                     "pathname": "/orgId/projectId/issues/268/events/904/",
@@ -1229,8 +1229,12 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                 }
                               >
                                 <a
-                                  onClick={[Function]}
-                                  style={Object {}}
+                                  href={
+                                    Object {
+                                      "pathname": "/orgId/projectId/issues/268/events/904/",
+                                      "search": "",
+                                    }
+                                  }
                                 >
                                   <EventOrGroupTitle
                                     data={
@@ -1341,7 +1345,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                     </span>
                                   </EventOrGroupTitle>
                                 </a>
-                              </Link>
+                              </ProjectLink>
                             </h3>
                             <div
                               className="event-message truncate"
@@ -2139,9 +2143,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             <h3
                               className="truncate"
                             >
-                              <Link
-                                onlyActiveOnIndex={false}
-                                style={Object {}}
+                              <ProjectLink
                                 to={
                                   Object {
                                     "pathname": "/orgId/projectId/issues/268/events/904/",
@@ -2150,8 +2152,12 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                 }
                               >
                                 <a
-                                  onClick={[Function]}
-                                  style={Object {}}
+                                  href={
+                                    Object {
+                                      "pathname": "/orgId/projectId/issues/268/events/904/",
+                                      "search": "",
+                                    }
+                                  }
                                 >
                                   <EventOrGroupTitle
                                     data={
@@ -2262,7 +2268,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                     </span>
                                   </EventOrGroupTitle>
                                 </a>
-                              </Link>
+                              </ProjectLink>
                             </h3>
                             <div
                               className="event-message truncate"
@@ -2573,9 +2579,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             <h3
                               className="truncate"
                             >
-                              <Link
-                                onlyActiveOnIndex={false}
-                                style={Object {}}
+                              <ProjectLink
                                 to={
                                   Object {
                                     "pathname": "/orgId/projectId/issues/268/events/904/",
@@ -2584,8 +2588,12 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                 }
                               >
                                 <a
-                                  onClick={[Function]}
-                                  style={Object {}}
+                                  href={
+                                    Object {
+                                      "pathname": "/orgId/projectId/issues/268/events/904/",
+                                      "search": "",
+                                    }
+                                  }
                                 >
                                   <EventOrGroupTitle
                                     data={
@@ -2696,7 +2704,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                     </span>
                                   </EventOrGroupTitle>
                                 </a>
-                              </Link>
+                              </ProjectLink>
                             </h3>
                             <div
                               className="event-message truncate"

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -669,9 +669,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                               <h3
                                 className="truncate"
                               >
-                                <Link
-                                  onlyActiveOnIndex={false}
-                                  style={Object {}}
+                                <ProjectLink
                                   to={
                                     Object {
                                       "pathname": "/orgId/projectId/issues/271/",
@@ -680,8 +678,12 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                   }
                                 >
                                   <a
-                                    onClick={[Function]}
-                                    style={Object {}}
+                                    href={
+                                      Object {
+                                        "pathname": "/orgId/projectId/issues/271/",
+                                        "search": "",
+                                      }
+                                    }
                                   >
                                     <span
                                       className="error-level truncate"
@@ -751,7 +753,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       </span>
                                     </EventOrGroupTitle>
                                   </a>
-                                </Link>
+                                </ProjectLink>
                               </h3>
                               <div
                                 className="event-message truncate"
@@ -1758,9 +1760,7 @@ exports[`Issues Similar View renders with mocked data 2`] = `
                               <h3
                                 className="truncate"
                               >
-                                <Link
-                                  onlyActiveOnIndex={false}
-                                  style={Object {}}
+                                <ProjectLink
                                   to={
                                     Object {
                                       "pathname": "/orgId/projectId/issues/271/",
@@ -1769,8 +1769,12 @@ exports[`Issues Similar View renders with mocked data 2`] = `
                                   }
                                 >
                                   <a
-                                    onClick={[Function]}
-                                    style={Object {}}
+                                    href={
+                                      Object {
+                                        "pathname": "/orgId/projectId/issues/271/",
+                                        "search": "",
+                                      }
+                                    }
                                   >
                                     <span
                                       className="error-level truncate"
@@ -1840,7 +1844,7 @@ exports[`Issues Similar View renders with mocked data 2`] = `
                                       </span>
                                     </EventOrGroupTitle>
                                   </a>
-                                </Link>
+                                </ProjectLink>
                               </h3>
                               <div
                                 className="event-message truncate"


### PR DESCRIPTION
Add environment parameter to link for event, group and releases lists

We want to do this so open in new tab will open the same environment if it's specified