### PR TITLE
fix: Show discard all button for issues stuck in reprocessing

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -804,7 +804,7 @@ urlpatterns = patterns(
         name='sentry-api-0-project-reprocessing'
     ),
     url(
-        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/processingissues/discard$',
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/processingissues/discard/$',
         ProjectProcessingIssuesDiscardEndpoint.as_view(),
         name='sentry-api-0-project-discard-processing-issues'
     ),

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -134,8 +134,7 @@ const ProjectProcessingIssues = createReactClass({
     this.setState({
       expected: this.state.expected + 1,
     });
-    // Note: inconsistency with missing trailing slash, but matches route in backend
-    this.api.request(`/projects/${orgId}/${projectId}/processingissues/discard`, {
+    this.api.request(`/projects/${orgId}/${projectId}/processingissues/discard/`, {
       method: 'DELETE',
       success: (data, _, jqXHR) => {
         let expected = this.state.expected - 1;
@@ -190,12 +189,12 @@ const ProjectProcessingIssues = createReactClass({
 
   renderDebugTable() {
     let body;
-
     if (this.state.loading) body = this.renderLoading();
     else if (this.state.error) body = <LoadingError onRetry={this.fetchData} />;
     else if (
       this.state.processingIssues.hasIssues ||
-      this.state.processingIssues.resolveableIssues
+      this.state.processingIssues.resolveableIssues ||
+      this.state.processingIssues.issuesProcessing
     )
       body = this.renderResults();
     else body = this.renderEmpty();
@@ -322,6 +321,27 @@ const ProjectProcessingIssues = createReactClass({
         </div>
       );
     }
+    let processingRow = null;
+    if (this.state.processingIssues.issuesProcessing > 0) {
+      processingRow = (
+        <div className="list-group-item alert-info">
+          <div className="row row-flex row-center-vertically">
+            <div className="col-sm-12">
+              <span
+                className="icon icon-processing play"
+                style={{display: 'inline', marginRight: 12}}
+              />
+              {tn(
+                'Reprocessing %d event …',
+                'Reprocessing %d events …',
+                this.state.processingIssues.issuesProcessing
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div>
         {fixLinkBlock}
@@ -346,6 +366,7 @@ const ProjectProcessingIssues = createReactClass({
             </div>
           </div>
           <div className="list-group">
+            {processingRow}
             {this.state.processingIssues.issues.map((item, idx) => {
               return (
                 <div key={idx} className="list-group-item">


### PR DESCRIPTION
We got a support ticket reporting that event is stuck in reprocessing and never disappears.
It must be some kind of race condition, nevertheless this PR should show the `Discard all` button even if there is an event currently in reprocessing.

Event stuck in reprocessing: 
![screenshot 2018-04-20 09 12 01](https://user-images.githubusercontent.com/363802/39036376-88d34080-447d-11e8-8995-0c168524c587.png)

Processing issues page before:
![screenshot 2018-04-20 09 12 21](https://user-images.githubusercontent.com/363802/39036383-91afd880-447d-11e8-9152-754c5bccb187.png)

after:
![screenshot 2018-04-20 09 25 58](https://user-images.githubusercontent.com/363802/39036390-97a24610-447d-11e8-9698-a667851b8e1e.png)

After pressing `Discard all` the event stuck in reprocessing is gone.
Note: I know this doesn't really fix the root cause of it but I guess it will take much more time to track this down.