### PR TITLE
feat: Support searches that combine Environment and Release:latest

### DIFF
--- a/src/sentry/search/base.py
+++ b/src/sentry/search/base.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 from sentry.utils.services import Service
 
 ANY = object()
-EMPTY = object()
 
 
 class SearchBackend(Service):

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -8,29 +8,13 @@ from django.db import DataError
 from django.utils import timezone
 
 from sentry.constants import STATUS_CHOICES
-from sentry.models import EventUser, Release, User
-from sentry.search.base import ANY, EMPTY
+from sentry.models import EventUser, User
+from sentry.search.base import ANY
 from sentry.utils.auth import find_users
 
 
 class InvalidQuery(Exception):
     pass
-
-
-def parse_release(project, value):
-    # TODO(dcramer): add environment support
-    if value == 'latest':
-        value = Release.objects.filter(
-            organization_id=project.organization_id,
-            projects=project,
-        ).extra(select={
-            'sort': 'COALESCE(date_released, date_added)',
-        }).order_by('-sort').values_list(
-            'version', flat=True
-        ).first()
-        if value is None:
-            return EMPTY
-    return value
 
 
 def get_user_tag(project, key, value):
@@ -364,9 +348,9 @@ def parse_query(project, query, user):
             elif key == 'subscribed':
                 results['subscribed_by'] = parse_user_value(value, user)
             elif key in ('first-release', 'firstRelease'):
-                results['first_release'] = parse_release(project, value)
+                results['first_release'] = value
             elif key == 'release':
-                results['tags']['sentry:release'] = parse_release(project, value)
+                results['tags']['sentry:release'] = value
             elif key == 'dist':
                 results['tags']['sentry:dist'] = value
             elif key == 'user':

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -573,7 +573,7 @@ class LegacyTagStorage(TagStorage):
 
     def get_group_ids_for_search_filter(
             self, project_id, environment_id, tags, candidates=None, limit=1000):
-        from sentry.search.base import ANY, EMPTY
+        from sentry.search.base import ANY
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
 
@@ -587,10 +587,7 @@ class LegacyTagStorage(TagStorage):
         # for each remaining tag, find matches contained in our
         # existing set, pruning it down each iteration
         for k, v in tag_lookups:
-            if v is EMPTY:
-                return None
-
-            elif v != ANY:
+            if v != ANY:
                 base_qs = GroupTagValue.objects.filter(
                     key=k,
                     value=v,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -390,12 +390,9 @@ class SnubaTagStorage(TagStorage):
 
     # Search
     def get_group_ids_for_search_filter(self, project_id, environment_id, tags):
-        from sentry.search.base import ANY, EMPTY
+        from sentry.search.base import ANY
+
         start, end = self.get_time_range()
-        # Any EMPTY value means there can be no results for this query so
-        # return an empty list immediately.
-        if any(val == EMPTY for _, val in six.iteritems(tags)):
-            return []
 
         filters = {
             'environment': [environment_id],

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -796,7 +796,7 @@ class V2TagStorage(TagStorage):
 
     def get_group_ids_for_search_filter(
             self, project_id, environment_id, tags, candidates=None, limit=1000):
-        from sentry.search.base import ANY, EMPTY
+        from sentry.search.base import ANY
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
 
@@ -810,10 +810,7 @@ class V2TagStorage(TagStorage):
         # for each remaining tag, find matches contained in our
         # existing set, pruning it down each iteration
         for k, v in tag_lookups:
-            if v is EMPTY:
-                return None
-
-            elif v != ANY:
+            if v != ANY:
                 base_qs = GroupTagValue.objects.filter(
                     project_id=project_id,
                     _key__key=k,

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -15,7 +15,7 @@ from sentry.models import (
     GroupSubscription, Release, ReleaseEnvironment, ReleaseProjectEnvironment
 )
 from sentry.search.base import ANY
-from sentry.search.django.backend import DjangoSearchBackend, parse_release
+from sentry.search.django.backend import DjangoSearchBackend, get_latest_release
 from sentry.tagstore.v2.backend import AGGREGATE_ENVIRONMENT_ID
 from sentry.testutils import TestCase
 
@@ -717,7 +717,7 @@ class DjangoSearchBackendTest(TestCase):
         with pytest.raises(Release.DoesNotExist):
             # no releases exist period
             environment = None
-            result = parse_release(self.project, environment, 'latest')
+            result = get_latest_release(self.project, environment)
 
         old = Release.objects.create(
             organization_id=self.project.organization_id,
@@ -754,16 +754,16 @@ class DjangoSearchBackendTest(TestCase):
 
         # latest overall (no environment filter)
         environment = None
-        result = parse_release(self.project, environment, 'latest')
+        result = get_latest_release(self.project, environment)
         assert result == newest.version
 
         # latest in environment
         environment = self.environment
-        result = parse_release(self.project, environment, 'latest')
+        result = get_latest_release(self.project, environment)
         assert result == new.version
 
         with pytest.raises(Release.DoesNotExist):
             # environment with no releases
             environment = self.create_environment()
-            result = parse_release(self.project, environment, 'latest')
+            result = get_latest_release(self.project, environment)
             assert result == new.version

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -11,10 +11,11 @@ from django.conf import settings
 from sentry import tagstore
 from sentry.event_manager import ScoreClause
 from sentry.models import (
-    Environment, Event, GroupAssignee, GroupBookmark, GroupEnvironment, GroupStatus, GroupSubscription
+    Environment, Event, GroupAssignee, GroupBookmark, GroupEnvironment, GroupStatus,
+    GroupSubscription, Release, ReleaseEnvironment, ReleaseProjectEnvironment
 )
 from sentry.search.base import ANY
-from sentry.search.django.backend import DjangoSearchBackend
+from sentry.search.django.backend import DjangoSearchBackend, parse_release
 from sentry.tagstore.v2.backend import AGGREGATE_ENVIRONMENT_ID
 from sentry.testutils import TestCase
 
@@ -711,3 +712,58 @@ class DjangoSearchBackendTest(TestCase):
             subscribed_by=self.user,
         )
         assert set(results) == set([])
+
+    def test_parse_release_latest(self):
+        with pytest.raises(Release.DoesNotExist):
+            # no releases exist period
+            environment = None
+            result = parse_release(self.project, environment, 'latest')
+
+        old = Release.objects.create(
+            organization_id=self.project.organization_id,
+            version='old'
+        )
+        old.add_project(self.project)
+
+        new_date = old.date_added + timedelta(minutes=1)
+        new = Release.objects.create(
+            version='new-but-in-environment',
+            organization_id=self.project.organization_id,
+            date_released=new_date,
+        )
+        new.add_project(self.project)
+        ReleaseEnvironment.get_or_create(
+            project=self.project,
+            release=new,
+            environment=self.environment,
+            datetime=new_date,
+        )
+        ReleaseProjectEnvironment.get_or_create(
+            project=self.project,
+            release=new,
+            environment=self.environment,
+            datetime=new_date,
+        )
+
+        newest = Release.objects.create(
+            version='newest-overall',
+            organization_id=self.project.organization_id,
+            date_released=old.date_added + timedelta(minutes=5),
+        )
+        newest.add_project(self.project)
+
+        # latest overall (no environment filter)
+        environment = None
+        result = parse_release(self.project, environment, 'latest')
+        assert result == newest.version
+
+        # latest in environment
+        environment = self.environment
+        result = parse_release(self.project, environment, 'latest')
+        assert result == new.version
+
+        with pytest.raises(Release.DoesNotExist):
+            # environment with no releases
+            environment = self.create_environment()
+            result = parse_release(self.project, environment, 'latest')
+            assert result == new.version

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -5,7 +5,7 @@ import mock
 from datetime import datetime, timedelta
 from django.utils import timezone
 
-from sentry.models import EventUser, GroupStatus, Release
+from sentry.models import EventUser, GroupStatus
 from sentry.testutils import TestCase
 from sentry.search.base import ANY
 from sentry.search.utils import parse_query, get_numeric_field_value
@@ -287,19 +287,6 @@ class ParseQueryTest(TestCase):
         result = self.parse_query('first-release:bar')
         assert result == {'first_release': 'bar', 'tags': {}, 'query': ''}
 
-    def test_first_release_latest(self):
-        old = Release.objects.create(organization_id=self.project.organization_id, version='a')
-        old.add_project(self.project)
-        new = Release.objects.create(
-            version='b',
-            organization_id=self.project.organization_id,
-            date_released=old.date_added + timedelta(minutes=1),
-        )
-        new.add_project(self.project)
-
-        result = self.parse_query('first-release:latest')
-        assert result == {'tags': {}, 'first_release': new.version, 'query': ''}
-
     def test_release(self):
         result = self.parse_query('release:bar')
         assert result == {'tags': {'sentry:release': 'bar'}, 'query': ''}
@@ -307,19 +294,6 @@ class ParseQueryTest(TestCase):
     def test_dist(self):
         result = self.parse_query('dist:123')
         assert result == {'tags': {'sentry:dist': '123'}, 'query': ''}
-
-    def test_release_latest(self):
-        old = Release.objects.create(organization_id=self.project.organization_id, version='a')
-        old.add_project(self.project)
-        new = Release.objects.create(
-            version='b',
-            organization_id=self.project.organization_id,
-            date_released=old.date_added + timedelta(minutes=1),
-        )
-        new.add_project(self.project)
-
-        result = self.parse_query('release:latest')
-        assert result == {'tags': {'sentry:release': new.version}, 'query': ''}
 
     def test_padded_spacing(self):
         result = self.parse_query('release:bar  foo   bar')


### PR DESCRIPTION
This also removes all current usages of the special `EMPTY` sentinel.
Release parsing now happens inside the search backend because the
hydrated environment object is available there.