### PR TITLE
tests(python): Fix selenium teardown errors

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -43,7 +43,7 @@ querystring_parser>=1.2.3,<2.0.0
 raven>=6.0.0,<=6.4.0
 redis>=2.10.3,<2.10.6
 requests[security]>=2.18.4,<2.19.0
-selenium==3.8.0
+selenium==3.11.0
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0
 setproctitle>=1.1.7,<1.2.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -32,7 +32,7 @@ petname>=2.0,<2.1
 Pillow>=3.2.0,<=4.2.1
 progressbar2>=3.10,<3.11
 psycopg2>=2.6.0,<2.8.0
-pytest>=3.1.2,<3.2.0
+pytest>=3.5.0,<3.6.0
 pytest-django>=2.9.1,<2.10.0
 pytest-html>=1.9.0,<1.10.0
 python-dateutil>=2.0.0,<3.0.0

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import logging
 import os
 import pytest
-import signal
 
 from datetime import datetime
 from django.conf import settings
@@ -288,13 +287,9 @@ def browser(request, percy, live_server):
     def fin():
         # Teardown Selenium.
         try:
-            driver.close()
+            driver.quit()
         except Exception:
             pass
-        # TODO: remove this when fixed in: https://github.com/seleniumhq/selenium/issues/767
-        if hasattr(driver, 'service'):
-            driver.service.process.send_signal(signal.SIGTERM)
-        driver.quit()
 
     request.node._driver = driver
     request.addfinalizer(fin)


### PR DESCRIPTION
* upgrades `selenium` to 3.11.0 
* upgrades `pytest` to 3.5
