### PR TITLE
fix: Use project slug instead of name for document title

### DIFF
--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -112,7 +112,7 @@ const ProjectContext = createReactClass({
   },
 
   getTitle() {
-    if (this.state.project) return this.state.project.name;
+    if (this.state.project) return this.state.project.slug;
     return 'Sentry';
   },
 

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -30,7 +30,7 @@ class CreateProjectTest(AcceptanceTestCase):
         self.browser.snapshot(name='create project')
 
         self.browser.click('.new-project-submit')
-        self.browser.wait_until(title='Java')
+        self.browser.wait_until(title='java')
         self.browser.wait_until_not('.loading')
 
         project = Project.objects.get(organization=self.org)

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -112,10 +112,10 @@ exports[`Configure should render correctly render() should render platform docs 
           }
         >
           <SideEffect(DocumentTitle)
-            title="Project Name"
+            title="project-slug"
           >
             <DocumentTitle
-              title="Project Name"
+              title="project-slug"
             >
               <ProjectDocsContext>
                 <ProjectInstallPlatform


### PR DESCRIPTION
Since project name is deprecated we should use the slug for the document title

This also matches what is used in the settings pages