### PR TITLE
feat(api): Expand broadcasts API to support administration

### DIFF
--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -15,23 +15,13 @@ from django.template.response import TemplateResponse
 from django.utils.translation import ugettext, ugettext_lazy as _
 from pprint import saferepr
 from sentry.models import (
-    ApiKey, AuthIdentity, AuthProvider, AuditLogEntry, Broadcast, Option, Organization,
+    ApiKey, AuthIdentity, AuthProvider, AuditLogEntry, Option, Organization,
     OrganizationMember, Project, Team, User
 )
 from sentry.utils.html import escape
 
 csrf_protect_m = method_decorator(csrf_protect)
 sensitive_post_parameters_m = method_decorator(sensitive_post_parameters())
-
-
-class BroadcastAdmin(admin.ModelAdmin):
-    list_display = ('title', 'message', 'is_active', 'date_added')
-    list_filter = ('is_active', )
-    search_fields = ('title', 'message', 'link')
-    readonly_fields = ('upstream_id', 'date_added')
-
-
-admin.site.register(Broadcast, BroadcastAdmin)
 
 
 class OptionAdmin(admin.ModelAdmin):

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -19,6 +19,7 @@ from rest_framework.views import APIView
 
 from sentry import tsdb
 from sentry.app import raven
+from sentry.auth import access
 from sentry.models import Environment
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
@@ -159,6 +160,10 @@ class Endpoint(APIView):
                 self.kwargs = kwargs
             else:
                 handler = self.http_method_not_allowed
+
+            if getattr(request, 'access', None) is None:
+                # setup default access
+                request.access = access.from_request(request)
 
             response = handler(request, *args, **kwargs)
 

--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import
+
+import logging
+
+from django.db import IntegrityError, transaction
+from django.db.models import Q
+from django.utils import timezone
+from rest_framework.permissions import IsAuthenticated
+
+from sentry.api.base import Endpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.api.validators import AdminBroadcastValidator, BroadcastValidator
+from sentry.auth.superuser import is_active_superuser
+from sentry.models import Broadcast, BroadcastSeen
+
+logger = logging.getLogger('sentry')
+
+
+class BroadcastDetailsEndpoint(Endpoint):
+    permission_classes = (IsAuthenticated, )
+
+    def _get_broadcast(self, request, broadcast_id):
+        if is_active_superuser(request) and request.access.has_permission('broadcasts.admin'):
+            queryset = Broadcast.objects
+        else:
+            queryset = Broadcast.objects.filter(
+                Q(date_expires__isnull=True) | Q(date_expires__gt=timezone.now()),
+                is_active=True,
+            )
+
+        try:
+            return queryset.get(id=broadcast_id)
+        except Broadcast.DoesNotExist:
+            raise ResourceDoesNotExist
+
+    def _get_validator(self, request):
+        if is_active_superuser(request):
+            return AdminBroadcastValidator
+        return BroadcastValidator
+
+    def _serialize_response(self, request, broadcast):
+        context = serialize(broadcast, request.user)
+        if is_active_superuser(request):
+            context['userCount'] = BroadcastSeen.objects.filter(broadcast=broadcast).count()
+        return self.respond(context)
+
+    def get(self, request, broadcast_id):
+        broadcast = self._get_broadcast(request, broadcast_id)
+        return self._serialize_response(request, broadcast)
+
+    def put(self, request, broadcast_id):
+        broadcast = self._get_broadcast(request, broadcast_id)
+        validator = self._get_validator(request)(data=request.DATA, partial=True)
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        result = validator.object
+
+        update_kwargs = {}
+        if result.get('title'):
+            update_kwargs['title'] = result['title']
+        if result.get('message'):
+            update_kwargs['message'] = result['message']
+        if result.get('link'):
+            update_kwargs['link'] = result['link']
+        if result.get('isActive') is not None:
+            update_kwargs['is_active'] = result['isActive']
+        if result.get('dateExpires', -1) != -1:
+            update_kwargs['date_expires'] = result['dateExpires']
+        if update_kwargs:
+            with transaction.atomic():
+                broadcast.update(**update_kwargs)
+                logger.info('broadcasts.update', extra={
+                    'ip_address': request.META['REMOTE_ADDR'],
+                    'user_id': request.user.id,
+                    'broadcast_id': broadcast.id,
+                    'data': update_kwargs,
+                })
+
+        if result.get('hasSeen'):
+            try:
+                with transaction.atomic():
+                    BroadcastSeen.objects.create(
+                        broadcast=broadcast,
+                        user=request.user,
+                    )
+            except IntegrityError:
+                pass
+
+        return self._serialize_response(request, broadcast)

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -1,41 +1,99 @@
 from __future__ import absolute_import
 
+import logging
+import six
+
 from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.utils import timezone
-from rest_framework import serializers
+from operator import or_
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
+from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
+from sentry.api.validators import AdminBroadcastValidator, BroadcastValidator
+from sentry.auth.superuser import is_active_superuser
+from sentry.db.models.query import in_icontains
 from sentry.models import Broadcast, BroadcastSeen
+from sentry.search.utils import tokenize_query
 
-
-class BroadcastSerializer(serializers.Serializer):
-    hasSeen = serializers.BooleanField()
+logger = logging.getLogger('sentry')
 
 
 class BroadcastIndexEndpoint(Endpoint):
     permission_classes = (IsAuthenticated, )
 
     def get(self, request):
-        # limit to only a few "recent" broadcasts
-        broadcasts = list(
-            Broadcast.objects.filter(
+        if request.GET.get('show') == 'all' and is_active_superuser(
+                request) and request.access.has_permission('broadcasts.admin'):
+            # superusers can slice and dice
+            queryset = Broadcast.objects.filter(
+                Q(date_expires__isnull=True) | Q(date_expires__gt=timezone.now()),
+            )
+        else:
+            # only allow active broadcasts if they're not a superuser
+            queryset = Broadcast.objects.filter(
                 Q(date_expires__isnull=True) | Q(date_expires__gt=timezone.now()),
                 is_active=True,
-            ).order_by('-date_added')[:5]
+            ).order_by('-date_added')
+
+        query = request.GET.get('query')
+        if query:
+            tokens = tokenize_query(query)
+            for key, value in six.iteritems(tokens):
+                if key == 'query':
+                    value = ' '.join(value)
+                    queryset = queryset.filter(
+                        Q(title__icontains=value) | Q(
+                            message__icontains=value) | Q(link__icontains=value)
+                    )
+                elif key == 'id':
+                    queryset = queryset.filter(id__in=value)
+                elif key == 'link':
+                    queryset = queryset.filter(in_icontains('link', value))
+                elif key == 'status':
+                    filters = []
+                    for v in value:
+                        v = v.lower()
+                        if v == 'active':
+                            filters.append(
+                                Q(date_expires__isnull=True, is_active=True) | Q(
+                                    date_expires__gt=timezone.now(), is_active=True)
+                            )
+                        elif v == 'inactive':
+                            filters.append(
+                                Q(date_expires__lt=timezone.now()) | Q(is_active=False)
+                            )
+                        else:
+                            queryset = queryset.none()
+                    if filters:
+                        queryset = queryset.filter(reduce(or_, filters))
+                else:
+                    queryset = queryset.none()
+
+        sort_by = request.GET.get('sortBy')
+        if sort_by == 'expires':
+            order_by = '-date_expires'
+            paginator_cls = DateTimePaginator
+        else:
+            order_by = '-date_added'
+            paginator_cls = DateTimePaginator
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by=order_by,
+            on_results=lambda x: serialize(x, request.user),
+            paginator_cls=paginator_cls,
         )
 
-        return Response(serialize(broadcasts, request.user))
-
     def put(self, request):
-        serializer = BroadcastSerializer(data=request.DATA, partial=True)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+        validator = BroadcastValidator(data=request.DATA, partial=True)
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
 
-        result = serializer.object
+        result = validator.object
 
         queryset = Broadcast.objects.filter(
             is_active=True,
@@ -49,7 +107,7 @@ class BroadcastIndexEndpoint(Endpoint):
 
         if result.get('hasSeen'):
             if not request.user.is_authenticated():
-                return Response(status=401)
+                return self.respond(status=401)
 
             if ids:
                 unseen_queryset = queryset
@@ -70,4 +128,40 @@ class BroadcastIndexEndpoint(Endpoint):
                 except IntegrityError:
                     pass
 
-        return Response(result)
+        return self.respond(result)
+
+    def post(self, request):
+        if not (is_active_superuser(request) and request.access.has_permission('broadcasts.admin')):
+            return self.respond(status=401)
+
+        validator = AdminBroadcastValidator(data=request.DATA)
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        result = validator.object
+
+        with transaction.atomic():
+            broadcast = Broadcast.objects.create(
+                title=result['title'],
+                message=result['message'],
+                link=result['link'],
+                is_active=result.get('isActive') or False,
+                date_expires=result.get('expiresAt'),
+            )
+            logger.info('broadcasts.create', extra={
+                'ip_address': request.META['REMOTE_ADDR'],
+                'user_id': request.user.id,
+                'broadcast_id': broadcast.id,
+            })
+
+        if result.get('hasSeen'):
+            try:
+                with transaction.atomic():
+                    BroadcastSeen.objects.create(
+                        broadcast=broadcast,
+                        user=request.user,
+                    )
+            except IntegrityError:
+                pass
+
+        return self.respond(serialize(broadcast, request.user))

--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -31,5 +31,6 @@ class BroadcastSerializer(Serializer):
             'link': obj.link,
             'isActive': obj.is_active,
             'dateCreated': obj.date_added,
+            'dateExpires': obj.date_expires,
             'hasSeen': attrs['seen'],
         }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -10,6 +10,7 @@ from .endpoints.api_tokens import ApiTokensEndpoint
 from .endpoints.assistant import AssistantEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.authenticator_index import AuthenticatorIndexEndpoint
+from .endpoints.broadcast_details import BroadcastDetailsEndpoint
 from .endpoints.broadcast_index import BroadcastIndexEndpoint
 from .endpoints.catchall import CatchallEndpoint
 from .endpoints.chunk import ChunkUploadEndpoint
@@ -201,6 +202,7 @@ urlpatterns = patterns(
     # Broadcasts
     url(r'^broadcasts/$', BroadcastIndexEndpoint.as_view(),
         name='sentry-api-0-broadcast-index'),
+    url(r'^broadcasts/(?P<broadcast_id>[^\/]+)/$', BroadcastDetailsEndpoint.as_view()),
 
     # Project transfer
     url(r'^accept-transfer/$', AcceptProjectTransferEndpoint.as_view(),

--- a/src/sentry/api/validators/broadcast.py
+++ b/src/sentry/api/validators/broadcast.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+
+
+class BroadcastValidator(serializers.Serializer):
+    hasSeen = serializers.BooleanField(required=False)
+
+
+class AdminBroadcastValidator(BroadcastValidator):
+    title = serializers.CharField(max_length=32, required=True)
+    message = serializers.CharField(max_length=32, required=True)
+    link = serializers.URLField(required=True)
+    isActive = serializers.BooleanField(required=False)
+    dateExpires = serializers.DateTimeField(required=False)

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -106,3 +106,11 @@ def in_iexact(column, values):
     query = '{}__iexact'.format(column)
 
     return reduce(or_, [Q(**{query: v}) for v in values])
+
+
+def in_icontains(column, values):
+    from operator import or_
+
+    query = '{}__icontains'.format(column)
+
+    return reduce(or_, [Q(**{query: v}) for v in values])

--- a/src/sentry/models/userpermission.py
+++ b/src/sentry/models/userpermission.py
@@ -4,6 +4,10 @@ from django.db import models
 
 from sentry.db.models import Model, FlexibleForeignKey, sane_repr
 
+KNOWN_PERMISSIONS = (
+    'broadcasts.admin',
+)
+
 
 class UserPermission(Model):
     __core__ = True

--- a/src/sentry/static/sentry/app/components/forms/dateTimeField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/dateTimeField.jsx
@@ -1,0 +1,7 @@
+import InputField from './inputField';
+
+export default class DateTimeField extends InputField {
+  getType() {
+    return 'datetime-local';
+  }
+}

--- a/src/sentry/static/sentry/app/components/forms/index.jsx
+++ b/src/sentry/static/sentry/app/components/forms/index.jsx
@@ -1,6 +1,7 @@
 export {default as ApiForm} from './apiForm';
 export {default as BooleanField} from './booleanField';
 export {default as EmailField} from './emailField';
+export {default as DateTimeField} from './dateTimeField';
 export {default as Form} from './form';
 export {default as FormState} from './state';
 export {default as GenericField} from './genericField';

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -94,6 +94,7 @@ export default {
       // all needed by sentry.io
       ApiForm: require('./components/forms/apiForm').default,
       BooleanField: require('./components/forms/booleanField').default,
+      DateTimeField: require('./components/forms/dateTimeField').default,
       EmailField: require('./components/forms/emailField').default,
       Form: require('./components/forms/form').default,
       RangeField: require('./components/forms/rangeField').default,

--- a/src/sentry/static/sentry/app/stores/configStore.jsx
+++ b/src/sentry/static/sentry/app/stores/configStore.jsx
@@ -28,6 +28,7 @@ const ConfigStore = Reflux.createStore({
 
     // TODO(dcramer): abstract this out of ConfigStore
     if (config.user) {
+      config.user.permissions = new Set(config.user.permissions);
       moment.tz.setDefault(config.user.options.timezone);
       setLocale(config.user.options.language || 'en');
     }

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -16,6 +16,7 @@ import random
 import six
 import warnings
 
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from django.utils.text import slugify
 from exam import fixture
@@ -26,7 +27,7 @@ from uuid import uuid4
 from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
     OrganizationMemberTeam, Project, Team, User, UserEmail, Release, Commit, ReleaseCommit,
-    CommitAuthor, Repository, CommitFileChange, ProjectDSymFile, File
+    CommitAuthor, Repository, CommitFileChange, ProjectDSymFile, File, UserPermission
 )
 
 loremipsum = Generator()
@@ -615,3 +616,10 @@ class Fixtures(object):
             project = self.project
 
         return ProjectDSymFile.objects.create(project=project, **kwargs)
+
+    def add_user_permission(self, user, permission):
+        try:
+            with transaction.atomic():
+                UserPermission.objects.create(user=user, permission=permission)
+        except IntegrityError:
+            raise

--- a/tests/sentry/api/endpoints/test_broadcast_details.py
+++ b/tests/sentry/api/endpoints/test_broadcast_details.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.models import Broadcast, BroadcastSeen
+from sentry.testutils import APITestCase
+
+
+class BroadcastDetailsTest(APITestCase):
+    def test_simple(self):
+        broadcast1 = Broadcast.objects.create(message='bar', is_active=True)
+        Broadcast.objects.create(message='foo', is_active=False)
+
+        self.login_as(user=self.user)
+
+        response = self.client.get('/api/0/broadcasts/{}/'.format(broadcast1.id))
+        assert response.status_code == 200
+        assert response.data['id'] == six.text_type(broadcast1.id)
+
+
+class BroadcastUpdateTest(APITestCase):
+    def test_regular_user(self):
+        broadcast1 = Broadcast.objects.create(message='bar', is_active=True)
+        broadcast2 = Broadcast.objects.create(message='foo', is_active=False)
+
+        self.add_user_permission(user=self.user, permission='broadcasts.admin')
+        self.login_as(user=self.user)
+
+        response = self.client.put('/api/0/broadcasts/{}/'.format(broadcast1.id), {
+            'hasSeen': '1',
+            'message': 'foobar',
+        })
+        assert response.status_code == 200
+        assert response.data['hasSeen']
+
+        assert BroadcastSeen.objects.filter(
+            user=self.user,
+            broadcast=broadcast1,
+        ).exists()
+        assert not BroadcastSeen.objects.filter(
+            user=self.user,
+            broadcast=broadcast2,
+        ).exists()
+        broadcast1 = Broadcast.objects.get(id=broadcast1.id)
+        assert broadcast1.message == 'bar'
+        broadcast2 = Broadcast.objects.get(id=broadcast2.id)
+        assert broadcast2.message == 'foo'
+
+    def test_superuser(self):
+        broadcast1 = Broadcast.objects.create(message='bar', is_active=True)
+        broadcast2 = Broadcast.objects.create(message='foo', is_active=False)
+
+        self.add_user_permission(user=self.user, permission='broadcasts.admin')
+        self.login_as(user=self.user, superuser=True)
+
+        response = self.client.put('/api/0/broadcasts/{}/'.format(broadcast1.id), {
+            'hasSeen': '1',
+            'message': 'foobar',
+        })
+        assert response.status_code == 200
+        assert response.data['hasSeen']
+
+        assert BroadcastSeen.objects.filter(
+            user=self.user,
+            broadcast=broadcast1,
+        ).exists()
+        assert not BroadcastSeen.objects.filter(
+            user=self.user,
+            broadcast=broadcast2,
+        ).exists()
+        broadcast1 = Broadcast.objects.get(id=broadcast1.id)
+        assert broadcast1.message == 'foobar'
+        broadcast2 = Broadcast.objects.get(id=broadcast2.id)
+        assert broadcast2.message == 'foo'

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import six
 
-from django.core.urlresolvers import reverse
-
 from sentry.models import Broadcast, BroadcastSeen
 from sentry.testutils import APITestCase
 
@@ -13,12 +11,87 @@ class BroadcastListTest(APITestCase):
         broadcast1 = Broadcast.objects.create(message='bar', is_active=True)
         Broadcast.objects.create(message='foo', is_active=False)
 
+        self.add_user_permission(user=self.user, permission='broadcasts.admin')
         self.login_as(user=self.user)
-        url = reverse('sentry-api-0-broadcast-index')
-        response = self.client.get(url)
+
+        response = self.client.get('/api/0/broadcasts/')
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]['id'] == six.text_type(broadcast1.id)
+
+    def test_superuser_with_all(self):
+        Broadcast.objects.create(message='bar', is_active=True)
+        Broadcast.objects.create(message='foo', is_active=False)
+
+        self.add_user_permission(user=self.user, permission='broadcasts.admin')
+        self.login_as(user=self.user, superuser=True)
+
+        response = self.client.get('/api/0/broadcasts/?show=all')
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+        response = self.client.get('/api/0/broadcasts/?show=all&query=status:active')
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+        response = self.client.get('/api/0/broadcasts/?show=all&query=status:inactive')
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+        response = self.client.get('/api/0/broadcasts/?show=all&query=status:zzz')
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
+        response = self.client.get('/api/0/broadcasts/?show=all&query=foo')
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+        response = self.client.get('/api/0/broadcasts/?show=all&query=zzz')
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
+    def test_basic_user_with_all(self):
+        broadcast1 = Broadcast.objects.create(message='bar', is_active=True)
+        Broadcast.objects.create(message='foo', is_active=False)
+
+        self.add_user_permission(user=self.user, permission='broadcasts.admin')
+        self.login_as(user=self.user, superuser=False)
+
+        response = self.client.get('/api/0/broadcasts/?show=all')
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == six.text_type(broadcast1.id)
+
+
+class BroadcastCreateTest(APITestCase):
+    def test_basic_user(self):
+        self.add_user_permission(user=self.user, permission='broadcasts.admin')
+        self.login_as(user=self.user, superuser=False)
+
+        response = self.client.post('/api/0/broadcasts/', {
+            'title': 'bar',
+            'message': 'foo',
+            'link': 'http://example.com',
+        })
+
+        assert response.status_code == 401
+
+    def test_superuser(self):
+        self.add_user_permission(user=self.user, permission='broadcasts.admin')
+        self.login_as(user=self.user, superuser=True)
+
+        response = self.client.post('/api/0/broadcasts/', {
+            'title': 'bar',
+            'message': 'foo',
+            'link': 'http://example.com',
+        })
+
+        assert response.status_code == 200, response.data
+
+        broadcast = Broadcast.objects.get(id=response.data['id'])
+        assert broadcast.title == 'bar'
+        assert broadcast.message == 'foo'
+        assert broadcast.link == 'http://example.com'
 
 
 class BroadcastUpdateTest(APITestCase):
@@ -27,8 +100,7 @@ class BroadcastUpdateTest(APITestCase):
         broadcast2 = Broadcast.objects.create(message='foo', is_active=False)
 
         self.login_as(user=self.user)
-        url = reverse('sentry-api-0-broadcast-index')
-        response = self.client.put(url, {'hasSeen': '1'})
+        response = self.client.put('/api/0/broadcasts/', {'hasSeen': '1'})
         assert response.status_code == 200
         assert response.data['hasSeen']
 

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -15,8 +15,7 @@ class FromUserTest(TestCase):
         user = self.create_user()
 
         result = access.from_user(user, organization)
-        assert not result.is_active
-        assert result.sso_is_valid
+        assert not result.sso_is_valid
         assert not result.requires_sso
         assert not result.scopes
         assert not result.has_team_access(team)
@@ -33,7 +32,6 @@ class FromUserTest(TestCase):
         team = self.create_team(organization=organization)
 
         result = access.from_user(user, organization)
-        assert result.is_active
         assert result.sso_is_valid
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
@@ -54,7 +52,6 @@ class FromUserTest(TestCase):
         team = self.create_team(organization=organization)
 
         result = access.from_user(user, organization)
-        assert result.is_active
         assert result.sso_is_valid
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
@@ -76,7 +73,6 @@ class FromUserTest(TestCase):
         team = self.create_team(organization=organization)
 
         result = access.from_user(user, organization)
-        assert result.is_active
         assert result.sso_is_valid
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
@@ -94,7 +90,6 @@ class FromUserTest(TestCase):
         )
 
         result = access.from_user(user, organization)
-        assert result.is_active
         assert result.sso_is_valid
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
@@ -150,8 +145,13 @@ class FromUserTest(TestCase):
         anon_user = AnonymousUser()
         organization = self.create_organization(owner=user)
         result = access.from_user(anon_user, organization)
+        assert result is access.DEFAULT
 
-        assert not result.is_active
+    def test_inactive_user(self):
+        user = self.create_user(is_active=False)
+        organization = self.create_organization(owner=user)
+        result = access.from_user(user, organization)
+        assert result is access.DEFAULT
 
 
 class DefaultAccessTest(TestCase):


### PR DESCRIPTION
This exposes details and update endpoints for broadcasts, as well as allowing superusers to search and view all broadcasts (e.g. inactive).