### PR TITLE
fix(ui): Add border radius to user widget avatar

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1185,6 +1185,7 @@
     top: 0;
     right: 0;
     box-shadow: 0 0 0 5px #fff;
+    border-radius: 5px;
   }
 
   .btn-group {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/38213292-9018358c-3675-11e8-93f3-63a09f108023.png)

Note the border radius.

vs 
![image](https://user-images.githubusercontent.com/1421724/38213315-9ff16cbc-3675-11e8-9ba0-3de9bffd2114.png)
