### PR TITLE
[WIP] feat(github-apps): Set up GitHub Apps installation flow

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1236,6 +1236,7 @@ SENTRY_USE_X_FORWARDED_FOR = True
 
 SENTRY_DEFAULT_INTEGRATIONS = (
     'sentry.integrations.slack.SlackIntegration',
+    'sentry.integrations.github.GitHubIntegration',
     'sentry.integrations.jira.JiraIntegration',
 )
 

--- a/src/sentry/identity/__init__.py
+++ b/src/sentry/identity/__init__.py
@@ -5,6 +5,7 @@ from .manager import IdentityManager  # NOQA
 from .oauth2 import *  # NOQA
 
 from .slack import *  # NOQA
+from .github import *  # NOQA
 
 
 default_manager = IdentityManager()
@@ -17,3 +18,4 @@ unregister = default_manager.unregister
 # TODO(epurkhiser): Should this be moved into it's own plugin, it should be
 # initialized there.
 register(SlackIdentityProvider)  # NOQA
+register(GitHubIdentityProvider)  # NOQA

--- a/src/sentry/identity/github/__init__.py
+++ b/src/sentry/identity/github/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from sentry.utils.imports import import_submodules
+
+import_submodules(globals(), __name__, __path__)

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from sentry import options
+from sentry.options.manager import FLAG_PRIORITIZE_DISK
+from sentry.identity.oauth2 import OAuth2Provider
+
+options.register('github.client-id', flags=FLAG_PRIORITIZE_DISK)
+options.register('github.client-secret', flags=FLAG_PRIORITIZE_DISK)
+
+
+class GitHubIdentityProvider(OAuth2Provider):
+    key = 'github'
+    name = 'GitHub'
+
+    oauth_access_token_url = 'https://github.com/login/oauth/access_token'
+    oauth_authorize_url = 'https://github.com/login/oauth/authorize'
+
+    oauth_scopes = ()
+
+    def get_oauth_client_id(self):
+        return options.get('github.client-id')
+
+    def get_oauth_client_secret(self):
+        return options.get('github.client-secret')
+
+    def build_identity(self, data):
+        data = data['data']
+
+        return {
+            'type': 'github',
+            'id': data['user']['id'],
+            'email': data['user']['email'],
+            'scopes': sorted(data['scope'].split(',')),
+            'data': self.get_oauth_data(data),
+        }

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -1,7 +1,21 @@
 from __future__ import absolute_import
 
+from sentry import http
 from sentry import options
 from sentry.identity.oauth2 import OAuth2Provider
+
+
+def get_user_info(access_token):
+    session = http.build_session()
+    resp = session.get(
+        'https://api.github.com/user',
+        params={'access_token': access_token},
+        headers={'Accept': 'application/vnd.github.machine-man-preview+json'}
+    )
+    resp.raise_for_status()
+    resp = resp.json()
+
+    return resp
 
 
 class GitHubIdentityProvider(OAuth2Provider):
@@ -21,11 +35,12 @@ class GitHubIdentityProvider(OAuth2Provider):
 
     def build_identity(self, data):
         data = data['data']
+        user = get_user_info(data['access_token'])
 
         return {
             'type': 'github',
-            'id': data['user']['id'],
-            'email': data['user']['email'],
-            'scopes': sorted(data['scope'].split(',')),
+            'id': user['id'],
+            'email': user['email'],
+            'scopes': [],  # GitHub apps do not have user scopes
             'data': self.get_oauth_data(data),
         }

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 
 from sentry import options
-from sentry.options.manager import FLAG_PRIORITIZE_DISK
 from sentry.identity.oauth2 import OAuth2Provider
-
-options.register('github.client-id', flags=FLAG_PRIORITIZE_DISK)
-options.register('github.client-secret', flags=FLAG_PRIORITIZE_DISK)
 
 
 class GitHubIdentityProvider(OAuth2Provider):

--- a/src/sentry/integrations/github/__init__.py
+++ b/src/sentry/integrations/github/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from sentry.utils.imports import import_submodules
+
+import_submodules(globals(), __name__, __path__)

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import
 import six
-from sentry import http
+from sentry import http, options
+from sentry.options.manager import FLAG_PRIORITIZE_DISK
 from sentry.integrations import Integration, IntegrationMetadata
 from sentry.utils.pipeline import NestedPipelineView, PipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.utils.http import absolute_uri
+
+options.register('github.app-name', flags=FLAG_PRIORITIZE_DISK)
 
 DESCRIPTION = """
     Install GitHub Apps
@@ -96,10 +99,13 @@ class GitHubIntegration(Integration):
 
 
 class GitHubInstallationRedirect(PipelineView):
+    def get_app_url(self):
+        name = options.get('github.app-name')
+        return 'https://github.com/apps/%s' % name
 
     def dispatch(self, request, pipeline):
         if 'installation_id' in request.GET:
             pipeline.bind_state('installation_id', request.GET['installation_id'])
             return pipeline.next_step()
 
-        return self.redirect('https://github.com/apps/testing-github')
+        return self.redirect(self.get_app_url())

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,0 +1,105 @@
+from __future__ import absolute_import
+import six
+from sentry import http
+from sentry.integrations import Integration, IntegrationMetadata
+from sentry.utils.pipeline import NestedPipelineView, PipelineView
+from sentry.identity.pipeline import IdentityProviderPipeline
+from sentry.utils.http import absolute_uri
+
+DESCRIPTION = """
+    Install GitHub Apps
+"""
+
+
+metadata = IntegrationMetadata(
+    description=DESCRIPTION.strip(),
+    author='The Sentry Team',
+    issue_url='',
+    source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/github',
+    aspects={}
+)
+
+
+class GitHubIntegration(Integration):
+    key = 'github'
+    name = 'GitHub'
+    metadata = metadata
+
+    setup_dialog_config = {
+        'width': 600,
+        'height': 900,
+    }
+
+    def get_pipeline_views(self):
+        identity_pipeline_config = {
+            'oauth_scopes': (),
+            'redirect_url': absolute_uri('/extensions/github/setup/'),
+        }
+
+        identity_pipeline_view = NestedPipelineView(
+            bind_key='identity',
+            provider_key='github',
+            pipeline_cls=IdentityProviderPipeline,
+            config=identity_pipeline_config,
+        )
+
+        return [GitHubInstallationRedirect(), identity_pipeline_view]
+
+    def get_config(self):
+        return [{
+            'name': 'github',
+            'label': 'GitHub',
+            'type': 'text',
+            'metadata': metadata,
+            'required': True,
+        }]
+
+    def get_installation_info(self, access_token):
+        payload = {
+            'access_token': access_token,
+        }
+
+        session = http.build_session()
+        resp = session.get(
+            'https://api.github.com/user/installations',
+            params=payload,
+            headers={'Accept': 'application/vnd.github.machine-man-preview+json'}
+        )
+        resp.raise_for_status()
+        resp = resp.json()
+
+        return resp['installations']
+
+    def build_integration(self, state):
+        data = state['identity']['data']
+        installation_info = self.get_installation_info(data['access_token'])
+        for installation in installation_info:
+            if state['installation_id'] == six.text_type(installation['id']):
+                integration = {
+                    'name': installation['account']['login'],
+                    'external_id': installation['id'],
+                    'metadata': {
+                        'access_token': data['access_token'],
+                        'icon': installation['account']['avatar_url'],
+                        'domain_name': installation['account']['html_url'],
+                    }
+                }
+                if installation['account']['type'] == 'User':
+                    integration['user_identity'] = {
+                        'type': 'github',
+                        'external_id': installation['account']['id'],
+                        'scopes': [],
+                        'data': {},
+                    }
+
+                return integration
+
+
+class GitHubInstallationRedirect(PipelineView):
+
+    def dispatch(self, request, pipeline):
+        if 'installation_id' in request.GET:
+            pipeline.bind_state('installation_id', request.GET['installation_id'])
+            return pipeline.next_step()
+
+        return self.redirect('https://github.com/apps/testing-github')

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from django.utils.translation import ugettext_lazy as _
+
 from sentry import http, options
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations import Integration, IntegrationMetadata
@@ -17,6 +19,7 @@ DESCRIPTION = """
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     author='The Sentry Team',
+    noun=_('Installation'),
     issue_url='',
     source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/github',
     aspects={}

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,15 +1,13 @@
 from __future__ import absolute_import
 
 from sentry import http, options
-from sentry.options.manager import FLAG_PRIORITIZE_DISK
-from sentry.integrations import Integration, IntegrationMetadata
-from sentry.utils.pipeline import NestedPipelineView, PipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
+from sentry.integrations import Integration, IntegrationMetadata
+from sentry.pipeline import NestedPipelineView, PipelineView
 from sentry.utils.http import absolute_uri
 
 from .utils import get_jwt
 
-options.register('github.app-name', flags=FLAG_PRIORITIZE_DISK)
 
 DESCRIPTION = """
     Install GitHub Apps

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -12,7 +12,7 @@ from .utils import get_jwt
 
 
 DESCRIPTION = """
-    Install GitHub Apps
+    Fill me out
 """
 
 
@@ -20,7 +20,7 @@ metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     author='The Sentry Team',
     noun=_('Installation'),
-    issue_url='',
+    issue_url='https://github.com/getsentry/sentry/issues/new?title=GitHub%20Integration:%20&labels=Component%3A%20Integrations',
     source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/github',
     aspects={}
 )
@@ -32,8 +32,8 @@ class GitHubIntegration(Integration):
     metadata = metadata
 
     setup_dialog_config = {
-        'width': 600,
-        'height': 900,
+        'width': 1030,
+        'height': 1000,
     }
 
     def get_pipeline_views(self):
@@ -73,20 +73,15 @@ class GitHubIntegration(Integration):
             'https://api.github.com/app/installations/%s' % installation_id,
             headers={
                 'Authorization': 'Bearer %s' % get_jwt(),
-                # TODO(jess): remove this whenever it's out of preview
                 'Accept': 'application/vnd.github.machine-man-preview+json',
             }
         )
         resp.raise_for_status()
         installation_resp = resp.json()
 
-        payload = {
-            'access_token': access_token,
-        }
-
         resp = session.get(
             'https://api.github.com/user/installations',
-            params=payload,
+            params={'access_token': access_token},
             headers={'Accept': 'application/vnd.github.machine-man-preview+json'}
         )
         resp.raise_for_status()

--- a/src/sentry/integrations/github/payload.py
+++ b/src/sentry/integrations/github/payload.py
@@ -15,7 +15,7 @@ from sentry import options
 from sentry.utils import json
 from sentry.api.base import Endpoint
 
-logger = logging.getLogger('sentry.webhooks')
+logger = logging.getLogger('sentry.integrations.github')
 
 
 class GitHubAppsEndpoint(Endpoint):

--- a/src/sentry/integrations/github/payload.py
+++ b/src/sentry/integrations/github/payload.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import
+
+import hashlib
+import hmac
+import logging
+import six
+
+from django.http import HttpResponse
+from django.utils.crypto import constant_time_compare
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from simplejson import JSONDecodeError
+from sentry import options
+
+from sentry.utils import json
+from sentry.api.base import Endpoint
+
+logger = logging.getLogger('sentry.webhooks')
+
+
+class GitHubAppsEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request, *args, **kwargs):
+        return super(GitHubAppsEndpoint, self).dispatch(request, *args, **kwargs)
+
+    def get_secret(self):
+        return options.get('github.webhook-secret')
+
+    def is_valid_signature(self, method, body, secret, signature):
+        if method == 'sha1':
+            mod = hashlib.sha1
+        else:
+            raise NotImplementedError('signature method %s is not supported' % (method, ))
+        expected = hmac.new(
+            key=secret.encode('utf-8'),
+            msg=body,
+            digestmod=mod,
+        ).hexdigest()
+        return constant_time_compare(expected, signature)
+
+    def post(self, request, *kwargs):
+
+        secret = self.get_secret()
+
+        if secret is None:
+            logger.error(
+                'github.webhook.missing-secret',
+            )
+            return HttpResponse(status=401)
+
+        body = six.binary_type(request.body)
+        if not body:
+            logger.error(
+                'github.webhook.missing-body',
+            )
+            return HttpResponse(status=400)
+
+        try:
+            method, signature = request.META['HTTP_X_HUB_SIGNATURE'].split('=', 1)
+        except (KeyError, IndexError):
+            logger.error(
+                'github.webhook.missing-signature',
+            )
+            return HttpResponse(status=400)
+
+        if not self.is_valid_signature(method, body, self.get_secret(), signature):
+            logger.error(
+                'github.webhook.invalid-signature',
+            )
+            return HttpResponse(status=401)
+
+        try:
+            json.loads(body.decode('utf-8'))
+        except JSONDecodeError:
+            logger.error(
+                'github.webhook.invalid-json',
+                exc_info=True,
+            )
+            return HttpResponse(status=400)
+
+        return HttpResponse(status=200)

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import, print_function
+
+from django.conf.urls import patterns, url
+
+from .payload import GitHubAppsEndpoint
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^payload/$', GitHubAppsEndpoint.as_view()),
+)

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+import calendar
+import datetime
+import jwt
+import time
+
+from sentry import options
+
+
+def get_jwt():
+    exp = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
+    exp = calendar.timegm(exp.timetuple())
+    # Generate the JWT
+    payload = {
+        # issued at time
+        'iat': int(time.time()),
+        # JWT expiration time (10 minute maximum)
+        'exp': exp,
+        # Integration's GitHub identifier
+        'iss': options.get('github.app-id'),
+    }
+
+    return jwt.encode(payload, options.get('github.private-key'), algorithm='RS256')

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -117,7 +117,12 @@ register('cloudflare.secret-key', default='')
 # Tagstore
 register('tagstore.multi-sampling', default=0.0)
 
+
 # Slack Integration
 register('slack.client-id', flags=FLAG_PRIORITIZE_DISK)
 register('slack.client-secret', flags=FLAG_PRIORITIZE_DISK)
 register('slack.verification-token', flags=FLAG_PRIORITIZE_DISK)
+
+# GitHubApps
+register('github.webhook-secret', default='')
+

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -125,4 +125,5 @@ register('slack.verification-token', flags=FLAG_PRIORITIZE_DISK)
 
 # GitHubApps
 register('github.webhook-secret', default='')
-
+register('github.private-key', default='')
+register('github.app-id', default=0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -117,13 +117,15 @@ register('cloudflare.secret-key', default='')
 # Tagstore
 register('tagstore.multi-sampling', default=0.0)
 
-
 # Slack Integration
 register('slack.client-id', flags=FLAG_PRIORITIZE_DISK)
 register('slack.client-secret', flags=FLAG_PRIORITIZE_DISK)
 register('slack.verification-token', flags=FLAG_PRIORITIZE_DISK)
 
-# GitHubApps
+# Github Integration
+register('github.app-id', default=0)
+register('github.app-name', default='')
 register('github.webhook-secret', default='')
 register('github.private-key', default='')
-register('github.app-id', default=0)
+register('github.client-id', flags=FLAG_PRIORITIZE_DISK)
+register('github.client-secret', flags=FLAG_PRIORITIZE_DISK)

--- a/src/sentry/static/sentry/app/views/projectPlugins/organizationIntegrations.jsx
+++ b/src/sentry/static/sentry/app/views/projectPlugins/organizationIntegrations.jsx
@@ -39,7 +39,7 @@ export default class OrganizationIntegrations extends AsyncComponent {
   renderBody() {
     let {orgId, projectId} = this.props;
     let orgFeatures = new Set(this.state.organization.features);
-    let internalIntegrations = new Set(['jira']);
+    let internalIntegrations = new Set(['jira', 'github']);
 
     const integrations = this.state.config.providers
       .filter(provider => {

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -144,6 +144,10 @@ def pytest_configure(config):
             'slack.client-id': 'slack-client-id',
             'slack.client-secret': 'slack-client-secret',
             'slack.verification-token': 'slack-verification-token',
+
+            'github.app-name': 'sentry-test-app',
+            'github.client-id': 'github-client-id',
+            'github.client-secret': 'github-client-secret',
         }
     )
 
@@ -192,8 +196,10 @@ def register_extensions():
     from sentry import integrations
     from sentry.integrations.example import ExampleIntegration
     from sentry.integrations.slack import SlackIntegration
+    from sentry.integrations.github import GitHubIntegration
     integrations.register(ExampleIntegration)
     integrations.register(SlackIntegration)
+    integrations.register(GitHubIntegration)
 
     from sentry.plugins import bindings
     from sentry.plugins.providers.dummy import DummyRepositoryProvider

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -495,6 +495,7 @@ urlpatterns += patterns(
     url(r'^extensions/cloudflare/', include('sentry.integrations.cloudflare.urls')),
     url(r'^extensions/jira/', include('sentry.integrations.jira.urls')),
     url(r'^extensions/slack/', include('sentry.integrations.slack.urls')),
+    url(r'^extensions/github/', include('sentry.integrations.github.urls')),
 
     url(r'^plugins/', include('sentry.plugins.base.urls')),
 

--- a/tests/js/spec/views/projectPlugins/pluginNavigation.integration.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/pluginNavigation.integration.spec.jsx
@@ -21,7 +21,7 @@ describe('PluginNavigation Integration', function() {
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/`,
       method: 'GET',
-      body: org,
+      body: {organization: org},
     });
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/plugins/`,

--- a/tests/sentry/integrations/github/__init__.py
+++ b/tests/sentry/integrations/github/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1,0 +1,136 @@
+from __future__ import absolute_import
+
+import responses
+import six
+from mock import patch
+
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse
+
+from sentry.integrations.github import GitHubIntegration
+from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration, OrganizationIntegration
+from sentry.testutils import IntegrationTestCase
+
+
+class GitHubIntegrationTest(IntegrationTestCase):
+    provider = GitHubIntegration
+
+    @patch('sentry.integrations.github.integration.get_jwt', return_value='jwt_token_1')
+    def assert_setup_flow(self, get_jwt, installation_id='install_id_1', user_id='user_id_1'):
+        responses.reset()
+
+        resp = self.client.get(self.init_path)
+        assert resp.status_code == 302
+        redirect = urlparse(resp['Location'])
+        assert redirect.scheme == 'https'
+        assert redirect.netloc == 'github.com'
+        assert redirect.path == '/apps/sentry-test-app'
+
+        # App installation ID is provided, mveo thr
+        resp = self.client.get('{}?{}'.format(
+            self.setup_path,
+            urlencode({'installation_id': installation_id})
+        ))
+
+        assert resp.status_code == 302
+        redirect = urlparse(resp['Location'])
+        assert redirect.scheme == 'https'
+        assert redirect.netloc == 'github.com'
+        assert redirect.path == '/login/oauth/authorize'
+
+        params = parse_qs(redirect.query)
+        assert params['state']
+        assert params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
+        assert params['response_type'] == ['code']
+        assert params['client_id'] == ['github-client-id']
+        # once we've asserted on it, switch to a singular values to make life
+        # easier
+        authorize_params = {k: v[0] for k, v in six.iteritems(params)}
+
+        access_token = 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
+
+        responses.add(
+            responses.POST, 'https://github.com/login/oauth/access_token',
+            json={'access_token': access_token}
+        )
+
+        responses.add(
+            responses.GET, 'https://api.github.com/user',
+            json={'id': user_id}
+        )
+
+        responses.add(
+            responses.GET,
+            u'https://api.github.com/app/installations/{}'.format(installation_id),
+            json={
+                'id': installation_id,
+                'account': {
+                    'login': 'Test Organization',
+                    'avatar_url': 'http://example.com/avatar.png',
+                    'html_url': 'https://github.com/Test-Organization',
+                },
+            }
+        )
+
+        responses.add(
+            responses.GET, u'https://api.github.com/user/installations',
+            json={
+                'installations': [{'id': installation_id}],
+            }
+        )
+
+        resp = self.client.get('{}?{}'.format(
+            self.setup_path,
+            urlencode({
+                'code': 'oauth-code',
+                'state': authorize_params['state'],
+            })
+        ))
+
+        mock_access_token_request = responses.calls[0].request
+        req_params = parse_qs(mock_access_token_request.body)
+        assert req_params['grant_type'] == ['authorization_code']
+        assert req_params['code'] == ['oauth-code']
+        assert req_params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
+        assert req_params['client_id'] == ['github-client-id']
+        assert req_params['client_secret'] == ['github-client-secret']
+
+        assert resp.status_code == 200
+
+        auth_header = responses.calls[2].request.headers['Authorization']
+        assert auth_header == 'Bearer jwt_token_1'
+
+        self.assertDialogSuccess(resp)
+
+    @responses.activate
+    def test_basic_flow(self):
+        self.assert_setup_flow()
+
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        assert integration.external_id == 'install_id_1'
+        assert integration.name == 'Test Organization'
+        assert integration.metadata == {
+            'access_token': None,
+            'expires_at': None,
+            'icon': 'http://example.com/avatar.png',
+            'domain_name': 'github.com/Test-Organization',
+        }
+        oi = OrganizationIntegration.objects.get(
+            integration=integration,
+            organization=self.organization,
+        )
+        assert oi.config == {}
+
+        idp = IdentityProvider.objects.get(
+            type='github',
+            organization=self.organization,
+        )
+        identity = Identity.objects.get(
+            idp=idp,
+            user=self.user,
+            external_id='user_id_1',
+        )
+        assert identity.status == IdentityStatus.VALID
+        assert identity.data == {
+            'access_token': 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
+        }


### PR DESCRIPTION
This is the installation setup in order to support GitHub Apps.

**A user will be able to:**
* Install our GitHub App
* Choose whether to install it on an organization or user account
* Authorize their GitHub account with the App (following [this](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/))

The github installation will be connected to the sentry organization the user is in when they start the flow. 

**Still to do:**
- [ ] `github.client-id`, `github.client-secret`, `github.webhook-secret` should be from Sentry's GitHub App 
- [x] Remove`'https://github.com/apps/testing-github'` and replace with Sentry's public install url
- [x] Save user identity when installing on an org (payload we get back is a bit different I think..)
- [x] Add in `internal-catchall`

cc @getsentry/app 