### PR TITLE
feat(assistant): Export GuideAnchor component for use in getsentry

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -129,6 +129,7 @@ export default {
     DynamicWrapper: require('./components/dynamicWrapper').default,
     Form: require('./components/forms/form').default,
     FormState: require('./components/forms/index').FormState,
+    GuideAnchor: require('./components/assistant/guideAnchor').default,
     HookStore: require('./stores/hookStore').default,
     Indicators: require('./components/indicators').default,
     IndicatorStore: require('./stores/indicatorStore').default,


### PR DESCRIPTION
This exports the GuideAnchor component which is part of the foundation needed for getsentry side guides for assistant. 

Related to [this PR](https://github.com/getsentry/getsentry/pull/1839) which sets up the getsentry endpoint.