### PR TITLE
feat(buffers): Move process_pending task to it's own queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -441,6 +441,7 @@ CELERY_QUEUES = [
     Queue('alerts', routing_key='alerts'),
     Queue('auth', routing_key='auth'),
     Queue('assemble', routing_key='assemble'),
+    Queue('buffers.process_pending', routing_key='buffers.process_pending'),
     Queue('commits', routing_key='commits'),
     Queue('cleanup', routing_key='cleanup'),
     Queue('default', routing_key='default'),
@@ -521,7 +522,7 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(seconds=10),
         'options': {
             'expires': 10,
-            'queue': 'counters-0',
+            'queue': 'buffers.process_pending',
         }
     },
     'sync-options': {

--- a/src/sentry/queue/routers.py
+++ b/src/sentry/queue/routers.py
@@ -7,7 +7,6 @@ from celery import current_app
 
 COUNTER_TASKS = set(
     [
-        'sentry.tasks.process_buffer.process_pending',
         'sentry.tasks.process_buffer.process_incr',
     ]
 )

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -16,7 +16,10 @@ from sentry.utils.locking import UnableToAcquireLock
 logger = logging.getLogger(__name__)
 
 
-@instrumented_task(name='sentry.tasks.process_buffer.process_pending')
+@instrumented_task(
+    name='sentry.tasks.process_buffer.process_pending',
+    queue='buffers.process_pending',
+)
 def process_pending(partition=None):
     """
     Process pending buffers.


### PR DESCRIPTION
Now that we schedule 1 `process_pending` task per partition, the contention from all of the comparatively expensive `process_pending` tasks are more likely to block `process_incr` work from being done.

We can see this reflected in this graph: 
![image](https://user-images.githubusercontent.com/375744/38100292-dbbd62ce-3331-11e8-8005-e7d70122df53.png)

This just splits `process_pending` out into it's own queue so we can isolate the more expensive workloads from the cheap workloads.