### PR TITLE
fix(tagstore): Override all delete methods to pass project_id

### DIFF
--- a/src/sentry/tagstore/v2/models/grouptagkey.py
+++ b/src/sentry/tagstore/v2/models/grouptagkey.py
@@ -39,7 +39,7 @@ class GroupTagKey(Model):
 
     __repr__ = sane_repr('project_id', 'group_id', '_key')
 
-    def delete_for_merge(self):
+    def delete(self):
         using = router.db_for_read(GroupTagKey)
         cursor = connections[using].cursor()
         cursor.execute(

--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -45,7 +45,7 @@ class GroupTagValue(Model):
 
     __repr__ = sane_repr('project_id', 'group_id', '_key', '_value')
 
-    def delete_for_merge(self):
+    def delete(self):
         using = router.db_for_read(GroupTagValue)
         cursor = connections[using].cursor()
         cursor.execute(

--- a/src/sentry/tagstore/v2/models/tagvalue.py
+++ b/src/sentry/tagstore/v2/models/tagvalue.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function
 
 import six
 
-from django.db import models
+from django.db import models, router, connections
 from django.utils import timezone
 
 from sentry.api.serializers import Serializer, register
@@ -47,6 +47,17 @@ class TagValue(Model):
         index_together = (('project_id', '_key', 'last_seen'), )
 
     __repr__ = sane_repr('project_id', '_key', 'value')
+
+    def delete(self):
+        using = router.db_for_read(TagValue)
+        cursor = connections[using].cursor()
+        cursor.execute(
+            """
+            DELETE FROM tagstore_tagvalue
+            WHERE project_id = %s
+              AND id = %s
+        """, [self.project_id, self.id]
+        )
 
     @property
     def key(self):

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -334,11 +334,7 @@ def merge_objects(models, group, new_group, limit=1000, logger=None, transaction
                     obj.merge_counts(new_group)
 
                 obj_id = obj.id
-
-                if hasattr(model, 'delete_for_merge'):
-                    obj.delete_for_merge()
-                else:
-                    obj.delete()
+                obj.delete()
 
                 if logger is not None:
                     delete_logger.debug(


### PR DESCRIPTION
I don't think we care about Django signals or anything on these... so override `delete` is probably OK? But need Django expert to weigh in here.