### PR TITLE
feat(api): Update documentation to reflect security header support

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -25,6 +25,7 @@ class ProjectKeySerializer(Serializer):
                 'secret': obj.dsn_private,
                 'public': obj.dsn_public,
                 'csp': obj.csp_endpoint,
+                'security': obj.security_endpoint,
                 'minidump': obj.minidump_endpoint,
             },
             'dateCreated': obj.date_added,

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -175,6 +175,18 @@ class ProjectKey(Model):
         )
 
     @property
+    def security_endpoint(self):
+        endpoint = settings.SENTRY_PUBLIC_ENDPOINT or settings.SENTRY_ENDPOINT
+        if not endpoint:
+            endpoint = options.get('system.url-prefix')
+
+        return '%s%s?sentry_key=%s' % (
+            endpoint,
+            reverse('sentry-api-security-report', args=[self.project_id]),
+            self.public_key,
+        )
+
+    @property
     def minidump_endpoint(self):
         endpoint = settings.SENTRY_PUBLIC_ENDPOINT or settings.SENTRY_ENDPOINT
         if not endpoint:

--- a/src/sentry/static/sentry/app/components/previewFeature.jsx
+++ b/src/sentry/static/sentry/app/components/previewFeature.jsx
@@ -1,0 +1,14 @@
+import React, {Component} from 'react';
+import {t} from '../locale';
+
+export default class PreviewFeature extends Component {
+  render() {
+    return (
+      <div className="alert alert-block alert-warn">
+        {t(
+          'This feature is a preview and may change in the future. Thanks for being an early adopter!'
+        )}
+      </div>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/data/forms/cspReports.jsx
+++ b/src/sentry/static/sentry/app/data/forms/cspReports.jsx
@@ -6,7 +6,7 @@ export const route = '/settings/:orgId/:projectId/csp/';
 const formGroups = [
   {
     // Form "section"/"panel"
-    title: 'Settings',
+    title: 'CSP Settings',
     fields: [
       {
         name: 'sentry:csp_ignored_sources_defaults',

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -367,14 +367,30 @@ const projectSettingsRoutes = (
         import(/*webpackChunkName: "ProjectUserFeedbackSettings"*/ './views/settings/project/projectUserFeedback')}
       component={errorHandler(LazyLoad)}
     />
-    <Route
-      key="csp/"
-      path="csp/"
-      name="CSP Reports"
-      componentPromise={() =>
-        import(/*webpackChunkName: "ProjectCspReports"*/ './views/settings/project/projectCspReports')}
-      component={errorHandler(LazyLoad)}
-    />
+    <Redirect from="csp/" to="security-headers/" />
+    <Route key="security-headers/" path="security-headers/" name="Security Headers">
+      <IndexRoute
+        componentPromise={() =>
+          import(/*webpackChunkName: "ProjectSecurityHeaders"*/ './views/settings/projectSecurityHeaders')}
+        component={errorHandler(LazyLoad)}
+      />
+      <Route
+        path="csp/"
+        key="csp/"
+        name="Content Security Policy"
+        componentPromise={() =>
+          import(/*webpackChunkName: "ProjectCspReports"*/ './views/settings/projectSecurityHeaders/csp')}
+        component={errorHandler(LazyLoad)}
+      />
+      <Route
+        path="expect-ct/"
+        key="expect-ct/"
+        name="Certificate Transparency"
+        componentPromise={() =>
+          import(/*webpackChunkName: "ProjectExpectCtReports"*/ './views/settings/projectSecurityHeaders/expectCt')}
+        component={errorHandler(LazyLoad)}
+      />
+    </Route>
     <Route path="plugins/" name="Integrations" component={errorHandler(ProjectPlugins)} />
     <Route
       path="plugins/:pluginId/"

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -157,7 +157,9 @@ const ProjectSettings = createReactClass({
             >
               {t('Error Tracking')}
             </ListLink>
-            <ListLink to={`${pathPrefix}/csp/`}>{t('CSP Reports')}</ListLink>
+            <ListLink to={`${pathPrefix}/security-headers/`}>
+              {t('Security Headers')}
+            </ListLink>
             <ListLink to={`${pathPrefix}/user-feedback/`}>{t('User Feedback')}</ListLink>
             <ListLink to={`${pathPrefix}/filters/`}>{t('Inbound Filters')}</ListLink>
             <ListLink to={`${pathPrefix}/keys/`}>{t('Client Keys')} (DSN)</ListLink>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/index.jsx
@@ -154,14 +154,16 @@ class Field extends React.Component {
         hasControlState={!flexibleControlStateSize}
         style={style}
       >
-        <FieldDescription inline={inline} htmlFor={id}>
-          {label && (
-            <FieldLabel>
-              {label} {required && <FieldRequiredBadge />}
-            </FieldLabel>
-          )}
-          {help && <FieldHelp>{help}</FieldHelp>}
-        </FieldDescription>
+        {(label || help) && (
+          <FieldDescription inline={inline} htmlFor={id}>
+            {label && (
+              <FieldLabel>
+                {label} {required && <FieldRequiredBadge />}
+              </FieldLabel>
+            )}
+            {help && <FieldHelp>{help}</FieldHelp>}
+          </FieldDescription>
+        )}
 
         {Control}
       </FieldWrapper>

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -87,8 +87,8 @@ export default function getConfiguration({project}) {
           title: t('Error Tracking'),
         },
         {
-          path: `${pathPrefix}/csp/`,
-          title: t('CSP Reports'),
+          path: `${pathPrefix}/security-headers/`,
+          title: t('Security Headers'),
         },
         {
           path: `${pathPrefix}/user-feedback/`,

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
@@ -15,7 +15,7 @@ class ProjectKeyCredentials extends React.Component {
 
     showDsn: PropTypes.bool,
     showDsnPublic: PropTypes.bool,
-    showCspEndpoint: PropTypes.bool,
+    showSecurityEndpoint: PropTypes.bool,
     showMinidump: PropTypes.bool,
     showPublicKey: PropTypes.bool,
     showSecretKey: PropTypes.bool,
@@ -25,7 +25,7 @@ class ProjectKeyCredentials extends React.Component {
   static defaultProps = {
     showDsn: true,
     showDsnPublic: true,
-    showCspEndpoint: true,
+    showSecurityEndpoint: true,
     showMinidump: true,
     showPublicKey: false,
     showSecretKey: false,
@@ -38,7 +38,7 @@ class ProjectKeyCredentials extends React.Component {
       data,
       showDsn,
       showDsnPublic,
-      showCspEndpoint,
+      showSecurityEndpoint,
       showMinidump,
       showPublicKey,
       showSecretKey,
@@ -61,23 +61,19 @@ class ProjectKeyCredentials extends React.Component {
           </Field>
         )}
 
-        {showCspEndpoint && (
+        {showSecurityEndpoint && (
           <Field
-            label={t('CSP Endpoint')}
-            help={tct(
-              'Use your CSP endpoint in the [directive] directive in your [header] header.',
-              {
-                directive: <code>report-uri</code>,
-                header: <code>Content-Security-Policy</code>,
-              }
+            label={t('Security Header Endpoint')}
+            help={t(
+              'Use your security header endpoint for features like CSP and Expect-CT reports.'
             )}
             inline={false}
             flexibleControlStateSize
           >
             <TextCopyInput>
               {getDynamicText({
-                value: data.dsn.csp,
-                fixed: data.dsn.csp.replace(
+                value: data.dsn.security,
+                fixed: data.dsn.security.replace(
                   new RegExp(`\/${projectId}$`),
                   '/<<projectId>>'
                 ),

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/expectCt.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/expectCt.jsx
@@ -1,0 +1,84 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import {t, tct} from '../../../locale';
+import AsyncView from '../../asyncView';
+import ExternalLink from '../../../components/externalLink';
+import {Panel, PanelBody, PanelHeader} from '../../../components/panels';
+import PreviewFeature from '../../../components/previewFeature';
+import ReportUri, {getSecurityDsn} from './reportUri';
+import SettingsPageHeader from '../components/settingsPageHeader';
+import TextBlock from '../components/text/textBlock';
+
+const CodeBlock = styled.pre`
+  word-break: break-all;
+  white-space: pre-wrap;
+`;
+
+export default class ProjectExpectCtReports extends AsyncView {
+  static propTypes = {
+    setProjectNavSection: PropTypes.func,
+  };
+
+  componentWillMount() {
+    super.componentWillMount();
+    this.props.setProjectNavSection('settings');
+  }
+
+  getEndpoints() {
+    let {orgId, projectId} = this.props.params;
+    return [['keyList', `/projects/${orgId}/${projectId}/keys/`]];
+  }
+
+  getInstructions() {
+    return `Expect-CT: report-uri="${getSecurityDsn(this.state.keyList)}"`;
+  }
+
+  renderBody() {
+    return (
+      <div>
+        <SettingsPageHeader title={t('Certificate Transparency')} />
+
+        <PreviewFeature />
+
+        <ReportUri keyList={this.state.keyList} params={this.props.params} />
+
+        <Panel>
+          <PanelHeader>{'About'}</PanelHeader>
+          <PanelBody disablePadding={false}>
+            <TextBlock>
+              {tct(
+                `[link:Certificate Transparency]
+      (CT) is a security standard which helps track and identify valid certificates, allowing identification of maliciously issued certificates`,
+                {
+                  link: (
+                    <ExternalLink href="https://en.wikipedia.org/wiki/Certificate_Transparency" />
+                  ),
+                }
+              )}
+            </TextBlock>
+            <TextBlock>
+              {tct(
+                "To configure reports in Sentry, you'll need to configure the [header] a header from your server:",
+                {
+                  header: <code>Expect-CT</code>,
+                }
+              )}
+            </TextBlock>
+
+            <CodeBlock>{this.getInstructions()}</CodeBlock>
+
+            <TextBlock noMargin>
+              {tct('For more information, see [link:the article on MDN].', {
+                link: (
+                  <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT" />
+                ),
+              })}
+            </TextBlock>
+          </PanelBody>
+        </Panel>
+      </div>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/index.jsx
@@ -1,0 +1,105 @@
+import {Box, Flex} from 'grid-emotion';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import {t, tct} from '../../../locale';
+import AsyncView from '../../asyncView';
+import Button from '../../../components/buttons/button';
+import {Panel, PanelBody, PanelHeader, PanelItem} from '../../../components/panels';
+import recreateRoute from '../../../utils/recreateRoute';
+import ReportUri from './reportUri';
+import PreviewFeature from '../../../components/previewFeature';
+import SettingsPageHeader from '../components/settingsPageHeader';
+import TextBlock from '../components/text/textBlock';
+
+const HeaderName = styled.span`
+  font-size: 1.2em;
+`;
+
+export default class ProjectSecurityHeaders extends AsyncView {
+  static propTypes = {
+    setProjectNavSection: PropTypes.func,
+  };
+
+  componentWillMount() {
+    super.componentWillMount();
+    this.props.setProjectNavSection('settings');
+  }
+
+  getEndpoints() {
+    let {orgId, projectId} = this.props.params;
+    return [['keyList', `/projects/${orgId}/${projectId}/keys/`]];
+  }
+
+  getReports() {
+    return [
+      {
+        name: 'Content Security Policy (CSP)',
+        url: recreateRoute('csp/', this.props),
+      },
+      {
+        name: 'Certificate Transparency (Expect-CT)',
+        url: recreateRoute('expect-ct/', this.props),
+      },
+    ];
+  }
+
+  renderBody() {
+    return (
+      <div>
+        <SettingsPageHeader title={t('Security Header Reports')} />
+
+        <PreviewFeature />
+
+        <ReportUri keyList={this.state.keyList} params={this.props.params} />
+
+        <Panel>
+          <PanelHeader>{t('Additional Configuration')}</PanelHeader>
+          <PanelBody disablePadding={false}>
+            <TextBlock style={{marginBottom: 20}}>
+              {tct(
+                'In addition to the [key_param] parameter, you may also pass the following within the querystring for the report URI:',
+                {
+                  key_param: <code>sentry_key</code>,
+                }
+              )}
+            </TextBlock>
+            <table className="table" style={{marginBottom: 0}}>
+              <tr>
+                <th style={{padding: '8px 5px'}}>sentry_environment</th>
+                <td style={{padding: '8px 5px'}}>
+                  {t('The environment name (e.g. production)')}.
+                </td>
+              </tr>
+              <tr>
+                <th style={{padding: '8px 5px'}}>sentry_release</th>
+                <td style={{padding: '8px 5px'}}>
+                  {t('The version of the application.')}
+                </td>
+              </tr>
+            </table>
+          </PanelBody>
+        </Panel>
+
+        <Panel>
+          <PanelHeader>{t('Supported Formats')}</PanelHeader>
+          <PanelBody>
+            {this.getReports().map(({name, description, url}) => (
+              <PanelItem key={url} p={0} direction="column">
+                <Flex flex="1" p={2} align="center">
+                  <Box flex="1">
+                    <HeaderName>{name}</HeaderName>
+                  </Box>
+                  <Button to={url} priority="primary">
+                    {t('Instructions')}
+                  </Button>
+                </Flex>
+              </PanelItem>
+            ))}
+          </PanelBody>
+        </Panel>
+      </div>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/reportUri.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/reportUri.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Link} from 'react-router';
+
+import {tct} from '../../../locale';
+import AsyncView from '../../asyncView';
+import Field from '../components/forms/field';
+import getDynamicText from '../../../utils/getDynamicText';
+import {Panel, PanelAlert, PanelBody, PanelHeader} from '../../../components/panels';
+import TextCopyInput from '../components/forms/textCopyInput';
+
+const DEFAULT_ENDPOINT = 'https://sentry.example.com/api/security-report/';
+
+export const getSecurityDsn = keyList => {
+  let endpoint = keyList.length ? keyList[0].dsn.security : DEFAULT_ENDPOINT;
+  return getDynamicText({
+    value: endpoint,
+    fixed: DEFAULT_ENDPOINT,
+  });
+};
+
+export default class ReportUri extends AsyncView {
+  static propTypes = {
+    keyList: PropTypes.array.isRequired,
+  };
+
+  render() {
+    let {orgId, projectId} = this.props.params;
+    return (
+      <Panel>
+        <PanelHeader>{'Report URI'}</PanelHeader>
+        <PanelBody>
+          <PanelAlert type="info">
+            {tct(
+              "We've automatically pulled these credentials from your available [link:Client Keys]",
+              {
+                link: <Link to={`/settings/${orgId}/${projectId}/keys/`} />,
+              }
+            )}
+          </PanelAlert>
+          <Field inline={false} flexibleControlStateSize>
+            <TextCopyInput>{getSecurityDsn(this.props.keyList)}</TextCopyInput>
+          </Field>
+        </PanelBody>
+      </Panel>
+    );
+  }
+}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -62,9 +62,18 @@ window.TestStubs = {
     ...params,
   }),
 
-  location: () => ({
+  location: (params = {}) => ({
     query: {},
     pathame: '/mock-pathname/',
+    ...params,
+  }),
+
+  routerProps: (params = {}) => ({
+    location: TestStubs.location(),
+    params: {},
+    routes: [],
+    stepBack: () => {},
+    ...params,
   }),
 
   routerContext: ([context, childContextTypes] = []) => ({
@@ -746,6 +755,8 @@ window.TestStubs = {
           public: 'http://188ee45a58094d939428d8585aa6f661@dev.getsentry.net:8000/1',
           csp:
             'http://dev.getsentry.net:8000/api/1/csp-report/?sentry_key=188ee45a58094d939428d8585aa6f661',
+          security:
+            'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f661',
         },
         public: '188ee45a58094d939428d8585aa6f661',
         secret: 'a33bf9aba64c4bbdaf873bb9023b6d2d',

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectCspReports renders 1`] = `
+<SideEffect(DocumentTitle)
+  title="Sentry"
+>
+  <div>
+    <SettingsPageHeading
+      title="Content Security Policy"
+    />
+    <PreviewFeature />
+    <ReportUri
+      keyList={Array []}
+      params={
+        Object {
+          "orgId": "org-slug",
+          "projectId": "project-slug",
+        }
+      }
+    />
+    <Form
+      allowUndo={false}
+      apiEndpoint="/projects/org-slug/project-slug/"
+      apiMethod="PUT"
+      cancelLabel="Cancel"
+      className="form-stacked"
+      footerClass="form-actions align-right"
+      initialData={Object {}}
+      onSubmitError={[Function]}
+      onSubmitSuccess={[Function]}
+      requireChanges={false}
+      saveOnBlur={true}
+      submitDisabled={false}
+      submitLabel="Save Changes"
+      submitPriority="primary"
+    >
+      <JsonForm
+        additionalFieldProps={Object {}}
+        forms={
+          Array [
+            Object {
+              "fields": Array [
+                Object {
+                  "getData": [Function],
+                  "help": "Our default list will attempt to ignore common issues and reduce noise.",
+                  "label": "Use default ignored sources",
+                  "name": "sentry:csp_ignored_sources_defaults",
+                  "type": "boolean",
+                },
+                Object {
+                  "extraHelp": "Separate multiple entries with a newline.",
+                  "getData": [Function],
+                  "help": "Additional field names to match against when scrubbing data for all projects. Separate multiple entries with a newline.",
+                  "label": "Additional ignored sources",
+                  "multiline": true,
+                  "name": "sentry:csp_ignored_sources",
+                  "placeholder": "e.g. file://*, *.example.com, example.com, etc...",
+                  "type": "string",
+                },
+              ],
+              "title": "CSP Settings",
+            },
+          ]
+        }
+      />
+    </Form>
+    <Panel>
+      <PanelHeader>
+        About
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={false}
+        flex={false}
+      >
+        <TextBlock>
+          <span
+            key="4"
+          >
+            <ExternalLink
+              href="https://en.wikipedia.org/wiki/Content_Security_Policy"
+              key="1"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              <span
+                key="0"
+              >
+                Content Security Policy
+              </span>
+            </ExternalLink>
+            <span
+              key="2"
+            >
+              
+            (CSP) is a security standard which helps prevent cross-site scripting (XSS),
+            clickjacking and other code injection attacks resulting from execution of
+            malicious content in the trusted web page context. It's enforced by browser
+            vendors, and Sentry supports capturing CSP violations using the standard
+            reporting hooks.
+            </span>
+          </span>
+        </TextBlock>
+        <TextBlock>
+          <span
+            key="5"
+          >
+            <span
+              key="0"
+            >
+              To configure 
+            </span>
+            <acronym
+              key="2"
+              title="Content Security Policy"
+            >
+              <span
+                key="1"
+              >
+                CSP
+              </span>
+            </acronym>
+            <span
+              key="3"
+            >
+               reports
+              in Sentry, you'll need to send a header from your server describing your
+              policy, as well specifying the authenticated Sentry endpoint.
+            </span>
+          </span>
+        </TextBlock>
+        <TextBlock
+          noMargin={true}
+        >
+          For example, in Python you might achieve this via a simple web middleware
+        </TextBlock>
+        <CodeBlock>
+          def middleware(request, response):
+    response['Content-Security-Policy'] = \\
+        "default-src *; " \\
+        "script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.example.com cdn.ravenjs.com; " \\
+        "style-src 'self' 'unsafe-inline' cdn.example.com; " \\
+        "img-src * data:; " \\
+        "report-uri https://sentry.example.com/api/security-report/"
+    return response
+
+        </CodeBlock>
+        <TextBlock
+          noMargin={true}
+        >
+          Alternatively you can setup CSP reports to simply send reports rather than
+              actually enforcing the policy
+        </TextBlock>
+        <CodeBlock>
+          def middleware(request, response):
+    response['Content-Security-Policy-Report-Only'] = \\
+        "default-src 'self'; " \\
+        "report-uri https://sentry.example.com/api/security-report/"
+    return response
+
+        </CodeBlock>
+        <TextBlock
+          className="css-46b038"
+          noMargin={true}
+        >
+          <span
+            key="5"
+          >
+            <span
+              key="0"
+            >
+              We recommend setting this up to only run on a percentage of requests, as
+              otherwise you may find that you've quickly exhausted your quota. For more
+              information, take a look at 
+            </span>
+            <a
+              href="http://www.html5rocks.com/en/tutorials/security/content-security-policy/"
+              key="2"
+            >
+              <span
+                key="1"
+              >
+                the article on html5rocks.com
+              </span>
+            </a>
+            <span
+              key="3"
+            >
+              .
+            </span>
+          </span>
+        </TextBlock>
+      </PanelBody>
+    </Panel>
+  </div>
+</SideEffect(DocumentTitle)>
+`;

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectSecurityHeaders renders 1`] = `
+<SideEffect(DocumentTitle)
+  title="Sentry"
+>
+  <div>
+    <SettingsPageHeading
+      title="Security Header Reports"
+    />
+    <PreviewFeature />
+    <ReportUri
+      keyList={Array []}
+      params={
+        Object {
+          "orgId": "org-slug",
+          "projectId": "project-slug",
+        }
+      }
+    />
+    <Panel>
+      <PanelHeader>
+        Additional Configuration
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={false}
+        flex={false}
+      >
+        <TextBlock
+          style={
+            Object {
+              "marginBottom": 20,
+            }
+          }
+        >
+          <span
+            key="4"
+          >
+            <span
+              key="0"
+            >
+              In addition to the 
+            </span>
+            <code
+              key="1"
+            >
+              sentry_key
+            </code>
+            <span
+              key="2"
+            >
+               parameter, you may also pass the following within the querystring for the report URI:
+            </span>
+          </span>
+        </TextBlock>
+        <table
+          className="table"
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <tr>
+            <th
+              style={
+                Object {
+                  "padding": "8px 5px",
+                }
+              }
+            >
+              sentry_environment
+            </th>
+            <td
+              style={
+                Object {
+                  "padding": "8px 5px",
+                }
+              }
+            >
+              The environment name (e.g. production)
+              .
+            </td>
+          </tr>
+          <tr>
+            <th
+              style={
+                Object {
+                  "padding": "8px 5px",
+                }
+              }
+            >
+              sentry_release
+            </th>
+            <td
+              style={
+                Object {
+                  "padding": "8px 5px",
+                }
+              }
+            >
+              The version of the application.
+            </td>
+          </tr>
+        </table>
+      </PanelBody>
+    </Panel>
+    <Panel>
+      <PanelHeader>
+        Supported Formats
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={true}
+        flex={false}
+      >
+        <PanelItem
+          direction="column"
+          p={0}
+        >
+          <Flex
+            align="center"
+            flex="1"
+            p={2}
+          >
+            <Box
+              flex="1"
+            >
+              <HeaderName>
+                Content Security Policy (CSP)
+              </HeaderName>
+            </Box>
+            <Button
+              disabled={false}
+              priority="primary"
+            >
+              Instructions
+            </Button>
+          </Flex>
+        </PanelItem>
+        <PanelItem
+          direction="column"
+          p={0}
+        >
+          <Flex
+            align="center"
+            flex="1"
+            p={2}
+          >
+            <Box
+              flex="1"
+            >
+              <HeaderName>
+                Certificate Transparency (Expect-CT)
+              </HeaderName>
+            </Box>
+            <Button
+              disabled={false}
+              priority="primary"
+            >
+              Instructions
+            </Button>
+          </Flex>
+        </PanelItem>
+      </PanelBody>
+    </Panel>
+  </div>
+</SideEffect(DocumentTitle)>
+`;

--- a/tests/js/spec/views/projectSecurityHeaders/projectCspReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectCspReports.spec.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
-import {mount} from 'enzyme';
-import ProjectCspReports from 'app/views/settings/project/projectCspReports';
+import {shallow} from 'enzyme';
+import ProjectCspReports from 'app/views/settings/projectSecurityHeaders/csp';
+
+import {mountWithTheme} from '../../../../helpers';
 
 describe('ProjectCspReports', function() {
   let org = TestStubs.Organization();
   let project = TestStubs.Project();
-  let url = `/projects/${org.slug}/${project.slug}/`;
+  let projectUrl = `/projects/${org.slug}/${project.slug}/`;
+  let routeUrl = `/projects/${org.slug}/${project.slug}/csp/`;
 
   beforeEach(function() {
     MockApiClient.clearMockResponses();
@@ -16,7 +19,7 @@ describe('ProjectCspReports', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url,
+      url: projectUrl,
       method: 'GET',
       body: {
         options: {},
@@ -24,19 +27,38 @@ describe('ProjectCspReports', function() {
     });
   });
 
-  it('can enable default ignored sources', function() {
-    let wrapper = mount(
+  it('renders', function() {
+    let wrapper = shallow(
       <ProjectCspReports
         organization={org}
         project={project}
         setProjectNavSection={() => {}}
-        params={{orgId: org.slug, projectId: project.slug}}
+        {...TestStubs.routerProps({
+          params: {orgId: org.slug, projectId: project.slug},
+          location: TestStubs.location({pathname: routeUrl}),
+        })}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('can enable default ignored sources', function() {
+    let wrapper = mountWithTheme(
+      <ProjectCspReports
+        organization={org}
+        project={project}
+        setProjectNavSection={() => {}}
+        {...TestStubs.routerProps({
+          params: {orgId: org.slug, projectId: project.slug},
+          location: TestStubs.location({pathname: routeUrl}),
+        })}
       />,
       TestStubs.routerContext()
     );
 
     let mock = MockApiClient.addMockResponse({
-      url,
+      url: projectUrl,
       method: 'PUT',
     });
 
@@ -46,7 +68,7 @@ describe('ProjectCspReports', function() {
     wrapper.find('Switch').simulate('click');
 
     expect(mock).toHaveBeenCalledWith(
-      url,
+      projectUrl,
       expect.objectContaining({
         method: 'PUT',
         data: {
@@ -59,18 +81,21 @@ describe('ProjectCspReports', function() {
   });
 
   it('can set additional ignored sources', function() {
-    let wrapper = mount(
+    let wrapper = mountWithTheme(
       <ProjectCspReports
         organization={org}
         project={project}
         setProjectNavSection={() => {}}
-        params={{orgId: org.slug, projectId: project.slug}}
+        {...TestStubs.routerProps({
+          params: {orgId: org.slug, projectId: project.slug},
+          location: TestStubs.location({pathname: routeUrl}),
+        })}
       />,
       TestStubs.routerContext()
     );
 
     let mock = MockApiClient.addMockResponse({
-      url,
+      url: projectUrl,
       method: 'PUT',
     });
 
@@ -88,7 +113,7 @@ test2`,
       .simulate('blur');
 
     expect(mock).toHaveBeenCalledWith(
-      url,
+      projectUrl,
       expect.objectContaining({
         method: 'PUT',
         data: {

--- a/tests/js/spec/views/projectSecurityHeaders/projectExpectCtReports.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectExpectCtReports.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import ProjectExpectCtReports from 'app/views/settings/projectSecurityHeaders/expectCt';
+
+jest.mock('app/utils/recreateRoute');
+
+describe('ProjectExpectCtReports', function() {
+  let org = TestStubs.Organization();
+  let project = TestStubs.Project();
+  let url = `/projects/${org.slug}/${project.slug}/expect-ct/`;
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/keys/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('renders', function() {
+    let wrapper = shallow(
+      <ProjectExpectCtReports
+        organization={org}
+        project={project}
+        setProjectNavSection={() => {}}
+        {...TestStubs.routerProps({
+          params: {orgId: org.slug, projectId: project.slug},
+          location: TestStubs.location({pathname: url}),
+        })}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/js/spec/views/projectSecurityHeaders/projectSecurityHeaders.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectSecurityHeaders.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import ProjectSecurityHeaders from 'app/views/settings/projectSecurityHeaders';
+
+jest.mock('app/utils/recreateRoute');
+
+describe('ProjectSecurityHeaders', function() {
+  let org = TestStubs.Organization();
+  let project = TestStubs.Project();
+  let url = `/projects/${org.slug}/${project.slug}/`;
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/keys/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('renders', function() {
+    let wrapper = shallow(
+      <ProjectSecurityHeaders
+        organization={org}
+        project={project}
+        setProjectNavSection={() => {}}
+        {...TestStubs.routerProps({
+          params: {orgId: org.slug, projectId: project.slug},
+          location: TestStubs.location({pathname: url}),
+        })}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Switch to the new security header reporting endpoint for CSP and expose Expect-CT as a first-class citizen.

Fixes GH-7005