### PR TITLE
fix(setup): Correct anonymous beacon configuration

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -16,7 +16,7 @@ from sentry.options import (
     FLAG_ALLOW_EMPTY,
     register,
 )
-from sentry.utils.types import Dict, String, Sequence
+from sentry.utils.types import Bool, Dict, String, Sequence
 
 # Cache
 # register('cache.backend', flags=FLAG_NOSTORE)
@@ -94,7 +94,7 @@ register('api.rate-limit.org-create', default=5, flags=FLAG_ALLOW_EMPTY | FLAG_P
 
 # Beacon
 
-register('beacon.anonymous', default=True, flags=FLAG_REQUIRED)
+register('beacon.anonymous', type=Bool, flags=FLAG_REQUIRED)
 
 # Filestore
 register('filestore.backend', default='filesystem', flags=FLAG_NOSTORE)

--- a/src/sentry/static/sentry/app/components/forms/radioBooleanField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/radioBooleanField.jsx
@@ -10,6 +10,14 @@ export default class RadioBooleanField extends InputField {
     ...InputField.propTypes,
     yesLabel: PropTypes.string.isRequired,
     noLabel: PropTypes.string.isRequired,
+    yesFirst: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    ...InputField.defaultProps,
+    yesLabel: 'Yes',
+    noLabel: 'No',
+    yesFirst: true,
   };
 
   coerceValue(props) {
@@ -27,34 +35,49 @@ export default class RadioBooleanField extends InputField {
   }
 
   getField() {
+    let yesOption = (
+      <div className="radio" key="yes">
+        <label style={{fontWeight: 'normal'}}>
+          <input
+            type="radio"
+            value="true"
+            name={this.props.name}
+            checked={this.state.value === true}
+            onChange={this.onChange.bind(this)}
+            disabled={this.props.disabled}
+          />{' '}
+          {this.props.yesLabel}
+        </label>
+      </div>
+    );
+    let noOption = (
+      <div className="radio" key="no">
+        <label style={{fontWeight: 'normal'}}>
+          <input
+            type="radio"
+            name={this.props.name}
+            value="false"
+            checked={this.state.value === false}
+            onChange={this.onChange.bind(this)}
+            disabled={this.props.disabled}
+          />{' '}
+          {this.props.noLabel}
+        </label>
+      </div>
+    );
     return (
       <div className="control-group radio-boolean">
-        <div className="radio">
-          <label style={{fontWeight: 'normal'}}>
-            <input
-              type="radio"
-              value="true"
-              name={this.props.name}
-              checked={this.state.value === true}
-              onChange={this.onChange.bind(this)}
-              disabled={this.props.disabled}
-            />{' '}
-            {this.props.yesLabel}
-          </label>
-        </div>
-        <div className="radio">
-          <label style={{fontWeight: 'normal'}}>
-            <input
-              type="radio"
-              name={this.props.name}
-              value="false"
-              checked={this.state.value === false}
-              onChange={this.onChange.bind(this)}
-              disabled={this.props.disabled}
-            />{' '}
-            {this.props.noLabel}
-          </label>
-        </div>
+        {this.props.yesFirst ? (
+          <React.Fragment>
+            {yesOption}
+            {noOption}
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            {noOption}
+            {yesOption}
+          </React.Fragment>
+        )}
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/options.jsx
+++ b/src/sentry/static/sentry/app/options.jsx
@@ -102,8 +102,10 @@ const definitions = [
     key: 'beacon.anonymous',
     label: 'Usage Statistics',
     component: RadioBooleanField,
-    yesLabel: 'Send my contact information along with usage statistics',
-    noLabel: 'Please keep my usage information anonymous',
+    // yes and no are inverted here due to the nature of this configuration
+    noLabel: 'Send my contact information along with usage statistics',
+    yesLabel: 'Please keep my usage information anonymous',
+    yesFirst: false,
     help: tct(
       'If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the [link:documentation].',
       {

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -56,7 +56,9 @@ def send_beacon():
         end=end,
     )['events.total']
 
-    anonymous = options.get('beacon.anonymous')
+    # we need this to be explicitly configured and it defaults to None,
+    # which is the same as False
+    anonymous = options.get('beacon.anonymous') is not False
 
     payload = {
         'install_id': install_id,

--- a/tests/js/spec/components/forms/__snapshots__/radioBooleanField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/radioBooleanField.spec.jsx.snap
@@ -10,50 +10,54 @@ exports[`RadioBooleanField render() renders with form context 1`] = `
     <div
       className="control-group radio-boolean"
     >
-      <div
-        className="radio"
-      >
-        <label
-          style={
-            Object {
-              "fontWeight": "normal",
-            }
-          }
+      <React.Fragment>
+        <div
+          className="radio"
+          key="yes"
         >
-          <input
-            checked={true}
-            disabled={false}
-            name="fieldName"
-            onChange={[Function]}
-            type="radio"
-            value="true"
-          />
-           
-          Yes
-        </label>
-      </div>
-      <div
-        className="radio"
-      >
-        <label
-          style={
-            Object {
-              "fontWeight": "normal",
+          <label
+            style={
+              Object {
+                "fontWeight": "normal",
+              }
             }
-          }
+          >
+            <input
+              checked={true}
+              disabled={false}
+              name="fieldName"
+              onChange={[Function]}
+              type="radio"
+              value="true"
+            />
+             
+            Yes
+          </label>
+        </div>
+        <div
+          className="radio"
+          key="no"
         >
-          <input
-            checked={false}
-            disabled={false}
-            name="fieldName"
-            onChange={[Function]}
-            type="radio"
-            value="false"
-          />
-           
-          No
-        </label>
-      </div>
+          <label
+            style={
+              Object {
+                "fontWeight": "normal",
+              }
+            }
+          >
+            <input
+              checked={false}
+              disabled={false}
+              name="fieldName"
+              onChange={[Function]}
+              type="radio"
+              value="false"
+            />
+             
+            No
+          </label>
+        </div>
+      </React.Fragment>
     </div>
   </div>
 </div>
@@ -69,50 +73,54 @@ exports[`RadioBooleanField render() renders without form context 1`] = `
     <div
       className="control-group radio-boolean"
     >
-      <div
-        className="radio"
-      >
-        <label
-          style={
-            Object {
-              "fontWeight": "normal",
-            }
-          }
+      <React.Fragment>
+        <div
+          className="radio"
+          key="yes"
         >
-          <input
-            checked={false}
-            disabled={false}
-            name="fieldName"
-            onChange={[Function]}
-            type="radio"
-            value="true"
-          />
-           
-          Yes
-        </label>
-      </div>
-      <div
-        className="radio"
-      >
-        <label
-          style={
-            Object {
-              "fontWeight": "normal",
+          <label
+            style={
+              Object {
+                "fontWeight": "normal",
+              }
             }
-          }
+          >
+            <input
+              checked={false}
+              disabled={false}
+              name="fieldName"
+              onChange={[Function]}
+              type="radio"
+              value="true"
+            />
+             
+            Yes
+          </label>
+        </div>
+        <div
+          className="radio"
+          key="no"
         >
-          <input
-            checked={false}
-            disabled={false}
-            name="fieldName"
-            onChange={[Function]}
-            type="radio"
-            value="false"
-          />
-           
-          No
-        </label>
-      </div>
+          <label
+            style={
+              Object {
+                "fontWeight": "normal",
+              }
+            }
+          >
+            <input
+              checked={false}
+              disabled={false}
+              name="fieldName"
+              onChange={[Function]}
+              type="radio"
+              value="false"
+            />
+             
+            No
+          </label>
+        </div>
+      </React.Fragment>
     </div>
   </div>
 </div>

--- a/tests/js/spec/views/__snapshots__/adminSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/adminSettings.spec.jsx.snap
@@ -204,9 +204,10 @@ exports[`AdminSettings render() renders 1`] = `
         key="beacon.anonymous"
         label="Usage Statistics"
         name="beacon.anonymous"
-        noLabel="Please keep my usage information anonymous"
+        noLabel="Send my contact information along with usage statistics"
         required={false}
-        yesLabel="Send my contact information along with usage statistics"
+        yesFirst={false}
+        yesLabel="Please keep my usage information anonymous"
       />
     </ApiForm>
   </div>


### PR DESCRIPTION
The logic for beacon.anonymous was inverted (yes was no, no was yes). This also adjusts RadioBooleanField so the yesLabel can be deprioritized.

Fixes APP-113