### PR TITLE
feat: Move Create Ownership Rule button to sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -11,6 +11,7 @@ import ApiMixin from '../../mixins/apiMixin';
 import GroupState from '../../mixins/groupState';
 import {assignToUser, assignToActor} from '../../actionCreators/group';
 import {t} from '../../locale';
+import {openCreateOwnershipRule} from '../../actionCreators/modal';
 
 const SuggestedOwners = createReactClass({
   displayName: 'SuggestedOwners',
@@ -190,23 +191,54 @@ const SuggestedOwners = createReactClass({
 
   render() {
     let {committers, owners} = this.state;
-    let showOwners = new Set(this.getOrganization().features).has('code-owners');
 
-    if (committers.length == 0 && (!showOwners || owners.length == 0)) {
-      return null;
-    }
+    let group = this.getGroup();
+    let project = this.getProject();
+    let org = this.getOrganization();
+
+    let orgFeatures = new Set(org.features);
+    let showOwners = orgFeatures.has('code-owners');
+
+    let showCreateRule = showOwners && orgFeatures.has('internal-catchall');
+
+    let showSuggestedAssignees =
+      committers.length > 0 || (showOwners && owners.length > 0);
 
     return (
-      <div className="m-b-1">
-        <h6>
-          <span>{t('Suggested Assignees')}</span>
-          <small style={{background: '#FFFFFF'}}>{t('Click to assign')}</small>
-        </h6>
-        <div className="avatar-grid">
-          {committers.map(this.renderCommitter)}
-          {showOwners && owners.map(this.renderOwner)}
-        </div>
-      </div>
+      <React.Fragment>
+        {showSuggestedAssignees && (
+          <div className="m-b-1">
+            <h6>
+              <span>{t('Suggested Assignees')}</span>
+              <small style={{background: '#FFFFFF'}}>{t('Click to assign')}</small>
+            </h6>
+
+            <div className="avatar-grid">
+              {committers.map(this.renderCommitter)}
+              {showOwners && owners.map(this.renderOwner)}
+            </div>
+          </div>
+        )}
+        {showCreateRule && (
+          <div className="m-b-1">
+            <h6>
+              <span>{t('Ownership Rules')}</span>
+            </h6>
+
+            <a
+              onClick={() =>
+                openCreateOwnershipRule({
+                  project,
+                  organization: org,
+                  issueId: group.id,
+                })}
+              className="btn btn-default btn-sm btn-create-ownership-rule"
+            >
+              {t('Create Ownership Rule')}
+            </a>
+          </div>
+        )}
+      </React.Fragment>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -19,7 +19,6 @@ import ShareIssue from '../../components/shareIssue';
 
 import ResolveActions from '../../components/actions/resolve';
 import IgnoreActions from '../../components/actions/ignore';
-import {openCreateOwnershipRule} from '../../actionCreators/modal';
 
 class DeleteActions extends React.Component {
   static propTypes = {
@@ -222,8 +221,6 @@ const GroupDetailsActions = createReactClass({
     }
 
     let hasRelease = this.getProjectFeatures().has('releases');
-    let hasOwners =
-      orgFeatures.has('code-owners') && orgFeatures.has('internal-catchall');
 
     // account for both old and new style plugins
     let hasIssueTracking = group.pluginActions.length || group.pluginIssues.length;
@@ -259,22 +256,6 @@ const GroupDetailsActions = createReactClass({
           onDelete={this.onDelete}
           onDiscard={this.onDiscard}
         />
-
-        {hasOwners && (
-          <div className="btn-group">
-            <a
-              onClick={() =>
-                openCreateOwnershipRule({
-                  project,
-                  organization: org,
-                  issueId: group.id,
-                })}
-              className={'btn btn-default btn-sm btn-create-ownership-rule'}
-            >
-              {t('Create Ownership Rule')}
-            </a>
-          </div>
-        )}
 
         {orgFeatures.has('shared-issues') && (
           <div className="btn-group">


### PR DESCRIPTION
Move the create ownership rule button below Suggested Assignees in sidebar. Not sure if this should be part of the same section.

<img width="500" alt="screen shot 2018-04-19 at 10 59 56 am" src="https://user-images.githubusercontent.com/1779792/39009609-f02e805e-43c0-11e8-99c2-0fdbbff8672a.png">
