### PR TITLE
fix(db): Also reconnect on django.db.utils.InterfaceError

### DIFF
--- a/src/sentry/db/postgres/helpers.py
+++ b/src/sentry/db/postgres/helpers.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 import psycopg2
 import six
 
-from django.db.utils import DatabaseError
+from django.db.utils import DatabaseError, InterfaceError
 
 
 def can_reconnect(exc):
-    if isinstance(exc, psycopg2.InterfaceError):
+    if isinstance(exc, (psycopg2.InterfaceError, InterfaceError)):
         return True
     # elif isinstance(exc, psycopg2.OperationalError):
     #     exc_msg = six.text_type(exc)


### PR DESCRIPTION
Once a psycopg2 connection got into this state, we will 100% error since
a reconnect isn't even attempted.

I'm not sure if this is behavior that has changed, but it seems to have
been around for a long time and somehow hasn't hurt bad yet except on
tagstore.

I have confirmed this behavior and reproduced it manually through
`sentry shell` by stopping and starting Postgres behind a running
session. Prior to this patch, if I restarted Postgres, the session was
100% broken, and after the patch, it fixes itself and will retry.

Fixes SENTRY-65S