### PR TITLE
feat: finish adding support for organization and team avatars

### DIFF
--- a/src/sentry/api/bases/avatar.py
+++ b/src/sentry/api/bases/avatar.py
@@ -48,7 +48,7 @@ class AvatarMixin(object):
         }
 
     def get_avatar_filename(self, obj):
-        return '{}.png'.format(obj.id)
+        return u'{}.png'.format(obj.id)
 
     def put(self, request, **kwargs):
         obj = kwargs[self.object_type]

--- a/src/sentry/api/bases/avatar.py
+++ b/src/sentry/api/bases/avatar.py
@@ -47,6 +47,9 @@ class AvatarMixin(object):
             'kwargs': {self.object_type: obj},
         }
 
+    def get_avatar_filename(self, obj):
+        return '{}.png'.format(obj.id)
+
     def put(self, request, **kwargs):
         obj = kwargs[self.object_type]
         serializer = AvatarSerializer(
@@ -62,7 +65,7 @@ class AvatarMixin(object):
             relation={self.object_type: obj},
             type=result['avatar_type'],
             avatar=result.get('avatar_photo'),
-            filename='{}.png'.format(obj.id),
+            filename=self.get_avatar_filename(obj),
         )
 
         return Response(serialize(obj, request.user))

--- a/src/sentry/api/endpoints/organization_avatar.py
+++ b/src/sentry/api/endpoints/organization_avatar.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from sentry.api.bases.avatar import AvatarMixin
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models import OrganizationAvatar
+
+
+class OrganizationAvatarEndpoint(AvatarMixin, OrganizationEndpoint):
+    object_type = 'organization'
+    model = OrganizationAvatar
+
+    def get_avatar_filename(self, obj):
+        # for consistency with organization details endpoint
+        return '{}.png'.format(obj.slug)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -46,6 +46,7 @@ from .endpoints.organization_api_key_details import OrganizationApiKeyDetailsEnd
 from .endpoints.organization_auth_providers import OrganizationAuthProvidersEndpoint
 from .endpoints.organization_auth_provider_details import OrganizationAuthProviderDetailsEndpoint
 from .endpoints.organization_auth_provider_send_reminders import OrganizationAuthProviderSendRemindersEndpoint
+from .endpoints.organization_avatar import OrganizationAvatarEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
 from .endpoints.organization_shortid import ShortIdLookupEndpoint
 from .endpoints.organization_slugs import SlugsUpdateEndpoint
@@ -364,6 +365,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/auth-provider/send-reminders/$',
         OrganizationAuthProviderSendRemindersEndpoint.as_view(),
         name='sentry-api-0-organization-auth-provider-send-reminders'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/avatar/$',
+        OrganizationAvatarEndpoint.as_view(),
+        name='sentry-api-0-organization-avatar'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/config/integrations/$',

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -266,7 +266,7 @@ STATIC_URL = '/_static/{version}/'
 
 # various middleware will use this to identify resources which should not access
 # cookies
-ANONYMOUS_STATIC_PREFIXES = ('/_static/', '/avatar/')
+ANONYMOUS_STATIC_PREFIXES = ('/_static/', '/avatar/', '/organization-avatar/')
 
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -266,7 +266,7 @@ STATIC_URL = '/_static/{version}/'
 
 # various middleware will use this to identify resources which should not access
 # cookies
-ANONYMOUS_STATIC_PREFIXES = ('/_static/', '/avatar/', '/organization-avatar/')
+ANONYMOUS_STATIC_PREFIXES = ('/_static/', '/avatar/', '/organization-avatar/', '/team-avatar/')
 
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -87,6 +87,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         'security', 'terms', 'from', 'sponsorship', 'for', 'at', 'platforms', 'branding', 'vs',
         'answers', '_admin', 'support', 'contact', 'onboarding', 'ext', 'extension', 'extensions',
         'plugins', 'themonitor', 'settings', 'legal', 'avatar', 'organization-avatar',
+        'team-avatar',
     )
 )
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -86,7 +86,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         'pricing', 'subscribe', 'enterprise', 'about', 'jobs', 'thanks', 'guide', 'privacy',
         'security', 'terms', 'from', 'sponsorship', 'for', 'at', 'platforms', 'branding', 'vs',
         'answers', '_admin', 'support', 'contact', 'onboarding', 'ext', 'extension', 'extensions',
-        'plugins', 'themonitor', 'settings', 'legal',
+        'plugins', 'themonitor', 'settings', 'legal', 'avatar', 'organization-avatar',
     )
 )
 

--- a/src/sentry/middleware/user.py
+++ b/src/sentry/middleware/user.py
@@ -7,7 +7,9 @@ from django.utils import timezone
 
 class UserActiveMiddleware(object):
     disallowed_paths = (
-        'sentry.web.frontend.generic.static_media', 'sentry.web.frontend.user_avatar',
+        'sentry.web.frontend.generic.static_media',
+        'sentry.web.frontend.user_avatar',
+        'sentry.web.frontend.organization_avatar',
     )
 
     def process_view(self, request, view_func, view_args, view_kwargs):

--- a/src/sentry/middleware/user.py
+++ b/src/sentry/middleware/user.py
@@ -8,8 +8,9 @@ from django.utils import timezone
 class UserActiveMiddleware(object):
     disallowed_paths = (
         'sentry.web.frontend.generic.static_media',
-        'sentry.web.frontend.user_avatar',
         'sentry.web.frontend.organization_avatar',
+        'sentry.web.frontend.team_avatar',
+        'sentry.web.frontend.user_avatar',
     )
 
     def process_view(self, request, view_func, view_args, view_kwargs):

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -5,13 +5,14 @@ import six
 
 from django.core.context_processors import csrf
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound, HttpResponseRedirect
 from django.middleware.csrf import CsrfViewMiddleware
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt
 from sudo.views import redirect_to_sudo
 
 from sentry import roles
+from sentry.api.serializers import serialize
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
@@ -21,7 +22,8 @@ from sentry.models import (
 from sentry.utils import auth
 from sentry.utils.audit import create_audit_entry
 from sentry.web.helpers import render_to_response
-from sentry.api.serializers import serialize
+from sentry.web.frontend.generic import FOREVER_CACHE
+
 
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger('sentry.audit.ui')
@@ -531,3 +533,32 @@ class ProjectView(OrganizationView):
         kwargs['organization'] = active_organization
 
         return (args, kwargs)
+
+
+class AvatarPhotoView(View):
+    model = None
+
+    def get(self, request, *args, **kwargs):
+        avatar_id = kwargs['avatar_id']
+        try:
+            avatar = self.model.objects.get(ident=avatar_id)
+        except self.model.DoesNotExist:
+            return HttpResponseNotFound()
+
+        photo = avatar.file
+        if not photo:
+            return HttpResponseNotFound()
+
+        size = request.GET.get('s')
+        photo_file = photo.getfile()
+        if size:
+            try:
+                size = int(size)
+            except ValueError:
+                return HttpResponseBadRequest()
+            else:
+                photo_file = avatar.get_cached_photo(size)
+
+        res = HttpResponse(photo_file, content_type='image/png')
+        res['Cache-Control'] = FOREVER_CACHE
+        return res

--- a/src/sentry/web/frontend/organization_avatar.py
+++ b/src/sentry/web/frontend/organization_avatar.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+from sentry.models import OrganizationAvatar
+from sentry.web.frontend.base import AvatarPhotoView
+
+
+class OrganizationAvatarPhotoView(AvatarPhotoView):
+    model = OrganizationAvatar

--- a/src/sentry/web/frontend/team_avatar.py
+++ b/src/sentry/web/frontend/team_avatar.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+from sentry.models import TeamAvatar
+from sentry.web.frontend.base import AvatarPhotoView
+
+
+class TeamAvatarPhotoView(AvatarPhotoView):
+    model = TeamAvatar

--- a/src/sentry/web/frontend/user_avatar.py
+++ b/src/sentry/web/frontend/user_avatar.py
@@ -8,9 +8,6 @@ from sentry.web.frontend.generic import FOREVER_CACHE
 
 
 class UserAvatarPhotoView(View):
-    def get_file_name(self, user):
-        return '%s.png' % user.id
-
     def get(self, request, *args, **kwargs):
         avatar_id = kwargs['avatar_id']
         try:

--- a/src/sentry/web/frontend/user_avatar.py
+++ b/src/sentry/web/frontend/user_avatar.py
@@ -1,34 +1,8 @@
 from __future__ import absolute_import
 
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
-from django.views.generic import View
-
 from sentry.models import UserAvatar
-from sentry.web.frontend.generic import FOREVER_CACHE
+from sentry.web.frontend.base import AvatarPhotoView
 
 
-class UserAvatarPhotoView(View):
-    def get(self, request, *args, **kwargs):
-        avatar_id = kwargs['avatar_id']
-        try:
-            avatar = UserAvatar.objects.get(ident=avatar_id)
-        except UserAvatar.DoesNotExist:
-            return HttpResponseNotFound()
-
-        photo = avatar.file
-        if not photo:
-            return HttpResponseNotFound()
-
-        size = request.GET.get('s')
-        photo_file = photo.getfile()
-        if size:
-            try:
-                size = int(size)
-            except ValueError:
-                return HttpResponseBadRequest()
-            else:
-                photo_file = avatar.get_cached_photo(size)
-
-        res = HttpResponse(photo_file, content_type='image/png')
-        res['Cache-Control'] = FOREVER_CACHE
-        return res
+class UserAvatarPhotoView(AvatarPhotoView):
+    model = UserAvatar

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -36,6 +36,7 @@ from sentry.web.frontend.mailgun_inbound_webhook import \
 from sentry.web.frontend.oauth_authorize import OAuthAuthorizeView
 from sentry.web.frontend.oauth_token import OAuthTokenView
 from sentry.auth.providers.saml2 import SAML2AcceptACSView, SAML2SLSView, SAML2MetadataView
+from sentry.web.frontend.organization_avatar import OrganizationAvatarPhotoView
 from sentry.web.frontend.organization_auth_settings import \
     OrganizationAuthSettingsView
 from sentry.web.frontend.organization_integration_setup import \
@@ -439,6 +440,11 @@ urlpatterns += patterns(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/settings/transfer/$',
         TransferProjectView.as_view(),
         name='sentry-transfer-project'
+    ),
+    url(
+        r'^organization-avatar/(?P<avatar_id>[^\/]+)/$',
+        OrganizationAvatarPhotoView.as_view(),
+        name='sentry-organization-avatar-url'
     ),
     url(
         r'^avatar/(?P<avatar_id>[^\/]+)/$',

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -37,6 +37,7 @@ from sentry.web.frontend.oauth_authorize import OAuthAuthorizeView
 from sentry.web.frontend.oauth_token import OAuthTokenView
 from sentry.auth.providers.saml2 import SAML2AcceptACSView, SAML2SLSView, SAML2MetadataView
 from sentry.web.frontend.organization_avatar import OrganizationAvatarPhotoView
+from sentry.web.frontend.team_avatar import TeamAvatarPhotoView
 from sentry.web.frontend.organization_auth_settings import \
     OrganizationAuthSettingsView
 from sentry.web.frontend.organization_integration_setup import \
@@ -442,14 +443,19 @@ urlpatterns += patterns(
         name='sentry-transfer-project'
     ),
     url(
+        r'^avatar/(?P<avatar_id>[^\/]+)/$',
+        UserAvatarPhotoView.as_view(),
+        name='sentry-user-avatar-url'
+    ),
+    url(
         r'^organization-avatar/(?P<avatar_id>[^\/]+)/$',
         OrganizationAvatarPhotoView.as_view(),
         name='sentry-organization-avatar-url'
     ),
     url(
-        r'^avatar/(?P<avatar_id>[^\/]+)/$',
-        UserAvatarPhotoView.as_view(),
-        name='sentry-user-avatar-url'
+        r'^team-avatar/(?P<avatar_id>[^\/]+)/$',
+        TeamAvatarPhotoView.as_view(),
+        name='sentry-team-avatar-url'
     ),
 
     # Generic

--- a/tests/sentry/api/endpoints/test_organization_avatar.py
+++ b/tests/sentry/api/endpoints/test_organization_avatar.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import
+
+import six
+
+from base64 import b64encode
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import OrganizationAvatar
+from sentry.testutils import APITestCase
+
+
+class OrganizationAvatarTest(APITestCase):
+    def test_get(self):
+        organization = self.organization  # force creation
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-organization-avatar',
+            kwargs={
+                'organization_slug': organization.slug,
+            }
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data['id'] == six.text_type(organization.id)
+        assert response.data['avatar']['avatarType'] == 'letter_avatar'
+        assert response.data['avatar']['avatarUuid'] is None
+
+    def test_upload(self):
+        organization = self.organization  # force creation
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-organization-avatar',
+            kwargs={
+                'organization_slug': organization.slug,
+            }
+        )
+        response = self.client.put(
+            url,
+            data={
+                'avatar_type': 'upload',
+                'avatar_photo': b64encode(self.load_fixture('avatar.jpg')),
+            },
+            format='json'
+        )
+
+        avatar = OrganizationAvatar.objects.get(organization=organization)
+        assert response.status_code == 200, response.content
+        assert avatar.get_avatar_type_display() == 'upload'
+        assert avatar.file
+
+    def test_put_bad(self):
+        organization = self.organization  # force creation
+        OrganizationAvatar.objects.create(organization=organization)
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-organization-avatar',
+            kwargs={
+                'organization_slug': organization.slug,
+            }
+        )
+        response = self.client.put(url, data={'avatar_type': 'upload'}, format='json')
+
+        avatar = OrganizationAvatar.objects.get(organization=organization)
+        assert response.status_code == 400
+        assert avatar.get_avatar_type_display() == 'letter_avatar'
+
+        response = self.client.put(url, data={'avatar_type': 'foo'}, format='json')
+        assert response.status_code == 400
+        assert avatar.get_avatar_type_display() == 'letter_avatar'
+
+    def test_put_forbidden(self):
+        organization = self.organization  # force creation
+        user = self.create_user(email='a@example.com')
+
+        self.login_as(user=user)
+        url = reverse(
+            'sentry-api-0-organization-avatar',
+            kwargs={
+                'organization_slug': organization.slug,
+            }
+        )
+        response = self.client.put(url, data={'avatar_type': 'letter_avatar'}, format='json')
+
+        assert response.status_code == 403

--- a/tests/sentry/web/frontend/test_organization_avatar.py
+++ b/tests/sentry/web/frontend/test_organization_avatar.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from six import BytesIO
+
+from sentry.models import File, OrganizationAvatar
+from sentry.testutils import TestCase
+from sentry.web.frontend.generic import FOREVER_CACHE
+
+
+class OrganizationAvatarTest(TestCase):
+    def test_headers(self):
+        org = self.create_organization()
+        photo = File.objects.create(name='test.png', type='avatar.file')
+        photo.putfile(BytesIO(b'test'))
+        avatar = OrganizationAvatar.objects.create(organization=org, file=photo)
+        url = reverse('sentry-organization-avatar-url', kwargs={'avatar_id': avatar.ident})
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response['Cache-Control'] == FOREVER_CACHE
+        assert response.get('Vary') is None
+        assert response.get('Set-Cookie') is None

--- a/tests/sentry/web/frontend/test_team_avatar.py
+++ b/tests/sentry/web/frontend/test_team_avatar.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from six import BytesIO
+
+from sentry.models import File, TeamAvatar
+from sentry.testutils import TestCase
+from sentry.web.frontend.generic import FOREVER_CACHE
+
+
+class TeamAvatarTest(TestCase):
+    def test_headers(self):
+        team = self.create_team()
+        photo = File.objects.create(name='test.png', type='avatar.file')
+        photo.putfile(BytesIO(b'test'))
+        avatar = TeamAvatar.objects.create(team=team, file=photo)
+        url = reverse('sentry-team-avatar-url', kwargs={'avatar_id': avatar.ident})
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response['Cache-Control'] == FOREVER_CACHE
+        assert response.get('Vary') is None
+        assert response.get('Set-Cookie') is None


### PR DESCRIPTION
- refactors the `UserAvatarPhotoView` to pull most of it into a base class
- uses that base class to add support for getting team and org avatars
- adds a dedicated org avatar endpoint (previously was editable from org details endpoint)