### PR TITLE
fix(environments): Fix environment querystring parsing

### DIFF
--- a/src/sentry/static/sentry/app/utils/queryString.jsx
+++ b/src/sentry/static/sentry/app/utils/queryString.jsx
@@ -9,9 +9,9 @@ export function formatQueryString(qs) {
 // to match the way tag searches are being done
 export function getQueryEnvironment(qs) {
   // A match with quotes will lazily match any characters within quotation marks
-  const matchWithQuotes = qs.match(/environment:"(.*?)"/);
+  const matchWithQuotes = qs.match(/(?:^|\s)environment:"(.*?)"/);
   // A match without quotes will match any non space character
-  const matchWithoutQuotes = qs.match(/environment:([^\s]*)/);
+  const matchWithoutQuotes = qs.match(/(?:^|\s)environment:([^\s]*)/);
 
   if (matchWithQuotes) {
     return matchWithQuotes[1];
@@ -23,14 +23,14 @@ export function getQueryEnvironment(qs) {
 }
 
 export function getQueryStringWithEnvironment(qs, env) {
-  const qsWithoutEnv = qs.replace(/environment:[^\s]*/g, '');
+  const qsWithoutEnv = qs.replace(/(?:^|\s)environment:[^\s]*/g, '');
   return formatQueryString(
     env === null ? qsWithoutEnv : `${qsWithoutEnv} environment:${env}`
   );
 }
 
 export function getQueryStringWithoutEnvironment(qs) {
-  return formatQueryString(qs.replace(/environment:[^\s]*/g, ''));
+  return formatQueryString(qs.replace(/(?:^|\s)environment:[^\s]*/g, ''));
 }
 
 export default {

--- a/tests/js/spec/utils/queryString.spec.js
+++ b/tests/js/spec/utils/queryString.spec.js
@@ -31,6 +31,11 @@ describe('getQueryEnvironment()', function() {
     const qs = 'is:unresolved is:unassigned environment:"my environment"';
     expect(utils.getQueryEnvironment(qs)).toBe('my environment');
   });
+
+  it('handles query property similar to `environment`', function() {
+    const qs = 'test_environment:development';
+    expect(utils.getQueryEnvironment(qs)).toBe(null);
+  });
 });
 
 describe('getQueryStringWithEnvironment', function() {
@@ -61,6 +66,13 @@ describe('getQueryStringWithEnvironment', function() {
       'is:unresolved is:unassigned environment:test.com'
     );
   });
+
+  it('handles query property similar to `environment`', function() {
+    const qs = 'test_environment:development';
+    expect(utils.getQueryStringWithEnvironment(qs, 'test.com')).toBe(
+      'test_environment:development environment:test.com'
+    );
+  });
 });
 
 describe('getQueryStringWithoutEnvironment', function() {
@@ -75,6 +87,13 @@ describe('getQueryStringWithoutEnvironment', function() {
     const qs = 'is:unresolved environment: is:unassigned';
     expect(utils.getQueryStringWithoutEnvironment(qs)).toBe(
       'is:unresolved is:unassigned'
+    );
+  });
+
+  it('handles query property similar to `environment`', function() {
+    const qs = 'test_environment:development';
+    expect(utils.getQueryStringWithoutEnvironment(qs)).toBe(
+      'test_environment:development'
     );
   });
 });


### PR DESCRIPTION
Ensure that querystring token ending in `environment` is not handled as environment
Ensure that `environment` occurs at the beginning or after a space in the string
e.g. test_environment:"production" should not be valid