### PR TITLE
fix: Make Snuba TSDB backend fit in

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -166,3 +166,38 @@ class SnubaTSDB(BaseTSDB):
             return (items.keys(), list(set.union(*(set(v) for v in items.values()))))
         else:
             return (None, None)
+
+    # The following are no-ops, but implemented here to avoid NotImplementedErrors everywhere.
+
+    def incr(self, model, key, timestamp=None, count=1, environment_id=None):
+        pass
+
+    def merge(self, model, destination, sources, timestamp=None, environment_ids=None):
+        pass
+
+    def delete(self, models, keys, start=None, end=None, timestamp=None, environment_ids=None):
+        pass
+
+    def record(self, model, key, values, timestamp=None, environment_id=None):
+        pass
+
+    def merge_distinct_counts(self, model, destination, sources,
+                              timestamp=None, environment_ids=None):
+        pass
+
+    def delete_distinct_counts(self, models, keys, start=None, end=None,
+                               timestamp=None, environment_ids=None):
+        pass
+
+    def record_frequency_multi(self, requests, timestamp=None, environment_id=None):
+        pass
+
+    def merge_frequencies(self, model, destination, sources, timestamp=None, environment_ids=None):
+        pass
+
+    def delete_frequencies(self, models, keys, start=None, end=None,
+                           timestamp=None, environment_ids=None):
+        pass
+
+    def flush(self):
+        pass


### PR DESCRIPTION
This is not quite necessary yet, as we are still testing individial
snuba TSDB methods individually, but this just makes it so that the
Snuba TSDB backend is closer to a drop-in replacement for the redis one
(ie. doesn't raise NotImplementedErrors on write ops) without having to
refactor all caller sites to remove incr() etc. calls.

The remaining ~50 or so failing tests when running the entire test suite
with `settings.SENTRY_TSDB = 'sentry.tsdb.snuba.SnubaTSDB'` are all
data-related test assertion failures, or TSDBModels that the Snuba
backend doesn't support.