### PR TITLE
fix: Project ownership HTML formatting

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
@@ -63,10 +63,10 @@ class ProjectOwnership extends AsyncView {
             </p>
             <p>
               {t('Globbing Syntax:')}
-              <pre>
+              <CodeBlock>
                 {`* matches everything
 ? matches any single character`}
-              </pre>
+              </CodeBlock>
             </p>
             Examples:
             <CodeBlock>

--- a/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
@@ -34,10 +34,10 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
         </p>
         <p>
           Globbing Syntax:
-          <pre>
+          <CodeBlock>
             * matches everything
 ? matches any single character
-          </pre>
+          </CodeBlock>
         </p>
         Examples:
         <CodeBlock>


### PR DESCRIPTION
Make code blocks consistent, `<pre>` is not a valid descendant of `<p>`