### PR TITLE
fix: Include md5 hash of checksum when checksum isn't a valid hash on…

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 import math
+import re
 import six
 
 from datetime import datetime, timedelta
@@ -46,6 +47,7 @@ from sentry.utils.validators import is_float
 from sentry.stacktraces import normalize_in_app
 
 
+HASH_RE = re.compile(r'^[0-9a-f]{32}$')
 DEFAULT_FINGERPRINT_VALUES = frozenset(['{{ default }}', '{{default}}'])
 
 
@@ -600,7 +602,10 @@ class EventManager(object):
         if fingerprint:
             hashes = [md5_from_hash(h) for h in get_hashes_from_fingerprint(event, fingerprint)]
         elif checksum:
-            hashes = [checksum]
+            if HASH_RE.match(checksum):
+                hashes = [checksum]
+            else:
+                hashes = [md5_from_hash([checksum]), checksum]
             data['checksum'] = checksum
         else:
             hashes = [md5_from_hash(h) for h in get_hashes_for_event(event)]

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -1134,6 +1134,19 @@ class EventManagerTest(TransactionTestCase):
         )
         manager.normalize()
 
+    def test_checksum_rehashed(self):
+        checksum = 'invalid checksum hash'
+        manager = EventManager(
+            self.make_event(**{
+                'checksum': checksum,
+            })
+        )
+        manager.normalize()
+        event = manager.save(self.project.id)
+
+        hashes = [gh.hash for gh in GroupHash.objects.filter(group=event.group)]
+        assert hashes == [md5_from_hash(checksum), checksum]
+
 
 class ProcessTimestampTest(TestCase):
     def test_iso_timestamp(self):


### PR DESCRIPTION
… its own

Some users send checksums that aren't hash-like at all, which makes it
very confusing for downstream consumers like Snuba. This includes a
proper md5 sum as the 'primary hash' if the user's checksum
doesn't already appear to be a valid hash.

---

Not sure what exactly this means for migrating existing data. Any group that receives a new event should get a proper md5 attached to it so that future Snuba queries work. I don't forsee any bad effects on existing data, though? Need a ted here.

I included the same code on the Snuba writer side so that we're backwards compatible with old data in Kafka: https://github.com/getsentry/snuba/pull/3