### PR TITLE
fix(assistant): Move record assistant cues to guidestore to decrease dups

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/helper.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/helper.jsx
@@ -15,7 +15,6 @@ import GuideStore from '../../stores/guideStore';
 import CueIcon from './cueIcon';
 import AssistantContainer from './assistantContainer';
 import CloseIcon from './closeIcon';
-import HookStore from '../../stores/hookStore';
 
 // AssistantHelper is responsible for rendering the cue message, guide drawer and support drawer.
 const AssistantHelper = createReactClass({
@@ -36,17 +35,6 @@ const AssistantHelper = createReactClass({
 
   componentDidMount() {
     fetchGuides();
-  },
-
-  componentDidUpdate(prevProps, prevState) {
-    if (this.state.currentGuide && !prevState.currentGuide) {
-      HookStore.get('analytics:event').forEach(cb =>
-        cb('assistant.guide_cued', {
-          guide: this.state.currentGuide.id,
-          cue: this.state.currentGuide.cue,
-        })
-      );
-    }
   },
 
   onGuideStateChange(data) {

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -20,6 +20,7 @@ const GuideStore = Reflux.createStore({
       currentOrg: null,
 
       forceShow: false,
+      prevGuide: null,
     };
     this.listenTo(GuideActions.fetchSucceeded, this.onFetchSucceeded);
     this.listenTo(GuideActions.closeGuideOrSupport, this.onCloseGuideOrSupport);
@@ -85,6 +86,25 @@ const GuideStore = Reflux.createStore({
     this.updateCurrentGuide();
   },
 
+  recordCue(id, cue) {
+    HookStore.get('analytics:event').forEach(cb =>
+      cb('assistant.guide_cued', {
+        guide: id,
+        cue,
+      })
+    );
+  },
+
+  updatePrevGuide(bestGuide) {
+    if (!this.state.prevGuide) {
+      this.recordCue(bestGuide.id, bestGuide.cue);
+      this.state.prevGuide = bestGuide;
+    } else if (this.state.prevGuide && this.state.prevGuide.id !== bestGuide.id) {
+      this.recordCue(bestGuide.id, bestGuide.cue);
+      this.state.prevGuide = bestGuide;
+    }
+  },
+
   updateCurrentGuide() {
     let availableTargets = [...this.state.anchors].map(a => a.props.target);
 
@@ -108,6 +128,8 @@ const GuideStore = Reflux.createStore({
         step => step.target && availableTargets.indexOf(step.target) >= 0
       );
     }
+
+    bestGuide ? this.updatePrevGuide(bestGuide) : null;
 
     this.state.currentGuide = bestGuide;
 

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -130,7 +130,7 @@ const GuideStore = Reflux.createStore({
         step => step.target && availableTargets.indexOf(step.target) >= 0
       );
     }
-
+    this.updatePrevGuide(bestGuide);
     this.state.currentGuide = bestGuide;
 
     this.state.currentStep = this.state.forceShow ? 1 : 0;

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -98,10 +98,7 @@ const GuideStore = Reflux.createStore({
   updatePrevGuide(bestGuide) {
     if (!bestGuide) return;
 
-    if (
-      !this.state.prevGuide ||
-      (this.state.prevGuide && this.state.prevGuide.id !== bestGuide.id)
-    ) {
+    if (!this.state.prevGuide || this.state.prevGuide.id !== bestGuide.id) {
       this.recordCue(bestGuide.id, bestGuide.cue);
       this.state.prevGuide = bestGuide;
     }

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -96,10 +96,12 @@ const GuideStore = Reflux.createStore({
   },
 
   updatePrevGuide(bestGuide) {
-    if (!this.state.prevGuide) {
-      this.recordCue(bestGuide.id, bestGuide.cue);
-      this.state.prevGuide = bestGuide;
-    } else if (this.state.prevGuide && this.state.prevGuide.id !== bestGuide.id) {
+    if (!bestGuide) return;
+
+    if (
+      !this.state.prevGuide ||
+      (this.state.prevGuide && this.state.prevGuide.id !== bestGuide.id)
+    ) {
       this.recordCue(bestGuide.id, bestGuide.cue);
       this.state.prevGuide = bestGuide;
     }
@@ -128,8 +130,6 @@ const GuideStore = Reflux.createStore({
         step => step.target && availableTargets.indexOf(step.target) >= 0
       );
     }
-
-    bestGuide ? this.updatePrevGuide(bestGuide) : null;
 
     this.state.currentGuide = bestGuide;
 

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -98,11 +98,11 @@ describe('GuideStore', function() {
     GuideStore.onRegisterAnchor(anchor1);
     GuideStore.onRegisterAnchor(anchor2);
     GuideStore.onFetchSucceeded(data);
-    expect(mockRecordCue).toHaveBeenCalledWith(data['issue']['id'], data['issue']['cue']);
+    expect(mockRecordCue).toHaveBeenCalledWith(data.issue.id, data.issue.cue);
     expect(mockRecordCue).toHaveBeenCalledTimes(1);
     GuideStore.onCloseGuideOrSupport();
-    expect(GuideStore.state.currentGuide).toEqual(data['other']);
-    expect(mockRecordCue).toHaveBeenCalledWith(data['other']['id'], data['other']['cue']);
+    expect(GuideStore.state.currentGuide).toEqual(data.other);
+    expect(mockRecordCue).toHaveBeenCalledWith(data.other.id, data.other.cue);
     expect(mockRecordCue).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -24,6 +24,17 @@ describe('GuideStore', function() {
         ],
         seen: false,
       },
+      other: {
+        cue: 'Some other guide here',
+        id: 2,
+        page: 'random',
+        required_targets: ['target 1'],
+        steps: [
+          {message: 'Message 1', target: 'target 1', title: '1. Title 1'},
+          {message: 'Message 2', target: 'target 2', title: '2. Title 2'},
+        ],
+        seen: false,
+      },
     };
   });
 
@@ -64,6 +75,7 @@ describe('GuideStore', function() {
 
   it('should not show seen guides', function() {
     data.issue.seen = true;
+    data.other.seen = true;
     GuideStore.onRegisterAnchor(anchor1);
     GuideStore.onRegisterAnchor(anchor2);
     GuideStore.onFetchSucceeded(data);
@@ -77,5 +89,20 @@ describe('GuideStore', function() {
     GuideStore.state.forceShow = true;
     GuideStore.onFetchSucceeded(data);
     expect(GuideStore.state.currentGuide).not.toEqual(null);
+  });
+
+  it('should update', function() {
+    let mockRecordCue = jest.fn();
+    GuideStore.recordCue = mockRecordCue;
+
+    GuideStore.onRegisterAnchor(anchor1);
+    GuideStore.onRegisterAnchor(anchor2);
+    GuideStore.onFetchSucceeded(data);
+    expect(mockRecordCue).toHaveBeenCalledWith(data['issue']['id'], data['issue']['cue']);
+    expect(mockRecordCue).toHaveBeenCalledTimes(1);
+    GuideStore.onCloseGuideOrSupport();
+    expect(GuideStore.state.currentGuide).toEqual(data['other']);
+    expect(mockRecordCue).toHaveBeenCalledWith(data['other']['id'], data['other']['cue']);
+    expect(mockRecordCue).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -91,7 +91,7 @@ describe('GuideStore', function() {
     expect(GuideStore.state.currentGuide).not.toEqual(null);
   });
 
-  it('should update', function() {
+  it('should record analytics events when guide is cued', function() {
     let mockRecordCue = jest.fn();
     GuideStore.recordCue = mockRecordCue;
 
@@ -101,8 +101,23 @@ describe('GuideStore', function() {
     expect(mockRecordCue).toHaveBeenCalledWith(data.issue.id, data.issue.cue);
     expect(mockRecordCue).toHaveBeenCalledTimes(1);
     GuideStore.onCloseGuideOrSupport();
+
+    // Should trigger a record when a new guide is cued
     expect(GuideStore.state.currentGuide).toEqual(data.other);
     expect(mockRecordCue).toHaveBeenCalledWith(data.other.id, data.other.cue);
     expect(mockRecordCue).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not send multiple cue analytics events for same guide', function() {
+    let mockRecordCue = jest.fn();
+    GuideStore.recordCue = mockRecordCue;
+
+    GuideStore.onRegisterAnchor(anchor1);
+    GuideStore.onRegisterAnchor(anchor2);
+    GuideStore.onFetchSucceeded(data);
+    expect(mockRecordCue).toHaveBeenCalledWith(data.issue.id, data.issue.cue);
+    expect(mockRecordCue).toHaveBeenCalledTimes(1);
+    GuideStore.updateCurrentGuide();
+    expect(mockRecordCue).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Currently we rely on reacts' `componentDidMount` to record when a fresh guide is presented to a user but this is problematic for cases like the `issue tour` assistant guide where cycling through older events will refresh the page. This moves essentially the same behaviour to `guidestore` which hangs on to which guide was served up previously and only records the event if the new guide is different than the last one.