### PR TITLE
fix(ui): Autofocus primary action in confirm modal

### DIFF
--- a/src/sentry/static/sentry/app/components/confirm.jsx
+++ b/src/sentry/static/sentry/app/components/confirm.jsx
@@ -149,6 +149,7 @@ class Confirm extends React.PureComponent {
               disabled={this.state.disableConfirmButton}
               priority={priority}
               onClick={this.handleConfirm}
+              autoFocus
             >
               {confirmText}
             </Button>

--- a/tests/js/spec/components/__snapshots__/confirm.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirm.spec.jsx.snap
@@ -56,6 +56,7 @@ exports[`Confirm renders 1`] = `
         Cancel
       </Button>
       <Button
+        autoFocus={true}
         disabled={false}
         onClick={[Function]}
         priority="primary"


### PR DESCRIPTION
Add autofocus to primary action in confirm modal, so that users can press `enter` to perform primary action

Fixes #7864 