### PR TITLE
ref(slack): Encapsulate Slack request logic outside endpoints

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import
 
 from sentry import analytics
-from sentry import http, options
+from sentry import http
 from sentry.api import client
 from sentry.api.base import Endpoint
-from sentry.models import Group, Integration, Project, Identity, IdentityProvider, ApiKey
+from sentry.models import Group, Project, Identity, IdentityProvider, ApiKey
 from sentry.utils import json
 
 from .link_identity import build_linking_url
+from .requests import SlackActionRequest, SlackRequestError
 from .utils import build_attachment, logger
 
 LINK_IDENTITY_MESSAGE = "Looks like you haven't linked your Sentry account with your Slack identity yet! <{associate_url}|Link your identity now> to perform actions in Sentry through Slack."
@@ -151,53 +152,21 @@ class SlackActionEndpoint(Endpoint):
         logging_data = {}
 
         try:
-            data = request.DATA
-        except (ValueError, TypeError):
-            logger.error('slack.action.invalid-json', extra=logging_data, exc_info=True)
-            return self.respond(status=400)
+            slack_request = SlackActionRequest(request)
+            slack_request.validate()
+        except SlackRequestError as e:
+            return self.respond(status=e.status)
 
-        try:
-            data = json.loads(data['payload'])
-        except (KeyError, IndexError, TypeError, ValueError):
-            logger.error('slack.action.invalid-payload', extra=logging_data, exc_info=True)
-            return self.respond(status=400)
+        data = slack_request.data
 
-        event_id = data.get('event_id')
-        team_id = data.get('team', {}).get('id')
         channel_id = data.get('channel', {}).get('id')
         user_id = data.get('user', {}).get('id')
-        callback_id = data.get('callback_id')
 
-        logging_data.update({
-            'slack_team_id': team_id,
-            'slack_channel_id': channel_id,
-            'slack_user_id': user_id,
-            'slack_event_id': event_id,
-            'slack_callback_id': callback_id,
-        })
-
-        token = data.get('token')
-        if token != options.get('slack.verification-token'):
-            logger.error('slack.action.invalid-token', extra=logging_data)
-            return self.respond(status=401)
-
-        logger.info('slack.action', extra=logging_data)
-
-        try:
-            integration = Integration.objects.get(
-                provider='slack',
-                external_id=team_id,
-            )
-        except Integration.DoesNotExist:
-            logger.error('slack.action.invalid-team-id', extra=logging_data)
-            return self.respond(status=403)
-
+        integration = slack_request.integration
         logging_data['integration_id'] = integration.id
 
-        callback_data = json.loads(callback_id)
-
         # Determine the issue group action is being taken on
-        group_id = callback_data['issue']
+        group_id = slack_request.callback_data['issue']
 
         # Actions list may be empty when receiving a dialog response
         action_list = data.get('actions', [])
@@ -217,7 +186,7 @@ class SlackActionEndpoint(Endpoint):
         try:
             idp = IdentityProvider.objects.get(
                 type='slack',
-                external_id=team_id,
+                external_id=slack_request.team_id,
             )
         except IdentityProvider.DoesNotExist:
             logger.error('slack.action.invalid-team-id', extra=logging_data)
@@ -241,7 +210,7 @@ class SlackActionEndpoint(Endpoint):
             })
 
         # Handle status dialog submission
-        if data['type'] == 'dialog_submission' and 'resolve_type' in data['submission']:
+        if slack_request.type == 'dialog_submission' and 'resolve_type' in data['submission']:
             # Masquerade a status action
             action = {
                 'name': 'status',
@@ -256,11 +225,17 @@ class SlackActionEndpoint(Endpoint):
             group = Group.objects.get(id=group.id)
             attachment = build_attachment(group, identity=identity, actions=[action])
 
-            body = self.construct_reply(attachment, is_message=callback_data['is_message'])
+            body = self.construct_reply(
+                attachment,
+                is_message=slack_request.callback_data['is_message']
+            )
 
             # use the original response_url to update the link attachment
             session = http.build_session()
-            req = session.post(callback_data['orig_response_url'], json=body)
+            req = session.post(
+                slack_request.callback_data['orig_response_url'],
+                json=body,
+            )
             resp = req.json()
             if not resp.get('ok'):
                 logger.error('slack.action.response-error', extra={'response': resp})

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -4,11 +4,12 @@ import json
 import re
 import six
 
-from sentry import http, options
+from sentry import http
 from sentry.api.base import Endpoint
-from sentry.models import Group, Integration, Project
+from sentry.models import Group, Project
 
 from .utils import build_attachment, logger
+from .requests import SlackEventRequest, SlackRequestError
 
 # XXX(dcramer): this could be more tightly bound to our configured domain,
 # but slack limits what we can unfurl anyways so its probably safe
@@ -83,61 +84,21 @@ class SlackEventEndpoint(Endpoint):
 
     # TODO(dcramer): implement app_uninstalled and tokens_revoked
     def post(self, request):
-        logging_data = {}
-
         try:
-            data = request.DATA
-        except (ValueError, TypeError):
-            logger.error('slack.event.invalid-json', extra=logging_data)
-            return self.respond(status=400)
+            slack_request = SlackEventRequest(request)
+            slack_request.validate()
+        except SlackRequestError as e:
+            return self.respond(status=e.status)
 
-        event_id = data.get('event_id')
-        team_id = data.get('team_id')
-        api_app_id = data.get('api_app_id')
-        # TODO(dcramer): should we verify this here?
-        # authed_users = data.get('authed_users')
+        if slack_request.is_challenge():
+            return self.on_url_verification(request, slack_request.data)
 
-        logging_data.update({
-            'slack_team_id': team_id,
-            'slack_api_app_id': api_app_id,
-            'slack_event_id': event_id,
-        })
-
-        token = data.get('token')
-        if token != options.get('slack.verification-token'):
-            logger.error('slack.event.invalid-token', extra=logging_data)
-            return self.respond(status=400)
-        payload_type = data.get('type')
-        logger.info('slack.event.{}'.format(payload_type), extra=logging_data)
-        if payload_type == 'url_verification':
-            return self.on_url_verification(request, data)
-
-        try:
-            integration = Integration.objects.get(
-                provider='slack',
-                external_id=team_id,
+        if slack_request.type == 'link_shared':
+            return self.on_link_shared(
+                request,
+                slack_request.integration,
+                slack_request.data.get('token'),
+                slack_request.data.get('event'),
             )
-        except Integration.DoesNotExist:
-            logger.error('slack.event.unknown-team-id', extra=logging_data)
-            return self.respond(status=400)
 
-        logging_data['integration_id'] = integration.id
-
-        event_data = data.get('event')
-        if not event_data:
-            logger.error('slack.event.invalid-event-data', extra=logging_data)
-            return self.respond(status=400)
-
-        event_type = event_data.get('type')
-        if not event_data:
-            logger.error('slack.event.invalid-event-type', extra=logging_data)
-            return self.respond(status=400)
-
-        logging_data['slack_event_type'] = event_type
-        if event_type == 'link_shared':
-            resp = self.on_link_shared(request, integration, token, event_data)
-        else:
-            resp = None
-        if resp:
-            return resp
         return self.respond()

--- a/src/sentry/integrations/slack/requests.py
+++ b/src/sentry/integrations/slack/requests.py
@@ -1,0 +1,214 @@
+from __future__ import absolute_import
+
+from sentry import options
+from sentry.models import Integration
+from sentry.utils import json
+from sentry.utils.cache import memoize
+
+from .utils import logger
+
+
+class SlackRequestError(Exception):
+    """
+    Something was invalid about the request from Slack.
+
+    Includes the status the endpoint should return, based on the error.
+    """
+
+    def __init__(self, status):
+        self.status = status
+
+
+class SlackRequest(object):
+    """
+    Encapsulation of a request from Slack.
+
+    Action and Event requests share much of the same validation needs and data
+    access characteristics.
+
+    Raises ``SlackRequestError`` if the request in invalid in some way (the
+    payload missing, it not being JSON, etc.) ``SlackRequestError`` will also
+    have the appropriate response code the endpoint should respond with, for
+    the error that was raised.
+    """
+
+    def __init__(self, request):
+        self.request = request
+        self.integration = None
+        self._data = {}
+        self._log_request()
+
+    def validate(self):
+        """
+        Ensure everything is present to properly process this request
+        """
+        self._authorize()
+        self._validate_data()
+        self._validate_integration()
+
+    def is_challenge(self):
+        return False
+
+    @property
+    def type(self):
+        # Found in different places, so this is implemented in each request's
+        # specific object (``SlackEventRequest`` and ``SlackActionRequest``).
+        raise NotImplementedError
+
+    @property
+    def team_id(self):
+        """
+        Provide a normalized interface to ``team_id``, which Action and Event
+        requests provide in different places.
+        """
+        return self.data.get('team_id') or self.data.get('team', {}).get('id')
+
+    @property
+    def data(self):
+        if not self._data:
+            self._validate_data()
+        return self._data
+
+    @property
+    def logging_data(self):
+        data = {
+            'slack_team_id': self.team_id,
+            'slack_channel_id': self.data.get('channel', {}).get('id'),
+            'slack_user_id': self.data.get('user', {}).get('id'),
+            'slack_event_id': self.data.get('event_id'),
+            'slack_callback_id': self.data.get('callback_id'),
+            'slack_api_app_id': self.data.get('api_app_id'),
+        }
+
+        if self.integration:
+            data['integration_id'] = self.integration.id
+
+        return dict((k, v) for k, v in data.items() if v)
+
+    def _validate_data(self):
+        try:
+            self._data = self.request.DATA
+        except (ValueError, TypeError):
+            raise SlackRequestError(status=400)
+
+    def _authorize(self):
+        if self.data.get('token') != options.get('slack.verification-token'):
+            self._error('slack.action.invalid-token')
+            raise SlackRequestError(status=401)
+
+    def _validate_integration(self):
+        try:
+            self.integration = Integration.objects.get(
+                provider='slack',
+                external_id=self.team_id,
+            )
+        except Integration.DoesNotExist:
+            self._error('slack.action.invalid-team-id')
+            raise SlackRequestError(status=403)
+
+    def _log_request(self):
+        self._info('slack.request')
+
+    def _error(self, key):
+        logger.error(key, extra=self.logging_data)
+
+    def _info(self, key):
+        logger.info(key, extra=self.logging_data)
+
+
+class SlackEventRequest(SlackRequest):
+    """
+    An Event request sent from Slack.
+
+    These requests require the same Data and Token validation as all other
+    requests from Slack, but also event data validation.
+
+    Challenge Requests
+    ------------------
+    Slack Event requests first start with a "challenge request". This is just a
+    request Sentry needs to verifying using it's shared key.
+
+    Challenge requests will have a ``type`` of ``url_verification``.
+    """
+
+    def validate(self):
+        if self.is_challenge():
+            # Challenge requests only include the Token and data to verify the
+            # request, so only validate those.
+            self._authorize()
+            self._validate_data()
+        else:
+            # Non-Challenge requests need to validate everything plus the data
+            # about the event.
+            super(SlackEventRequest, self).validate()
+            self._validate_event()
+
+    def is_challenge(self):
+        return self.data.get('type') == 'url_verification'
+
+    @property
+    def type(self):
+        return self.data.get('event', {}).get('type')
+
+    def _validate_event(self):
+        if not self.data.get('event'):
+            self._error('slack.event.invalid-event-data')
+            raise SlackRequestError(status=400)
+
+        if not self.data.get('event', {}).get('type'):
+            self._error('slack.event.invalid-event-type')
+            raise SlackRequestError(status=400)
+
+    def _log_request(self):
+        self._info('slack.event.{}'.format(self.type))
+
+
+class SlackActionRequest(SlackRequest):
+    """
+    An Action request sent from Slack.
+
+    Action requests nest their data inside of a ``payload`` key in the request
+    body, for some reason. Therefor they require an extra bit of data
+    validation.
+    """
+
+    def __init__(self, request):
+        super(SlackActionRequest, self).__init__(request)
+        self._callback_data = None
+
+    @property
+    def type(self):
+        return self.data.get('type')
+
+    @memoize
+    def callback_data(self):
+        """
+        We store certain data in ``callback_id`` as JSON. It's a bit hacky, but
+        it's the simplest way to store state without saving it on the Sentry
+        side.
+
+        Data included in this field:
+            - issue: the ID of the corresponding Issue
+            - orig_response_url: URL from the original message we received
+            - is_message: did the original message have a 'message' type
+        """
+        return json.loads(self.data.get('callback_id'))
+
+    def _validate_data(self):
+        """
+        Action requests provide the body of the request differently than Event
+        requests (nested in a ``payload`` attribute), so there's extra
+        validation needed.
+        """
+        super(SlackActionRequest, self)._validate_data()
+
+        if 'payload' not in self.request.DATA:
+            raise SlackRequestError(status=400)
+
+        try:
+            self._data = json.loads(self.data['payload'])
+        except (KeyError, IndexError, TypeError, ValueError):
+            raise SlackRequestError(status=400)
+
+    def _log_request(self):
+        self._info('slack.action')

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -14,6 +14,7 @@ LINK_SHARED_EVENT = """{
     "channel": "Cxxxxxx",
     "user": "Uxxxxxxx",
     "message_ts": "123456789.9875",
+    "team_id": "TXXXXXXX1",
     "links": [
         {
             "domain": "example.com",
@@ -104,7 +105,7 @@ class UrlVerificationEventTest(BaseEventTest):
                 'token': 'fizzbuzz',
             }
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 401, resp.content
 
 
 class LinkSharedEventTest(BaseEventTest):

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -1,0 +1,180 @@
+from __future__ import absolute_import
+
+import json
+import mock
+
+from sentry import options
+from sentry.utils.cache import memoize
+from sentry.testutils import TestCase
+from sentry.integrations.slack.requests import (
+    SlackRequest,
+    SlackEventRequest,
+    SlackActionRequest,
+    SlackRequestError,
+)
+
+
+class SlackRequestTest(TestCase):
+    def setUp(self):
+        super(SlackRequestTest, self).setUp()
+
+        self.request = mock.Mock()
+        self.request.DATA = {
+            'type': 'foo',
+            'team_id': 'T001',
+            'channel': {'id': '1'},
+            'user': {'id': '2'},
+            'api_app_id': 'S1',
+        }
+
+    @memoize
+    def slack_request(self):
+        return SlackRequest(self.request)
+
+    def test_exposes_data(self):
+        assert self.slack_request.data['type'] == 'foo'
+
+    def test_exposes_team_id(self):
+        assert self.slack_request.team_id == 'T001'
+
+    def test_collects_logging_data(self):
+        assert self.slack_request.logging_data == {
+            'slack_team_id': 'T001',
+            'slack_channel_id': '1',
+            'slack_user_id': '2',
+            'slack_api_app_id': 'S1',
+        }
+
+    def test_disregards_None_logging_values(self):
+        self.request.DATA['api_app_id'] = None
+
+        assert self.slack_request.logging_data == {
+            'slack_team_id': 'T001',
+            'slack_channel_id': '1',
+            'slack_user_id': '2',
+        }
+
+    def test_validate_existence_of_data(self):
+        type(self.request).DATA = mock.PropertyMock(side_effect=ValueError())
+
+        with self.assertRaises(SlackRequestError):
+            self.slack_request.validate()
+
+    def test_returns_400_on_invalid_data(self):
+        type(self.request).DATA = mock.PropertyMock(side_effect=ValueError())
+
+        with self.assertRaises(SlackRequestError) as e:
+            self.slack_request.validate()
+            assert e.status == 400
+
+    def test_validates_token(self):
+        self.request.DATA['token'] = 'notthetoken'
+
+        with self.assertRaises(SlackRequestError):
+            self.slack_request.validate()
+
+    def test_returns_401_on_invalid_token(self):
+        self.request.DATA['token'] = 'notthetoken'
+
+        with self.assertRaises(SlackRequestError) as e:
+            self.slack_request.validate()
+            assert e.status == 401
+
+    def test_validates_existence_of_integration(self):
+        with self.assertRaises(SlackRequestError) as e:
+            self.slack_request.validate()
+            assert e.status == 403
+
+
+class SlackEventRequestTest(TestCase):
+    def setUp(self):
+        super(SlackEventRequestTest, self).setUp()
+
+        self.request = mock.Mock()
+        self.request.DATA = {
+            'type': 'foo',
+            'team_id': 'T001',
+            'event_id': 'E1',
+            'event': {'type': 'bar'},
+            'channel': {'id': '1'},
+            'user': {'id': '2'},
+            'api_app_id': 'S1',
+        }
+
+    @memoize
+    def slack_request(self):
+        return SlackEventRequest(self.request)
+
+    def test_ignores_event_validation_on_challenge_request(self):
+        self.request.DATA = {
+            'token': options.get('slack.verification-token'),
+            'challenge': 'abc123',
+            'type': 'url_verification',
+        }
+
+        # It would raise if it didn't skip event validation and didn't find
+        # the `event` key.
+        self.slack_request.validate()
+
+    def test_is_challenge(self):
+        self.request.DATA = {
+            'token': options.get('slack.verification-token'),
+            'challenge': 'abc123',
+            'type': 'url_verification',
+        }
+
+        assert self.slack_request.is_challenge()
+
+    def test_validate_missing_event(self):
+        self.request.DATA.pop('event')
+
+        with self.assertRaises(SlackRequestError):
+            self.slack_request.validate()
+
+    def test_validate_missing_event_type(self):
+        self.request.DATA['event'] = {}
+
+        with self.assertRaises(SlackRequestError):
+            self.slack_request.validate()
+
+    def test_type(self):
+        assert self.slack_request.type == 'bar'
+
+
+class SlackActionRequestTest(TestCase):
+    def setUp(self):
+        super(SlackActionRequestTest, self).setUp()
+
+        self.request = mock.Mock()
+        self.request.DATA = {
+            'payload': json.dumps({
+                'type': 'foo',
+                'team': {'id': 'T001'},
+                'channel': {'id': '1'},
+                'user': {'id': '2'},
+                'token': options.get('slack.verification-token'),
+                'callback_id': '{"issue":"I1"}',
+            })
+        }
+
+    @memoize
+    def slack_request(self):
+        return SlackActionRequest(self.request)
+
+    def test_type(self):
+        assert self.slack_request.type == 'foo'
+
+    def test_callback_data(self):
+        assert self.slack_request.callback_data == {'issue': 'I1'}
+
+    def test_validates_existence_of_payload(self):
+        self.request.DATA.pop('payload')
+
+        with self.assertRaises(SlackRequestError):
+            self.slack_request.validate()
+
+    def test_validates_payload_json(self):
+        self.request.DATA['payload'] = 'notjson'
+
+        with self.assertRaises(SlackRequestError):
+            self.slack_request.validate()


### PR DESCRIPTION
There's a bunch of shared logic between the Slack Event and Action endpoints. Particularly validating the request to ensure we have everything needed to respond.

This pulls out a lot of that logic, along with some data access, into separate objects to clean up the endpoint code a bit.