### PR TITLE
ref(services): Log all exceptions thrown in executor

### DIFF
--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -288,6 +288,10 @@ class ServiceDelegator(Service):
                 active_backends[base] = backend
                 try:
                     return getattr(backend, attribute_name)(*args, **kwargs)
+                except Exception as error:
+                    logger.warning('Caught %s in executor while calling %r on %r: %s',
+                                   type(error).__name__, attribute_name, backend, error, exc_info=True)
+                    raise
                 finally:
                     # Unmark the backend as active.
                     assert active_backends[base] is backend


### PR DESCRIPTION
This ensures that any exception thrown in a secondary backend is logged at a warning level, even if it's not raised in the main thread by calling `result()` on the returned `Future` instance.