### PR TITLE
test(snuba): Test frequency series with Release objects

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -165,7 +165,7 @@ class SnubaTSDB(BaseTSDB):
         #    {group:{timestamp:{agg:count}}}
         # into
         #    {group: [(timestamp, {agg: count, ...}), ...]}
-        return {k: result[k].items() for k in result}
+        return {k: sorted(result[k].items()) for k in result}
 
     def get_frequency_totals(self, model, items, start, end=None, rollup=None, environment_id=None):
         return self.get_data(model, items, start, end, rollup, environment_id,


### PR DESCRIPTION
Test that frequency series works, also using release objects, which have
to have their ID->version mapping dereferenced and reconstructed in the
snuba stack. Uncovered and fixed at least one bug with timestamp order.