### PR TITLE
fix(slack): Ensure users can't associate multiple slack IDs

### DIFF
--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -78,9 +78,10 @@ class SlackLinkIdentitiyView(BaseView):
         if not created:
             # TODO(epurkhiser): In this case we probably want to prompt and
             # warn them that they had a previous identity linked to slack.
-            identity.external_id = params['slack_id']
-            identity.status = IdentityStatus.VALID
-            identity.save()
+            identity.update(
+                external_id=params['slack_id'],
+                status=IdentityStatus.VALID
+            )
 
         payload = {
             'replace_original': False,

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -66,12 +66,21 @@ class SlackLinkIdentitiyView(BaseView):
         # TODO(epurkhiser): We could do some fancy slack querying here to
         # render a nice linking page with info about the user their linking.
 
-        Identity.objects.get_or_create(
-            external_id=params['slack_id'],
+        identity, created = Identity.objects.get_or_create(
             user=request.user,
             idp=idp,
-            status=IdentityStatus.VALID,
+            defaults={
+                'external_id': params['slack_id'],
+                'status': IdentityStatus.VALID,
+            },
         )
+
+        if not created:
+            # TODO(epurkhiser): In this case we probably want to prompt and
+            # warn them that they had a previous identity linked to slack.
+            identity.external_id = params['slack_id']
+            identity.status = IdentityStatus.VALID
+            identity.save()
 
         payload = {
             'replace_original': False,

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -108,7 +108,7 @@ class SlackIntegrationLinkIdentityTest(TestCase):
         )
         responses.add(
             method=responses.POST,
-            url='https://slack.com/api/chat.postEphemeral',
+            url='http://example.slack.com/response_url',
             body='{"ok": true}',
             status=200,
             content_type='application/json',

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -95,7 +95,7 @@ class SlackIntegrationLinkIdentityTest(TestCase):
             'integration_id': self.integration.id,
             'organization_id': self.org.id,
             'slack_id': 'new-slack-id',
-            'notify_channel_id': 'my-channel',
+            'channel_id': 'my-channel',
             'response_url': 'http://example.slack.com/response_url',
         }
 

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -96,13 +96,15 @@ class SlackIntegrationLinkIdentityTest(TestCase):
             'organization_id': self.org.id,
             'slack_id': 'new-slack-id',
             'notify_channel_id': 'my-channel',
+            'response_url': 'http://example.slack.com/response_url',
         }
 
         linking_url = build_linking_url(
             self.integration,
             self.org,
             'new-slack-id',
-            'my-channel'
+            'my-channel',
+            'http://example.slack.com/response_url'
         )
         responses.add(
             method=responses.POST,


### PR DESCRIPTION
Enfoces a single slack identity per user as constrainted by the unique constraint added in https://github.com/getsentry/sentry/pull/7746.