### PR TITLE
feat(ui): Fix footer to bottom of window

### DIFF
--- a/src/sentry/static/sentry/app/components/narrowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.jsx
@@ -1,8 +1,6 @@
 import jQuery from 'jquery';
 import React from 'react';
 
-import Footer from '../components/footer';
-
 class NarrowLayout extends React.Component {
   componentWillMount() {
     jQuery(document.body).addClass('narrow');
@@ -14,7 +12,7 @@ class NarrowLayout extends React.Component {
 
   render() {
     return (
-      <div className="app">
+      <React.Fragment>
         <div className="pattern-bg" />
         <div className="container">
           <div className="box box-modal">
@@ -26,8 +24,7 @@ class NarrowLayout extends React.Component {
             <div className="box-content with-padding">{this.props.children}</div>
           </div>
         </div>
-        <Footer />
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/components/narrowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.jsx
@@ -12,7 +12,7 @@ class NarrowLayout extends React.Component {
 
   render() {
     return (
-      <React.Fragment>
+      <div className="app">
         <div className="pattern-bg" />
         <div className="container">
           <div className="box box-modal">
@@ -24,7 +24,7 @@ class NarrowLayout extends React.Component {
             <div className="box-content with-padding">{this.props.children}</div>
           </div>
         </div>
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails.jsx
@@ -132,11 +132,11 @@ class OrganizationDetailsBody extends Component {
         return <DeletionInProgress organization={organization} />;
       }
     return (
-      <div>
+      <React.Fragment>
         <Sidebar />
         {this.props.children}
         <Footer />
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/projectDetailsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/projectDetailsLayout.jsx
@@ -39,7 +39,7 @@ const ProjectDetailsLayout = createReactClass({
     if (!this.context.project) return null;
 
     return (
-      <div>
+      <React.Fragment>
         <ProjectHeader
           activeSection={this.state.projectNavSection}
           project={this.context.project}
@@ -55,7 +55,7 @@ const ProjectDetailsLayout = createReactClass({
             })}
           </div>
         </div>
-      </div>
+      </React.Fragment>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -242,8 +242,13 @@ const ProjectContext = createReactClass({
   },
 
   renderBody() {
-    if (this.state.loading) return <LoadingIndicator />;
-    else if (this.state.error) {
+    if (this.state.loading) {
+      return (
+        <div className="loading-full-layout">
+          <LoadingIndicator />
+        </div>
+      );
+    } else if (this.state.error) {
       switch (this.state.errorType) {
         case ERROR_TYPES.PROJECT_NOT_FOUND:
           return (

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -11,6 +11,7 @@ body {
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
   padding-left: @sidebar-width;
+  min-height: 100vh;
 
   // Fake sidebar rendering until actual sidebar is loaded
 
@@ -23,12 +24,6 @@ body {
     background-image: none;
     background-color: #fcfcfc;
     padding: 0;
-    min-height: 100vh;
-
-    #blk_router,
-    .app {
-      min-height: 100vh;
-    }
 
     .messages-container {
       margin: 0;
@@ -37,6 +32,10 @@ body {
       z-index: 1000;
     }
   }
+}
+
+#blk_router {
+  min-height: 100vh;
 }
 
 /**
@@ -132,6 +131,7 @@ body.auth {
 .app {
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
 }
 
 .container {
@@ -139,6 +139,7 @@ body.auth {
   padding-left: 30px;
   padding-right: 30px;
   width: 100% !important;
+  flex: 1;
 }
 
 /**

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -142,6 +142,13 @@ body.auth {
   flex: 1;
 }
 
+// So loader can take up full height so that footer is fixed to bottom of screen
+.loading-full-layout {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
 /**
 * Project level subheader
 * ============================================================================

--- a/src/sentry/static/sentry/less/organization.less
+++ b/src/sentry/static/sentry/less/organization.less
@@ -14,6 +14,8 @@
 }
 
 .organization-home {
+  flex: 1;
+
   .sub-header {
     margin-bottom: 30px;
 

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -5,41 +5,45 @@ exports[`OrganizationDetails render() deletion in progress should render a delet
   class="app"
 >
   <div
-    class="pattern-bg"
-  />
-  <div
-    class="container"
+    class="app"
   >
     <div
-      class="box box-modal"
+      class="pattern-bg"
+    />
+    <div
+      class="container"
     >
       <div
-        class="box-header"
+        class="box box-modal"
       >
-        <a
-          href="/"
+        <div
+          class="box-header"
         >
-          <span
-            class="icon-sentry-logo"
-          />
-        </a>
-      </div>
-      <div
-        class="box-content with-padding"
-      >
-        <p>
-          <span>
+          <a
+            href="/"
+          >
+            <span
+              class="icon-sentry-logo"
+            />
+          </a>
+        </div>
+        <div
+          class="box-content with-padding"
+        >
+          <p>
             <span>
-              The 
+              <span>
+                The 
+              </span>
+              <strong>
+                org-slug
+              </strong>
+              <span>
+                 organization is currently in the process of being deleted from Sentry.
+              </span>
             </span>
-            <strong>
-              org-slug
-            </strong>
-            <span>
-               organization is currently in the process of being deleted from Sentry.
-            </span>
-          </span>
-        </p>
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -51,66 +55,70 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
   class="app"
 >
   <div
-    class="pattern-bg"
-  />
-  <div
-    class="container"
+    class="app"
   >
     <div
-      class="box box-modal"
+      class="pattern-bg"
+    />
+    <div
+      class="container"
     >
       <div
-        class="box-header"
+        class="box box-modal"
       >
-        <a
-          href="/"
+        <div
+          class="box-header"
         >
-          <span
-            class="icon-sentry-logo"
-          />
-        </a>
-      </div>
-      <div
-        class="box-content with-padding"
-      >
-        <h3>
-          Deletion Scheduled
-        </h3>
-        <p>
-          <span>
-            <span>
-              The 
-            </span>
-            <strong>
-              org-slug
-            </strong>
-            <span>
-               organization is currently scheduled for deletion.
-            </span>
-          </span>
-        </p>
-        <div>
+          <a
+            href="/"
+          >
+            <span
+              class="icon-sentry-logo"
+            />
+          </a>
+        </div>
+        <div
+          class="box-content with-padding"
+        >
+          <h3>
+            Deletion Scheduled
+          </h3>
           <p>
-            Would you like to cancel this process and restore the organization back to the original state?
+            <span>
+              <span>
+                The 
+              </span>
+              <strong>
+                org-slug
+              </strong>
+              <span>
+                 organization is currently scheduled for deletion.
+              </span>
+            </span>
           </p>
-          <p>
-            <button
-              class="button button-primary"
-              role="button"
-            >
-              <div
-                class="button-label css-5ipae5"
+          <div>
+            <p>
+              Would you like to cancel this process and restore the organization back to the original state?
+            </p>
+            <p>
+              <button
+                class="button button-primary"
+                role="button"
               >
-                Restore Organization
-              </div>
-            </button>
+                <div
+                  class="button-label css-5ipae5"
+                >
+                  Restore Organization
+                </div>
+              </button>
+            </p>
+          </div>
+          <p>
+            <small>
+              Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
+            </small>
           </p>
         </div>
-        <p>
-          <small>
-            Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
-          </small>
-        </p>
       </div>
     </div>
   </div>
@@ -122,52 +130,56 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
   class="app"
 >
   <div
-    class="pattern-bg"
-  />
-  <div
-    class="container"
+    class="app"
   >
     <div
-      class="box box-modal"
+      class="pattern-bg"
+    />
+    <div
+      class="container"
     >
       <div
-        class="box-header"
+        class="box box-modal"
       >
-        <a
-          href="/"
+        <div
+          class="box-header"
         >
-          <span
-            class="icon-sentry-logo"
-          />
-        </a>
-      </div>
-      <div
-        class="box-content with-padding"
-      >
-        <h3>
-          Deletion Scheduled
-        </h3>
-        <p>
-          <span>
+          <a
+            href="/"
+          >
+            <span
+              class="icon-sentry-logo"
+            />
+          </a>
+        </div>
+        <div
+          class="box-content with-padding"
+        >
+          <h3>
+            Deletion Scheduled
+          </h3>
+          <p>
             <span>
-              The 
+              <span>
+                The 
+              </span>
+              <strong>
+                org-slug
+              </strong>
+              <span>
+                 organization is currently scheduled for deletion.
+              </span>
             </span>
-            <strong>
-              org-slug
-            </strong>
-            <span>
-               organization is currently scheduled for deletion.
-            </span>
-          </span>
-        </p>
-        <p>
-          If this is a mistake, contact an organization owner and ask them to restore this organization.
-        </p>
-        <p>
-          <small>
-            Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
-          </small>
-        </p>
+          </p>
+          <p>
+            If this is a mistake, contact an organization owner and ask them to restore this organization.
+          </p>
+          <p>
+            <small>
+              Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
+            </small>
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -1,289 +1,175 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[
-  `OrganizationDetails render() deletion in progress should render a deletion in progress prompt 1`
-] = `
+exports[`OrganizationDetails render() deletion in progress should render a deletion in progress prompt 1`] = `
 <div
   class="app"
 >
   <div
-    class="app"
+    class="pattern-bg"
+  />
+  <div
+    class="container"
   >
     <div
-      class="pattern-bg"
-    />
-    <div
-      class="container"
+      class="box box-modal"
     >
       <div
-        class="box box-modal"
+        class="box-header"
       >
-        <div
-          class="box-header"
+        <a
+          href="/"
         >
-          <a
-            href="/"
-          >
-            <span
-              class="icon-sentry-logo"
-            />
-          </a>
-        </div>
-        <div
-          class="box-content with-padding"
-        >
-          <p>
+          <span
+            class="icon-sentry-logo"
+          />
+        </a>
+      </div>
+      <div
+        class="box-content with-padding"
+      >
+        <p>
+          <span>
             <span>
-              <span>
-                The 
-              </span>
-              <strong>
-                org-slug
-              </strong>
-              <span>
-                 organization is currently in the process of being deleted from Sentry.
-              </span>
+              The 
             </span>
-          </p>
-        </div>
+            <strong>
+              org-slug
+            </strong>
+            <span>
+               organization is currently in the process of being deleted from Sentry.
+            </span>
+          </span>
+        </p>
       </div>
     </div>
-    <footer>
-      <div
-        class="container"
-      >
-        <div
-          class="pull-right"
-        >
-          <a
-            class="hidden-xs"
-            href="/api/"
-          >
-            API
-          </a>
-          <a
-            href="/docs/"
-          >
-            Docs
-          </a>
-          <a
-            class="hidden-xs"
-            href="https://github.com/getsentry/sentry"
-            rel="noreferrer"
-          >
-            Contribute
-          </a>
-        </div>
-        <a
-          class="icon-sentry-logo"
-          href="/"
-        />
-      </div>
-    </footer>
   </div>
 </div>
 `;
 
-exports[
-  `OrganizationDetails render() pending deletion should render a restoration prompt 1`
-] = `
+exports[`OrganizationDetails render() pending deletion should render a restoration prompt 1`] = `
 <div
   class="app"
 >
   <div
-    class="app"
+    class="pattern-bg"
+  />
+  <div
+    class="container"
   >
     <div
-      class="pattern-bg"
-    />
-    <div
-      class="container"
+      class="box box-modal"
     >
       <div
-        class="box box-modal"
+        class="box-header"
       >
-        <div
-          class="box-header"
+        <a
+          href="/"
         >
-          <a
-            href="/"
-          >
-            <span
-              class="icon-sentry-logo"
-            />
-          </a>
-        </div>
-        <div
-          class="box-content with-padding"
-        >
-          <h3>
-            Deletion Scheduled
-          </h3>
-          <p>
+          <span
+            class="icon-sentry-logo"
+          />
+        </a>
+      </div>
+      <div
+        class="box-content with-padding"
+      >
+        <h3>
+          Deletion Scheduled
+        </h3>
+        <p>
+          <span>
             <span>
-              <span>
-                The 
-              </span>
-              <strong>
-                org-slug
-              </strong>
-              <span>
-                 organization is currently scheduled for deletion.
-              </span>
+              The 
             </span>
+            <strong>
+              org-slug
+            </strong>
+            <span>
+               organization is currently scheduled for deletion.
+            </span>
+          </span>
+        </p>
+        <div>
+          <p>
+            Would you like to cancel this process and restore the organization back to the original state?
           </p>
-          <div>
-            <p>
-              Would you like to cancel this process and restore the organization back to the original state?
-            </p>
-            <p>
-              <button
-                class="button button-primary"
-                role="button"
+          <p>
+            <button
+              class="button button-primary"
+              role="button"
+            >
+              <div
+                class="button-label css-5ipae5"
               >
-                <div
-                  class="button-label css-5ipae5"
-                >
-                  Restore Organization
-                </div>
-              </button>
-            </p>
-          </div>
-          <p>
-            <small>
-              Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
-            </small>
+                Restore Organization
+              </div>
+            </button>
           </p>
         </div>
+        <p>
+          <small>
+            Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
+          </small>
+        </p>
       </div>
     </div>
-    <footer>
-      <div
-        class="container"
-      >
-        <div
-          class="pull-right"
-        >
-          <a
-            class="hidden-xs"
-            href="/api/"
-          >
-            API
-          </a>
-          <a
-            href="/docs/"
-          >
-            Docs
-          </a>
-          <a
-            class="hidden-xs"
-            href="https://github.com/getsentry/sentry"
-            rel="noreferrer"
-          >
-            Contribute
-          </a>
-        </div>
-        <a
-          class="icon-sentry-logo"
-          href="/"
-        />
-      </div>
-    </footer>
   </div>
 </div>
 `;
 
-exports[
-  `OrganizationDetails render() pending deletion should render a restoration prompt without action for members 1`
-] = `
+exports[`OrganizationDetails render() pending deletion should render a restoration prompt without action for members 1`] = `
 <div
   class="app"
 >
   <div
-    class="app"
+    class="pattern-bg"
+  />
+  <div
+    class="container"
   >
     <div
-      class="pattern-bg"
-    />
-    <div
-      class="container"
+      class="box box-modal"
     >
       <div
-        class="box box-modal"
+        class="box-header"
       >
-        <div
-          class="box-header"
+        <a
+          href="/"
         >
-          <a
-            href="/"
-          >
-            <span
-              class="icon-sentry-logo"
-            />
-          </a>
-        </div>
-        <div
-          class="box-content with-padding"
-        >
-          <h3>
-            Deletion Scheduled
-          </h3>
-          <p>
+          <span
+            class="icon-sentry-logo"
+          />
+        </a>
+      </div>
+      <div
+        class="box-content with-padding"
+      >
+        <h3>
+          Deletion Scheduled
+        </h3>
+        <p>
+          <span>
             <span>
-              <span>
-                The 
-              </span>
-              <strong>
-                org-slug
-              </strong>
-              <span>
-                 organization is currently scheduled for deletion.
-              </span>
+              The 
             </span>
-          </p>
-          <p>
-            If this is a mistake, contact an organization owner and ask them to restore this organization.
-          </p>
-          <p>
-            <small>
-              Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
-            </small>
-          </p>
-        </div>
+            <strong>
+              org-slug
+            </strong>
+            <span>
+               organization is currently scheduled for deletion.
+            </span>
+          </span>
+        </p>
+        <p>
+          If this is a mistake, contact an organization owner and ask them to restore this organization.
+        </p>
+        <p>
+          <small>
+            Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed.
+          </small>
+        </p>
       </div>
     </div>
-    <footer>
-      <div
-        class="container"
-      >
-        <div
-          class="pull-right"
-        >
-          <a
-            class="hidden-xs"
-            href="/api/"
-          >
-            API
-          </a>
-          <a
-            href="/docs/"
-          >
-            Docs
-          </a>
-          <a
-            class="hidden-xs"
-            href="https://github.com/getsentry/sentry"
-            rel="noreferrer"
-          >
-            Contribute
-          </a>
-        </div>
-        <a
-          class="icon-sentry-logo"
-          href="/"
-        />
-      </div>
-    </footer>
   </div>
 </div>
 `;


### PR DESCRIPTION
Uses a combination of `min-height: 100vh` and flex box on
containers so that the footer is fixed to the bottom of the screen.

* Removes a few un-needed DOM nodes and replaces them with `React.Fragment`
* Removes extra "div.app" and Footer from `NarrowLayout` since Footer was being hidden from CSS anyway

![fixed-footer](https://user-images.githubusercontent.com/79684/39006527-1f038de2-43b8-11e8-9d54-daff61a9ca74.gif)
