### PR TITLE
fix(ui): Clean up `DropdownMenu` click handlers and close delays for nested menus

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownLink.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.jsx
@@ -58,7 +58,7 @@ class DropdownLink extends React.Component {
     // .dropdown-actor-title = flexbox to fix vertical alignment on firefox
     // Need the extra container because dropdown-menu alignment is off if `dropdown-actor` is a flexbox
     return (
-      <DropdownMenu {...otherProps}>
+      <DropdownMenu alwaysRenderMenu={alwaysRenderMenu} {...otherProps}>
         {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
           let shouldRenderMenu = alwaysRenderMenu || isOpen;
           let cx = classNames('dropdown-actor', className, {

--- a/src/sentry/static/sentry/app/components/dropdownMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.jsx
@@ -223,7 +223,12 @@ class DropdownMenu extends React.Component {
 
         // Only handle mouse enter for nested dropdowns
         if (!isNestedDropdown) return;
-        this.handleOpen(...args);
+
+        if (this.mouseLeaveId) window.clearTimeout(this.mouseLeaveId);
+
+        this.mouseEnterId = window.setTimeout(() => {
+          this.handleOpen(...args);
+        }, MENU_CLOSE_DELAY);
       },
 
       onMouseLeave: (...args) => {
@@ -231,6 +236,7 @@ class DropdownMenu extends React.Component {
           onMouseLeave(...args);
         }
 
+        if (this.mouseEnterId) window.clearTimeout(this.mouseEnterId);
         this.handleMouseLeave(...args);
       },
       onClick: (...args) => {

--- a/src/sentry/static/sentry/app/constants/index.jsx
+++ b/src/sentry/static/sentry/app/constants/index.jsx
@@ -48,3 +48,5 @@ export const DEFAULT_FUSE_OPTIONS = {
   // tokenize: true,
   // findAllMatches: true,
 };
+
+export const MENU_CLOSE_DELAY = 200;

--- a/src/sentry/static/sentry/less/dropdowns.less
+++ b/src/sentry/static/sentry/less/dropdowns.less
@@ -39,10 +39,6 @@
   }
 
   &:hover > span {
-    > .dropdown-menu {
-      display: block;
-    }
-
     > a:after {
       border-left-color: #fff;
     }

--- a/tests/js/spec/components/__snapshots__/dropdownLink.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownLink.spec.jsx.snap
@@ -13,6 +13,7 @@ exports[`DropdownLink renders and anchors to left by default 1`] = `
   topLevelClasses="top-level-class"
 >
   <DropdownMenu
+    alwaysRenderMenu={true}
     keepMenuOpen={false}
     onClose={[Function]}
     onOpen={[Function]}
@@ -40,6 +41,7 @@ exports[`DropdownLink renders and anchors to left by default 1`] = `
       <ul
         className="dropdown-menu"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <div>
@@ -67,6 +69,7 @@ exports[`DropdownLink renders and anchors to right 1`] = `
   topLevelClasses="top-level-class"
 >
   <DropdownMenu
+    alwaysRenderMenu={true}
     keepMenuOpen={false}
     onClose={[Function]}
     onOpen={[Function]}
@@ -94,6 +97,7 @@ exports[`DropdownLink renders and anchors to right 1`] = `
       <ul
         className="dropdown-menu"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <div>

--- a/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
@@ -357,6 +357,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
         title=""
       >
         <DropdownMenu
+          alwaysRenderMenu={true}
           keepMenuOpen={false}
         >
           <span
@@ -380,6 +381,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
             <ul
               className="dropdown-menu"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <MenuItem
@@ -406,6 +408,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                   title="For…"
                 >
                   <DropdownMenu
+                    alwaysRenderMenu={true}
                     isNestedDropdown={true}
                     keepMenuOpen={false}
                   >
@@ -429,6 +432,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                       <ul
                         className="dropdown-menu"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
                         <MenuItem
@@ -944,6 +948,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                   title="Until this occurs again…"
                 >
                   <DropdownMenu
+                    alwaysRenderMenu={true}
                     isNestedDropdown={true}
                     keepMenuOpen={false}
                   >
@@ -967,6 +972,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                       <ul
                         className="dropdown-menu"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
                         <li
@@ -982,6 +988,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="10 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -1005,6 +1012,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -1376,6 +1384,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="100 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -1399,6 +1408,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -1770,6 +1780,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="1,000 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -1793,6 +1804,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -2164,6 +2176,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="10,000 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -2187,6 +2200,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -2558,6 +2572,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="100,000 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -2581,6 +2596,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -2982,6 +2998,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                   title="Until this affects an additional…"
                 >
                   <DropdownMenu
+                    alwaysRenderMenu={true}
                     isNestedDropdown={true}
                     keepMenuOpen={false}
                   >
@@ -3005,6 +3022,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                       <ul
                         className="dropdown-menu"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
                         <li
@@ -3020,6 +3038,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="10 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -3043,6 +3062,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -3414,6 +3434,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="100 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -3437,6 +3458,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -3808,6 +3830,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="1,000 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -3831,6 +3854,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -4202,6 +4226,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="10,000 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -4225,6 +4250,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -4596,6 +4622,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                             title="100,000 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -4619,6 +4646,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -5310,6 +5338,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
         title=""
       >
         <DropdownMenu
+          alwaysRenderMenu={true}
           keepMenuOpen={false}
         >
           <span
@@ -5333,6 +5362,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
             <ul
               className="dropdown-menu"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <MenuItem
@@ -5359,6 +5389,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                   title="For…"
                 >
                   <DropdownMenu
+                    alwaysRenderMenu={true}
                     isNestedDropdown={true}
                     keepMenuOpen={false}
                   >
@@ -5382,6 +5413,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                       <ul
                         className="dropdown-menu"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
                         <MenuItem
@@ -5592,6 +5624,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                   title="Until this occurs again…"
                 >
                   <DropdownMenu
+                    alwaysRenderMenu={true}
                     isNestedDropdown={true}
                     keepMenuOpen={false}
                   >
@@ -5615,6 +5648,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                       <ul
                         className="dropdown-menu"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
                         <li
@@ -5630,6 +5664,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="10 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -5653,6 +5688,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -5780,6 +5816,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="100 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -5803,6 +5840,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -5930,6 +5968,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="1,000 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -5953,6 +5992,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -6080,6 +6120,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="10,000 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -6103,6 +6144,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -6230,6 +6272,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="100,000 times"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -6253,6 +6296,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -6410,6 +6454,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                   title="Until this affects an additional…"
                 >
                   <DropdownMenu
+                    alwaysRenderMenu={true}
                     isNestedDropdown={true}
                     keepMenuOpen={false}
                   >
@@ -6433,6 +6478,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                       <ul
                         className="dropdown-menu"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
                         <li
@@ -6448,6 +6494,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="10 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -6471,6 +6518,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -6598,6 +6646,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="100 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -6621,6 +6670,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -6748,6 +6798,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="1,000 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -6771,6 +6822,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -6898,6 +6950,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="10,000 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -6921,6 +6974,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem
@@ -7048,6 +7102,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                             title="100,000 users"
                           >
                             <DropdownMenu
+                              alwaysRenderMenu={true}
                               isNestedDropdown={true}
                               keepMenuOpen={false}
                             >
@@ -7071,6 +7126,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
                                 <ul
                                   className="dropdown-menu"
                                   onClick={[Function]}
+                                  onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
                                   <MenuItem

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -207,6 +207,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
         title=""
       >
         <DropdownMenu
+          alwaysRenderMenu={true}
           keepMenuOpen={false}
         >
           <span
@@ -230,6 +231,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
             <ul
               className="dropdown-menu"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <MenuItem
@@ -592,6 +594,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
         title=""
       >
         <DropdownMenu
+          alwaysRenderMenu={true}
           keepMenuOpen={false}
         >
           <span
@@ -615,6 +618,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
             <ul
               className="dropdown-menu"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <MenuItem

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
+
 import {mount} from 'enzyme';
 import DropdownLink from 'app/components/dropdownLink';
+
+import {MENU_CLOSE_DELAY} from 'app/constants';
+
+jest.useFakeTimers();
 
 describe('DropdownLink', function() {
   const INPUT_1 = {
@@ -200,8 +205,36 @@ describe('DropdownLink', function() {
       wrapper.find('.dropdown-menu a').simulate('mouseEnter');
       expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
 
+      // Leaving Nested Menu
       wrapper.find('a.nested-menu').simulate('mouseLeave');
 
+      // Nested menus have close delay
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
+      jest.advanceTimersByTime(MENU_CLOSE_DELAY - 1);
+      wrapper.update();
+
+      // Re-entering nested menu will cancel close
+      wrapper.find('a.nested-menu').simulate('mouseEnter');
+      jest.advanceTimersByTime(2);
+      wrapper.update();
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
+
+      // Re-entering an actor will also cancel close
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
+      jest.advanceTimersByTime(MENU_CLOSE_DELAY - 1);
+      wrapper.update();
+      wrapper
+        .find('.dropdown-menu a')
+        .first()
+        .simulate('mouseEnter');
+      jest.advanceTimersByTime(2);
+      wrapper.update();
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
+
+      // Leave menu
+      wrapper.find('a.nested-menu').simulate('mouseLeave');
+      jest.runAllTimers();
+      wrapper.update();
       expect(wrapper.find('.dropdown-menu')).toHaveLength(1);
     });
 

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -202,7 +202,10 @@ describe('DropdownLink', function() {
     });
 
     it('Opens / closes on mouse enter and leave', function() {
+      // Nested menus have delay on open
       wrapper.find('.dropdown-menu a').simulate('mouseEnter');
+      jest.runAllTimers();
+      wrapper.update();
       expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
 
       // Leaving Nested Menu
@@ -214,6 +217,7 @@ describe('DropdownLink', function() {
       wrapper.update();
 
       // Re-entering nested menu will cancel close
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
       wrapper.find('a.nested-menu').simulate('mouseEnter');
       jest.advanceTimersByTime(2);
       wrapper.update();
@@ -245,13 +249,19 @@ describe('DropdownLink', function() {
 
     it('closes when second level nested actor is clicked', function() {
       wrapper.find('a.nested-menu').simulate('mouseEnter');
+      jest.runAllTimers();
+      wrapper.update();
       wrapper.find('a.nested-menu-2 span').simulate('click');
       expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
     });
 
     it('closes when third level nested actor is clicked', function() {
       wrapper.find('a.nested-menu').simulate('mouseEnter');
+      jest.runAllTimers();
+      wrapper.update();
       wrapper.find('a.nested-menu-2').simulate('mouseEnter');
+      jest.runAllTimers();
+      wrapper.update();
       wrapper.find('#nested-actor-3').simulate('click');
       expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
     });

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -55,6 +55,7 @@ exports[`GroupReleaseStats renders 1`] = `
           title="All Environments"
         >
           <DropdownMenu
+            alwaysRenderMenu={true}
             keepMenuOpen={false}
           >
             <span
@@ -80,6 +81,7 @@ exports[`GroupReleaseStats renders 1`] = `
               <ul
                 className="dropdown-menu"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >
                 <MenuItem

--- a/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
+++ b/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
@@ -110,6 +110,7 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
         topLevelClasses="project-dropdown"
       >
         <DropdownMenu
+          alwaysRenderMenu={false}
           isOpen={true}
           keepMenuOpen={false}
           onClose={[Function]}
@@ -136,6 +137,7 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
             <ul
               className="dropdown-menu"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <li
@@ -301,6 +303,7 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
         topLevelClasses="project-dropdown"
       >
         <DropdownMenu
+          alwaysRenderMenu={false}
           isOpen={true}
           keepMenuOpen={false}
           onClose={[Function]}
@@ -327,6 +330,7 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
             <ul
               className="dropdown-menu"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <li
@@ -707,6 +711,7 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
         topLevelClasses="project-dropdown is-empty"
       >
         <DropdownMenu
+          alwaysRenderMenu={false}
           isOpen={true}
           keepMenuOpen={false}
           onClose={[Function]}
@@ -733,6 +738,7 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
             <ul
               className="dropdown-menu"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <li


### PR DESCRIPTION
* `DropdownLinks` always render menu (even when not displayed) -- previously `DropdownMenu` attach click listeners to document when menu gets mounted. Change this so if `alwaysRenderMenu` is true, then attach listeners when menu is displayed.

* Add a close delay to `DropdownMenu` for nested dropdowns so that there is some leeway when you mouse out of a menu (or if there's a gap between your dropdown actor and dropdown menu).