### PR TITLE
feat(digest): Owners digests

### DIFF
--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -84,6 +84,9 @@ class Actor(object):
             return False
         return (self.id, self.type) == (other.id, other.type)
 
+    def __neq__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash((self.id, self.type))
 

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -84,7 +84,7 @@ class Actor(object):
             return False
         return (self.id, self.type) == (other.id, other.type)
 
-    def __neq__(self, other):
+    def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self):

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -84,6 +84,12 @@ class Actor(object):
             return False
         return (self.id, self.type) == (other.id, other.type)
 
+    def __hash__(self):
+        return hash((self.id, self.type))
+
+    def __repr__(self):
+        return '<Actor id=%s, type=%s>' % (six.text_type(self.id), six.text_type(self.type))
+
 
 class ActorField(serializers.WritableField):
     def to_native(self, obj):

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -36,7 +36,7 @@ def get_personalized_digests(project_id, digest, user_ids):
     # Once with this statement and again with the call to ProjectOwnership.get_actors()
     # Will follow up with another PR to reduce the number of queries.
     if ProjectOwnership.objects.filter(project_id=project_id).exists():
-        events = get_events_from_digest(digest)
+        events = get_event_from_groups_in_digest(digest)
         events_by_actor = build_events_by_actor(project_id, events, user_ids)
         events_by_user = convert_actors_to_users(events_by_actor, user_ids)
         for user_id, user_events in six.iteritems(events_by_user):
@@ -46,7 +46,12 @@ def get_personalized_digests(project_id, digest, user_ids):
             yield user_id, digest
 
 
-def get_events_from_digest(digest):
+def get_event_from_groups_in_digest(digest):
+    """
+    get_event_from_groups_in_digest(digest: Digest)
+
+    Gets the first event from each group in the digest
+    """
     events = []
     for rule_groups in six.itervalues(digest):
         for group_records in six.itervalues(rule_groups):
@@ -112,7 +117,7 @@ def convert_actors_to_users(events_by_actor, user_ids):
         elif actor.type == User:
             events_by_user[actor.id].update(events)
         else:
-            raise ValueError('Unknown Actor type')
+            raise ValueError('Unknown Actor type: %s' % actor.type)
     return events_by_user
 
 

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 
-from collections import Counter
+from collections import Counter, OrderedDict
 
 
 # TODO(tkaemming): This should probably just be part of `build_digest`.
@@ -23,3 +23,24 @@ def get_digest_metadata(digest):
                     end = record.datetime
 
     return start, end, counts
+
+
+def get_personalized_digests(project, digest, user_ids):
+    pass
+
+
+def build_custom_digest(original_digest, user_id, events_by_users):
+    user_digest = OrderedDict()
+    for rule, rule_groups in six.iteritems(original_digest):
+        user_rule_groups = OrderedDict()
+        for group, group_records in six.iteritems(rule_groups):
+            user_group_records = [
+                record for record in group_records
+                if user_id in events_by_users[record.value.event]
+            ]
+            if user_group_records:
+                user_rule_groups[group] = user_group_records
+
+        if user_rule_groups:
+            user_digest[rule] = user_rule_groups
+    return user_digest

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -39,8 +39,8 @@ def get_personalized_digests(project_id, digest, user_ids):
         events = get_events_from_digest(digest)
         events_by_actor = build_events_by_actor(project_id, events, user_ids)
         events_by_user = convert_actors_to_users(events_by_actor, user_ids)
-        for user_id in six.iterkeys(events_by_user):
-            yield user_id, build_custom_digest(digest, events_by_user[user_id])
+        for user_id, user_events in six.iteritems(events_by_user):
+            yield user_id, build_custom_digest(digest, user_events)
     else:
         for user_id in user_ids:
             yield user_id, digest
@@ -75,7 +75,7 @@ def build_custom_digest(original_digest, events):
 
 def build_events_by_actor(project_id, events, user_ids):
     """
-    build_events_by_actor(project_id: Int, events: Set[Event], user_ids: Set[Int]) -> Map[Actor:Set(Event)]
+    build_events_by_actor(project_id: Int, events: Set(Events), user_ids: Set[]) -> Map[Actor:Set(Events)]
     """
     events_by_actor = defaultdict(set)
     for event in events:
@@ -93,7 +93,7 @@ def build_events_by_actor(project_id, events, user_ids):
 
 def convert_actors_to_users(events_by_actor, user_ids):
     """
-    convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)], user_ids: List(Int)) -> Map[user_id:Int, Set(Event)]
+    convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)], user_ids: List(Int)) -> Map[User_Id:Set(Events)]
     """
     events_by_user = defaultdict(set)
     team_actors = [actor for actor in six.iterkeys(events_by_actor) if actor.type == Team]

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import six
 
 from collections import Counter, OrderedDict
+from sentry.models import ProjectOwnership, Team, User
 
 
 # TODO(tkaemming): This should probably just be part of `build_digest`.
@@ -25,11 +26,38 @@ def get_digest_metadata(digest):
     return start, end, counts
 
 
-def get_personalized_digests(project, digest, user_ids):
-    pass
+def get_personalized_digests(project_id, digest, user_ids):
+    """
+    get_personalized_digests(project: Project, digest: Digest, users: Set[User]) -> Iterator[User, Digest]
+    """
+    # TODO(LB): I Know this is inefficent.
+    if not ProjectOwnership.objects.filter(project_id=project_id).exists():
+        return ProjectOwnership.Everyone
+    records = get_records_from_digests(digest)
+    events = [record.value.event for record in records]
+
+    events_by_actor = build_events_by_actor(project_id, events)
+    events_by_users = convert_actors_to_user_set(events_by_actor)
+
+    for user_id in user_ids:
+        yield user_id, build_custom_digest(digest, user_id, events_by_users)
+
+
+def get_records_from_digests(digest):
+    """
+    get_records_from_digests(digest: Digest) -> Set(Records)
+    """
+    records = set()
+    for rule, rule_groups in six.iteritems(digest):
+        for group, group_records in six.iteritems(rule_groups):
+            records.update(group_records)
+    return records
 
 
 def build_custom_digest(original_digest, user_id, events_by_users):
+    """
+    build_custom_digest(original_digest: Digest, user_id: Int, events_by_users: Map[User_Id:Set(Events)]) -> Digest
+    """
     user_digest = OrderedDict()
     for rule, rule_groups in six.iteritems(original_digest):
         user_rule_groups = OrderedDict()
@@ -44,3 +72,48 @@ def build_custom_digest(original_digest, user_id, events_by_users):
         if user_rule_groups:
             user_digest[rule] = user_rule_groups
     return user_digest
+
+
+def build_events_by_actor(project_id, events):
+    """
+    build_events_by_actor(project_id: Int, events: Set(Events)) -> Map[Actor:Set(Events)]
+    """
+    events_by_actor = {}
+    for event in events:
+        # TODO(LB): I Know this is inefficent. Just wanted to make as few changes
+        # as possible for now. Can follow up with another PR
+        actors = ProjectOwnership.get_owners(project_id, event)
+        for actor in actors:
+            if actor in events_by_actor:
+                events_by_actor[actor].update(event)
+            else:
+                events_by_actor[actor] = set(event)
+    return events_by_actor
+
+
+def convert_actors_to_user_set(events_by_actor):
+    """
+    convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)]) -> Map[User_Id:Set(Events)]
+    """
+    user_by_events = {}
+    for actor, events in six.iteritems(events_by_actor):
+        if actor.type == Team:
+            user_ids = team_to_user_ids(actor.id)
+            for user_id in user_ids:
+                if user_id in user_by_events:
+                    user_by_events[user_id].update(events)
+                else:
+                    user_by_events[user_id] = events
+        else:
+            user_by_events[actor.id] = events
+    return user_by_events
+
+
+def team_to_user_ids(team_id):
+    """
+    team_to_user_ids(team_id:Int) -> List(User_ids)
+    """
+    return User.objects.filter(
+        is_active=True,
+        sentry_orgmember_set__organizationmemberteam__team_id=team_id,
+    ).values_list('id', flat=True)

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 import six
 
-from collections import Counter, OrderedDict
-from sentry.models import OrganizationMemberTeam, ProjectOwnership, Team
+from collections import Counter, defaultdict, OrderedDict
+from sentry.models import OrganizationMemberTeam, ProjectOwnership, Team, User
 
 
 # TODO(tkaemming): This should probably just be part of `build_digest`.
@@ -28,7 +28,7 @@ def get_digest_metadata(digest):
 
 def get_personalized_digests(project_id, digest, user_ids):
     """
-    get_personalized_digests(project: Project, digest: Digest, users: Set[User]) -> Iterator[User, Digest]
+    get_personalized_digests(project: Project, digest: Digest, user_ids: Set[Int]) -> Iterator[user_id: Int, digest: Digest]
     """
     # TODO(LB): I Know this is inefficent.
     # In the case that ProjectOwnership does exist, I do the same query twice.
@@ -37,8 +37,8 @@ def get_personalized_digests(project_id, digest, user_ids):
     if ProjectOwnership.objects.filter(project_id=project_id).exists():
         events = get_events_from_digest(digest)
         events_by_actor = build_events_by_actor(project_id, events)
-        events_by_user = convert_actors_to_user_set(events_by_actor, user_ids)
-        for user_id in user_ids:
+        events_by_user = convert_actors_to_users(events_by_actor, user_ids)
+        for user_id in six.iterkeys(events_by_user):
             yield user_id, build_custom_digest(digest, events_by_user[user_id])
     else:
         for user_id in user_ids:
@@ -84,7 +84,7 @@ def build_events_by_actor(project_id, events):
     """
     build_events_by_actor(project_id: Int, events: Set(Events)) -> Map[Actor:Set(Events)]
     """
-    events_by_actor = {}
+    events_by_actor = defaultdict(set)
     for event in events:
         # TODO(LB): I Know this is inefficent.
         # ProjectOwnership.get_owners is O(n) queries and I'm doing that O(len(events)) times
@@ -94,27 +94,19 @@ def build_events_by_actor(project_id, events):
         if actors == ProjectOwnership.Everyone:
             actors = [actors]
         for actor in actors:
-            if actor in events_by_actor:
-                events_by_actor[actor].add(event)
-            else:
-                events_by_actor[actor] = set([event])
+            events_by_actor[actor].add(event)
     return events_by_actor
 
 
-def convert_actors_to_user_set(events_by_actor, user_ids):
+def convert_actors_to_users(events_by_actor, user_ids):
     """
     convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)], user_ids: List(Int)) -> Map[User_Id:Set(Events)]
     """
-    def add_user_id(user_id, events, user_by_events):
-        if user_id in user_by_events:
-            user_by_events[user_id].update(set(events))
-        else:
-            user_by_events[user_id] = set(events)
-
-    user_by_events = {}
+    user_by_events = defaultdict(set)
     if ProjectOwnership.Everyone in events_by_actor:
+        events = events_by_actor[ProjectOwnership.Everyone]
         for user_id in user_ids:
-            user_by_events[user_id] = set(events_by_actor[ProjectOwnership.Everyone])
+            user_by_events[user_id] = set(events)
         del events_by_actor[ProjectOwnership.Everyone]
 
     team_actors = [actor for actor in six.iterkeys(events_by_actor) if actor.type == Team]
@@ -122,22 +114,22 @@ def convert_actors_to_user_set(events_by_actor, user_ids):
     for actor, events in six.iteritems(events_by_actor):
         if actor.type == Team:
             try:
-                user_ids = teams_to_user_ids[actor.id]
+                team_user_ids = teams_to_user_ids[actor.id]
             except KeyError:
                 # TODO(LB): Not certain what to do if a team has no active members
                 # Created a Test to reflect my assumptions here.
                 pass
             else:
-                for user_id in user_ids:
-                    add_user_id(user_id, events, user_by_events)
-        else:
-            add_user_id(actor.id, events, user_by_events)
+                for user_id in team_user_ids:
+                    user_by_events[user_id].update(events)
+        elif actor.type == User:
+            user_by_events[actor.id].update(events)
     return user_by_events
 
 
 def team_actors_to_user_ids(team_actors, user_ids):
     """
-    team_actors_to_user_ids(team_actors: List(Actors), user_ids: List(Int)) -> Map[TeamActor: Set(User_ids)]
+    team_actors_to_user_ids(team_actors: List(Actors), user_ids: List(Int)) -> Map[team_id:Int, user_ids:Set(Int)]
     """
     team_ids = [actor.id for actor in team_actors]
     members = OrganizationMemberTeam.objects.filter(
@@ -146,12 +138,9 @@ def team_actors_to_user_ids(team_actors, user_ids):
         organizationmember__user_id__in=user_ids,
     ).select_related('organizationmember')
 
-    team_members = {}
+    team_members = defaultdict(set)
     for member in members:
         user_id = member.organizationmember.user_id
-        if member.team_id in team_members:
-            team_members[member.team_id].add(user_id)
-        else:
-            team_members[member.team_id] = set([user_id])
+        team_members[member.team_id].add(user_id)
 
     return team_members

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -108,8 +108,6 @@ def convert_actors_to_users(events_by_actor, user_ids):
             try:
                 team_user_ids = teams_to_user_ids[actor.id]
             except KeyError:
-                # TODO(LB): Not certain what to do if a team has no active members
-                # Created a Test to reflect my assumptions here.
                 pass
             else:
                 for user_id in team_user_ids:

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -94,11 +94,11 @@ def convert_actors_to_users(events_by_actor, user_ids):
     """
     convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)], user_ids: List(Int)) -> Map[User_Id:Set(Events)]
     """
-    user_by_events = defaultdict(set)
+    events_by_user = defaultdict(set)
     if ProjectOwnership.Everyone in events_by_actor:
         events = events_by_actor[ProjectOwnership.Everyone]
         for user_id in user_ids:
-            user_by_events[user_id] = set(events)
+            events_by_user[user_id] = set(events)
         del events_by_actor[ProjectOwnership.Everyone]
 
     team_actors = [actor for actor in six.iterkeys(events_by_actor) if actor.type == Team]
@@ -113,10 +113,10 @@ def convert_actors_to_users(events_by_actor, user_ids):
                 pass
             else:
                 for user_id in team_user_ids:
-                    user_by_events[user_id].update(events)
+                    events_by_user[user_id].update(events)
         elif actor.type == User:
-            user_by_events[actor.id].update(events)
-    return user_by_events
+            events_by_user[actor.id].update(events)
+    return events_by_user
 
 
 def team_actors_to_user_ids(team_actors, user_ids):

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -78,12 +78,12 @@ def build_events_by_actor(project_id, events):
     for event in events:
         # TODO(LB): I Know this is inefficent. Just wanted to make as few changes
         # as possible for now. Can follow up with another PR
-        actors = ProjectOwnership.get_owners(project_id, event)
+        actors, __ = ProjectOwnership.get_owners(project_id, event.data)
         for actor in actors:
             if actor in events_by_actor:
-                events_by_actor[actor].update(event)
+                events_by_actor[actor].add(event)
             else:
-                events_by_actor[actor] = set(event)
+                events_by_actor[actor] = set([event])
     return events_by_actor
 
 

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -75,7 +75,7 @@ def build_custom_digest(original_digest, events):
 
 def build_events_by_actor(project_id, events, user_ids):
     """
-    build_events_by_actor(project_id: Int, events: Set(Events), user_ids: Set[]) -> Map[Actor:Set(Events)]
+    build_events_by_actor(project_id: Int, events: Set(Events), user_ids: Set[Int]) -> Map[Actor, Set(Events)]
     """
     events_by_actor = defaultdict(set)
     for event in events:
@@ -93,7 +93,7 @@ def build_events_by_actor(project_id, events, user_ids):
 
 def convert_actors_to_users(events_by_actor, user_ids):
     """
-    convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)], user_ids: List(Int)) -> Map[User_Id:Set(Events)]
+    convert_actors_to_user_set(events_by_actor: Map[Actor, Set(Events)], user_ids: List(Int)) -> Map[user_id: Int, Set(Events)]
     """
     events_by_user = defaultdict(set)
     team_actors = [actor for actor in six.iterkeys(events_by_actor) if actor.type == Team]

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -45,14 +45,6 @@ def get_personalized_digests(project_id, digest, user_ids):
             yield user_id, digest
 
 
-def sort_records(records):
-    """
-    Sorts records for fetch_state method
-    fetch_state is expecting these records to be ordered from newest to oldest
-    """
-    return sorted(records, key=lambda r: r.value.event.datetime, reverse=True)
-
-
 def get_events_from_digest(digest):
     events = []
     for rule_groups in six.itervalues(digest):
@@ -74,7 +66,7 @@ def build_custom_digest(original_digest, events):
                 if record.value.event in events
             ]
             if user_group_records:
-                user_rule_groups[group] = sort_records(user_group_records)
+                user_rule_groups[group] = user_group_records
         if user_rule_groups:
             user_digest[rule] = user_rule_groups
     return user_digest
@@ -130,6 +122,8 @@ def convert_actors_to_users(events_by_actor, user_ids):
 def team_actors_to_user_ids(team_actors, user_ids):
     """
     team_actors_to_user_ids(team_actors: List(Actors), user_ids: List(Int)) -> Map[team_id:Int, user_ids:Set(Int)]
+
+    Will not include a team in the result if there are no active members in a team.
     """
     team_ids = [actor.id for actor in team_actors]
     members = OrganizationMemberTeam.objects.filter(

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from collections import Counter, OrderedDict
-from sentry.models import ProjectOwnership, Team, User
+from sentry.models import OrganizationMemberTeam, ProjectOwnership, Team, User
 
 
 # TODO(tkaemming): This should probably just be part of `build_digest`.
@@ -34,12 +34,20 @@ def get_personalized_digests(project_id, digest, user_ids):
     if ProjectOwnership.objects.filter(project_id=project_id).exists():
         events = get_events_from_digest(digest)
         events_by_actor = build_events_by_actor(project_id, events)
-        events_by_users = convert_actors_to_user_set(events_by_actor)
+        events_by_user = convert_actors_to_user_set(events_by_actor, user_ids)
         for user_id in user_ids:
-            yield user_id, build_custom_digest(digest, user_id, events_by_users)
+            yield user_id, build_custom_digest(digest, events_by_user[user_id])
     else:
         for user_id in user_ids:
             yield user_id, digest
+
+
+def sort_records(records):
+    """
+    Sorts records for fetch_state method
+    fetch_state is expecting these records to be ordered from newest to oldest
+    """
+    return sorted(records, key=lambda r: r.value.event.datetime, reverse=True)
 
 
 def get_events_from_digest(digest):
@@ -50,7 +58,7 @@ def get_events_from_digest(digest):
     return set(events)
 
 
-def build_custom_digest(original_digest, user_id, events_by_users):
+def build_custom_digest(original_digest, events):
     """
     build_custom_digest(original_digest: Digest, user_id: Int, events_by_users: Map[User_Id:Set(Events)]) -> Digest
     """
@@ -60,11 +68,10 @@ def build_custom_digest(original_digest, user_id, events_by_users):
         for group, group_records in six.iteritems(rule_groups):
             user_group_records = [
                 record for record in group_records
-                if user_id in events_by_users[record.value.event]
+                if record.value.event in events
             ]
             if user_group_records:
-                user_rule_groups[group] = user_group_records
-
+                user_rule_groups[group] = sort_records(user_group_records)
         if user_rule_groups:
             user_digest[rule] = user_rule_groups
     return user_digest
@@ -87,26 +94,55 @@ def build_events_by_actor(project_id, events):
     return events_by_actor
 
 
-def convert_actors_to_user_set(events_by_actor):
+def convert_actors_to_user_set(events_by_actor, user_ids):
     """
-    convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)]) -> Map[User_Id:Set(Events)]
+    convert_actors_to_user_set(events_by_actor: Map[Actor:Set(Events)], user_ids: List(Int)) -> Map[User_Id:Set(Events)]
     """
     user_by_events = {}
+    team_actors = [actor for actor in six.iterkeys(events_by_actor) if actor.type == Team]
+    teams_to_user_ids = team_actors_to_user_ids(team_actors, user_ids)
     for actor, events in six.iteritems(events_by_actor):
         if actor.type == Team:
-            user_ids = team_to_user_ids(actor.id)
-            for user_id in user_ids:
-                if user_id in user_by_events:
-                    user_by_events[user_id].update(events)
-                else:
-                    user_by_events[user_id] = events
+            try:
+                user_ids = teams_to_user_ids[actor.id]
+            except KeyError:
+                pass  # TODO(LB) Not certain what to do if a team has no members
+            else:
+                for user_id in user_ids:
+                    if user_id in user_by_events:
+                        user_by_events[user_id].update(events)
+                    else:
+                        user_by_events[user_id] = events
         else:
             user_by_events[actor.id] = events
     return user_by_events
 
 
+def team_actors_to_user_ids(team_actors, user_ids):
+    """
+    team_actors_to_user_ids(team_actors: List(Actors), user_ids: List(Int)) -> Map[TeamActor: Set(User_ids)]
+    """
+    team_ids = [actor.id for actor in team_actors]
+    members = OrganizationMemberTeam.objects.filter(
+        team_id__in=team_ids,
+        is_active=True,
+        organizationmember__user_id__in=user_ids,
+    ).select_related('organizationmember')
+
+    team_members = {}
+    for member in members:
+        user_id = member.organizationmember.user_id
+        if member.team_id in team_members:
+            team_members[member.team_id].add(user_id)
+        else:
+            team_members[member.team_id] = set([user_id])
+
+    return team_members
+
+
 def team_to_user_ids(team_id):
     """
+    Defunct first attempt but O(n) Queries. Switching to team_actors_to_user_id
     team_to_user_ids(team_id:Int) -> List(User_ids)
     """
     return User.objects.filter(

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -253,7 +253,7 @@ class GetPersonalizedDigestsTestCase(TestCase):
             Actor(self.user3.id, User): set(self.team1_events),
             Actor(self.user4.id, User): set(self.user4_events),
         }
-        assert build_events_by_actor(self.project.id, events) == events_by_actor
+        assert build_events_by_actor(self.project.id, events, self.user_ids) == events_by_actor
 
     def test_simple(self):
         rule = self.project.rule_set.all()[0]

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -19,52 +19,7 @@ from sentry.ownership.grammar import Rule, Owner, Matcher, dump_schema
 from sentry.testutils import TestCase
 
 
-class UtilitiesTestCase(TestCase):
-    def create_event_data(self, filename, url='http://example.com'):
-        data = {
-            'tags': [('level', 'error')],
-            'sentry.interfaces.Stacktrace': {
-                'frames': [
-                    {
-                        'lineno': 1,
-                        'filename': filename,
-                    },
-                ],
-            },
-            'sentry.interfaces.Http': {
-                'url': url
-            },
-        }
-        return data
-
-    def create_events(self, start_time, project, filenames=None, urls=None):
-        events = []
-        for index, label in enumerate(filenames or urls):
-            group = self.create_group(
-                project=project,
-                first_seen=start_time - timedelta(days=index + 1),
-                last_seen=start_time - timedelta(hours=index + 1),
-                message='group%d' % index
-            )
-            if filenames is not None:
-                event = self.create_event(
-                    group=group,
-                    message=group.message,
-                    datetime=group.last_seen,
-                    project=project,
-                    data=self.create_event_data(filename=label)
-                )
-            else:
-                event = self.create_event(
-                    group=group,
-                    message=group.message,
-                    datetime=group.last_seen,
-                    project=project,
-                    data=self.create_event_data('foo.bar', url=label)
-                )
-            events.append(event)
-        return events
-
+class UtilitiesHelpersTestCase(TestCase):
     def test_get_events_from_digest(self):
         project = self.create_project()
         rule = project.rule_set.all()[0]
@@ -166,97 +121,40 @@ class UtilitiesTestCase(TestCase):
         }
         assert convert_actors_to_user_set(events_by_actor, user_by_events.keys()) == user_by_events
 
-    def test_build_events_by_actor(self):
-        user1 = self.create_user()
-        user2 = self.create_user()
-        user3 = self.create_user()
-        user4 = self.create_user()
 
-        team1 = self.create_team()
-        team2 = self.create_team()
-        team3 = self.create_team()
+class UtilitiesTestCase(TestCase):
+    def setUp(self):
+        self.user1 = self.create_user()
+        self.user2 = self.create_user()
+        self.user3 = self.create_user()
+        self.user4 = self.create_user()
 
-        self.project = self.create_project(teams=[team1, team2, team3])
+        self.team1 = self.create_team()
+        self.team2 = self.create_team()
+        self.team3 = self.create_team()
 
-        self.create_member(user=user1, organization=self.organization, teams=[team1])
-        self.create_member(user=user2, organization=self.organization, teams=[team2])
-        self.create_member(user=user3, organization=self.organization, teams=[team1, team2])
-        self.create_member(user=user4, organization=self.organization, teams=[team3])
+        self.project = self.create_project(teams=[self.team1, self.team2, self.team3])
 
-        team1_events = set([
-            self.create_event(data=self.create_event_data('hello.py')),
-            self.create_event(data=self.create_event_data('goodbye.py')),
-            self.create_event(data=self.create_event_data('hola.py')),
-            self.create_event(data=self.create_event_data('adios.py')),
-        ])
-        team2_events = set([
-            self.create_event(data=self.create_event_data('old.cbl')),
-            self.create_event(data=self.create_event_data('retro.cbl')),
-            self.create_event(data=self.create_event_data('cool.cbl')),
-            self.create_event(data=self.create_event_data('gem.cbl')),
-        ])
-        user4_events = set([
-            self.create_event(data=self.create_event_data('foo.bar', 'helloworld.org')),
-            self.create_event(data=self.create_event_data('bar.foo', 'helloworld.org')),
-        ])
-
-        team1_matcher = Matcher('path', '*.py')
-        team2_matcher = Matcher('path', '*.cbl')
-        user4_matcher = Matcher('url', '*.org')
-
-        ProjectOwnership.objects.create(
-            project_id=self.project.id,
-            schema=dump_schema([
-                Rule(team1_matcher, [
-                    Owner('team', team1.slug),
-                    Owner('user', user3.email),
-                ]),
-                Rule(team2_matcher, [
-                    Owner('team', team2.slug),
-                ]),
-                Rule(user4_matcher, [
-                    Owner('user', user4.email),
-                ]),
-            ]),
-            fallthrough=True,
-        )
-        events = team1_events.union(team2_events.union(user4_events))
-
-        events_by_actor = {
-            Actor(team1.id, Team): team1_events,
-            Actor(team2.id, Team): team2_events,
-            Actor(user3.id, User): team1_events,
-            Actor(user4.id, User): user4_events,
-        }
-        assert build_events_by_actor(self.project.id, events) == events_by_actor
-
-    def test_get_personalized_digests(self):
-        user1 = self.create_user()
-        user2 = self.create_user()
-        user3 = self.create_user()
-        user4 = self.create_user()
-
-        team1 = self.create_team()
-        team2 = self.create_team()
-        team3 = self.create_team()
-
-        self.project = self.create_project(teams=[team1, team2, team3])
-
-        self.create_member(user=user1, organization=self.organization, teams=[team1])
-        self.create_member(user=user2, organization=self.organization, teams=[team2])
-        self.create_member(user=user3, organization=self.organization, teams=[team1, team2])
-        self.create_member(user=user4, organization=self.organization, teams=[team3])
+        self.create_member(user=self.user1, organization=self.organization, teams=[self.team1])
+        self.create_member(user=self.user2, organization=self.organization, teams=[self.team2])
+        self.create_member(
+            user=self.user3,
+            organization=self.organization,
+            teams=[
+                self.team1,
+                self.team2])
+        self.create_member(user=self.user4, organization=self.organization, teams=[self.team3])
 
         start_time = timezone.now()
 
-        team1_events = self.create_events(
+        self.team1_events = self.create_events(
             start_time, self.project, [
                 'hello.py', 'goodbye.py', 'hola.py', 'adios.py'])
-        team2_events = self.create_events(
+        self.team2_events = self.create_events(
             start_time, self.project, [
                 'old.cbl', 'retro.cbl', 'cool.cbl', 'gem.cbl'])
 
-        user4_events = [
+        self.user4_events = [
             self.create_event(
                 group=self.create_group(
                     project=self.project), data=self.create_event_data(
@@ -266,43 +164,158 @@ class UtilitiesTestCase(TestCase):
                     project=self.project), data=self.create_event_data(
                     'bar.foo', 'helloworld.org')),
         ]
-        team1_matcher = Matcher('path', '*.py')
-        team2_matcher = Matcher('path', '*.cbl')
-        user4_matcher = Matcher('url', '*.org')
+        self.team1_matcher = Matcher('path', '*.py')
+        self.team2_matcher = Matcher('path', '*.cbl')
+        self.user4_matcher = Matcher('url', '*.org')
 
         ProjectOwnership.objects.create(
             project_id=self.project.id,
             schema=dump_schema([
-                Rule(team1_matcher, [
-                    Owner('team', team1.slug),
-                    Owner('user', user3.email),
+                Rule(self.team1_matcher, [
+                    Owner('team', self.team1.slug),
+                    Owner('user', self.user3.email),
                 ]),
-                Rule(team2_matcher, [
-                    Owner('team', team2.slug),
+                Rule(self.team2_matcher, [
+                    Owner('team', self.team2.slug),
                 ]),
-                Rule(user4_matcher, [
-                    Owner('user', user4.email),
+                Rule(self.user4_matcher, [
+                    Owner('user', self.user4.email),
                 ]),
             ]),
             fallthrough=True,
         )
 
-        rule = self.project.rule_set.all()[0]
-        records = [event_to_record(event, (rule, ))
-                   for event in team1_events + team2_events + user4_events]
-        digest = build_digest(self.project, sort_records(records))
-
-        expected_result = {
-            user1.id: set(team1_events),
-            user2.id: set(team2_events),
-            user3.id: set(team1_events + team2_events),
-            user4.id: set(user4_events),
+    def create_event_data(self, filename, url='http://example.com'):
+        data = {
+            'tags': [('level', 'error')],
+            'sentry.interfaces.Stacktrace': {
+                'frames': [
+                    {
+                        'lineno': 1,
+                        'filename': filename,
+                    },
+                ],
+            },
+            'sentry.interfaces.Http': {
+                'url': url
+            },
         }
-        user_ids = expected_result.keys()
+        return data
+
+    def create_events(self, start_time, project, filenames=None, urls=None):
+        events = []
+        for index, label in enumerate(filenames or urls):
+            group = self.create_group(
+                project=project,
+                first_seen=start_time - timedelta(days=index + 1),
+                last_seen=start_time - timedelta(hours=index + 1),
+                message='group%d' % index
+            )
+            if filenames is not None:
+                event = self.create_event(
+                    group=group,
+                    message=group.message,
+                    datetime=group.last_seen,
+                    project=project,
+                    data=self.create_event_data(filename=label)
+                )
+            else:
+                event = self.create_event(
+                    group=group,
+                    message=group.message,
+                    datetime=group.last_seen,
+                    project=project,
+                    data=self.create_event_data('foo.bar', url=label)
+                )
+            events.append(event)
+        return events
+
+    def assert_get_personalized_digests(self, project, digest, user_ids, expected_result):
         result_user_ids = []
-        for user_id, user_digest in get_personalized_digests(self.project.id, digest, user_ids):
+        for user_id, user_digest in get_personalized_digests(project.id, digest, user_ids):
             assert user_id in expected_result
             assert expected_result[user_id] == get_events_from_digest(user_digest)
             result_user_ids.append(user_id)
 
         assert sorted(user_ids) == sorted(result_user_ids)
+
+    def test_build_events_by_actor(self):
+        events = self.team1_events + self.team2_events + self.user4_events
+
+        events_by_actor = {
+            Actor(self.team1.id, Team): set(self.team1_events),
+            Actor(self.team2.id, Team): set(self.team2_events),
+            Actor(self.user3.id, User): set(self.team1_events),
+            Actor(self.user4.id, User): set(self.user4_events),
+        }
+        assert build_events_by_actor(self.project.id, events) == events_by_actor
+
+    def test_get_personalized_digests(self):
+        rule = self.project.rule_set.all()[0]
+        records = [event_to_record(event, (rule, ))
+                   for event in self.team1_events + self.team2_events + self.user4_events]
+        digest = build_digest(self.project, sort_records(records))
+
+        expected_result = {
+            self.user1.id: set(self.team1_events),
+            self.user2.id: set(self.team2_events),
+            self.user3.id: set(self.team1_events + self.team2_events),
+            self.user4.id: set(self.user4_events),
+        }
+        user_ids = expected_result.keys()
+        self.assert_get_personalized_digests(self.project, digest, user_ids, expected_result)
+
+    def test_team_without_members(self):
+        team = self.create_team()
+        project = self.create_project(teams=[team])
+        ProjectOwnership.objects.create(
+            project_id=project.id,
+            schema=dump_schema([
+                Rule(Matcher('path', '*.cpp'), [
+                    Owner('team', team.slug),
+                ]),
+            ]),
+            fallthrough=True,
+        )
+        rule = project.rule_set.all()[0]
+        records = [
+            event_to_record(event, (rule, )) for event in self.create_events(timezone.now(), project, [
+                'hello.py', 'goodbye.py', 'hola.py', 'adios.py'])
+        ]
+        digest = build_digest(project, sort_records(records))
+        user_ids = [member.user_id for member in team.member_set]
+        assert not user_ids
+        for user_id, user_digest in get_personalized_digests(project.id, digest, user_ids):
+            assert False  # no users in this team no digests should be processed
+
+    def test_only_everyone(self):
+        rule = self.project.rule_set.all()[0]
+        events = self.create_events(
+            timezone.now(), self.project, [
+                'hello.moz', 'goodbye.moz', 'hola.moz', 'adios.moz'])
+        records = [event_to_record(event, (rule, )) for event in events]
+        digest = build_digest(self.project, sort_records(records))
+        expected_result = {
+            self.user1.id: set(events),
+            self.user2.id: set(events),
+            self.user3.id: set(events),
+            self.user4.id: set(events),
+        }
+        user_ids = expected_result.keys()
+        self.assert_get_personalized_digests(self.project, digest, user_ids, expected_result)
+
+    def test_everyone_with_owners(self):
+        rule = self.project.rule_set.all()[0]
+        events = self.create_events(
+            timezone.now(), self.project, [
+                'hello.moz', 'goodbye.moz', 'hola.moz', 'adios.moz'])
+        records = [event_to_record(event, (rule, )) for event in events + self.team1_events]
+        digest = build_digest(self.project, sort_records(records))
+        expected_result = {
+            self.user1.id: set(events + self.team1_events),
+            self.user2.id: set(events),
+            self.user3.id: set(events + self.team1_events),
+            self.user4.id: set(events),
+        }
+        user_ids = expected_result.keys()
+        self.assert_get_personalized_digests(self.project, digest, user_ids, expected_result)

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+from sentry.digests.notifications import build_digest, event_to_record
+from sentry.digests.utilities import (
+    # get_personalized_digests,
+    get_events_from_digest,
+    # build_custom_digest,
+    # build_events_by_actor,
+    # convert_actors_to_user_set,
+    team_to_user_ids,
+)
+from sentry.testutils import TestCase
+
+
+class UtilitiesTestCase(TestCase):
+    def test_get_events_from_digest(self):
+        project = self.create_project()
+        rule = project.rule_set.all()[0]
+        events = [
+            self.create_event(group=self.create_group(project=project)),
+            self.create_event(group=self.create_group(project=project)),
+            self.create_event(group=self.create_group(project=project)),
+            self.create_event(group=self.create_group(project=project)),
+            self.create_event(group=self.create_group(project=project)),
+        ]
+        digest = build_digest(
+            project,
+            (
+                event_to_record(events[4], (rule, )),
+                event_to_record(events[3], (rule, )),
+                event_to_record(events[2], (rule, )),
+                event_to_record(events[1], (rule, )),
+                event_to_record(events[0], (rule, )),
+            ),
+        )
+
+        assert get_events_from_digest(digest) == set(events)
+
+    def test_team_to_user_ids(self):
+        team1 = self.create_team()
+        team2 = self.create_team()
+        users = [self.create_user() for i in range(0, 6)]
+
+        self.create_member(user=users[0], organization=self.organization, teams=[team1])
+        self.create_member(user=users[1], organization=self.organization, teams=[team1])
+        self.create_member(user=users[2], organization=self.organization, teams=[team1])
+        self.create_member(user=users[3], organization=self.organization, teams=[team1, team2])
+        self.create_member(user=users[4], organization=self.organization, teams=[team2, self.team])
+        self.create_member(user=users[5], organization=self.organization, teams=[team2])
+
+        assert sorted(team_to_user_ids(team1.id)) == [
+            users[0].id, users[1].id, users[2].id, users[3].id]
+        assert sorted(team_to_user_ids(team2.id)) == [users[3].id, users[4].id, users[5].id]

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import
 
+
 from sentry.api.fields.actor import Actor
 from sentry.digests.notifications import build_digest, event_to_record
 from sentry.digests.utilities import (
-    # get_personalized_digests,
-    get_events_from_digest,
-    # build_custom_digest,
     build_events_by_actor,
     convert_actors_to_user_set,
+    get_events_from_digest,
+    get_personalized_digests,
+    sort_records,
     team_to_user_ids,
+    team_actors_to_user_ids,
 )
 from sentry.models import ProjectOwnership, Team, User
 from sentry.ownership.grammar import Rule, Owner, Matcher, dump_schema
@@ -72,6 +74,27 @@ class UtilitiesTestCase(TestCase):
             users[0].id, users[1].id, users[2].id, users[3].id]
         assert sorted(team_to_user_ids(team2.id)) == [users[3].id, users[4].id, users[5].id]
 
+    # team without users not checked
+    def test_team_actors_to_user_ids(self):
+        team1 = self.create_team()
+        team2 = self.create_team()
+        users = [self.create_user() for i in range(0, 6)]
+
+        self.create_member(user=users[0], organization=self.organization, teams=[team1])
+        self.create_member(user=users[1], organization=self.organization, teams=[team1])
+        self.create_member(user=users[2], organization=self.organization, teams=[team1])
+        self.create_member(user=users[3], organization=self.organization, teams=[team1, team2])
+        self.create_member(user=users[4], organization=self.organization, teams=[team2, self.team])
+        self.create_member(user=users[5], organization=self.organization, teams=[team2])
+
+        team_actors = [Actor(team1.id, Team), Actor(team2.id, Team)]
+        user_ids = [user.id for user in users]
+
+        assert team_actors_to_user_ids(team_actors, user_ids) == {
+            team1.id: set([users[0].id, users[1].id, users[2].id, users[3].id]),
+            team2.id: set([users[3].id, users[4].id, users[5].id]),
+        }
+
     def test_convert_actors_to_user_set(self):
         user1 = self.create_user()
         user2 = self.create_user()
@@ -102,7 +125,7 @@ class UtilitiesTestCase(TestCase):
         events_by_actor = {
             Actor(team1.id, Team): team1_events,
             Actor(team2.id, Team): team2_events,
-            Actor(user1.id, User): team1_events.union(team2_events),
+            Actor(user3.id, User): team1_events.union(team2_events),
             Actor(user4.id, User): user4_events,
         }
         user_by_events = {
@@ -111,7 +134,7 @@ class UtilitiesTestCase(TestCase):
             user3.id: team1_events.union(team2_events),
             user4.id: user4_events,
         }
-        assert convert_actors_to_user_set(events_by_actor) == user_by_events
+        assert convert_actors_to_user_set(events_by_actor, user_by_events.keys()) == user_by_events
 
     def test_build_events_by_actor(self):
         user1 = self.create_user()
@@ -176,3 +199,108 @@ class UtilitiesTestCase(TestCase):
             Actor(user4.id, User): user4_events,
         }
         assert build_events_by_actor(self.project.id, events) == events_by_actor
+
+    def test_get_personalized_digests(self):
+        user1 = self.create_user()
+        user2 = self.create_user()
+        user3 = self.create_user()
+        user4 = self.create_user()
+
+        team1 = self.create_team()
+        team2 = self.create_team()
+        team3 = self.create_team()
+
+        self.project = self.create_project(teams=[team1, team2, team3])
+
+        self.create_member(user=user1, organization=self.organization, teams=[team1])
+        self.create_member(user=user2, organization=self.organization, teams=[team2])
+        self.create_member(user=user3, organization=self.organization, teams=[team1, team2])
+        self.create_member(user=user4, organization=self.organization, teams=[team3])
+
+        team1_events = [
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('hello.py')),
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('goodbye.py')),
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('hola.py')),
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('adios.py')),
+        ]
+        team2_events = [
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('old.cbl')),
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('retro.cbl')),
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('cool.cbl')),
+            self.create_event(
+                group=self.create_group(
+                    project=self.project),
+                data=self.create_event_data('gem.cbl')),
+        ]
+        user4_events = [
+            self.create_event(
+                group=self.create_group(
+                    project=self.project), data=self.create_event_data(
+                    'foo.bar', 'helloworld.org')),
+            self.create_event(
+                group=self.create_group(
+                    project=self.project), data=self.create_event_data(
+                    'bar.foo', 'helloworld.org')),
+        ]
+
+        team1_matcher = Matcher('path', '*.py')
+        team2_matcher = Matcher('path', '*.cbl')
+        user4_matcher = Matcher('url', '*.org')
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            schema=dump_schema([
+                Rule(team1_matcher, [
+                    Owner('team', team1.slug),
+                    Owner('user', user3.email),
+                ]),
+                Rule(team2_matcher, [
+                    Owner('team', team2.slug),
+                ]),
+                Rule(user4_matcher, [
+                    Owner('user', user4.email),
+                ]),
+            ]),
+            fallthrough=True,
+        )
+
+        rule = self.project.rule_set.all()[0]
+        records = [event_to_record(event, (rule, ))
+                   for event in team1_events + team2_events + user4_events]
+        digest = build_digest(self.project, sort_records(records))
+
+        expected_result = {
+            user1.id: set(team1_events),
+            user2.id: set(team2_events),
+            user3.id: set(team1_events + team2_events),
+            user4.id: set(user4_events),
+        }
+        user_ids = expected_result.keys()
+        result_user_ids = []
+        for user_id, user_digest in get_personalized_digests(self.project.id, digest, user_ids):
+            assert user_id in expected_result
+            assert expected_result[user_id] == get_events_from_digest(user_digest)
+            result_user_ids.append(user_id)
+
+        assert sorted(user_ids) == sorted(result_user_ids)

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -1,18 +1,38 @@
 from __future__ import absolute_import
 
+from sentry.api.fields.actor import Actor
 from sentry.digests.notifications import build_digest, event_to_record
 from sentry.digests.utilities import (
     # get_personalized_digests,
     get_events_from_digest,
     # build_custom_digest,
-    # build_events_by_actor,
-    # convert_actors_to_user_set,
+    build_events_by_actor,
+    convert_actors_to_user_set,
     team_to_user_ids,
 )
+from sentry.models import ProjectOwnership, Team, User
+from sentry.ownership.grammar import Rule, Owner, Matcher, dump_schema
 from sentry.testutils import TestCase
 
 
 class UtilitiesTestCase(TestCase):
+    def create_event_data(self, filename, url='http://example.com'):
+        data = {
+            'tags': [('level', 'error')],
+            'sentry.interfaces.Stacktrace': {
+                'frames': [
+                    {
+                        'lineno': 1,
+                        'filename': filename,
+                    },
+                ],
+            },
+            'sentry.interfaces.Http': {
+                'url': url
+            },
+        }
+        return data
+
     def test_get_events_from_digest(self):
         project = self.create_project()
         rule = project.rule_set.all()[0]
@@ -51,3 +71,108 @@ class UtilitiesTestCase(TestCase):
         assert sorted(team_to_user_ids(team1.id)) == [
             users[0].id, users[1].id, users[2].id, users[3].id]
         assert sorted(team_to_user_ids(team2.id)) == [users[3].id, users[4].id, users[5].id]
+
+    def test_convert_actors_to_user_set(self):
+        user1 = self.create_user()
+        user2 = self.create_user()
+        user3 = self.create_user()
+        user4 = self.create_user()
+
+        team1 = self.create_team()
+        team2 = self.create_team()
+
+        self.create_member(user=user1, organization=self.organization, teams=[team1])
+        self.create_member(user=user2, organization=self.organization, teams=[team2])
+        self.create_member(user=user3, organization=self.organization, teams=[team1, team2])
+        self.create_member(user=user4, organization=self.organization, teams=[])
+
+        team1_events = set([
+            self.create_event(),
+            self.create_event(),
+            self.create_event(),
+            self.create_event(),
+        ])
+        team2_events = set([
+            self.create_event(),
+            self.create_event(),
+            self.create_event(),
+            self.create_event(),
+        ])
+        user4_events = set([self.create_event(), self.create_event()])
+        events_by_actor = {
+            Actor(team1.id, Team): team1_events,
+            Actor(team2.id, Team): team2_events,
+            Actor(user1.id, User): team1_events.union(team2_events),
+            Actor(user4.id, User): user4_events,
+        }
+        user_by_events = {
+            user1.id: team1_events,
+            user2.id: team2_events,
+            user3.id: team1_events.union(team2_events),
+            user4.id: user4_events,
+        }
+        assert convert_actors_to_user_set(events_by_actor) == user_by_events
+
+    def test_build_events_by_actor(self):
+        user1 = self.create_user()
+        user2 = self.create_user()
+        user3 = self.create_user()
+        user4 = self.create_user()
+
+        team1 = self.create_team()
+        team2 = self.create_team()
+        team3 = self.create_team()
+
+        self.project = self.create_project(teams=[team1, team2, team3])
+
+        self.create_member(user=user1, organization=self.organization, teams=[team1])
+        self.create_member(user=user2, organization=self.organization, teams=[team2])
+        self.create_member(user=user3, organization=self.organization, teams=[team1, team2])
+        self.create_member(user=user4, organization=self.organization, teams=[team3])
+
+        team1_events = set([
+            self.create_event(data=self.create_event_data('hello.py')),
+            self.create_event(data=self.create_event_data('goodbye.py')),
+            self.create_event(data=self.create_event_data('hola.py')),
+            self.create_event(data=self.create_event_data('adios.py')),
+        ])
+        team2_events = set([
+            self.create_event(data=self.create_event_data('old.cbl')),
+            self.create_event(data=self.create_event_data('retro.cbl')),
+            self.create_event(data=self.create_event_data('cool.cbl')),
+            self.create_event(data=self.create_event_data('gem.cbl')),
+        ])
+        user4_events = set([
+            self.create_event(data=self.create_event_data('foo.bar', 'helloworld.org')),
+            self.create_event(data=self.create_event_data('bar.foo', 'helloworld.org')),
+        ])
+
+        team1_matcher = Matcher('path', '*.py')
+        team2_matcher = Matcher('path', '*.cbl')
+        user4_matcher = Matcher('url', '*.org')
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            schema=dump_schema([
+                Rule(team1_matcher, [
+                    Owner('team', team1.slug),
+                    Owner('user', user3.email),
+                ]),
+                Rule(team2_matcher, [
+                    Owner('team', team2.slug),
+                ]),
+                Rule(user4_matcher, [
+                    Owner('user', user4.email),
+                ]),
+            ]),
+            fallthrough=True,
+        )
+        events = team1_events.union(team2_events.union(user4_events))
+
+        events_by_actor = {
+            Actor(team1.id, Team): team1_events,
+            Actor(team2.id, Team): team2_events,
+            Actor(user3.id, User): team1_events,
+            Actor(user4.id, User): user4_events,
+        }
+        assert build_events_by_actor(self.project.id, events) == events_by_actor

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -118,7 +118,7 @@ class UtilitiesHelpersTestCase(TestCase):
         assert convert_actors_to_user_set(events_by_actor, user_by_events.keys()) == user_by_events
 
 
-class UtilitiesTestCase(TestCase):
+class GetPersonalizedDigestsTestCase(TestCase):
     def setUp(self):
         self.user1 = self.create_user()
         self.user2 = self.create_user()
@@ -246,7 +246,7 @@ class UtilitiesTestCase(TestCase):
         }
         assert build_events_by_actor(self.project.id, events) == events_by_actor
 
-    def test_get_personalized_digests(self):
+    def test_simple(self):
         rule = self.project.rule_set.all()[0]
         records = [event_to_record(event, (rule, ))
                    for event in self.team1_events + self.team2_events + self.user4_events]


### PR DESCRIPTION
This PR takes the digests notifications and adds code to make it owner-aware. If owners are specified, it will send custom digests to each user, only sending the groups in the digests that are relevant to that user. If owners aren't specified it will send the digests to all sendable users as before.