### PR TITLE
fix(stream): Do not refetch stream twice if environment changes

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -6,6 +6,7 @@ import {Link, browserHistory} from 'react-router';
 import Cookies from 'js-cookie';
 import {StickyContainer, Sticky} from 'react-sticky';
 import classNames from 'classnames';
+import {isEqual, omit} from 'lodash';
 
 import SentryTypes from '../../proptypes';
 import ApiMixin from '../../mixins/apiMixin';
@@ -119,7 +120,14 @@ const Stream = createReactClass({
       ? nextSearchId
       : nextSearchId !== this.state.searchId;
 
-    if (searchIdChanged || nextProps.location.search !== this.props.location.search) {
+    // We omit environment when we check the the query has changed as we
+    // handle environment changes separately
+    let queryChanged = !isEqual(
+      omit(nextProps.location.query, 'environment'),
+      omit(this.props.location.query, 'environment')
+    );
+
+    if (searchIdChanged || queryChanged) {
       this.setState(this.getQueryState(nextProps), this.fetchData);
     }
   },


### PR DESCRIPTION
We handle environment changes separately so we need to ignore this when
no other part of the query string is changing