### PR TITLE
fix(auth): Initialize state data if necessary

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -780,7 +780,7 @@ class AuthHelper(object):
         return HttpResponseRedirect(redirect_uri)
 
     def bind_state(self, key, value):
-        data = self.state.data
+        data = self.state.data or {}
         data[key] = value
 
         self.state.data = data


### PR DESCRIPTION
In this case the users request will likely error out later, since their auth state has expired, but at least we won't 500 here.

Fixes [SENTRY-525](https://sentry.io/share/issue/844dde7feaa84deb96fced602d30c76c/)