### PR TITLE
ref(newsletter): Allow unverified emails to subscribe

### DIFF
--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -63,11 +63,6 @@ class UserSubscriptionsEndpoint(UserEndpoint):
         result = validator.object
         email = UserEmail.get_primary_email(user)
 
-        # Can't handle subscriptions without a verified email
-        if not email.is_verified:
-            return self.respond({'detail': 'Must have verified email to subscribe to newsletter.'},
-                                status=400)
-
         kwargs = {
             'list_id': result['listId'],
             'subscribed': result['subscribed'],

--- a/tests/sentry/api/endpoints/test_user_subscriptions.py
+++ b/tests/sentry/api/endpoints/test_user_subscriptions.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from sentry import newsletter
+from sentry.models import UserEmail
 from sentry.testutils import APITestCase
 
 
@@ -43,6 +44,14 @@ class UserSubscriptionsNewsletterTest(APITestCase):
             'listId': '123',
         })
         assert response.status_code == 400, response.content
+
+    def test_unverified_emails(self):
+        UserEmail.objects.get(email=self.user.email).update(is_verified=False)
+        response = self.client.put(self.url, data={
+            'listId': '123',
+            'subscribed': True,
+        })
+        assert response.status_code == 204, response.content
 
     def test_unsubscribe(self):
         response = self.client.put(self.url, data={


### PR DESCRIPTION
Decouple email verification from email subscription such that these two
states are independent of one another.

/cc @dcramer