### PR TITLE
 feat(environments): Query string does not display default environment

### DIFF
--- a/src/sentry/static/sentry/app/constants.jsx
+++ b/src/sentry/static/sentry/app/constants.jsx
@@ -33,3 +33,5 @@ export const DEFAULT_API_SCOPES = [
 export const DEFAULT_TOAST_DURATION = 6000;
 
 export const CSRF_COOKIE_NAME = window.csrfCookieName || 'sc';
+
+export const ALL_ENVIRONMENTS_KEY = '__all_environments__';

--- a/src/sentry/static/sentry/app/stores/environmentStore.jsx
+++ b/src/sentry/static/sentry/app/stores/environmentStore.jsx
@@ -5,6 +5,7 @@ import ProjectActions from '../actions/projectActions';
 import EnvironmentActions from '../actions/environmentActions';
 
 import {setActiveEnvironment} from '../actionCreators/environments';
+import {ALL_ENVIRONMENTS_KEY} from '../constants';
 
 const PRODUCTION_ENV_NAMES = new Set([
   'production',
@@ -19,7 +20,7 @@ const DEFAULT_EMPTY_ROUTING_NAME = 'none';
 
 const EnvironmentStore = Reflux.createStore({
   init() {
-    this.items = null;
+    this.items = [];
     this.hidden = null;
     this.defaultEnvironment = null;
     this.listenTo(EnvironmentActions.loadData, this.loadInitialData);
@@ -31,7 +32,10 @@ const EnvironmentStore = Reflux.createStore({
   loadInitialData(items, activeEnvironmentName) {
     this.loadActiveData(items);
     // Update the default environment in the latest context store
-    const activeEnvironment = this.getByName(activeEnvironmentName) || this.getDefault();
+    let activeEnvironment = null;
+    if (activeEnvironmentName !== ALL_ENVIRONMENTS_KEY) {
+      activeEnvironment = this.getByName(activeEnvironmentName) || this.getDefault();
+    }
     setActiveEnvironment(activeEnvironment);
   },
 
@@ -59,7 +63,7 @@ const EnvironmentStore = Reflux.createStore({
   },
 
   getByName(name) {
-    const envs = this.items || [];
+    const envs = this.items;
     return envs.find(item => item.name === name) || null;
   },
 
@@ -80,7 +84,7 @@ const EnvironmentStore = Reflux.createStore({
   // Default environment is either the first based on the set of common names
   // or the first in the environment list if none match
   getDefault() {
-    let allEnvs = this.items || [];
+    let allEnvs = this.items;
 
     let defaultEnv = allEnvs.find(e => e.name === this.defaultEnvironment);
 

--- a/src/sentry/static/sentry/app/stores/environmentStore.jsx
+++ b/src/sentry/static/sentry/app/stores/environmentStore.jsx
@@ -32,6 +32,8 @@ const EnvironmentStore = Reflux.createStore({
   loadInitialData(items, activeEnvironmentName) {
     this.loadActiveData(items);
     // Update the default environment in the latest context store
+    // The active environment will be null (aka All Environments) if the name matches
+    // ALL_ENVIRONMENTS_KEY otherwise find the environment matching the name provided
     let activeEnvironment = null;
     if (activeEnvironmentName !== ALL_ENVIRONMENTS_KEY) {
       activeEnvironment = this.getByName(activeEnvironmentName) || this.getDefault();

--- a/src/sentry/static/sentry/app/utils/withEnvironmentInQueryString.jsx
+++ b/src/sentry/static/sentry/app/utils/withEnvironmentInQueryString.jsx
@@ -66,8 +66,11 @@ const withEnvironmentInQueryString = WrappedComponent =>
       if (hasEnvironmentsFeature && environmentHasChanged) {
         const {query, pathname} = this.props.location;
         if (environment === defaultEnvironment) {
+          // We never show environment in the query string if it's the default one
           delete query.environment;
         } else {
+          // We show ?environment=__all_environments__ in the query string if 'All environments'
+          // is selected and that is not the default
           const envName = environment ? environment.name : ALL_ENVIRONMENTS_KEY;
           query.environment = envName;
         }

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -133,7 +133,7 @@ const ProjectContext = createReactClass({
   },
 
   fetchData() {
-    let {orgId, projectId} = this.props;
+    let {orgId, projectId, location} = this.props;
     // we fetch core access/information from the global organization data
     let activeProject = this.identifyProject();
     let hasAccess = activeProject && activeProject.hasAccess;
@@ -164,7 +164,12 @@ const ProjectContext = createReactClass({
           // assuming here that this means the project is considered the active project
           setActiveProject(project);
 
-          loadEnvironments(envs, project.defaultEnvironment);
+          // If an environment is specified in the query string, load it instead of default
+          const queryEnv = location.query.environment;
+          const envName =
+            typeof queryEnv === 'undefined' ? project.defaultEnvironment : queryEnv;
+
+          loadEnvironments(envs, envName);
         },
         () => {
           this.setState({

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -19,8 +19,7 @@ import Panel from '../settings/components/panel';
 import PanelBody from '../settings/components/panelBody';
 import PanelHeader from '../settings/components/panelHeader';
 import RuleNodeList from './ruleNodeList';
-
-const ALL_ENVIRONMENTS_KEY = '__all_environments__';
+import {ALL_ENVIRONMENTS_KEY} from '../../constants';
 
 const FREQUENCY_CHOICES = [
   ['5', t('5 minutes')],

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -40,7 +40,7 @@ window.TestStubs = {
     setRouteLeaveHook: sinon.spy(),
     isActive: sinon.spy(),
     createHref: sinon.spy(),
-    location: {},
+    location: {query: {}},
   }),
 
   location: () => ({

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -83,7 +83,11 @@ exports[`Configure should render correctly render() should render platform docs 
         }
       >
         <ProjectContext
-          location={Object {}}
+          location={
+            Object {
+              "query": Object {},
+            }
+          }
           orgId="testOrg"
           projectId="project-slug"
           router={
@@ -93,7 +97,9 @@ exports[`Configure should render correctly render() should render platform docs 
               "goBack": [Function],
               "goForward": [Function],
               "isActive": [Function],
-              "location": Object {},
+              "location": Object {
+                "query": Object {},
+              },
               "push": [Function],
               "replace": [Function],
               "setRouteLeaveHook": [Function],

--- a/tests/js/spec/views/onboarding/configure/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/configure/index.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {shallow, mount} from 'enzyme';
 
 import {Client} from 'app/api';
@@ -158,7 +159,7 @@ describe('Configure should render correctly', function() {
         childContextTypes: {
           organization: SentryTypes.Organization,
           project: SentryTypes.Project,
-          router: SentryTypes.object,
+          router: PropTypes.object,
         },
       });
 


### PR DESCRIPTION
Environments are only reflected in the query string if the are not default
All environments is represented with `?environment=__all_environments__`

A number of components that use this higher order component currently rely on the environment in the querystring being the correct one, so we will need to modify these as well