### PR TITLE
fix(slack): Use response_url to notify on link success

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -218,7 +218,8 @@ class SlackActionEndpoint(Endpoint):
                 integration,
                 group.organization,
                 user_id,
-                channel_id
+                channel_id,
+                data.get('response_url')
             )
 
             return self.respond({

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -108,7 +108,13 @@ class StatusActionTest(BaseEventTest):
             'domain': 'example',
         })
 
-        associate_url = build_linking_url(self.integration, self.org, 'invalid-id', 'C065W1189')
+        associate_url = build_linking_url(
+            self.integration,
+            self.org,
+            'invalid-id',
+            'C065W1189',
+            self.response_url
+        )
 
         assert resp.status_code == 200, resp.content
         assert resp.data['response_type'] == 'ephemeral'

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -43,14 +43,16 @@ class SlackIntegrationLinkIdentityTest(TestCase):
             'integration_id': self.integration.id,
             'organization_id': self.org.id,
             'slack_id': 'new-slack-id',
-            'notify_channel_id': 'my-channel',
+            'channel_id': 'my-channel',
+            'response_url': 'http://example.slack.com/response_url',
         }
 
         linking_url = build_linking_url(
             self.integration,
             self.org,
             'new-slack-id',
-            'my-channel'
+            'my-channel',
+            'http://example.slack.com/response_url'
         )
 
         resp = self.client.get(linking_url)
@@ -60,7 +62,7 @@ class SlackIntegrationLinkIdentityTest(TestCase):
 
         responses.add(
             method=responses.POST,
-            url='https://slack.com/api/chat.postEphemeral',
+            url='http://example.slack.com/response_url',
             body='{"ok": true}',
             status=200,
             content_type='application/json',


### PR DESCRIPTION
Using the `chat.postEphemeral` method doesn't guarantee that we can post into a channel (it may be private where the bot has not yet been added).  Instead we can use the `response_url` given when the action was taken that prompted the user to link their account, which is tied to the channel they're linking from.

Fixes SENTRY-66R