### PR TITLE
fix(plugins): Don't send a social auth url for plugins that don't use social auth

### DIFF
--- a/src/sentry/plugins/providers/base.py
+++ b/src/sentry/plugins/providers/base.py
@@ -131,12 +131,19 @@ class ProviderMixin(object):
             'error_type': 'unknown',
         }
         if isinstance(error, InvalidIdentity):
-            context.update(
-                {
-                    'error_type': 'auth',
-                    'auth_url': reverse('socialauth_associate', args=[self.auth_provider])
-                }
-            )
+            if self.auth_provider is None:
+                context.update(
+                    {
+                        'message': 'Your authentication credentials are invalid. Please check your project settings.'
+                    }
+                )
+            else:
+                context.update(
+                    {
+                        'error_type': 'auth',
+                        'auth_url': reverse('socialauth_associate', args=[self.auth_provider])
+                    }
+                )
             status = 400
         elif isinstance(error, PluginError):
             # TODO(dcramer): we should have a proper validation error


### PR DESCRIPTION
fixes SENTRY-553

![screenshot 2018-03-20 18 04 54](https://user-images.githubusercontent.com/5026776/37690603-368b5a1e-2c69-11e8-984a-7856a88dd72d.png)
