### PR TITLE
fix(ui): Detailed error alignment

### DIFF
--- a/src/sentry/static/sentry/less/errors.less
+++ b/src/sentry/static/sentry/less/errors.less
@@ -14,6 +14,10 @@
   opacity: 0.3;
 }
 
+.detailed-error-content {
+  margin-top: 8px;
+}
+
 .detailed-error-content-footer {
   margin-top: 18px;
   border-top: 1px solid @trim;


### PR DESCRIPTION
The text was not aligned to the center of the icon.

Old alignment
![screen shot 2018-03-27 at 10 58 46](https://user-images.githubusercontent.com/1421724/37985539-d6dc633e-31ad-11e8-8928-6d36f2a7b143.png)

New Alignment
![screen shot 2018-03-27 at 10 58 41](https://user-images.githubusercontent.com/1421724/37985540-d6ff2e00-31ad-11e8-8c13-6e51086073dc.png)
