### PR TITLE
Added MS Teams Plugin Link to List

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -64,6 +64,7 @@ The following plugins are available and maintained by members of the Sentry comm
 * `sentry-groveio <https://github.com/mattrobenolt/sentry-groveio>`_
 * `sentry-irccat <https://github.com/russss/sentry-irccat>`_
 * `sentry-lighthouse <https://github.com/gthb/sentry-lighthouse>`_
+* `sentry-msteams <https://github.com/Neko-Design/sentry-msteams>`_
 * `sentry-notifico <https://github.com/lukegb/sentry-notifico>`_
 * `sentry-searchbutton <https://github.com/timmyomahony/sentry-searchbutton>`_
 * `sentry-sprintly <https://github.com/mattrobenolt/sentry-sprintly>`_


### PR DESCRIPTION
Created an integration for Microsoft Teams chat system to send notifications and alerts. Similar to existing messaging tools like Slack etc.

Takes a single parameter at this stage, just the WebHook URL created in MS Teams, and sends a notification with the culprit and a link back to the event that triggered the notification.