### PR TITLE
fix(slack): Use a fixed size dialog title

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -101,7 +101,7 @@ class SlackActionEndpoint(Endpoint):
 
         dialog = {
             'callback_id': callback_id,
-            'title': u'Resolve {}'.format(group.qualified_short_id),
+            'title': u'Resolve Issue',
             'submit_label': 'Resolve',
             'elements': [RESOLVE_SELECTOR],
         }


### PR DESCRIPTION
Slack imposes a 24 character limit on dialog titles, some project names overflow this and cause the dialog to fail to open.

Documentation reference [here on slack](https://api.slack.com/dialogs#top-level_dialog_attributes).

Fixes [SENTRY-66Q](https://sentry.io/share/issue/d92d4e2811754c838fd35482e3183024/)