### PR TITLE
feat(environments): Do not refetch when environment changes in query

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -6,6 +6,8 @@ import {Link, browserHistory} from 'react-router';
 import Cookies from 'js-cookie';
 import {StickyContainer, Sticky} from 'react-sticky';
 import classNames from 'classnames';
+import qs from 'query-string';
+import {omit, isEqual} from 'lodash';
 
 import SentryTypes from '../../proptypes';
 import ApiMixin from '../../mixins/apiMixin';
@@ -119,7 +121,17 @@ const Stream = createReactClass({
       ? nextSearchId
       : nextSearchId !== this.state.searchId;
 
-    if (searchIdChanged || nextProps.location.search !== this.props.location.search) {
+    // We are using qs.parse with location.search since this.props.location.query
+    // returns the same value as nextProps.location.query
+    let currentSearchTerm = qs.parse(this.props.location.search);
+    let nextSearchTerm = qs.parse(nextProps.location.search);
+
+    let searchTermChanged = !isEqual(
+      omit(currentSearchTerm, 'environment'),
+      omit(nextSearchTerm, 'environment')
+    );
+
+    if (searchIdChanged || searchTermChanged) {
       this.setState(this.getQueryState(nextProps), this.fetchData);
     }
   },


### PR DESCRIPTION
We handle environment changes separately so we need to ignore this when
no other part of the query string is changing

Same as #7673 but using location.search instead of location.query