### PR TITLE
fix(integrations): Remove onclose window handler

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrationConfig.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrationConfig.jsx
@@ -135,7 +135,6 @@ export default class OrganizationIntegrationConfig extends AsyncView {
     );
 
     this.dialog.focus();
-    this.dialog.onclose = () => document.location.refresh();
   };
 
   receiveMessage = message => {


### PR DESCRIPTION
This wasn't actually used for anything and does not necessarily work. The user would have to close the window while _not_ on the slack website.

Fixes JAVASCRIPT-3H5