### PR TITLE
ref(stream): Prevent unnecessary fetch

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -97,10 +97,9 @@ const Stream = createReactClass({
 
     this.fetchSavedSearches();
     this.fetchProcessingIssues();
-  },
-
-  componentDidMount() {
-    this.fetchData();
+    if (!this.state.loading) {
+      this.fetchData();
+    }
   },
 
   componentWillReceiveProps(nextProps) {

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -30,7 +30,8 @@ exports[`Stream render() displays the group list 1`] = `
         orgId="org-slug"
         projectId="project-slug"
         query="is:unresolved"
-        queryCount={null}
+        queryCount={0}
+        queryMaxCount={0}
         savedSearchList={
           Array [
             Object {
@@ -65,7 +66,7 @@ exports[`Stream render() displays the group list 1`] = `
       </ul>
       <Pagination
         onCursor={[Function]}
-        pageLinks=""
+        pageLinks="<http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"1443575731:0:1\\", <http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"1443575731:0:0"
       />
     </div>
     <StreamSidebar
@@ -180,7 +181,8 @@ exports[`Stream toggles environment select all environments 1`] = `
         orgId="org-slug"
         projectId="project-slug"
         query="is:unresolved"
-        queryCount={null}
+        queryCount={0}
+        queryMaxCount={0}
         savedSearchList={
           Array [
             Object {
@@ -215,7 +217,7 @@ exports[`Stream toggles environment select all environments 1`] = `
       </ul>
       <Pagination
         onCursor={[Function]}
-        pageLinks=""
+        pageLinks="<http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"1443575731:0:1\\", <http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"1443575731:0:0"
       />
     </div>
     <StreamSidebar

--- a/tests/js/spec/views/stream/stream.spec.jsx
+++ b/tests/js/spec/views/stream/stream.spec.jsx
@@ -29,6 +29,8 @@ describe('Stream', function() {
   let project;
   let savedSearch;
 
+  let groupListRequest;
+
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
 
@@ -47,7 +49,7 @@ describe('Stream', function() {
     });
     savedSearch = {id: '789', query: 'is:unresolved', name: 'test'};
 
-    MockApiClient.addMockResponse({
+    groupListRequest = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/issues/',
       body: [TestStubs.Group()],
       headers: {
@@ -87,13 +89,11 @@ describe('Stream', function() {
   });
 
   describe('fetchData()', function() {
-    beforeEach(function() {
-      wrapper = shallow(<Stream {...props} />, {
-        context,
-      });
-    });
     describe('complete handler', function() {
       beforeEach(function() {
+        wrapper = shallow(<Stream {...props} />, {
+          context,
+        });
         sandbox.stub(CursorPoller.prototype, 'setEndpoint');
       });
 
@@ -149,6 +149,23 @@ describe('Stream', function() {
         expect(CursorPoller.prototype.setEndpoint.notCalled).toBeTruthy();
       });
     }); // complete handler
+
+    it('calls fetchData once on mount for a saved search', function() {
+      props.location = {query: {}};
+      props.params.searchId = '1';
+      wrapper = shallow(<Stream {...props} />, {
+        context,
+      });
+
+      expect(groupListRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls fetchData once on mount if there is a query', function() {
+      wrapper = shallow(<Stream {...props} />, {
+        context,
+      });
+      expect(groupListRequest).toHaveBeenCalledTimes(1);
+    });
 
     it('should cancel any previous, unfinished fetches', function() {
       let requestCancel = sandbox.stub();


### PR DESCRIPTION
Do not fetch stream data on mount if loading is true

Move fetchData into componentWillMount so it can happen earlier with the other API calls