### PR TITLE
fix(Alert Rules): Update Alert Rule Labels on Save

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install-brew:
 	@hash brew 2> /dev/null && brew bundle || (echo '! Homebrew not found, skipping system dependencies.')
 
 install-python:
-	# must be executed serialially
+	# must be executed serially
 	$(MAKE) install-python-base
 	$(MAKE) install-python-develop
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -47,6 +47,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             project=project,
             id=rule_id,
         )
+
         serializer = RuleSerializer(
             {
                 'actionMatch': rule.data.get('action_match') or Rule.DEFAULT_ACTION_MATCH,

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -37,14 +37,10 @@ class RuleSerializer(Serializer):
             'id':
             six.text_type(obj.id) if obj.id else None,
             'conditions': [
-                dict({
-                    'name': _generate_rule_label(obj.project, obj, o),
-                }, **o) for o in obj.data.get('conditions', [])
+                dict(o.items() + [('name', _generate_rule_label(obj.project, obj, o))]) for o in obj.data.get('conditions', [])
             ],
             'actions': [
-                dict({
-                    'name': _generate_rule_label(obj.project, obj, o),
-                }, **o) for o in obj.data.get('actions', [])
+                dict(o.items() + [('name', _generate_rule_label(obj.project, obj, o))]) for o in obj.data.get('actions', [])
             ],
             'actionMatch':
             obj.data.get('action_match') or Rule.DEFAULT_ACTION_MATCH,

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -162,8 +162,9 @@ class UpdateProjectRuleTest(APITestCase):
                       'interval': '1h',
                       'id': 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
                       'value': 666,
-                      'name': 'An event is seen more than 30 times in 1m'}],
-                  'id': '28',
+                      'name': 'An event is seen more than 30 times in 1m'
+                  }],
+                  'id': rule.id,
                   'actions': [{
                       'id': 'sentry.rules.actions.notify_event.NotifyEventAction',
                       'name': 'Send a notification (for all legacy integrations)'}],
@@ -173,9 +174,6 @@ class UpdateProjectRuleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data['conditions'][0]['name'] == 'An event is seen more than 666 times in 1h'
-
-        rule = Rule.objects.get(id=rule.id)
-        assert rule.data['conditions'][0]['name'] == 'An event is seen more than 666 times in 1h'
 
     def test_with_environment(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
This fixes the bug reported by @ceorourke  where rules serialize with the wrong labels after being edited.


The frontend sends conditions with "name" keys, which get dutifully stored inside the data field of rules. Then, when serializing, they win out over the computed value. yuck. The solution was to change the way the new dictionary is built so our computed name always wins.

