### PR TITLE
feat(ui): Add "saveOnBlur: false" override for individual fields

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -16,7 +16,13 @@ const formGroups = [
         type: 'string',
         required: true,
         label: t('Name'),
-        help: t('A unique ID used to identify this organization.'),
+        help: t('A unique ID used to identify this organization'),
+
+        saveOnBlur: false,
+        saveMessageAlertType: 'info',
+        saveMessage: t(
+          'You will be redirected to the new organization slug after saving'
+        ),
       },
       {
         name: 'name',
@@ -36,7 +42,7 @@ const formGroups = [
         name: 'isEarlyAdopter',
         type: 'boolean',
         label: t('Early Adopter'),
-        help: t("Opt-in to new features before they're released to the public."),
+        help: t("Opt-in to new features before they're released to the public"),
       },
     ],
   },
@@ -54,7 +60,7 @@ const formGroups = [
           (initialData.availableRoles &&
             initialData.availableRoles.map(r => [r.id, r.name])) ||
           [],
-        help: t('The default role new members will receive.'),
+        help: t('The default role new members will receive'),
         disabled: ({access}) => !access.has('org:admin'),
       },
       {
@@ -62,7 +68,7 @@ const formGroups = [
         type: 'boolean',
         required: true,
         label: t('Open Membership'),
-        help: t('Allow organization members to freely join or leave any team.'),
+        help: t('Allow organization members to freely join or leave any team'),
       },
     ],
   },
@@ -74,7 +80,7 @@ const formGroups = [
         name: 'require2FA',
         type: 'boolean',
         label: t('Require Two-Factor Authentication'),
-        help: t('Require two-factor authentication for all members.'),
+        help: t('Require two-factor authentication for all members'),
         confirm: t(
           'Enabling this feature will disable all accounts without two-factor authentication. It will also send an email to all users to enable two-factor authentication. Do you want to continue?'
         ),
@@ -85,7 +91,7 @@ const formGroups = [
         type: 'boolean',
 
         label: t('Allow Shared Issues'),
-        help: t('Enable sharing of limited details on issues to anonymous users.'),
+        help: t('Enable sharing of limited details on issues to anonymous users'),
       },
       {
         name: 'enhancedPrivacy',
@@ -93,21 +99,21 @@ const formGroups = [
 
         label: t('Enhanced Privacy'),
         help: t(
-          'Enable enhanced privacy controls to limit personally identifiable information (PII) as well as source code in things like notifications.'
+          'Enable enhanced privacy controls to limit personally identifiable information (PII) as well as source code in things like notifications'
         ),
       },
       {
         name: 'dataScrubber',
         type: 'boolean',
         label: t('Require Data Scrubber'),
-        help: t('Require server-side data scrubbing be enabled for all projects.'),
+        help: t('Require server-side data scrubbing be enabled for all projects'),
       },
       {
         name: 'dataScrubberDefaults',
         type: 'boolean',
         label: t('Require Using Default Scrubbers'),
         help: t(
-          'Require the default scrubbers be applied to prevent things like passwords and credit cards from being stored for all projects.'
+          'Require the default scrubbers be applied to prevent things like passwords and credit cards from being stored for all projects'
         ),
       },
       {
@@ -135,7 +141,7 @@ const formGroups = [
           'Field names which data scrubbers should ignore. Separate multiple entries with a newline.'
         ),
         extraHelp: t(
-          'Note: These fields will be used in addition to project specific fields.'
+          'Note: These fields will be used in addition to project specific fields'
         ),
         getValue: val => extractMultilineFields(val),
         setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
@@ -145,7 +151,7 @@ const formGroups = [
         type: 'boolean',
         label: t('Prevent Storing of IP Addresses'),
         help: t(
-          'Preventing IP addresses from being stored for new events on all projects.'
+          'Preventing IP addresses from being stored for new events on all projects'
         ),
       },
     ],

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -98,6 +98,15 @@ export const fields = {
       }
       return tn('%d hour', '%d hours', val);
     },
+    saveOnBlur: false,
+    saveMessage: tct(
+      '[Caution]: Enabling auto resolve will immediately resolve anything that has ' +
+        'not been seen within this period of time. There is no undo!',
+      {
+        Caution: <strong>Caution</strong>,
+      }
+    ),
+    saveMessageAlertType: 'warning',
   },
 
   dataScrubber: {

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -58,6 +58,10 @@ export const fields = {
     label: t('Name'),
     placeholder: t('my-service-name'),
     help: t('A unique ID used to identify this project'),
+
+    saveOnBlur: false,
+    saveMessageAlertType: 'info',
+    saveMessage: t('You will be redirected to the new project slug after saving'),
   },
   team: {
     name: 'team',
@@ -200,13 +204,13 @@ export const fields = {
     placeholder: t('X-Sentry-Token'),
     label: t('Security Token Header'),
     help: t(
-      'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended.'
+      'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended'
     ),
   },
   verifySSL: {
     name: 'verifySSL',
     type: 'boolean',
     label: t('Verify TLS/SSL'),
-    help: t('Outbound requests will verify TLS (sometimes known as SSL) connections.'),
+    help: t('Outbound requests will verify TLS (sometimes known as SSL) connections'),
   },
 };

--- a/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
+++ b/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
@@ -17,6 +17,10 @@ const formGroups = [
         label: t('Name'),
         placeholder: 'e.g. api-team',
         help: t('A unique ID used to identify the team'),
+
+        saveOnBlur: false,
+        saveMessageAlertType: 'info',
+        saveMessage: t('You will be redirected to the new team slug after saving'),
       },
       {
         name: 'name',

--- a/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/projectGeneralSettings.jsx
@@ -25,17 +25,6 @@ import TextBlock from './settings/components/text/textBlock';
 import TextField from './settings/components/forms/textField';
 import recreateRoute from '../utils/recreateRoute';
 
-const AutoResolveFooter = () => (
-  <PanelAlert type="warning">
-    <strong>
-      {t(
-        'Note: Enabling auto resolve will immediately resolve anything that has ' +
-          'not been seen within this period of time. There is no undo!'
-      )}
-    </strong>
-  </PanelAlert>
-);
-
 class ProjectGeneralSettings extends AsyncView {
   static propTypes = {
     onChangeSlug: PropTypes.func,
@@ -273,7 +262,6 @@ class ProjectGeneralSettings extends AsyncView {
             {...jsonFormProps}
             title={t('Event Settings')}
             fields={[fields.resolveAge]}
-            renderFooter={() => <AutoResolveFooter />}
           />
 
           <JsonForm

--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.jsx
@@ -32,7 +32,14 @@ export default class FieldFromConfig extends React.Component {
       help: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
       visible: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
       disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+      /**
+       * Should show a "return key" icon in input?
+       */
       showReturnButton: PropTypes.bool,
+      /**
+       * Iff false, disable saveOnBlur for field, instead show a save/cancel button
+       */
+      saveOnBlur: PropTypes.bool,
       getValue: PropTypes.func,
       setValue: PropTypes.func,
     }).isRequired,

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -361,7 +361,7 @@ class FormField extends React.Component {
               return (
                 <PanelAlert type={saveMessageAlertType}>
                   <MessageAndActions>
-                    <Message>{saveMessage}</Message>
+                    <div>{saveMessage}</div>
                     <Actions>
                       <CancelButton onClick={this.handleCancelField}>
                         {t('Cancel')}
@@ -386,14 +386,14 @@ export default FormField;
 const MessageAndActions = styled('div')`
   display: flex;
   justify-content: space-between;
-`;
-
-const Message = styled('div')`
-  flex: 1;
+  align-items: center;
 `;
 
 const Actions = styled('div')`
-  flex-shrink: 0;
+  height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 `;
 
 const CancelButton = styled(Button)`

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -275,6 +275,7 @@ class FormField extends React.Component {
 
     model.handleSaveField(name, model.getValue(name));
   };
+
   handleCancelField = (...args) => {
     let {name} = this.props;
     let model = this.getModel();

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -11,6 +11,7 @@ import Field from '../field';
 import FieldControl from '../field/fieldControl';
 import FormState from '../../../../../components/forms/state';
 import InlineSvg from '../../../../../components/inlineSvg';
+import PanelAlert from '../../../../../components/panels/panelAlert';
 import Spinner from '../spinner';
 import returnButton from '../returnButton';
 import space from '../../../../../styles/space';
@@ -146,6 +147,18 @@ class FormField extends React.Component {
     saveOnBlur: PropTypes.bool,
 
     /**
+     * If saveOnBlur is false, then an optional saveMessage can be used to let
+     * the user know what's going to happen when they save a field.
+     */
+    saveMessage: PropTypes.node,
+
+    /**
+     * The "alert type" to use for the save message.
+     * Probably only "info"/"warning" should be used.
+     */
+    saveMessageAlertType: PropTypes.oneOf(['', 'info', 'warning', 'success', 'error']),
+
+    /**
      * Should hide error message?
      */
     hideErrorMessage: PropTypes.bool,
@@ -275,6 +288,8 @@ class FormField extends React.Component {
       hideErrorMessage,
       flexibleControlStateSize,
       saveOnBlur,
+      saveMessage,
+      saveMessageAlertType,
       ...props
     } = this.props;
     let id = this.getId();
@@ -343,14 +358,19 @@ class FormField extends React.Component {
               if (!showFieldSave) return null;
 
               return (
-                <ExplicitSaveRow>
-                  <CancelButton onClick={this.handleCancelField}>
-                    {t('Cancel')}
-                  </CancelButton>
-                  <SaveButton priority="primary" onClick={this.handleSaveField}>
-                    {t('Save')}
-                  </SaveButton>
-                </ExplicitSaveRow>
+                <PanelAlert type={saveMessageAlertType}>
+                  <MessageAndActions>
+                    <Message>{saveMessage}</Message>
+                    <Actions>
+                      <CancelButton onClick={this.handleCancelField}>
+                        {t('Cancel')}
+                      </CancelButton>
+                      <SaveButton priority="primary" onClick={this.handleSaveField}>
+                        {t('Save')}
+                      </SaveButton>
+                    </Actions>
+                  </MessageAndActions>
+                </PanelAlert>
               );
             }}
           </Observer>
@@ -362,14 +382,22 @@ class FormField extends React.Component {
 
 export default FormField;
 
-const ExplicitSaveRow = styled('div')`
+const MessageAndActions = styled('div')`
   display: flex;
-  justify-content: flex-end;
-  padding: ${space(1)};
-  border-bottom: 1px solid ${p => p.theme.borderLight};
+  justify-content: space-between;
 `;
 
-const CancelButton = styled(Button)``;
+const Message = styled('div')`
+  flex: 1;
+`;
+
+const Actions = styled('div')`
+  flex-shrink: 0;
+`;
+
+const CancelButton = styled(Button)`
+  margin-left: ${space(2)};
+`;
 const SaveButton = styled(Button)`
-  margin-left: ${space(0.5)};
+  margin-left: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -286,11 +286,10 @@ class FormModel {
   @action
   updateShowReturnButtonState(id, value) {
     let isValueChanged = value !== this.initialData[id];
-    // Update field state to "show save" if save on blur is disabled for this field
     let shouldShowReturnButton = this.getDescriptor(id, 'showReturnButton');
 
-    // Only update display if changed
     if (!shouldShowReturnButton) return;
+    // Only update state if state has changed
     if (this.getFieldState(id, 'showReturnButton') === isValueChanged) return;
 
     this.setFieldState(id, 'showReturnButton', isValueChanged);

--- a/tests/js/spec/views/organizationGeneralSettingsView.spec.jsx
+++ b/tests/js/spec/views/organizationGeneralSettingsView.spec.jsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import {mount} from 'enzyme';
 import {browserHistory} from 'react-router';
+import React from 'react';
+
+import {mount} from 'enzyme';
+import OrganizationGeneralSettingsView from 'app/views/settings/organization/general/organizationGeneralSettingsView';
 import recreateRoute from 'app/utils/recreateRoute';
 
-import OrganizationGeneralSettingsView from 'app/views/settings/organization/general/organizationGeneralSettingsView';
+import {mountWithTheme} from '../../../helpers';
 
 jest.mock('jquery');
 jest.mock('app/utils/recreateRoute');
@@ -71,7 +73,7 @@ describe('OrganizationGeneralSettingsView', function() {
   });
 
   it('changes org slug and redirects to new slug', async function() {
-    let wrapper = mount(
+    let wrapper = mountWithTheme(
       <OrganizationGeneralSettingsView params={{orgId: org.slug}} />,
       TestStubs.routerContext()
     );
@@ -90,7 +92,7 @@ describe('OrganizationGeneralSettingsView', function() {
       .simulate('change', {target: {value: 'new-slug'}})
       .simulate('blur');
 
-    wrapper.update();
+    wrapper.find('SaveButton').simulate('click');
     expect(mock).toHaveBeenCalledWith(
       ENDPOINT,
       expect.objectContaining({
@@ -295,6 +297,8 @@ describe('OrganizationGeneralSettingsView', function() {
     wrapper.update();
     wrapper.find('Switch[name="require2FA"]').simulate('click');
 
+    // hide console.error for this test
+    sinon.stub(console, 'error');
     // Confirm but has API failure
     wrapper
       .find(
@@ -305,5 +309,7 @@ describe('OrganizationGeneralSettingsView', function() {
     await tick();
     wrapper.update();
     expect(wrapper.find('Switch[name="require2FA"]').prop('isActive')).toBe(false);
+    // eslint-disable-next-line no-console
+    console.error.restore();
   });
 });

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -143,7 +143,7 @@ describe('NewTeamSettings', function() {
     ).not.toBe('Remove Team');
   });
 
-  xit('can remove team', async function() {
+  it('can remove team', async function() {
     let team = TestStubs.Team();
     let deleteMock = MockApiClient.addMockResponse({
       url: `/teams/org/${team.slug}/`,
@@ -183,6 +183,7 @@ describe('NewTeamSettings', function() {
       })
     );
 
+    await tick();
     await tick();
     expect(routerPushMock).toHaveBeenCalledWith('/settings/org/teams/');
 

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -5,6 +5,7 @@ import {mount, shallow} from 'enzyme';
 import TeamSettings from 'app/views/settings/team/teamSettings.old';
 import TeamStore from 'app/stores/teamStore';
 import NewTeamSettings from 'app/views/settings/team/teamSettings';
+import {mountWithTheme} from '../../../helpers';
 
 const childContextTypes = {
   organization: PropTypes.object,
@@ -73,7 +74,7 @@ describe('NewTeamSettings', function() {
       method: 'PUT',
     });
 
-    let wrapper = mount(
+    let wrapper = mountWithTheme(
       <NewTeamSettings
         routes={[]}
         params={{orgId: 'org', teamId: team.slug}}
@@ -101,6 +102,8 @@ describe('NewTeamSettings', function() {
       .find('input[name="slug"]')
       .simulate('change', {target: {value: 'new-slug'}})
       .simulate('blur');
+
+    wrapper.find('SaveButton').simulate('click');
 
     expect(putMock).toHaveBeenCalledWith(
       `/teams/org/${team.slug}/`,


### PR DESCRIPTION
Turns save on blur off for: "slug" inputs and "Auto Resolve" field.

One line save messages look funny:
![image](https://user-images.githubusercontent.com/79684/38590277-059d36d4-3ce5-11e8-9a5a-ba7d082118e0.png)
