### PR TITLE
ref(slack): On response error, store full response

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -116,9 +116,7 @@ class SlackActionEndpoint(Endpoint):
         req = session.post('https://slack.com/api/dialog.open', data=payload)
         resp = req.json()
         if not resp.get('ok'):
-            logger.error('slack.action.response-error', extra={
-                'error': resp.get('error'),
-            })
+            logger.error('slack.action.response-error', extra={'response': resp})
 
     def construct_reply(self, attachment, is_message=False):
         # XXX(epurkhiser): Slack is inconsistent about it's expected responses
@@ -248,9 +246,7 @@ class SlackActionEndpoint(Endpoint):
             req = session.post(callback_data['orig_response_url'], json=body)
             resp = req.json()
             if not resp.get('ok'):
-                logger.error('slack.action.response-error', extra={
-                    'error': resp.get('error'),
-                })
+                logger.error('slack.action.response-error', extra={'response': resp})
 
             return self.respond()
 

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -77,9 +77,8 @@ class SlackEventEndpoint(Endpoint):
         req.raise_for_status()
         resp = req.json()
         if not resp.get('ok'):
-            logger.error('slack.event.unfurl-error', extra={
-                'error': resp.get('error'),
-            })
+            logger.error('slack.event.unfurl-error', extra={'response': resp})
+
         return self.respond()
 
     # TODO(dcramer): implement app_uninstalled and tokens_revoked


### PR DESCRIPTION
Trying to get a bit more insight into some of these.

The issue is that right now the error message is a little too vague. Checkout  [SENTRY-66Q](https://sentry.io/share/issue/d92d4e2811754c838fd35482e3183024/) to see what i mean; `{"error":"validation_errors"}` - What were they!?