### PR TITLE
fix(newsletter): Remove newsletter update in email verification signal

### DIFF
--- a/src/sentry/receivers/useremail.py
+++ b/src/sentry/receivers/useremail.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 
 from django.db import IntegrityError
 from django.db.models.signals import post_save
-from django.utils import timezone
 
 from sentry.models import User, UserEmail
-from sentry.signals import email_verified
 
 
 def create_user_email(instance, created, **kwargs):
@@ -17,20 +15,3 @@ def create_user_email(instance, created, **kwargs):
 
 
 post_save.connect(create_user_email, sender=User, dispatch_uid="create_user_email", weak=False)
-
-
-@email_verified.connect(weak=False)
-def verify_newsletter_subscription(sender, **kwargs):
-    from sentry import newsletter
-
-    if not newsletter.is_enabled():
-        return
-
-    if not sender.is_primary():
-        return
-
-    newsletter.update_subscription(
-        sender.user,
-        verified=True,
-        verified_date=timezone.now(),
-    )


### PR DESCRIPTION
Decouple email verification from newsletter subscriptions. The idea is that someone with an unverified email can consent to receive marketing communications and later verify their email; we won't consider the consent "usable" until the email is verified.