### PR TITLE
feat(eventDetails): link to release from event release tag

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -10,6 +10,9 @@ import {isUrl, deviceNameMapper} from '../../utils';
 import {t} from '../../locale';
 import Pills from '../pills';
 import Pill from '../pill';
+import VersionHoverCard from '../versionHoverCard';
+import InlineSvg from '../inlineSvg';
+import TextLink from '../textLink';
 
 class EventTags extends React.Component {
   static propTypes = {
@@ -48,6 +51,20 @@ class EventTags extends React.Component {
                   <a href={tag.value} className="external-icon">
                     <em className="icon-open" />
                   </a>
+                )}
+                {tag.key == 'release' && (
+                  <VersionHoverCard
+                    version={tag.value}
+                    orgId={orgId}
+                    projectId={projectId}
+                  >
+                    <TextLink
+                      to={`/${orgId}/${projectId}/releases/${tag.value}/`}
+                      style={{paddingLeft: '3px'}}
+                    >
+                      <InlineSvg src="icon-circle-info" size="16px" />
+                    </TextLink>
+                  </VersionHoverCard>
                 )}
               </Pill>
             );

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -59,10 +59,13 @@ class EventTags extends React.Component {
                     projectId={projectId}
                   >
                     <TextLink
+                      style={{
+                        color: '#625471',
+                        paddingLeft: '4px',
+                      }}
                       to={`/${orgId}/${projectId}/releases/${tag.value}/`}
-                      style={{paddingLeft: '3px'}}
                     >
-                      <InlineSvg src="icon-circle-info" size="16px" />
+                      <InlineSvg src="icon-circle-info" size="14px" />
                     </TextLink>
                   </VersionHoverCard>
                 )}

--- a/src/sentry/static/sentry/less/group-similar.less
+++ b/src/sentry/static/sentry/less/group-similar.less
@@ -87,7 +87,7 @@
     width: 264px;
 
     &:after {
-      right: 13px;
+      right: 3px;
     }
     .hovercard-body {
       min-height: auto;

--- a/src/sentry/static/sentry/less/group-similar.less
+++ b/src/sentry/static/sentry/less/group-similar.less
@@ -87,7 +87,7 @@
     width: 264px;
 
     &:after {
-      right: 3px;
+      right: 13px;
     }
     .hovercard-body {
       min-height: auto;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5915546/37985669-463d4ed2-31ae-11e8-91b4-ba94bc351f6f.png)

^this icon is the ( i ) info now

i click this all the time when debugging people's sourcemaps and it annoys me that it doesn't go to the release. 
(the blue text still makes a search, but now there's a nice way to go to the release details)

