### PR TITLE
feat(auth): Remove default is_managed state from SSO accounts

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -380,7 +380,6 @@ class AuthHelper(object):
             username=uuid4().hex,
             email=identity['email'],
             name=identity.get('name', '')[:200],
-            is_managed=True,
         )
 
         try:
@@ -479,52 +478,43 @@ class AuthHelper(object):
             # TODO(dcramer): its possible they have multiple accounts and at
             # least one is managed (per the check below)
             try:
-                existing_user = self._find_existing_user(identity['email'])
+                acting_user = self._find_existing_user(identity['email'])
             except IndexError:
-                existing_user = None
+                acting_user = None
+            login_form = self._get_login_form(acting_user)
+        else:
+            acting_user = request.user
 
-            verified_email = existing_user and existing_user.emails.filter(
-                is_verified=True,
-                email__iexact=identity['email'],
-            ).exists()
+        verified_email = acting_user and acting_user.emails.filter(
+            is_verified=True,
+            email__iexact=identity['email'],
+        ).exists()
 
-            # If they already have an SSO account and the identity provider says
-            # the email matches we go ahead and let them merge it. This is the
-            # only way to prevent them having duplicate accounts, and because
-            # we trust identity providers, its considered safe.
-            if existing_user and existing_user.is_managed and verified_email:
-                # we only allow this flow to happen if the existing user has
-                # membership, otherwise we short circuit because it might be
-                # an attempt to hijack membership of another organization
-                has_membership = OrganizationMember.objects.filter(
-                    user=existing_user,
-                    organization=self.organization,
-                ).exists()
-                if has_membership:
-                    if not auth.login(
-                        request,
-                        existing_user,
-                        after_2fa=request.build_absolute_uri(),
-                        organization_id=self.organization.id
-                    ):
-                        return HttpResponseRedirect(auth.get_login_redirect(self.request))
-                    # assume they've confirmed they want to attach the identity
-                    op = 'confirm'
-                else:
-                    # force them to create a new account
-                    existing_user = None
-
-            login_form = self._get_login_form(existing_user)
-        elif request.user.is_managed:
-            # per the above, try to auto merge if the user was originally an
-            # SSO account but is still logged in
+        # If they already have an SSO account and the identity provider says
+        # the email matches we go ahead and let them merge it. This is the
+        # only way to prevent them having duplicate accounts, and because
+        # we trust identity providers, its considered safe.
+        if acting_user and identity.get('email_verified') and verified_email:
+            # we only allow this flow to happen if the existing user has
+            # membership, otherwise we short circuit because it might be
+            # an attempt to hijack membership of another organization
             has_membership = OrganizationMember.objects.filter(
-                user=request.user,
+                user=acting_user,
                 organization=self.organization,
             ).exists()
             if has_membership:
+                if not auth.login(
+                    request,
+                    acting_user,
+                    after_2fa=request.build_absolute_uri(),
+                    organization_id=self.organization.id
+                ):
+                    return HttpResponseRedirect(auth.get_login_redirect(self.request))
                 # assume they've confirmed they want to attach the identity
                 op = 'confirm'
+            else:
+                # force them to create a new account
+                acting_user = None
 
         if op == 'confirm' and request.user.is_authenticated():
             auth_identity = self._handle_attach_identity(identity)
@@ -566,7 +556,7 @@ class AuthHelper(object):
 
             return self.respond(
                 'sentry/auth-confirm-identity.html', {
-                    'existing_user': existing_user,
+                    'existing_user': acting_user,
                     'identity': identity,
                     'login_form': login_form,
                     'identity_display_name': self._get_display_name(identity),

--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -72,6 +72,7 @@ class Provider(object):
         >>>     "id": "foo@example.com",
         >>>     "email": "foo@example.com",
         >>>     "name": "Foo Bar",
+        >>>     "email_verified": True,
         >>> }
 
         The ``email`` and ``id`` keys are required, ``name`` is optional.
@@ -79,6 +80,9 @@ class Provider(object):
         The ``id`` may be passed in as a ``MigratingIdentityId`` should the
         the id key be migrating from one value to another and have multiple
         lookup values.
+
+        The provider is trustable and the email address is verified by the provider,
+        the ``email_verified`` attribute should be set to ``True``.
 
         If the identity can not be constructed an ``IdentityNotValid`` error
         should be raised.

--- a/src/sentry/auth/providers/dummy.py
+++ b/src/sentry/auth/providers/dummy.py
@@ -9,8 +9,11 @@ from sentry.auth.provider import MigratingIdentityId
 class AskEmail(AuthView):
     def dispatch(self, request, helper):
         if 'email' in request.POST:
+            if 'id' in request.POST:
+                helper.bind_state('id', request.POST.get('id'))
             helper.bind_state('email', request.POST.get('email'))
             helper.bind_state('legacy_email', request.POST.get('legacy_email'))
+            helper.bind_state('email_verified', bool(request.POST.get('email_verified')))
             return helper.next_step()
 
         return HttpResponse(DummyProvider.TEMPLATE)
@@ -25,8 +28,9 @@ class DummyProvider(Provider):
 
     def build_identity(self, state):
         return {
-            'id': MigratingIdentityId(id=state['email'], legacy_id=state.get('legacy_email')),
+            'id': MigratingIdentityId(id=state.get('id', state['email']), legacy_id=state.get('legacy_email')),
             'email': state['email'],
+            'email_verified': state['email_verified'],
             'name': 'Dummy',
         }
 

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -72,7 +72,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         user = auth_identity.user
         assert user.email == 'foo@example.com'
         assert not user.has_usable_password()
-        assert user.is_managed
+        assert not user.is_managed
 
         member = OrganizationMember.objects.get(
             organization=organization,
@@ -485,12 +485,14 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert getattr(member.flags, 'sso:linked')
         assert not getattr(member.flags, 'sso:invalid')
 
-    def test_flow_managed_duplicate_users_with_membership(self):
+    def test_flow_duplicate_users_with_membership_and_verified(self):
         """
         Given an existing authenticated user, and an updated identity (e.g.
         the ident changed from the SSO provider), we should be re-linking
         the identity automatically (without prompt) assuming the user is
         a member of the org.
+
+        This only works when the email is mapped to an identical identity.
         """
         organization = self.create_organization(name='foo', owner=self.user)
         auth_provider = AuthProvider.objects.create(
@@ -525,7 +527,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # we're suggesting the identity changed (as if the Google ident was
         # updated to be something else)
-        resp = self.client.post(path, {'email': 'adfadsf@example.com'})
+        resp = self.client.post(path, {
+            'email': 'bar@example.com',
+            'id': '123',
+            'email_verified': '1',
+        })
 
         # there should be no prompt as we auto merge the identity
         assert resp.status_code == 302
@@ -535,7 +541,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
             id=auth_identity.id,
         )
 
-        assert auth_identity.ident == 'adfadsf@example.com'
+        assert auth_identity.ident == '123'
 
         new_user = auth_identity.user
         assert new_user == user
@@ -547,6 +553,51 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         assert getattr(member.flags, 'sso:linked')
         assert not getattr(member.flags, 'sso:invalid')
+
+    def test_flow_duplicate_users_without_verified(self):
+        """
+        Given an existing authenticated user, and an updated identity (e.g.
+        the ident changed from the SSO provider), we should be re-linking
+        the identity automatically (without prompt) assuming the user is
+        a member of the org.
+        """
+        organization = self.create_organization(name='foo', owner=self.user)
+        auth_provider = AuthProvider.objects.create(
+            organization=organization,
+            provider='dummy',
+        )
+
+        # setup a 'previous' identity, such as when we migrated Google from
+        # the old idents to the new
+        user = self.create_user('bar@example.com', is_active=False, is_managed=True)
+        AuthIdentity.objects.create(
+            auth_provider=auth_provider, user=user, ident='bar@example.com'
+        )
+
+        # they must be a member for the auto merge to happen
+        self.create_member(
+            organization=organization,
+            user=user,
+        )
+
+        # user needs to be logged in
+        self.login_as(user)
+
+        path = reverse('sentry-auth-organization', args=[organization.slug])
+
+        resp = self.client.post(path, {'init': True})
+
+        assert resp.status_code == 200
+        assert self.provider.TEMPLATE in resp.content.decode('utf-8')
+
+        path = reverse('sentry-auth-sso')
+
+        # we're suggesting the identity changed (as if the Google ident was
+        # updated to be something else)
+        resp = self.client.post(path, {'email': 'adfadsf@example.com'})
+
+        # there should be no prompt as we auto merge the identity
+        assert resp.status_code == 200
 
     def test_flow_managed_duplicate_users_without_membership(self):
         """
@@ -579,7 +630,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # we're suggesting the identity changed (as if the Google ident was
         # updated to be something else)
-        resp = self.client.post(path, {'email': 'adfadsf@example.com'})
+        resp = self.client.post(path, {'email': 'adfadsf@example.com', 'email_verified': '1'})
 
         self.assertTemplateUsed(resp, 'sentry/auth-confirm-link.html')
         assert resp.status_code == 200


### PR DESCRIPTION
This changes the behavior of automatic merging to always happen if emails are verified and removes the use of is_managed for SSO.