### PR TITLE
ref(services): Add `internal:optin` handler for explicitly sending to Sentry

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -621,6 +621,11 @@ LOGGING = {
             'filters': ['sentry:internal'],
             'class': 'raven.contrib.django.handlers.SentryHandler',
         },
+        'internal:optin': {
+            'level': 'WARNING',
+            'filters': ['sentry:internal'],
+            'class': 'raven.contrib.django.handlers.SentryHandler',
+        },
         'metrics': {
             'level': 'WARNING',
             'filters': ['important_django_request'],
@@ -666,6 +671,10 @@ LOGGING = {
         },
         'sentry.rules': {
             'handlers': ['console'],
+            'propagate': False,
+        },
+        'sentry.utils.services': {
+            'handlers': ['internal:optin'],
             'propagate': False,
         },
         'multiprocessing': {


### PR DESCRIPTION
This ensures the exceptions logged in 71983fac8303653b65c3bd845f2c7dd900d5ac48 actually go somewhere (namely, Sentry.)