### PR TITLE
fix(member-search): Remove getMembers state dependency

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
@@ -210,13 +210,13 @@ class OrganizationMembersView extends AsyncView {
 
   handleChange = evt => {
     let searchQuery = evt.target.value;
-    this.setState({searchQuery}, this.getMembers);
+    this.getMembers(searchQuery);
+    this.setState({searchQuery});
   };
 
-  getMembers = debounce(() => {
+  getMembers = debounce(searchQuery => {
     let {params} = this.props;
     let {orgId} = params || {};
-    let {searchQuery} = this.state;
 
     this.api.request(`/organizations/${orgId}/members/?query=${searchQuery}`, {
       method: 'GET',


### PR DESCRIPTION
Echoes some of the changes from https://github.com/getsentry/sentry/pull/8048 - unnecessary delays could occur from having `getMembers` wait for the state to update. Since it doesn't really need to be tied to the state at this point, this PR Instead passes the search query as an argument to `getMembers`.