### PR TITLE
fix(ui): Better padding on external-icon in pills

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1732,6 +1732,7 @@ ul.faces {
 
     .external-icon {
       display: inline;
+      padding: 0 0 0 8px;
     }
   }
 


### PR DESCRIPTION
![screen shot 2018-03-29 at 16 14 16](https://user-images.githubusercontent.com/1421724/38117866-51a9ebe4-336c-11e8-9953-9678915f6ee0.png)

vs the old one the spacing was wrong

![screen shot 2018-03-29 at 16 14 57](https://user-images.githubusercontent.com/1421724/38117872-5a45c7f0-336c-11e8-9e00-160a2451b5ec.png)
