### PR TITLE
WIP fix(release): Update Release details when groups are merged

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -180,6 +180,7 @@ class Release(Model):
         # ReleaseCommit.release
         # ReleaseEnvironment.release_id
         # ReleaseProject.release
+        # ReleaseProjectEnvironment.release
         # GroupRelease.release_id
         # GroupResolution.release
         # Group.first_release


### PR DESCRIPTION
Created a method that updates the release details (new issues count, first seen, last seen) when groups are merged. 

TODO: 
- First seen, last seen
- Figure out how performant this code should be and restructure accordingly
