### PR TITLE
perf(tagstore): Optimize TagKey and TagValue creation to be done in bulk

### DIFF
--- a/src/sentry/tagstore/v2/models/tagkey.py
+++ b/src/sentry/tagstore/v2/models/tagkey.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 
 import six
 
-from django.db import models, router, connections
+from django.db import models, router, connections, transaction, IntegrityError
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.api.serializers import Serializer, register
@@ -90,6 +90,88 @@ class TagKey(Model):
             cache.set(cache_key, rv, 3600)
 
         return rv, created
+
+    @classmethod
+    def get_or_create_bulk(cls, project_id, environment_id, keys):
+        # Attempt to create a bunch of models in one big batch with as few
+        # queries and cache calls as possible.
+        # In best case, this is all done in 1 cache get.
+        # In ideal case, we'll do 3 queries total instead of N.
+        # Absolute worst case, we still just do O(n) queries, but this should be rare.
+        key_to_model = {key: None for key in keys}
+        remaining_keys = set(keys)
+
+        # First attempt to hit from cache, which in theory is the hot case
+        cache_key_to_key = {cls.get_cache_key(project_id, environment_id, key): key for key in keys}
+        cache_key_to_models = cache.get_many(cache_key_to_key.keys())
+        for model in cache_key_to_models.values():
+            key_to_model[model.key] = model
+            remaining_keys.remove(model.key)
+
+        if not remaining_keys:
+            # 100% cache hit on all items, good work team
+            return key_to_model
+
+        # If we have some misses, we want to first check if
+        # all of the misses actually exist in the database
+        # already in one bulk query.
+        to_cache = {}
+        for model in cls.objects.filter(
+            project_id=project_id,
+            environment_id=environment_id,
+            key__in=remaining_keys,
+        ):
+            key_to_model[model.key] = to_cache[cls.get_cache_key(
+                project_id, environment_id, model.key)] = model
+            remaining_keys.remove(model.key)
+
+        # If we have found them all, cache all these misses
+        # and return all the hits.
+        if not remaining_keys:
+            cache.set_many(to_cache, 3600)
+            return key_to_model
+
+        # At this point, we need to create all of our keys, since they
+        # don't exist in cache or the database.
+
+        # First attempt to create them all in one bulk query
+        try:
+            with transaction.atomic():
+                cls.objects.bulk_create([
+                    cls(
+                        project_id=project_id,
+                        environment_id=environment_id,
+                        key=key,
+                    )
+                    for key in remaining_keys
+                ])
+        except IntegrityError:
+            pass
+        else:
+            # If we succeed, the shitty part is we need one
+            # more query to get back the actual rows with their ids.
+            for model in cls.objects.filter(
+                project_id=project_id,
+                environment_id=environment_id,
+                key__in=remaining_keys
+            ):
+                key_to_model[model.key] = to_cache[cls.get_cache_key(
+                    project_id, environment_id, model.key)] = model
+                remaining_keys.remove(model.key)
+
+            cache.set_many(to_cache, 3600)
+
+            # Not clear if this could actually happen, but if it does,
+            # guard ourselves against returning bad data.
+            if not remaining_keys:
+                return key_to_model
+
+        # Fall back to just doing it manually
+        # This case will only ever happen in a race condition.
+        for key in remaining_keys:
+            key_to_model[key] = cls.get_or_create(project_id, environment_id, key)[0]
+
+        return key_to_model
 
 
 @register(TagKey)


### PR DESCRIPTION
TagValue isn't able to be optimized as much as TagKey, but this should
reduce a good chunk of queries for each event.