### PR TITLE
fix(alert-rules): Redirect on alert rule creation

### DIFF
--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
@@ -134,8 +135,14 @@ const RuleEditor = createReactClass({
       method: rule.id ? 'PUT' : 'POST',
       data,
       success: resp => {
+        const shouldRedirect = !rule.id;
         this.setState({error: null, loading: false, rule: resp});
-
+        // Redirect to correct ID if /new
+        if (shouldRedirect) {
+          browserHistory.replace(
+            `/${org.slug}/${project.slug}/settings/alerts/rules/${resp.id}`
+          );
+        }
         addSuccessMessage(rule.id ? t('Updated alert rule') : t('Created alert rule'));
       },
       error: response => {

--- a/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/ruleEditor/index.jsx
@@ -140,7 +140,7 @@ const RuleEditor = createReactClass({
         // Redirect to correct ID if /new
         if (shouldRedirect) {
           browserHistory.replace(
-            `/${org.slug}/${project.slug}/settings/alerts/rules/${resp.id}`
+            `/${org.slug}/${project.slug}/settings/alerts/rules/${resp.id}/`
           );
         }
         addSuccessMessage(rule.id ? t('Updated alert rule') : t('Created alert rule'));

--- a/tests/acceptance/test_project_alert_settings.py
+++ b/tests/acceptance/test_project_alert_settings.py
@@ -58,5 +58,4 @@ class ProjectAlertSettingsTest(AcceptanceTestCase):
     def test_rules_load(self):
         self.browser.get(self.path2)
         self.browser.wait_until_not('.loading-indicator')
-        self.browser.wait_until('.rules-list')
         self.browser.snapshot('project alert rules')


### PR DESCRIPTION
We should redirect from /new to the correct rule id on creation