### PR TITLE
feat(ui): Propagate team changes to `ProjectsStore`

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/indicator.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/indicator.jsx
@@ -20,6 +20,9 @@ export function addMessage(msg, type, options = {}) {
   duration = typeof duration === 'undefined' ? DEFAULT_TOAST_DURATION : duration;
 
   let action = options.append ? 'append' : 'replace';
+  // XXX: This won't actually return the indicator since we are firing an action
+  // Behavior will be different than when calling IndicatorStore.add directly, but
+  // you can just add a new message and it will by default replace active indicator
   return IndicatorActions[action](msg, type, {...options, duration});
 }
 

--- a/src/sentry/static/sentry/app/actionCreators/indicator.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/indicator.jsx
@@ -20,10 +20,10 @@ export function addMessage(msg, type, options = {}) {
   duration = typeof duration === 'undefined' ? DEFAULT_TOAST_DURATION : duration;
 
   let action = options.append ? 'append' : 'replace';
-  // XXX: This won't actually return the indicator since we are firing an action
-  // Behavior will be different than when calling IndicatorStore.add directly, but
-  // you can just add a new message and it will by default replace active indicator
-  return IndicatorActions[action](msg, type, {...options, duration});
+  // XXX: This differs from `IndicatorStore.add` since it won't return the indicator that is created
+  // because we are firing an action. You can just add a new message and it will, by default,
+  // replace active indicator
+  IndicatorActions[action](msg, type, {...options, duration});
 }
 
 function addMessageWithType(type) {

--- a/src/sentry/static/sentry/app/actionCreators/projects.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/projects.jsx
@@ -1,4 +1,8 @@
-import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {
+  addLoadingMessage,
+  addErrorMessage,
+  addSuccessMessage,
+} from 'app/actionCreators/indicator';
 import {tct} from 'app/locale';
 import ProjectActions from 'app/actions/projectActions';
 
@@ -93,38 +97,96 @@ export function transferProject(api, orgId, project, email) {
 /**
  * Associate a team with a project
  */
-export function addTeamToProject(api, orgSlug, projectSlug, teamSlug) {
-  let endpoint = `/projects/${orgSlug}/${projectSlug}/teams/${teamSlug}/`;
+
+/**
+ *  Adds a team to a project
+ *
+ * @param {Client} api API Client
+ * @param {String} orgSlug Organization Slug
+ * @param {String} projectSlug Project Slug
+ * @param {String} teamSlug Team Slug
+ */
+export function addTeamToProject(api, orgSlug, projectSlug, team) {
+  let endpoint = `/projects/${orgSlug}/${projectSlug}/teams/${team.slug}/`;
+
+  addLoadingMessage();
+  ProjectActions.addTeam(team);
 
   return api
     .requestPromise(endpoint, {
       method: 'POST',
     })
     .then(
-      () => {
+      project => {
         addSuccessMessage(
           tct('[team] has been added to the [project] project', {
-            team: `#${teamSlug}`,
+            team: `#${team.slug}`,
             project: projectSlug,
-          }),
-          undefined,
-          {append: true}
+          })
         );
+        ProjectActions.addTeamSuccess(team, projectSlug);
+        ProjectActions.updateSuccess(project);
       },
       err => {
         addErrorMessage(
           tct('Unable to add [team] to the [project] project', {
-            team: `#${teamSlug}`,
+            team: `#${team.slug}`,
             project: projectSlug,
-          }),
-          undefined,
-          {append: true}
+          })
         );
+        ProjectActions.addTeamError();
         throw err;
       }
     );
 }
 
+/**
+ *  Removes a team from a project
+ *
+ * @param {Client} api API Client
+ * @param {String} orgSlug Organization Slug
+ * @param {String} projectSlug Project Slug
+ * @param {String} teamSlug Team Slug
+ */
+export function removeTeamFromProject(api, orgSlug, projectSlug, teamSlug) {
+  let endpoint = `/projects/${orgSlug}/${projectSlug}/teams/${teamSlug}/`;
+
+  addLoadingMessage();
+  ProjectActions.removeTeam(teamSlug);
+
+  return api
+    .requestPromise(endpoint, {
+      method: 'DELETE',
+    })
+    .then(
+      project => {
+        addSuccessMessage(
+          tct('[team] has been removed from the [project] project', {
+            team: `#${teamSlug}`,
+            project: projectSlug,
+          })
+        );
+        ProjectActions.removeTeamSuccess(teamSlug, projectSlug);
+        ProjectActions.updateSuccess(project);
+      },
+      err => {
+        addErrorMessage(
+          tct('Unable to remove [team] from the [project] project', {
+            team: `#${teamSlug}`,
+            project: projectSlug,
+          })
+        );
+        ProjectActions.removeTeamError(err);
+        throw err;
+      }
+    );
+}
+
+/**
+ * Change a project's slug
+ * @param {String} prev Previous slug
+ * @param {String} next New slug
+ */
 export function changeProjectSlug(prev, next) {
   ProjectActions.changeSlug(prev, next);
 }

--- a/src/sentry/static/sentry/app/actionCreators/projects.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/projects.jsx
@@ -104,7 +104,7 @@ export function transferProject(api, orgId, project, email) {
  * @param {Client} api API Client
  * @param {String} orgSlug Organization Slug
  * @param {String} projectSlug Project Slug
- * @param {String} teamSlug Team Slug
+ * @param {String} team Team data object
  */
 export function addTeamToProject(api, orgSlug, projectSlug, team) {
   let endpoint = `/projects/${orgSlug}/${projectSlug}/teams/${team.slug}/`;

--- a/src/sentry/static/sentry/app/actions/projectActions.jsx
+++ b/src/sentry/static/sentry/app/actions/projectActions.jsx
@@ -13,4 +13,10 @@ export default Reflux.createActions([
   'removeProjectSuccess',
   'setActive',
   'changeSlug',
+  'addTeam',
+  'addTeamSuccess',
+  'addTeamError',
+  'removeTeam',
+  'removeTeamSuccess',
+  'removeTeamError',
 ]);

--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -64,6 +64,9 @@ export class Client {
     };
   }
 
+  /**
+   * Attempt to cancel all active XHR requests
+   */
   clear() {
     for (let id in this.activeRequests) {
       this.activeRequests[id].cancel();

--- a/src/sentry/static/sentry/app/stores/projectsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStore.jsx
@@ -2,6 +2,7 @@ import Reflux from 'reflux';
 import _ from 'lodash';
 
 import ProjectActions from 'app/actions/projectActions';
+import TeamActions from 'app/actions/teamActions';
 
 const ProjectsStore = Reflux.createStore({
   init() {
@@ -10,6 +11,9 @@ const ProjectsStore = Reflux.createStore({
     this.listenTo(ProjectActions.updateSuccess, this.onUpdateSuccess);
     this.listenTo(ProjectActions.loadStatsSuccess, this.onStatsLoadSuccess);
     this.listenTo(ProjectActions.changeSlug, this.onChangeSlug);
+    this.listenTo(ProjectActions.addTeamSuccess, this.onAddTeam);
+    this.listenTo(ProjectActions.removeTeamSuccess, this.onRemoveTeam);
+    this.listenTo(TeamActions.removeTeamSuccess, this.onDeleteTeam);
   },
 
   reset() {
@@ -37,9 +41,8 @@ const ProjectsStore = Reflux.createStore({
 
     this.itemsById = {
       ...this.itemsById,
+      [newProject.id]: newProject,
     };
-
-    this.itemsById[newProject.id] = newProject;
 
     // Ideally we'd always trigger this.itemsById, but following existing patterns
     // so we don't break things
@@ -47,13 +50,20 @@ const ProjectsStore = Reflux.createStore({
   },
 
   onCreateSuccess(project) {
-    this.itemsById[project.id] = project;
+    this.itemsById = {
+      ...this.itemsById,
+      [project.id]: project,
+    };
     this.trigger(new Set([project.id]));
   },
 
   onUpdateSuccess(data) {
     let project = this.getById(data.id);
-    Object.assign(project, data);
+    let newProject = Object.assign({}, project, data);
+    this.itemsById = {
+      ...this.itemsById,
+      [project.id]: newProject,
+    };
     this.trigger(new Set([data.id]));
   },
 
@@ -66,6 +76,71 @@ const ProjectsStore = Reflux.createStore({
       }
     });
     this.trigger(new Set(touchedIds));
+  },
+
+  /**
+   * Listener for when a team is completely removed
+   * @param {String} teamSlug Team Slug
+   */
+  onDeleteTeam(teamSlug) {
+    this.onRemoveTeam(teamSlug);
+  },
+
+  onRemoveTeam(teamSlug, projectSlug) {
+    let project = this.getBySlug(projectSlug);
+
+    if (!project) {
+      // Look for team in all projects
+      let projectIds = this.getWithTeam(teamSlug).map(projectWithTeam => {
+        this.removeTeamFromProject(teamSlug, projectWithTeam);
+        return projectWithTeam.id;
+      });
+
+      this.trigger(new Set([projectIds]));
+      return;
+    }
+
+    this.removeTeamFromProject(teamSlug, project);
+    this.trigger(new Set([project.id]));
+  },
+
+  onAddTeam(team, projectSlug) {
+    let project = this.getBySlug(projectSlug);
+
+    // Don't do anything if we can't find a project
+    if (!project) return;
+
+    this.itemsById = {
+      ...this.itemsById,
+      [project.id]: {
+        ...project,
+        teams: [...project.teams, team],
+      },
+    };
+
+    this.trigger(new Set([project.id]));
+  },
+
+  // Note, does not trigger
+  removeTeamFromProject(teamSlug, project) {
+    let newTeams = project.teams.filter(({slug}) => slug !== teamSlug);
+
+    this.itemsById = {
+      ...this.itemsById,
+      [project.id]: {
+        ...project,
+        teams: newTeams,
+      },
+    };
+  },
+
+  /**
+   * Returns a list of projects that has the specified team
+   *
+   * @param {String} teamSlug Slug of team to find in projects
+   */
+  getWithTeam(teamSlug) {
+    return this.getAll().filter(({teams}) => teams.find(({slug}) => slug === teamSlug));
   },
 
   getAll() {

--- a/src/sentry/static/sentry/app/stores/projectsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStore.jsx
@@ -83,22 +83,18 @@ const ProjectsStore = Reflux.createStore({
    * @param {String} teamSlug Team Slug
    */
   onDeleteTeam(teamSlug) {
-    this.onRemoveTeam(teamSlug);
+    // Look for team in all projects
+    let projectIds = this.getWithTeam(teamSlug).map(projectWithTeam => {
+      this.removeTeamFromProject(teamSlug, projectWithTeam);
+      return projectWithTeam.id;
+    });
+
+    this.trigger(new Set([projectIds]));
   },
 
   onRemoveTeam(teamSlug, projectSlug) {
     let project = this.getBySlug(projectSlug);
-
-    if (!project) {
-      // Look for team in all projects
-      let projectIds = this.getWithTeam(teamSlug).map(projectWithTeam => {
-        this.removeTeamFromProject(teamSlug, projectWithTeam);
-        return projectWithTeam.id;
-      });
-
-      this.trigger(new Set([projectIds]));
-      return;
-    }
+    if (!project) return;
 
     this.removeTeamFromProject(teamSlug, project);
     this.trigger(new Set([project.id]));
@@ -121,7 +117,7 @@ const ProjectsStore = Reflux.createStore({
     this.trigger(new Set([project.id]));
   },
 
-  // Note, does not trigger
+  // Internal method, does not trigger
   removeTeamFromProject(teamSlug, project) {
     let newTeams = project.teams.filter(({slug}) => slug !== teamSlug);
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -3,13 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-  removeIndicator,
-} from 'app/actionCreators/indicator';
-import {addTeamToProject} from 'app/actionCreators/projects';
+import {removeTeamFromProject, addTeamToProject} from 'app/actionCreators/projects';
 import {getOrganizationState} from 'app/mixins/organizationState';
 import {openCreateTeamModal} from 'app/actionCreators/modal';
 import {t, tct} from 'app/locale';
@@ -19,7 +13,7 @@ import Button from 'app/components/buttons/button';
 import Confirm from 'app/components/confirm';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import EmptyMessage from '../components/emptyMessage';
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/link';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
@@ -50,24 +44,16 @@ const TeamRow = createReactClass({
   handleRemove() {
     if (this.state.loading) return;
 
-    let loadingIndicator = addLoadingMessage(t('Saving changes...'));
     let {orgId, projectId, team} = this.props;
-    this.api.request(`/projects/${orgId}/${projectId}/teams/${team.slug}/`, {
-      method: 'DELETE',
-      success: (d, _, jqXHR) => {
-        this.props.onRemove();
-        addSuccessMessage(t(`#${team.slug} has been removed from project`));
-        removeIndicator(loadingIndicator);
-      },
-      error: () => {
+
+    removeTeamFromProject(this.api, orgId, projectId, team.slug)
+      .then(() => this.props.onRemove())
+      .catch(() => {
         this.setState({
           error: true,
           loading: false,
         });
-        removeIndicator(loadingIndicator);
-        addErrorMessage(t(`Unable to remove #${team.slug} from project`));
-      },
-    });
+      });
   },
 
   render() {
@@ -138,7 +124,7 @@ class ProjectTeams extends AsyncView {
 
     let {orgId, projectId} = this.props.params;
 
-    addTeamToProject(this.api, orgId, projectId, team.slug).then(
+    addTeamToProject(this.api, orgId, projectId, team).then(
       () => {
         this.handleAddedTeam(team);
       },

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -13,7 +13,7 @@ import Button from 'app/components/buttons/button';
 import Confirm from 'app/components/confirm';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
-import EmptyMessage from '../components/emptyMessage';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/link';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';

--- a/tests/js/spec/stores/projectsStore.spec.jsx
+++ b/tests/js/spec/stores/projectsStore.spec.jsx
@@ -1,0 +1,135 @@
+import ProjectsStore from 'app/stores/projectsStore';
+import ProjectActions from 'app/actions/projectActions';
+import TeamActions from 'app/actions/teamActions';
+
+describe('ProjectsStore', function() {
+  let teamFoo = TestStubs.Team({
+    slug: 'team-foo',
+  });
+  let teamBar = TestStubs.Team({
+    slug: 'team-bar',
+  });
+  let projectFoo = TestStubs.Project({
+    id: '2',
+    slug: 'foo',
+    name: 'Foo',
+    teams: [teamFoo],
+  });
+  let projectBar = TestStubs.Project({
+    id: '10',
+    slug: 'bar',
+    name: 'Bar',
+    teams: [teamFoo, teamBar],
+  });
+
+  beforeEach(function() {
+    ProjectsStore.reset();
+    ProjectsStore.loadInitialData([projectFoo, projectBar]);
+  });
+
+  it('updates when slug changes', async function() {
+    ProjectActions.changeSlug('foo', 'new-project');
+    await tick();
+    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+      slug: 'new-project',
+    });
+    expect(ProjectsStore.itemsById[projectBar.id]).toBeDefined();
+  });
+
+  it('adds project to store on "create success"', async function() {
+    let project = TestStubs.Project({id: '11', slug: 'created-project'});
+    ProjectActions.createSuccess(project);
+    await tick();
+    expect(ProjectsStore.itemsById[project.id]).toMatchObject({
+      id: '11',
+      slug: 'created-project',
+    });
+    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+      id: '2',
+      slug: 'foo',
+      name: 'Foo',
+    });
+    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+      id: '10',
+      slug: 'bar',
+    });
+  });
+
+  it('updates a project in store', async function() {
+    // Create a new project, but should have same id as `projectBar`
+    let project = TestStubs.Project({id: '10', slug: 'bar', name: 'New Name'});
+    ProjectActions.updateSuccess(project);
+    await tick();
+    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+      id: '10',
+      slug: 'bar',
+      name: 'New Name',
+    });
+    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+      id: '2',
+      slug: 'foo',
+      name: 'Foo',
+    });
+  });
+
+  it('can remove a team from a single project', async function() {
+    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+      teams: [
+        expect.objectContaining({slug: 'team-foo'}),
+        expect.objectContaining({slug: 'team-bar'}),
+      ],
+    });
+    ProjectActions.removeTeamSuccess('team-foo', 'bar');
+    await tick();
+
+    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+      teams: [expect.objectContaining({slug: 'team-bar'})],
+    });
+    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+      teams: [expect.objectContaining({slug: 'team-foo'})],
+    });
+  });
+
+  it('removes a team from all projects when team is deleted', async function() {
+    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+      teams: [
+        expect.objectContaining({slug: 'team-foo'}),
+        expect.objectContaining({slug: 'team-bar'}),
+      ],
+    });
+    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+      teams: [expect.objectContaining({slug: 'team-foo'})],
+    });
+
+    TeamActions.removeTeamSuccess('team-foo');
+    await tick();
+
+    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+      teams: [expect.objectContaining({slug: 'team-bar'})],
+    });
+    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+      teams: [],
+    });
+  });
+
+  it('can add a team to a project', async function() {
+    let team = TestStubs.Team({
+      slug: 'new-team',
+    });
+    ProjectActions.addTeamSuccess(team, 'foo');
+    await tick();
+
+    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+      teams: [
+        expect.objectContaining({slug: 'team-foo'}),
+        expect.objectContaining({slug: 'team-bar'}),
+      ],
+    });
+    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+      teams: [
+        expect.objectContaining({slug: 'team-foo'}),
+        expect.objectContaining({slug: 'new-team'}),
+      ],
+    });
+  });
+});

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -101,8 +101,11 @@ describe('ProjectTeams', function() {
       })
     );
 
+    await tick();
+
     // Remove second team
     wrapper
+      .update()
       .find('PanelBody Button')
       .first()
       .simulate('click');


### PR DESCRIPTION
* refactor "remove team from project" to use an action creator
* update ProjectsStore when remove/add team to project occurs
* update ProjectsStore when team is completely removed
* change `views/ProjectTeams` to use remove team action creator