### PR TITLE
fix(environments): Always fetch projects and environments before load

### DIFF
--- a/tests/js/spec/views/onboarding/configure/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/configure/index.spec.jsx
@@ -113,7 +113,7 @@ describe('Configure should render correctly', function() {
       expect(handleSubmitStub.callCount).toEqual(1);
     });
 
-    it('should render platform docs', function() {
+    it('should render platform docs', function(done) {
       let props = {
         ...baseProps,
       };
@@ -162,7 +162,11 @@ describe('Configure should render correctly', function() {
         },
       });
 
-      expect(wrapper).toMatchSnapshot();
+      setTimeout(() => {
+        wrapper.update();
+        expect(wrapper).toMatchSnapshot();
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
We'll always need projects and environment data before we can load any of the project pages

Fixes a bug where default environment would be selected incorrectly if environments endpoint is returned first