### PR TITLE
fix(ui): Fix create team before create project

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/teams.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/teams.jsx
@@ -108,7 +108,7 @@ export function createTeam(api, team, params, options) {
       data => {
         TeamActions.createTeamSuccess(data);
         addSuccessMessage(
-          tct('[team] has been add to the [organization] organization', {
+          tct('[team] has been added to the [organization] organization', {
             team: `#${data.slug}`,
             organization: params.orgId,
           })

--- a/src/sentry/static/sentry/app/views/onboarding/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createProject.jsx
@@ -1,17 +1,22 @@
 import PropTypes from 'prop-types';
 import Raven from 'raven-js';
 import React from 'react';
+import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import {browserHistory, Link} from 'react-router';
+import styled from 'react-emotion';
 
-import ApiMixin from '../../mixins/apiMixin';
-import OrganizationState from '../../mixins/organizationState';
-import ProjectActions from '../../actions/projectActions';
-
+import {Panel} from '../../components/panels';
 import {getPlatformName} from './utils';
-import OnboardingProject from '../onboarding/project';
-
+import {openCreateTeamModal} from '../../actionCreators/modal';
 import {t} from '../../locale';
+import ApiMixin from '../../mixins/apiMixin';
+import Button from '../../components/buttons/button';
+import OnboardingProject from '../onboarding/project';
+import OrganizationState from '../../mixins/organizationState';
+import PanelAlert from '../../components/panels/panelAlert';
+import ProjectActions from '../../actions/projectActions';
+import TeamActions from '../../actions/teamActions';
+import space from '../../styles/space';
 
 const CreateProject = createReactClass({
   displayName: 'CreateProject',
@@ -21,10 +26,15 @@ const CreateProject = createReactClass({
   },
 
   contextTypes: {
+    router: PropTypes.object,
     location: PropTypes.object,
   },
 
-  mixins: [ApiMixin, OrganizationState],
+  mixins: [
+    ApiMixin,
+    OrganizationState,
+    Reflux.listenTo(TeamActions.createTeamSuccess, 'onTeamCreated'),
+  ],
 
   getDefaultProps() {
     return {
@@ -51,7 +61,18 @@ const CreateProject = createReactClass({
     };
   },
 
+  onTeamCreated() {
+    let {router} = this.context;
+
+    // After team gets created we need to force OrganizationContext to basically remount
+    router.replace({
+      pathname: router.location.pathname,
+      state: 'refresh',
+    });
+  },
+
   createProject() {
+    let {router} = this.context;
     let {slug} = this.getOrganization();
     let {projectName, platform, team, inFlight} = this.state;
 
@@ -77,7 +98,7 @@ const CreateProject = createReactClass({
         // navigate to new url _now_
         const url = this.props.getDocsUrl({slug, projectSlug: data.slug, platform});
         this.setState({inFlight: false});
-        browserHistory.push(url);
+        router.push(url);
       },
       error: err => {
         this.setState({
@@ -100,7 +121,8 @@ const CreateProject = createReactClass({
 
   render() {
     let {projectName, platform, error} = this.state;
-    let {slug, teams} = this.getOrganization();
+    let organization = this.getOrganization();
+    let {teams} = organization;
     let accessTeams = teams.filter(team => team.hasAccess);
 
     const stepProps = {
@@ -125,16 +147,29 @@ const CreateProject = createReactClass({
         {accessTeams.length ? (
           <OnboardingProject {...stepProps} />
         ) : (
-          <div>
-            <h4>
-              {t(
-                'You cannot create a new project because there are no teams to assign it to.'
-              )}
-            </h4>
-            <Link to={`/organizations/${slug}/teams/new/`} className="btn btn-primary">
-              {t('Create a Team')}
-            </Link>
-          </div>
+          <Panel
+            title={t('Cannot Create Project')}
+            body={
+              <React.Fragment>
+                <PanelAlert type="error">
+                  {t(
+                    'You cannot create a new project because there are no teams to assign it to.'
+                  )}
+                </PanelAlert>
+                <CreateTeamBody>
+                  <Button
+                    priority="primary"
+                    onClick={() =>
+                      openCreateTeamModal({
+                        organization,
+                      })}
+                  >
+                    {t('Create a Team')}
+                  </Button>
+                </CreateTeamBody>
+              </React.Fragment>
+            }
+          />
         )}
       </div>
     );
@@ -142,3 +177,9 @@ const CreateProject = createReactClass({
 });
 
 export default CreateProject;
+
+const CreateTeamBody = styled('div')`
+  display: flex;
+  justify-content: center;
+  padding: ${space(2)};
+`;

--- a/src/sentry/static/sentry/app/views/onboarding/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createProject.jsx
@@ -158,6 +158,7 @@ const CreateProject = createReactClass({
                 </PanelAlert>
                 <CreateTeamBody>
                   <Button
+                    className="ref-create-team"
                     priority="primary"
                     onClick={() =>
                       openCreateTeamModal({

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -1,22 +1,21 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import DocumentTitle from 'react-document-title';
+import React from 'react';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
 import moment from 'moment';
 
+import {setActiveOrganization} from '../actionCreators/organizations';
+import {t} from '../locale';
 import ApiMixin from '../mixins/apiMixin';
+import BroadcastModal from '../components/broadcastModal';
+import ConfigStore from '../stores/configStore';
 import HookStore from '../stores/hookStore';
 import LoadingError from '../components/loadingError';
 import LoadingIndicator from '../components/loadingIndicator';
-import BroadcastModal from '../components/broadcastModal';
+import ProjectActions from '../actions/projectActions';
+import ProjectsStore from '../stores/projectsStore';
 import SentryTypes from '../proptypes';
 import TeamStore from '../stores/teamStore';
-import ProjectsStore from '../stores/projectsStore';
-import ProjectActions from '../actions/projectActions';
-import ConfigStore from '../stores/configStore';
-import {setActiveOrganization} from '../actionCreators/organizations';
-
-import {t} from '../locale';
 
 let ERROR_TYPES = {
   ORG_NOT_FOUND: 'ORG_NOT_FOUND',

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -48,7 +48,19 @@ class CreateProjectTest(AcceptanceTestCase):
         )
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading')
-        self.browser.snapshot(name='create project no teams')
+        self.browser.snapshot(name='create project no teams - index')
+
+        self.browser.click('.ref-create-team')
+        self.browser.wait_until('.modal-dialog')
+        input = self.browser.element('input[name="name"]')
+        input.send_keys('New Team')
+
+        self.browser.snapshot(name='create project no teams - create team modal')
+        self.browser.element('.modal-dialog form').submit()
+
+        # After creating team, should end up in onboarding screen
+        self.browser.wait_until('.onboarding-info')
+        self.browser.snapshot(name='create project no teams - after create team')
 
     def test_many_teams(self):
         self.team = self.create_team(organization=self.org, name='Mariachi Band')

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -1,24 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CreateProject render() should block if you have access to no teams 1`] = `
+exports[`CreateProject should block if you have access to no teams 1`] = `
 <div>
-  <div>
-    <h4>
-      You cannot create a new project because there are no teams to assign it to.
-    </h4>
-    <Link
-      className="btn btn-primary"
-      onlyActiveOnIndex={false}
-      style={Object {}}
-      to="/organizations/testOrg/teams/new/"
-    >
-      Create a Team
-    </Link>
-  </div>
+  <Panel
+    body={
+      <UNDEFINED>
+        <PanelAlert
+          m={0}
+          mb={0}
+          type="error"
+        >
+          You cannot create a new project because there are no teams to assign it to.
+        </PanelAlert>
+        <CreateTeamBody>
+          <Button
+            disabled={false}
+            onClick={[Function]}
+            priority="primary"
+          >
+            Create a Team
+          </Button>
+        </CreateTeamBody>
+      </UNDEFINED>
+    }
+    title="Cannot Create Project"
+  />
 </div>
 `;
 
-exports[`CreateProject render() should deal with incorrect platform name if its provided by url 1`] = `
+exports[`CreateProject should deal with incorrect platform name if its provided by url 1`] = `
 <CreateProject
   getDocsUrl={[Function]}
   location={
@@ -804,7 +814,7 @@ exports[`CreateProject render() should deal with incorrect platform name if its 
 </CreateProject>
 `;
 
-exports[`CreateProject render() should fill in platform name if its provided by url 1`] = `
+exports[`CreateProject should fill in platform name if its provided by url 1`] = `
 <CreateProject
   getDocsUrl={[Function]}
   location={
@@ -1200,7 +1210,7 @@ exports[`CreateProject render() should fill in platform name if its provided by 
 </CreateProject>
 `;
 
-exports[`CreateProject render() should fill in project name if its empty when platform is chosen 1`] = `
+exports[`CreateProject should fill in project name if its empty when platform is chosen 1`] = `
 <CreateProject
   getDocsUrl={[Function]}
   location={

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -14,6 +14,7 @@ exports[`CreateProject should block if you have access to no teams 1`] = `
         </PanelAlert>
         <CreateTeamBody>
           <Button
+            className="ref-create-team"
             disabled={false}
             onClick={[Function]}
             priority="primary"

--- a/tests/js/spec/views/onboarding/createProject.spec.jsx
+++ b/tests/js/spec/views/onboarding/createProject.spec.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 import {shallow, mount} from 'enzyme';
 
 import CreateProject from 'app/views/onboarding/createProject';
+import {openCreateTeamModal} from 'app/actionCreators/modal';
+import {mountWithTheme} from '../../../../helpers';
+
+jest.mock('app/actionCreators/modal');
 
 describe('CreateProject', function() {
   const baseProps = {
@@ -34,6 +38,30 @@ describe('CreateProject', function() {
     });
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('can create a new team if no access to teams', function() {
+    let props = {
+      ...baseProps,
+    };
+
+    let wrapper = mountWithTheme(<CreateProject {...props} />, {
+      context: {
+        organization: {
+          id: '1',
+          slug: 'testOrg',
+          teams: [{slug: 'test', id: '1', name: 'test', hasAccess: false}],
+        },
+        location: {query: {}},
+      },
+      childContextTypes: {
+        organization: PropTypes.object,
+        location: PropTypes.object,
+      },
+    });
+
+    wrapper.find('CreateTeamBody Button').simulate('click');
+    expect(openCreateTeamModal).toHaveBeenCalled();
   });
 
   it('should fill in project name if its empty when platform is chosen', function() {

--- a/tests/js/spec/views/onboarding/createProject.spec.jsx
+++ b/tests/js/spec/views/onboarding/createProject.spec.jsx
@@ -2,144 +2,131 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 
-import {Client} from 'app/api';
 import CreateProject from 'app/views/onboarding/createProject';
 
 describe('CreateProject', function() {
-  let sandbox;
+  const baseProps = {
+    location: {query: {}},
+    params: {
+      projectId: '',
+      orgId: 'testOrg',
+    },
+  };
 
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-    this.stubbedApiRequest = sandbox.stub(Client.prototype, 'request');
-  });
-
-  afterEach(function() {
-    sandbox.restore();
-  });
-
-  describe('render()', function() {
-    const baseProps = {
-      location: {query: {}},
-      params: {
-        projectId: '',
-        orgId: 'testOrg',
-      },
+  it('should block if you have access to no teams', function() {
+    let props = {
+      ...baseProps,
     };
 
-    it('should block if you have access to no teams', function() {
-      let props = {
-        ...baseProps,
-      };
-
-      let wrapper = shallow(<CreateProject {...props} />, {
-        context: {
-          organization: {
-            id: '1',
-            slug: 'testOrg',
-            teams: [{slug: 'test', id: '1', name: 'test', hasAccess: false}],
-          },
-          location: {query: {}},
+    let wrapper = shallow(<CreateProject {...props} />, {
+      context: {
+        organization: {
+          id: '1',
+          slug: 'testOrg',
+          teams: [{slug: 'test', id: '1', name: 'test', hasAccess: false}],
         },
-        childContextTypes: {
-          organization: PropTypes.object,
-          location: PropTypes.object,
-        },
-      });
-      expect(wrapper).toMatchSnapshot();
+        location: {query: {}},
+      },
+      childContextTypes: {
+        organization: PropTypes.object,
+        location: PropTypes.object,
+      },
     });
 
-    it('should fill in project name if its empty when platform is chosen', function() {
-      let props = {
-        ...baseProps,
-      };
+    expect(wrapper).toMatchSnapshot();
+  });
 
-      let wrapper = mount(<CreateProject {...props} />, {
-        context: {
-          organization: {
-            id: '1',
-            slug: 'testOrg',
-            teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
-          },
-          router: TestStubs.router(),
-          location: {query: {}},
+  it('should fill in project name if its empty when platform is chosen', function() {
+    let props = {
+      ...baseProps,
+    };
+
+    let wrapper = mount(<CreateProject {...props} />, {
+      context: {
+        organization: {
+          id: '1',
+          slug: 'testOrg',
+          teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
         },
-        childContextTypes: {
-          router: PropTypes.object,
-          organization: PropTypes.object,
-          location: PropTypes.object,
-        },
-      });
-
-      let node = wrapper.find('PlatformCard').first();
-      node.simulate('click');
-      expect(wrapper.state().projectName).toBe('C#');
-
-      node = wrapper.find('PlatformCard').last();
-      node.simulate('click');
-      expect(wrapper.state().projectName).toBe('Ruby');
-
-      //but not replace it when project name is something else:
-      wrapper.setState({projectName: 'another'});
-
-      node = wrapper.find('PlatformCard').first();
-      node.simulate('click');
-      expect(wrapper.state().projectName).toBe('another');
-
-      expect(wrapper).toMatchSnapshot();
+        router: TestStubs.router(),
+        location: {query: {}},
+      },
+      childContextTypes: {
+        router: PropTypes.object,
+        organization: PropTypes.object,
+        location: PropTypes.object,
+      },
     });
 
-    it('should fill in platform name if its provided by url', function() {
-      let props = {
-        ...baseProps,
-      };
+    let node = wrapper.find('PlatformCard').first();
+    node.simulate('click');
+    expect(wrapper.state().projectName).toBe('C#');
 
-      let wrapper = mount(<CreateProject {...props} />, {
-        context: {
-          organization: {
-            id: '1',
-            slug: 'testOrg',
-            teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
-          },
-          router: TestStubs.router(),
-          location: {query: {platform: 'ruby'}},
+    node = wrapper.find('PlatformCard').last();
+    node.simulate('click');
+    expect(wrapper.state().projectName).toBe('Ruby');
+
+    //but not replace it when project name is something else:
+    wrapper.setState({projectName: 'another'});
+
+    node = wrapper.find('PlatformCard').first();
+    node.simulate('click');
+    expect(wrapper.state().projectName).toBe('another');
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should fill in platform name if its provided by url', function() {
+    let props = {
+      ...baseProps,
+    };
+
+    let wrapper = mount(<CreateProject {...props} />, {
+      context: {
+        organization: {
+          id: '1',
+          slug: 'testOrg',
+          teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
         },
-        childContextTypes: {
-          router: PropTypes.object,
-          organization: PropTypes.object,
-          location: PropTypes.object,
-        },
-      });
-
-      expect(wrapper.state().projectName).toBe('Ruby');
-
-      expect(wrapper).toMatchSnapshot();
+        router: TestStubs.router(),
+        location: {query: {platform: 'ruby'}},
+      },
+      childContextTypes: {
+        router: PropTypes.object,
+        organization: PropTypes.object,
+        location: PropTypes.object,
+      },
     });
 
-    it('should deal with incorrect platform name if its provided by url', function() {
-      let props = {
-        ...baseProps,
-      };
+    expect(wrapper.state().projectName).toBe('Ruby');
 
-      let wrapper = mount(<CreateProject {...props} />, {
-        context: {
-          organization: {
-            id: '1',
-            slug: 'testOrg',
-            teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
-          },
-          router: TestStubs.router(),
-          location: {query: {platform: 'XrubyROOLs'}},
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should deal with incorrect platform name if its provided by url', function() {
+    let props = {
+      ...baseProps,
+    };
+
+    let wrapper = mount(<CreateProject {...props} />, {
+      context: {
+        organization: {
+          id: '1',
+          slug: 'testOrg',
+          teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
         },
-        childContextTypes: {
-          router: PropTypes.object,
-          organization: PropTypes.object,
-          location: PropTypes.object,
-        },
-      });
-
-      expect(wrapper.state().projectName).toBe('');
-
-      expect(wrapper).toMatchSnapshot();
+        router: TestStubs.router(),
+        location: {query: {platform: 'XrubyROOLs'}},
+      },
+      childContextTypes: {
+        router: PropTypes.object,
+        organization: PropTypes.object,
+        location: PropTypes.object,
+      },
     });
+
+    expect(wrapper.state().projectName).toBe('');
+
+    expect(wrapper).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Previously, after creating a team, the create project view did not update with the new team, so it would display the same "create a team first" error.

Also moved create a team into a modal

![create-project-no-team](https://user-images.githubusercontent.com/79684/38893692-e37a7a70-423f-11e8-8807-8b2620d21b9f.gif)
