### PR TITLE
ref(snuba): Change top tags/values query to use new snuba

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -242,12 +242,14 @@ class SnubaTagStorage(TagStorage):
             'issue': [group_id],
         }
         aggregations = [
-            ['topK(10)', 'tags.value', 'top'],
             ['count()', '', 'count'],
-            ['uniq', 'tags.key', 'uniq'],
+            ['topK(10)', 'tags_value', 'top'],
+            ['uniq', 'tags_value', 'uniq'],
         ]
-        results = snuba.query(start, end, ['tags.key'], None, filters,
-                              aggregations, arrayjoin='tags')
+        conditions = [
+            ['tags_value', 'IS NOT NULL', None],
+        ]
+        results = snuba.query(start, end, ['tags_key'], conditions, filters, aggregations)
 
         return [{
             'id': key,


### PR DESCRIPTION
Top tags/values will now return the full set of normal and promoted tags
and top values using the `tags_key` and `tags_value` special columns.