### PR TITLE
feat(wizard): Replace ___MINIDUMP_URL___ with the actual endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_docs_platform.py
+++ b/src/sentry/api/endpoints/project_docs_platform.py
@@ -18,6 +18,7 @@ def replace_keys(html, project_key):
     html = html.replace('___PUBLIC_KEY___', project_key.public_key)
     html = html.replace('___SECRET_KEY___', project_key.secret_key)
     html = html.replace('___PROJECT_ID___', six.text_type(project_key.project_id))
+    html = html.replace('___MINIDUMP_URL___', project_key.minidump_endpoint)
 
     # If we actually render this in the main UI we can also provide
     # extra information about the project (org slug and project slug)


### PR DESCRIPTION
This adds a new magic string for rendering the minidump endpoint in docs.
See https://github.com/getsentry/sentry-docs/pull/221

## Example (Electron)

<img width="770" alt="screen shot 2018-04-06 at 09 05 20" src="https://user-images.githubusercontent.com/1433023/38407444-bdd56d1c-3979-11e8-8e55-6cb4848fa2b4.png">

