### PR TITLE
fix(api): Don't filter projects by team access in org project endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -78,9 +78,8 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     }, status=400
                 )
         else:
-            team_list = list(request.access.teams)
             queryset = Project.objects.filter(
-                teams__in=team_list,
+                organization=organization,
             ).prefetch_related('teams')
 
         query = request.GET.get('query')


### PR DESCRIPTION
i don't think this is inconsistent with other endpoints and most places in the UI should already be filtering by `hasAccess` or `isMember`