### PR TITLE
ci(snuba): Add snuba test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,20 @@ matrix:
         - memcached
         - redis-server
         - postgresql
+    - python: 2.7
+      env: TEST_SUITE=snuba FLASK_DEBUG=1 CLICKHOUSE_TABLE=test SNUBA=http://localhost:8000
+      services:
+        - docker
+        - memcached
+        - redis-server
+        - postgresql
+      before_install:
+        - docker run -d --name clickhouse-server -p 9000:9000 -p 9009:9009 -p 8123:8123 --ulimit nofile=262144:262144 yandex/clickhouse-server
+        - docker run -d --env FLASK_DEBUG=1 --env CLICKHOUSE_TABLE=test --name snuba -p 8000:8000 --link clickhouse-server:clickhouse-server getsentry/snuba
+        - docker ps -a
+  allow_failures:
+    - python: 2.7
+      env: TEST_SUITE=snuba FLASK_DEBUG=1 CLICKHOUSE_TABLE=test SNUBA=http://localhost:8000
 notifications:
   webhooks:
     urls:

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,11 @@ test-network:
 	py.test tests/network --cov . --cov-report="xml:coverage.xml" --junit-xml="junit.xml"
 	@echo ""
 
+test-snuba:
+	@echo "--> Running snuba tests"
+	py.test tests/snuba --cov . --cov-report="xml:coverage.xml" --junit-xml="junit.xml"
+	@echo ""
+
 test-acceptance: build-platform-assets
 	@echo "--> Building static assets"
 	@${NPM_ROOT}/.bin/webpack --display errors-only
@@ -222,6 +227,7 @@ travis-install-acceptance: install-yarn travis-install-postgres
 	mkdir -p ~/.bin
 	mv ~/chromedriver ~/.bin/
 travis-install-network: travis-install-postgres
+travis-install-snuba: travis-install-postgres
 travis-install-js:
 	$(MAKE) travis-upgrade-pip
 	$(MAKE) travis-install-python install-yarn
@@ -239,6 +245,7 @@ travis-lint-postgres: lint-python
 travis-lint-mysql: lint-python
 travis-lint-acceptance: travis-noop
 travis-lint-network: lint-python
+travis-lint-snuba: lint-python
 travis-lint-js: lint-js
 travis-lint-cli: travis-noop
 travis-lint-dist: travis-noop
@@ -252,6 +259,7 @@ travis-test-postgres: test-python
 travis-test-mysql: test-python
 travis-test-acceptance: test-acceptance
 travis-test-network: test-network
+travis-test-snuba: test-snuba
 travis-test-js:
 	$(MAKE) test-js
 	$(MAKE) test-styleguide
@@ -270,9 +278,10 @@ travis-scan-postgres: scan-python
 travis-scan-mysql: scan-python
 travis-scan-acceptance: travis-noop
 travis-scan-network: travis-noop
+travis-scan-snuba: scan-python
 travis-scan-js: travis-noop
 travis-scan-cli: travis-noop
 travis-scan-dist: travis-noop
 travis-scan-django-18: travis-noop
 
-.PHONY: travis-scan-sqlite travis-scan-postgres travis-scan-mysql travis-scan-acceptance travis-scan-network travis-scan-js travis-scan-cli travis-scan-dist travis-scan-django-18
+.PHONY: travis-scan-sqlite travis-scan-postgres travis-scan-mysql travis-scan-acceptance travis-scan-network travis-scan-snuba travis-scan-js travis-scan-cli travis-scan-dist travis-scan-django-18

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -4,11 +4,12 @@ from dateutil.parser import parse as parse_datetime
 import json
 import requests
 import six
+import os
 
 from sentry.models import Group, GroupHash, Environment, Release, ReleaseProject
 from sentry.utils.dates import to_timestamp
 
-SNUBA = 'http://localhost:5000'
+SNUBA = os.environ.get('SNUBA', 'http://localhost:5000')
 
 
 def query(start, end, groupby, conditions=None, filter_keys=None,

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+from datetime import datetime, timedelta
+import requests
+import json
+import time
+
+from exam import before
+
+from sentry.testutils import TestCase
+from sentry.utils.snuba import query, SNUBA
+
+
+class SnubaTest(TestCase):
+    @before
+    def setup(self):
+        r = requests.post(SNUBA + '/tests/drop')
+        assert r.status_code == 200
+
+    def test(self):
+        now = datetime.now()
+
+        events = [{
+            'event_id': 'x' * 32,
+            'primary_hash': '1' * 32,
+            'project_id': 1,
+            'message': 'message',
+            'platform': 'python',
+            'datetime': now.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            'data': {
+                'received': time.mktime(now.timetuple()),
+            }
+        }]
+
+        r = requests.post(SNUBA + '/tests/insert', data=json.dumps(events))
+        assert r.status_code == 200
+
+        r = query(
+            start=now - timedelta(days=1),
+            end=now + timedelta(days=1),
+            groupby=['project_id'],
+            filter_keys={'project_id': [1]},
+        )
+        assert r == {1: 1}


### PR DESCRIPTION
See Travis here: https://travis-ci.org/getsentry/sentry/builds/361287639

So this adds a new test suite to Sentry called `snuba` that runs the tests in `./tests/snuba/` against real (dockerized) Clickhouse and Snuba services.

It is marked to allow failures because both CH and Snuba docker images are currently using `latest` since we are iterating quickly and I think bumping versions regularly will be a pain. Note that since failures are allowed this means the onus is on us, the Snuba team, to check Travis builds manually.

Snuba builds a new container off any pushes to `master` here: https://hub.docker.com/r/getsentry/snuba/

If debug mode is on, Snuba will accept requests on a couple of new endpoints, designed to allow external users to insert events (that go through the *same* pipeline of processing and writing as they would in production) and also to drop events (so that each test can start with a clean state of the world): https://github.com/getsentry/snuba/blob/ffdca4b0362c28ea01b101ab3067095d93056b36/snuba/api.py#L104

The goal here is to have end-to-end tests against Snuba in the same way we test against Postgres.