### PR TITLE
ref(settings): Deprecate secret DSN

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
@@ -47,12 +47,7 @@ class ProjectKeyCredentials extends React.Component {
     return (
       <React.Fragment>
         {showDsnPublic && (
-          <Field
-            label={t('DSN')}
-            help={t('Use this DSN to configure all of our SDKs.')}
-            inline={false}
-            flexibleControlStateSize
-          >
+          <Field label={t('DSN')} inline={false} flexibleControlStateSize>
             <TextCopyInput>
               {getDynamicText({
                 value: data.dsn.public,

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
@@ -47,7 +47,12 @@ class ProjectKeyCredentials extends React.Component {
     return (
       <React.Fragment>
         {showDsnPublic && (
-          <Field label={t('DSN')} inline={false} flexibleControlStateSize>
+          <Field
+            label={t('DSN')}
+            help={t('Use this DSN to configure all of our SDKs.')}
+            inline={false}
+            flexibleControlStateSize
+          >
             <TextCopyInput>
               {getDynamicText({
                 value: data.dsn.public,

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {t, tct} from '../../../../locale';
-import ExternalLink from '../../../../components/externalLink';
 import Field from '../../components/forms/field';
 import TextCopyInput from '../../components/forms/textCopyInput';
 import SentryTypes from '../../../../proptypes';
@@ -47,36 +46,8 @@ class ProjectKeyCredentials extends React.Component {
 
     return (
       <React.Fragment>
-        {showDsn && (
-          <Field label={t('DSN')} inline={false} flexibleControlStateSize>
-            <TextCopyInput>
-              {getDynamicText({
-                value: data.dsn.secret,
-                fixed: data.dsn.secret.replace(
-                  new RegExp(`\/${projectId}$`),
-                  '/<<projectId>>'
-                ),
-              })}
-            </TextCopyInput>
-          </Field>
-        )}
-
         {showDsnPublic && (
-          <Field
-            label={t('DSN (Public)')}
-            help={tct(
-              'Use your public DSN with browser-based SDKs such as [link:raven-js].',
-              {
-                link: (
-                  <ExternalLink href="https://github.com/getsentry/raven-js">
-                    raven-js
-                  </ExternalLink>
-                ),
-              }
-            )}
-            inline={false}
-            flexibleControlStateSize
-          >
+          <Field label={t('DSN')} inline={false} flexibleControlStateSize>
             <TextCopyInput>
               {getDynamicText({
                 value: data.dsn.public,
@@ -130,6 +101,25 @@ class ProjectKeyCredentials extends React.Component {
               {getDynamicText({
                 value: data.dsn.minidump,
                 fixed: data.dsn.minidump.replace(
+                  new RegExp(`\/${projectId}$`),
+                  '/<<projectId>>'
+                ),
+              })}
+            </TextCopyInput>
+          </Field>
+        )}
+
+        {showDsn && (
+          <Field
+            label={t('DSN (Legacy)')}
+            help={t('Use this DSN with server-side SDKs in older versions of Sentry.')}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput>
+              {getDynamicText({
+                value: data.dsn.secret,
+                fixed: data.dsn.secret.replace(
                   new RegExp(`\/${projectId}$`),
                   '/<<projectId>>'
                 ),


### PR DESCRIPTION
Renames _"DSN"_ to _"DSN (Legacy)"_ and moves it to the bottom of the list to indicate that the secret should no longer be used. Also renames _"DSN (Public)"_ to _"DSN"_.

## Screenshot

<img width="823" alt="screen shot 2018-04-17 at 07 49 55" src="https://user-images.githubusercontent.com/1433023/38851077-8dfe2dec-4214-11e8-89e9-4e2af73818bc.png">
