### PR TITLE
build: Bump symbolic to 5.0.1

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -52,7 +52,7 @@ statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
 sqlparse>=0.1.16,<0.2.0
-symbolic>=4.0.0,<5.0.0
+symbolic>=5.0.0,<6.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 urllib3>=1.22,<1.23

--- a/src/sentry/models/dsymfile.py
+++ b/src/sentry/models/dsymfile.py
@@ -25,7 +25,7 @@ from django.db import models, transaction, IntegrityError
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
-from symbolic import FatObject, SymbolicError, UnsupportedObjectFile, \
+from symbolic import FatObject, SymbolicError, ObjectErrorUnsupportedObject, \
     SymCache, SYMCACHE_LATEST_VERSION
 
 from sentry import options
@@ -382,7 +382,7 @@ def detect_dif_from_path(path):
     # macho style debug symbols
     try:
         fo = FatObject.from_path(path)
-    except UnsupportedObjectFile as e:
+    except ObjectErrorUnsupportedObject as e:
         raise BadDif("Unsupported debug information file: %s" % e)
     except SymbolicError as e:
         logger.warning('dsymfile.bad-fat-object', exc_info=True)


### PR DESCRIPTION
Updates to the latest symbolic version. Error types have changed. 