### PR TITLE
chore: Add `.pytest_cache/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ example/db.sqlite
 /test_cli/
 Gemfile.lock
 .idea/
+.pytest_cache/
 .vscode/tags
 coverage.xml
 junit.xml


### PR DESCRIPTION
Stole this from GH-7925 so that I stop accidentally staging it 