### PR TITLE
ref(ui): Change `<ProjectContext>` to use `ProjectsStore`

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/projects.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/projects.jsx
@@ -124,3 +124,7 @@ export function addTeamToProject(api, orgSlug, projectSlug, teamSlug) {
       }
     );
 }
+
+export function changeProjectSlug(prev, next) {
+  ProjectActions.changeSlug(prev, next);
+}

--- a/src/sentry/static/sentry/app/actions/projectActions.jsx
+++ b/src/sentry/static/sentry/app/actions/projectActions.jsx
@@ -12,4 +12,5 @@ export default Reflux.createActions([
   'removeProjectError',
   'removeProjectSuccess',
   'setActive',
+  'changeSlug',
 ]);

--- a/src/sentry/static/sentry/app/components/panels/panelAlert.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.jsx
@@ -1,4 +1,3 @@
-import {withTheme} from 'emotion-theming';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -49,4 +48,4 @@ class PanelAlert extends React.Component {
   }
 }
 
-export default withTheme(PanelAlert);
+export default PanelAlert;

--- a/src/sentry/static/sentry/app/stores/projectsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStore.jsx
@@ -27,10 +27,8 @@ const ProjectsStore = Reflux.createStore({
   onChangeSlug(prevSlug, newSlug) {
     let prevProject = this.getBySlug(prevSlug);
 
-    if (!prevProject) {
-      // This shouldn't happen
-      return;
-    }
+    // This shouldn't happen
+    if (!prevProject) return;
 
     this.itemsById[newSlug] = {
       ...prevProject,

--- a/src/sentry/static/sentry/app/stores/projectsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStore.jsx
@@ -9,6 +9,7 @@ const ProjectsStore = Reflux.createStore({
     this.listenTo(ProjectActions.createSuccess, this.onCreateSuccess);
     this.listenTo(ProjectActions.updateSuccess, this.onUpdateSuccess);
     this.listenTo(ProjectActions.loadStatsSuccess, this.onStatsLoadSuccess);
+    this.listenTo(ProjectActions.changeSlug, this.onChangeSlug);
   },
 
   reset() {
@@ -21,6 +22,28 @@ const ProjectsStore = Reflux.createStore({
       return map;
     }, {});
     this.trigger(new Set(Object.keys(this.itemsById)));
+  },
+
+  onChangeSlug(prevSlug, newSlug) {
+    let prevProject = this.getBySlug(prevSlug);
+
+    if (!prevProject) {
+      // This shouldn't happen
+      return;
+    }
+
+    this.itemsById[newSlug] = {
+      ...prevProject,
+      slug: newSlug,
+    };
+
+    this.itemsById = {
+      ...this.itemsById,
+    };
+
+    // Ideally we'd always trigger this.itemsById, but following existing patterns
+    // so we don't break things
+    this.trigger(new Set([prevProject.id]));
   },
 
   onCreateSuccess(project) {

--- a/src/sentry/static/sentry/app/stores/projectsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStore.jsx
@@ -30,7 +30,7 @@ const ProjectsStore = Reflux.createStore({
     // This shouldn't happen
     if (!prevProject) return;
 
-    this.itemsById[newSlug] = {
+    const newProject = {
       ...prevProject,
       slug: newSlug,
     };
@@ -38,6 +38,8 @@ const ProjectsStore = Reflux.createStore({
     this.itemsById = {
       ...this.itemsById,
     };
+
+    this.itemsById[newProject.id] = newProject;
 
     // Ideally we'd always trigger this.itemsById, but following existing patterns
     // so we don't break things

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -84,6 +84,11 @@ const OrganizationContext = createReactClass({
           hooks.push(cb(data));
         });
 
+        setActiveOrganization(data);
+
+        TeamStore.loadInitialData(data.teams);
+        ProjectsStore.loadInitialData(data.projects);
+
         this.setState({
           organization: data,
           loading: false,
@@ -92,11 +97,6 @@ const OrganizationContext = createReactClass({
           hooks,
           showBroadcast: this.shouldShowBroadcast(data),
         });
-
-        setActiveOrganization(data);
-
-        TeamStore.loadInitialData(data.teams);
-        ProjectsStore.loadInitialData(data.projects);
       },
 
       error: (_, textStatus, errorThrown) => {

--- a/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
@@ -338,7 +338,7 @@ const ProjectGeneralSettingsContainer = createReactClass({
 
     if (!project) return;
 
-    browserHistory.push(
+    browserHistory.replace(
       recreateRoute('', {
         ...this.props,
         params: {

--- a/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
@@ -1,8 +1,16 @@
+import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
 
+import {
+  changeProjectSlug,
+  removeProject,
+  transferProject,
+} from '../actionCreators/projects';
+import {fields} from '../data/forms/projectGeneralSettings';
 import {getOrganizationState} from '../mixins/organizationState';
-import {removeProject, transferProject} from '../actionCreators/projects';
 import {t, tct} from '../locale';
 import AsyncView from './asyncView';
 import Button from '../components/buttons/button';
@@ -11,10 +19,11 @@ import Field from './settings/components/forms/field';
 import Form from './settings/components/forms/form';
 import JsonForm from './settings/components/forms/jsonForm';
 import {Panel, PanelAlert, PanelHeader} from '../components/panels';
+import ProjectsStore from '../stores/projectsStore';
 import SettingsPageHeader from './settings/components/settingsPageHeader';
 import TextBlock from './settings/components/text/textBlock';
 import TextField from './settings/components/forms/textField';
-import {fields} from '../data/forms/projectGeneralSettings';
+import recreateRoute from '../utils/recreateRoute';
 
 const AutoResolveFooter = () => (
   <PanelAlert type="warning">
@@ -27,7 +36,11 @@ const AutoResolveFooter = () => (
   </PanelAlert>
 );
 
-export default class ProjectGeneralSettings extends AsyncView {
+class ProjectGeneralSettings extends AsyncView {
+  static propTypes = {
+    onChangeSlug: PropTypes.func,
+  };
+
   static contextTypes = {
     organization: PropTypes.object.isRequired,
   };
@@ -237,9 +250,10 @@ export default class ProjectGeneralSettings extends AsyncView {
           apiMethod="PUT"
           apiEndpoint={endpoint}
           onSubmitSuccess={resp => {
-            // Reload if slug has changed
             if (projectId !== resp.slug) {
-              window.location = `/${organization.slug}/${resp.slug}/settings/`;
+              changeProjectSlug(projectId, resp.slug);
+              // Container will redirect after stores get updated with new slug
+              this.props.onChangeSlug(resp.slug);
             }
           }}
         >
@@ -315,3 +329,34 @@ export default class ProjectGeneralSettings extends AsyncView {
     );
   }
 }
+
+const ProjectGeneralSettingsContainer = createReactClass({
+  mixins: [Reflux.listenTo(ProjectsStore, 'onProjectsUpdate')],
+  onProjectsUpdate(projects) {
+    if (!this.changedSlug) return;
+    let project = ProjectsStore.getBySlug(this.changedSlug);
+
+    if (!project) return;
+
+    browserHistory.push(
+      recreateRoute('', {
+        ...this.props,
+        params: {
+          ...this.props.params,
+          projectId: this.changedSlug,
+        },
+      })
+    );
+  },
+
+  render() {
+    return (
+      <ProjectGeneralSettings
+        onChangeSlug={newSlug => (this.changedSlug = newSlug)}
+        {...this.props}
+      />
+    );
+  },
+});
+
+export default ProjectGeneralSettingsContainer;

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -105,7 +105,8 @@ const ProjectContext = createReactClass({
       prevState.project !== this.state.project ||
       prevState.organization !== this.state.organization
     ) {
-      let docTitle = this.refs.docTitle;
+      if (!this.docTitle) return;
+      let docTitle = this.docTitleRef.docTitle;
       if (docTitle) docTitle.forceUpdate();
     }
   },
@@ -271,7 +272,7 @@ const ProjectContext = createReactClass({
 
   render() {
     return (
-      <DocumentTitle ref="docTitle" title={this.getTitle()}>
+      <DocumentTitle ref={ref => (this.docTitleRef = ref)} title={this.getTitle()}>
         {this.renderBody()}
       </DocumentTitle>
     );

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -1,23 +1,23 @@
+import {withRouter} from 'react-router';
+import DocumentTitle from 'react-document-title';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import DocumentTitle from 'react-document-title';
-import {withRouter} from 'react-router';
+import createReactClass from 'create-react-class';
 
-import ApiMixin from '../../mixins/apiMixin';
-
-import MemberListStore from '../../stores/memberListStore';
-import LoadingError from '../../components/loadingError';
-import LoadingIndicator from '../../components/loadingIndicator';
-import MissingProjectMembership from '../../components/missingProjectMembership';
-import OrganizationState from '../../mixins/organizationState';
-import SentryTypes from '../../proptypes';
-import ProjectsStore from '../../stores/projectsStore';
-import recreateRoute from '../../utils/recreateRoute';
 import {loadEnvironments} from '../../actionCreators/environments';
 import {setActiveProject} from '../../actionCreators/projects';
 import {t} from '../../locale';
+import ApiMixin from '../../mixins/apiMixin';
+import LoadingError from '../../components/loadingError';
+import LoadingIndicator from '../../components/loadingIndicator';
+import MemberListStore from '../../stores/memberListStore';
+import MissingProjectMembership from '../../components/missingProjectMembership';
+import OrganizationState from '../../mixins/organizationState';
+import ProjectsStore from '../../stores/projectsStore';
+import recreateRoute from '../../utils/recreateRoute';
+import SentryTypes from '../../proptypes';
+import withProjects from '../../utils/withProjects';
 
 const ERROR_TYPES = {
   MISSING_MEMBERSHIP: 'MISSING_MEMBERSHIP',
@@ -40,6 +40,7 @@ const ProjectContext = createReactClass({
      * If true, this will not change `state.loading` during `fetchData` phase
      */
     skipReload: PropTypes.bool,
+    projects: PropTypes.arrayOf(SentryTypes.Project),
     projectId: PropTypes.string,
     orgId: PropTypes.string,
     location: PropTypes.object,
@@ -128,16 +129,9 @@ const ProjectContext = createReactClass({
   },
 
   identifyProject() {
-    let {projectId} = this.props;
+    let {projects, projectId} = this.props;
     let projectSlug = projectId;
-    let activeProject = null;
-    let org = this.context.organization;
-    org.projects.forEach(project => {
-      if (project.slug == projectSlug) {
-        activeProject = project;
-      }
-    });
-    return activeProject;
+    return projects.find(({slug}) => slug === projectSlug) || null;
   },
 
   fetchData() {
@@ -286,4 +280,4 @@ const ProjectContext = createReactClass({
 
 export {ProjectContext};
 
-export default withRouter(ProjectContext);
+export default withProjects(withRouter(ProjectContext));

--- a/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/repositories/organizationRepositories.jsx
@@ -1,5 +1,4 @@
 import {Box, Flex} from 'grid-emotion';
-import {withTheme} from 'emotion-theming';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -15,13 +14,13 @@ import SettingsPageHeader from '../../components/settingsPageHeader';
 import TextBlock from '../../components/text/textBlock';
 import AddRepositoryLink from './addRepositoryLink';
 
-const RepoRow = withTheme(styled(SpreadLayout)`
+const RepoRow = styled(SpreadLayout)`
   border-bottom: 1px solid ${p => p.theme.borderLight};
 
   &:last-child {
     border-bottom: none;
   }
-`);
+`;
 
 class OrganizationRepositories extends React.Component {
   static propTypes = {

--- a/tests/acceptance/test_organization_settings.py
+++ b/tests/acceptance/test_organization_settings.py
@@ -84,8 +84,9 @@ class OrganizationSettingsTest(AcceptanceTestCase):
             self.browser.wait_until_not('.loading-indicator')
             assert not self.browser.element_exists('.ref-organization-settings .error')
             self.browser.click('#require2FA')
+
             self.browser.wait_until('.modal')
             self.browser.click('.modal .button-primary')
             self.browser.wait_until_not('.modal')
-            self.load_organization_helper("setting 2fa without 2fa enabled")
             self.browser.wait_until('.ref-toast.ref-error')
+            self.load_organization_helper("setting 2fa without 2fa enabled")

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -10,6 +10,18 @@ import Adapter from 'enzyme-adapter-react-16';
 jest.mock('app/translations');
 jest.mock('app/api');
 jest.mock('scroll-to-element', () => {});
+jest.mock('react-router', () => {
+  const ReactRouter = require.requireActual('react-router');
+  return {
+    Link: ReactRouter.Link,
+    withRouter: ReactRouter.withRouter,
+    browserHistory: {
+      push: jest.fn(),
+      replace: jest.fn(),
+      listen: jest.fn(() => {}),
+    },
+  };
+});
 
 const constantDate = new Date('2017-10-17T04:41:20'); //National Pasta Day
 MockDate.set(constantDate);
@@ -37,7 +49,7 @@ window.Raven = {
 };
 window.TestStubs = {
   // react-router's 'router' context
-  router: () => ({
+  router: (params = {}) => ({
     push: sinon.spy(),
     replace: sinon.spy(),
     go: sinon.spy(),
@@ -47,6 +59,7 @@ window.TestStubs = {
     isActive: sinon.spy(),
     createHref: sinon.spy(),
     location: {query: {}},
+    ...params,
   }),
 
   location: () => ({

--- a/tests/js/spec/views/__snapshots__/organizationAuthList.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationAuthList.spec.jsx.snap
@@ -16,7 +16,7 @@ exports[`OrganizationAuthList renders 1`] = `
       disablePadding={true}
       flex={false}
     >
-      <WithTheme(PanelAlert)
+      <PanelAlert
         m={0}
         mb={0}
         type="info"
@@ -44,7 +44,7 @@ exports[`OrganizationAuthList renders 1`] = `
           </ExternalLink>
         </span>
         .
-      </WithTheme(PanelAlert)>
+      </PanelAlert>
       <form
         action="/organizations/org-slug/auth/configure/"
         method="POST"
@@ -87,7 +87,7 @@ exports[`OrganizationAuthList renders with no providers 1`] = `
       disablePadding={true}
       flex={false}
     >
-      <WithTheme(PanelAlert)
+      <PanelAlert
         m={0}
         mb={0}
         type="info"
@@ -115,7 +115,7 @@ exports[`OrganizationAuthList renders with no providers 1`] = `
           </ExternalLink>
         </span>
         .
-      </WithTheme(PanelAlert)>
+      </PanelAlert>
       <form
         action="/organizations/org-slug/auth/configure/"
         method="POST"

--- a/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -58,7 +58,7 @@ exports[`OrganizationRepositories renders with a repository 1`] = `
       flex={false}
     >
       <Box>
-        <WithTheme(RepoRow)
+        <RepoRow
           key="4"
         >
           <Box
@@ -110,7 +110,7 @@ exports[`OrganizationRepositories renders with a repository 1`] = `
               </Button>
             </Confirm>
           </Box>
-        </WithTheme(RepoRow)>
+        </RepoRow>
       </Box>
     </PanelBody>
   </Panel>

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -14,7 +14,7 @@ exports[`Configure should render correctly render() should redirect to if no mat
     >
       Configure your application
     </h2>
-    <withRouter(ProjectContext)
+    <withProjects
       orgId="testOrg"
       projectId="project-slug"
       style={
@@ -40,7 +40,7 @@ exports[`Configure should render correctly render() should redirect to if no mat
           }
         />
       </ProjectDocsContext>
-    </withRouter(ProjectContext)>
+    </withProjects>
     <Waiting
       hasEvent={false}
       skip={[Function]}
@@ -73,7 +73,7 @@ exports[`Configure should render correctly render() should render platform docs 
       >
         Configure your application
       </h2>
-      <withRouter(ProjectContext)
+      <withProjects
         orgId="testOrg"
         projectId="project-slug"
         style={
@@ -82,28 +82,26 @@ exports[`Configure should render correctly render() should render platform docs 
           }
         }
       >
-        <ProjectContext
-          location={
-            Object {
-              "query": Object {},
-            }
-          }
+        <withRouter(ProjectContext)
           orgId="testOrg"
           projectId="project-slug"
-          router={
-            Object {
-              "createHref": [Function],
-              "go": [Function],
-              "goBack": [Function],
-              "goForward": [Function],
-              "isActive": [Function],
-              "location": Object {
-                "query": Object {},
+          projects={
+            Array [
+              Object {
+                "hasAccess": true,
+                "id": "testProject",
+                "isBookmarked": false,
+                "name": "Test Project",
+                "slug": "project-slug",
+                "teams": Array [
+                  Object {
+                    "hasAccess": true,
+                    "id": "coolid",
+                    "slug": "coolteam",
+                  },
+                ],
               },
-              "push": [Function],
-              "replace": [Function],
-              "setRouteLeaveHook": [Function],
-            }
+            ]
           }
           style={
             Object {
@@ -111,95 +109,133 @@ exports[`Configure should render correctly render() should render platform docs 
             }
           }
         >
-          <SideEffect(DocumentTitle)
-            title="project-slug"
+          <ProjectContext
+            location={
+              Object {
+                "query": Object {},
+              }
+            }
+            orgId="testOrg"
+            projectId="project-slug"
+            projects={
+              Array [
+                Object {
+                  "hasAccess": true,
+                  "id": "testProject",
+                  "isBookmarked": false,
+                  "name": "Test Project",
+                  "slug": "project-slug",
+                  "teams": Array [
+                    Object {
+                      "hasAccess": true,
+                      "id": "coolid",
+                      "slug": "coolteam",
+                    },
+                  ],
+                },
+              ]
+            }
+            router={
+              Object {
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "isActive": [Function],
+                "location": Object {
+                  "query": Object {},
+                },
+                "push": [Function],
+                "replace": [Function],
+                "setRouteLeaveHook": [Function],
+              }
+            }
+            style={
+              Object {
+                "marginBottom": 30,
+              }
+            }
           >
-            <DocumentTitle
+            <SideEffect(DocumentTitle)
               title="project-slug"
             >
-              <ProjectDocsContext>
-                <ProjectInstallPlatform
-                  linkPath={[Function]}
-                  params={
-                    Object {
-                      "orgId": "testOrg",
-                      "platform": "node",
-                      "projectId": "project-slug",
+              <DocumentTitle
+                title="project-slug"
+              >
+                <ProjectDocsContext>
+                  <ProjectInstallPlatform
+                    linkPath={[Function]}
+                    params={
+                      Object {
+                        "orgId": "testOrg",
+                        "platform": "node",
+                        "projectId": "project-slug",
+                      }
                     }
-                  }
-                  platformData={
-                    Object {
-                      "dsn": "https://9ed7cdc60:20e868d7b@sentry.io/300733",
-                      "dsnPublic": "https://9ed7cdc6581145bcb46044b77bd82aa0@sentry.io/300733",
-                      "platforms": Array [
-                        Object {
-                          "id": "javascript",
-                          "integrations": Array [
-                            Object {
-                              "id": "node",
-                              "link": "https://docs.getsentry.com/hosted/clients/csharp/",
-                              "name": "node",
-                              "type": "language",
-                            },
-                          ],
-                          "name": "js",
-                        },
-                      ],
+                    platformData={
+                      Object {
+                        "dsn": "https://9ed7cdc60:20e868d7b@sentry.io/300733",
+                        "dsnPublic": "https://9ed7cdc6581145bcb46044b77bd82aa0@sentry.io/300733",
+                        "platforms": Array [
+                          Object {
+                            "id": "javascript",
+                            "integrations": Array [
+                              Object {
+                                "id": "node",
+                                "link": "https://docs.getsentry.com/hosted/clients/csharp/",
+                                "name": "node",
+                                "type": "language",
+                              },
+                            ],
+                            "name": "js",
+                          },
+                        ],
+                      }
                     }
-                  }
-                >
-                  <div
-                    className="install row"
                   >
                     <div
-                      className="install-content col-md-10"
+                      className="install row"
                     >
-                      <Panel>
-                        <StyledPanel>
-                          <div
-                            className="css-wfa8ap-StyledPanel css-5bw71w0"
-                          >
-                            <PanelHeader
-                              hasButtons={true}
+                      <div
+                        className="install-content col-md-10"
+                      >
+                        <Panel>
+                          <StyledPanel>
+                            <div
+                              className="css-wfa8ap-StyledPanel css-5bw71w0"
                             >
-                              <StyledPanelHeader
+                              <PanelHeader
                                 hasButtons={true}
                               >
-                                <Component
-                                  className="css-vzwv85-StyledPanelHeader css-1t1cqk30"
+                                <StyledPanelHeader
                                   hasButtons={true}
                                 >
-                                  <Flex
-                                    align="center"
+                                  <Component
                                     className="css-vzwv85-StyledPanelHeader css-1t1cqk30"
-                                    justify="space-between"
+                                    hasButtons={true}
                                   >
-                                    <Base
+                                    <Flex
                                       align="center"
-                                      className="css-1t1cqk30 css-1h9uuh9"
+                                      className="css-vzwv85-StyledPanelHeader css-1t1cqk30"
                                       justify="space-between"
                                     >
-                                      <div
+                                      <Base
+                                        align="center"
                                         className="css-1t1cqk30 css-1h9uuh9"
-                                        is={null}
+                                        justify="space-between"
                                       >
-                                        Configure node
-                                        <Button
-                                          disabled={false}
-                                          external={true}
-                                          href="https://docs.getsentry.com/hosted/clients/csharp/"
-                                          size="small"
+                                        <div
+                                          className="css-1t1cqk30 css-1h9uuh9"
+                                          is={null}
                                         >
-                                          <ExternalLink
-                                            className="button button-default button-sm"
+                                          Configure node
+                                          <Button
                                             disabled={false}
+                                            external={true}
                                             href="https://docs.getsentry.com/hosted/clients/csharp/"
-                                            onClick={[Function]}
-                                            rel="noreferrer noopener"
-                                            role="button"
-                                            target="_blank"
+                                            size="small"
                                           >
-                                            <a
+                                            <ExternalLink
                                               className="button button-default button-sm"
                                               disabled={false}
                                               href="https://docs.getsentry.com/hosted/clients/csharp/"
@@ -208,177 +244,187 @@ exports[`Configure should render correctly render() should render platform docs 
                                               role="button"
                                               target="_blank"
                                             >
-                                              <Flex
-                                                align="center"
-                                                className="button-label"
+                                              <a
+                                                className="button button-default button-sm"
+                                                disabled={false}
+                                                href="https://docs.getsentry.com/hosted/clients/csharp/"
+                                                onClick={[Function]}
+                                                rel="noreferrer noopener"
+                                                role="button"
+                                                target="_blank"
                                               >
-                                                <Base
+                                                <Flex
                                                   align="center"
-                                                  className="button-label css-5ipae5"
+                                                  className="button-label"
                                                 >
-                                                  <div
+                                                  <Base
+                                                    align="center"
                                                     className="button-label css-5ipae5"
-                                                    is={null}
                                                   >
-                                                    Full Documentation
-                                                  </div>
-                                                </Base>
-                                              </Flex>
-                                            </a>
-                                          </ExternalLink>
-                                        </Button>
-                                      </div>
-                                    </Base>
-                                  </Flex>
-                                </Component>
-                              </StyledPanelHeader>
-                            </PanelHeader>
-                            <PanelBody
-                              direction="column"
-                              disablePadding={false}
-                              flex={false}
-                            >
-                              <div
-                                className="css-1pugmsu-padding"
+                                                    <div
+                                                      className="button-label css-5ipae5"
+                                                      is={null}
+                                                    >
+                                                      Full Documentation
+                                                    </div>
+                                                  </Base>
+                                                </Flex>
+                                              </a>
+                                            </ExternalLink>
+                                          </Button>
+                                        </div>
+                                      </Base>
+                                    </Flex>
+                                  </Component>
+                                </StyledPanelHeader>
+                              </PanelHeader>
+                              <PanelBody
+                                direction="column"
+                                disablePadding={false}
+                                flex={false}
                               >
-                                <TextBlock>
-                                  <Component
-                                    className="css-ms59cf-TextBlock css-1gwew8k0"
-                                  >
-                                    <div
+                                <div
+                                  className="css-1pugmsu-padding"
+                                >
+                                  <TextBlock>
+                                    <Component
                                       className="css-ms59cf-TextBlock css-1gwew8k0"
                                     >
-                                      <span
-                                        key="8"
+                                      <div
+                                        className="css-ms59cf-TextBlock css-1gwew8k0"
                                       >
                                         <span
-                                          key="0"
-                                        >
-                                          
-             This is a quick getting started guide. For in-depth instructions
-             on integrating Sentry with 
-                                        </span>
-                                        <span
-                                          key="2"
-                                        >
-                                          node
-                                        </span>
-                                        <span
-                                          key="3"
-                                        >
-                                          , view
-             
-                                        </span>
-                                        <a
-                                          href="https://docs.getsentry.com/hosted/clients/csharp/"
-                                          key="5"
+                                          key="8"
                                         >
                                           <span
-                                            key="4"
+                                            key="0"
                                           >
-                                            our complete documentation
+                                            
+             This is a quick getting started guide. For in-depth instructions
+             on integrating Sentry with 
                                           </span>
-                                        </a>
-                                        <span
-                                          key="6"
-                                        >
-                                          .
+                                          <span
+                                            key="2"
+                                          >
+                                            node
+                                          </span>
+                                          <span
+                                            key="3"
+                                          >
+                                            , view
+             
+                                          </span>
+                                          <a
+                                            href="https://docs.getsentry.com/hosted/clients/csharp/"
+                                            key="5"
+                                          >
+                                            <span
+                                              key="4"
+                                            >
+                                              our complete documentation
+                                            </span>
+                                          </a>
+                                          <span
+                                            key="6"
+                                          >
+                                            .
             
+                                          </span>
                                         </span>
-                                      </span>
-                                    </div>
-                                  </Component>
-                                </TextBlock>
-                                <DocumentationWrapper
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="css-1k2bws-DocumentationWrapper css-1igogt70"
+                                      </div>
+                                    </Component>
+                                  </TextBlock>
+                                  <DocumentationWrapper
                                     dangerouslySetInnerHTML={
                                       Object {
                                         "__html": undefined,
                                       }
                                     }
-                                  />
-                                </DocumentationWrapper>
-                              </div>
-                            </PanelBody>
-                          </div>
-                        </StyledPanel>
-                      </Panel>
-                    </div>
-                    <div
-                      className="install-sidebar col-md-2"
-                    >
-                      <LanguageNav
-                        active={true}
-                        key="javascript"
-                        name="js"
+                                  >
+                                    <div
+                                      className="css-1k2bws-DocumentationWrapper css-1igogt70"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": undefined,
+                                        }
+                                      }
+                                    />
+                                  </DocumentationWrapper>
+                                </div>
+                              </PanelBody>
+                            </div>
+                          </StyledPanel>
+                        </Panel>
+                      </div>
+                      <div
+                        className="install-sidebar col-md-2"
                       >
-                        <div
-                          className="install-language-nav"
+                        <LanguageNav
+                          active={true}
+                          key="javascript"
+                          name="js"
                         >
-                          <ul
-                            className="list-group"
+                          <div
+                            className="install-language-nav"
                           >
-                            <li
-                              className="list-group-item list-group-header"
+                            <ul
+                              className="list-group"
                             >
-                              <a
-                                onClick={[Function]}
+                              <li
+                                className="list-group-item list-group-header"
+                              >
+                                <a
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "display": "block",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className="pull-right"
+                                  >
+                                    <span
+                                      className="icon-minus"
+                                    />
+                                  </span>
+                                  <strong>
+                                    js
+                                  </strong>
+                                </a>
+                              </li>
+                              <span
                                 style={
                                   Object {
                                     "display": "block",
                                   }
                                 }
                               >
-                                <span
-                                  className="pull-right"
-                                >
-                                  <span
-                                    className="icon-minus"
-                                  />
-                                </span>
-                                <strong>
-                                  js
-                                </strong>
-                              </a>
-                            </li>
-                            <span
-                              style={
-                                Object {
-                                  "display": "block",
-                                }
-                              }
-                            >
-                              <Link
-                                className="list-group-item"
-                                key="node"
-                                to="/onboarding/testOrg/project-slug/configure/node/"
-                              >
-                                <a
+                                <Link
                                   className="list-group-item"
-                                  href="/onboarding/testOrg/project-slug/configure/node/"
+                                  key="node"
+                                  to="/onboarding/testOrg/project-slug/configure/node/"
                                 >
-                                  node
-                                </a>
-                              </Link>
-                            </span>
-                          </ul>
-                        </div>
-                      </LanguageNav>
+                                  <a
+                                    className="list-group-item"
+                                    href="/onboarding/testOrg/project-slug/configure/node/"
+                                  >
+                                    node
+                                  </a>
+                                </Link>
+                              </span>
+                            </ul>
+                          </div>
+                        </LanguageNav>
+                      </div>
                     </div>
-                  </div>
-                </ProjectInstallPlatform>
-              </ProjectDocsContext>
-            </DocumentTitle>
-          </SideEffect(DocumentTitle)>
-        </ProjectContext>
-      </withRouter(ProjectContext)>
+                  </ProjectInstallPlatform>
+                </ProjectDocsContext>
+              </DocumentTitle>
+            </SideEffect(DocumentTitle)>
+          </ProjectContext>
+        </withRouter(ProjectContext)>
+      </withProjects>
       <Waiting
         hasEvent={false}
         skip={[Function]}
@@ -433,7 +479,7 @@ exports[`Configure should render correctly render() shouldn't redirect for a fou
     >
       Configure your application
     </h2>
-    <withRouter(ProjectContext)
+    <withProjects
       orgId="testOrg"
       projectId="project-slug"
       style={
@@ -459,7 +505,7 @@ exports[`Configure should render correctly render() shouldn't redirect for a fou
           }
         />
       </ProjectDocsContext>
-    </withRouter(ProjectContext)>
+    </withProjects>
     <Waiting
       hasEvent={false}
       skip={[Function]}

--- a/tests/js/spec/views/onboarding/configure/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/configure/index.spec.jsx
@@ -4,7 +4,8 @@ import {shallow, mount} from 'enzyme';
 
 import {Client} from 'app/api';
 import Configure from 'app/views/onboarding/configure';
-import SentryTypes from '../../../../../../src/sentry/static/sentry/app/proptypes';
+import ProjectsStore from 'app/stores/projectsStore';
+import SentryTypes from 'app/proptypes';
 
 describe('Configure should render correctly', function() {
   let sandbox;
@@ -52,10 +53,28 @@ describe('Configure should render correctly', function() {
       url: '/projects/testOrg/project-slug/docs/node/',
       body: {},
     });
+
+    ProjectsStore.loadInitialData([
+      {
+        name: 'Test Project',
+        slug: 'project-slug',
+        id: 'testProject',
+        hasAccess: true,
+        isBookmarked: false,
+        teams: [
+          {
+            slug: 'coolteam',
+            id: 'coolid',
+            hasAccess: true,
+          },
+        ],
+      },
+    ]);
   });
 
   afterEach(function() {
     sandbox.restore();
+    ProjectsStore.loadInitialData([]);
   });
 
   describe('render()', function() {

--- a/tests/js/spec/views/projects/projectContext.spec.jsx
+++ b/tests/js/spec/views/projects/projectContext.spec.jsx
@@ -32,6 +32,7 @@ describe('projectContext component', function() {
     const projectContext = (
       <ProjectContext
         params={{orgId: org.slug, projectId: project.slug}}
+        projects={[]}
         routes={routes}
         router={router}
         location={location}


### PR DESCRIPTION
Changes `<ProjectContext>` to use projects from `ProjectsStore` instead
of directly from organization context (via `withProjects` HoC).

Also fixes project slug update to not require a full browser refresh.