### PR TITLE
bugfix: deduplicate errors before logging them more than once in the event

### DIFF
--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -380,6 +380,16 @@ def get_stacktrace_processing_task(infos, processors):
     )
 
 
+def dedup_errors(errors):
+    # This operation scales bad but we do not expect that many items to
+    # end up in rv, so that should be okay enough to do.
+    rv = []
+    for error in errors:
+        if error not in rv:
+            rv.append(error)
+    return rv
+
+
 def process_stacktraces(data, make_processors=None):
     infos = find_stacktraces_in_data(data)
     if make_processors is None:
@@ -418,7 +428,7 @@ def process_stacktraces(data, make_processors=None):
                 )
                 changed = True
             if errors:
-                data.setdefault('errors', []).extend(errors)
+                data.setdefault('errors', []).extend(dedup_errors(errors))
                 changed = True
 
     finally:

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -960,7 +960,15 @@ class JavascriptIntegrationTest(TestCase):
                     {
                         'type': 'Error',
                         'stacktrace': {
+                            # Add two frames.  We only want to see the
+                            # error once though.
                             'frames': [
+                                {
+                                    'abs_path': 'http://example.com/file.min.js',
+                                    'filename': 'file.min.js',
+                                    'lineno': 1,
+                                    'colno': 39,
+                                },
                                 {
                                     'abs_path': 'http://example.com/file.min.js',
                                     'filename': 'file.min.js',


### PR DESCRIPTION
This fixes the issue where we end up with lots of duplicated error data in storage.