### PR TITLE
fix(ui): Show helpful error message if <Form> is missing

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -199,6 +199,9 @@ class FormField extends React.Component {
   }
 
   getModel() {
+    if (this.context.form === undefined) {
+      throw new Error('Make sure to wrap your fields into <Form/>');
+    }
     return this.context.form;
   }
 


### PR DESCRIPTION
While I was hammering in a new field into the new settings page (maybe it was also like this before), I got a weird error not telling me anything helpful.
After debugging I found out that I missed the `<Form/>` component 🤦‍♂️ 😅 
Nevertheless, I've added a better error description to hopefully spare the next developer to for the same mistake he did.

**Before:** 
![settings-before](https://user-images.githubusercontent.com/363802/39187827-8ff7cce2-47ce-11e8-9a73-6b532fc68ea3.png)

**After:** 
![settings-after](https://user-images.githubusercontent.com/363802/39187837-95002e50-47ce-11e8-9135-284d7137719d.png)
