### PR TITLE
reorganize imports due to PEP-8 warnings

### DIFF
--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -7,15 +7,16 @@ sentry.wsgi
 """
 from __future__ import absolute_import
 
-import os
 import os.path
 import sys
+from django.conf import settings
+from django.core.handlers.wsgi import WSGIHandler
 
 # Add the project to the python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 # Configure the application only if it seemingly isnt already configured
-from django.conf import settings
+
 if not settings.configured:
     from sentry.runner import configure
     configure()
@@ -25,8 +26,6 @@ if settings.SESSION_FILE_PATH and not os.path.exists(settings.SESSION_FILE_PATH)
         os.makedirs(settings.SESSION_FILE_PATH)
     except OSError:
         pass
-
-from django.core.handlers.wsgi import WSGIHandler
 
 
 class FileWrapperWSGIHandler(WSGIHandler):


### PR DESCRIPTION
my IDE issues PEP-8 warnings so I reorganized the imports