### PR TITLE
ref(ui): Project Alerts hierarchy and crumbs

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -56,9 +56,9 @@ import OrganizationGeneralSettingsView from './views/settings/organization/gener
 import OrganizationStats from './views/organizationStats';
 import OrganizationTeams from './views/organizationTeams';
 import OrganizationTeamsProjectsView from './views/organizationTeamsProjects';
-import ProjectAlertRules from './views/projectAlertRules';
-import ProjectAlertRuleDetails from './views/projectAlertRuleDetails';
-import ProjectAlertSettings from './views/projectAlertSettings';
+import ProjectAlertRules from './views/settings/projectAlerts/projectAlertRules';
+import ProjectAlertRuleDetails from './views/settings/projectAlerts/projectAlertRuleDetails';
+import ProjectAlertSettings from './views/settings/projectAlerts/projectAlertSettings';
 import ProjectEnvironments from './views/projectEnvironments';
 import ProjectTags from './views/projectTags';
 import ProjectChooser from './views/projectChooser';
@@ -248,22 +248,20 @@ const projectSettingsRoutes = (
         import(/*webpackChunkName: "ProjectTeams"*/ './views/settings/project/projectTeams')}
       component={errorHandler(LazyLoad)}
     />
-    <Route name="Alerts" path="alerts/" component={errorHandler(ProjectAlertSettings)} />
-    <Route
-      path="alerts/rules/"
-      name="Alert Rules"
-      component={errorHandler(ProjectAlertRules)}
-    />
-    <Route
-      path="alerts/rules/new/"
-      name="New Alert Rule"
-      component={errorHandler(ProjectAlertRuleDetails)}
-    />
-    <Route
-      path="alerts/rules/:ruleId/"
-      name="Edit Alert Rule"
-      component={errorHandler(ProjectAlertRuleDetails)}
-    />
+
+    <Route name="Alerts" path="alerts/">
+      <IndexRoute component={errorHandler(ProjectAlertSettings)} />
+      <Route path="rules/" name="Rules" component={null}>
+        <IndexRoute component={errorHandler(ProjectAlertRules)} />
+        <Route path="new/" name="New" component={errorHandler(ProjectAlertRuleDetails)} />
+        <Route
+          path=":ruleId/"
+          name="Edit"
+          component={errorHandler(ProjectAlertRuleDetails)}
+        />
+      </Route>
+    </Route>
+
     <Route
       name="Environments"
       path="environments/"

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
@@ -76,10 +76,15 @@ class ProjectCrumb extends React.Component {
           </ProjectName>
         }
         onSelect={item => {
+          let lastRoute = routes[routes.length - 1];
+          // We have to make an exception for "Project Alerts Rule Edit" route
+          // Since these models are project specific, we need to traverse up a route when switching projects
+          let stepBack = lastRoute.path === ':ruleId/' ? -1 : undefined;
           browserHistory.push(
             recreateRoute('', {
               routes,
               params: {...params, projectId: item.value},
+              stepBack,
             })
           );
         }}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRuleDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRuleDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import SentryTypes from '../proptypes';
-import AsyncView from './asyncView';
+import SentryTypes from '../../../proptypes';
+import AsyncView from '../../asyncView';
 import RuleEditor from './ruleEditor';
 
 class ProjectAlertRuleDetails extends AsyncView {
@@ -27,6 +27,7 @@ class ProjectAlertRuleDetails extends AsyncView {
         actions={actions}
         conditions={conditions}
         params={this.props.params}
+        routes={this.props.routes}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
@@ -4,26 +4,25 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
-import {t, tct} from '../locale';
-import ApiMixin from '../mixins/apiMixin';
-import Button from '../components/buttons/button';
-import Confirm from '../components/confirm';
-import Duration from '../components/duration';
+import {Panel, PanelBody, PanelHeader} from '../../../components/panels';
 import {
   addSuccessMessage,
   addErrorMessage,
   addLoadingMessage,
   removeIndicator,
-} from '../actionCreators/indicator';
-
-import ListLink from '../components/listLink';
-import LoadingError from '../components/loadingError';
-import LoadingIndicator from '../components/loadingIndicator';
-import {Panel, PanelBody, PanelHeader} from '../components/panels';
-import EmptyStateWarning from '../components/emptyStateWarning';
-import SettingsPageHeader from './settings/components/settingsPageHeader';
-import recreateRoute from '../utils/recreateRoute';
-import EnvironmentStore from '../stores/environmentStore';
+} from '../../../actionCreators/indicator';
+import {t, tct} from '../../../locale';
+import ApiMixin from '../../../mixins/apiMixin';
+import Button from '../../../components/buttons/button';
+import Confirm from '../../../components/confirm';
+import Duration from '../../../components/duration';
+import EmptyStateWarning from '../../../components/emptyStateWarning';
+import EnvironmentStore from '../../../stores/environmentStore';
+import ListLink from '../../../components/listLink';
+import LoadingError from '../../../components/loadingError';
+import LoadingIndicator from '../../../components/loadingIndicator';
+import SettingsPageHeader from '../components/settingsPageHeader';
+import recreateRoute from '../../../utils/recreateRoute';
 
 const TextColorLink = styled(Link)`
   color: ${p => p.theme.gray3};
@@ -270,7 +269,7 @@ const ProjectAlertRules = createReactClass({
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         <SettingsPageHeader
           title={t('Alerts')}
           action={
@@ -285,19 +284,15 @@ const ProjectAlertRules = createReactClass({
           }
           tabs={
             <ul className="nav nav-tabs" style={{borderBottom: '1px solid #ddd'}}>
-              <ListLink
-                to={recreateRoute('alerts/', {...this.props, stepBack: -1})}
-                index={true}
-              >
+              <ListLink to={recreateRoute('alerts', {...this.props, stepBack: -4})}>
                 {t('Settings')}
               </ListLink>
               <ListLink to={recreateRoute('', this.props)}>{t('Rules')}</ListLink>
             </ul>
           }
         />
-
         {this.renderBody()}
-      </div>
+      </React.Fragment>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import {t} from '../locale';
-import AlertLink from '../components/alertLink';
-import AsyncView from './asyncView';
-import Button from '../components/buttons/button';
-import Form from './settings/components/forms/form';
-import JsonForm from './settings/components/forms/jsonForm';
-import ListLink from '../components/listLink';
-import {PanelAlert} from '../components/panels';
-import PluginList from '../components/pluginList';
-import SentryTypes from '../proptypes';
-import SettingsPageHeader from './settings/components/settingsPageHeader';
-import {fields} from '../data/forms/projectAlerts';
-import recreateRoute from '../utils/recreateRoute';
+import {t} from '../../../locale';
+import AlertLink from '../../../components/alertLink';
+import AsyncView from '../../asyncView';
+import Button from '../../../components/buttons/button';
+import Form from '../components/forms/form';
+import JsonForm from '../components/forms/jsonForm';
+import ListLink from '../../../components/listLink';
+import {PanelAlert} from '../../../components/panels';
+import PluginList from '../../../components/pluginList';
+import SentryTypes from '../../../proptypes';
+import SettingsPageHeader from '../components/settingsPageHeader';
+import {fields} from '../../../data/forms/projectAlerts';
+import recreateRoute from '../../../utils/recreateRoute';
 
 export default class ProjectAlertSettings extends AsyncView {
   static propTypes = {
@@ -67,7 +67,7 @@ export default class ProjectAlertSettings extends AsyncView {
     let {organization} = this.props;
 
     return (
-      <div>
+      <React.Fragment>
         <SettingsPageHeader
           title={t('Alerts')}
           action={
@@ -135,7 +135,7 @@ export default class ProjectAlertSettings extends AsyncView {
           onEnablePlugin={this.handleEnablePlugin}
           onDisablePlugin={this.handleDisablePlugin}
         />
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/index.jsx
@@ -123,7 +123,7 @@ const RuleEditor = createReactClass({
         // Redirect to correct ID if /new
         if (isNew) {
           browserHistory.replace(
-            `/${organization.slug}/${project.slug}/settings/alerts/rules/${resp.id}/`
+            recreateRoute(`${resp.id}/`, {...this.props, stepBack: -1})
           );
         }
         addSuccessMessage(isNew ? t('Created alert rule') : t('Updated alert rule'));

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/index.jsx
@@ -5,20 +5,22 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
-import {Select2Field, TextField} from '../../components/forms';
-import Button from '../../components/buttons/button';
+import {ALL_ENVIRONMENTS_KEY} from '../../../../constants';
+import {Panel, PanelBody, PanelHeader} from '../../../../components/panels';
+import {Select2Field, TextField} from '../../../../components/forms';
 import {
   addErrorMessage,
   addSuccessMessage,
   addMessage,
-} from '../../actionCreators/indicator';
-import {t} from '../../locale';
-import ApiMixin from '../../mixins/apiMixin';
-import EnvironmentStore from '../../stores/environmentStore';
-import LoadingIndicator from '../../components/loadingIndicator';
-import {Panel, PanelBody, PanelHeader} from '../../components/panels';
+} from '../../../../actionCreators/indicator';
+import {t} from '../../../../locale';
+import ApiMixin from '../../../../mixins/apiMixin';
+import Button from '../../../../components/buttons/button';
+import EnvironmentStore from '../../../../stores/environmentStore';
+import LoadingIndicator from '../../../../components/loadingIndicator';
 import RuleNodeList from './ruleNodeList';
-import {ALL_ENVIRONMENTS_KEY} from '../../constants';
+import recreateRoute from '../../../../utils/recreateRoute';
+import space from '../../../../styles/space';
 
 const FREQUENCY_CHOICES = [
   ['5', t('5 minutes')],
@@ -305,11 +307,14 @@ const RuleEditor = createReactClass({
               )}
             </AlertRuleRow>
 
-            <div className="actions">
+            <ActionBar>
+              <CancelButton to={recreateRoute('', {...this.props, stepBack: -1})}>
+                {t('Cancel')}
+              </CancelButton>
               <Button priority="primary" disabled={loading}>
                 {t('Save Rule')}
               </Button>
-            </div>
+            </ActionBar>
           </PanelBody>
         </Panel>
       </form>
@@ -318,3 +323,15 @@ const RuleEditor = createReactClass({
 });
 
 export default RuleEditor;
+
+const CancelButton = styled(Button)`
+  margin-right: ${space(1)};
+`;
+
+const ActionBar = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  padding: ${space(2)};
+  border-top: 1px solid ${p => p.theme.borderLight};
+  margin: 0 -20px -20px;
+`;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/ruleNode.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/ruleNode.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
-import Button from '../../components/buttons/button';
-import {Select2Field, NumberField, TextField} from '../../components/forms';
+import Button from '../../../../components/buttons/button';
+import {Select2Field, NumberField, TextField} from '../../../../components/forms';
 
 class RuleNode extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/ruleNodeList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/ruleNodeList.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import SelectInput from '../../components/selectInput';
+import SelectInput from '../../../../components/selectInput';
 import RuleNode from './ruleNode';
 
 class RuleNodeList extends React.Component {

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -168,12 +168,6 @@
       }
     }
   }
-
-  .actions {
-    padding: 20px;
-    border-top: 1px solid lighten(@trim, 4);
-    margin: 0 -20px -20px;
-  }
 }
 
 /**

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -9,6 +9,58 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
       "ruleId": "1",
     }
   }
+  routes={
+    Array [
+      Object {
+        "path": "/",
+      },
+      Object {
+        "indexRoute": Object {},
+        "name": "Settings",
+        "newnew": true,
+        "path": "/settings/",
+      },
+      Object {
+        "name": "Organization",
+        "path": ":orgId/",
+      },
+      Object {
+        "name": "Project",
+        "path": ":projectId/",
+      },
+      Object {},
+      Object {
+        "indexRoute": Object {
+          "name": "General",
+        },
+      },
+      Object {
+        "indexRoute": Object {},
+        "name": "Alerts",
+        "path": "alerts/",
+      },
+      Object {
+        "childRoutes": Array [
+          Object {
+            "name": "New",
+            "path": "new/",
+          },
+          Object {
+            "name": "Edit",
+            "path": ":ruleId/",
+          },
+        ],
+        "component": null,
+        "indexRoute": Object {},
+        "name": "Rules",
+        "path": "rules/",
+      },
+      Object {
+        "name": "Edit",
+        "path": ":ruleId/",
+      },
+    ]
+  }
 >
   <SideEffect(DocumentTitle)
     title="Sentry"
@@ -78,6 +130,58 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
             "slug": "project-slug",
             "teams": Array [],
           }
+        }
+        routes={
+          Array [
+            Object {
+              "path": "/",
+            },
+            Object {
+              "indexRoute": Object {},
+              "name": "Settings",
+              "newnew": true,
+              "path": "/settings/",
+            },
+            Object {
+              "name": "Organization",
+              "path": ":orgId/",
+            },
+            Object {
+              "name": "Project",
+              "path": ":projectId/",
+            },
+            Object {},
+            Object {
+              "indexRoute": Object {
+                "name": "General",
+              },
+            },
+            Object {
+              "indexRoute": Object {},
+              "name": "Alerts",
+              "path": "alerts/",
+            },
+            Object {
+              "childRoutes": Array [
+                Object {
+                  "name": "New",
+                  "path": "new/",
+                },
+                Object {
+                  "name": "Edit",
+                  "path": ":ruleId/",
+                },
+              ],
+              "component": null,
+              "indexRoute": Object {},
+              "name": "Rules",
+              "path": "rules/",
+            },
+            Object {
+              "name": "Edit",
+              "path": ":ruleId/",
+            },
+          ]
         }
       >
         <form
@@ -162,7 +266,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
+                        className="css-1pc4igl-AlertRuleRow css-1qt54040"
                       >
                         Every time 
                         <Select2Field
@@ -647,7 +751,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
+                        className="css-1pc4igl-AlertRuleRow css-1qt54040"
                       >
                         Perform these actions at most once every 
                         <Select2Field
@@ -799,36 +903,50 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                     </AlertRuleRow>
                     <ActionBar>
                       <div
-                        className="css-wq91e7-ActionBar css-svkcde2"
+                        className="css-wq91e7-ActionBar css-1qt54042"
                       >
-                        <CancelButton>
+                        <CancelButton
+                          to="/settings/org-slug/project-slug/alerts/rules/"
+                        >
                           <Button
-                            className="css-1yc33o1-CancelButton css-svkcde1"
+                            className="css-1yc33o1-CancelButton css-1qt54041"
                             disabled={false}
+                            to="/settings/org-slug/project-slug/alerts/rules/"
                           >
-                            <button
-                              className="css-1yc33o1-CancelButton css-svkcde1 button button-default"
+                            <Link
+                              className="css-1yc33o1-CancelButton css-1qt54041 button button-default"
                               disabled={false}
                               onClick={[Function]}
+                              onlyActiveOnIndex={false}
                               role="button"
+                              style={Object {}}
+                              to="/settings/org-slug/project-slug/alerts/rules/"
                             >
-                              <Flex
-                                align="center"
-                                className="button-label"
+                              <a
+                                className="css-1yc33o1-CancelButton css-1qt54041 button button-default"
+                                disabled={false}
+                                onClick={[Function]}
+                                role="button"
+                                style={Object {}}
                               >
-                                <Base
+                                <Flex
                                   align="center"
-                                  className="button-label css-5ipae5"
+                                  className="button-label"
                                 >
-                                  <div
+                                  <Base
+                                    align="center"
                                     className="button-label css-5ipae5"
-                                    is={null}
                                   >
-                                    Cancel
-                                  </div>
-                                </Base>
-                              </Flex>
-                            </button>
+                                    <div
+                                      className="button-label css-5ipae5"
+                                      is={null}
+                                    >
+                                      Cancel
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </a>
+                            </Link>
                           </Button>
                         </CancelButton>
                         <Button
@@ -880,6 +998,58 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
       "orgId": "org-slug",
       "projectId": "project-slug",
     }
+  }
+  routes={
+    Array [
+      Object {
+        "path": "/",
+      },
+      Object {
+        "indexRoute": Object {},
+        "name": "Settings",
+        "newnew": true,
+        "path": "/settings/",
+      },
+      Object {
+        "name": "Organization",
+        "path": ":orgId/",
+      },
+      Object {
+        "name": "Project",
+        "path": ":projectId/",
+      },
+      Object {},
+      Object {
+        "indexRoute": Object {
+          "name": "General",
+        },
+      },
+      Object {
+        "indexRoute": Object {},
+        "name": "Alerts",
+        "path": "alerts/",
+      },
+      Object {
+        "childRoutes": Array [
+          Object {
+            "name": "New",
+            "path": "new/",
+          },
+          Object {
+            "name": "Edit",
+            "path": ":ruleId/",
+          },
+        ],
+        "component": null,
+        "indexRoute": Object {},
+        "name": "Rules",
+        "path": "rules/",
+      },
+      Object {
+        "name": "Edit",
+        "path": ":ruleId/",
+      },
+    ]
   }
 >
   <SideEffect(DocumentTitle)
@@ -949,6 +1119,58 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
             "slug": "project-slug",
             "teams": Array [],
           }
+        }
+        routes={
+          Array [
+            Object {
+              "path": "/",
+            },
+            Object {
+              "indexRoute": Object {},
+              "name": "Settings",
+              "newnew": true,
+              "path": "/settings/",
+            },
+            Object {
+              "name": "Organization",
+              "path": ":orgId/",
+            },
+            Object {
+              "name": "Project",
+              "path": ":projectId/",
+            },
+            Object {},
+            Object {
+              "indexRoute": Object {
+                "name": "General",
+              },
+            },
+            Object {
+              "indexRoute": Object {},
+              "name": "Alerts",
+              "path": "alerts/",
+            },
+            Object {
+              "childRoutes": Array [
+                Object {
+                  "name": "New",
+                  "path": "new/",
+                },
+                Object {
+                  "name": "Edit",
+                  "path": ":ruleId/",
+                },
+              ],
+              "component": null,
+              "indexRoute": Object {},
+              "name": "Rules",
+              "path": "rules/",
+            },
+            Object {
+              "name": "Edit",
+              "path": ":ruleId/",
+            },
+          ]
         }
       >
         <form
@@ -1033,7 +1255,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
+                        className="css-1pc4igl-AlertRuleRow css-1qt54040"
                       >
                         Every time 
                         <Select2Field
@@ -1347,7 +1569,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
+                        className="css-1pc4igl-AlertRuleRow css-1qt54040"
                       >
                         Perform these actions at most once every 
                         <Select2Field
@@ -1500,36 +1722,50 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                     </AlertRuleRow>
                     <ActionBar>
                       <div
-                        className="css-wq91e7-ActionBar css-svkcde2"
+                        className="css-wq91e7-ActionBar css-1qt54042"
                       >
-                        <CancelButton>
+                        <CancelButton
+                          to="/settings/org-slug/project-slug/alerts/rules/"
+                        >
                           <Button
-                            className="css-1yc33o1-CancelButton css-svkcde1"
+                            className="css-1yc33o1-CancelButton css-1qt54041"
                             disabled={false}
+                            to="/settings/org-slug/project-slug/alerts/rules/"
                           >
-                            <button
-                              className="css-1yc33o1-CancelButton css-svkcde1 button button-default"
+                            <Link
+                              className="css-1yc33o1-CancelButton css-1qt54041 button button-default"
                               disabled={false}
                               onClick={[Function]}
+                              onlyActiveOnIndex={false}
                               role="button"
+                              style={Object {}}
+                              to="/settings/org-slug/project-slug/alerts/rules/"
                             >
-                              <Flex
-                                align="center"
-                                className="button-label"
+                              <a
+                                className="css-1yc33o1-CancelButton css-1qt54041 button button-default"
+                                disabled={false}
+                                onClick={[Function]}
+                                role="button"
+                                style={Object {}}
                               >
-                                <Base
+                                <Flex
                                   align="center"
-                                  className="button-label css-5ipae5"
+                                  className="button-label"
                                 >
-                                  <div
+                                  <Base
+                                    align="center"
                                     className="button-label css-5ipae5"
-                                    is={null}
                                   >
-                                    Cancel
-                                  </div>
-                                </Base>
-                              </Flex>
-                            </button>
+                                    <div
+                                      className="button-label css-5ipae5"
+                                      is={null}
+                                    >
+                                      Cancel
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </a>
+                            </Link>
                           </Button>
                         </CancelButton>
                         <Button

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -162,7 +162,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-70hiur0"
+                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
                       >
                         Every time 
                         <Select2Field
@@ -280,7 +280,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                       >
                         <RuleNodes>
                           <div
-                            className="css-wlwbnk-RuleNodes css-mr9tnj0"
+                            className="css-wlwbnk-RuleNodes css-e8p6eg0"
                           >
                             <RuleNode
                               data={
@@ -302,11 +302,11 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             >
                               <RuleNodeRow>
                                 <div
-                                  className="css-1poe0fr-RuleNodeRow css-i92rqo0"
+                                  className="css-1poe0fr-RuleNodeRow css-1f92yv60"
                                 >
                                   <RuleNodeForm>
                                     <div
-                                      className="css-7h5qyd-RuleNodeForm css-i92rqo1"
+                                      className="css-7h5qyd-RuleNodeForm css-1f92yv61"
                                     >
                                       <input
                                         name="id"
@@ -318,7 +318,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   </RuleNodeForm>
                                   <RuleNodeControls>
                                     <div
-                                      className="css-1d10zz4-RuleNodeControls css-i92rqo2"
+                                      className="css-1d10zz4-RuleNodeControls css-1f92yv62"
                                     >
                                       <Button
                                         disabled={false}
@@ -520,7 +520,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                       <div>
                         <RuleNodes>
                           <div
-                            className="css-wlwbnk-RuleNodes css-mr9tnj0"
+                            className="css-wlwbnk-RuleNodes css-e8p6eg0"
                           >
                             <RuleNode
                               data={
@@ -542,11 +542,11 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             >
                               <RuleNodeRow>
                                 <div
-                                  className="css-1poe0fr-RuleNodeRow css-i92rqo0"
+                                  className="css-1poe0fr-RuleNodeRow css-1f92yv60"
                                 >
                                   <RuleNodeForm>
                                     <div
-                                      className="css-7h5qyd-RuleNodeForm css-i92rqo1"
+                                      className="css-7h5qyd-RuleNodeForm css-1f92yv61"
                                     >
                                       <input
                                         name="id"
@@ -558,7 +558,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   </RuleNodeForm>
                                   <RuleNodeControls>
                                     <div
-                                      className="css-1d10zz4-RuleNodeControls css-i92rqo2"
+                                      className="css-1d10zz4-RuleNodeControls css-1f92yv62"
                                     >
                                       <Button
                                         disabled={false}
@@ -647,7 +647,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-70hiur0"
+                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
                       >
                         Perform these actions at most once every 
                         <Select2Field
@@ -797,38 +797,70 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                          for an issue.
                       </h6>
                     </AlertRuleRow>
-                    <div
-                      className="actions"
-                    >
-                      <Button
-                        disabled={false}
-                        priority="primary"
+                    <ActionBar>
+                      <div
+                        className="css-wq91e7-ActionBar css-svkcde2"
                       >
-                        <button
-                          className="button button-primary"
-                          disabled={false}
-                          onClick={[Function]}
-                          role="button"
-                        >
-                          <Flex
-                            align="center"
-                            className="button-label"
+                        <CancelButton>
+                          <Button
+                            className="css-1yc33o1-CancelButton css-svkcde1"
+                            disabled={false}
                           >
-                            <Base
-                              align="center"
-                              className="button-label css-5ipae5"
+                            <button
+                              className="css-1yc33o1-CancelButton css-svkcde1 button button-default"
+                              disabled={false}
+                              onClick={[Function]}
+                              role="button"
                             >
-                              <div
-                                className="button-label css-5ipae5"
-                                is={null}
+                              <Flex
+                                align="center"
+                                className="button-label"
                               >
-                                Save Rule
-                              </div>
-                            </Base>
-                          </Flex>
-                        </button>
-                      </Button>
-                    </div>
+                                <Base
+                                  align="center"
+                                  className="button-label css-5ipae5"
+                                >
+                                  <div
+                                    className="button-label css-5ipae5"
+                                    is={null}
+                                  >
+                                    Cancel
+                                  </div>
+                                </Base>
+                              </Flex>
+                            </button>
+                          </Button>
+                        </CancelButton>
+                        <Button
+                          disabled={false}
+                          priority="primary"
+                        >
+                          <button
+                            className="button button-primary"
+                            disabled={false}
+                            onClick={[Function]}
+                            role="button"
+                          >
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
+                              <Base
+                                align="center"
+                                className="button-label css-5ipae5"
+                              >
+                                <div
+                                  className="button-label css-5ipae5"
+                                  is={null}
+                                >
+                                  Save Rule
+                                </div>
+                              </Base>
+                            </Flex>
+                          </button>
+                        </Button>
+                      </div>
+                    </ActionBar>
                   </div>
                 </PanelBody>
               </div>
@@ -1001,7 +1033,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-70hiur0"
+                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
                       >
                         Every time 
                         <Select2Field
@@ -1113,7 +1145,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                       >
                         <RuleNodes>
                           <div
-                            className="css-wlwbnk-RuleNodes css-mr9tnj0"
+                            className="css-wlwbnk-RuleNodes css-e8p6eg0"
                           />
                         </RuleNodes>
                         <fieldset>
@@ -1267,7 +1299,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                       <div>
                         <RuleNodes>
                           <div
-                            className="css-wlwbnk-RuleNodes css-mr9tnj0"
+                            className="css-wlwbnk-RuleNodes css-e8p6eg0"
                           />
                         </RuleNodes>
                         <fieldset>
@@ -1315,7 +1347,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                     <hr />
                     <AlertRuleRow>
                       <h6
-                        className="css-1pc4igl-AlertRuleRow css-70hiur0"
+                        className="css-1pc4igl-AlertRuleRow css-svkcde0"
                       >
                         Perform these actions at most once every 
                         <Select2Field
@@ -1466,38 +1498,70 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                          for an issue.
                       </h6>
                     </AlertRuleRow>
-                    <div
-                      className="actions"
-                    >
-                      <Button
-                        disabled={false}
-                        priority="primary"
+                    <ActionBar>
+                      <div
+                        className="css-wq91e7-ActionBar css-svkcde2"
                       >
-                        <button
-                          className="button button-primary"
-                          disabled={false}
-                          onClick={[Function]}
-                          role="button"
-                        >
-                          <Flex
-                            align="center"
-                            className="button-label"
+                        <CancelButton>
+                          <Button
+                            className="css-1yc33o1-CancelButton css-svkcde1"
+                            disabled={false}
                           >
-                            <Base
-                              align="center"
-                              className="button-label css-5ipae5"
+                            <button
+                              className="css-1yc33o1-CancelButton css-svkcde1 button button-default"
+                              disabled={false}
+                              onClick={[Function]}
+                              role="button"
                             >
-                              <div
-                                className="button-label css-5ipae5"
-                                is={null}
+                              <Flex
+                                align="center"
+                                className="button-label"
                               >
-                                Save Rule
-                              </div>
-                            </Base>
-                          </Flex>
-                        </button>
-                      </Button>
-                    </div>
+                                <Base
+                                  align="center"
+                                  className="button-label css-5ipae5"
+                                >
+                                  <div
+                                    className="button-label css-5ipae5"
+                                    is={null}
+                                  >
+                                    Cancel
+                                  </div>
+                                </Base>
+                              </Flex>
+                            </button>
+                          </Button>
+                        </CancelButton>
+                        <Button
+                          disabled={false}
+                          priority="primary"
+                        >
+                          <button
+                            className="button button-primary"
+                            disabled={false}
+                            onClick={[Function]}
+                            role="button"
+                          >
+                            <Flex
+                              align="center"
+                              className="button-label"
+                            >
+                              <Base
+                                align="center"
+                                className="button-label css-5ipae5"
+                              >
+                                <div
+                                  className="button-label css-5ipae5"
+                                  is={null}
+                                >
+                                  Save Rule
+                                </div>
+                              </Base>
+                            </Flex>
+                          </button>
+                        </Button>
+                      </div>
+                    </ActionBar>
                   </div>
                 </PanelBody>
               </div>

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -10,185 +10,25 @@ exports[`projectAlertRules renders 1`] = `
   }
   routes={Array []}
 >
-  <SettingsPageHeading
-    action={
-      <Button
-        disabled={false}
-        icon="icon-circle-add"
-        priority="primary"
-        size="small"
-        to="new/"
-      >
-        New Alert Rule
-      </Button>
-    }
-    tabs={
-      <ul
-        className="nav nav-tabs"
-        style={
-          Object {
-            "borderBottom": "1px solid #ddd",
-          }
-        }
-      >
-        <ListLink
-          activeClassName="active"
-          index={false}
-          to="alerts"
-        >
-          Settings
-        </ListLink>
-        <ListLink
-          activeClassName="active"
-          index={false}
-          to=""
-        >
-          Rules
-        </ListLink>
-      </ul>
-    }
-    title="Alerts"
+  <SideEffect(DocumentTitle)
+    title="Sentry"
   >
-    <Wrapper
-      tabs={
-        <ul
-          className="nav nav-tabs"
-          style={
-            Object {
-              "borderBottom": "1px solid #ddd",
-            }
-          }
-        >
-          <ListLink
-            activeClassName="active"
-            index={false}
-            to="alerts"
-          >
-            Settings
-          </ListLink>
-          <ListLink
-            activeClassName="active"
-            index={false}
-            to=""
-          >
-            Rules
-          </ListLink>
-        </ul>
-      }
+    <DocumentTitle
+      title="Sentry"
     >
-      <div
-        className="css-foidy-Wrapper css-17jmgia0"
-      >
-        <Flex
-          align="center"
-        >
-          <Base
-            align="center"
-            className="css-5ipae5"
+      <SettingsPageHeading
+        action={
+          <Button
+            disabled={false}
+            icon="icon-circle-add"
+            priority="primary"
+            size="small"
+            to="new/"
           >
-            <div
-              className="css-5ipae5"
-              is={null}
-            >
-              <Title>
-                <div
-                  className="css-zmdcxu-Title css-17jmgia1"
-                >
-                  Alerts
-                </div>
-              </Title>
-              <div>
-                <Button
-                  disabled={false}
-                  icon="icon-circle-add"
-                  priority="primary"
-                  size="small"
-                  to="new/"
-                >
-                  <Link
-                    className="button button-primary button-sm"
-                    disabled={false}
-                    onClick={[Function]}
-                    onlyActiveOnIndex={false}
-                    role="button"
-                    style={Object {}}
-                    to="new/"
-                  >
-                    <a
-                      className="button button-primary button-sm"
-                      disabled={false}
-                      onClick={[Function]}
-                      role="button"
-                      style={Object {}}
-                    >
-                      <Flex
-                        align="center"
-                        className="button-label"
-                      >
-                        <Base
-                          align="center"
-                          className="button-label css-5ipae5"
-                        >
-                          <div
-                            className="button-label css-5ipae5"
-                            is={null}
-                          >
-                            <Icon
-                              size="small"
-                            >
-                              <Base
-                                className="css-11bwulm-Icon css-1vxxnb60"
-                                size="small"
-                              >
-                                <div
-                                  className="css-11bwulm-Icon css-1vxxnb60"
-                                  is={null}
-                                  size="small"
-                                >
-                                  <StyledInlineSvg
-                                    size="12px"
-                                    src="icon-circle-add"
-                                  >
-                                    <InlineSvg
-                                      className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
-                                      size="12px"
-                                      src="icon-circle-add"
-                                    >
-                                      <StyledSvg
-                                        className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
-                                        height="12px"
-                                        viewBox={Object {}}
-                                        width="12px"
-                                      >
-                                        <svg
-                                          className="css-1vxxnb61 css-1rlza0i-StyledSvg css-adkcw30"
-                                          height="12px"
-                                          viewBox={Object {}}
-                                          width="12px"
-                                        >
-                                          <use
-                                            href="#test"
-                                            xlinkHref="#test"
-                                          />
-                                        </svg>
-                                      </StyledSvg>
-                                    </InlineSvg>
-                                  </StyledInlineSvg>
-                                </div>
-                              </Base>
-                            </Icon>
-                            New Alert Rule
-                          </div>
-                        </Base>
-                      </Flex>
-                    </a>
-                  </Link>
-                </Button>
-              </div>
-            </div>
-          </Base>
-        </Flex>
-        <div>
+            New Alert Rule
+          </Button>
+        }
+        tabs={
           <ul
             className="nav nav-tabs"
             style={
@@ -202,381 +42,549 @@ exports[`projectAlertRules renders 1`] = `
               index={false}
               to="alerts"
             >
-              <li
-                className=""
-              >
-                <Link
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to="alerts"
-                >
-                  <a
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    Settings
-                  </a>
-                </Link>
-              </li>
+              Settings
             </ListLink>
             <ListLink
               activeClassName="active"
               index={false}
               to=""
             >
-              <li
-                className=""
-              >
-                <Link
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to=""
-                >
-                  <a
-                    style={Object {}}
-                  >
-                    Rules
-                  </a>
-                </Link>
-              </li>
+              Rules
             </ListLink>
           </ul>
-        </div>
-      </div>
-    </Wrapper>
-  </SettingsPageHeading>
-  <div
-    className="rules-list"
-  >
-    <RuleRow
-      data={
-        Object {
-          "actions": Array [
-            Object {
-              "id": "sentry.rules.actions.notify1",
-              "name": "Send a notification to all services",
-            },
-          ],
-          "conditions": Array [
-            Object {
-              "id": "sentry.rules.conditions.1",
-              "name": "An alert is first seen",
-            },
-          ],
-          "environment": "staging",
-          "id": "1",
-          "name": "My alert rule",
         }
-      }
-      key="1"
-      onDelete={[Function]}
-      orgId="org1"
-      params={
-        Object {
-          "orgId": "org1",
-          "projectId": "project1",
-        }
-      }
-      projectId="project1"
-      routes={Array []}
-    >
-      <Panel>
-        <StyledPanel>
-          <div
-            className="css-wfa8ap-StyledPanel css-5bw71w0"
-          >
-            <PanelHeader
-              align="center"
-              className="css-1lx593h"
-              justify="space-between"
+        title="Alerts"
+      >
+        <Wrapper
+          tabs={
+            <ul
+              className="nav nav-tabs"
+              style={
+                Object {
+                  "borderBottom": "1px solid #ddd",
+                }
+              }
             >
-              <StyledPanelHeader
-                align="center"
-                className="css-1lx593h"
-                justify="space-between"
+              <ListLink
+                activeClassName="active"
+                index={false}
+                to="alerts"
               >
-                <Component
+                Settings
+              </ListLink>
+              <ListLink
+                activeClassName="active"
+                index={false}
+                to=""
+              >
+                Rules
+              </ListLink>
+            </ul>
+          }
+        >
+          <div
+            className="css-foidy-Wrapper css-17jmgia0"
+          >
+            <Flex
+              align="center"
+            >
+              <Base
+                align="center"
+                className="css-5ipae5"
+              >
+                <div
+                  className="css-5ipae5"
+                  is={null}
+                >
+                  <Title>
+                    <div
+                      className="css-zmdcxu-Title css-17jmgia1"
+                    >
+                      Alerts
+                    </div>
+                  </Title>
+                  <div>
+                    <Button
+                      disabled={false}
+                      icon="icon-circle-add"
+                      priority="primary"
+                      size="small"
+                      to="new/"
+                    >
+                      <Link
+                        className="button button-primary button-sm"
+                        disabled={false}
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        role="button"
+                        style={Object {}}
+                        to="new/"
+                      >
+                        <a
+                          className="button button-primary button-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          role="button"
+                          style={Object {}}
+                        >
+                          <Flex
+                            align="center"
+                            className="button-label"
+                          >
+                            <Base
+                              align="center"
+                              className="button-label css-5ipae5"
+                            >
+                              <div
+                                className="button-label css-5ipae5"
+                                is={null}
+                              >
+                                <Icon
+                                  size="small"
+                                >
+                                  <Base
+                                    className="css-11bwulm-Icon css-1vxxnb60"
+                                    size="small"
+                                  >
+                                    <div
+                                      className="css-11bwulm-Icon css-1vxxnb60"
+                                      is={null}
+                                      size="small"
+                                    >
+                                      <StyledInlineSvg
+                                        size="12px"
+                                        src="icon-circle-add"
+                                      >
+                                        <InlineSvg
+                                          className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
+                                          size="12px"
+                                          src="icon-circle-add"
+                                        >
+                                          <StyledSvg
+                                            className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
+                                            height="12px"
+                                            viewBox={Object {}}
+                                            width="12px"
+                                          >
+                                            <svg
+                                              className="css-1vxxnb61 css-1rlza0i-StyledSvg css-adkcw30"
+                                              height="12px"
+                                              viewBox={Object {}}
+                                              width="12px"
+                                            >
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </StyledSvg>
+                                        </InlineSvg>
+                                      </StyledInlineSvg>
+                                    </div>
+                                  </Base>
+                                </Icon>
+                                New Alert Rule
+                              </div>
+                            </Base>
+                          </Flex>
+                        </a>
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              </Base>
+            </Flex>
+            <div>
+              <ul
+                className="nav nav-tabs"
+                style={
+                  Object {
+                    "borderBottom": "1px solid #ddd",
+                  }
+                }
+              >
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  to="alerts"
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to="alerts"
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Settings
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        style={Object {}}
+                      >
+                        Rules
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+              </ul>
+            </div>
+          </div>
+        </Wrapper>
+      </SettingsPageHeading>
+      <div
+        className="rules-list"
+      >
+        <RuleRow
+          data={
+            Object {
+              "actions": Array [
+                Object {
+                  "id": "sentry.rules.actions.notify1",
+                  "name": "Send a notification to all services",
+                },
+              ],
+              "conditions": Array [
+                Object {
+                  "id": "sentry.rules.conditions.1",
+                  "name": "An alert is first seen",
+                },
+              ],
+              "environment": "staging",
+              "id": "1",
+              "name": "My alert rule",
+            }
+          }
+          key="1"
+          onDelete={[Function]}
+          orgId="org1"
+          params={
+            Object {
+              "orgId": "org1",
+              "projectId": "project1",
+            }
+          }
+          projectId="project1"
+          routes={Array []}
+        >
+          <Panel>
+            <StyledPanel>
+              <div
+                className="css-wfa8ap-StyledPanel css-5bw71w0"
+              >
+                <PanelHeader
                   align="center"
-                  className="css-18dfj8-StyledPanelHeader css-1t1cqk30"
+                  className="css-1lx593h"
                   justify="space-between"
                 >
-                  <Flex
+                  <StyledPanelHeader
                     align="center"
-                    className="css-18dfj8-StyledPanelHeader css-1t1cqk30"
+                    className="css-1lx593h"
                     justify="space-between"
                   >
-                    <Base
+                    <Component
                       align="center"
-                      className="css-1t1cqk30 css-mmen68"
+                      className="css-18dfj8-StyledPanelHeader css-1t1cqk30"
                       justify="space-between"
                     >
-                      <div
-                        className="css-1t1cqk30 css-mmen68"
-                        is={null}
+                      <Flex
+                        align="center"
+                        className="css-18dfj8-StyledPanelHeader css-1t1cqk30"
+                        justify="space-between"
                       >
-                        <TextColorLink
-                          to="1/"
+                        <Base
+                          align="center"
+                          className="css-1t1cqk30 css-mmen68"
+                          justify="space-between"
                         >
-                          <Link
-                            className="css-1763h46-TextColorLink css-3fp7tn0"
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to="1/"
+                          <div
+                            className="css-1t1cqk30 css-mmen68"
+                            is={null}
                           >
-                            <a
-                              className="css-1763h46-TextColorLink css-3fp7tn0"
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              My alert rule
-                               - 
-                              All Environments
-                            </a>
-                          </Link>
-                        </TextColorLink>
-                        <div>
-                          <Button
-                            disabled={false}
-                            size="small"
-                            style={
-                              Object {
-                                "marginRight": 5,
-                              }
-                            }
-                            to="1/"
-                          >
-                            <Link
-                              className="button button-default button-sm"
-                              disabled={false}
-                              onClick={[Function]}
-                              onlyActiveOnIndex={false}
-                              role="button"
-                              style={
-                                Object {
-                                  "marginRight": 5,
-                                }
-                              }
+                            <TextColorLink
                               to="1/"
                             >
-                              <a
-                                className="button button-default button-sm"
+                              <Link
+                                className="css-1763h46-TextColorLink css-ksblzz0"
+                                onlyActiveOnIndex={false}
+                                style={Object {}}
+                                to="1/"
+                              >
+                                <a
+                                  className="css-1763h46-TextColorLink css-ksblzz0"
+                                  onClick={[Function]}
+                                  style={Object {}}
+                                >
+                                  My alert rule
+                                   - 
+                                  All Environments
+                                </a>
+                              </Link>
+                            </TextColorLink>
+                            <div>
+                              <Button
                                 disabled={false}
-                                onClick={[Function]}
-                                role="button"
+                                size="small"
                                 style={
                                   Object {
                                     "marginRight": 5,
                                   }
                                 }
+                                to="1/"
                               >
-                                <Flex
-                                  align="center"
-                                  className="button-label"
-                                >
-                                  <Base
-                                    align="center"
-                                    className="button-label css-5ipae5"
-                                  >
-                                    <div
-                                      className="button-label css-5ipae5"
-                                      is={null}
-                                    >
-                                      Edit Rule
-                                    </div>
-                                  </Base>
-                                </Flex>
-                              </a>
-                            </Link>
-                          </Button>
-                          <Confirm
-                            cancelText="Cancel"
-                            confirmText="Confirm"
-                            message="Are you sure you want to remove this rule?"
-                            onConfirm={[Function]}
-                            priority="primary"
-                          >
-                            <Button
-                              disabled={false}
-                              onClick={[Function]}
-                              size="small"
-                            >
-                              <button
-                                className="button button-default button-sm"
-                                disabled={false}
-                                onClick={[Function]}
-                                role="button"
-                              >
-                                <Flex
-                                  align="center"
-                                  className="button-label"
-                                >
-                                  <Base
-                                    align="center"
-                                    className="button-label css-5ipae5"
-                                  >
-                                    <div
-                                      className="button-label css-5ipae5"
-                                      is={null}
-                                    >
-                                      <span
-                                        className="icon-trash"
-                                      />
-                                    </div>
-                                  </Base>
-                                </Flex>
-                              </button>
-                            </Button>
-                            <Modal
-                              animation={false}
-                              autoFocus={true}
-                              backdrop={true}
-                              bsClass="modal"
-                              dialogComponentClass={[Function]}
-                              enforceFocus={true}
-                              keyboard={true}
-                              manager={
-                                ModalManager {
-                                  "add": [Function],
-                                  "containers": Array [],
-                                  "data": Array [],
-                                  "handleContainerOverflow": true,
-                                  "hideSiblingNodes": true,
-                                  "isTopModal": [Function],
-                                  "modals": Array [],
-                                  "remove": [Function],
-                                }
-                              }
-                              onHide={[Function]}
-                              renderBackdrop={[Function]}
-                              restoreFocus={true}
-                              show={false}
-                            >
-                              <Modal
-                                autoFocus={true}
-                                backdrop={true}
-                                backdropClassName="modal-backdrop"
-                                containerClassName="modal-open"
-                                enforceFocus={true}
-                                keyboard={true}
-                                manager={
-                                  ModalManager {
-                                    "add": [Function],
-                                    "containers": Array [],
-                                    "data": Array [],
-                                    "handleContainerOverflow": true,
-                                    "hideSiblingNodes": true,
-                                    "isTopModal": [Function],
-                                    "modals": Array [],
-                                    "remove": [Function],
+                                <Link
+                                  className="button button-default button-sm"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  onlyActiveOnIndex={false}
+                                  role="button"
+                                  style={
+                                    Object {
+                                      "marginRight": 5,
+                                    }
                                   }
-                                }
-                                onEntering={[Function]}
-                                onExited={[Function]}
-                                onHide={[Function]}
-                                renderBackdrop={[Function]}
-                                restoreFocus={true}
-                                show={false}
-                              />
-                            </Modal>
-                          </Confirm>
-                        </div>
-                      </div>
-                    </Base>
-                  </Flex>
-                </Component>
-              </StyledPanelHeader>
-            </PanelHeader>
-            <PanelBody
-              direction="column"
-              disablePadding={true}
-              flex={false}
-            >
-              <div
-                className=""
-              >
-                <RuleDescriptionRow>
+                                  to="1/"
+                                >
+                                  <a
+                                    className="button button-default button-sm"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    role="button"
+                                    style={
+                                      Object {
+                                        "marginRight": 5,
+                                      }
+                                    }
+                                  >
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
+                                      <Base
+                                        align="center"
+                                        className="button-label css-5ipae5"
+                                      >
+                                        <div
+                                          className="button-label css-5ipae5"
+                                          is={null}
+                                        >
+                                          Edit Rule
+                                        </div>
+                                      </Base>
+                                    </Flex>
+                                  </a>
+                                </Link>
+                              </Button>
+                              <Confirm
+                                cancelText="Cancel"
+                                confirmText="Confirm"
+                                message="Are you sure you want to remove this rule?"
+                                onConfirm={[Function]}
+                                priority="primary"
+                              >
+                                <Button
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  size="small"
+                                >
+                                  <button
+                                    className="button button-default button-sm"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    role="button"
+                                  >
+                                    <Flex
+                                      align="center"
+                                      className="button-label"
+                                    >
+                                      <Base
+                                        align="center"
+                                        className="button-label css-5ipae5"
+                                      >
+                                        <div
+                                          className="button-label css-5ipae5"
+                                          is={null}
+                                        >
+                                          <span
+                                            className="icon-trash"
+                                          />
+                                        </div>
+                                      </Base>
+                                    </Flex>
+                                  </button>
+                                </Button>
+                                <Modal
+                                  animation={false}
+                                  autoFocus={true}
+                                  backdrop={true}
+                                  bsClass="modal"
+                                  dialogComponentClass={[Function]}
+                                  enforceFocus={true}
+                                  keyboard={true}
+                                  manager={
+                                    ModalManager {
+                                      "add": [Function],
+                                      "containers": Array [],
+                                      "data": Array [],
+                                      "handleContainerOverflow": true,
+                                      "hideSiblingNodes": true,
+                                      "isTopModal": [Function],
+                                      "modals": Array [],
+                                      "remove": [Function],
+                                    }
+                                  }
+                                  onHide={[Function]}
+                                  renderBackdrop={[Function]}
+                                  restoreFocus={true}
+                                  show={false}
+                                >
+                                  <Modal
+                                    autoFocus={true}
+                                    backdrop={true}
+                                    backdropClassName="modal-backdrop"
+                                    containerClassName="modal-open"
+                                    enforceFocus={true}
+                                    keyboard={true}
+                                    manager={
+                                      ModalManager {
+                                        "add": [Function],
+                                        "containers": Array [],
+                                        "data": Array [],
+                                        "handleContainerOverflow": true,
+                                        "hideSiblingNodes": true,
+                                        "isTopModal": [Function],
+                                        "modals": Array [],
+                                        "remove": [Function],
+                                      }
+                                    }
+                                    onEntering={[Function]}
+                                    onExited={[Function]}
+                                    onHide={[Function]}
+                                    renderBackdrop={[Function]}
+                                    restoreFocus={true}
+                                    show={false}
+                                  />
+                                </Modal>
+                              </Confirm>
+                            </div>
+                          </div>
+                        </Base>
+                      </Flex>
+                    </Component>
+                  </StyledPanelHeader>
+                </PanelHeader>
+                <PanelBody
+                  direction="column"
+                  disablePadding={true}
+                  flex={false}
+                >
                   <div
-                    className="css-16pvk6d-RuleDescriptionRow css-3fp7tn1"
+                    className=""
                   >
-                    <RuleDescriptionColumn>
+                    <RuleDescriptionRow>
                       <div
-                        className="css-ta36pl-RuleDescriptionColumn css-3fp7tn2"
+                        className="css-16pvk6d-RuleDescriptionRow css-ksblzz1"
                       >
-                        <Condition>
+                        <RuleDescriptionColumn>
                           <div
-                            className="css-1d9hhun-Condition css-3fp7tn3"
+                            className="css-ta36pl-RuleDescriptionColumn css-ksblzz2"
                           >
-                            <h6>
-                              When 
-                              <strong />
-                               of these conditions are met:
-                            </h6>
-                            <table
-                              className="conditions-list table"
-                            >
-                              <tbody>
-                                <tr
-                                  key="0"
+                            <Condition>
+                              <div
+                                className="css-1d9hhun-Condition css-ksblzz3"
+                              >
+                                <h6>
+                                  When 
+                                  <strong />
+                                   of these conditions are met:
+                                </h6>
+                                <table
+                                  className="conditions-list table"
                                 >
-                                  <td>
-                                    An alert is first seen
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
+                                  <tbody>
+                                    <tr
+                                      key="0"
+                                    >
+                                      <td>
+                                        An alert is first seen
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </Condition>
                           </div>
-                        </Condition>
-                      </div>
-                    </RuleDescriptionColumn>
-                    <RuleDescriptionColumn>
-                      <div
-                        className="css-ta36pl-RuleDescriptionColumn css-3fp7tn2"
-                      >
-                        <Condition>
+                        </RuleDescriptionColumn>
+                        <RuleDescriptionColumn>
                           <div
-                            className="css-1d9hhun-Condition css-3fp7tn3"
+                            className="css-ta36pl-RuleDescriptionColumn css-ksblzz2"
                           >
-                            <h6>
-                              Take these actions at most
-                               
-                              <strong>
-                                once every 
-                                <Duration
-                                  seconds={NaN}
+                            <Condition>
+                              <div
+                                className="css-1d9hhun-Condition css-ksblzz3"
+                              >
+                                <h6>
+                                  Take these actions at most
+                                   
+                                  <strong>
+                                    once every 
+                                    <Duration
+                                      seconds={NaN}
+                                    >
+                                      <span>
+                                        NaN ms
+                                      </span>
+                                    </Duration>
+                                  </strong>
+                                   
+                                  for an issue:
+                                </h6>
+                                <table
+                                  className="actions-list table"
                                 >
-                                  <span>
-                                    NaN ms
-                                  </span>
-                                </Duration>
-                              </strong>
-                               
-                              for an issue:
-                            </h6>
-                            <table
-                              className="actions-list table"
-                            >
-                              <tbody>
-                                <tr
-                                  key="0"
-                                >
-                                  <td>
-                                    Send a notification to all services
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
+                                  <tbody>
+                                    <tr
+                                      key="0"
+                                    >
+                                      <td>
+                                        Send a notification to all services
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </Condition>
                           </div>
-                        </Condition>
+                        </RuleDescriptionColumn>
                       </div>
-                    </RuleDescriptionColumn>
+                    </RuleDescriptionRow>
                   </div>
-                </RuleDescriptionRow>
+                </PanelBody>
               </div>
-            </PanelBody>
-          </div>
-        </StyledPanel>
-      </Panel>
-    </RuleRow>
-  </div>
+            </StyledPanel>
+          </Panel>
+        </RuleRow>
+      </div>
+    </DocumentTitle>
+  </SideEffect(DocumentTitle)>
 </ProjectAlertRules>
 `;

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -10,19 +10,46 @@ exports[`projectAlertRules renders 1`] = `
   }
   routes={Array []}
 >
-  <div>
-    <SettingsPageHeading
-      action={
-        <Button
-          disabled={false}
-          icon="icon-circle-add"
-          priority="primary"
-          size="small"
-          to="new/"
+  <SettingsPageHeading
+    action={
+      <Button
+        disabled={false}
+        icon="icon-circle-add"
+        priority="primary"
+        size="small"
+        to="new/"
+      >
+        New Alert Rule
+      </Button>
+    }
+    tabs={
+      <ul
+        className="nav nav-tabs"
+        style={
+          Object {
+            "borderBottom": "1px solid #ddd",
+          }
+        }
+      >
+        <ListLink
+          activeClassName="active"
+          index={false}
+          to="alerts"
         >
-          New Alert Rule
-        </Button>
-      }
+          Settings
+        </ListLink>
+        <ListLink
+          activeClassName="active"
+          index={false}
+          to=""
+        >
+          Rules
+        </ListLink>
+      </ul>
+    }
+    title="Alerts"
+  >
+    <Wrapper
       tabs={
         <ul
           className="nav nav-tabs"
@@ -34,8 +61,8 @@ exports[`projectAlertRules renders 1`] = `
         >
           <ListLink
             activeClassName="active"
-            index={true}
-            to="alerts/"
+            index={false}
+            to="alerts"
           >
             Settings
           </ListLink>
@@ -48,10 +75,120 @@ exports[`projectAlertRules renders 1`] = `
           </ListLink>
         </ul>
       }
-      title="Alerts"
     >
-      <Wrapper
-        tabs={
+      <div
+        className="css-foidy-Wrapper css-17jmgia0"
+      >
+        <Flex
+          align="center"
+        >
+          <Base
+            align="center"
+            className="css-5ipae5"
+          >
+            <div
+              className="css-5ipae5"
+              is={null}
+            >
+              <Title>
+                <div
+                  className="css-zmdcxu-Title css-17jmgia1"
+                >
+                  Alerts
+                </div>
+              </Title>
+              <div>
+                <Button
+                  disabled={false}
+                  icon="icon-circle-add"
+                  priority="primary"
+                  size="small"
+                  to="new/"
+                >
+                  <Link
+                    className="button button-primary button-sm"
+                    disabled={false}
+                    onClick={[Function]}
+                    onlyActiveOnIndex={false}
+                    role="button"
+                    style={Object {}}
+                    to="new/"
+                  >
+                    <a
+                      className="button button-primary button-sm"
+                      disabled={false}
+                      onClick={[Function]}
+                      role="button"
+                      style={Object {}}
+                    >
+                      <Flex
+                        align="center"
+                        className="button-label"
+                      >
+                        <Base
+                          align="center"
+                          className="button-label css-5ipae5"
+                        >
+                          <div
+                            className="button-label css-5ipae5"
+                            is={null}
+                          >
+                            <Icon
+                              size="small"
+                            >
+                              <Base
+                                className="css-11bwulm-Icon css-1vxxnb60"
+                                size="small"
+                              >
+                                <div
+                                  className="css-11bwulm-Icon css-1vxxnb60"
+                                  is={null}
+                                  size="small"
+                                >
+                                  <StyledInlineSvg
+                                    size="12px"
+                                    src="icon-circle-add"
+                                  >
+                                    <InlineSvg
+                                      className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
+                                      size="12px"
+                                      src="icon-circle-add"
+                                    >
+                                      <StyledSvg
+                                        className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
+                                        height="12px"
+                                        viewBox={Object {}}
+                                        width="12px"
+                                      >
+                                        <svg
+                                          className="css-1vxxnb61 css-1rlza0i-StyledSvg css-adkcw30"
+                                          height="12px"
+                                          viewBox={Object {}}
+                                          width="12px"
+                                        >
+                                          <use
+                                            href="#test"
+                                            xlinkHref="#test"
+                                          />
+                                        </svg>
+                                      </StyledSvg>
+                                    </InlineSvg>
+                                  </StyledInlineSvg>
+                                </div>
+                              </Base>
+                            </Icon>
+                            New Alert Rule
+                          </div>
+                        </Base>
+                      </Flex>
+                    </a>
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </Base>
+        </Flex>
+        <div>
           <ul
             className="nav nav-tabs"
             style={
@@ -62,283 +199,158 @@ exports[`projectAlertRules renders 1`] = `
           >
             <ListLink
               activeClassName="active"
-              index={true}
-              to="alerts/"
+              index={false}
+              to="alerts"
             >
-              Settings
+              <li
+                className=""
+              >
+                <Link
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to="alerts"
+                >
+                  <a
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    Settings
+                  </a>
+                </Link>
+              </li>
             </ListLink>
             <ListLink
               activeClassName="active"
               index={false}
               to=""
             >
-              Rules
+              <li
+                className=""
+              >
+                <Link
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to=""
+                >
+                  <a
+                    style={Object {}}
+                  >
+                    Rules
+                  </a>
+                </Link>
+              </li>
             </ListLink>
           </ul>
-        }
-      >
-        <div
-          className="css-foidy-Wrapper css-17jmgia0"
-        >
-          <Flex
-            align="center"
-          >
-            <Base
-              align="center"
-              className="css-5ipae5"
-            >
-              <div
-                className="css-5ipae5"
-                is={null}
-              >
-                <Title>
-                  <div
-                    className="css-zmdcxu-Title css-17jmgia1"
-                  >
-                    Alerts
-                  </div>
-                </Title>
-                <div>
-                  <Button
-                    disabled={false}
-                    icon="icon-circle-add"
-                    priority="primary"
-                    size="small"
-                    to="new/"
-                  >
-                    <Link
-                      className="button button-primary button-sm"
-                      disabled={false}
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      role="button"
-                      style={Object {}}
-                      to="new/"
-                    >
-                      <a
-                        className="button button-primary button-sm"
-                        disabled={false}
-                        onClick={[Function]}
-                        role="button"
-                        style={Object {}}
-                      >
-                        <Flex
-                          align="center"
-                          className="button-label"
-                        >
-                          <Base
-                            align="center"
-                            className="button-label css-5ipae5"
-                          >
-                            <div
-                              className="button-label css-5ipae5"
-                              is={null}
-                            >
-                              <Icon
-                                size="small"
-                              >
-                                <Base
-                                  className="css-11bwulm-Icon css-1vxxnb60"
-                                  size="small"
-                                >
-                                  <div
-                                    className="css-11bwulm-Icon css-1vxxnb60"
-                                    is={null}
-                                    size="small"
-                                  >
-                                    <StyledInlineSvg
-                                      size="12px"
-                                      src="icon-circle-add"
-                                    >
-                                      <InlineSvg
-                                        className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
-                                        size="12px"
-                                        src="icon-circle-add"
-                                      >
-                                        <StyledSvg
-                                          className="css-1ov3rcq-StyledInlineSvg css-1vxxnb61"
-                                          height="12px"
-                                          viewBox={Object {}}
-                                          width="12px"
-                                        >
-                                          <svg
-                                            className="css-1vxxnb61 css-1rlza0i-StyledSvg css-adkcw30"
-                                            height="12px"
-                                            viewBox={Object {}}
-                                            width="12px"
-                                          >
-                                            <use
-                                              href="#test"
-                                              xlinkHref="#test"
-                                            />
-                                          </svg>
-                                        </StyledSvg>
-                                      </InlineSvg>
-                                    </StyledInlineSvg>
-                                  </div>
-                                </Base>
-                              </Icon>
-                              New Alert Rule
-                            </div>
-                          </Base>
-                        </Flex>
-                      </a>
-                    </Link>
-                  </Button>
-                </div>
-              </div>
-            </Base>
-          </Flex>
-          <div>
-            <ul
-              className="nav nav-tabs"
-              style={
-                Object {
-                  "borderBottom": "1px solid #ddd",
-                }
-              }
-            >
-              <ListLink
-                activeClassName="active"
-                index={true}
-                to="alerts/"
-              >
-                <li
-                  className=""
-                >
-                  <Link
-                    onlyActiveOnIndex={true}
-                    style={Object {}}
-                    to="alerts/"
-                  >
-                    <a
-                      onClick={[Function]}
-                      style={Object {}}
-                    >
-                      Settings
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-              <ListLink
-                activeClassName="active"
-                index={false}
-                to=""
-              >
-                <li
-                  className=""
-                >
-                  <Link
-                    onlyActiveOnIndex={false}
-                    style={Object {}}
-                    to=""
-                  >
-                    <a
-                      style={Object {}}
-                    >
-                      Rules
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-            </ul>
-          </div>
         </div>
-      </Wrapper>
-    </SettingsPageHeading>
-    <div
-      className="rules-list"
+      </div>
+    </Wrapper>
+  </SettingsPageHeading>
+  <div
+    className="rules-list"
+  >
+    <RuleRow
+      data={
+        Object {
+          "actions": Array [
+            Object {
+              "id": "sentry.rules.actions.notify1",
+              "name": "Send a notification to all services",
+            },
+          ],
+          "conditions": Array [
+            Object {
+              "id": "sentry.rules.conditions.1",
+              "name": "An alert is first seen",
+            },
+          ],
+          "environment": "staging",
+          "id": "1",
+          "name": "My alert rule",
+        }
+      }
+      key="1"
+      onDelete={[Function]}
+      orgId="org1"
+      params={
+        Object {
+          "orgId": "org1",
+          "projectId": "project1",
+        }
+      }
+      projectId="project1"
+      routes={Array []}
     >
-      <RuleRow
-        data={
-          Object {
-            "actions": Array [
-              Object {
-                "id": "sentry.rules.actions.notify1",
-                "name": "Send a notification to all services",
-              },
-            ],
-            "conditions": Array [
-              Object {
-                "id": "sentry.rules.conditions.1",
-                "name": "An alert is first seen",
-              },
-            ],
-            "environment": "staging",
-            "id": "1",
-            "name": "My alert rule",
-          }
-        }
-        key="1"
-        onDelete={[Function]}
-        orgId="org1"
-        params={
-          Object {
-            "orgId": "org1",
-            "projectId": "project1",
-          }
-        }
-        projectId="project1"
-        routes={Array []}
-      >
-        <Panel>
-          <StyledPanel>
-            <div
-              className="css-wfa8ap-StyledPanel css-5bw71w0"
+      <Panel>
+        <StyledPanel>
+          <div
+            className="css-wfa8ap-StyledPanel css-5bw71w0"
+          >
+            <PanelHeader
+              align="center"
+              className="css-1lx593h"
+              justify="space-between"
             >
-              <PanelHeader
+              <StyledPanelHeader
                 align="center"
                 className="css-1lx593h"
                 justify="space-between"
               >
-                <StyledPanelHeader
+                <Component
                   align="center"
-                  className="css-1lx593h"
+                  className="css-18dfj8-StyledPanelHeader css-1t1cqk30"
                   justify="space-between"
                 >
-                  <Component
+                  <Flex
                     align="center"
                     className="css-18dfj8-StyledPanelHeader css-1t1cqk30"
                     justify="space-between"
                   >
-                    <Flex
+                    <Base
                       align="center"
-                      className="css-18dfj8-StyledPanelHeader css-1t1cqk30"
+                      className="css-1t1cqk30 css-mmen68"
                       justify="space-between"
                     >
-                      <Base
-                        align="center"
+                      <div
                         className="css-1t1cqk30 css-mmen68"
-                        justify="space-between"
+                        is={null}
                       >
-                        <div
-                          className="css-1t1cqk30 css-mmen68"
-                          is={null}
+                        <TextColorLink
+                          to="1/"
                         >
-                          <TextColorLink
+                          <Link
+                            className="css-1763h46-TextColorLink css-3fp7tn0"
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to="1/"
+                          >
+                            <a
+                              className="css-1763h46-TextColorLink css-3fp7tn0"
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              My alert rule
+                               - 
+                              All Environments
+                            </a>
+                          </Link>
+                        </TextColorLink>
+                        <div>
+                          <Button
+                            disabled={false}
+                            size="small"
+                            style={
+                              Object {
+                                "marginRight": 5,
+                              }
+                            }
                             to="1/"
                           >
                             <Link
-                              className="css-1763h46-TextColorLink css-fislzb0"
-                              onlyActiveOnIndex={false}
-                              style={Object {}}
-                              to="1/"
-                            >
-                              <a
-                                className="css-1763h46-TextColorLink css-fislzb0"
-                                onClick={[Function]}
-                                style={Object {}}
-                              >
-                                My alert rule
-                                 - 
-                                All Environments
-                              </a>
-                            </Link>
-                          </TextColorLink>
-                          <div>
-                            <Button
+                              className="button button-default button-sm"
                               disabled={false}
-                              size="small"
+                              onClick={[Function]}
+                              onlyActiveOnIndex={false}
+                              role="button"
                               style={
                                 Object {
                                   "marginRight": 5,
@@ -346,93 +358,104 @@ exports[`projectAlertRules renders 1`] = `
                               }
                               to="1/"
                             >
-                              <Link
+                              <a
                                 className="button button-default button-sm"
                                 disabled={false}
                                 onClick={[Function]}
-                                onlyActiveOnIndex={false}
                                 role="button"
                                 style={
                                   Object {
                                     "marginRight": 5,
                                   }
                                 }
-                                to="1/"
                               >
-                                <a
-                                  className="button button-default button-sm"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  role="button"
-                                  style={
-                                    Object {
-                                      "marginRight": 5,
-                                    }
-                                  }
+                                <Flex
+                                  align="center"
+                                  className="button-label"
                                 >
-                                  <Flex
+                                  <Base
                                     align="center"
-                                    className="button-label"
+                                    className="button-label css-5ipae5"
                                   >
-                                    <Base
-                                      align="center"
+                                    <div
                                       className="button-label css-5ipae5"
+                                      is={null}
                                     >
-                                      <div
-                                        className="button-label css-5ipae5"
-                                        is={null}
-                                      >
-                                        Edit Rule
-                                      </div>
-                                    </Base>
-                                  </Flex>
-                                </a>
-                              </Link>
-                            </Button>
-                            <Confirm
-                              cancelText="Cancel"
-                              confirmText="Confirm"
-                              message="Are you sure you want to remove this rule?"
-                              onConfirm={[Function]}
-                              priority="primary"
+                                      Edit Rule
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </a>
+                            </Link>
+                          </Button>
+                          <Confirm
+                            cancelText="Cancel"
+                            confirmText="Confirm"
+                            message="Are you sure you want to remove this rule?"
+                            onConfirm={[Function]}
+                            priority="primary"
+                          >
+                            <Button
+                              disabled={false}
+                              onClick={[Function]}
+                              size="small"
                             >
-                              <Button
+                              <button
+                                className="button button-default button-sm"
                                 disabled={false}
                                 onClick={[Function]}
-                                size="small"
+                                role="button"
                               >
-                                <button
-                                  className="button button-default button-sm"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  role="button"
+                                <Flex
+                                  align="center"
+                                  className="button-label"
                                 >
-                                  <Flex
+                                  <Base
                                     align="center"
-                                    className="button-label"
+                                    className="button-label css-5ipae5"
                                   >
-                                    <Base
-                                      align="center"
+                                    <div
                                       className="button-label css-5ipae5"
+                                      is={null}
                                     >
-                                      <div
-                                        className="button-label css-5ipae5"
-                                        is={null}
-                                      >
-                                        <span
-                                          className="icon-trash"
-                                        />
-                                      </div>
-                                    </Base>
-                                  </Flex>
-                                </button>
-                              </Button>
+                                      <span
+                                        className="icon-trash"
+                                      />
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </button>
+                            </Button>
+                            <Modal
+                              animation={false}
+                              autoFocus={true}
+                              backdrop={true}
+                              bsClass="modal"
+                              dialogComponentClass={[Function]}
+                              enforceFocus={true}
+                              keyboard={true}
+                              manager={
+                                ModalManager {
+                                  "add": [Function],
+                                  "containers": Array [],
+                                  "data": Array [],
+                                  "handleContainerOverflow": true,
+                                  "hideSiblingNodes": true,
+                                  "isTopModal": [Function],
+                                  "modals": Array [],
+                                  "remove": [Function],
+                                }
+                              }
+                              onHide={[Function]}
+                              renderBackdrop={[Function]}
+                              restoreFocus={true}
+                              show={false}
+                            >
                               <Modal
-                                animation={false}
                                 autoFocus={true}
                                 backdrop={true}
-                                bsClass="modal"
-                                dialogComponentClass={[Function]}
+                                backdropClassName="modal-backdrop"
+                                containerClassName="modal-open"
                                 enforceFocus={true}
                                 keyboard={true}
                                 manager={
@@ -447,138 +470,113 @@ exports[`projectAlertRules renders 1`] = `
                                     "remove": [Function],
                                   }
                                 }
+                                onEntering={[Function]}
+                                onExited={[Function]}
                                 onHide={[Function]}
                                 renderBackdrop={[Function]}
                                 restoreFocus={true}
                                 show={false}
-                              >
-                                <Modal
-                                  autoFocus={true}
-                                  backdrop={true}
-                                  backdropClassName="modal-backdrop"
-                                  containerClassName="modal-open"
-                                  enforceFocus={true}
-                                  keyboard={true}
-                                  manager={
-                                    ModalManager {
-                                      "add": [Function],
-                                      "containers": Array [],
-                                      "data": Array [],
-                                      "handleContainerOverflow": true,
-                                      "hideSiblingNodes": true,
-                                      "isTopModal": [Function],
-                                      "modals": Array [],
-                                      "remove": [Function],
-                                    }
-                                  }
-                                  onEntering={[Function]}
-                                  onExited={[Function]}
-                                  onHide={[Function]}
-                                  renderBackdrop={[Function]}
-                                  restoreFocus={true}
-                                  show={false}
-                                />
-                              </Modal>
-                            </Confirm>
-                          </div>
+                              />
+                            </Modal>
+                          </Confirm>
                         </div>
-                      </Base>
-                    </Flex>
-                  </Component>
-                </StyledPanelHeader>
-              </PanelHeader>
-              <PanelBody
-                direction="column"
-                disablePadding={true}
-                flex={false}
+                      </div>
+                    </Base>
+                  </Flex>
+                </Component>
+              </StyledPanelHeader>
+            </PanelHeader>
+            <PanelBody
+              direction="column"
+              disablePadding={true}
+              flex={false}
+            >
+              <div
+                className=""
               >
-                <div
-                  className=""
-                >
-                  <RuleDescriptionRow>
-                    <div
-                      className="css-16pvk6d-RuleDescriptionRow css-fislzb1"
-                    >
-                      <RuleDescriptionColumn>
-                        <div
-                          className="css-ta36pl-RuleDescriptionColumn css-fislzb2"
-                        >
-                          <Condition>
-                            <div
-                              className="css-1d9hhun-Condition css-fislzb3"
+                <RuleDescriptionRow>
+                  <div
+                    className="css-16pvk6d-RuleDescriptionRow css-3fp7tn1"
+                  >
+                    <RuleDescriptionColumn>
+                      <div
+                        className="css-ta36pl-RuleDescriptionColumn css-3fp7tn2"
+                      >
+                        <Condition>
+                          <div
+                            className="css-1d9hhun-Condition css-3fp7tn3"
+                          >
+                            <h6>
+                              When 
+                              <strong />
+                               of these conditions are met:
+                            </h6>
+                            <table
+                              className="conditions-list table"
                             >
-                              <h6>
-                                When 
-                                <strong />
-                                 of these conditions are met:
-                              </h6>
-                              <table
-                                className="conditions-list table"
-                              >
-                                <tbody>
-                                  <tr
-                                    key="0"
-                                  >
-                                    <td>
-                                      An alert is first seen
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </Condition>
-                        </div>
-                      </RuleDescriptionColumn>
-                      <RuleDescriptionColumn>
-                        <div
-                          className="css-ta36pl-RuleDescriptionColumn css-fislzb2"
-                        >
-                          <Condition>
-                            <div
-                              className="css-1d9hhun-Condition css-fislzb3"
+                              <tbody>
+                                <tr
+                                  key="0"
+                                >
+                                  <td>
+                                    An alert is first seen
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </Condition>
+                      </div>
+                    </RuleDescriptionColumn>
+                    <RuleDescriptionColumn>
+                      <div
+                        className="css-ta36pl-RuleDescriptionColumn css-3fp7tn2"
+                      >
+                        <Condition>
+                          <div
+                            className="css-1d9hhun-Condition css-3fp7tn3"
+                          >
+                            <h6>
+                              Take these actions at most
+                               
+                              <strong>
+                                once every 
+                                <Duration
+                                  seconds={NaN}
+                                >
+                                  <span>
+                                    NaN ms
+                                  </span>
+                                </Duration>
+                              </strong>
+                               
+                              for an issue:
+                            </h6>
+                            <table
+                              className="actions-list table"
                             >
-                              <h6>
-                                Take these actions at most
-                                 
-                                <strong>
-                                  once every 
-                                  <Duration
-                                    seconds={NaN}
-                                  >
-                                    <span>
-                                      NaN ms
-                                    </span>
-                                  </Duration>
-                                </strong>
-                                 
-                                for an issue:
-                              </h6>
-                              <table
-                                className="actions-list table"
-                              >
-                                <tbody>
-                                  <tr
-                                    key="0"
-                                  >
-                                    <td>
-                                      Send a notification to all services
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </Condition>
-                        </div>
-                      </RuleDescriptionColumn>
-                    </div>
-                  </RuleDescriptionRow>
-                </div>
-              </PanelBody>
-            </div>
-          </StyledPanel>
-        </Panel>
-      </RuleRow>
-    </div>
+                              <tbody>
+                                <tr
+                                  key="0"
+                                >
+                                  <td>
+                                    Send a notification to all services
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </Condition>
+                      </div>
+                    </RuleDescriptionColumn>
+                  </div>
+                </RuleDescriptionRow>
+              </div>
+            </PanelBody>
+          </div>
+        </StyledPanel>
+      </Panel>
+    </RuleRow>
   </div>
 </ProjectAlertRules>
 `;

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -4,7 +4,7 @@ exports[`ProjectAlertSettings render() renders 1`] = `
 <SideEffect(DocumentTitle)
   title="Project Alert Settings - Sentry"
 >
-  <div>
+  <React.Fragment>
     <SettingsPageHeading
       action={
         <Button
@@ -185,6 +185,6 @@ exports[`ProjectAlertSettings render() renders 1`] = `
         }
       }
     />
-  </div>
+  </React.Fragment>
 </SideEffect(DocumentTitle)>
 `;

--- a/tests/js/spec/views/projectAlertRuleDetails.spec.jsx
+++ b/tests/js/spec/views/projectAlertRuleDetails.spec.jsx
@@ -6,9 +6,45 @@ import ProjectAlertRuleDetails from 'app/views/settings/projectAlerts/projectAle
 import EnvironmentStore from 'app/stores/environmentStore';
 
 jest.mock('jquery');
-jest.mock('app/utils/recreateRoute');
 
 describe('ProjectAlertRuleDetails', function() {
+  let projectAlertRuleDetailsRoutes = [
+    {
+      path: '/',
+    },
+    {
+      newnew: true,
+      path: '/settings/',
+      name: 'Settings',
+      indexRoute: {},
+    },
+    {
+      name: 'Organization',
+      path: ':orgId/',
+    },
+    {
+      name: 'Project',
+      path: ':projectId/',
+    },
+    {},
+    {
+      indexRoute: {name: 'General'},
+    },
+    {
+      name: 'Alerts',
+      path: 'alerts/',
+      indexRoute: {},
+    },
+    {
+      path: 'rules/',
+      name: 'Rules',
+      component: null,
+      indexRoute: {},
+      childRoutes: [{path: 'new/', name: 'New'}, {path: ':ruleId/', name: 'Edit'}],
+    },
+    {path: ':ruleId/', name: 'Edit'},
+  ];
+
   beforeEach(function() {
     browserHistory.replace = jest.fn();
     MockApiClient.addMockResponse({
@@ -39,6 +75,7 @@ describe('ProjectAlertRuleDetails', function() {
 
       wrapper = mount(
         <ProjectAlertRuleDetails
+          routes={projectAlertRuleDetailsRoutes}
           params={{orgId: 'org-slug', projectId: 'project-slug'}}
         />,
         {
@@ -79,7 +116,7 @@ describe('ProjectAlertRuleDetails', function() {
       });
 
       it('updates URL', function() {
-        let url = '/org-slug/project-slug/settings/alerts/rules/1/';
+        let url = '/settings/org-slug/project-slug/alerts/rules/1/';
         expect(browserHistory.replace).toHaveBeenCalledWith(url);
       });
     });
@@ -97,6 +134,7 @@ describe('ProjectAlertRuleDetails', function() {
 
       wrapper = mount(
         <ProjectAlertRuleDetails
+          routes={projectAlertRuleDetailsRoutes}
           params={{orgId: 'org-slug', projectId: 'project-slug', ruleId: '1'}}
         />,
         {

--- a/tests/js/spec/views/projectAlertRuleDetails.spec.jsx
+++ b/tests/js/spec/views/projectAlertRuleDetails.spec.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import {mount} from 'enzyme';
 import {browserHistory} from 'react-router';
 
-import ProjectAlertRuleDetails from 'app/views/projectAlertRuleDetails';
+import ProjectAlertRuleDetails from 'app/views/settings/projectAlerts/projectAlertRuleDetails';
 import EnvironmentStore from 'app/stores/environmentStore';
 
 jest.mock('jquery');
+jest.mock('app/utils/recreateRoute');
 
 describe('ProjectAlertRuleDetails', function() {
   beforeEach(function() {

--- a/tests/js/spec/views/projectAlertRules.spec.jsx
+++ b/tests/js/spec/views/projectAlertRules.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import ProjectAlertRules from 'app/views/projectAlertRules';
+import ProjectAlertRules from 'app/views/settings/projectAlerts/projectAlertRules';
 
 describe('projectAlertRules', function() {
   let deleteMock;

--- a/tests/js/spec/views/projectAlertSettings.spec.jsx
+++ b/tests/js/spec/views/projectAlertSettings.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {Client} from 'app/api';
-import ProjectAlertSettings from 'app/views/projectAlertSettings';
+import ProjectAlertSettings from 'app/views/settings/projectAlerts/projectAlertSettings';
 
 describe('ProjectAlertSettings', function() {
   let org;


### PR DESCRIPTION
* Move related components into "views/settings/projectAlerts" dir

* Add routes hierarchy so it reflects in breadcrumbs
![image](https://user-images.githubusercontent.com/79684/38585871-5085d3be-3cd0-11e8-9e78-f234eba29be2.png)

* RuleEditor: Add "Cancel" button + align to right
![image](https://user-images.githubusercontent.com/79684/38585858-47143ca8-3cd0-11e8-9ab9-940ba5345fc3.png)

* Change "ProjectAlertRules" to use `AsyncView` - otherwise there is stale data when switching using project breadcrumb (rules don't get refetched)
* Fix crumb to not keep "Edit Rule" view when switching projects