### PR TITLE
fix: Broken project chooser

### DIFF
--- a/src/sentry/static/sentry/app/views/projectChooser.jsx
+++ b/src/sentry/static/sentry/app/views/projectChooser.jsx
@@ -63,7 +63,7 @@ const ProjectChooser = createReactClass({
       throw new Error('User arrived on project chooser without a valid task id.');
     }
     return (
-      <div className="container" css={{'padding-left': '90px'}}>
+      <div className="container" css={{'padding-left': '90px', 'padding-top': '30px'}}>
         <SettingsPageHeader title="Projects" />
         <Panel>
           <PanelHeader hasButtons>{t('Projects')}</PanelHeader>

--- a/src/sentry/static/sentry/app/views/projectChooser.jsx
+++ b/src/sentry/static/sentry/app/views/projectChooser.jsx
@@ -2,17 +2,36 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import $ from 'jquery';
-import {t} from '../locale';
+import {Box} from 'grid-emotion';
+import styled from 'react-emotion';
 
+import {t} from '../locale';
+import Link from '../components/link';
 import OrganizationState from '../mixins/organizationState';
+import {sortProjects} from '../utils';
+import theme from '../utils/theme';
 import TodoList from '../components/onboardingWizard/todos';
+import Panel from './settings/components/panel';
+import PanelBody from './settings/components/panelBody';
+import PanelHeader from './settings/components/panelHeader';
+import PanelItem from './settings/components/panelItem';
+import SettingsPageHeader from './settings/components/settingsPageHeader';
+import ProjectLabel from '../components/projectLabel';
+import SentryTypes from '../proptypes';
+
+const StyledProjectLabel = styled(ProjectLabel)`
+  color: ${p => p.theme.blue};
+`;
 
 const ProjectChooser = createReactClass({
   displayName: 'ProjectChooser',
-  mixins: [OrganizationState],
 
+  propTypes: {
+    organization: SentryTypes.Organization,
+  },
+
+  mixins: [OrganizationState],
   componentWillMount() {
-    $(document.body).addClass('narrow');
     this.redirectNoMultipleProjects();
   },
 
@@ -40,7 +59,6 @@ const ProjectChooser = createReactClass({
     let task = TodoList.TASKS.filter(
       task_inst => task_inst.task == this.props.location.query.task
     )[0];
-    let features = new Set(org.features);
 
     // Expect onboarding=1 and task=<task id> parameters and task.featureLocation == 'project'
     // TODO throw up report dialog if not true
@@ -48,29 +66,28 @@ const ProjectChooser = createReactClass({
       throw new Error('User arrived on project chooser without a valid task id.');
     }
     return (
-      <div className="container">
-        <h3>{t('Choose a project')}</h3>
-        <div className="box">
-          <div className="box-content">
-            <table className="table">
-              <tbody>
-                {org.projects.map(project => {
-                  return (
-                    <tr key={project.id}>
-                      <td>
-                        <h4>
-                          <a href={`/${org.slug}/${project.slug}/${task.location}`}>
-                            {features.has('new-teams') ? project.slug : project.name}
-                          </a>
-                        </h4>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </div>
+      <div className="container" css={{'padding-left': '90px'}}>
+        <SettingsPageHeader title="Projects" />
+        <Panel>
+          <PanelHeader hasButtons>{t('Projects')}</PanelHeader>
+          <PanelBody css={{width: '100%'}}>
+            {sortProjects(org.projects).map((project, i) => (
+              <PanelItem p={0} key={project.id} align="center">
+                <Box p={2} flex="1">
+                  <Link
+                    to={`/${org.slug}/${project.slug}/${task.location}`}
+                    css={{color: theme.gray3}}
+                  >
+                    <StyledProjectLabel
+                      project={project}
+                      organization={this.props.organization}
+                    />
+                  </Link>
+                </Box>
+              </PanelItem>
+            ))}
+          </PanelBody>
+        </Panel>
       </div>
     );
   },

--- a/src/sentry/static/sentry/app/views/projectChooser.jsx
+++ b/src/sentry/static/sentry/app/views/projectChooser.jsx
@@ -19,10 +19,6 @@ import SettingsPageHeader from './settings/components/settingsPageHeader';
 import ProjectLabel from '../components/projectLabel';
 import SentryTypes from '../proptypes';
 
-const StyledProjectLabel = styled(ProjectLabel)`
-  color: ${p => p.theme.blue};
-`;
-
 const ProjectChooser = createReactClass({
   displayName: 'ProjectChooser',
 
@@ -31,6 +27,7 @@ const ProjectChooser = createReactClass({
   },
 
   mixins: [OrganizationState],
+
   componentWillMount() {
     this.redirectNoMultipleProjects();
   },
@@ -92,5 +89,9 @@ const ProjectChooser = createReactClass({
     );
   },
 });
+
+const StyledProjectLabel = styled(ProjectLabel)`
+  color: ${p => p.theme.blue};
+`;
 
 export default ProjectChooser;

--- a/tests/js/spec/views/__snapshots__/projectChooser.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectChooser.spec.jsx.snap
@@ -3,6 +3,7 @@
 exports[`ProjectChooser renders 1`] = `
 .glamor-3 {
   padding-left: 90px;
+  padding-top: 30px;
 }
 
 .glamor-2 {

--- a/tests/js/spec/views/__snapshots__/projectChooser.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectChooser.spec.jsx.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectChooser renders 1`] = `
+.glamor-3 {
+  padding-left: 90px;
+}
+
+.glamor-2 {
+  width: 100%;
+}
+
+.glamor-0 {
+  color: #645574;
+}
+
+<div
+  className="glamor-3 container"
+>
+  <SettingsPageHeading
+    title="Projects"
+  />
+  <Panel>
+    <PanelHeader
+      hasButtons={true}
+    >
+      Projects
+    </PanelHeader>
+    <PanelBody
+      className="glamor-2"
+      direction="column"
+      disablePadding={true}
+      flex={false}
+    >
+      <PanelItem
+        align="center"
+        p={0}
+      >
+        <Box
+          flex="1"
+          p={2}
+        >
+          <Link
+            className="glamor-0"
+            to="/org/test-project/settings/install/"
+          >
+            <StyledProjectLabel
+              project={
+                Object {
+                  "isMember": true,
+                  "name": "Test Project",
+                  "slug": "test-project",
+                  "team": Object {
+                    "isMember": true,
+                    "name": "Test Team",
+                    "projects": Array [
+                      Object {
+                        "name": "Test Project",
+                        "slug": "test-project",
+                      },
+                      Object {
+                        "name": "Another Project",
+                        "slug": "another-project",
+                      },
+                    ],
+                    "slug": "test-team",
+                  },
+                }
+              }
+            />
+          </Link>
+        </Box>
+      </PanelItem>
+      <PanelItem
+        align="center"
+        p={0}
+      >
+        <Box
+          flex="1"
+          p={2}
+        >
+          <Link
+            className="glamor-0"
+            to="/org/another-project/settings/install/"
+          >
+            <StyledProjectLabel
+              project={
+                Object {
+                  "isMember": true,
+                  "name": "Another Project",
+                  "slug": "another-project",
+                  "team": Object {
+                    "isMember": true,
+                    "name": "Test Team",
+                    "projects": Array [
+                      Object {
+                        "name": "Test Project",
+                        "slug": "test-project",
+                      },
+                      Object {
+                        "name": "Another Project",
+                        "slug": "another-project",
+                      },
+                    ],
+                    "slug": "test-team",
+                  },
+                }
+              }
+            />
+          </Link>
+        </Box>
+      </PanelItem>
+    </PanelBody>
+  </Panel>
+</div>
+`;

--- a/tests/js/spec/views/projectChooser.spec.jsx
+++ b/tests/js/spec/views/projectChooser.spec.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import ProjectChooser from 'app/views/projectChooser';
+
+describe('ProjectChooser', function() {
+  const mockOrg = {
+    id: 'org',
+    slug: 'org',
+    teams: [
+      {
+        name: 'Test Team',
+        slug: 'test-team',
+        isMember: true,
+        projects: [
+          {
+            slug: 'test-project',
+            name: 'Test Project',
+          },
+          {
+            slug: 'another-project',
+            name: 'Another Project',
+          },
+        ],
+      },
+    ],
+    projects: [
+      {
+        slug: 'test-project',
+        name: 'Test Project',
+        isMember: true,
+        team: {
+          name: 'Test Team',
+          slug: 'test-team',
+          isMember: true,
+          projects: [
+            {
+              slug: 'test-project',
+              name: 'Test Project',
+            },
+            {
+              slug: 'another-project',
+              name: 'Another Project',
+            },
+          ],
+        },
+      },
+      {
+        slug: 'another-project',
+        name: 'Another Project',
+        isMember: true,
+        team: {
+          name: 'Test Team',
+          slug: 'test-team',
+          isMember: true,
+          projects: [
+            {
+              slug: 'test-project',
+              name: 'Test Project',
+            },
+            {
+              slug: 'another-project',
+              name: 'Another Project',
+            },
+          ],
+        },
+      },
+    ],
+    access: [],
+  };
+
+  it('renders', function() {
+    let wrapper = shallow(
+      <ProjectChooser
+        location={{
+          pathname: 'https://sentry.io/organizations/tester1/projects/choose/',
+          query: {onboarding: '1', task: '2'},
+          search: '?onboarding=1&task=2',
+        }}
+      />,
+      {
+        context: {
+          organization: mockOrg,
+        },
+      }
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
The css on project picker broke somewhere along the way. This tries to fix it up, reuse a few components instead of directly using html that was there before. Because this is linked to the to do list task of sending first event, pagination isn't a concern and implementing search is also not a concern unless you have concerns with these assumptions.

TODO:
- [x] Add test