### PR TITLE
refs(newsletter): Subscribe to all default lists when granting consent

### DIFF
--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -96,14 +96,14 @@ class UserSubscriptionsEndpoint(UserEndpoint):
         kwargs = {
             'subscribed': result['subscribed'],
             'verified': email.is_verified,
-            'list_id': newsletter.get_default_list_id(),
+            'list_ids': newsletter.get_default_list_ids(),
         }
         if not result['subscribed']:
             kwargs['unsubscribed_date'] = timezone.now()
         else:
             kwargs['subscribed_date'] = timezone.now()
 
-        newsletter.create_or_update_subscription(user, **kwargs)
+        newsletter.create_or_update_subscriptions(user, **kwargs)
 
         user.update(
             flags=F('flags').bitand(~User.flags.newsletter_consent_prompt),

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -243,7 +243,7 @@ class RegistrationForm(forms.ModelForm):
         if commit:
             user.save()
             if self.cleaned_data.get('subscribe'):
-                newsletter.create_or_update_subscription(user, list_id=newsletter.get_default_list_id())
+                newsletter.create_or_update_subscriptions(user, list_ids=newsletter.get_default_list_ids())
         return user
 
 


### PR DESCRIPTION
Using `create_or_update_subscriptions` will change the default subscription
from `DEFAULT_LIST_ID` to `DEFAULT_LISTS` on the newsletter service; by
making this change, a user who consents to receive marketing communication
will be subscribed to all default lists, not just the single default ID that
is deprecated.

Covered by existing tests, since the behavior should be the same for the dummy
newsletter backend with this change.