### PR TITLE
feat(environments): Update environment on querystring change

### DIFF
--- a/src/sentry/static/sentry/app/utils/withEnvironmentInQueryString.jsx
+++ b/src/sentry/static/sentry/app/utils/withEnvironmentInQueryString.jsx
@@ -60,22 +60,33 @@ const withEnvironmentInQueryString = WrappedComponent =>
       // We update the environment to match the query string if they are out of sync and
       // new props are received. This is required so the back button triggers a return
       // to the previous environment
-      const {organization, environment} = this.state;
-      const environmentString = nextProps.location.query.environment;
+      const {organization} = this.state;
 
       // TODO(lyn): Remove this block when environments feature is active
       const hasEnvironmentsFeature = this.hasEnvironmentsFeature(organization);
       if (!hasEnvironmentsFeature) return;
       // End remove block
 
-      const nextEnvironment =
-        environmentString === ALL_ENVIRONMENTS_KEY
-          ? null
-          : EnvironmentStore.getByName(environmentString) ||
-            EnvironmentStore.getDefault();
+      const currentQueryEnv = this.getEnvironmentFromQueryString(
+        this.props.location.search
+      );
+      const nextQueryEnv = this.getEnvironmentFromQueryString(nextProps.location.search);
+      const queryEnvironmentHasChanged = currentQueryEnv !== nextQueryEnv;
+      if (queryEnvironmentHasChanged) {
+        setActiveEnvironment(nextQueryEnv);
+      }
+    },
 
-      if (nextEnvironment !== environment) {
-        setActiveEnvironment(nextEnvironment);
+    getEnvironmentFromQueryString(searchTerm) {
+      const envName = qs.parse(searchTerm).environment;
+
+      switch (envName) {
+        case ALL_ENVIRONMENTS_KEY:
+          return null;
+        case undefined:
+          return EnvironmentStore.getDefault();
+        default:
+          return EnvironmentStore.getByName(envName);
       }
     },
 

--- a/src/sentry/static/sentry/app/utils/withEnvironmentInQueryString.jsx
+++ b/src/sentry/static/sentry/app/utils/withEnvironmentInQueryString.jsx
@@ -8,6 +8,7 @@ import qs from 'query-string';
 import EnvironmentStore from '../stores/environmentStore';
 import LatestContextStore from '../stores/latestContextStore';
 import {ALL_ENVIRONMENTS_KEY} from '../constants';
+import {setActiveEnvironment} from '../actionCreators/environments';
 
 const withEnvironmentInQueryString = WrappedComponent =>
   createReactClass({
@@ -52,6 +53,29 @@ const withEnvironmentInQueryString = WrappedComponent =>
             browserHistory.replace(`${pathname}?${qs.stringify(query)}`);
           }
         }
+      }
+    },
+
+    componentWillReceiveProps(nextProps) {
+      // We update the environment to match the query string if they are out of sync and
+      // new props are received. This is required so the back button triggers a return
+      // to the previous environment
+      const {organization, environment} = this.state;
+      const environmentString = nextProps.location.query.environment;
+
+      // TODO(lyn): Remove this block when environments feature is active
+      const hasEnvironmentsFeature = this.hasEnvironmentsFeature(organization);
+      if (!hasEnvironmentsFeature) return;
+      // End remove block
+
+      const nextEnvironment =
+        environmentString === ALL_ENVIRONMENTS_KEY
+          ? null
+          : EnvironmentStore.getByName(environmentString) ||
+            EnvironmentStore.getDefault();
+
+      if (nextEnvironment !== environment) {
+        setActiveEnvironment(nextEnvironment);
       }
     },
 

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -392,6 +392,7 @@ window.TestStubs = {
       return [
         {id: '1', name: 'production', isHidden: false},
         {id: '2', name: 'staging', isHidden: false},
+        {id: '3', name: 'test', isHidden: false},
       ];
     }
   },

--- a/tests/js/spec/utils/withEnvironmentInQueryString.spec.jsx
+++ b/tests/js/spec/utils/withEnvironmentInQueryString.spec.jsx
@@ -4,6 +4,7 @@ import {browserHistory} from 'react-router';
 
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 import LatestContextStore from 'app/stores/latestContextStore';
+import EnvironmentStore from 'app/stores/environmentStore';
 
 class BasicComponent extends React.Component {
   render() {
@@ -19,6 +20,10 @@ describe('withEnvironmentInQueryString', function() {
     LatestContextStore.onSetActiveOrganization({
       features: ['environments'],
     });
+  });
+
+  afterEach(function() {
+    LatestContextStore.reset();
   });
 
   describe('updates environment', function() {
@@ -88,6 +93,23 @@ describe('withEnvironmentInQueryString', function() {
       expect(browserHistory.replace).toHaveBeenCalledWith(
         'http://lol/?environment=staging'
       );
+    });
+  });
+
+  describe('navigation', async function() {
+    it('updates active environment on querystring change', async function() {
+      EnvironmentStore.loadInitialData(TestStubs.Environments());
+
+      const wrapper = shallow(
+        <WrappedComponent location={{pathname: 'http://lol/', search: '', query: {}}} />,
+        TestStubs.routerContext()
+      );
+      expect(LatestContextStore.getInitialState().environment).toBeNull();
+      wrapper
+        .instance()
+        .componentWillReceiveProps({location: {search: '?environment=staging'}});
+      await tick();
+      expect(LatestContextStore.getInitialState().environment.name).toBe('staging');
     });
   });
 });

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -530,6 +530,10 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             "staging",
                             "Staging",
                           ],
+                          Array [
+                            "test",
+                            "Test",
+                          ],
                         ]
                       }
                       className=""
@@ -590,6 +594,12 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               value="staging"
                             >
                               Staging
+                            </option>
+                            <option
+                              key="test"
+                              value="test"
+                            >
+                              Test
                             </option>
                           </select>
                         </div>
@@ -1434,6 +1444,10 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                             "staging",
                             "Staging",
                           ],
+                          Array [
+                            "test",
+                            "Test",
+                          ],
                         ]
                       }
                       className=""
@@ -1494,6 +1508,12 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               value="staging"
                             >
                               Staging
+                            </option>
+                            <option
+                              key="test"
+                              value="test"
+                            >
+                              Test
                             </option>
                           </select>
                         </div>

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -758,6 +758,141 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                   </StyledPanelItem>
                 </PanelItem>
               </EnvironmentRow>
+              <EnvironmentRow
+                actionText="Hide"
+                environment={
+                  Object {
+                    "displayName": "Test",
+                    "id": "3",
+                    "name": "test",
+                    "urlRoutingName": "test",
+                  }
+                }
+                isDefault={false}
+                isHidden={false}
+                key="3"
+                name="test"
+                onHide={[Function]}
+                onSetAsDefault={[Function]}
+                shouldShowAction={true}
+                shouldShowSetDefault={true}
+              >
+                <PanelItem
+                  align="center"
+                  justify="space-between"
+                  p={2}
+                >
+                  <StyledPanelItem
+                    align="center"
+                    justify="space-between"
+                    p={2}
+                  >
+                    <Base
+                      align="center"
+                      className="css-qcergp-StyledPanelItem css-q9h14u0"
+                      justify="space-between"
+                      p={2}
+                    >
+                      <div
+                        className="css-qcergp-StyledPanelItem css-q9h14u0"
+                        is={null}
+                      >
+                        <Flex
+                          align="center"
+                        >
+                          <Base
+                            align="center"
+                            className="css-5ipae5"
+                          >
+                            <div
+                              className="css-5ipae5"
+                              is={null}
+                            >
+                              Test
+                               
+                              <code>
+                                test
+                              </code>
+                            </div>
+                          </Base>
+                        </Flex>
+                        <div>
+                          <EnvironmentButton
+                            onClick={[Function]}
+                            size="xsmall"
+                          >
+                            <Button
+                              className="css-10adnmx-EnvironmentButton css-d1dasp0"
+                              disabled={false}
+                              onClick={[Function]}
+                              size="xsmall"
+                            >
+                              <button
+                                className="css-10adnmx-EnvironmentButton css-d1dasp0 button button-default button-xs"
+                                disabled={false}
+                                onClick={[Function]}
+                                role="button"
+                              >
+                                <Flex
+                                  align="center"
+                                  className="button-label"
+                                >
+                                  <Base
+                                    align="center"
+                                    className="button-label css-5ipae5"
+                                  >
+                                    <div
+                                      className="button-label css-5ipae5"
+                                      is={null}
+                                    >
+                                      Set as default
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </button>
+                            </Button>
+                          </EnvironmentButton>
+                          <EnvironmentButton
+                            onClick={[Function]}
+                            size="xsmall"
+                          >
+                            <Button
+                              className="css-10adnmx-EnvironmentButton css-d1dasp0"
+                              disabled={false}
+                              onClick={[Function]}
+                              size="xsmall"
+                            >
+                              <button
+                                className="css-10adnmx-EnvironmentButton css-d1dasp0 button button-default button-xs"
+                                disabled={false}
+                                onClick={[Function]}
+                                role="button"
+                              >
+                                <Flex
+                                  align="center"
+                                  className="button-label"
+                                >
+                                  <Base
+                                    align="center"
+                                    className="button-label css-5ipae5"
+                                  >
+                                    <div
+                                      className="button-label css-5ipae5"
+                                      is={null}
+                                    >
+                                      Hide
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </button>
+                            </Button>
+                          </EnvironmentButton>
+                        </div>
+                      </div>
+                    </Base>
+                  </StyledPanelItem>
+                </PanelItem>
+              </EnvironmentRow>
             </div>
           </PanelBody>
         </div>


### PR DESCRIPTION
This is so the back button correctly triggers a return to the previous environment