### PR TITLE
fix(stream): long text overlaps graph

### DIFF
--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -204,7 +204,7 @@ const CompactIssue = createReactClass({
         className={className}
         onClick={this.toggleSelect}
         direction="column"
-        style={{padding: '12px 16px 6px'}}
+        style={{paddingTop: '12px', paddingBottom: '6px'}}
       >
         <CompactIssueHeader data={issue} orgId={orgId} projectId={projectId} />
         {this.props.statsPeriod && (


### PR DESCRIPTION
<img width="763" alt="2018-04-04_1904" src="https://user-images.githubusercontent.com/435981/38343867-2435729a-383b-11e8-9f0e-923a61bef6bc.png">

it looks like the inline style from this fix (https://github.com/getsentry/sentry/pull/7932/files) is overriding a line of padding that created a kind of faux-layout for compact stream items.

I tested this both with and without the `with-graph` class and everything seems to look fine both ways. I don't think the lost 16px right padding will matter, as the css from `StyledPanelItem` should take care of it.