### PR TITLE
fix(alerts): Move rule enabled checks to the frontend

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -24,10 +24,8 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 'id': node.id,
                 'label': node.label,
                 'html': node.render_form(),
+                'enabled': node.is_enabled(),
             }
-
-            if not node.is_enabled():
-                continue
 
             if rule_type.startswith('condition/'):
                 condition_list.append(context)

--- a/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/ruleNodeList.jsx
@@ -81,7 +81,7 @@ class RuleNodeList extends React.Component {
         <fieldset className="node-selector">
           <SelectInput onChange={this.onAddRow} style={{width: '100%'}}>
             <option key="blank" />
-            {this.props.nodes.map(node => {
+            {this.props.nodes.filter(n => n.enabled).map(node => {
               return (
                 <option value={node.id} key={node.id}>
                   {node.label}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -645,6 +645,7 @@ window.TestStubs = {
           html: 'Send a notification for all services',
           id: 'sentry.rules.actions.notify1',
           label: 'Send a notification for all services',
+          enabled: true,
         },
       ],
       conditions: [
@@ -652,6 +653,7 @@ window.TestStubs = {
           html: 'An event is seen',
           id: 'sentry.rules.conditions.1',
           label: 'An event is seen',
+          enabled: true,
         },
       ],
     };

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -77,6 +77,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
         actions={
           Array [
             Object {
+              "enabled": true,
               "html": "Send a notification for all services",
               "id": "sentry.rules.actions.notify1",
               "label": "Send a notification for all services",
@@ -86,6 +87,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
         conditions={
           Array [
             Object {
+              "enabled": true,
               "html": "An event is seen",
               "id": "sentry.rules.conditions.1",
               "label": "An event is seen",
@@ -301,6 +303,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                       nodes={
                         Array [
                           Object {
+                            "enabled": true,
                             "html": "An event is seen",
                             "id": "sentry.rules.conditions.1",
                             "label": "An event is seen",
@@ -435,6 +438,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                       nodes={
                         Array [
                           Object {
+                            "enabled": true,
                             "html": "Send a notification for all services",
                             "id": "sentry.rules.actions.notify1",
                             "label": "Send a notification for all services",
@@ -750,6 +754,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
         actions={
           Array [
             Object {
+              "enabled": true,
               "html": "Send a notification for all services",
               "id": "sentry.rules.actions.notify1",
               "label": "Send a notification for all services",
@@ -759,6 +764,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
         conditions={
           Array [
             Object {
+              "enabled": true,
               "html": "An event is seen",
               "id": "sentry.rules.conditions.1",
               "label": "An event is seen",
@@ -974,6 +980,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                       nodes={
                         Array [
                           Object {
+                            "enabled": true,
                             "html": "An event is seen",
                             "id": "sentry.rules.conditions.1",
                             "label": "An event is seen",
@@ -1108,6 +1115,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                       nodes={
                         Array [
                           Object {
+                            "enabled": true,
                             "html": "Send a notification for all services",
                             "id": "sentry.rules.actions.notify1",
                             "label": "Send a notification for all services",

--- a/tests/js/spec/views/ruleEditor/ruleNodeList.spec.jsx
+++ b/tests/js/spec/views/ruleEditor/ruleNodeList.spec.jsx
@@ -10,11 +10,13 @@ describe('RuleNodeList', function() {
     sampleNodes = [
       {
         id: 'sentry.rules.conditions.every_event.EveryEventCondition',
+        enabled: true,
         label: 'An event is seen',
         html: 'An event is seen',
       },
       {
         id: 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
+        enabled: false,
         label: 'An event is seen more than {value} times in {interval}',
         html:
           'An event is seen more than <input id="id_value" name="value" placeholder="100" type="number" /> times ' +
@@ -43,6 +45,7 @@ describe('RuleNodeList', function() {
       expect(wrapper.state('items')[0]).toHaveProperty('key_attr', 0);
       expect(wrapper.state('items')[1]).toHaveProperty('key_attr', 1);
       expect(wrapper.state('counter')).toEqual(2);
+      expect(wrapper.find('.node-selector option[value]').length).toEqual(1);
     });
   });
 

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -23,5 +23,5 @@ class ProjectRuleConfigurationTest(APITestCase):
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
-        assert len(response.data['actions']) == 2
+        assert len(response.data['actions']) == 3
         assert len(response.data['conditions']) == 8


### PR DESCRIPTION
If an rule becomes disabled the frontend can still render the form for it.