### PR TITLE
fix(actors): correct avatar classname placement in team avatars

### DIFF
--- a/src/sentry/static/sentry/app/components/teamAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/teamAvatar.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -24,11 +25,11 @@ class TeamAvatar extends React.Component {
     let {team, hasTooltip} = this.props;
     let displayName = this.getDisplayName();
     return (
-      <span className={this.props.className}>
-        <Tooltip title={displayName} disabled={!hasTooltip}>
+      <Tooltip title={displayName} disabled={!hasTooltip}>
+        <span className={classNames('avatar', this.props.className)}>
           <LetterAvatar identifier={team.slug} displayName={displayName} />
-        </Tooltip>
-      </span>
+        </span>
+      </Tooltip>
     );
   }
 }

--- a/tests/js/spec/components/__snapshots__/teamAvatar.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/teamAvatar.spec.jsx.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TeamAvatar render() renders 1`] = `
-<span
-  className="avatar"
+<Tooltip
+  disabled={true}
+  title="team-slug"
 >
-  <Tooltip
-    disabled={true}
-    title="team-slug"
+  <span
+    className="avatar avatar"
   >
     <LetterAvatar
       displayName="team-slug"
       identifier="team-slug"
     />
-  </Tooltip>
-</span>
+  </span>
+</Tooltip>
 `;


### PR DESCRIPTION
bring team avatar into sync with avatar so the classnames are in the right place and the style work. fixes invisible team owners

related to https://github.com/getsentry/sentry/pull/7646