### PR TITLE
feat(assistant): Remove Assistant from Mobile

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/helper.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/helper.jsx
@@ -142,6 +142,9 @@ const AssistantHelper = createReactClass({
 //this globally controls the size of the component
 const StyledHelper = styled('div')`
   font-size: 1.4rem;
+  @media (max-width: 600px) {
+    display: none;
+  }
 `;
 
 const StyledCueText = styled('span')`


### PR DESCRIPTION
Assistant isn't mobile optimized. Removing it with a media query for now.