### PR TITLE
optimization(settings): use transform instead of position for switch

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -845,13 +845,13 @@ table.integrations {
 
   .switch-toggle {
     top: 2px;
-    left: 2px;
+    transform: translate(2px, 0);
     .square(@switch-sm-height - 6); // (3*2) Room for border and padding on top and bottom
   }
 
   &.switch-on {
     .switch-toggle {
-      left: @switch-sm-height + 2;
+      transform: translate(@switch-sm-height + 2, 0);
     }
   }
 }
@@ -865,13 +865,13 @@ table.integrations {
 
   .switch-toggle {
     top: 4px;
-    left: 4px;
+    transform: translate(4px, 0);
     .square(@switch-lg-height - 10); // (10*2) Room for border and padding on top and bottom
   }
 
   &.switch-on {
     .switch-toggle {
-      left: @switch-lg-height + 4;
+      transform: translate(@switch-lg-height + 4, 0);
     }
   }
 }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -845,13 +845,13 @@ table.integrations {
 
   .switch-toggle {
     top: 2px;
-    transform: translate(2px, 0);
+    transform: translateX(2px);
     .square(@switch-sm-height - 6); // (3*2) Room for border and padding on top and bottom
   }
 
   &.switch-on {
     .switch-toggle {
-      transform: translate(@switch-sm-height + 2, 0);
+      transform: translateX(@switch-sm-height + 2);
     }
   }
 }
@@ -865,13 +865,13 @@ table.integrations {
 
   .switch-toggle {
     top: 4px;
-    transform: translate(4px, 0);
+    transform: translateX(4px);
     .square(@switch-lg-height - 10); // (10*2) Room for border and padding on top and bottom
   }
 
   &.switch-on {
     .switch-toggle {
-      transform: translate(@switch-lg-height + 4, 0);
+      transform: translateX(@switch-lg-height + 4);
     }
   }
 }


### PR DESCRIPTION
https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/
> Often, position is animated by setting the left and top properties. The problem is, as shown above, left and top both trigger layout operations, and that's expensive. The better solution is to use a translate on the element, which does not trigger layout.