### PR TITLE
Ref: Prettier transfer project dialog

### DIFF
--- a/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
@@ -170,11 +170,10 @@ export default class ProjectGeneralSettings extends AsyncView {
                   </TextBlock>
                   <TextBlock>
                     {t(
-                      'Please enter the owner of the organization you would like to transfer this project to.'
+                      'Please enter the organization owner you would like to transfer this project to.'
                     )}
                   </TextBlock>
                   <Panel>
-                    <PanelHeader>{t('Transfer to')}</PanelHeader>
                     <Form
                       hideFooter
                       onFieldChange={this.handleTransferFieldChange}


### PR DESCRIPTION
![localhost_8000_settings_organization_default_project_earth_settings_](https://user-images.githubusercontent.com/1421724/37678239-b103bbf8-2c3a-11e8-918a-d83968eb79e7.png)

Versus the old one which had a hanging word used a unneeded panel heading:

![localhost_8000_settings_organization_default_project_earth_settings_ 1](https://user-images.githubusercontent.com/1421724/37678276-ce55606c-2c3a-11e8-96ec-bdbd88512085.png)

