### PR TITLE
fix(slack): Remove flaky app.permissions.info

### DIFF
--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -16,32 +16,6 @@ class SlackNotifyActionTest(RuleTestCase):
     def setUp(self):
         event = self.get_event()
 
-        self.permissions = {
-            'ok': True,
-            'info': {
-                'channel': {
-                    'resources': {
-                        'wildcard': True,
-                        'excluded_ids': [],
-                        'ids': [],
-                    },
-                },
-                'im': {
-                    'resources': {
-                        'ids': ['member-id', 'morty-id'],
-                    },
-                },
-            },
-        }
-
-        responses.add(
-            method=responses.GET,
-            url='https://slack.com/api/apps.permissions.info',
-            status=200,
-            content_type='application/json',
-            body=json.dumps(self.permissions),
-        )
-
         self.integration = Integration.objects.create(
             provider='slack',
             name='Awesome Team',


### PR DESCRIPTION
These checks aren't actually required since Slack has confirmed that using `{ims,groups,channels}.list` will correctly return only channels the app has access to.