### PR TITLE
feat(ui): Maintain route when switching settings breadcrumb

### DIFF
--- a/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
@@ -39,6 +39,11 @@ export default class ProjectGeneralSettings extends AsyncView {
     this._form = {};
   }
 
+  getTitle() {
+    let {projectId} = this.props.params;
+    return t('%s Settings', projectId);
+  }
+
   getEndpoints() {
     let {orgId, projectId} = this.props.params;
     return [['data', `/projects/${orgId}/${projectId}/`]];

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -35,6 +35,10 @@ const ProjectContext = createReactClass({
   displayName: 'ProjectContext',
 
   propTypes: {
+    /**
+     * If true, this will not change `state.loading` during `fetchData` phase
+     */
+    skipReload: PropTypes.bool,
     projectId: PropTypes.string,
     orgId: PropTypes.string,
     location: PropTypes.object,
@@ -73,7 +77,9 @@ const ProjectContext = createReactClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.projectId !== this.props.projectId) {
+    if (nextProps.projectId === this.props.projectId) return;
+
+    if (!nextProps.skipReload) {
       this.remountComponent();
     }
   },
@@ -133,13 +139,13 @@ const ProjectContext = createReactClass({
   },
 
   fetchData() {
-    let {orgId, projectId, location} = this.props;
+    let {orgId, projectId, location, skipReload} = this.props;
     // we fetch core access/information from the global organization data
     let activeProject = this.identifyProject();
     let hasAccess = activeProject && activeProject.hasAccess;
 
     this.setState({
-      loading: true,
+      loading: !skipReload ? true : undefined,
       // we bind project initially, but it'll rebind
       project: activeProject,
     });

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -144,11 +144,12 @@ const ProjectContext = createReactClass({
     let activeProject = this.identifyProject();
     let hasAccess = activeProject && activeProject.hasAccess;
 
-    this.setState({
-      loading: !skipReload ? true : undefined,
+    this.setState(state => ({
+      // if `skipReload` is true, then don't change loading state
+      loading: skipReload ? state.loading : true,
       // we bind project initially, but it'll rebind
       project: activeProject,
-    });
+    }));
 
     if (activeProject && hasAccess) {
       setActiveProject(null);

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/organizationCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/organizationCrumb.jsx
@@ -48,8 +48,14 @@ class OrganizationCrumb extends React.Component {
           </TextLink>
         }
         onSelect={item => {
+          // If we are currently in a project context, and we're attempting to switch organizations,
+          // then we need to default to index route (e.g. `route`)
+          //
+          // Otherwise, using empty string ('') will keep the current route path but with target org
+          let hasProjectParam = !!params.projectId;
+          let destination = hasProjectParam ? route : '';
           browserHistory.push(
-            recreateRoute(route, {
+            recreateRoute(destination, {
               routes,
               params: {...params, orgId: item.value},
             })

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
@@ -13,14 +13,19 @@ import replaceRouterParams from '../../../../utils/replaceRouterParams';
 import withLatestContext from '../../../../utils/withLatestContext';
 import withProjects from '../../../../utils/withProjects';
 
+const HEIGHT = '24px';
 const ProjectName = styled.div`
   display: flex;
 
   .loading {
     width: 26px;
-    height: 24px;
+    height: ${HEIGHT};
     margin: 0;
   }
+`;
+
+const ProjectTextLink = styled(TextLink)`
+  line-height: ${HEIGHT};
 `;
 
 class ProjectCrumb extends React.Component {
@@ -58,14 +63,14 @@ class ProjectCrumb extends React.Component {
               <LoadingIndicator mini />
             ) : (
               <div>
-                <TextLink
+                <ProjectTextLink
                   to={replaceRouterParams('/settings/:orgId/:projectId/', {
                     orgId: latestOrganization.slug,
                     projectId: latestProject.slug,
                   })}
                 >
                   {latestProject.slug}
-                </TextLink>
+                </ProjectTextLink>
               </div>
             )}
           </ProjectName>

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
@@ -72,7 +72,7 @@ class ProjectCrumb extends React.Component {
         }
         onSelect={item => {
           browserHistory.push(
-            recreateRoute(route, {
+            recreateRoute('', {
               routes,
               params: {...params, projectId: item.value},
             })

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/teamCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/teamCrumb.jsx
@@ -38,7 +38,7 @@ class TeamCrumb extends React.Component {
         }
         onSelect={item => {
           browserHistory.push(
-            recreateRoute(route, {
+            recreateRoute('', {
               routes,
               params: {...params, teamId: item.value},
             })

--- a/src/sentry/static/sentry/app/views/settings/project/projectSettingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectSettingsLayout.jsx
@@ -14,7 +14,12 @@ class ProjectSettingsLayout extends React.Component {
     let {orgId, projectId} = this.props.params;
 
     return (
-      <ProjectContext {...this.props.params} orgId={orgId} projectId={projectId}>
+      <ProjectContext
+        {...this.props.params}
+        skipReload
+        orgId={orgId}
+        projectId={projectId}
+      >
         <SettingsLayout
           {...this.props}
           renderNavigation={() => <ProjectSettingsNavigation {...this.props} />}

--- a/tests/js/spec/views/onboarding/configure/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/configure/index.spec.jsx
@@ -133,9 +133,11 @@ describe('Configure should render correctly', function() {
                 slug: 'project-slug',
                 id: 'testProject',
                 hasAccess: true,
+                isBookmarked: false,
                 teams: [
                   {
                     id: 'coolteam',
+                    slug: 'coolteam',
                     hasAccess: true,
                   },
                 ],
@@ -144,6 +146,7 @@ describe('Configure should render correctly', function() {
             teams: [
               {
                 id: 'coolteam',
+                slug: 'coolteam',
                 hasAccess: true,
                 projects: [
                   {


### PR DESCRIPTION
* Add page title to project general settings
* Add a "skipReload" property for `<ProjectContext>` (just affects new settings)
* Keep breadcrumb height the same between loading and project name

cc @saragilford 

