### PR TITLE
ref(tagstore) create a keys_and_top_values method

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -1,14 +1,10 @@
 from __future__ import absolute_import
 
-import six
-
-from collections import defaultdict
 from rest_framework.response import Response
 
 from sentry import tagstore
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.group import GroupEndpoint
-from sentry.api.serializers import serialize
 from sentry.models import Environment
 
 
@@ -18,37 +14,8 @@ class GroupTagsEndpoint(GroupEndpoint, EnvironmentMixin):
             environment_id = self._get_environment_id_from_request(
                 request, group.project.organization_id)
         except Environment.DoesNotExist:
-            group_tag_keys = []
-        else:
-            group_tag_keys = tagstore.get_group_tag_keys(group.project_id, group.id, environment_id)
+            return []
 
-        # O(N) db access
-        data = []
-        all_top_values = []
-        for group_tag_key in group_tag_keys:
-            total_values = tagstore.get_group_tag_value_count(
-                group.project_id, group.id, environment_id, group_tag_key.key)
-            top_values = tagstore.get_top_group_tag_values(
-                group.project_id, group.id, environment_id, group_tag_key.key, limit=10)
-
-            all_top_values.extend(top_values)
-
-            data.append(
-                {
-                    'id': six.text_type(group_tag_key.id),
-                    'key': tagstore.get_standardized_key(group_tag_key.key),
-                    'name': tagstore.get_tag_key_label(group_tag_key.key),
-                    'uniqueValues': group_tag_key.values_seen,
-                    'totalValues': total_values,
-                }
-            )
-
-        # Serialize all of the values at once to avoid O(n) serialize/db queries
-        top_values_by_key = defaultdict(list)
-        for value in serialize(all_top_values, request.user):
-            top_values_by_key[value['key']].append(value)
-
-        for d in data:
-            d['topValues'] = top_values_by_key[d['key']]
-
+        data = tagstore.get_group_tag_keys_and_top_values(
+            group.project_id, group.id, environment_id)
         return Response(data)

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -14,8 +14,9 @@ class GroupTagsEndpoint(GroupEndpoint, EnvironmentMixin):
             environment_id = self._get_environment_id_from_request(
                 request, group.project.organization_id)
         except Environment.DoesNotExist:
-            return []
+            data = []
+        else:
+            data = tagstore.get_group_tag_keys_and_top_values(
+                group.project_id, group.id, environment_id)
 
-        data = tagstore.get_group_tag_keys_and_top_values(
-            group.project_id, group.id, environment_id)
         return Response(data)

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -63,3 +63,10 @@ class GroupTagsTest(APITestCase):
 
         assert data[2]['key'] == 'release'  # Formatted from sentry:release
         assert len(data[2]['topValues']) == 1
+
+    def test_invalid_env(self):
+        this_group = self.create_group()
+        self.login_as(user=self.user)
+        url = '/api/0/issues/{}/tags/'.format(this_group.id)
+        response = self.client.get(url, {'environment': 'notreal'}, format='json')
+        assert response.data == []

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -7,25 +7,21 @@ from sentry.testutils import APITestCase
 class GroupTagsTest(APITestCase):
     def test_simple(self):
         this_group = self.create_group()
-        this_group.data['tags'] = (['foo', 'bar'], ['biz', 'baz'])
+        this_group.data['tags'] = (['foo', ['bar', 'quux']], ['biz', 'baz'], [
+                                   'sentry:release', 'releaseme'])
+
         this_group.save()
 
         other_group = self.create_group()
-        other_group.data['tags'] = (['abc', 'xyz'], )
+        other_group.data['tags'] = (['abc', 'xyz'],)
         other_group.save()
 
         for group in (this_group, other_group):
-            for key, value in group.data['tags']:
+            for key, values in group.data['tags']:
                 tagstore.create_tag_key(
                     project_id=group.project_id,
                     environment_id=None,
                     key=key,
-                )
-                tagstore.create_tag_value(
-                    project_id=group.project_id,
-                    environment_id=None,
-                    key=key,
-                    value=value,
                 )
                 tagstore.create_group_tag_key(
                     project_id=group.project_id,
@@ -33,17 +29,37 @@ class GroupTagsTest(APITestCase):
                     environment_id=None,
                     key=key,
                 )
-                tagstore.create_group_tag_value(
-                    project_id=group.project_id,
-                    group_id=group.id,
-                    environment_id=None,
-                    key=key,
-                    value=value,
-                )
+
+                if not isinstance(values, list):
+                    values = [values]
+                for value in values:
+                    tagstore.create_tag_value(
+                        project_id=group.project_id,
+                        environment_id=None,
+                        key=key,
+                        value=value,
+                    )
+                    tagstore.create_group_tag_value(
+                        project_id=group.project_id,
+                        group_id=group.id,
+                        environment_id=None,
+                        key=key,
+                        value=value,
+                    )
 
         self.login_as(user=self.user)
 
         url = '/api/0/issues/{}/tags/'.format(this_group.id)
         response = self.client.get(url, format='json')
         assert response.status_code == 200, response.content
-        assert len(response.data) == 2
+        assert len(response.data) == 3
+
+        data = sorted(response.data, key=lambda r: r['key'])
+        assert data[0]['key'] == 'biz'
+        assert len(data[0]['topValues']) == 1
+
+        assert data[1]['key'] == 'foo'
+        assert len(data[1]['topValues']) == 2
+
+        assert data[2]['key'] == 'release'  # Formatted from sentry:release
+        assert len(data[2]['topValues']) == 1


### PR DESCRIPTION
Create a tagstore method that returns top keys and their top values as
plain python objects. This should make it possible to use a different
non-django backend to return this data.