### PR TITLE
fix(snuba): Return the same rollups (for now)

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -171,12 +171,6 @@ class SnubaTSDB(BaseTSDB):
         return self.get_data(model, items, start, end, rollup, environment_id,
                              aggregation='count()')
 
-    def get_optimal_rollup(self, start, end=None):
-        """
-        Always return the smallest rollup as we can bucket on any granularity.
-        """
-        return self.rollups.keys()[0]
-
     def flatten_keys(self, items):
         """
         Returns a normalized set of keys based on the various formats accepted


### PR DESCRIPTION
SnubaTSDB can in theory return any resolution of time series ,
but for side-by-side testing with RedisTSDB, we should keep deferring
to the base class for now so we always get the same rollup as RedisTSDB