### PR TITLE
ref(ui): Use jest mock fns instead of sinon spies

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/team/teamSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamSettings.jsx
@@ -2,19 +2,19 @@ import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {addErrorMessage, addLoadingMessage} from '../../../actionCreators/indicator';
+import {Panel, PanelHeader} from '../../../components/panels';
+import {addErrorMessage, addSuccessMessage} from '../../../actionCreators/indicator';
 import {removeTeam} from '../../../actionCreators/teams';
 import {t, tct} from '../../../locale';
 import AsyncView from '../../asyncView';
+import Button from '../../../components/buttons/button';
+import Confirm from '../../../components/confirm';
+import Field from '../components/forms/field';
 import Form from '../components/forms/form';
 import JsonForm from '../components/forms/jsonForm';
+import SentryTypes from '../../../proptypes';
 import TeamModel from './model';
 import teamSettingsFields from '../../../data/forms/teamSettingsFields';
-import {Panel, PanelHeader} from '../../../components/panels';
-import Field from '../components/forms/field';
-import Button from '../../../components/buttons/button';
-import SentryTypes from '../../../proptypes';
-import Confirm from '../../../components/confirm';
 
 export default class TeamSettings extends AsyncView {
   static propTypes = {
@@ -46,10 +46,7 @@ export default class TeamSettings extends AsyncView {
 
   handleSubmitSuccess = (resp, model, id, change) => {
     if (id === 'slug') {
-      addLoadingMessage(t('Slug changed, refreshing page...'));
-      window.location.assign(
-        `/settings/${this.props.params.orgId}/teams/${model.getValue(id)}/settings/`
-      );
+      addSuccessMessage(t('Team name changed'));
       this.props.router.push(
         `/settings/${this.props.params.orgId}/teams/${model.getValue(id)}/settings/`
       );
@@ -64,9 +61,10 @@ export default class TeamSettings extends AsyncView {
   };
 
   renderBody() {
-    let team = this.props.team;
+    let {location, organization} = this.context;
+    let {team} = this.props;
 
-    let access = new Set(this.context.organization.access);
+    let access = new Set(organization.access);
 
     return (
       <React.Fragment>
@@ -83,7 +81,7 @@ export default class TeamSettings extends AsyncView {
           }}
         >
           <Box>
-            <JsonForm location={this.context.location} forms={teamSettingsFields} />
+            <JsonForm location={location} forms={teamSettingsFields} />
           </Box>
         </Form>
 

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -50,14 +50,14 @@ window.Raven = {
 window.TestStubs = {
   // react-router's 'router' context
   router: (params = {}) => ({
-    push: sinon.spy(),
-    replace: sinon.spy(),
-    go: sinon.spy(),
-    goBack: sinon.spy(),
-    goForward: sinon.spy(),
-    setRouteLeaveHook: sinon.spy(),
-    isActive: sinon.spy(),
-    createHref: sinon.spy(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    go: jest.fn(),
+    goBack: jest.fn(),
+    goForward: jest.fn(),
+    setRouteLeaveHook: jest.fn(),
+    isActive: jest.fn(),
+    createHref: jest.fn(),
     location: {query: {}},
     ...params,
   }),

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -137,17 +137,17 @@ exports[`Configure should render correctly render() should render platform docs 
             }
             router={
               Object {
-                "createHref": [Function],
-                "go": [Function],
-                "goBack": [Function],
-                "goForward": [Function],
-                "isActive": [Function],
+                "createHref": [MockFunction],
+                "go": [MockFunction],
+                "goBack": [MockFunction],
+                "goForward": [MockFunction],
+                "isActive": [MockFunction],
                 "location": Object {
                   "query": Object {},
                 },
-                "push": [Function],
-                "replace": [Function],
-                "setRouteLeaveHook": [Function],
+                "push": [MockFunction],
+                "replace": [MockFunction],
+                "setRouteLeaveHook": [MockFunction],
               }
             }
             style={

--- a/tests/js/spec/views/organizationMembersView.spec.jsx
+++ b/tests/js/spec/views/organizationMembersView.spec.jsx
@@ -330,6 +330,6 @@ describe('OrganizationMembersView', function() {
 
     wrapper.find('PanelHeader form').simulate('submit');
 
-    expect(routerContext.context.router.push.calledOnce).toBe(true);
+    expect(routerContext.context.router.push).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/js/spec/views/organizationProjects.spec.jsx
+++ b/tests/js/spec/views/organizationProjects.spec.jsx
@@ -83,7 +83,7 @@ describe('OrganizationProjectsView', function() {
       );
 
       wrapper.find('PanelHeader form').simulate('submit');
-      expect(routerOrganizationContext.context.router.push.calledOnce).toBe(true);
+      expect(routerOrganizationContext.context.router.push).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/js/spec/views/projects/projectContext.spec.jsx
+++ b/tests/js/spec/views/projects/projectContext.spec.jsx
@@ -46,7 +46,7 @@ describe('projectContext component', function() {
       childContextTypes: {organization: SentryTypes.Organization},
     });
 
-    expect(router.replace.calledOnce).toBeTruthy();
-    expect(router.replace.args[0]).toEqual([`/${org.slug}/renamed-slug/`]);
+    expect(router.replace).toHaveBeenCalledTimes(1);
+    expect(router.replace).toHaveBeenCalledWith(`/${org.slug}/renamed-slug/`);
   });
 });

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -67,21 +67,24 @@ describe('NewTeamSettings', function() {
     window.location.assign.restore();
   });
 
-  it('can change name and slug', function(done) {
+  it('can change name and slug', async function() {
     let team = TestStubs.Team();
     let putMock = MockApiClient.addMockResponse({
       url: `/teams/org/${team.slug}/`,
       method: 'PUT',
     });
+    let mountOptions = TestStubs.routerContext();
+    let {router} = mountOptions.context;
 
     let wrapper = mountWithTheme(
       <NewTeamSettings
         routes={[]}
+        router={router}
         params={{orgId: 'org', teamId: team.slug}}
         team={team}
         onTeamChange={() => {}}
       />,
-      TestStubs.routerContext()
+      mountOptions
     );
 
     wrapper
@@ -114,12 +117,8 @@ describe('NewTeamSettings', function() {
       })
     );
 
-    setTimeout(() => {
-      expect(
-        window.location.assign.calledWith('/settings/org/teams/new-slug/settings/')
-      ).toBe(true);
-      done();
-    }, 1);
+    await tick();
+    expect(router.push).toHaveBeenCalledWith('/settings/org/teams/new-slug/settings/');
   });
 
   it('needs team:admin in order to see remove team button', function() {


### PR DESCRIPTION
...this allows us to be able to jest matchers on our router mock.

Also fixes a bad merge where we both use a full browser redirect after team slug is changed when a react router redirect will suffice.