### PR TITLE
fix(minidump): Allow debug images without identifier

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -51,7 +51,7 @@ statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=3.0.0,<4.0.0
+symbolic>=4.0.0,<5.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23

--- a/src/sentry/interfaces/debug_meta.py
+++ b/src/sentry/interfaces/debug_meta.py
@@ -28,7 +28,7 @@ def _addr(x):
 def process_symbolic_image(image):
     try:
         symbolic_image = {
-            'id': normalize_debug_id(image['id']),
+            'id': normalize_debug_id(image.get('id')),
             'image_addr': _addr(image.get('image_addr')),
             'image_size': parse_addr(image['image_size']),
             'image_vmaddr': _addr(image.get('image_vmaddr') or 0),

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -33,7 +33,7 @@ class DebugMetaInterface extends React.Component {
         version = (evt.release && evt.release.shortVersion) || 'unknown';
       } else
         version = `${img.major_version}.${img.minor_version}.${img.revision_version}`;
-    } else version = img.id || img.uuid;
+    } else version = img.id || img.uuid || '<none>';
 
     if (version) return [name, version];
 


### PR DESCRIPTION
This allows `symbolic` debug images without identifier. The actual fix was implemented in https://github.com/getsentry/symbolic/pull/67, which is why a bump of `symbolic` is needed to deploy this.

Fixes SENTRY-5P5