### PR TITLE
fix(newsletter): Remove update_subscription call when adding an email

### DIFF
--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -577,12 +577,6 @@ def show_emails(request):
                 new_email.set_hash()
                 new_email.save()
                 user.send_confirm_email_singular(new_email)
-                # Update newsletter subscription and mark as unverified
-                newsletter.update_subscription(
-                    user=user,
-                    create=True,
-                    verified=False,
-                )
 
                 logger.info(
                     'user.email.add',


### PR DESCRIPTION
Similar to #8169, avoid updating newsletter subscriptions when adding
a new email. Email verification is decoupled from newsletter subscriptions
now.

Fixes SENTRY-6GJ.