### PR TITLE
 fix(project-search): Add typeahead search to org projects

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
@@ -72,13 +72,13 @@ export default class OrganizationProjectsView extends AsyncView {
 
   handleChange = evt => {
     let searchQuery = evt.target.value;
-    this.setState({searchQuery}, this.getProjects);
+    this.getProjects(searchQuery);
+    this.setState({searchQuery});
   };
 
-  getProjects = debounce(() => {
+  getProjects = debounce(searchQuery => {
     let {params} = this.props;
     let {orgId} = params || {};
-    let {searchQuery} = this.state;
 
     this.api.request(`/organizations/${orgId}/projects/?query=${searchQuery}`, {
       method: 'GET',

--- a/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
@@ -2,6 +2,7 @@ import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import idx from 'idx';
+import {debounce} from 'lodash';
 
 import {getOrganizationState} from '../../../../mixins/organizationState';
 import {sortProjects} from '../../../../utils';
@@ -22,6 +23,14 @@ export default class OrganizationProjectsView extends AsyncView {
     router: PropTypes.object.isRequired,
     organization: SentryTypes.Organization,
   };
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    super.componentWillReceiveProps(nextProps, nextContext);
+    let searchQuery = idx(nextProps, _ => _.location.query.query);
+    if (searchQuery !== idx(this.props, _ => _.location.query.query)) {
+      this.setState({searchQuery});
+    }
+  }
 
   getEndpoints() {
     let {orgId} = this.props.params;
@@ -52,7 +61,7 @@ export default class OrganizationProjectsView extends AsyncView {
   getDefaultState() {
     return {
       ...super.getDefaultState(),
-      searchQuery: idx(this.props, _ => _.location.query.query),
+      searchQuery: idx(this.props, _ => _.location.query.query) || '',
     };
   }
 
@@ -61,7 +70,25 @@ export default class OrganizationProjectsView extends AsyncView {
     return `${org.name} Projects`;
   }
 
-  onSearch = e => {
+  handleChange = evt => {
+    let searchQuery = evt.target.value;
+    this.setState({searchQuery}, this.getProjects);
+  };
+
+  getProjects = debounce(() => {
+    let {params} = this.props;
+    let {orgId} = params || {};
+    let {searchQuery} = this.state;
+
+    this.api.request(`/organizations/${orgId}/projects/?query=${searchQuery}`, {
+      method: 'GET',
+      success: data => {
+        this.setState({projectList: data});
+      },
+    });
+  }, 200);
+
+  handleSearch = e => {
     let {router} = this.context;
     let {location} = this.props;
     e.preventDefault();
@@ -104,10 +131,10 @@ export default class OrganizationProjectsView extends AsyncView {
           <PanelHeader hasButtons>
             {t('Projects')}
 
-            <form onSubmit={this.onSearch}>
+            <form onSubmit={this.handleSearch}>
               <Input
                 value={this.state.searchQuery}
-                onChange={e => this.setState({searchQuery: e.target.value})}
+                onChange={this.handleChange}
                 className="search"
                 placeholder="search"
               />

--- a/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
@@ -183,11 +183,13 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                               className="search"
                               onChange={[Function]}
                               placeholder="search"
+                              value=""
                             >
                               <input
                                 className="search css-qqayil-Input css-jwa1yb0"
                                 onChange={[Function]}
                                 placeholder="search"
+                                value=""
                               />
                             </Input>
                           </form>

--- a/tests/js/spec/views/organizationProjects.spec.jsx
+++ b/tests/js/spec/views/organizationProjects.spec.jsx
@@ -4,6 +4,8 @@ import {mount} from 'enzyme';
 import {Client} from 'app/api';
 import OrganizationProjectsViewContainer from 'app/views/settings/organization/projects/organizationProjectsView';
 
+jest.mock('lodash/debounce', () => jest.fn(fn => fn));
+
 describe('OrganizationProjectsView', function() {
   let org;
   let project;
@@ -54,6 +56,34 @@ describe('OrganizationProjectsView', function() {
       wrapper.find('.icon-star-outline').simulate('click');
       expect(wrapper.find('.icon-star-solid')).toBeTruthy();
       expect(projectsPutMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should search organization projects', async function() {
+      let searchMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/projects/?query=${project.slug}`,
+        body: [],
+      });
+      let routerOrganizationContext = TestStubs.routerOrganizationContext();
+      let wrapper = mount(
+        <OrganizationProjectsViewContainer location={{}} params={{orgId: org.slug}} />,
+        routerOrganizationContext
+      );
+
+      expect(searchMock).not.toHaveBeenCalled();
+
+      wrapper.find('Input').simulate('change', {target: {value: `${project.slug}`}});
+
+      expect(wrapper.state('searchQuery')).toBe(`${project.slug}`);
+      expect(searchMock).toHaveBeenCalled();
+      expect(searchMock).toHaveBeenCalledWith(
+        `/organizations/${org.slug}/projects/?query=${project.slug}`,
+        expect.objectContaining({
+          method: 'GET',
+        })
+      );
+
+      wrapper.find('PanelHeader form').simulate('submit');
+      expect(routerOrganizationContext.context.router.push.calledOnce).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Matches the search input to the query params correctly and adds the typeahead for projects. 