### PR TITLE
feat(ui): Add tabindexes to login page

### DIFF
--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -51,12 +51,14 @@ class AuthenticationForm(forms.Form):
         max_length=128,
         widget=forms.TextInput(attrs={
             'placeholder': _('username or email'),
+            'tabindex': 1,
         }),
     )
     password = forms.CharField(
         label=_('Password'),
         widget=forms.PasswordInput(attrs={
             'placeholder': _('password'),
+            'tabindex': 2,
         }),
     )
 


### PR DESCRIPTION
Small change to something that was annoying me. `<Tab>` now goes right to username, then password.

Also, not _really_ a feature, per se, but didn't seem like a fix either. :man_shrugging: