### PR TITLE
fix(ui): Correct color / spacing / font of release tag hovercard

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -12,7 +12,6 @@ import Pills from '../pills';
 import Pill from '../pill';
 import VersionHoverCard from '../versionHoverCard';
 import InlineSvg from '../inlineSvg';
-import TextLink from '../textLink';
 
 class EventTags extends React.Component {
   static propTypes = {
@@ -54,19 +53,14 @@ class EventTags extends React.Component {
                 )}
                 {tag.key == 'release' && (
                   <VersionHoverCard
+                    containerClassName="pill-icon"
                     version={tag.value}
                     orgId={orgId}
                     projectId={projectId}
                   >
-                    <TextLink
-                      style={{
-                        color: '#625471',
-                        paddingLeft: '4px',
-                      }}
-                      to={`/${orgId}/${projectId}/releases/${tag.value}/`}
-                    >
+                    <Link to={`/${orgId}/${projectId}/releases/${tag.value}/`}>
                       <InlineSvg src="icon-circle-info" size="14px" />
-                    </TextLink>
+                    </Link>
                   </VersionHoverCard>
                 )}
               </Pill>

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -241,7 +241,7 @@ const VersionHoverCard = createReactClass({
     }
 
     return (
-      <Hovercard header={header} body={body}>
+      <Hovercard {...this.props} header={header} body={body}>
         {this.props.children}
       </Hovercard>
     );

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -23,6 +23,9 @@
   box-shadow: 0 0 35px 0 rgba(67, 62, 75, 0.2);
   border: 1px solid @trim;
 
+  // The hovercard may appear in different contexts, don't inherit fonts
+  font-family: @font-family-base;
+
   // Default align hovercard top-middle
   bottom: 28px;
   left: 50%;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -441,9 +441,8 @@ pre.plain {
 
 .external-icon {
   .transition(0.1s linear color);
-  color: inherit;
   font-size: 11px;
-  padding: 0 5px;
+  margin: 0 5px;
   color: @gray-light;
   line-height: 1;
 
@@ -1730,9 +1729,26 @@ ul.faces {
       vertical-align: text-bottom;
     }
 
+    .pill-icon,
     .external-icon {
+      .transition(0.1s linear color);
       display: inline;
-      padding: 0 0 0 8px;
+      margin: 0 0 0 8px;
+      color: @gray-light;
+
+      &:hover {
+        color: @gray;
+      }
+    }
+
+    // Some pill icons are hovercard wrappers, so select the direct anchor
+    // element and correctly color that
+    .pill-icon > a {
+      color: @gray-light;
+
+      &:hover {
+        color: @gray;
+      }
     }
   }
 


### PR DESCRIPTION
The color and spacing now more closely matches the external url icon
![screen shot 2018-03-29 at 16 19 10](https://user-images.githubusercontent.com/1421724/38118004-f358afa2-336c-11e8-832e-6203dd88a940.png)

The font is correct now, and the alignment of the tooltip is correct (before it was off center due to padding applied to the icon itself).

![screen shot 2018-03-29 at 16 19 48](https://user-images.githubusercontent.com/1421724/38118018-04120bfe-336d-11e8-81bd-eddaccf47a20.png)

