### PR TITLE
feat(digests): Sort Records prior to fetching state

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -53,7 +53,18 @@ def event_to_record(event, rules):
     )
 
 
+def sort_records(records):
+    """
+    Sorts records for fetch_state method
+    fetch_state is expecting these records to be ordered from newest to oldest
+    """
+    return sorted(records, key=lambda r: r.value.event.datetime, reverse=True)
+
+
 def fetch_state(project, records):
+    # Sort records added to ensure that records are returned in reverse chronological order
+    records = sort_records(records)
+
     # This reads a little strange, but remember that records are returned in
     # reverse chronological order, and we query the database in chronological
     # order.

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -7,6 +7,9 @@ from collections import (
 from exam import fixture
 from six.moves import reduce
 
+from datetime import timedelta
+from django.utils import timezone
+
 from sentry.digests import Record
 from sentry.digests.notifications import (
     Notification,
@@ -14,6 +17,7 @@ from sentry.digests.notifications import (
     rewrite_record,
     group_records,
     sort_group_contents,
+    sort_records,
     sort_rule_groups,
 )
 from sentry.models import Rule
@@ -141,3 +145,60 @@ class SortRecordsTestCase(TestCase):
                 (rules[0], OrderedDict(((groups[0], []), ))),
             )
         )
+
+
+class SortWholeRecordsTestCase(TestCase):
+    def setUp(self):
+        self.group = self.create_group(
+            first_seen=timezone.now() - timedelta(days=3),
+            last_seen=timezone.now() - timedelta(hours=3),
+            project=self.project,
+            message='hello  world this is a group',
+            logger='root',
+        )
+        self.group1 = self.create_group(
+            project=self.project,
+            first_seen=timezone.now() - timedelta(days=2),
+            last_seen=timezone.now() - timedelta(hours=2),
+            message='group 2',
+            logger='root',
+        )
+        self.group2 = self.create_group(
+            project=self.project,
+            first_seen=timezone.now() - timedelta(days=1),
+            last_seen=timezone.now() - timedelta(hours=1),
+            message='group 3',
+            logger='root',
+        )
+        self.event_single_user = self.create_event(
+            group=self.group,
+            message=self.group.message,
+            datetime=self.group.last_seen,
+            project=self.project,
+        )
+        self.event_all_users = self.create_event(
+            group=self.group1,
+            message=self.group1.message,
+            datetime=self.group1.last_seen,
+            project=self.project,
+        )
+        self.event_team = self.create_event(
+            group=self.group2,
+            message=self.group2.message,
+            datetime=self.group2.last_seen,
+            project=self.project,
+        )
+
+        self.rule = self.project.rule_set.all()[0]
+
+    def test_sort_records(self):
+        record1 = event_to_record(self.event_team, (self.rule,))
+        record2 = event_to_record(self.event_all_users, (self.rule,))
+        record3 = event_to_record(self.event_single_user, (self.rule,))
+
+        records = sort_records((record2, record3, record1))
+
+        assert len(records) == 3
+        assert records[0] == record1
+        assert records[1] == record2
+        assert records[2] == record3


### PR DESCRIPTION
As part of the owner's digest work for Sentry 9, I found myself needing to rebuild digests for individual users when adapting digests to accommodate owners. The `fetch_state` function in `/digests/notifications.py` makes the assumption that records are in reverse chronological order because (???? I'm not sure... ???). I added a function to sort the records prior to fetching state in order to prevent errors further down the digest creation process.