### PR TITLE
feat(ui): Confirm when disabling security features (APP-119)

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -81,9 +81,14 @@ const formGroups = [
         type: 'boolean',
         label: t('Require Two-Factor Authentication'),
         help: t('Require two-factor authentication for all members'),
-        confirm: t(
-          'Enabling this feature will disable all accounts without two-factor authentication. It will also send an email to all users to enable two-factor authentication. Do you want to continue?'
-        ),
+        confirm: {
+          true: t(
+            'Enabling this feature will disable all accounts without two-factor authentication. It will also send an email to all users to enable two-factor authentication. Do you want to continue?'
+          ),
+          false: t(
+            'Are you sure you want to allow users to access your organization without having two-factor authentication enabled?'
+          ),
+        },
         visible: ({features}) => features.has('require-2fa'),
       },
       {
@@ -92,6 +97,9 @@ const formGroups = [
 
         label: t('Allow Shared Issues'),
         help: t('Enable sharing of limited details on issues to anonymous users'),
+        confirm: {
+          true: t('Are you sure you want to allow sharing issues to anonymous users?'),
+        },
       },
       {
         name: 'enhancedPrivacy',
@@ -101,12 +109,22 @@ const formGroups = [
         help: t(
           'Enable enhanced privacy controls to limit personally identifiable information (PII) as well as source code in things like notifications'
         ),
+        confirm: {
+          false: t(
+            'Disabling this can have privacy implications for ALL projects, are you sure you want to continue?'
+          ),
+        },
       },
       {
         name: 'dataScrubber',
         type: 'boolean',
         label: t('Require Data Scrubber'),
         help: t('Require server-side data scrubbing be enabled for all projects'),
+        confirm: {
+          false: t(
+            'Disabling this can have privacy implications for ALL projects, are you sure you want to continue?'
+          ),
+        },
       },
       {
         name: 'dataScrubberDefaults',
@@ -115,6 +133,11 @@ const formGroups = [
         help: t(
           'Require the default scrubbers be applied to prevent things like passwords and credit cards from being stored for all projects'
         ),
+        confirm: {
+          false: t(
+            'Disabling this can have privacy implications for ALL projects, are you sure you want to continue?'
+          ),
+        },
       },
       {
         name: 'sensitiveFields',
@@ -153,6 +176,11 @@ const formGroups = [
         help: t(
           'Preventing IP addresses from being stored for new events on all projects'
         ),
+        confirm: {
+          false: t(
+            'Disabling this can have privacy implications for ALL projects, are you sure you want to continue?'
+          ),
+        },
       },
     ],
   },

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -124,6 +124,9 @@ export const fields = {
     // `props` are the props given to FormField
     setValue: (val, props) =>
       (props.organization && props.organization[props.name]) || val,
+    confirm: {
+      false: t('Are you sure you want to disable server-side data scrubbing?'),
+    },
   },
   dataScrubberDefaults: {
     name: 'dataScrubberDefaults',
@@ -137,6 +140,9 @@ export const fields = {
     // `props` are the props given to FormField
     setValue: (val, props) =>
       (props.organization && props.organization[props.name]) || val,
+    confirm: {
+      false: t('Are you sure you want to disable using default scrubbers?'),
+    },
   },
   scrubIPAddresses: {
     name: 'scrubIPAddresses',
@@ -148,6 +154,9 @@ export const fields = {
       (props.organization && props.organization[props.name]) || val,
     label: t('Prevent Storing of IP Addresses'),
     help: t('Preventing IP addresses from being stored for new events'),
+    confirm: {
+      false: t('Are you sure you want to disable scrubbing IP addresses?'),
+    },
   },
   sensitiveFields: {
     name: 'sensitiveFields',

--- a/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.jsx
@@ -8,7 +8,10 @@ import Confirm from '../../../../components/confirm';
 export default class BooleanField extends InputField {
   static propTypes = {
     ...InputField.propTypes,
-    confirm: PropTypes.node,
+    confirm: PropTypes.shape({
+      true: PropTypes.node,
+      false: PropTypes.node,
+    }),
   };
   coerceValue(value) {
     return value ? true : false;
@@ -42,16 +45,17 @@ export default class BooleanField extends InputField {
 
           if (confirm) {
             return (
-              <Confirm message={confirm} onConfirm={() => handleChange({})}>
+              <Confirm
+                renderMessage={() => confirm[!value]}
+                onConfirm={() => handleChange({})}
+              >
                 {({open}) => (
                   <Switch
                     {...switchProps}
                     toggle={e => {
                       // If we have a `confirm` prop and enabling switch
                       // Then show confirm dialog, otherwise propagate change as normal
-                      //
-                      // TODO(billy): We will probably want a way to control if it happens on enable or disable
-                      if (!value) {
+                      if (confirm[!value]) {
                         // Open confirm modal
                         open();
                         return;


### PR DESCRIPTION
Allows confirm modals when enabling or disabling boolean switches. Adds some messages when disabling privacy-related settings in org/project settings.