### PR TITLE
feat(minidump): Store minidumps in a temp directory for debugging

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1306,3 +1306,8 @@ SOUTH_TESTS_MIGRATE = os.environ.get('SOUTH_TESTS_MIGRATE', '0') == '1'
 
 TERMS_URL = None
 PRIVACY_URL = None
+
+# Toggles whether minidumps should be cached
+SENTRY_MINIDUMP_CACHE = False
+# The location for cached minidumps
+SENTRY_MINIDUMP_PATH = '/tmp/minidump'

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -164,6 +164,7 @@ def sdk_info_to_sdk_id(sdk_info):
 
 def merge_minidump_event(data, minidump):
     if isinstance(minidump, InMemoryUploadedFile):
+        minidump.open()  # seek to start
         state = ProcessState.from_minidump_buffer(minidump.read())
     elif isinstance(minidump, TemporaryUploadedFile):
         state = ProcessState.from_minidump(minidump.temporary_file_path())

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -567,7 +567,7 @@ class MinidumpView(StoreView):
         # Assign our own UUID so we can track this minidump. We cannot trust the
         # uploaded filename, and if reading the minidump fails there is no way
         # we can ever retrieve the original UUID from the minidump.
-        event_id = uuid.uuid4().hex
+        event_id = data.get('event_id') or uuid.uuid4().hex
         data['event_id'] = event_id
 
         # At this point, we only extract the bare minimum information


### PR DESCRIPTION
This PR stores minidumps in a temporary location on our webservers for debugging purposes. They should be deleted within 24-48 hours.

Fixes SENTRY-6CW