### PR TITLE
feature(ui): introduce Text component

### DIFF
--- a/docs-ui/components/text.stories.js
+++ b/docs-ui/components/text.stories.js
@@ -12,16 +12,17 @@ storiesOf('Text', module).add(
         <h1>Text styles</h1>
         <p>
           Not having to override margin, padding, and line-height on native text elements
-          is a feature in the app UI world, but when you need those styles to "just work"
-          it can be quite frustrating to find they're not supported.
+          is a feature in the app UI world — that's why things like reset.css,
+          normalize.css, etc exist. But in situations where you need those styles to "just
+          work" it can be quite frustrating to find out they're not supported.
         </p>
 
         <h2>Introducing the Text component</h2>
 
         <p>
-          The Text component unlocks styles on native text components on-demand in a way
-          that's simple, familiar, and easy to remember. Here are the components it
-          supports:
+          The Text component unlocks basic type styles on native text components on-demand
+          in a way that's simple, familiar, and easy to remember. Here are the components
+          it supports:
         </p>
 
         <h3>Headings</h3>

--- a/docs-ui/components/text.stories.js
+++ b/docs-ui/components/text.stories.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import Text from 'sentry-ui/text';
+
+storiesOf('Text', module).add(
+  'default',
+  withInfo('On-demand styling for native dom elements')(() => (
+    <div style={{padding: 20, backgroundColor: '#ffffff'}}>
+      <Text>
+        <h1>Text styles</h1>
+        <p>
+          Not having to override margin, padding, and line-height on native text elements
+          is a feature in the app UI world, but when you need those styles to "just work"
+          it can be quite frustrating to find they're not supported.
+        </p>
+
+        <h2>Introducing the Text component</h2>
+
+        <p>
+          The Text component unlocks styles on native text components on-demand in a way
+          that's simple, familiar, and easy to remember. Here are the components it
+          supports:
+        </p>
+
+        <h3>Headings</h3>
+
+        <p>Headings are styled as they should be. Here's a quick sampling:</p>
+
+        <h1>This is a H1 heading</h1>
+        <h2>This is a H2 heading</h2>
+        <h3>This is a H3 heading</h3>
+        <h4>This is a H4 heading</h4>
+        <h5>This is a H5 heading</h5>
+        <h6>This is a H6 heading</h6>
+
+        <h3>Paragraph</h3>
+
+        <p>
+          Paragraphs are essential to communicating complex ideas to our users. However,
+          we can't rely on them alone.
+        </p>
+
+        <h3>Lists</h3>
+        <p>Lists are a goto when it comes to conveying complex ideas. Unordered lists:</p>
+        <ul>
+          <li>
+            Help chunk out larger ideas into bite size pieces that are a little easier to
+            consume
+          </li>
+          <li>Make it easy for a user to scan text for key information</li>
+          <li>Help break up walls of text</li>
+        </ul>
+
+        <p>Ordered lists:</p>
+
+        <ol>
+          <li>Are</li>
+          <li>great</li>
+          <li>too</li>
+        </ol>
+
+        <h3>Blockquote</h3>
+
+        <blockquote>
+          LOL have you ever tried to quote something in the app? Who cares, it's
+          supported.
+        </blockquote>
+
+        <p>
+          That's it for now. You'll notice that there's no margin doubling up with the
+          padding of this container. That's because the last child in a Text component has{' '}
+          <code>margin-bottom: 0</code>. Byyyeeee.
+        </p>
+      </Text>
+    </div>
+  ))
+);

--- a/src/sentry/static/sentry/app/components/text.jsx
+++ b/src/sentry/static/sentry/app/components/text.jsx
@@ -1,0 +1,61 @@
+import styled from 'react-emotion';
+
+const Text = styled.div`
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  ul,
+  ol,
+  table,
+  dl,
+  blockquote,
+  form {
+    margin-bottom: 20px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    line-height: 1.2;
+  }
+
+  p,
+  ul,
+  ol,
+  blockquote {
+    line-height: 1.5;
+  }
+
+  h1 {
+    font-size: 32px;
+  }
+
+  h2 {
+    font-size: 26px;
+  }
+
+  h3 {
+    font-size: 22px;
+  }
+
+  h4 {
+    font-size: 18px;
+  }
+
+  h5 {
+    font-size: 16px;
+  }
+`;
+
+export default Text;

--- a/src/sentry/static/sentry/app/components/text.jsx
+++ b/src/sentry/static/sentry/app/components/text.jsx
@@ -38,23 +38,23 @@ const Text = styled.div`
   }
 
   h1 {
-    font-size: 32px;
+    font-size: 2em;
   }
 
   h2 {
-    font-size: 26px;
+    font-size: 1.75em;
   }
 
   h3 {
-    font-size: 22px;
+    font-size: 1.5em;
   }
 
   h4 {
-    font-size: 18px;
+    font-size: 1.25em;
   }
 
   h5 {
-    font-size: 16px;
+    font-size: 1em;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/text.jsx
+++ b/src/sentry/static/sentry/app/components/text.jsx
@@ -14,7 +14,7 @@ const Text = styled.div`
   dl,
   blockquote,
   form {
-    margin-bottom: 20px;
+    margin-bottom: 1.25em;
 
     &:last-child {
       margin-bottom: 0;

--- a/src/sentry/static/sentry/app/components/text.jsx
+++ b/src/sentry/static/sentry/app/components/text.jsx
@@ -14,7 +14,7 @@ const Text = styled.div`
   dl,
   blockquote,
   form {
-    margin-bottom: 1.25em;
+    margin-bottom: 20px;
 
     &:last-child {
       margin-bottom: 0;

--- a/src/sentry/static/sentry/app/components/text.jsx
+++ b/src/sentry/static/sentry/app/components/text.jsx
@@ -13,7 +13,8 @@ const Text = styled.div`
   table,
   dl,
   blockquote,
-  form {
+  form,
+  pre {
     margin-bottom: 20px;
 
     &:last-child {


### PR DESCRIPTION
Not having to override margin, padding, and line-height on native text elements is a feature in the app UI world — that's why things like reset.css, normalize.css, etc exist. But in situations where you need those styles to "just work" it can be quite frustrating to find out they're not supported.

This PR introduces a `<Text />` component that unlocks basic type styles on native text components on-demand. Here's a screenshot from storybook:

<img width="974" alt="screen shot 2018-04-24 at 3 38 13 pm" src="https://user-images.githubusercontent.com/30713/39217607-a611a64a-47d5-11e8-8870-6ead691fe589.png">

This can be used when needed or you can base new components on it like so:

```
const CommentBody = styled(Text)`font-size: 14px;`; 
```

`<Text />` font sizes are em-based. In the above example type scale would be calculated with a smaller 14px base instead of our 16px default. 

Thoughts on this approach? cc @getsentry/app 