### PR TITLE
fix(ui): Fix settings sidebar width + footer positioning

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -70,7 +70,7 @@ const Container = styled(Flex)`
 `;
 
 const SidebarWrapper = styled(Box)`
-  flex: 0 0 ${p => p.theme.settings.sidebarWidth};
+  width: ${p => p.theme.settings.sidebarWidth};
 `;
 
 const Content = styled(Box)`

--- a/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsLayout.jsx
@@ -122,7 +122,7 @@ class SettingsLayout extends React.Component {
             </Flex>
           </Container>
         </SettingsHeader>
-        <Container>
+        <Container flex="1">
           {typeof renderNavigation === 'function' && (
             <SidebarWrapper>{renderNavigation()}</SidebarWrapper>
           )}

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -22,7 +22,13 @@ body {
     overflow-y: scroll;
     background-image: none;
     background-color: #fcfcfc;
-    padding: 0 0 40px;
+    padding: 0;
+    min-height: 100vh;
+
+    #blk_router,
+    .app {
+      min-height: 100vh;
+    }
 
     .messages-container {
       margin: 0;

--- a/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
@@ -29,7 +29,9 @@ exports[`SettingsLayout renders 1`] = `
       </Flex>
     </Container>
   </SettingsHeader>
-  <Container>
+  <Container
+    flex="1"
+  >
     <Content>
       <NewSettingsWarning />
     </Content>


### PR DESCRIPTION
At large widths, certain views in the new settings would have differing widths so the main content area would jump from max width to a width that's slightly smaller.


Re: footer, use `100vh` on certain containers so that footer is fixed to the bottom:

before:
![image](https://user-images.githubusercontent.com/79684/39003654-1f843db4-43b0-11e8-96e6-836442efc2f5.png)

after:
![image](https://user-images.githubusercontent.com/79684/39003604-07afe2d8-43b0-11e8-8aa9-62fb97dd65ae.png)

browser support: https://caniuse.com/#feat=viewport-units