### PR TITLE
fix(audit-log): Make clear when ondemand set to unlimited

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -273,6 +273,8 @@ class AuditLogEntry(Model):
             return 'removed rule "%s"' % (self.data['label'], )
 
         elif self.event == AuditLogEntryEvent.SET_ONDEMAND:
+            if self.data['ondemand'] == -1:
+                return 'changed on-demand spend to unlimited'
             return 'changed on-demand max spend to $%d' % (self.data['ondemand'] / 100, )
         elif self.event == AuditLogEntryEvent.TRIAL_STARTED:
             return 'started trial'


### PR DESCRIPTION
Before:
<img width="802" alt="screen shot 2018-04-19 at 8 31 34 pm" src="https://user-images.githubusercontent.com/15368179/39029444-b3387b78-4410-11e8-9111-8237c1dda0e4.png">

After:
<img width="814" alt="screen shot 2018-04-19 at 8 27 15 pm" src="https://user-images.githubusercontent.com/15368179/39029403-761020c0-4410-11e8-806e-3c417e7616f8.png">

cc @JTCunning @getsentry/cops 