### PR TITLE
ref(minidump): Remove the minidump feature flag

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -150,7 +150,7 @@ class ProjectSerializer(Serializer):
         feature_list = []
         for feature in (
             'global-events', 'data-forwarding', 'rate-limits', 'discard-groups', 'similarity-view',
-            'custom-inbound-filters', 'minidump',
+            'custom-inbound-filters',
         ):
             if features.has('projects:' + feature, obj, actor=user):
                 feature_list.append(feature)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -765,7 +765,6 @@ SENTRY_FEATURES = {
     'projects:rate-limits': True,
     'projects:discard-groups': False,
     'projects:custom-inbound-filters': False,
-    'projects:minidump': False,
 }
 
 # Default time zone for localization in the UI.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -765,6 +765,7 @@ SENTRY_FEATURES = {
     'projects:rate-limits': True,
     'projects:discard-groups': False,
     'projects:custom-inbound-filters': False,
+    'projects:minidump': True,
 }
 
 # Default time zone for localization in the UI.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -35,7 +35,6 @@ default_manager.add('projects:servicehooks', ProjectFeature)  # NOQA
 default_manager.add('projects:similarity-indexing', ProjectFeature)  # NOQA
 default_manager.add('projects:discard-groups', ProjectFeature)  # NOQA
 default_manager.add('projects:custom-inbound-filters', ProjectFeature)  # NOQA
-default_manager.add('projects:minidump', ProjectFeature)  # NOQA
 default_manager.add('organizations:environments', OrganizationFeature)  # NOQA
 default_manager.add('user:assistant')
 

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -35,6 +35,7 @@ default_manager.add('projects:servicehooks', ProjectFeature)  # NOQA
 default_manager.add('projects:similarity-indexing', ProjectFeature)  # NOQA
 default_manager.add('projects:discard-groups', ProjectFeature)  # NOQA
 default_manager.add('projects:custom-inbound-filters', ProjectFeature)  # NOQA
+default_manager.add('projects:minidump', ProjectFeature)  # NOQA
 default_manager.add('organizations:environments', OrganizationFeature)  # NOQA
 default_manager.add('user:assistant')
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/index.jsx
@@ -37,7 +37,6 @@ const KeyRow = createReactClass({
     projectId: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
     access: PropTypes.object.isRequired,
-    features: PropTypes.object.isRequired,
     onToggle: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
   },
@@ -114,7 +113,7 @@ const KeyRow = createReactClass({
   },
 
   render() {
-    let {access, features, data} = this.props;
+    let {access, data} = this.props;
     let editUrl = recreateRoute(`${data.id}/`, this.props);
     let controls = [
       <Button key="edit" to={editUrl} size="small">
@@ -175,11 +174,7 @@ const KeyRow = createReactClass({
           btnText={t('Expand')}
         >
           <PanelBody>
-            <ProjectKeyCredentials
-              projectId={`${data.projectId}`}
-              data={data}
-              features={features}
-            />
+            <ProjectKeyCredentials projectId={`${data.projectId}`} data={data} />
           </PanelBody>
         </ClippedBox>
       </ClientKeyItemPanel>
@@ -262,7 +257,6 @@ export default class ProjectKeys extends AsyncView {
     let {routes, params} = this.props;
     let {orgId, projectId} = params;
     let access = getOrganizationState(this.context.organization).getAccess();
-    let features = new Set(this.context.project.features);
 
     return (
       <div>
@@ -270,7 +264,6 @@ export default class ProjectKeys extends AsyncView {
           {this.state.keyList.map(key => {
             return (
               <KeyRow
-                features={features}
                 api={this.api}
                 routes={routes}
                 params={params}

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
@@ -12,7 +12,6 @@ class ProjectKeyCredentials extends React.Component {
   static propTypes = {
     projectId: PropTypes.string.isRequired,
     data: SentryTypes.ProjectKey,
-    features: PropTypes.object,
 
     showDsn: PropTypes.bool,
     showDsnPublic: PropTypes.bool,
@@ -35,7 +34,6 @@ class ProjectKeyCredentials extends React.Component {
 
   render() {
     let {
-      features,
       projectId,
       data,
       showDsn,
@@ -116,30 +114,29 @@ class ProjectKeyCredentials extends React.Component {
           </Field>
         )}
 
-        {showMinidump &&
-          features.has('minidump') && (
-            <Field
-              label={t('Minidump Endpoint')}
-              help={tct(
-                'Use this endpoint to upload minidump crash reports, for example with Electron, Crashpad or Breakpad.',
-                {
-                  /* TODO: add a link to minidump docs */
-                }
-              )}
-              inline={false}
-              flexibleControlStateSize
-            >
-              <TextCopyInput>
-                {getDynamicText({
-                  value: data.dsn.minidump,
-                  fixed: data.dsn.minidump.replace(
-                    new RegExp(`\/${projectId}$`),
-                    '/<<projectId>>'
-                  ),
-                })}
-              </TextCopyInput>
-            </Field>
-          )}
+        {showMinidump && (
+          <Field
+            label={t('Minidump Endpoint')}
+            help={tct(
+              'Use this endpoint to upload minidump crash reports, for example with Electron, Crashpad or Breakpad.',
+              {
+                /* TODO: add a link to minidump docs */
+              }
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput>
+              {getDynamicText({
+                value: data.dsn.minidump,
+                fixed: data.dsn.minidump.replace(
+                  new RegExp(`\/${projectId}$`),
+                  '/<<projectId>>'
+                ),
+              })}
+            </TextCopyInput>
+          </Field>
+        )}
 
         {showPublicKey && (
           <Field label={t('Public Key')} inline={true} flexibleControlStateSize>

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -288,7 +288,6 @@ const KeySettings = createReactClass({
     organization: PropTypes.object.isRequired,
     project: PropTypes.object.isRequired,
     access: PropTypes.object.isRequired,
-    features: PropTypes.object.isRequired,
     data: SentryTypes.ProjectKey.isRequired,
     onRemove: PropTypes.func.isRequired,
     rateLimitsEnabled: PropTypes.bool,
@@ -327,7 +326,7 @@ const KeySettings = createReactClass({
 
   render() {
     let {keyId, orgId, projectId} = this.props.params;
-    let {access, features, data, rateLimitsEnabled, organization, project} = this.props;
+    let {access, data, rateLimitsEnabled, organization, project} = this.props;
     let apiEndpoint = `/projects/${orgId}/${projectId}/keys/${keyId}/`;
 
     return (
@@ -383,7 +382,6 @@ const KeySettings = createReactClass({
             <ProjectKeyCredentials
               projectId={`${data.projectId}`}
               data={data}
-              features={features}
               showPublicKey
               showSecretKey
               showProjectId
@@ -460,7 +458,6 @@ export default class ProjectKeyDetails extends AsyncView {
           organization={organization}
           project={project}
           access={access}
-          features={features}
           params={params}
           rateLimitsEnabled={hasRateLimitsEnabled}
           data={data}


### PR DESCRIPTION
Once https://github.com/getsentry/sentry/pull/7802 is merged, minidumps can be used without restriction. Hence, the feature can default to `True` now and the feature check in the UI can go away.