### PR TITLE
Remove unnecessary step from getting started flow

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -695,7 +695,8 @@ const Stream = createReactClass({
           </p>
           <p>
             <Link
-              to={`/${org.slug}/${project.slug}/getting-started/`}
+              to={`/${org.slug}/${project.slug}/getting-started/${project.platform ||
+                ''}`}
               className="btn btn-primary btn-lg"
             >
               {t('Installation Instructions')}


### PR DESCRIPTION
If the project platform has already been set (during onboarding), don't
ask for it again when a user clicks on "Installation Instructions" in
the empty issue stream.