### PR TITLE
fix(auditlog): Handle audit log entry for org restore

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -293,7 +293,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         if serializer.is_valid():
             organization, changed_data = serializer.save()
 
-            if was_pending_deletion and organization.status == OrganizationStatus.VISIBLE:
+            if was_pending_deletion:
                 self.create_audit_entry(
                     request=request,
                     organization=organization,


### PR DESCRIPTION
Really fix the audit log entry for when an Organization is restored after being queued for deletion. 

When testing this locally, this would always come out to be true, even though it shouldn't be possible since an organization's status cannot be both `PENDING_DELETION` and `VISIBLE`:

```
if was_pending_deletion and organization.status == OrganizationStatus.VISIBLE:
```

Previous PR: #8081 

