### PR TITLE
feat(assistant): Add click tracking events for assistant

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/helper.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/helper.jsx
@@ -10,6 +10,7 @@ import GuideStore from '../../stores/guideStore';
 import CueIcon from './cueIcon';
 import AssistantContainer from './assistantContainer';
 import CloseIcon from './closeIcon';
+import HookStore from '../../stores/hookStore';
 
 // AssistantHelper is responsible for rendering the cue message, guide drawer and support drawer.
 const AssistantHelper = createReactClass({
@@ -46,6 +47,16 @@ const AssistantHelper = createReactClass({
   },
 
   handleDrawerOpen() {
+    let {currentGuide} = this.state;
+
+    HookStore.get('analytics:event').forEach(cb =>
+      cb('assistant.guide', {
+        guide: currentGuide.id,
+        cue: currentGuide.cue,
+        action: 'drawer opened',
+      })
+    );
+
     this.setState({
       isDrawerOpen: true,
     });
@@ -60,6 +71,16 @@ const AssistantHelper = createReactClass({
 
   handleDismiss(e) {
     dismiss(this.state.currentGuide.id);
+
+    HookStore.get('analytics:event').forEach(cb =>
+      cb('assistant.guide', {
+        guide: currentGuide.id,
+        cue: currentGuide.cue,
+        action: 'guide dismissed',
+      })
+    );
+
+    dismiss(currentGuide.id);
     closeGuide();
   },
 
@@ -72,6 +93,16 @@ const AssistantHelper = createReactClass({
     let showDrawer = false;
     let {currentGuide, currentStep, isDrawerOpen} = this.state;
     let isGuideCued = currentGuide !== null;
+
+    if (isGuideCued) {
+      HookStore.get('analytics:event').forEach(cb =>
+        cb('assistant.guide', {
+          guide: currentGuide.id,
+          cue: currentGuide.cue,
+          action: 'guide cued',
+        })
+      );
+    }
 
     const cueText = isGuideCued ? currentGuide.cue : t('Need Help?');
     if (isDrawerOpen && (!isGuideCued || currentStep > 0)) {

--- a/src/sentry/static/sentry/app/components/assistant/helper.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/helper.jsx
@@ -48,18 +48,16 @@ const AssistantHelper = createReactClass({
 
   handleDrawerOpen() {
     let {currentGuide} = this.state;
-
+    this.setState({
+      isDrawerOpen: true,
+    });
+    nextStep();
     HookStore.get('analytics:event').forEach(cb =>
       cb('assistant.guide_opened', {
         guide: currentGuide.id,
         cue: currentGuide.cue,
       })
     );
-
-    this.setState({
-      isDrawerOpen: true,
-    });
-    nextStep();
   },
 
   handleSupportDrawerClose() {
@@ -69,6 +67,8 @@ const AssistantHelper = createReactClass({
   },
 
   handleDismiss(e) {
+    dismiss(this.state.currentGuide.id);
+    closeGuide();
     HookStore.get('analytics:event').forEach(cb =>
       cb('assistant.guide_dismissed', {
         guide: this.state.currentGuide.id,
@@ -76,8 +76,6 @@ const AssistantHelper = createReactClass({
         step: this.state.currentStep,
       })
     );
-    dismiss(this.state.currentGuide.id);
-    closeGuide();
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/assistant/helper.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/helper.jsx
@@ -50,10 +50,9 @@ const AssistantHelper = createReactClass({
     let {currentGuide} = this.state;
 
     HookStore.get('analytics:event').forEach(cb =>
-      cb('assistant.guide', {
+      cb('assistant.guide_opened', {
         guide: currentGuide.id,
         cue: currentGuide.cue,
-        action: 'drawer opened',
       })
     );
 
@@ -70,16 +69,13 @@ const AssistantHelper = createReactClass({
   },
 
   handleDismiss(e) {
-    dismiss(this.state.currentGuide.id);
-
     HookStore.get('analytics:event').forEach(cb =>
-      cb('assistant.guide', {
+      cb('assistant.guide_dismissed', {
         guide: this.state.currentGuide.id,
         cue: this.state.currentGuide.cue,
-        action: 'guide dismissed',
+        step: this.state.currentStep,
       })
     );
-
     dismiss(this.state.currentGuide.id);
     closeGuide();
   },
@@ -96,10 +92,9 @@ const AssistantHelper = createReactClass({
 
     if (isGuideCued) {
       HookStore.get('analytics:event').forEach(cb =>
-        cb('assistant.guide', {
+        cb('assistant.guide_cued', {
           guide: currentGuide.id,
           cue: currentGuide.cue,
-          action: 'guide cued',
         })
       );
     }

--- a/src/sentry/static/sentry/app/components/assistant/helper.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/helper.jsx
@@ -74,13 +74,13 @@ const AssistantHelper = createReactClass({
 
     HookStore.get('analytics:event').forEach(cb =>
       cb('assistant.guide', {
-        guide: currentGuide.id,
-        cue: currentGuide.cue,
+        guide: this.state.currentGuide.id,
+        cue: this.state.currentGuide.cue,
         action: 'guide dismissed',
       })
     );
 
-    dismiss(currentGuide.id);
+    dismiss(this.state.currentGuide.id);
     closeGuide();
   },
 

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -1,5 +1,6 @@
 import Reflux from 'reflux';
 import GuideActions from '../actions/guideActions';
+import HookStore from './hookStore';
 
 const GuideStore = Reflux.createStore({
   init() {
@@ -30,12 +31,30 @@ const GuideStore = Reflux.createStore({
   },
 
   onCloseGuide() {
-    this.state.guidesSeen.add(this.state.currentGuide.id);
+    let {currentGuide, guidesSeen} = this.state;
+
+    HookStore.get('analytics:event').forEach(cb =>
+      cb('assistant.guide', {
+        guide: currentGuide.id,
+        cue: currentGuide.cue,
+        action: 'closed guide',
+      })
+    );
+    guidesSeen.add(currentGuide.id);
     this.updateCurrentGuide();
   },
 
   onNextStep() {
     this.state.currentStep += 1;
+
+    HookStore.get('analytics:event').forEach(cb =>
+      cb('assistant.guide', {
+        guide: this.state.currentGuide.id,
+        cue: this.state.currentGuide.cue,
+        action: 'clicked next step',
+        step: this.state.currentStep,
+      })
+    );
     this.trigger(this.state);
   },
 

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -32,20 +32,19 @@ const GuideStore = Reflux.createStore({
 
   onCloseGuide() {
     let {currentGuide, guidesSeen} = this.state;
-
+    guidesSeen.add(currentGuide.id);
+    this.updateCurrentGuide();
     HookStore.get('analytics:event').forEach(cb =>
       cb('assistant.guide_closed', {
         guide: currentGuide.id,
         cue: currentGuide.cue,
       })
     );
-    guidesSeen.add(currentGuide.id);
-    this.updateCurrentGuide();
   },
 
   onNextStep() {
     this.state.currentStep += 1;
-
+    this.trigger(this.state);
     HookStore.get('analytics:event').forEach(cb =>
       cb('assistant.guide_next', {
         guide: this.state.currentGuide.id,
@@ -53,7 +52,6 @@ const GuideStore = Reflux.createStore({
         step: this.state.currentStep,
       })
     );
-    this.trigger(this.state);
   },
 
   onRegisterAnchor(anchor) {

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -34,10 +34,9 @@ const GuideStore = Reflux.createStore({
     let {currentGuide, guidesSeen} = this.state;
 
     HookStore.get('analytics:event').forEach(cb =>
-      cb('assistant.guide', {
+      cb('assistant.guide_closed', {
         guide: currentGuide.id,
         cue: currentGuide.cue,
-        action: 'closed guide',
       })
     );
     guidesSeen.add(currentGuide.id);
@@ -48,10 +47,9 @@ const GuideStore = Reflux.createStore({
     this.state.currentStep += 1;
 
     HookStore.get('analytics:event').forEach(cb =>
-      cb('assistant.guide', {
+      cb('assistant.guide_next', {
         guide: this.state.currentGuide.id,
         cue: this.state.currentGuide.cue,
-        action: 'clicked next step',
         step: this.state.currentStep,
       })
     );


### PR DESCRIPTION
Is this the right approach? i.e. using a single `event_type` and tagging it with an action field?

Linked to this reload [PR](https://github.com/getsentry/reload/pull/16)