### PR TITLE
fix(auditlog): Fix audit log entry for Org Restore

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -194,7 +194,8 @@ class OrganizationSerializer(serializers.Serializer):
                 'allow_joinleave': org.flags.allow_joinleave.is_set,
                 'enhanced_privacy': org.flags.enhanced_privacy.is_set,
                 'disable_shared_issues': org.flags.disable_shared_issues.is_set,
-                'early_adopter': org.flags.early_adopter.is_set
+                'early_adopter': org.flags.early_adopter.is_set,
+                'require_2fa': org.flags.require_2fa.is_set,
             }
         }
 
@@ -307,14 +308,14 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         'model': Organization.__name__,
                     }
                 )
-
-            self.create_audit_entry(
-                request=request,
-                organization=organization,
-                target_object=organization.id,
-                event=AuditLogEntryEvent.ORG_EDIT,
-                data=changed_data
-            )
+            else:
+                self.create_audit_entry(
+                    request=request,
+                    organization=organization,
+                    target_object=organization.id,
+                    event=AuditLogEntryEvent.ORG_EDIT,
+                    data=changed_data
+                )
 
             return Response(
                 serialize(

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -210,8 +210,8 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.ORG_ADD:
             return 'created the organization'
         elif self.event == AuditLogEntryEvent.ORG_EDIT:
-            return 'edited the organization setting(s): ' + (', '.join(u'{} {}'.format(k, v)
-                                                                       for k, v in self.data.items()))
+            return 'edited the organization setting: ' + (', '.join(u'{} {}'.format(k, v)
+                                                                    for k, v in self.data.items()))
         elif self.event == AuditLogEntryEvent.ORG_REMOVE:
             return 'removed the organization'
         elif self.event == AuditLogEntryEvent.ORG_RESTORE:

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -131,8 +131,10 @@ class OrganizationTest(TestCase):
     def test_flags_have_changed(self):
         org = self.create_organization()
         org.flags.early_adopter = True
+        org.flags.require_2fa = True
         assert org.flag_has_changed('early_adopter')
         assert org.flag_has_changed('allow_joinleave') is False
+        assert org.flag_has_changed('require_2fa') is True
 
     def test_send_setup_2fa_emails(self):
         owner = self.create_user('foo@example.com')

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -70,6 +70,20 @@ class CreateAuditEntryTest(TestCase):
         deleted_org = DeletedOrganization.objects.get(slug=self.org.slug)
         self.assert_valid_deleted_log(deleted_org, self.org)
 
+    def test_audit_entry_org_restore_log(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.org.id,
+            event=AuditLogEntryEvent.ORG_RESTORE,
+            data=self.org.get_audit_log_data(),
+        )
+
+        assert ('restored') in entry.get_note()
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == AuditLogEntryEvent.ORG_RESTORE
+
     def test_audit_entry_team_delete_log(self):
         entry = create_audit_entry(
             request=self.req,

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -81,7 +81,7 @@ class CreateAuditEntryTest(TestCase):
 
         assert ('restored') in entry.get_note()
         assert entry.actor == self.user
-        assert entry.target_object == self.project.id
+        assert entry.target_object == self.org.id
         assert entry.event == AuditLogEntryEvent.ORG_RESTORE
 
     def test_audit_entry_team_delete_log(self):


### PR DESCRIPTION
Fix the audit log entry for ORG.RESTORE. Also include audit log entry for require_2fa.

## `ORG.RESTORE` Before
<img width="895" alt="screen shot 2018-04-17 at 7 38 09 pm" src="https://user-images.githubusercontent.com/20312973/38909582-07e2f768-427a-11e8-925b-ef53db2c40c2.png">

## `ORG.RESTORE` After
<img width="896" alt="screen shot 2018-04-17 at 7 36 56 pm" src="https://user-images.githubusercontent.com/20312973/38909585-0fe335e0-427a-11e8-9a32-ac990d8b6ed7.png">

## 2FA Audit Log Entry
<img width="878" alt="screen shot 2018-04-17 at 8 02 21 pm" src="https://user-images.githubusercontent.com/20312973/38909630-4b13e7c2-427a-11e8-9218-f45f1279b62d.png">