### PR TITLE
fix(api): Make team serializer max length match model for name

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -45,7 +45,7 @@ class OrganizationTeamsPermission(OrganizationPermission):
 
 
 class TeamSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=200, required=False)
+    name = serializers.CharField(max_length=64, required=False)
     slug = serializers.RegexField(r'^[a-z0-9_\-]+$', max_length=50, required=False)
 
     def validate(self, attrs):

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -152,3 +152,15 @@ class OrganizationTeamsCreateTest(APITestCase):
         )
 
         assert resp.status_code == 409, resp.content
+
+    def test_name_too_long(self):
+        self.login_as(user=self.user)
+
+        resp = self.client.post(
+            self.path, data={
+                'name': 'x' * 65,
+                'slug': 'xxxxxxx',
+            }
+        )
+
+        assert resp.status_code == 400, resp.content


### PR DESCRIPTION
fixes SENTRY-63F