### PR TITLE
fix(slack): Add users:read permission for retrieving users list

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -39,6 +39,7 @@ class SlackIntegration(Integration):
 
     identity_oauth_scopes = frozenset([
         'channels:read',
+        'users:read'
         'chat:write',
         'links:read',
         'links:write',


### PR DESCRIPTION
Validating if a user was correct just didn't work correctly before after switching to workspace tokens.