### PR TITLE
chore: Remove unused hook

### DIFF
--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -9,7 +9,6 @@ let validHookNames = new Set([
   'settings:organization-navigation-config',
   'organization:header',
   'organization:sidebar',
-  'organization:dashboard:secondary-column',
   'routes',
   'routes:admin',
   'routes:organization',

--- a/src/sentry/static/sentry/app/views/organizationDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard.jsx
@@ -10,7 +10,6 @@ import ApiMixin from '../mixins/apiMixin';
 import {loadStats} from '../actionCreators/projects';
 
 import GroupStore from '../stores/groupStore';
-import HookStore from '../stores/hookStore';
 import ProjectsStore from '../stores/projectsStore';
 import TeamStore from '../stores/teamStore';
 
@@ -501,17 +500,9 @@ const OrganizationDashboard = createReactClass({
   },
 
   getInitialState() {
-    // Allow injection via getsentry et all
-    let hooks = HookStore.get('organization:dashboard:secondary-column').map(cb => {
-      return cb({
-        params: this.props.params,
-      });
-    });
-
     return {
       teams: TeamStore.getAll(),
       projects: ProjectsStore.getAll(),
-      hooks,
     };
   },
 
@@ -573,7 +564,6 @@ const OrganizationDashboard = createReactClass({
             )}
           </div>
           <div className="col-md-4">
-            {this.state.hooks}
             <EventsPerHour {...this.props} />
             {features.has('new-teams') ? (
               <ProjectList {...this.props} projects={this.state.projects} />


### PR DESCRIPTION
'organization:dashboard:secondary-column' is no longer used