### PR TITLE
fix(settings): alert message style improvements

### DIFF
--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -31,7 +31,9 @@ storiesOf('EmptyMessage', module)
     withInfo('Put this in a panel for maximum effect')(() => (
       <Panel>
         <PanelHeader>Members</PanelHeader>
-        <EmptyMessage icon="icon-user">Sentry is better with friends</EmptyMessage>
+        <EmptyMessage icon="icon-user" size="large">
+          Sentry is better with friends
+        </EmptyMessage>
       </Panel>
     ))
   )

--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -87,6 +87,9 @@ const theme = {
   },
 
   grid: 8,
+  fontSizeSmall: '12px',
+  fontSizeMedium: '16px',
+  fontSizeLarge: '18px',
 
   settings: {
     containerWidth: '1140px',
@@ -99,11 +102,6 @@ const theme = {
     familyMono: 'Monaco, Consolas, "Courier New", monospace',
     lineHeightHeading: '1.15',
     lineHeightBody: '1.4',
-    size: {
-      default: '12px',
-      small: '14px',
-      large: '18px',
-    },
   },
 };
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
@@ -13,6 +13,7 @@ import SettingsPageHeader from '../components/settingsPageHeader';
 import Switch from '../../../components/switch';
 import IndicatorStore from '../../../stores/indicatorStore';
 import TextBlock from '../components/text/textBlock';
+import EmptyMessage from '../components/emptyMessage';
 
 const ENDPOINT = '/users/me/subscriptions/';
 
@@ -101,31 +102,35 @@ class AccountSubscriptions extends AsyncView {
           </PanelHeader>
 
           <PanelBody>
-            {this.state.subscriptions.map((subscription, index) => (
-              <PanelItem p={2} align="center" key={subscription.listId}>
-                <Box flex="1">
-                  <SubscriptionName>{subscription.listName}</SubscriptionName>
-                  {subscription.listDescription && (
-                    <Description>{subscription.listDescription}</Description>
-                  )}
-                </Box>
-                <Flex direction="column" align="flex-end">
-                  <Switch
-                    isActive={subscription.subscribed}
-                    size="lg"
-                    toggle={this.handleToggle.bind(this, subscription, index)}
-                  />
-                  {subscription.subscribed && (
-                    <SubscribedDescription>
-                      <div>{subscription.email} on </div>
-                      <div>
-                        <DateTime shortDate date={subscription.subscribedDate} />
-                      </div>
-                    </SubscribedDescription>
-                  )}
-                </Flex>
-              </PanelItem>
-            ))}
+            {this.state.subscriptions.length ? (
+              this.state.subscriptions.map((subscription, index) => (
+                <PanelItem p={2} align="center" key={subscription.listId}>
+                  <Box flex="1">
+                    <SubscriptionName>{subscription.listName}</SubscriptionName>
+                    {subscription.listDescription && (
+                      <Description>{subscription.listDescription}</Description>
+                    )}
+                  </Box>
+                  <Flex direction="column" align="flex-end">
+                    <Switch
+                      isActive={subscription.subscribed}
+                      size="lg"
+                      toggle={this.handleToggle.bind(this, subscription, index)}
+                    />
+                    {subscription.subscribed && (
+                      <SubscribedDescription>
+                        <div>{subscription.email} on </div>
+                        <div>
+                          <DateTime shortDate date={subscription.subscribedDate} />
+                        </div>
+                      </SubscribedDescription>
+                    )}
+                  </Flex>
+                </PanelItem>
+              ))
+            ) : (
+              <EmptyMessage>{t("You don't have any subscriptions.")}</EmptyMessage>
+            )}
           </PanelBody>
         </Panel>
         <TextBlock>

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplications.jsx
@@ -157,22 +157,18 @@ class ApiApplications extends AsyncView {
       <div>
         <SettingsPageHeader title="API Applications" action={action} />
 
-        {isEmpty && (
-          <EmptyMessage>{t("You haven't created any applications yet.")}</EmptyMessage>
-        )}
+        <Panel>
+          <PanelHeader disablePadding>
+            <Flex align="center">
+              <Box px={2} flex="1">
+                {t('Application Name')}
+              </Box>
+            </Flex>
+          </PanelHeader>
 
-        {!isEmpty && (
-          <Panel>
-            <PanelHeader disablePadding>
-              <Flex align="center">
-                <Box px={2} flex="1">
-                  {t('Application Name')}
-                </Box>
-              </Flex>
-            </PanelHeader>
-
-            <PanelBody>
-              {this.state.appList.map(app => {
+          <PanelBody>
+            {!isEmpty ? (
+              this.state.appList.map(app => {
                 return (
                   <ApiApplicationRow
                     key={app.id}
@@ -180,10 +176,14 @@ class ApiApplications extends AsyncView {
                     onRemove={this.handleRemoveApplication}
                   />
                 );
-              })}
-            </PanelBody>
-          </Panel>
-        )}
+              })
+            ) : (
+              <EmptyMessage>
+                {t("You haven't created any applications yet.")}
+              </EmptyMessage>
+            )}
+          </PanelBody>
+        </Panel>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -10,14 +10,16 @@ const Wrapper = styled.div`
   flex-direction: column;
   color: ${p => p.theme.gray4};
   padding: ${p => p.theme.grid * 3}px;
-  font-size: 1.5em;
+  font-size: ${p => (p.theme.large ? '18px' : '16px')};
   font-weight: bold;
 `;
 
-const Icon = styled.div`
+const StyledInlineSvg = styled(InlineSvg)`
   display: block;
-  margin-bottom: ${p => p.theme.grid * 2.5}px;
   color: ${p => p.theme.gray1};
+  width: 2em;
+  height: 2em;
+  margin-bottom: 0.75em;
 `;
 
 const Action = styled.div`
@@ -25,14 +27,10 @@ const Action = styled.div`
   margin-top: ${p => p.theme.grid * 2.5}px;
 `;
 
-const EmptyMessage = ({icon, children, action}) => {
+const EmptyMessage = ({icon, children, action, size}) => {
   return (
-    <Wrapper>
-      {icon && (
-        <Icon>
-          <InlineSvg src={icon} size="48px" />
-        </Icon>
-      )}
+    <Wrapper size={size}>
+      {icon && <StyledInlineSvg src={icon} />}
       <div className="ref-message">{children}</div>
       {action && <Action>{action}</Action>}
     </Wrapper>
@@ -42,6 +40,7 @@ const EmptyMessage = ({icon, children, action}) => {
 EmptyMessage.propTypes = {
   icon: PropTypes.string,
   action: PropTypes.element,
+  size: PropTypes.oneOf(['large', 'medium']),
 };
 
 export default EmptyMessage;

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -10,7 +10,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   color: ${p => p.theme.gray4};
   padding: ${p => p.theme.grid * 3}px;
-  font-size: ${p => (p.theme.large ? '18px' : '16px')};
+  font-size: ${p => (p.theme.large ? p.theme.fontSizeLarge : p.theme.fontSizeMedium)};
   font-weight: bold;
 `;
 
@@ -24,7 +24,7 @@ const StyledInlineSvg = styled(InlineSvg)`
 
 const Action = styled.div`
   display: block;
-  margin-top: ${p => p.theme.grid * 2.5}px;
+  margin-top: 0.75em;
 `;
 
 const EmptyMessage = ({icon, children, action, size}) => {

--- a/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
@@ -248,7 +248,9 @@ const TeamMembers = createReactClass({
             </StyledMemberContainer>
           ))
         ) : (
-          <EmptyMessage icon="icon-user">Your Team is Empty</EmptyMessage>
+          <EmptyMessage icon="icon-user" size="large">
+            Your Team is Empty
+          </EmptyMessage>
         )}
       </Panel>
     );

--- a/src/sentry/static/sentry/app/views/settings/team/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamProjects.jsx
@@ -106,7 +106,9 @@ const TeamProjects = createReactClass({
         </PanelItem>
       ))
     ) : (
-      <EmptyMessage>{t("This team doesn't have access to any projects.")}</EmptyMessage>
+      <EmptyMessage size="large" icon="icon-circle-exclamation">
+        {t("This team doesn't have access to any projects.")}
+      </EmptyMessage>
     );
   },
 

--- a/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
@@ -38,7 +38,11 @@ exports[`AccountSubscriptions renders empty 1`] = `
         direction="column"
         disablePadding={true}
         flex={false}
-      />
+      >
+        <EmptyMessage>
+          You don't have any subscriptions.
+        </EmptyMessage>
+      </PanelBody>
     </Panel>
     <TextBlock>
       We’re applying GDPR consent and privacy policies to all Sentry contacts, regardless of location. You’ll be able to manage your subscriptions here and from an Unsubscribe link in the footer of all marketing emails.

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -81,7 +81,7 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: NaNpx;
-  font-size: 1.5em;
+  font-size: 16px;
   font-weight: bold;
 }
 
@@ -803,7 +803,7 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: NaNpx;
-  font-size: 1.5em;
+  font-size: 16px;
   font-weight: bold;
 }
 

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -81,7 +81,6 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: NaNpx;
-  font-size: 16px;
   font-weight: bold;
 }
 
@@ -803,7 +802,6 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: NaNpx;
-  font-size: 16px;
   font-weight: bold;
 }
 


### PR DESCRIPTION
We have gotten feedback that `AlertMessage` is very large. 

This is particularly problematic in instances like the one below, where other UI is going on. The giant text becomes the most important thing on the page.

![image](https://user-images.githubusercontent.com/435981/37990049-0325d28e-31ba-11e8-9e8a-6696cf62a792.png)

That said, i kinda think `AlertMessage` is *always* too big. It is just an empty message, after all. It shouldn't be bigger than the header of the page.

This pull gives us two size options: 16px and 18px. It uses em units to adjust the size of the margin, avatar, etc. because i still secretly like em units and they are useful here.

![image](https://user-images.githubusercontent.com/435981/37990271-a0241d5c-31ba-11e8-9fc4-aeb0925de867.png)

![image](https://user-images.githubusercontent.com/435981/37990291-b11558a6-31ba-11e8-8a9b-d2437f5b1125.png)

![image](https://user-images.githubusercontent.com/435981/37990308-b995ca42-31ba-11e8-81e0-4abadf92aa7f.png)

this also fixes up some places where alert message is either not used or used improperly:

![image](https://user-images.githubusercontent.com/435981/37990536-7101ef44-31bb-11e8-8ed6-5dd4033046e7.png)

![image](https://user-images.githubusercontent.com/435981/37990582-956371f0-31bb-11e8-9439-c2b351e189ac.png)
