### PR TITLE
fix(tagstore): Add project_id to TagKey update

### DIFF
--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -459,6 +459,7 @@ class V2TagStorage(TagStorage):
             updated = TagKey.objects.filter(
                 id=tagkey.id,
                 status=TagKeyStatus.VISIBLE,
+                project_id=project_id,
             ).update(status=TagKeyStatus.PENDING_DELETION)
 
             if updated:


### PR DESCRIPTION
Fixes SENTRY-648

Sigh. Looked for others, don't see any.