### PR TITLE
feat(ui): Change project search placeholder

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
@@ -109,7 +109,7 @@ export default class OrganizationProjectsView extends AsyncView {
                 value={this.state.searchQuery}
                 onChange={e => this.setState({searchQuery: e.target.value})}
                 className="search"
-                placeholder="search"
+                placeholder={t('Search Projects')}
               />
             </form>
           </PanelHeader>

--- a/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
@@ -182,12 +182,12 @@ exports[`OrganizationProjectsView render() Should render the projects in the sto
                             <Input
                               className="search"
                               onChange={[Function]}
-                              placeholder="search"
+                              placeholder="Search Projects"
                             >
                               <input
                                 className="search css-qqayil-Input css-jwa1yb0"
                                 onChange={[Function]}
-                                placeholder="search"
+                                placeholder="Search Projects"
                               />
                             </Input>
                           </form>


### PR DESCRIPTION
Change placeholder from 'search' to 'Search Projects':

![screen shot 2018-04-17 at 9 46 11 am](https://user-images.githubusercontent.com/15368179/38885546-2a95bb80-4228-11e8-8b83-67a0559c5796.png)
