### PR TITLE
from six.moves import xrange

### DIFF
--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import
 
 import logging
 import threading
-from Queue import Full, PriorityQueue
 from concurrent.futures import Future
-from concurrent.futures._base import RUNNING, FINISHED
+from concurrent.futures._base import FINISHED, RUNNING
 from time import time
 
+from six.moves import xrange
+from six.moves.queue import Full, PriorityQueue
 
 logger = logging.getLogger(__name__)
 

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
-import mock
-import pytest
-from Queue import Full
 from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
 from threading import Event
 
+import pytest
+from six.moves import xrange
+from six.moves.queue import Full
+
+import mock
 from sentry.utils.concurrent import FutureSet, SynchronousExecutor, ThreadedExecutor, TimedFuture
 
 


### PR DESCRIPTION
flake8 testing of https://github.com/getsentry/sentry on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/sentry/api/endpoints/broadcast_index.py:77:52: F821 undefined name 'reduce'
                        queryset = queryset.filter(reduce(or_, filters))
                                                   ^
./src/sentry/tagstore/legacy/backend.py:582:62: E999 SyntaxError: invalid syntax
        tag_lookups = sorted(six.iteritems(tags), key=lambda (k, v): v == ANY)
                                                             ^
./src/sentry/tagstore/v2/backend.py:805:62: E999 SyntaxError: invalid syntax
        tag_lookups = sorted(six.iteritems(tags), key=lambda (k, v): v == ANY)
                                                             ^
./src/sentry/utils/concurrent.py:168:22: F821 undefined name 'xrange'
            for i in xrange(self.__worker_count):
                     ^
./tests/sentry/utils/test_concurrent.py:14:47: F821 undefined name 'xrange'
    future_set = FutureSet([Future() for i in xrange(3)])
                                              ^
./tests/sentry/utils/test_concurrent.py:34:47: F821 undefined name 'xrange'
    future_set = FutureSet([Future() for i in xrange(3)])
                                              ^
./tests/snuba/tagstore/test_backend.py:68:55: F821 undefined name 'r'
            'datetime': (self.now - timedelta(seconds=r)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                                                      ^
./tests/snuba/tagstore/test_backend.py:70:69: F821 undefined name 'r'
                'received': calendar.timegm(self.now.timetuple()) - r,
                                                                    ^
2     E999 SyntaxError: invalid syntax
6     F821 undefined name 'reduce'
8
```