### PR TITLE
chore: Explicitly include `futures` in requirements

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -15,6 +15,7 @@ email-reply-parser>=0.2.0,<0.3.0
 enum34>=1.1.6,<1.2.0
 exam>=0.5.1
 functools32>=3.2.3,<3.3
+futures>=3.2.0,<4.0.0
 # broken on python3
 hiredis>=0.1.0,<0.2.0
 honcho>=1.0.0,<1.1.0


### PR DESCRIPTION
This previously was included as a transitive dependency somewhere, this
makes it explicit. I think that this technically could be `>=3.0.0` (we
need the fix for https://bugs.python.org/issue15015), but shinier is
better, right?