### PR TITLE
ref(newsletter): Various cleanup and fixes

### DIFF
--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -60,10 +60,11 @@ def add_email(email, user, subscribe_newsletter=False):
 
         # Update newsletter subscription and mark as unverified
         if subscribe_newsletter:
-            newsletter.update_subscription(user=user,
-                                           verified=False,
-                                           list_id=1,
-                                           )
+            newsletter.create_or_update_subscription(
+                user=user,
+                verified=False,
+                list_id=newsletter.get_default_list_id(),
+            )
         return new_email
 
 

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from rest_framework.response import Response
 from rest_framework import status
 
-from sentry.app import newsletter
+from sentry import newsletter
 from sentry.api.bases.user import UserEndpoint
 from sentry.models import UserEmail
 

--- a/src/sentry/app.py
+++ b/src/sentry/app.py
@@ -28,7 +28,6 @@ env = State()
 from sentry import search, tsdb  # NOQA
 from .buffer import backend as buffer  # NOQA
 from .digests import backend as digests  # NOQA
-from .newsletter import backend as newsletter  # NOQA
 from .nodestore import backend as nodestore  # NOQA
 from .quotas import backend as quotas  # NOQA
 from .ratelimits import backend as ratelimiter  # NOQA

--- a/src/sentry/newsletter/base.py
+++ b/src/sentry/newsletter/base.py
@@ -5,7 +5,7 @@ from sentry.utils.services import Service
 
 class Newsletter(Service):
     __all__ = (
-        'is_enabled', 'get_subscriptions', 'update_subscription',
+        'is_enabled', 'get_default_list_id', 'get_subscriptions', 'update_subscription',
         'create_or_update_subscription', 'optout_email',
     )
 
@@ -13,18 +13,31 @@ class Newsletter(Service):
 
     enabled = False
 
+    def get_default_list_id(self):
+        return self.DEFAULT_LIST_ID
+
     def is_enabled(self):
         return self.enabled
 
     def get_subscriptions(self, user):
         return None
 
-    def update_subscription(self, user, **kwargs):
+    def update_subscription(self, user, list_id=None, subscribed=True, create=None,
+                            verified=None, subscribed_date=None, unsubscribed_date=None, **kwargs):
         return None
 
-    def create_or_update_subscription(self, user, **kwargs):
-        kwargs['create'] = True
-        return self.update_subscription(user, **kwargs)
+    def create_or_update_subscription(self, user, list_id=None, subscribed=True, verified=None,
+                                      subscribed_date=None, unsubscribed_date=None, **kwargs):
+        return self.update_subscription(
+            user=user,
+            list_id=list_id,
+            subscribed=subscribed,
+            verified=verified,
+            subscribed_date=subscribed_date,
+            unsubscribed_date=unsubscribed_date,
+            create=True,
+            **kwargs
+        )
 
-    def optout_email(self, email, property):
+    def optout_email(self, email, **kwargs):
         raise NotImplementedError

--- a/src/sentry/newsletter/dummy.py
+++ b/src/sentry/newsletter/dummy.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import defaultdict
+from django.utils import timezone
+
+from .base import Newsletter
+
+
+class NewsletterSubscription(object):
+    def __init__(self, user, list_id, list_name=None, list_description=None, email=None, verified=None, subscribed=False, subscribed_date=None, unsubscribed_date=None, **kwargs):
+        self.email = user.email or email
+        self.list_id = list_id
+        self.list_description = list_description
+        self.list_name = list_name
+        # is the email address verified?
+        self.verified = user.email_set.get_or_create(email=user.email)[0].is_verified if verified is None else verified
+        # are they subscribed to ``list_id``
+        self.subscribed = subscribed
+        if subscribed:
+            self.subscribed_date = subscribed_date or timezone.now()
+        elif subscribed is False:
+            self.unsubscribed_date = unsubscribed_date or timezone.now()
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def update(self, verified=None, subscribed=None, subscribed_date=None, unsubscribed_date=None, **kwargs):
+        if verified is not None:
+            self.verified = verified
+        if subscribed is not None:
+            self.subscribed = subscribed
+        if subscribed_date is not None:
+            self.subscribed_date = subscribed_date
+        elif subscribed:
+            self.subscribed_date = timezone.now()
+        if unsubscribed_date is not None:
+            self.unsubscribed_date = unsubscribed_date
+        elif subscribed is False:
+            self.unsubscribed_date = timezone.now()
+
+
+class DummyNewsletter(Newsletter):
+    """
+    The ``DummyNewsletter`` implementation is primarily used for test cases. It uses a in-memory
+    store for tracking subscriptions, which means its not suitable for any real production use-case.
+    """
+
+    def __init__(self):
+        self._subscriptions = defaultdict(dict)
+        self._optout = set()
+        self._enabled = True
+
+    def enable(self):
+        self._enabled = True
+
+    def disable(self):
+        self._enabled = False
+
+    def clear(self):
+        self._subscriptions = defaultdict(dict)
+        self._optout = set()
+
+    def is_enabled(self):
+        return self._enabled
+
+    def get_subscriptions(self, user):
+        return {
+            'subscriptions': list(six.itervalues(self._subscriptions.get(user) or {}))
+        }
+
+    def update_subscription(self, user, list_id=None, create=False, **kwargs):
+        if list_id:
+            if create:
+                self._subscriptions[user].setdefault(list_id, NewsletterSubscription(user, list_id, subscribed=True))
+            self._subscriptions[user][list_id].update(**kwargs)
+        return self._subscriptions[user]
+
+    def optout_email(self, email, **kwargs):
+        self._optout.add(email)

--- a/src/sentry/receivers/useremail.py
+++ b/src/sentry/receivers/useremail.py
@@ -21,9 +21,9 @@ post_save.connect(create_user_email, sender=User, dispatch_uid="create_user_emai
 
 @email_verified.connect(weak=False)
 def verify_newsletter_subscription(sender, **kwargs):
-    from sentry.app import newsletter
+    from sentry import newsletter
 
-    if not newsletter.enabled:
+    if not newsletter.is_enabled():
         return
 
     if not sender.is_primary():

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -104,6 +104,9 @@ def pytest_configure(config):
     settings.SENTRY_TSDB = 'sentry.tsdb.inmemory.InMemoryTSDB'
     settings.SENTRY_TSDB_OPTIONS = {}
 
+    settings.SENTRY_NEWSLETTER = 'sentry.newsletter.dummy.DummyNewsletter'
+    settings.SENTRY_NEWSLETTER_OPTIONS = {}
+
     settings.BROKER_BACKEND = 'memory'
     settings.BROKER_URL = None
     settings.CELERY_ALWAYS_EAGER = False
@@ -201,6 +204,10 @@ def pytest_runtest_teardown(item):
     from sentry import tsdb
     # TODO(dcramer): this only works if this is the correct tsdb backend
     tsdb.flush()
+
+    # XXX(dcramer): only works with DummyNewsletter
+    from sentry import newsletter
+    newsletter.backend.clear()
 
     from sentry.utils.redis import clusters
 

--- a/src/sentry/web/frontend/account_security.py
+++ b/src/sentry/web/frontend/account_security.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.app import newsletter
+from sentry import newsletter
 from sentry.models import Authenticator
 from sentry.utils.auth import get_auth_providers
 from sentry.web.frontend.base import BaseView
@@ -13,6 +13,6 @@ class AccountSecurityView(BaseView):
                 'page': 'security',
                 'has_2fa': Authenticator.objects.user_has_2fa(request.user),
                 'AUTH_PROVIDERS': get_auth_providers(),
-                'has_newsletters': newsletter.is_enabled,
+                'has_newsletters': newsletter.is_enabled(),
             }
         )

--- a/tests/sentry/api/endpoints/test_user_subscriptions.py
+++ b/tests/sentry/api/endpoints/test_user_subscriptions.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
+from sentry import newsletter
 from sentry.testutils import APITestCase
 
 
@@ -10,6 +11,7 @@ class UserSubscriptionsTest(APITestCase):
         self.user = self.create_user(email='foo@example.com')
         self.login_as(self.user)
         self.url = reverse('sentry-api-0-user-subscriptions', kwargs={'user_id': self.user.id})
+        newsletter.backend.enable()
 
     def test_get_subscriptions(self):
         response = self.client.get(self.url)
@@ -21,3 +23,8 @@ class UserSubscriptionsTest(APITestCase):
             'subscribed': True,
         })
         assert response.status_code == 204, response.content
+        results = newsletter.get_subscriptions(self.user)['subscriptions']
+        assert len(results) == 1
+        assert results[0].list_id == 123
+        assert results[0].subscribed
+        assert results[0].verified


### PR DESCRIPTION
- Pass correct list_id for default newsletter subscription
- Fill in function signatures on Newsletter base
- Add DummyNewsletter for tests
- Utilize Newsletter.is_enabled from service
- Remove sentry.app.newsletter (in favor of sentry.newsletter)