### PR TITLE
ref(ui): Improve hovercards

### DIFF
--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -1,49 +1,99 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import intersection from 'lodash/intersection';
 
 class Hovercard extends React.Component {
   static propTypes = {
+    displayTimeout: PropTypes.number,
     className: PropTypes.string,
     containerClassName: PropTypes.string,
     header: PropTypes.node,
     body: PropTypes.node,
   };
 
+  static defaultProps = {
+    displayTimeout: 100,
+  };
+
   constructor(...args) {
     super(...args);
     this.state = {
       visible: false,
+      rendered: false,
     };
+    this.hoverWait = null;
+    this.cardElement = null;
   }
 
-  handleToggleHovercard = () => {
-    let {header, body} = this.props;
+  handleToggleOn = () => this.toggleHovercard(true);
+  handleToggleOff = () => this.toggleHovercard(false);
+
+  toggleHovercard = visible => {
+    const {header, body} = this.props;
 
     // Don't toggle hovercard if both of these are null
     if (!header && !body) return;
 
-    this.setState({
-      visible: !this.state.visible,
-    });
+    if (this.hoverWait !== null) {
+      clearTimeout(this.hoverWait);
+    }
+
+    const rendered = visible;
+    const timeout = this.props.displayTimeout;
+
+    // Immediately render the hovercard, but don't mark it as visible until
+    // after the delay period. This allows us to compute the size of the
+    // hovercard to position it before it is made visible.
+    if (visible) {
+      this.setState({rendered});
+    }
+
+    this.hoverWait = setTimeout(() => this.setState({visible, rendered}), timeout);
   };
 
-  render() {
-    let {containerClassName, className, header, body} = this.props;
-    let {visible} = this.state;
+  positionClasses() {
+    if (!this.cardElement || !this.state.visible) return {};
+    const rect = this.cardElement.getBoundingClientRect();
 
-    let containerCx = classNames('hovercard-container', containerClassName);
-    let cx = classNames('hovercard', className);
+    const classes = {
+      'hovercard-bottom': rect.top < 0,
+      'hovercard-left': rect.left < 0,
+      'hovercard-right': rect.right > window.innerWidth && !(rect.left < 0),
+    };
+
+    // If it's already been given a positon class do not use the recomputed
+    // position classes, since they will have been computed from it's new
+    // current correct position. Use the previous positions.
+    const currentClasses = intersection(this.cardElement.classList, Object.keys(classes));
+
+    return currentClasses.length > 0 ? currentClasses : classes;
+  }
+
+  render() {
+    const {containerClassName, className, header, body} = this.props;
+    const {rendered, visible} = this.state;
+
+    const containerCx = classNames('hovercard-container', containerClassName);
+    const cx = classNames('hovercard', this.positionClasses(), className, {
+      'with-header': header,
+      visible,
+    });
 
     return (
       <span
         className={containerCx}
-        onMouseEnter={this.handleToggleHovercard}
-        onMouseLeave={this.handleToggleHovercard}
+        onMouseEnter={this.handleToggleOn}
+        onMouseLeave={this.handleToggleOff}
       >
         {this.props.children}
-        {visible && (
-          <div className={cx}>
+        {rendered && (
+          <div
+            className={cx}
+            ref={e => {
+              this.cardElement = e;
+            }}
+          >
             <div className="hovercard-hoverlap" />
             {header && <div className="hovercard-header">{header}</div>}
             {body && <div className="hovercard-body">{body}</div>}

--- a/src/sentry/static/sentry/app/components/issueLink.jsx
+++ b/src/sentry/static/sentry/app/components/issueLink.jsx
@@ -44,7 +44,7 @@ export default class IssueLink extends React.Component {
 
     return (
       <div className={className}>
-        <div style={{marginBottom: 20}}>
+        <div style={{marginBottom: 15}}>
           <h3>
             <EventOrGroupTitle data={issue} />
           </h3>
@@ -74,7 +74,7 @@ export default class IssueLink extends React.Component {
             })}
           </div>
         </div>
-        <div className="row row-flex" style={{marginBottom: 20}}>
+        <div className="row row-flex" style={{marginBottom: 15}}>
           <div className="col-xs-6">
             <h6>First Seen</h6>
             <TimeSince date={issue.firstSeen} />

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -9,43 +9,132 @@
 
 .hovercard {
   @hovercard-padding: 15px;
-  border: none;
-  border-radius: 2px;
-  box-shadow: 0 0 0 1px rgba(52, 60, 69, 0.2), 0 1px 3px rgba(70, 82, 98, 0.25);
-  -webkit-background-clip: padding-box;
-  -moz-background-clip: padding;
+  @hovercard-width: 295px;
+  border-radius: 4px;
   background-clip: padding-box;
   background: #fff;
   color: @gray-darker;
   text-align: left;
   position: absolute;
   display: block;
-  right: 0;
-  bottom: 35px;
-  width: 295px;
   padding: 0;
-  border-radius: 5px;
   line-height: 1;
   z-index: 1000;
-  box-shadow: 0 6px 24px 0 rgba(67, 62, 75, 0.35), 0 1px 12px 0 rgba(67, 61, 74, 0.16);
+  box-shadow: 0 0 35px 0 rgba(67, 62, 75, 0.2);
+  border: 1px solid @trim;
+
+  // Default align hovercard top-middle
+  bottom: 28px;
+  left: 50%;
+  margin-left: -@hovercard-width / 2;
+  width: @hovercard-width;
+  visibility: hidden;
+
+  @keyframes hovercardSlideUp {
+    from {
+      transform: translateY(12px);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes hovercardSlideDown {
+    from {
+      transform: translateY(-12px);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes hovercardFadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  animation: hovercardFadeIn 100ms ease-in-out, hovercardSlideDown 100ms ease-in-out;
+
+  // Wait for the element to become visible
+  animation-play-state: paused;
+
+  &.visible {
+    visibility: visible;
+    animation-play-state: running;
+  }
+
+  &.hovercard-bottom {
+    bottom: initial;
+    top: 28px;
+
+    animation: hovercardFadeIn 100ms ease-in-out, hovercardSlideUp 100ms ease-in-out;
+
+    .hovercard-hoverlap {
+      top: -16px;
+    }
+
+    &:before,
+    &:after {
+      bottom: initial;
+      top: -20px;
+      // Avoid having
+      transform: rotate(180deg);
+    }
+
+    &:before {
+      top: -21px;
+    }
+
+    &.with-header:after {
+      border-top-color: @white-dark;
+    }
+  }
+
+  &.hovercard-left {
+    left: 0;
+    margin-left: 0;
+
+    &:before,
+    &:after {
+      left: 21px;
+      margin-left: 0;
+    }
+  }
+
+  &.hovercard-right {
+    left: initial;
+    right: 0;
+    margin-left: 0;
+
+    &:before,
+    &:after {
+      left: initial;
+      right: 21px;
+      margin-left: 0;
+    }
+  }
 
   &:before,
   &:after {
-    width: 0;
-    height: 0;
+    .square(0);
     content: '';
     display: block;
     position: absolute;
-  }
-
-  &:after {
     z-index: -1;
     bottom: -20px;
-    right: 21px;
-    border-bottom: 10px solid transparent;
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    border-top: 10px solid #fff;
+    left: 50%;
+    margin-left: -10px;
+    border: 10px solid transparent;
+    border-top-color: #fff;
+  }
+
+  &:before {
+    bottom: -21px;
+    border-top-color: @trim;
   }
 
   .hovercard-hoverlap {
@@ -57,12 +146,16 @@
   }
 
   .hovercard-header {
-    padding: @hovercard-padding;
+    font-size: 14px;
     background: @white-dark;
     border-bottom: 1px solid @trim;
-    border-radius: 5px 5px 0 0;
+    border-radius: 4px 4px 0 0;
     font-weight: 600;
     word-wrap: break-word;
+
+    // Thhe font needs a little extra padding. It has funny vert alignment.
+    padding: @hovercard-padding * 0.6 @hovercard-padding * 0.75;
+    padding-top: @hovercard-padding * 0.6 + 2px;
 
     .pull-right {
       a {
@@ -140,7 +233,9 @@
 
   h6 {
     color: @50 !important;
+    font-size: 11px;
     margin-bottom: 4px !important;
+    text-transform: uppercase;
   }
 
   p {
@@ -157,12 +252,8 @@
   .avatar-grid {
     margin-top: 7px;
 
-    .avatar-grid-item {
-      margin-bottom: 0;
-
-      .avatar {
-        .square(20px);
-      }
+    .avatar-grid-item .avatar {
+      .square(20px);
     }
 
     .tip {
@@ -192,7 +283,7 @@
   h3 {
     color: @gray-darkest;
     font-size: 14px;
-    margin: 0 0 8px;
+    margin: 0 0 5px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -919,6 +919,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                           }
                         />
                       }
+                      displayTimeout={100}
                     >
                       <span
                         className="hovercard-container"
@@ -1003,6 +1004,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                   >
                     <Hovercard
                       body={0}
+                      displayTimeout={100}
                     >
                       <span
                         className="hovercard-container"
@@ -2010,6 +2012,7 @@ exports[`Issues Similar View renders with mocked data 2`] = `
                           }
                         />
                       }
+                      displayTimeout={100}
                     >
                       <span
                         className="hovercard-container"
@@ -2094,6 +2097,7 @@ exports[`Issues Similar View renders with mocked data 2`] = `
                   >
                     <Hovercard
                       body={0}
+                      displayTimeout={100}
                     >
                       <span
                         className="hovercard-container"


### PR DESCRIPTION
- The card will now wait the `displayTimeout` delay before becoming visible.
 - The card will now correctly position itself on the top or bottom of the parent element and to the left or right not to clip outside of the viewport. By default it will position itself at the top center of the element.
 - The card now has a subtle animation in (opacity + 12px translateY)
 - Padding, margins, fonts, and borders have been cleaned up.

![screen shot 2018-03-27 at 17 29 26](https://user-images.githubusercontent.com/1421724/38001936-75d23fc8-31e4-11e8-8827-263096b97741.png)
![screen shot 2018-03-27 at 17 29 08](https://user-images.githubusercontent.com/1421724/38001937-75e9afbe-31e4-11e8-8b74-3f26e9a54205.png)
![screen shot 2018-03-27 at 17 31 22](https://user-images.githubusercontent.com/1421724/38001995-b751f9a2-31e4-11e8-883c-31a8f1bbf539.png)

![cards](https://user-images.githubusercontent.com/1421724/38001962-980a1f16-31e4-11e8-8f2c-525fac599e57.gif)

And for reference this is the old card
![screen shot 2018-03-27 at 17 32 36](https://user-images.githubusercontent.com/1421724/38002018-db124d24-31e4-11e8-8d69-d17f1c23779e.png)


