### PR TITLE
ref(ingest): Improve handling of duplicate event IDs

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -477,12 +477,35 @@ class EventManager(object):
 
         project = Project.objects.get_from_cache(id=project)
 
+        # Check to make sure we're not about to do a bunch of work that's
+        # already been done if we've processed an event with this ID. (This
+        # isn't a perfect solution -- this doesn't handle ``EventMapping`` and
+        # there's a race condition between here and when the event is actually
+        # saved, but it's an improvement. See GH-7677.)
+        try:
+            event = Event.objects.get(
+                project_id=project.id,
+                event_id=self.data['event_id'],
+            )
+        except Event.DoesNotExist:
+            pass
+        else:
+            self.logger.info(
+                'duplicate.found',
+                exc_info=True,
+                extra={
+                    'event_uuid': self.data['event_id'],
+                    'project_id': project.id,
+                    'model': Event.__name__,
+                }
+            )
+            return event
+
         data = self.data.copy()
 
         # First we pull out our top-level (non-data attr) kwargs
         event_id = data.pop('event_id')
         level = data.pop('level')
-
         culprit = data.pop('transaction', None)
         if not culprit:
             culprit = data.pop('culprit', None)
@@ -719,24 +742,6 @@ class EventManager(object):
                     }
                 )
                 return event
-
-        # We now always need to check the Event table for dupes
-        # since EventMapping isn't exactly the canonical source of truth.
-        if Event.objects.filter(
-            project_id=project.id,
-            event_id=event_id,
-        ).exists():
-            self.logger.info(
-                'duplicate.found',
-                exc_info=True,
-                extra={
-                    'event_uuid': event_id,
-                    'project_id': project.id,
-                    'group_id': group.id,
-                    'model': Event.__name__,
-                }
-            )
-            return event
 
         environment = Environment.get_or_create(
             project=project,

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -125,20 +125,6 @@ class EventManagerTest(TransactionTestCase):
             event_id=event_id,
         ).exists()
 
-    @mock.patch('sentry.event_manager.should_sample')
-    def test_sample_feature_flag(self, should_sample):
-        should_sample.return_value = True
-
-        manager = EventManager(self.make_event())
-        with self.feature('projects:sample-events'):
-            event = manager.save(1)
-        assert event.id
-
-        manager = EventManager(self.make_event())
-        with self.feature({'projects:sample-events': False}):
-            event = manager.save(1)
-        assert not event.id
-
     def test_tags_as_list(self):
         manager = EventManager(self.make_event(tags=[('foo', 'bar')]))
         data = manager.normalize()

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -57,11 +57,11 @@ class EventManagerTest(TransactionTestCase):
         # we had a regression which caused the default hash to just be
         # 'event.message' instead of '[event.message]' which caused it to
         # generate a hash per letter
-        manager = EventManager(self.make_event(message='foo bar'))
+        manager = EventManager(self.make_event(event_id='a', message='foo bar'))
         manager.normalize()
         event1 = manager.save(1)
 
-        manager = EventManager(self.make_event(message='foo baz'))
+        manager = EventManager(self.make_event(event_id='b', message='foo baz'))
         manager.normalize()
         event2 = manager.save(1)
 

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -694,6 +694,7 @@ class EventManagerTest(TransactionTestCase):
 
     def test_event_user(self):
         manager = EventManager(self.make_event(
+            event_id='a',
             environment='totally unique environment',
             **{'sentry.interfaces.User': {
                 'id': '1',
@@ -754,10 +755,13 @@ class EventManagerTest(TransactionTestCase):
 
         # ensure event user is mapped to tags in second attempt
         manager = EventManager(
-            self.make_event(**{'sentry.interfaces.User': {
-                'id': '1',
-                'name': 'jane',
-            }})
+            self.make_event(
+                event_id='b',
+                **{'sentry.interfaces.User': {
+                    'id': '1',
+                    'name': 'jane',
+                }}
+            )
         )
         manager.normalize()
         with self.tasks():

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -1076,7 +1076,7 @@ class EventManagerTest(TransactionTestCase):
         manager = EventManager(
             self.make_event(
                 message='foo',
-                event_id='a' * 32,
+                event_id='b' * 32,
                 fingerprint=['a' * 32],
             )
         )


### PR DESCRIPTION
References GH-7677.

This doesn't "fix" the issue per se (there's still a race condition when multiple events with the same ID are processed simultaneously and this doesn't handle race conditions within `EventManager`) but handles `Event` which was 80% of the duplicates over a 12 hour sample.

This also updates a bunch of tests that were sending duplicate IDs through the processing pipeline. We might want to use UUIDs when creating events in tests?