### PR TITLE
feat(ui): List all teams/users in Owners Input

### DIFF
--- a/src/sentry/static/sentry/app/components/buttons/button.jsx
+++ b/src/sentry/static/sentry/app/components/buttons/button.jsx
@@ -146,7 +146,7 @@ const getBoxShadow = active => ({priority, borderless, disabled}) => {
   return `box-shadow: ${active ? 'inset' : ''} 0 2px rgba(0, 0, 0, 0.05)`;
 };
 
-const getColors = ({priority, disabled, theme}) => {
+const getColors = ({priority, disabled, borderless, theme}) => {
   let themeName = disabled ? 'disabled' : priority || 'default';
   let {
     color,
@@ -160,7 +160,7 @@ const getColors = ({priority, disabled, theme}) => {
   return css`
     color: ${color};
     background-color: ${background};
-    border: 1px solid ${border || 'transparent'};
+    border: 1px solid ${!borderless && !!border ? border : 'transparent'};
 
     &:hover {
       color: ${color};
@@ -171,7 +171,10 @@ const getColors = ({priority, disabled, theme}) => {
     &:active {
       ${colorActive ? 'color: ${colorActive};' : ''};
       background: ${backgroundActive};
-      border: 1px solid ${borderActive || border || 'transparent'};
+      border: 1px solid
+        ${!borderless && (borderActive || border)
+          ? borderActive || border
+          : 'transparent'};
     }
   `;
 };

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.jsx
@@ -2,18 +2,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 import {Flex} from 'grid-emotion';
+
+import {t} from 'app/locale';
 import memberListStore from 'app/stores/memberListStore';
-import ProjectsStore from 'app/stores/projectsStore';
 import Button from 'app/components/buttons/button';
 import SelectField from 'app/components/forms/selectField';
 import TextOverflow from 'app/components/textOverflow';
 import InlineSvg from 'app/components/inlineSvg';
 import Input from 'app/views/settings/components/forms/controls/input';
 import SentryTypes from 'app/proptypes';
-import {buildUserId, buildTeamId} from 'app/utils';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import SelectOwners from 'app/views/settings/project/projectOwnership/selectOwners';
-import {t} from 'app/locale';
 
 const initialState = {
   text: '',
@@ -24,6 +23,7 @@ const initialState = {
 class RuleBuilder extends React.Component {
   static propTypes = {
     project: SentryTypes.Project,
+    organization: SentryTypes.Organization,
     onAddRule: PropTypes.func,
     urls: PropTypes.arrayOf(PropTypes.string),
     paths: PropTypes.arrayOf(PropTypes.string),
@@ -32,39 +32,6 @@ class RuleBuilder extends React.Component {
   constructor(props) {
     super(props);
     this.state = initialState;
-  }
-
-  mentionableUsers() {
-    return memberListStore.getAll().map(({id, name, email}) => ({
-      value: buildUserId(id),
-      label: name || email,
-      searchKey: `${email}  ${name}`,
-      actor: {
-        type: 'user',
-        id,
-        name,
-      },
-    }));
-  }
-
-  mentionableTeams() {
-    let {project} = this.props;
-    let projectData = ProjectsStore.getBySlug(project.slug);
-
-    if (!projectData) {
-      return [];
-    }
-
-    return projectData.teams.map(team => ({
-      value: buildTeamId(team.id),
-      label: `#${team.slug}`,
-      searchKey: `#${team.slug}`,
-      actor: {
-        type: 'team',
-        id: team.id,
-        name: team.slug,
-      },
-    }));
   }
 
   handleTypeChange = val => {
@@ -102,7 +69,7 @@ class RuleBuilder extends React.Component {
   };
 
   render() {
-    let {urls, paths} = this.props;
+    let {urls, paths, project, organization} = this.props;
     let {type, text, owners} = this.state;
 
     return (
@@ -154,7 +121,8 @@ class RuleBuilder extends React.Component {
           <Divider src="icon-chevron-right" />
           <Flex flex="1" align="center" mr={1}>
             <SelectOwners
-              options={[...this.mentionableTeams(), ...this.mentionableUsers()]}
+              organization={organization}
+              project={project}
               value={owners}
               onChange={this.handleChangeOwners}
             />

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
@@ -1,10 +1,24 @@
-import React from 'react';
+import {Flex} from 'grid-emotion';
 import PropTypes from 'prop-types';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Reflux from 'reflux';
+import styled from 'react-emotion';
 
+import {addTeamToProject} from 'app/actionCreators/projects';
+import {t} from 'app/locale';
+import {buildUserId, buildTeamId} from 'app/utils';
+import {Client} from 'app/api';
+import MemberListStore from 'app/stores/memberListStore';
+import ProjectsStore from 'app/stores/projectsStore';
+import TeamStore from 'app/stores/teamStore';
+import IdBadge from 'app/components/idBadge';
 import MultiSelectControl from 'app/components/forms/multiSelectControl';
 import ActorAvatar from 'app/components/actorAvatar';
-
-import {t} from 'app/locale';
+import SentryTypes from 'app/proptypes';
+import Button from 'app/components/buttons/button';
+import InlineSvg from 'app/components/inlineSvg';
+import Tooltip from 'app/components/tooltip';
 
 class ValueComponent extends React.Component {
   static propTypes = {
@@ -27,21 +41,231 @@ class ValueComponent extends React.Component {
 
 export default class SelectOwners extends React.Component {
   static propTypes = {
-    options: PropTypes.array.isRequired,
+    project: SentryTypes.Project,
+    organization: SentryTypes.Organization,
     value: PropTypes.array,
     onChange: PropTypes.func,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.api = new Client();
+
+    // See comments in `handleAddTeamToProject` for why we close the menu this way
+    this.projectsStoreMixin = Reflux.listenTo(ProjectsStore, () => {
+      this.closeSelectMenu();
+    });
+  }
+
+  state = {
+    loading: false,
+    inputValue: '',
+  };
+
+  componentDidMount() {
+    if (this.projectsStoreMixin) {
+      this.projectsStoreMixin.componentDidMount();
+    }
+  }
+
+  componentWillUnmount() {
+    this.api = null;
+
+    if (this.projectsStoreMixin) {
+      this.projectsStoreMixin.componentWillUnmount();
+    }
+  }
+
+  createMentionableUser(member) {
+    return {
+      value: buildUserId(member.id),
+      label: <IdBadge user={member} hideEmail useLink={false} />,
+      searchKey: `${member.email}  ${member.name}`,
+      actor: {
+        type: 'user',
+        id: member.id,
+        name: member.name,
+      },
+    };
+  }
+
+  createMentionableTeam(team) {
+    return {
+      value: buildTeamId(team.id),
+      label: <IdBadge team={team} />,
+      searchKey: `#${team.slug}`,
+      actor: {
+        type: 'team',
+        id: team.id,
+        name: team.slug,
+      },
+    };
+  }
+
+  getMentionableUsers() {
+    return MemberListStore.getAll().map(this.createMentionableUser);
+  }
+
+  getMentionableTeams() {
+    let {project} = this.props;
+    let projectData = ProjectsStore.getBySlug(project.slug);
+
+    if (!projectData) {
+      return [];
+    }
+
+    return projectData.teams.map(this.createMentionableTeam);
+  }
+
+  /**
+   * Get list of teams that are not in the current project, for use in `MultiSelectMenu`
+   *
+   * @param {Team[]} teamsInProject A list of teams that are in the current project
+   */
+  getTeamsNotInProject(teamsInProject = []) {
+    let teams = TeamStore.getAll() || [];
+    let excludedTeamIds = teamsInProject.map(({actor}) => actor.id);
+
+    return teams.filter(team => excludedTeamIds.indexOf(team.id) === -1).map(team => ({
+      value: buildTeamId(team.id),
+      label: (
+        <Flex justify="space-between">
+          <DisabledLabel>
+            <IdBadge team={team} />
+          </DisabledLabel>
+          <Tooltip title={t(`Add #${team.slug} to project`)}>
+            <Button
+              size="zero"
+              borderless
+              onClick={this.handleAddTeamToProject.bind(this, team)}
+            >
+              <InlineSvg src="icon-circle-add" />
+            </Button>
+          </Tooltip>
+        </Flex>
+      ),
+      disabled: true,
+      searchKey: `#${team.slug}`,
+      actor: {
+        type: 'team',
+        id: team.id,
+        name: team.slug,
+      },
+    }));
+  }
+
+  /**
+   * Closes the select menu by blurring input if possible since that seems to be the only
+   * way to close it.
+   */
+  closeSelectMenu() {
+    // Close select menu
+    if (this.selectRef) {
+      // eslint-disable-next-line react/no-find-dom-node
+      let input = ReactDOM.findDOMNode(this.selectRef).querySelector(
+        '.Select-input input'
+      );
+      if (input) {
+        // I don't think there's another way to close `react-select`
+        input.blur();
+      }
+    }
+  }
+
+  async handleAddTeamToProject(team) {
+    let {organization, project, value} = this.props;
+    // Copy old value
+    let oldValue = [...value];
+
+    // Optimistic update
+    this.props.onChange([...this.props.value, this.createMentionableTeam(team)]);
+
+    try {
+      // Try to add team to project
+      // Note: we can't close select menu here because we have to wait for ProjectsStore to update first
+      // The reason for this is because we have little control over `react-select`'s `AsyncSelect`
+      // We can't control when `handleLoadOptions` gets called, but it gets called when select closes, so
+      // wait for store to update before closing the menu. Otherwise, we'll have stale items in the select menu
+      await addTeamToProject(this.api, organization.slug, project.slug, team);
+    } catch (err) {
+      // Unable to add team to project, revert select menu value
+      this.props.onChange(oldValue);
+      this.closeSelectMenu();
+    }
+  }
+
+  handleInputChange = newValue => {
+    this.setState({inputValue: ''});
+    this.props.onChange(newValue);
+  };
+
+  handleLoadOptions = () => {
+    let {organization} = this.props;
+    let usersInProject = this.getMentionableUsers();
+    let teamsInProject = this.getMentionableTeams();
+    let teamsNotInProject = this.getTeamsNotInProject(teamsInProject);
+    let usersInProjectById = usersInProject.map(({actor}) => actor.id);
+
+    // Return a promise for `react-select`
+    return this.api
+      .requestPromise(`/organizations/${organization.slug}/members/`, {
+        query: this.state.inputValue,
+      })
+      .then(members => {
+        // Be careful here as we actually want the `users` object
+        return members
+          ? members
+              .filter(({user}) => user && usersInProjectById.indexOf(user.id) === -1)
+              .map(({user}) => ({
+                value: buildUserId(user.id),
+                disabled: true,
+                label: (
+                  <DisabledLabel>
+                    <IdBadge user={user} hideEmail useLink={false} />
+                  </DisabledLabel>
+                ),
+                searchKey: `${user.email}  ${user.name}`,
+                actor: {
+                  type: 'user',
+                  id: user.id,
+                  name: user.name,
+                },
+              }))
+          : [];
+      })
+      .then(members => {
+        return {
+          options: [
+            ...usersInProject,
+            ...teamsInProject,
+            ...teamsNotInProject,
+            ...members,
+          ],
+        };
+      });
   };
 
   render() {
     return (
       <MultiSelectControl
-        options={this.props.options}
-        style={{width: 200, overflow: 'visible'}}
+        filterOptions={(options, filterText) => {
+          return options.filter(({searchKey}) => searchKey.indexOf(filterText) > -1);
+        }}
+        ref={ref => (this.selectRef = ref)}
+        loadOptions={this.handleLoadOptions}
+        defaultOptions
+        async
+        cache={false}
         valueComponent={ValueComponent}
         placeholder={t('Add Owners')}
-        onChange={this.props.onChange}
+        onChange={this.handleInputChange}
         value={this.props.value}
+        css={{width: 200}}
       />
     );
   }
 }
+
+const DisabledLabel = styled('div')`
+  opacity: 0.5;
+`;

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
@@ -129,6 +129,9 @@ export default class SelectOwners extends React.Component {
   };
 
   createUnmentionableTeam = team => {
+    let {organization} = this.props;
+    let canAddTeam = organization.access.includes('project:write');
+
     return {
       ...this.createMentionableTeam(team),
       disabled: true,
@@ -142,10 +145,17 @@ export default class SelectOwners extends React.Component {
               <IdBadge team={team} />
             </Tooltip>
           </DisabledLabel>
-          <Tooltip title={t(`Add #${team.slug} to project`)}>
+          <Tooltip
+            title={
+              canAddTeam
+                ? t('Add %s to project', `#${team.slug}`)
+                : t('You do not have permission to add team to project.')
+            }
+          >
             <AddToProjectButton
               size="zero"
               borderless
+              disabled={!canAddTeam}
               onClick={this.handleAddTeamToProject.bind(this, team)}
             >
               <InlineSvg src="icon-circle-add" />

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import ConfigStore from 'app/stores/configStore';
 import theme from 'app/utils/theme';
 
+jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('app/utils/recreateRoute');
 jest.mock('app/translations');
 jest.mock('app/api');

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -8,7 +8,6 @@ import FormSearchStore from 'app/stores/formSearchStore';
 import {navigateTo} from 'app/actionCreators/navigation';
 
 jest.mock('jquery');
-jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('app/actionCreators/formSearch');
 jest.mock('app/actionCreators/navigation');
 

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -3,8 +3,6 @@ import {mount} from 'enzyme';
 
 import {ApiSource} from 'app/components/search/sources/apiSource';
 
-jest.mock('lodash/debounce', () => jest.fn(fn => fn));
-
 describe('ApiSource', function() {
   let wrapper;
   let org = TestStubs.Organization();

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -985,7 +985,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
             >
               <Component
                 aria-label="Learn more"
-                className="css-o6814l-StyledButton-getColors e17811v30"
+                className="css-dkprmi-StyledButton-getColors e17811v30"
                 disabled={false}
                 external={true}
                 href="https://status.sentry.io"
@@ -995,7 +995,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
               >
                 <ExternalLink
                   aria-label="Learn more"
-                  className="css-o6814l-StyledButton-getColors e17811v30"
+                  className="css-dkprmi-StyledButton-getColors e17811v30"
                   disabled={false}
                   href="https://status.sentry.io"
                   onClick={[Function]}
@@ -1006,7 +1006,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                 >
                   <a
                     aria-label="Learn more"
-                    className="css-o6814l-StyledButton-getColors e17811v30"
+                    className="css-dkprmi-StyledButton-getColors e17811v30"
                     disabled={false}
                     href="https://status.sentry.io"
                     onClick={[Function]}

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -416,7 +416,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                           >
                             <Component
                               aria-label="Compare"
-                              className="css-n5jzh7-StyledButton-getColors e17811v30"
+                              className="css-1rcxqx1-StyledButton-getColors e17811v30"
                               disabled={true}
                               href={null}
                               onClick={[Function]}
@@ -431,7 +431,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             >
                               <button
                                 aria-label="Compare"
-                                className="css-n5jzh7-StyledButton-getColors e17811v30"
+                                className="css-1rcxqx1-StyledButton-getColors e17811v30"
                                 disabled={true}
                                 href={null}
                                 onClick={[Function]}
@@ -503,7 +503,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                           >
                             <Component
                               aria-label="Collapse All"
-                              className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
+                              className="toggle-collapse-all css-dkprmi-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               role="button"
@@ -511,7 +511,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             >
                               <button
                                 aria-label="Collapse All"
-                                className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
+                                className="toggle-collapse-all css-dkprmi-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -1880,7 +1880,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                           >
                             <Component
                               aria-label="Compare"
-                              className="css-n5jzh7-StyledButton-getColors e17811v30"
+                              className="css-1rcxqx1-StyledButton-getColors e17811v30"
                               disabled={true}
                               href={null}
                               onClick={[Function]}
@@ -1895,7 +1895,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             >
                               <button
                                 aria-label="Compare"
-                                className="css-n5jzh7-StyledButton-getColors e17811v30"
+                                className="css-1rcxqx1-StyledButton-getColors e17811v30"
                                 disabled={true}
                                 href={null}
                                 onClick={[Function]}
@@ -1967,7 +1967,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                           >
                             <Component
                               aria-label="Collapse All"
-                              className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
+                              className="toggle-collapse-all css-dkprmi-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               role="button"
@@ -1975,7 +1975,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             >
                               <button
                                 aria-label="Collapse All"
-                                className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
+                                className="toggle-collapse-all css-dkprmi-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"

--- a/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -97,7 +97,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                     >
                       <Component
                         aria-label="New API Key"
-                        className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                        className="css-zvpqlo-StyledButton-getColors e17811v30"
                         disabled={false}
                         onClick={[Function]}
                         priority="primary"
@@ -106,7 +106,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                       >
                         <button
                           aria-label="New API Key"
-                          className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                          className="css-zvpqlo-StyledButton-getColors e17811v30"
                           disabled={false}
                           onClick={[Function]}
                           priority="primary"

--- a/tests/js/spec/views/__snapshots__/organizationIntegrationConfig.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationIntegrationConfig.spec.jsx.snap
@@ -150,14 +150,14 @@ exports[`OrganizationIntegrationConfig render() with one integration renders 1`]
                                   size="xsmall"
                                 >
                                   <Component
-                                    className="css-o6814l-StyledButton-getColors e17811v30"
+                                    className="css-dkprmi-StyledButton-getColors e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
                                     size="xsmall"
                                   >
                                     <button
-                                      className="css-o6814l-StyledButton-getColors e17811v30"
+                                      className="css-dkprmi-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
@@ -318,14 +318,14 @@ exports[`OrganizationIntegrationConfig render() with one integration renders 1`]
                                     size="small"
                                   >
                                     <Component
-                                      className="css-o6814l-StyledButton-getColors e17811v30"
+                                      className="css-dkprmi-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
                                     >
                                       <button
-                                        className="css-o6814l-StyledButton-getColors e17811v30"
+                                        className="css-dkprmi-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         role="button"

--- a/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
@@ -71,7 +71,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                         >
                           <Component
                             aria-label="Create Project"
-                            className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                            className="css-zvpqlo-StyledButton-getColors e17811v30"
                             disabled={false}
                             onClick={[Function]}
                             priority="primary"
@@ -81,7 +81,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                           >
                             <Link
                               aria-label="Create Project"
-                              className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                              className="css-zvpqlo-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               onlyActiveOnIndex={false}
@@ -93,7 +93,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                             >
                               <a
                                 aria-label="Create Project"
-                                className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                                className="css-zvpqlo-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 priority="primary"
@@ -562,7 +562,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                   >
                                     <Component
                                       aria-label="View Issues"
-                                      className="css-o6814l-StyledButton-getColors e17811v30"
+                                      className="css-dkprmi-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
@@ -571,7 +571,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                     >
                                       <Link
                                         aria-label="View Issues"
-                                        className="css-o6814l-StyledButton-getColors e17811v30"
+                                        className="css-dkprmi-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         onlyActiveOnIndex={false}
@@ -582,7 +582,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                       >
                                         <a
                                           aria-label="View Issues"
-                                          className="css-o6814l-StyledButton-getColors e17811v30"
+                                          className="css-dkprmi-StyledButton-getColors e17811v30"
                                           disabled={false}
                                           onClick={[Function]}
                                           role="button"

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -127,14 +127,14 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                 size="xsmall"
                                               >
                                                 <Component
-                                                  className="e1yghndz1 css-a0wrx4-StyledButton-getColors-StyledButton e17811v30"
+                                                  className="e1yghndz1 css-108zzii-StyledButton-getColors-StyledButton e17811v30"
                                                   disabled={false}
                                                   onClick={[Function]}
                                                   role="button"
                                                   size="xsmall"
                                                 >
                                                   <button
-                                                    className="e1yghndz1 css-a0wrx4-StyledButton-getColors-StyledButton e17811v30"
+                                                    className="e1yghndz1 css-108zzii-StyledButton-getColors-StyledButton e17811v30"
                                                     disabled={false}
                                                     onClick={[Function]}
                                                     role="button"
@@ -495,14 +495,14 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           size="small"
                         >
                           <Component
-                            className="css-o6814l-StyledButton-getColors e17811v30"
+                            className="css-dkprmi-StyledButton-getColors e17811v30"
                             disabled={false}
                             onClick={[Function]}
                             role="button"
                             size="small"
                           >
                             <button
-                              className="css-o6814l-StyledButton-getColors e17811v30"
+                              className="css-dkprmi-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               role="button"

--- a/tests/js/spec/views/__snapshots__/organizationTeamsProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamsProjects.spec.jsx.snap
@@ -246,7 +246,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                       >
                                         <Component
                                           aria-label="Manage Project"
-                                          className="css-o6814l-StyledButton-getColors e17811v30"
+                                          className="css-dkprmi-StyledButton-getColors e17811v30"
                                           disabled={false}
                                           onClick={[Function]}
                                           role="button"
@@ -255,7 +255,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                         >
                                           <Link
                                             aria-label="Manage Project"
-                                            className="css-o6814l-StyledButton-getColors e17811v30"
+                                            className="css-dkprmi-StyledButton-getColors e17811v30"
                                             disabled={false}
                                             onClick={[Function]}
                                             onlyActiveOnIndex={false}
@@ -266,7 +266,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                           >
                                             <a
                                               aria-label="Manage Project"
-                                              className="css-o6814l-StyledButton-getColors e17811v30"
+                                              className="css-dkprmi-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -103,7 +103,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
             <p>
               <button
                 aria-label="Restore Organization"
-                class="css-15f0jp2-StyledButton-getColors e17811v30"
+                class="css-1msljz8-StyledButton-getColors e17811v30"
                 priority="primary"
                 role="button"
               >

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProjectTeamsSettings render() renders 1`] = `
+exports[`Project Ownership Input renders 1`] = `
 <OwnerInput
   initialText="url:src @dummy@example.com"
   organization={
@@ -453,216 +453,270 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
             >
               <SelectOwners
                 onChange={[Function]}
-                options={Array []}
+                organization={
+                  Object {
+                    "access": Array [
+                      "org:read",
+                      "org:write",
+                      "org:admin",
+                      "project:read",
+                      "project:write",
+                      "project:admin",
+                      "team:read",
+                      "team:write",
+                      "team:admin",
+                    ],
+                    "features": Array [],
+                    "id": "3",
+                    "name": "Organization Name",
+                    "onboardingTasks": Array [],
+                    "projects": Array [],
+                    "slug": "org-slug",
+                    "status": Object {
+                      "id": "active",
+                      "name": "active",
+                    },
+                    "teams": Array [],
+                  }
+                }
+                project={
+                  Object {
+                    "hasAccess": true,
+                    "id": "2",
+                    "isBookmarked": false,
+                    "isMember": true,
+                    "name": "Project Name",
+                    "slug": "project-slug",
+                    "teams": Array [],
+                  }
+                }
                 value={Array []}
               >
                 <MultiSelectControl
+                  async={true}
+                  cache={false}
+                  className="css-1domaf0"
+                  defaultOptions={true}
+                  filterOptions={[Function]}
+                  loadOptions={[Function]}
                   onChange={[Function]}
-                  options={Array []}
                   placeholder="Add Owners"
-                  style={
-                    Object {
-                      "overflow": "visible",
-                      "width": 200,
-                    }
-                  }
                   value={Array []}
                   valueComponent={[Function]}
                 >
                   <SelectControl
+                    async={true}
+                    cache={false}
+                    className="css-1domaf0"
+                    defaultOptions={true}
+                    filterOptions={[Function]}
+                    loadOptions={[Function]}
                     multi={true}
                     onChange={[Function]}
-                    options={Array []}
                     placeholder="Add Owners"
-                    style={
-                      Object {
-                        "overflow": "visible",
-                        "width": 200,
-                      }
-                    }
                     value={Array []}
                     valueComponent={[Function]}
                   >
                     <StyledSelect
                       arrowRenderer={[Function]}
+                      async={true}
+                      cache={false}
+                      className="css-1domaf0"
+                      defaultOptions={true}
+                      filterOptions={[Function]}
+                      loadOptions={[Function]}
                       multi={true}
                       onChange={[Function]}
-                      options={Array []}
                       placeholder="Add Owners"
-                      style={
-                        Object {
-                          "overflow": "visible",
-                          "width": 200,
-                        }
-                      }
                       value={Array []}
                       valueComponent={[Function]}
                     >
                       <Component
                         arrowRenderer={[Function]}
-                        className="css-16280ey-StyledSelect eho28m20"
+                        async={true}
+                        cache={false}
+                        className="css-11osmt1-StyledSelect eho28m20"
+                        defaultOptions={true}
+                        filterOptions={[Function]}
+                        loadOptions={[Function]}
                         multi={true}
                         onChange={[Function]}
-                        options={Array []}
                         placeholder="Add Owners"
-                        style={
-                          Object {
-                            "overflow": "visible",
-                            "width": 200,
-                          }
-                        }
                         value={Array []}
                         valueComponent={[Function]}
                       >
-                        <Select
+                        <Async
                           arrowRenderer={[Function]}
-                          autosize={true}
-                          backspaceRemoves={true}
-                          backspaceToRemoveMessage="Press backspace to remove {label}"
-                          className="css-16280ey-StyledSelect eho28m20"
-                          clearAllText="Clear all"
-                          clearRenderer={[Function]}
-                          clearValueText="Clear value"
-                          clearable={true}
-                          closeOnSelect={true}
-                          deleteRemoves={true}
-                          delimiter=","
-                          disabled={false}
-                          escapeClearsValue={true}
+                          autoload={true}
+                          cache={false}
+                          className="css-11osmt1-StyledSelect eho28m20"
+                          defaultOptions={true}
                           filterOptions={[Function]}
                           ignoreAccents={true}
                           ignoreCase={true}
-                          inputProps={Object {}}
-                          isLoading={false}
-                          joinValues={false}
-                          labelKey="label"
-                          matchPos="any"
-                          matchProp="any"
-                          menuBuffer={0}
-                          menuRenderer={[Function]}
+                          loadOptions={[Function]}
+                          loadingPlaceholder="Loading..."
                           multi={true}
-                          noResultsText="No results found"
-                          onBlurResetsInput={true}
                           onChange={[Function]}
-                          onCloseResetsInput={true}
-                          onSelectResetsInput={true}
-                          openOnClick={true}
-                          optionComponent={[Function]}
                           options={Array []}
-                          pageSize={5}
                           placeholder="Add Owners"
-                          removeSelected={true}
-                          required={false}
-                          rtl={false}
-                          scrollMenuIntoView={true}
-                          searchable={true}
-                          simpleValue={false}
-                          style={
-                            Object {
-                              "overflow": "visible",
-                              "width": 200,
-                            }
-                          }
-                          tabSelectsValue={true}
-                          trimFilter={true}
+                          searchPromptText="Type to search"
                           value={Array []}
                           valueComponent={[Function]}
-                          valueKey="value"
                         >
-                          <div
-                            className="Select css-16280ey-StyledSelect eho28m20 is-clearable is-searchable Select--multi"
+                          <Select
+                            arrowRenderer={[Function]}
+                            autoload={true}
+                            autosize={true}
+                            backspaceRemoves={true}
+                            backspaceToRemoveMessage="Press backspace to remove {label}"
+                            cache={false}
+                            className="css-11osmt1-StyledSelect eho28m20"
+                            clearAllText="Clear all"
+                            clearRenderer={[Function]}
+                            clearValueText="Clear value"
+                            clearable={true}
+                            closeOnSelect={true}
+                            defaultOptions={true}
+                            deleteRemoves={true}
+                            delimiter=","
+                            disabled={false}
+                            escapeClearsValue={true}
+                            filterOptions={[Function]}
+                            ignoreAccents={true}
+                            ignoreCase={true}
+                            inputProps={Object {}}
+                            isLoading={true}
+                            joinValues={false}
+                            labelKey="label"
+                            loadOptions={[Function]}
+                            loadingPlaceholder="Loading..."
+                            matchPos="any"
+                            matchProp="any"
+                            menuBuffer={0}
+                            menuRenderer={[Function]}
+                            multi={true}
+                            noResultsText="Loading..."
+                            onBlurResetsInput={true}
+                            onChange={[Function]}
+                            onCloseResetsInput={true}
+                            onInputChange={[Function]}
+                            onSelectResetsInput={true}
+                            openOnClick={true}
+                            optionComponent={[Function]}
+                            options={Array []}
+                            pageSize={5}
+                            placeholder="Loading..."
+                            removeSelected={true}
+                            required={false}
+                            rtl={false}
+                            scrollMenuIntoView={true}
+                            searchPromptText="Type to search"
+                            searchable={true}
+                            simpleValue={false}
+                            tabSelectsValue={true}
+                            trimFilter={true}
+                            value={Array []}
+                            valueComponent={[Function]}
+                            valueKey="value"
                           >
                             <div
-                              className="Select-control"
-                              onKeyDown={[Function]}
-                              onMouseDown={[Function]}
-                              onTouchEnd={[Function]}
-                              onTouchMove={[Function]}
-                              onTouchStart={[Function]}
-                              style={
-                                Object {
-                                  "overflow": "visible",
-                                  "width": 200,
-                                }
-                              }
+                              className="Select css-11osmt1-StyledSelect eho28m20 is-clearable is-loading is-searchable Select--multi"
                             >
-                              <span
-                                className="Select-multi-value-wrapper"
-                                id="react-select-3--value"
-                              >
-                                <div
-                                  className="Select-placeholder"
-                                >
-                                  Add Owners
-                                </div>
-                                <AutosizeInput
-                                  aria-activedescendant="react-select-3--value"
-                                  aria-expanded="false"
-                                  aria-haspopup="false"
-                                  aria-owns=""
-                                  className="Select-input"
-                                  injectStyles={true}
-                                  minWidth="5"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  required={false}
-                                  role="combobox"
-                                  value=""
-                                >
-                                  <div
-                                    className="Select-input"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                      }
-                                    }
-                                  >
-                                    <input
-                                      aria-activedescendant="react-select-3--value"
-                                      aria-expanded="false"
-                                      aria-haspopup="false"
-                                      aria-owns=""
-                                      onBlur={[Function]}
-                                      onChange={[Function]}
-                                      onFocus={[Function]}
-                                      required={false}
-                                      role="combobox"
-                                      style={
-                                        Object {
-                                          "boxSizing": "content-box",
-                                          "width": "5px",
-                                        }
-                                      }
-                                      value=""
-                                    />
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 0,
-                                          "left": 0,
-                                          "overflow": "scroll",
-                                          "position": "absolute",
-                                          "top": 0,
-                                          "visibility": "hidden",
-                                          "whiteSpace": "pre",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </AutosizeInput>
-                              </span>
-                              <span
-                                className="Select-arrow-zone"
+                              <div
+                                className="Select-control"
+                                onKeyDown={[Function]}
                                 onMouseDown={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
                               >
                                 <span
-                                  className="icon-arrow-down"
-                                />
-                              </span>
+                                  className="Select-multi-value-wrapper"
+                                  id="react-select-3--value"
+                                >
+                                  <div
+                                    className="Select-placeholder"
+                                  >
+                                    Loading...
+                                  </div>
+                                  <AutosizeInput
+                                    aria-activedescendant="react-select-3--value"
+                                    aria-expanded="false"
+                                    aria-haspopup="false"
+                                    aria-owns=""
+                                    className="Select-input"
+                                    injectStyles={true}
+                                    minWidth="5"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    required={false}
+                                    role="combobox"
+                                    value=""
+                                  >
+                                    <div
+                                      className="Select-input"
+                                      style={
+                                        Object {
+                                          "display": "inline-block",
+                                        }
+                                      }
+                                    >
+                                      <input
+                                        aria-activedescendant="react-select-3--value"
+                                        aria-expanded="false"
+                                        aria-haspopup="false"
+                                        aria-owns=""
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        required={false}
+                                        role="combobox"
+                                        style={
+                                          Object {
+                                            "boxSizing": "content-box",
+                                            "width": "5px",
+                                          }
+                                        }
+                                        value=""
+                                      />
+                                      <div
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "left": 0,
+                                            "overflow": "scroll",
+                                            "position": "absolute",
+                                            "top": 0,
+                                            "visibility": "hidden",
+                                            "whiteSpace": "pre",
+                                          }
+                                        }
+                                      />
+                                    </div>
+                                  </AutosizeInput>
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  className="Select-loading-zone"
+                                >
+                                  <span
+                                    className="Select-loading"
+                                  />
+                                </span>
+                                <span
+                                  className="Select-arrow-zone"
+                                  onMouseDown={[Function]}
+                                >
+                                  <span
+                                    className="icon-arrow-down"
+                                  />
+                                </span>
+                              </div>
                             </div>
-                          </div>
-                        </Select>
+                          </Select>
+                        </Async>
                       </Component>
                     </StyledSelect>
                   </SelectControl>

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -500,6 +500,7 @@ exports[`Project Ownership Input renders 1`] = `
                   filterOptions={[Function]}
                   loadOptions={[Function]}
                   onChange={[Function]}
+                  onInputChange={[Function]}
                   placeholder="Add Owners"
                   value={Array []}
                   valueComponent={[Function]}
@@ -513,6 +514,7 @@ exports[`Project Ownership Input renders 1`] = `
                     loadOptions={[Function]}
                     multi={true}
                     onChange={[Function]}
+                    onInputChange={[Function]}
                     placeholder="Add Owners"
                     value={Array []}
                     valueComponent={[Function]}
@@ -527,6 +529,7 @@ exports[`Project Ownership Input renders 1`] = `
                       loadOptions={[Function]}
                       multi={true}
                       onChange={[Function]}
+                      onInputChange={[Function]}
                       placeholder="Add Owners"
                       value={Array []}
                       valueComponent={[Function]}
@@ -541,6 +544,7 @@ exports[`Project Ownership Input renders 1`] = `
                         loadOptions={[Function]}
                         multi={true}
                         onChange={[Function]}
+                        onInputChange={[Function]}
                         placeholder="Add Owners"
                         value={Array []}
                         valueComponent={[Function]}
@@ -558,6 +562,7 @@ exports[`Project Ownership Input renders 1`] = `
                           loadingPlaceholder="Loading..."
                           multi={true}
                           onChange={[Function]}
+                          onInputChange={[Function]}
                           options={Array []}
                           placeholder="Add Owners"
                           searchPromptText="Type to search"
@@ -748,7 +753,7 @@ exports[`Project Ownership Input renders 1`] = `
               size="zero"
             >
               <Component
-                className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
+                className="e1hyuoc79 css-1gabw8k-StyledButton-getColors-RuleAddButton e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"
@@ -756,7 +761,7 @@ exports[`Project Ownership Input renders 1`] = `
                 size="zero"
               >
                 <button
-                  className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
+                  className="e1hyuoc79 css-1gabw8k-StyledButton-getColors-RuleAddButton e17811v30"
                   disabled={false}
                   onClick={[Function]}
                   priority="primary"
@@ -921,7 +926,7 @@ url:http://example.com/settings/* #product"
           >
             <Component
               aria-label="Save Changes"
-              className="css-1oc9q3a-StyledButton-getColors e17811v30"
+              className="css-zvpqlo-StyledButton-getColors e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"
@@ -930,7 +935,7 @@ url:http://example.com/settings/* #product"
             >
               <button
                 aria-label="Save Changes"
-                className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                className="css-zvpqlo-StyledButton-getColors e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -440,7 +440,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           type="button"
                                         >
                                           <Component
-                                            className="css-o6814l-StyledButton-getColors e17811v30"
+                                            className="css-dkprmi-StyledButton-getColors e17811v30"
                                             disabled={false}
                                             onClick={[Function]}
                                             role="button"
@@ -449,7 +449,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                             type="button"
                                           >
                                             <button
-                                              className="css-o6814l-StyledButton-getColors e17811v30"
+                                              className="css-dkprmi-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
@@ -712,7 +712,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           type="button"
                                         >
                                           <Component
-                                            className="css-o6814l-StyledButton-getColors e17811v30"
+                                            className="css-dkprmi-StyledButton-getColors e17811v30"
                                             disabled={false}
                                             onClick={[Function]}
                                             role="button"
@@ -721,7 +721,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                             type="button"
                                           >
                                             <button
-                                              className="css-o6814l-StyledButton-getColors e17811v30"
+                                              className="css-dkprmi-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
@@ -987,7 +987,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             >
                               <Component
                                 aria-label="Cancel"
-                                className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
+                                className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -995,7 +995,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               >
                                 <Link
                                   aria-label="Cancel"
-                                  className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
+                                  className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   onlyActiveOnIndex={false}
@@ -1005,7 +1005,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 >
                                   <a
                                     aria-label="Cancel"
-                                    className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
+                                    className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -1052,7 +1052,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                           >
                             <Component
                               aria-label="Save Rule"
-                              className="css-15f0jp2-StyledButton-getColors e17811v30"
+                              className="css-1msljz8-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               priority="primary"
@@ -1060,7 +1060,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             >
                               <button
                                 aria-label="Save Rule"
-                                className="css-15f0jp2-StyledButton-getColors e17811v30"
+                                className="css-1msljz8-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 priority="primary"
@@ -1857,7 +1857,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                             >
                               <Component
                                 aria-label="Cancel"
-                                className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
+                                className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -1865,7 +1865,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               >
                                 <Link
                                   aria-label="Cancel"
-                                  className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
+                                  className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   onlyActiveOnIndex={false}
@@ -1875,7 +1875,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 >
                                   <a
                                     aria-label="Cancel"
-                                    className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
+                                    className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -1922,7 +1922,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                           >
                             <Component
                               aria-label="Save Rule"
-                              className="css-15f0jp2-StyledButton-getColors e17811v30"
+                              className="css-1msljz8-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               priority="primary"
@@ -1930,7 +1930,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                             >
                               <button
                                 aria-label="Save Rule"
-                                className="css-15f0jp2-StyledButton-getColors e17811v30"
+                                className="css-1msljz8-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 priority="primary"

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -122,7 +122,7 @@ exports[`projectAlertRules renders 1`] = `
                       >
                         <Component
                           aria-label="New Alert Rule"
-                          className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                          className="css-zvpqlo-StyledButton-getColors e17811v30"
                           disabled={false}
                           onClick={[Function]}
                           priority="primary"
@@ -132,7 +132,7 @@ exports[`projectAlertRules renders 1`] = `
                         >
                           <Link
                             aria-label="New Alert Rule"
-                            className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                            className="css-zvpqlo-StyledButton-getColors e17811v30"
                             disabled={false}
                             onClick={[Function]}
                             onlyActiveOnIndex={false}
@@ -144,7 +144,7 @@ exports[`projectAlertRules renders 1`] = `
                           >
                             <a
                               aria-label="New Alert Rule"
-                              className="css-1oc9q3a-StyledButton-getColors e17811v30"
+                              className="css-zvpqlo-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               priority="primary"
@@ -418,7 +418,7 @@ exports[`projectAlertRules renders 1`] = `
                                 >
                                   <Component
                                     aria-label="Edit Rule"
-                                    className="css-o6814l-StyledButton-getColors e17811v30"
+                                    className="css-dkprmi-StyledButton-getColors e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -432,7 +432,7 @@ exports[`projectAlertRules renders 1`] = `
                                   >
                                     <Link
                                       aria-label="Edit Rule"
-                                      className="css-o6814l-StyledButton-getColors e17811v30"
+                                      className="css-dkprmi-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       onlyActiveOnIndex={false}
@@ -447,7 +447,7 @@ exports[`projectAlertRules renders 1`] = `
                                     >
                                       <a
                                         aria-label="Edit Rule"
-                                        className="css-o6814l-StyledButton-getColors e17811v30"
+                                        className="css-dkprmi-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         role="button"
@@ -510,14 +510,14 @@ exports[`projectAlertRules renders 1`] = `
                                     size="small"
                                   >
                                     <Component
-                                      className="css-o6814l-StyledButton-getColors e17811v30"
+                                      className="css-dkprmi-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
                                     >
                                       <button
-                                        className="css-o6814l-StyledButton-getColors e17811v30"
+                                        className="css-dkprmi-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         role="button"

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -489,7 +489,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Set as default"
-                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -497,7 +497,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Set as default"
-                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -621,7 +621,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Set as default"
-                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -629,7 +629,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Set as default"
-                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -688,7 +688,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Hide"
-                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -696,7 +696,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Hide"
-                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -833,7 +833,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Hide"
-                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -841,7 +841,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Hide"
-                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -1392,7 +1392,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                               >
                                 <Component
                                   aria-label="Show"
-                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -1400,7 +1400,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                 >
                                   <button
                                     aria-label="Show"
-                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -194,7 +194,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                             >
                               <Component
                                 aria-label="Enable Plugin"
-                                className="css-1w79b6l-StyledButton-getColors e17811v30"
+                                className="css-cmo08-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -206,7 +206,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                               >
                                 <button
                                   aria-label="Enable Plugin"
-                                  className="css-1w79b6l-StyledButton-getColors e17811v30"
+                                  className="css-cmo08-StyledButton-getColors e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -254,14 +254,14 @@ exports[`ProjectPluginDetails renders 1`] = `
                             >
                               <Component
                                 aria-label="Reset Configuration"
-                                className="css-1w79b6l-StyledButton-getColors e17811v30"
+                                className="css-cmo08-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
                               >
                                 <button
                                   aria-label="Reset Configuration"
-                                  className="css-1w79b6l-StyledButton-getColors e17811v30"
+                                  className="css-cmo08-StyledButton-getColors e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -359,14 +359,14 @@ exports[`ProjectSavedSearches renders 1`] = `
                                             size="small"
                                           >
                                             <Component
-                                              className="css-o6814l-StyledButton-getColors e17811v30"
+                                              className="css-dkprmi-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
                                               size="small"
                                             >
                                               <button
-                                                className="css-o6814l-StyledButton-getColors e17811v30"
+                                                className="css-dkprmi-StyledButton-getColors e17811v30"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
@@ -644,14 +644,14 @@ exports[`ProjectSavedSearches renders 1`] = `
                                             size="small"
                                           >
                                             <Component
-                                              className="css-o6814l-StyledButton-getColors e17811v30"
+                                              className="css-dkprmi-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
                                               size="small"
                                             >
                                               <button
-                                                className="css-o6814l-StyledButton-getColors e17811v30"
+                                                className="css-dkprmi-StyledButton-getColors e17811v30"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 role="button"

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RuleBuilder render() renders 1`] = `
+exports[`RuleBuilder renders 1`] = `
 <RuleBuilder
   onAddRule={
     [MockFunction] {
@@ -9,6 +9,32 @@ exports[`RuleBuilder render() renders 1`] = `
           "path:some/path/* janedoe@example.com",
         ],
       ],
+    }
+  }
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
     }
   }
   project={
@@ -389,354 +415,270 @@ exports[`RuleBuilder render() renders 1`] = `
           >
             <SelectOwners
               onChange={[Function]}
-              options={
-                Array [
-                  Object {
-                    "actor": Object {
-                      "id": "1",
-                      "name": "Jane Doe",
-                      "type": "user",
-                    },
-                    "label": "Jane Doe",
-                    "searchKey": "janedoe@example.com  Jane Doe",
-                    "value": "user:1",
+              organization={
+                Object {
+                  "access": Array [
+                    "org:read",
+                    "org:write",
+                    "org:admin",
+                    "project:read",
+                    "project:write",
+                    "project:admin",
+                    "team:read",
+                    "team:write",
+                    "team:admin",
+                  ],
+                  "features": Array [],
+                  "id": "3",
+                  "name": "Organization Name",
+                  "onboardingTasks": Array [],
+                  "projects": Array [],
+                  "slug": "org-slug",
+                  "status": Object {
+                    "id": "active",
+                    "name": "active",
                   },
-                  Object {
-                    "actor": Object {
-                      "id": "2",
-                      "name": "John Smith",
-                      "type": "user",
-                    },
-                    "label": "John Smith",
-                    "searchKey": "johnsmith@example.com  John Smith",
-                    "value": "user:2",
-                  },
-                ]
+                  "teams": Array [],
+                }
+              }
+              project={
+                Object {
+                  "hasAccess": true,
+                  "id": "2",
+                  "isBookmarked": false,
+                  "isMember": true,
+                  "name": "Project Name",
+                  "slug": "project-slug",
+                  "teams": Array [],
+                }
               }
               value={Array []}
             >
               <MultiSelectControl
+                async={true}
+                cache={false}
+                className="css-1domaf0"
+                defaultOptions={true}
+                filterOptions={[Function]}
+                loadOptions={[Function]}
                 onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "actor": Object {
-                        "id": "1",
-                        "name": "Jane Doe",
-                        "type": "user",
-                      },
-                      "label": "Jane Doe",
-                      "searchKey": "janedoe@example.com  Jane Doe",
-                      "value": "user:1",
-                    },
-                    Object {
-                      "actor": Object {
-                        "id": "2",
-                        "name": "John Smith",
-                        "type": "user",
-                      },
-                      "label": "John Smith",
-                      "searchKey": "johnsmith@example.com  John Smith",
-                      "value": "user:2",
-                    },
-                  ]
-                }
                 placeholder="Add Owners"
-                style={
-                  Object {
-                    "overflow": "visible",
-                    "width": 200,
-                  }
-                }
                 value={Array []}
                 valueComponent={[Function]}
               >
                 <SelectControl
+                  async={true}
+                  cache={false}
+                  className="css-1domaf0"
+                  defaultOptions={true}
+                  filterOptions={[Function]}
+                  loadOptions={[Function]}
                   multi={true}
                   onChange={[Function]}
-                  options={
-                    Array [
-                      Object {
-                        "actor": Object {
-                          "id": "1",
-                          "name": "Jane Doe",
-                          "type": "user",
-                        },
-                        "label": "Jane Doe",
-                        "searchKey": "janedoe@example.com  Jane Doe",
-                        "value": "user:1",
-                      },
-                      Object {
-                        "actor": Object {
-                          "id": "2",
-                          "name": "John Smith",
-                          "type": "user",
-                        },
-                        "label": "John Smith",
-                        "searchKey": "johnsmith@example.com  John Smith",
-                        "value": "user:2",
-                      },
-                    ]
-                  }
                   placeholder="Add Owners"
-                  style={
-                    Object {
-                      "overflow": "visible",
-                      "width": 200,
-                    }
-                  }
                   value={Array []}
                   valueComponent={[Function]}
                 >
                   <StyledSelect
                     arrowRenderer={[Function]}
+                    async={true}
+                    cache={false}
+                    className="css-1domaf0"
+                    defaultOptions={true}
+                    filterOptions={[Function]}
+                    loadOptions={[Function]}
                     multi={true}
                     onChange={[Function]}
-                    options={
-                      Array [
-                        Object {
-                          "actor": Object {
-                            "id": "1",
-                            "name": "Jane Doe",
-                            "type": "user",
-                          },
-                          "label": "Jane Doe",
-                          "searchKey": "janedoe@example.com  Jane Doe",
-                          "value": "user:1",
-                        },
-                        Object {
-                          "actor": Object {
-                            "id": "2",
-                            "name": "John Smith",
-                            "type": "user",
-                          },
-                          "label": "John Smith",
-                          "searchKey": "johnsmith@example.com  John Smith",
-                          "value": "user:2",
-                        },
-                      ]
-                    }
                     placeholder="Add Owners"
-                    style={
-                      Object {
-                        "overflow": "visible",
-                        "width": 200,
-                      }
-                    }
                     value={Array []}
                     valueComponent={[Function]}
                   >
                     <Component
                       arrowRenderer={[Function]}
-                      className="css-16280ey-StyledSelect eho28m20"
+                      async={true}
+                      cache={false}
+                      className="css-11osmt1-StyledSelect eho28m20"
+                      defaultOptions={true}
+                      filterOptions={[Function]}
+                      loadOptions={[Function]}
                       multi={true}
                       onChange={[Function]}
-                      options={
-                        Array [
-                          Object {
-                            "actor": Object {
-                              "id": "1",
-                              "name": "Jane Doe",
-                              "type": "user",
-                            },
-                            "label": "Jane Doe",
-                            "searchKey": "janedoe@example.com  Jane Doe",
-                            "value": "user:1",
-                          },
-                          Object {
-                            "actor": Object {
-                              "id": "2",
-                              "name": "John Smith",
-                              "type": "user",
-                            },
-                            "label": "John Smith",
-                            "searchKey": "johnsmith@example.com  John Smith",
-                            "value": "user:2",
-                          },
-                        ]
-                      }
                       placeholder="Add Owners"
-                      style={
-                        Object {
-                          "overflow": "visible",
-                          "width": 200,
-                        }
-                      }
                       value={Array []}
                       valueComponent={[Function]}
                     >
-                      <Select
+                      <Async
                         arrowRenderer={[Function]}
-                        autosize={true}
-                        backspaceRemoves={true}
-                        backspaceToRemoveMessage="Press backspace to remove {label}"
-                        className="css-16280ey-StyledSelect eho28m20"
-                        clearAllText="Clear all"
-                        clearRenderer={[Function]}
-                        clearValueText="Clear value"
-                        clearable={true}
-                        closeOnSelect={true}
-                        deleteRemoves={true}
-                        delimiter=","
-                        disabled={false}
-                        escapeClearsValue={true}
+                        autoload={true}
+                        cache={false}
+                        className="css-11osmt1-StyledSelect eho28m20"
+                        defaultOptions={true}
                         filterOptions={[Function]}
                         ignoreAccents={true}
                         ignoreCase={true}
-                        inputProps={Object {}}
-                        isLoading={false}
-                        joinValues={false}
-                        labelKey="label"
-                        matchPos="any"
-                        matchProp="any"
-                        menuBuffer={0}
-                        menuRenderer={[Function]}
+                        loadOptions={[Function]}
+                        loadingPlaceholder="Loading..."
                         multi={true}
-                        noResultsText="No results found"
-                        onBlurResetsInput={true}
                         onChange={[Function]}
-                        onCloseResetsInput={true}
-                        onSelectResetsInput={true}
-                        openOnClick={true}
-                        optionComponent={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "actor": Object {
-                                "id": "1",
-                                "name": "Jane Doe",
-                                "type": "user",
-                              },
-                              "label": "Jane Doe",
-                              "searchKey": "janedoe@example.com  Jane Doe",
-                              "value": "user:1",
-                            },
-                            Object {
-                              "actor": Object {
-                                "id": "2",
-                                "name": "John Smith",
-                                "type": "user",
-                              },
-                              "label": "John Smith",
-                              "searchKey": "johnsmith@example.com  John Smith",
-                              "value": "user:2",
-                            },
-                          ]
-                        }
-                        pageSize={5}
+                        options={Array []}
                         placeholder="Add Owners"
-                        removeSelected={true}
-                        required={false}
-                        rtl={false}
-                        scrollMenuIntoView={true}
-                        searchable={true}
-                        simpleValue={false}
-                        style={
-                          Object {
-                            "overflow": "visible",
-                            "width": 200,
-                          }
-                        }
-                        tabSelectsValue={true}
-                        trimFilter={true}
+                        searchPromptText="Type to search"
                         value={Array []}
                         valueComponent={[Function]}
-                        valueKey="value"
                       >
-                        <div
-                          className="Select css-16280ey-StyledSelect eho28m20 is-clearable is-searchable Select--multi"
+                        <Select
+                          arrowRenderer={[Function]}
+                          autoload={true}
+                          autosize={true}
+                          backspaceRemoves={true}
+                          backspaceToRemoveMessage="Press backspace to remove {label}"
+                          cache={false}
+                          className="css-11osmt1-StyledSelect eho28m20"
+                          clearAllText="Clear all"
+                          clearRenderer={[Function]}
+                          clearValueText="Clear value"
+                          clearable={true}
+                          closeOnSelect={true}
+                          defaultOptions={true}
+                          deleteRemoves={true}
+                          delimiter=","
+                          disabled={false}
+                          escapeClearsValue={true}
+                          filterOptions={[Function]}
+                          ignoreAccents={true}
+                          ignoreCase={true}
+                          inputProps={Object {}}
+                          isLoading={true}
+                          joinValues={false}
+                          labelKey="label"
+                          loadOptions={[Function]}
+                          loadingPlaceholder="Loading..."
+                          matchPos="any"
+                          matchProp="any"
+                          menuBuffer={0}
+                          menuRenderer={[Function]}
+                          multi={true}
+                          noResultsText="Loading..."
+                          onBlurResetsInput={true}
+                          onChange={[Function]}
+                          onCloseResetsInput={true}
+                          onInputChange={[Function]}
+                          onSelectResetsInput={true}
+                          openOnClick={true}
+                          optionComponent={[Function]}
+                          options={Array []}
+                          pageSize={5}
+                          placeholder="Loading..."
+                          removeSelected={true}
+                          required={false}
+                          rtl={false}
+                          scrollMenuIntoView={true}
+                          searchPromptText="Type to search"
+                          searchable={true}
+                          simpleValue={false}
+                          tabSelectsValue={true}
+                          trimFilter={true}
+                          value={Array []}
+                          valueComponent={[Function]}
+                          valueKey="value"
                         >
                           <div
-                            className="Select-control"
-                            onKeyDown={[Function]}
-                            onMouseDown={[Function]}
-                            onTouchEnd={[Function]}
-                            onTouchMove={[Function]}
-                            onTouchStart={[Function]}
-                            style={
-                              Object {
-                                "overflow": "visible",
-                                "width": 200,
-                              }
-                            }
+                            className="Select css-11osmt1-StyledSelect eho28m20 is-clearable is-loading is-searchable Select--multi"
                           >
-                            <span
-                              className="Select-multi-value-wrapper"
-                              id="react-select-3--value"
-                            >
-                              <div
-                                className="Select-placeholder"
-                              >
-                                Add Owners
-                              </div>
-                              <AutosizeInput
-                                aria-activedescendant="react-select-3--value"
-                                aria-expanded="false"
-                                aria-haspopup="false"
-                                aria-owns=""
-                                className="Select-input"
-                                injectStyles={true}
-                                minWidth="5"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                required={false}
-                                role="combobox"
-                                value=""
-                              >
-                                <div
-                                  className="Select-input"
-                                  style={
-                                    Object {
-                                      "display": "inline-block",
-                                    }
-                                  }
-                                >
-                                  <input
-                                    aria-activedescendant="react-select-3--value"
-                                    aria-expanded="false"
-                                    aria-haspopup="false"
-                                    aria-owns=""
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    required={false}
-                                    role="combobox"
-                                    style={
-                                      Object {
-                                        "boxSizing": "content-box",
-                                        "width": "5px",
-                                      }
-                                    }
-                                    value=""
-                                  />
-                                  <div
-                                    style={
-                                      Object {
-                                        "height": 0,
-                                        "left": 0,
-                                        "overflow": "scroll",
-                                        "position": "absolute",
-                                        "top": 0,
-                                        "visibility": "hidden",
-                                        "whiteSpace": "pre",
-                                      }
-                                    }
-                                  />
-                                </div>
-                              </AutosizeInput>
-                            </span>
-                            <span
-                              className="Select-arrow-zone"
+                            <div
+                              className="Select-control"
+                              onKeyDown={[Function]}
                               onMouseDown={[Function]}
+                              onTouchEnd={[Function]}
+                              onTouchMove={[Function]}
+                              onTouchStart={[Function]}
                             >
                               <span
-                                className="icon-arrow-down"
-                              />
-                            </span>
+                                className="Select-multi-value-wrapper"
+                                id="react-select-3--value"
+                              >
+                                <div
+                                  className="Select-placeholder"
+                                >
+                                  Loading...
+                                </div>
+                                <AutosizeInput
+                                  aria-activedescendant="react-select-3--value"
+                                  aria-expanded="false"
+                                  aria-haspopup="false"
+                                  aria-owns=""
+                                  className="Select-input"
+                                  injectStyles={true}
+                                  minWidth="5"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  required={false}
+                                  role="combobox"
+                                  value=""
+                                >
+                                  <div
+                                    className="Select-input"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                      }
+                                    }
+                                  >
+                                    <input
+                                      aria-activedescendant="react-select-3--value"
+                                      aria-expanded="false"
+                                      aria-haspopup="false"
+                                      aria-owns=""
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      required={false}
+                                      role="combobox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "5px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </AutosizeInput>
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                className="Select-loading-zone"
+                              >
+                                <span
+                                  className="Select-loading"
+                                />
+                              </span>
+                              <span
+                                className="Select-arrow-zone"
+                                onMouseDown={[Function]}
+                              >
+                                <span
+                                  className="icon-arrow-down"
+                                />
+                              </span>
+                            </div>
                           </div>
-                        </div>
-                      </Select>
+                        </Select>
+                      </Async>
                     </Component>
                   </StyledSelect>
                 </SelectControl>
@@ -876,9 +818,35 @@ exports[`RuleBuilder render() renders 1`] = `
 </RuleBuilder>
 `;
 
-exports[`RuleBuilder renders with suggestions renders 1`] = `
+exports[`RuleBuilder renders with suggestions 1`] = `
 <RuleBuilder
   onAddRule={[MockFunction]}
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
+    }
+  }
   paths={
     Array [
       "a/bar",
@@ -1479,29 +1447,42 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
           >
             <SelectOwners
               onChange={[Function]}
-              options={
-                Array [
-                  Object {
-                    "actor": Object {
-                      "id": "1",
-                      "name": "Jane Doe",
-                      "type": "user",
-                    },
-                    "label": "Jane Doe",
-                    "searchKey": "janedoe@example.com  Jane Doe",
-                    "value": "user:1",
+              organization={
+                Object {
+                  "access": Array [
+                    "org:read",
+                    "org:write",
+                    "org:admin",
+                    "project:read",
+                    "project:write",
+                    "project:admin",
+                    "team:read",
+                    "team:write",
+                    "team:admin",
+                  ],
+                  "features": Array [],
+                  "id": "3",
+                  "name": "Organization Name",
+                  "onboardingTasks": Array [],
+                  "projects": Array [],
+                  "slug": "org-slug",
+                  "status": Object {
+                    "id": "active",
+                    "name": "active",
                   },
-                  Object {
-                    "actor": Object {
-                      "id": "2",
-                      "name": "John Smith",
-                      "type": "user",
-                    },
-                    "label": "John Smith",
-                    "searchKey": "johnsmith@example.com  John Smith",
-                    "value": "user:2",
-                  },
-                ]
+                  "teams": Array [],
+                }
+              }
+              project={
+                Object {
+                  "hasAccess": true,
+                  "id": "2",
+                  "isBookmarked": false,
+                  "isMember": true,
+                  "name": "Project Name",
+                  "slug": "project-slug",
+                  "teams": Array [],
+                }
               }
               value={
                 Array [
@@ -1511,7 +1492,26 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                       "name": "Jane Doe",
                       "type": "user",
                     },
-                    "label": "Jane Doe",
+                    "label": <IdBadge
+                      hideEmail={true}
+                      useLink={false}
+                      user={
+                        Object {
+                          "email": "janedoe@example.com",
+                          "flags": Object {
+                            "newsletter_consent_prompt": false,
+                          },
+                          "hasPasswordAuth": true,
+                          "id": "1",
+                          "isAuthenticated": true,
+                          "name": "Jane Doe",
+                          "options": Object {
+                            "timezone": "UTC",
+                          },
+                          "username": "foo@example.com",
+                        }
+                      }
+                    />,
                     "searchKey": "janedoe@example.com  Jane Doe",
                     "value": "user:1",
                   },
@@ -1519,38 +1519,14 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
               }
             >
               <MultiSelectControl
+                async={true}
+                cache={false}
+                className="css-1domaf0"
+                defaultOptions={true}
+                filterOptions={[Function]}
+                loadOptions={[Function]}
                 onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "actor": Object {
-                        "id": "1",
-                        "name": "Jane Doe",
-                        "type": "user",
-                      },
-                      "label": "Jane Doe",
-                      "searchKey": "janedoe@example.com  Jane Doe",
-                      "value": "user:1",
-                    },
-                    Object {
-                      "actor": Object {
-                        "id": "2",
-                        "name": "John Smith",
-                        "type": "user",
-                      },
-                      "label": "John Smith",
-                      "searchKey": "johnsmith@example.com  John Smith",
-                      "value": "user:2",
-                    },
-                  ]
-                }
                 placeholder="Add Owners"
-                style={
-                  Object {
-                    "overflow": "visible",
-                    "width": 200,
-                  }
-                }
                 value={
                   Array [
                     Object {
@@ -1559,7 +1535,26 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                         "name": "Jane Doe",
                         "type": "user",
                       },
-                      "label": "Jane Doe",
+                      "label": <IdBadge
+                        hideEmail={true}
+                        useLink={false}
+                        user={
+                          Object {
+                            "email": "janedoe@example.com",
+                            "flags": Object {
+                              "newsletter_consent_prompt": false,
+                            },
+                            "hasPasswordAuth": true,
+                            "id": "1",
+                            "isAuthenticated": true,
+                            "name": "Jane Doe",
+                            "options": Object {
+                              "timezone": "UTC",
+                            },
+                            "username": "foo@example.com",
+                          }
+                        }
+                      />,
                       "searchKey": "janedoe@example.com  Jane Doe",
                       "value": "user:1",
                     },
@@ -1568,39 +1563,15 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                 valueComponent={[Function]}
               >
                 <SelectControl
+                  async={true}
+                  cache={false}
+                  className="css-1domaf0"
+                  defaultOptions={true}
+                  filterOptions={[Function]}
+                  loadOptions={[Function]}
                   multi={true}
                   onChange={[Function]}
-                  options={
-                    Array [
-                      Object {
-                        "actor": Object {
-                          "id": "1",
-                          "name": "Jane Doe",
-                          "type": "user",
-                        },
-                        "label": "Jane Doe",
-                        "searchKey": "janedoe@example.com  Jane Doe",
-                        "value": "user:1",
-                      },
-                      Object {
-                        "actor": Object {
-                          "id": "2",
-                          "name": "John Smith",
-                          "type": "user",
-                        },
-                        "label": "John Smith",
-                        "searchKey": "johnsmith@example.com  John Smith",
-                        "value": "user:2",
-                      },
-                    ]
-                  }
                   placeholder="Add Owners"
-                  style={
-                    Object {
-                      "overflow": "visible",
-                      "width": 200,
-                    }
-                  }
                   value={
                     Array [
                       Object {
@@ -1609,7 +1580,26 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                           "name": "Jane Doe",
                           "type": "user",
                         },
-                        "label": "Jane Doe",
+                        "label": <IdBadge
+                          hideEmail={true}
+                          useLink={false}
+                          user={
+                            Object {
+                              "email": "janedoe@example.com",
+                              "flags": Object {
+                                "newsletter_consent_prompt": false,
+                              },
+                              "hasPasswordAuth": true,
+                              "id": "1",
+                              "isAuthenticated": true,
+                              "name": "Jane Doe",
+                              "options": Object {
+                                "timezone": "UTC",
+                              },
+                              "username": "foo@example.com",
+                            }
+                          }
+                        />,
                         "searchKey": "janedoe@example.com  Jane Doe",
                         "value": "user:1",
                       },
@@ -1619,39 +1609,15 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                 >
                   <StyledSelect
                     arrowRenderer={[Function]}
+                    async={true}
+                    cache={false}
+                    className="css-1domaf0"
+                    defaultOptions={true}
+                    filterOptions={[Function]}
+                    loadOptions={[Function]}
                     multi={true}
                     onChange={[Function]}
-                    options={
-                      Array [
-                        Object {
-                          "actor": Object {
-                            "id": "1",
-                            "name": "Jane Doe",
-                            "type": "user",
-                          },
-                          "label": "Jane Doe",
-                          "searchKey": "janedoe@example.com  Jane Doe",
-                          "value": "user:1",
-                        },
-                        Object {
-                          "actor": Object {
-                            "id": "2",
-                            "name": "John Smith",
-                            "type": "user",
-                          },
-                          "label": "John Smith",
-                          "searchKey": "johnsmith@example.com  John Smith",
-                          "value": "user:2",
-                        },
-                      ]
-                    }
                     placeholder="Add Owners"
-                    style={
-                      Object {
-                        "overflow": "visible",
-                        "width": 200,
-                      }
-                    }
                     value={
                       Array [
                         Object {
@@ -1660,7 +1626,26 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                             "name": "Jane Doe",
                             "type": "user",
                           },
-                          "label": "Jane Doe",
+                          "label": <IdBadge
+                            hideEmail={true}
+                            useLink={false}
+                            user={
+                              Object {
+                                "email": "janedoe@example.com",
+                                "flags": Object {
+                                  "newsletter_consent_prompt": false,
+                                },
+                                "hasPasswordAuth": true,
+                                "id": "1",
+                                "isAuthenticated": true,
+                                "name": "Jane Doe",
+                                "options": Object {
+                                  "timezone": "UTC",
+                                },
+                                "username": "foo@example.com",
+                              }
+                            }
+                          />,
                           "searchKey": "janedoe@example.com  Jane Doe",
                           "value": "user:1",
                         },
@@ -1670,40 +1655,15 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                   >
                     <Component
                       arrowRenderer={[Function]}
-                      className="css-16280ey-StyledSelect eho28m20"
+                      async={true}
+                      cache={false}
+                      className="css-11osmt1-StyledSelect eho28m20"
+                      defaultOptions={true}
+                      filterOptions={[Function]}
+                      loadOptions={[Function]}
                       multi={true}
                       onChange={[Function]}
-                      options={
-                        Array [
-                          Object {
-                            "actor": Object {
-                              "id": "1",
-                              "name": "Jane Doe",
-                              "type": "user",
-                            },
-                            "label": "Jane Doe",
-                            "searchKey": "janedoe@example.com  Jane Doe",
-                            "value": "user:1",
-                          },
-                          Object {
-                            "actor": Object {
-                              "id": "2",
-                              "name": "John Smith",
-                              "type": "user",
-                            },
-                            "label": "John Smith",
-                            "searchKey": "johnsmith@example.com  John Smith",
-                            "value": "user:2",
-                          },
-                        ]
-                      }
                       placeholder="Add Owners"
-                      style={
-                        Object {
-                          "overflow": "visible",
-                          "width": 200,
-                        }
-                      }
                       value={
                         Array [
                           Object {
@@ -1712,7 +1672,26 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                               "name": "Jane Doe",
                               "type": "user",
                             },
-                            "label": "Jane Doe",
+                            "label": <IdBadge
+                              hideEmail={true}
+                              useLink={false}
+                              user={
+                                Object {
+                                  "email": "janedoe@example.com",
+                                  "flags": Object {
+                                    "newsletter_consent_prompt": false,
+                                  },
+                                  "hasPasswordAuth": true,
+                                  "id": "1",
+                                  "isAuthenticated": true,
+                                  "name": "Jane Doe",
+                                  "options": Object {
+                                    "timezone": "UTC",
+                                  },
+                                  "username": "foo@example.com",
+                                }
+                              }
+                            />,
                             "searchKey": "janedoe@example.com  Jane Doe",
                             "value": "user:1",
                           },
@@ -1720,80 +1699,22 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                       }
                       valueComponent={[Function]}
                     >
-                      <Select
+                      <Async
                         arrowRenderer={[Function]}
-                        autosize={true}
-                        backspaceRemoves={true}
-                        backspaceToRemoveMessage="Press backspace to remove {label}"
-                        className="css-16280ey-StyledSelect eho28m20"
-                        clearAllText="Clear all"
-                        clearRenderer={[Function]}
-                        clearValueText="Clear value"
-                        clearable={true}
-                        closeOnSelect={true}
-                        deleteRemoves={true}
-                        delimiter=","
-                        disabled={false}
-                        escapeClearsValue={true}
+                        autoload={true}
+                        cache={false}
+                        className="css-11osmt1-StyledSelect eho28m20"
+                        defaultOptions={true}
                         filterOptions={[Function]}
                         ignoreAccents={true}
                         ignoreCase={true}
-                        inputProps={Object {}}
-                        isLoading={false}
-                        joinValues={false}
-                        labelKey="label"
-                        matchPos="any"
-                        matchProp="any"
-                        menuBuffer={0}
-                        menuRenderer={[Function]}
+                        loadOptions={[Function]}
+                        loadingPlaceholder="Loading..."
                         multi={true}
-                        noResultsText="No results found"
-                        onBlurResetsInput={true}
                         onChange={[Function]}
-                        onCloseResetsInput={true}
-                        onSelectResetsInput={true}
-                        openOnClick={true}
-                        optionComponent={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "actor": Object {
-                                "id": "1",
-                                "name": "Jane Doe",
-                                "type": "user",
-                              },
-                              "label": "Jane Doe",
-                              "searchKey": "janedoe@example.com  Jane Doe",
-                              "value": "user:1",
-                            },
-                            Object {
-                              "actor": Object {
-                                "id": "2",
-                                "name": "John Smith",
-                                "type": "user",
-                              },
-                              "label": "John Smith",
-                              "searchKey": "johnsmith@example.com  John Smith",
-                              "value": "user:2",
-                            },
-                          ]
-                        }
-                        pageSize={5}
+                        options={Array []}
                         placeholder="Add Owners"
-                        removeSelected={true}
-                        required={false}
-                        rtl={false}
-                        scrollMenuIntoView={true}
-                        searchable={true}
-                        simpleValue={false}
-                        style={
-                          Object {
-                            "overflow": "visible",
-                            "width": 200,
-                          }
-                        }
-                        tabSelectsValue={true}
-                        trimFilter={true}
+                        searchPromptText="Type to search"
                         value={
                           Array [
                             Object {
@@ -1802,92 +1723,190 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                                 "name": "Jane Doe",
                                 "type": "user",
                               },
-                              "label": "Jane Doe",
+                              "label": <IdBadge
+                                hideEmail={true}
+                                useLink={false}
+                                user={
+                                  Object {
+                                    "email": "janedoe@example.com",
+                                    "flags": Object {
+                                      "newsletter_consent_prompt": false,
+                                    },
+                                    "hasPasswordAuth": true,
+                                    "id": "1",
+                                    "isAuthenticated": true,
+                                    "name": "Jane Doe",
+                                    "options": Object {
+                                      "timezone": "UTC",
+                                    },
+                                    "username": "foo@example.com",
+                                  }
+                                }
+                              />,
                               "searchKey": "janedoe@example.com  Jane Doe",
                               "value": "user:1",
                             },
                           ]
                         }
                         valueComponent={[Function]}
-                        valueKey="value"
                       >
-                        <div
-                          className="Select css-16280ey-StyledSelect eho28m20 has-value is-clearable is-searchable Select--multi"
+                        <Select
+                          arrowRenderer={[Function]}
+                          autoload={true}
+                          autosize={true}
+                          backspaceRemoves={true}
+                          backspaceToRemoveMessage="Press backspace to remove {label}"
+                          cache={false}
+                          className="css-11osmt1-StyledSelect eho28m20"
+                          clearAllText="Clear all"
+                          clearRenderer={[Function]}
+                          clearValueText="Clear value"
+                          clearable={true}
+                          closeOnSelect={true}
+                          defaultOptions={true}
+                          deleteRemoves={true}
+                          delimiter=","
+                          disabled={false}
+                          escapeClearsValue={true}
+                          filterOptions={[Function]}
+                          ignoreAccents={true}
+                          ignoreCase={true}
+                          inputProps={Object {}}
+                          isLoading={true}
+                          joinValues={false}
+                          labelKey="label"
+                          loadOptions={[Function]}
+                          loadingPlaceholder="Loading..."
+                          matchPos="any"
+                          matchProp="any"
+                          menuBuffer={0}
+                          menuRenderer={[Function]}
+                          multi={true}
+                          noResultsText="Loading..."
+                          onBlurResetsInput={true}
+                          onChange={[Function]}
+                          onCloseResetsInput={true}
+                          onInputChange={[Function]}
+                          onSelectResetsInput={true}
+                          openOnClick={true}
+                          optionComponent={[Function]}
+                          options={Array []}
+                          pageSize={5}
+                          placeholder="Loading..."
+                          removeSelected={true}
+                          required={false}
+                          rtl={false}
+                          scrollMenuIntoView={true}
+                          searchPromptText="Type to search"
+                          searchable={true}
+                          simpleValue={false}
+                          tabSelectsValue={true}
+                          trimFilter={true}
+                          value={
+                            Array [
+                              Object {
+                                "actor": Object {
+                                  "id": "1",
+                                  "name": "Jane Doe",
+                                  "type": "user",
+                                },
+                                "label": <IdBadge
+                                  hideEmail={true}
+                                  useLink={false}
+                                  user={
+                                    Object {
+                                      "email": "janedoe@example.com",
+                                      "flags": Object {
+                                        "newsletter_consent_prompt": false,
+                                      },
+                                      "hasPasswordAuth": true,
+                                      "id": "1",
+                                      "isAuthenticated": true,
+                                      "name": "Jane Doe",
+                                      "options": Object {
+                                        "timezone": "UTC",
+                                      },
+                                      "username": "foo@example.com",
+                                    }
+                                  }
+                                />,
+                                "searchKey": "janedoe@example.com  Jane Doe",
+                                "value": "user:1",
+                              },
+                            ]
+                          }
+                          valueComponent={[Function]}
+                          valueKey="value"
                         >
                           <div
-                            className="Select-control"
-                            onKeyDown={[Function]}
-                            onMouseDown={[Function]}
-                            onTouchEnd={[Function]}
-                            onTouchMove={[Function]}
-                            onTouchStart={[Function]}
-                            style={
-                              Object {
-                                "overflow": "visible",
-                                "width": 200,
-                              }
-                            }
+                            className="Select css-11osmt1-StyledSelect eho28m20 has-value is-clearable is-loading is-searchable Select--multi"
                           >
-                            <span
-                              className="Select-multi-value-wrapper"
-                              id="react-select-5--value"
+                            <div
+                              className="Select-control"
+                              onKeyDown={[Function]}
+                              onMouseDown={[Function]}
+                              onTouchEnd={[Function]}
+                              onTouchMove={[Function]}
+                              onTouchStart={[Function]}
                             >
-                              <ValueComponent
-                                disabled={false}
-                                id="react-select-5--value-0"
-                                instancePrefix="react-select-5-"
-                                key="value-0-user:1"
-                                onClick={null}
-                                onRemove={[Function]}
-                                placeholder="Add Owners"
-                                value={
-                                  Object {
-                                    "actor": Object {
-                                      "id": "1",
-                                      "name": "Jane Doe",
-                                      "type": "user",
-                                    },
-                                    "label": "Jane Doe",
-                                    "searchKey": "janedoe@example.com  Jane Doe",
-                                    "value": "user:1",
-                                  }
-                                }
+                              <span
+                                className="Select-multi-value-wrapper"
+                                id="react-select-5--value"
                               >
-                                <a
-                                  onClick={[Function]}
-                                >
-                                  <ActorAvatar
-                                    actor={
-                                      Object {
+                                <ValueComponent
+                                  disabled={false}
+                                  id="react-select-5--value-0"
+                                  instancePrefix="react-select-5-"
+                                  key="value-0-user:1"
+                                  onClick={null}
+                                  onRemove={[Function]}
+                                  placeholder="Loading..."
+                                  value={
+                                    Object {
+                                      "actor": Object {
                                         "id": "1",
                                         "name": "Jane Doe",
                                         "type": "user",
-                                      }
+                                      },
+                                      "label": <IdBadge
+                                        hideEmail={true}
+                                        useLink={false}
+                                        user={
+                                          Object {
+                                            "email": "janedoe@example.com",
+                                            "flags": Object {
+                                              "newsletter_consent_prompt": false,
+                                            },
+                                            "hasPasswordAuth": true,
+                                            "id": "1",
+                                            "isAuthenticated": true,
+                                            "name": "Jane Doe",
+                                            "options": Object {
+                                              "timezone": "UTC",
+                                            },
+                                            "username": "foo@example.com",
+                                          }
+                                        }
+                                      />,
+                                      "searchKey": "janedoe@example.com  Jane Doe",
+                                      "value": "user:1",
                                     }
-                                    size={28}
+                                  }
+                                >
+                                  <a
+                                    onClick={[Function]}
                                   >
-                                    <Avatar
-                                      hasTooltip={true}
-                                      size={28}
-                                      user={
+                                    <ActorAvatar
+                                      actor={
                                         Object {
-                                          "email": "janedoe@example.com",
-                                          "flags": Object {
-                                            "newsletter_consent_prompt": false,
-                                          },
-                                          "hasPasswordAuth": true,
                                           "id": "1",
-                                          "isAuthenticated": true,
                                           "name": "Jane Doe",
-                                          "options": Object {
-                                            "timezone": "UTC",
-                                          },
-                                          "username": "foo@example.com",
+                                          "type": "user",
                                         }
                                       }
+                                      size={28}
                                     >
-                                      <UserAvatar
-                                        gravatar={true}
+                                      <Avatar
                                         hasTooltip={true}
                                         size={28}
                                         user={
@@ -1907,32 +1926,43 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                                           }
                                         }
                                       >
-                                        <BaseAvatar
-                                          gravatarId="janedoe@example.com"
+                                        <UserAvatar
+                                          gravatar={true}
                                           hasTooltip={true}
-                                          letterId="janedoe@example.com"
                                           size={28}
-                                          style={Object {}}
-                                          title="Jane Doe"
-                                          tooltip="Jane Doe (janedoe@example.com)"
-                                          type="gravatar"
+                                          user={
+                                            Object {
+                                              "email": "janedoe@example.com",
+                                              "flags": Object {
+                                                "newsletter_consent_prompt": false,
+                                              },
+                                              "hasPasswordAuth": true,
+                                              "id": "1",
+                                              "isAuthenticated": true,
+                                              "name": "Jane Doe",
+                                              "options": Object {
+                                                "timezone": "UTC",
+                                              },
+                                              "username": "foo@example.com",
+                                            }
+                                          }
                                         >
-                                          <Tooltip
-                                            disabled={false}
-                                            title="Jane Doe (janedoe@example.com)"
+                                          <BaseAvatar
+                                            gravatarId="janedoe@example.com"
+                                            hasTooltip={true}
+                                            letterId="janedoe@example.com"
+                                            size={28}
+                                            style={Object {}}
+                                            title="Jane Doe"
+                                            tooltip="Jane Doe (janedoe@example.com)"
+                                            type="gravatar"
                                           >
-                                            <StyledBaseAvatar
-                                              className="tip avatar"
-                                              style={
-                                                Object {
-                                                  "height": "28px",
-                                                  "width": "28px",
-                                                }
-                                              }
+                                            <Tooltip
+                                              disabled={false}
                                               title="Jane Doe (janedoe@example.com)"
                                             >
-                                              <span
-                                                className="tip avatar css-15umz1j-StyledBaseAvatar e1z0ohzl0"
+                                              <StyledBaseAvatar
+                                                className="tip avatar"
                                                 style={
                                                   Object {
                                                     "height": "28px",
@@ -1941,106 +1971,107 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
                                                 }
                                                 title="Jane Doe (janedoe@example.com)"
                                               >
-                                                <img
-                                                  onError={[Function]}
-                                                  onLoad={[Function]}
-                                                  src="undefined/avatar/e1f3994f2632af3d1c8c2dcc168a10e6?d=blank&s=32"
-                                                />
-                                              </span>
-                                            </StyledBaseAvatar>
-                                          </Tooltip>
-                                        </BaseAvatar>
-                                      </UserAvatar>
-                                    </Avatar>
-                                  </ActorAvatar>
-                                </a>
-                              </ValueComponent>
-                              <AutosizeInput
-                                aria-activedescendant="react-select-5--value"
-                                aria-expanded="false"
-                                aria-haspopup="false"
-                                aria-owns=""
-                                className="Select-input"
-                                injectStyles={true}
-                                minWidth="5"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                required={false}
-                                role="combobox"
-                                value=""
-                              >
-                                <div
+                                                <span
+                                                  className="tip avatar css-15umz1j-StyledBaseAvatar e1z0ohzl0"
+                                                  style={
+                                                    Object {
+                                                      "height": "28px",
+                                                      "width": "28px",
+                                                    }
+                                                  }
+                                                  title="Jane Doe (janedoe@example.com)"
+                                                >
+                                                  <img
+                                                    onError={[Function]}
+                                                    onLoad={[Function]}
+                                                    src="undefined/avatar/e1f3994f2632af3d1c8c2dcc168a10e6?d=blank&s=32"
+                                                  />
+                                                </span>
+                                              </StyledBaseAvatar>
+                                            </Tooltip>
+                                          </BaseAvatar>
+                                        </UserAvatar>
+                                      </Avatar>
+                                    </ActorAvatar>
+                                  </a>
+                                </ValueComponent>
+                                <AutosizeInput
+                                  aria-activedescendant="react-select-5--value"
+                                  aria-expanded="false"
+                                  aria-haspopup="false"
+                                  aria-owns=""
                                   className="Select-input"
-                                  style={
-                                    Object {
-                                      "display": "inline-block",
-                                    }
-                                  }
+                                  injectStyles={true}
+                                  minWidth="5"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  required={false}
+                                  role="combobox"
+                                  value=""
                                 >
-                                  <input
-                                    aria-activedescendant="react-select-5--value"
-                                    aria-expanded="false"
-                                    aria-haspopup="false"
-                                    aria-owns=""
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    required={false}
-                                    role="combobox"
-                                    style={
-                                      Object {
-                                        "boxSizing": "content-box",
-                                        "width": "5px",
-                                      }
-                                    }
-                                    value=""
-                                  />
                                   <div
+                                    className="Select-input"
                                     style={
                                       Object {
-                                        "height": 0,
-                                        "left": 0,
-                                        "overflow": "scroll",
-                                        "position": "absolute",
-                                        "top": 0,
-                                        "visibility": "hidden",
-                                        "whiteSpace": "pre",
+                                        "display": "inline-block",
                                       }
                                     }
-                                  />
-                                </div>
-                              </AutosizeInput>
-                            </span>
-                            <span
-                              aria-label="Clear all"
-                              className="Select-clear-zone"
-                              onMouseDown={[Function]}
-                              onTouchEnd={[Function]}
-                              onTouchMove={[Function]}
-                              onTouchStart={[Function]}
-                              title="Clear all"
-                            >
+                                  >
+                                    <input
+                                      aria-activedescendant="react-select-5--value"
+                                      aria-expanded="false"
+                                      aria-haspopup="false"
+                                      aria-owns=""
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      required={false}
+                                      role="combobox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "5px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </AutosizeInput>
+                              </span>
                               <span
-                                className="Select-clear"
-                                dangerouslySetInnerHTML={
-                                  Object {
-                                    "__html": "&times;",
-                                  }
-                                }
-                              />
-                            </span>
-                            <span
-                              className="Select-arrow-zone"
-                              onMouseDown={[Function]}
-                            >
+                                aria-hidden="true"
+                                className="Select-loading-zone"
+                              >
+                                <span
+                                  className="Select-loading"
+                                />
+                              </span>
                               <span
-                                className="icon-arrow-down"
-                              />
-                            </span>
+                                className="Select-arrow-zone"
+                                onMouseDown={[Function]}
+                              >
+                                <span
+                                  className="icon-arrow-down"
+                                />
+                              </span>
+                            </div>
                           </div>
-                        </div>
-                      </Select>
+                        </Select>
+                      </Async>
                     </Component>
                   </StyledSelect>
                 </SelectControl>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -462,6 +462,7 @@ exports[`RuleBuilder renders 1`] = `
                 filterOptions={[Function]}
                 loadOptions={[Function]}
                 onChange={[Function]}
+                onInputChange={[Function]}
                 placeholder="Add Owners"
                 value={Array []}
                 valueComponent={[Function]}
@@ -475,6 +476,7 @@ exports[`RuleBuilder renders 1`] = `
                   loadOptions={[Function]}
                   multi={true}
                   onChange={[Function]}
+                  onInputChange={[Function]}
                   placeholder="Add Owners"
                   value={Array []}
                   valueComponent={[Function]}
@@ -489,6 +491,7 @@ exports[`RuleBuilder renders 1`] = `
                     loadOptions={[Function]}
                     multi={true}
                     onChange={[Function]}
+                    onInputChange={[Function]}
                     placeholder="Add Owners"
                     value={Array []}
                     valueComponent={[Function]}
@@ -503,6 +506,7 @@ exports[`RuleBuilder renders 1`] = `
                       loadOptions={[Function]}
                       multi={true}
                       onChange={[Function]}
+                      onInputChange={[Function]}
                       placeholder="Add Owners"
                       value={Array []}
                       valueComponent={[Function]}
@@ -520,6 +524,7 @@ exports[`RuleBuilder renders 1`] = `
                         loadingPlaceholder="Loading..."
                         multi={true}
                         onChange={[Function]}
+                        onInputChange={[Function]}
                         options={Array []}
                         placeholder="Add Owners"
                         searchPromptText="Type to search"
@@ -710,7 +715,7 @@ exports[`RuleBuilder renders 1`] = `
             size="zero"
           >
             <Component
-              className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
+              className="e1hyuoc79 css-1gabw8k-StyledButton-getColors-RuleAddButton e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"
@@ -718,7 +723,7 @@ exports[`RuleBuilder renders 1`] = `
               size="zero"
             >
               <button
-                className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
+                className="e1hyuoc79 css-1gabw8k-StyledButton-getColors-RuleAddButton e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"
@@ -1493,6 +1498,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       "type": "user",
                     },
                     "label": <IdBadge
+                      avatarSize={24}
                       hideEmail={true}
                       useLink={false}
                       user={
@@ -1512,7 +1518,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         }
                       }
                     />,
-                    "searchKey": "janedoe@example.com  Jane Doe",
+                    "searchKey": "janedoe@example.com jane doe",
                     "value": "user:1",
                   },
                 ]
@@ -1526,6 +1532,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                 filterOptions={[Function]}
                 loadOptions={[Function]}
                 onChange={[Function]}
+                onInputChange={[Function]}
                 placeholder="Add Owners"
                 value={
                   Array [
@@ -1536,6 +1543,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         "type": "user",
                       },
                       "label": <IdBadge
+                        avatarSize={24}
                         hideEmail={true}
                         useLink={false}
                         user={
@@ -1555,7 +1563,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           }
                         }
                       />,
-                      "searchKey": "janedoe@example.com  Jane Doe",
+                      "searchKey": "janedoe@example.com jane doe",
                       "value": "user:1",
                     },
                   ]
@@ -1571,6 +1579,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                   loadOptions={[Function]}
                   multi={true}
                   onChange={[Function]}
+                  onInputChange={[Function]}
                   placeholder="Add Owners"
                   value={
                     Array [
@@ -1581,6 +1590,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           "type": "user",
                         },
                         "label": <IdBadge
+                          avatarSize={24}
                           hideEmail={true}
                           useLink={false}
                           user={
@@ -1600,7 +1610,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                             }
                           }
                         />,
-                        "searchKey": "janedoe@example.com  Jane Doe",
+                        "searchKey": "janedoe@example.com jane doe",
                         "value": "user:1",
                       },
                     ]
@@ -1617,6 +1627,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                     loadOptions={[Function]}
                     multi={true}
                     onChange={[Function]}
+                    onInputChange={[Function]}
                     placeholder="Add Owners"
                     value={
                       Array [
@@ -1627,6 +1638,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                             "type": "user",
                           },
                           "label": <IdBadge
+                            avatarSize={24}
                             hideEmail={true}
                             useLink={false}
                             user={
@@ -1646,7 +1658,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                               }
                             }
                           />,
-                          "searchKey": "janedoe@example.com  Jane Doe",
+                          "searchKey": "janedoe@example.com jane doe",
                           "value": "user:1",
                         },
                       ]
@@ -1663,6 +1675,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       loadOptions={[Function]}
                       multi={true}
                       onChange={[Function]}
+                      onInputChange={[Function]}
                       placeholder="Add Owners"
                       value={
                         Array [
@@ -1673,6 +1686,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                               "type": "user",
                             },
                             "label": <IdBadge
+                              avatarSize={24}
                               hideEmail={true}
                               useLink={false}
                               user={
@@ -1692,7 +1706,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                 }
                               }
                             />,
-                            "searchKey": "janedoe@example.com  Jane Doe",
+                            "searchKey": "janedoe@example.com jane doe",
                             "value": "user:1",
                           },
                         ]
@@ -1712,6 +1726,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         loadingPlaceholder="Loading..."
                         multi={true}
                         onChange={[Function]}
+                        onInputChange={[Function]}
                         options={Array []}
                         placeholder="Add Owners"
                         searchPromptText="Type to search"
@@ -1724,6 +1739,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                 "type": "user",
                               },
                               "label": <IdBadge
+                                avatarSize={24}
                                 hideEmail={true}
                                 useLink={false}
                                 user={
@@ -1743,7 +1759,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                   }
                                 }
                               />,
-                              "searchKey": "janedoe@example.com  Jane Doe",
+                              "searchKey": "janedoe@example.com jane doe",
                               "value": "user:1",
                             },
                           ]
@@ -1811,6 +1827,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                   "type": "user",
                                 },
                                 "label": <IdBadge
+                                  avatarSize={24}
                                   hideEmail={true}
                                   useLink={false}
                                   user={
@@ -1830,7 +1847,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                     }
                                   }
                                 />,
-                                "searchKey": "janedoe@example.com  Jane Doe",
+                                "searchKey": "janedoe@example.com jane doe",
                                 "value": "user:1",
                               },
                             ]
@@ -1869,6 +1886,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                         "type": "user",
                                       },
                                       "label": <IdBadge
+                                        avatarSize={24}
                                         hideEmail={true}
                                         useLink={false}
                                         user={
@@ -1888,7 +1906,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                           }
                                         }
                                       />,
-                                      "searchKey": "janedoe@example.com  Jane Doe",
+                                      "searchKey": "janedoe@example.com jane doe",
                                       "value": "user:1",
                                     }
                                   }
@@ -2103,7 +2121,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
             size="zero"
           >
             <Component
-              className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
+              className="e1hyuoc79 css-1gabw8k-StyledButton-getColors-RuleAddButton e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"
@@ -2111,7 +2129,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
               size="zero"
             >
               <button
-                className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
+                className="e1hyuoc79 css-1gabw8k-StyledButton-getColors-RuleAddButton e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -45,7 +45,14 @@ exports[`RuleBuilder renders 1`] = `
       "isMember": true,
       "name": "Project Name",
       "slug": "project-slug",
-      "teams": Array [],
+      "teams": Array [
+        Object {
+          "id": "3",
+          "isMember": true,
+          "name": "COOL TEAM",
+          "slug": "cool-team",
+        },
+      ],
     }
   }
 >
@@ -449,7 +456,14 @@ exports[`RuleBuilder renders 1`] = `
                   "isMember": true,
                   "name": "Project Name",
                   "slug": "project-slug",
-                  "teams": Array [],
+                  "teams": Array [
+                    Object {
+                      "id": "3",
+                      "isMember": true,
+                      "name": "COOL TEAM",
+                      "slug": "cool-team",
+                    },
+                  ],
                 }
               }
               value={Array []}
@@ -866,7 +880,14 @@ exports[`RuleBuilder renders with suggestions 1`] = `
       "isMember": true,
       "name": "Project Name",
       "slug": "project-slug",
-      "teams": Array [],
+      "teams": Array [
+        Object {
+          "id": "3",
+          "isMember": true,
+          "name": "COOL TEAM",
+          "slug": "cool-team",
+        },
+      ],
     }
   }
   urls={
@@ -1486,7 +1507,14 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                   "isMember": true,
                   "name": "Project Name",
                   "slug": "project-slug",
-                  "teams": Array [],
+                  "teams": Array [
+                    Object {
+                      "id": "3",
+                      "isMember": true,
+                      "name": "COOL TEAM",
+                      "slug": "cool-team",
+                    },
+                  ],
                 }
               }
               value={
@@ -1513,6 +1541,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           "name": "Jane Doe",
                           "options": Object {
                             "timezone": "UTC",
+                          },
+                          "user": Object {
+                            "email": "janedoe@example.com",
+                            "id": "1",
+                            "name": "Jane Doe",
                           },
                           "username": "foo@example.com",
                         }
@@ -1558,6 +1591,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                             "name": "Jane Doe",
                             "options": Object {
                               "timezone": "UTC",
+                            },
+                            "user": Object {
+                              "email": "janedoe@example.com",
+                              "id": "1",
+                              "name": "Jane Doe",
                             },
                             "username": "foo@example.com",
                           }
@@ -1605,6 +1643,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                               "name": "Jane Doe",
                               "options": Object {
                                 "timezone": "UTC",
+                              },
+                              "user": Object {
+                                "email": "janedoe@example.com",
+                                "id": "1",
+                                "name": "Jane Doe",
                               },
                               "username": "foo@example.com",
                             }
@@ -1654,6 +1697,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                 "options": Object {
                                   "timezone": "UTC",
                                 },
+                                "user": Object {
+                                  "email": "janedoe@example.com",
+                                  "id": "1",
+                                  "name": "Jane Doe",
+                                },
                                 "username": "foo@example.com",
                               }
                             }
@@ -1701,6 +1749,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                   "name": "Jane Doe",
                                   "options": Object {
                                     "timezone": "UTC",
+                                  },
+                                  "user": Object {
+                                    "email": "janedoe@example.com",
+                                    "id": "1",
+                                    "name": "Jane Doe",
                                   },
                                   "username": "foo@example.com",
                                 }
@@ -1754,6 +1807,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                     "name": "Jane Doe",
                                     "options": Object {
                                       "timezone": "UTC",
+                                    },
+                                    "user": Object {
+                                      "email": "janedoe@example.com",
+                                      "id": "1",
+                                      "name": "Jane Doe",
                                     },
                                     "username": "foo@example.com",
                                   }
@@ -1843,6 +1901,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                       "options": Object {
                                         "timezone": "UTC",
                                       },
+                                      "user": Object {
+                                        "email": "janedoe@example.com",
+                                        "id": "1",
+                                        "name": "Jane Doe",
+                                      },
                                       "username": "foo@example.com",
                                     }
                                   }
@@ -1856,7 +1919,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           valueKey="value"
                         >
                           <div
-                            className="Select css-11osmt1-StyledSelect eho28m20 has-value is-clearable is-loading is-searchable Select--multi"
+                            className="Select css-11osmt1-StyledSelect eho28m20 has-value is-clearable is-focused is-loading is-searchable Select--multi"
                           >
                             <div
                               className="Select-control"
@@ -1902,6 +1965,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                             "options": Object {
                                               "timezone": "UTC",
                                             },
+                                            "user": Object {
+                                              "email": "janedoe@example.com",
+                                              "id": "1",
+                                              "name": "Jane Doe",
+                                            },
                                             "username": "foo@example.com",
                                           }
                                         }
@@ -1940,6 +2008,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                             "options": Object {
                                               "timezone": "UTC",
                                             },
+                                            "user": Object {
+                                              "email": "janedoe@example.com",
+                                              "id": "1",
+                                              "name": "Jane Doe",
+                                            },
                                             "username": "foo@example.com",
                                           }
                                         }
@@ -1960,6 +2033,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                               "name": "Jane Doe",
                                               "options": Object {
                                                 "timezone": "UTC",
+                                              },
+                                              "user": Object {
+                                                "email": "janedoe@example.com",
+                                                "id": "1",
+                                                "name": "Jane Doe",
                                               },
                                               "username": "foo@example.com",
                                             }
@@ -2017,7 +2095,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                   aria-activedescendant="react-select-5--value"
                                   aria-expanded="false"
                                   aria-haspopup="false"
-                                  aria-owns=""
+                                  aria-owns="react-select-5--backspace-remove-message"
                                   className="Select-input"
                                   injectStyles={true}
                                   minWidth="5"
@@ -2040,7 +2118,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                       aria-activedescendant="react-select-5--value"
                                       aria-expanded="false"
                                       aria-haspopup="false"
-                                      aria-owns=""
+                                      aria-owns="react-select-5--backspace-remove-message"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onFocus={[Function]}
@@ -2069,6 +2147,13 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                     />
                                   </div>
                                 </AutosizeInput>
+                              </span>
+                              <span
+                                aria-live="assertive"
+                                className="Select-aria-only"
+                                id="react-select-5--backspace-remove-message"
+                              >
+                                Press backspace to remove [object Object]
                               </span>
                               <span
                                 aria-hidden="true"

--- a/tests/js/spec/views/app.spec.jsx
+++ b/tests/js/spec/views/app.spec.jsx
@@ -5,7 +5,6 @@ import App from 'app/views/app';
 import ConfigStore from 'app/stores/configStore';
 
 jest.mock('jquery');
-jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 
 describe('App', function() {
   beforeEach(function() {

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -525,7 +525,7 @@ exports[`CreateProject render() should render roles when available and allowed, 
           <Component
             aria-label="Add Member"
             busy={false}
-            className="invite-member-submit css-15f0jp2-StyledButton-getColors e17811v30"
+            className="invite-member-submit css-1msljz8-StyledButton-getColors e17811v30"
             disabled={false}
             onClick={[Function]}
             priority="primary"
@@ -533,7 +533,7 @@ exports[`CreateProject render() should render roles when available and allowed, 
           >
             <button
               aria-label="Add Member"
-              className="invite-member-submit css-15f0jp2-StyledButton-getColors e17811v30"
+              className="invite-member-submit css-1msljz8-StyledButton-getColors e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -256,7 +256,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                             >
                                               <Component
                                                 aria-label="Full Documentation"
-                                                className="css-o6814l-StyledButton-getColors e17811v30"
+                                                className="css-dkprmi-StyledButton-getColors e17811v30"
                                                 disabled={false}
                                                 external={true}
                                                 href="https://docs.getsentry.com/hosted/clients/csharp/"
@@ -266,7 +266,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                               >
                                                 <ExternalLink
                                                   aria-label="Full Documentation"
-                                                  className="css-o6814l-StyledButton-getColors e17811v30"
+                                                  className="css-dkprmi-StyledButton-getColors e17811v30"
                                                   disabled={false}
                                                   href="https://docs.getsentry.com/hosted/clients/csharp/"
                                                   onClick={[Function]}
@@ -277,7 +277,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                                 >
                                                   <a
                                                     aria-label="Full Documentation"
-                                                    className="css-o6814l-StyledButton-getColors e17811v30"
+                                                    className="css-dkprmi-StyledButton-getColors e17811v30"
                                                     disabled={false}
                                                     href="https://docs.getsentry.com/hosted/clients/csharp/"
                                                     onClick={[Function]}

--- a/tests/js/spec/views/organizationMembersView.spec.jsx
+++ b/tests/js/spec/views/organizationMembersView.spec.jsx
@@ -8,7 +8,6 @@ import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
 
 jest.mock('app/api');
 jest.mock('app/actionCreators/indicator');
-jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 
 describe('OrganizationMembersView', function() {
   let members = TestStubs.Members();

--- a/tests/js/spec/views/organizationProjects.spec.jsx
+++ b/tests/js/spec/views/organizationProjects.spec.jsx
@@ -4,8 +4,6 @@ import {mount} from 'enzyme';
 import {Client} from 'app/api';
 import OrganizationProjectsViewContainer from 'app/views/settings/organization/projects/organizationProjectsView';
 
-jest.mock('lodash/debounce', () => jest.fn(fn => fn));
-
 describe('OrganizationProjects', function() {
   let org;
   let project;

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import {Client} from 'app/api';
 import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
 
 jest.mock('jquery');
-describe('ProjectTeamsSettings', function() {
+describe('Project Ownership Input', function() {
   let org;
   let project;
   let put;
@@ -14,43 +13,46 @@ describe('ProjectTeamsSettings', function() {
     org = TestStubs.Organization();
     project = TestStubs.Project();
 
-    put = Client.addMockResponse({
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      method: 'GET',
+      body: [TestStubs.Members()],
+    });
+    put = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/ownership/`,
       method: 'PUT',
       body: {raw: 'url:src @dummy@example.com'},
     });
   });
 
-  describe('render()', function() {
-    it('renders', function() {
-      let wrapper = mount(
-        <OwnerInput
-          params={{orgId: org.slug, projectId: project.slug}}
-          organization={org}
-          initialText="url:src @dummy@example.com"
-          project={project}
-        />,
-        TestStubs.routerContext()
-      );
+  it('renders', function() {
+    let wrapper = mount(
+      <OwnerInput
+        params={{orgId: org.slug, projectId: project.slug}}
+        organization={org}
+        initialText="url:src @dummy@example.com"
+        project={project}
+      />,
+      TestStubs.routerContext()
+    );
 
-      let submit = wrapper.find('SaveButton button');
+    let submit = wrapper.find('SaveButton button');
 
-      expect(put).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
 
-      // if text is unchanged, submit button is disabled
-      submit.simulate('click');
-      expect(put).not.toHaveBeenCalled();
+    // if text is unchanged, submit button is disabled
+    submit.simulate('click');
+    expect(put).not.toHaveBeenCalled();
 
-      wrapper
-        .find(OwnerInput)
-        .instance()
-        .onChange({target: {value: 'new'}});
+    wrapper
+      .find(OwnerInput)
+      .instance()
+      .onChange({target: {value: 'new'}});
 
-      submit.simulate('click');
+    submit.simulate('click');
 
-      expect(put).toHaveBeenCalled();
+    expect(put).toHaveBeenCalled();
 
-      expect(wrapper.find(OwnerInput)).toMatchSnapshot();
-    });
+    expect(wrapper.find(OwnerInput)).toMatchSnapshot();
   });
 });

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -7,7 +7,6 @@ import FormSearchStore from 'app/stores/formSearchStore';
 import {navigateTo} from 'app/actionCreators/navigation';
 
 jest.mock('jquery');
-jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('app/actionCreators/formSearch');
 jest.mock('app/actionCreators/navigation');
 

--- a/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
@@ -165,7 +165,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
             >
               <Component
                 aria-label="Cancel"
-                className="css-1w79b6l-StyledButton-getColors e17811v30"
+                className="css-cmo08-StyledButton-getColors e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 role="button"
@@ -177,7 +177,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
               >
                 <button
                   aria-label="Cancel"
-                  className="css-1w79b6l-StyledButton-getColors e17811v30"
+                  className="css-cmo08-StyledButton-getColors e17811v30"
                   disabled={false}
                   onClick={[Function]}
                   role="button"
@@ -232,7 +232,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
               <Component
                 aria-label="Bulk resolve issues"
                 autoFocus={true}
-                className="css-15f0jp2-StyledButton-getColors e17811v30"
+                className="css-1msljz8-StyledButton-getColors e17811v30"
                 data-test-id="confirm-modal"
                 disabled={false}
                 onClick={[Function]}
@@ -242,7 +242,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                 <button
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
-                  className="css-15f0jp2-StyledButton-getColors e17811v30"
+                  className="css-1msljz8-StyledButton-getColors e17811v30"
                   data-test-id="confirm-modal"
                   disabled={false}
                   onClick={[Function]}
@@ -479,7 +479,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
             >
               <Component
                 aria-label="Cancel"
-                className="css-1w79b6l-StyledButton-getColors e17811v30"
+                className="css-cmo08-StyledButton-getColors e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 role="button"
@@ -491,7 +491,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
               >
                 <button
                   aria-label="Cancel"
-                  className="css-1w79b6l-StyledButton-getColors e17811v30"
+                  className="css-cmo08-StyledButton-getColors e17811v30"
                   disabled={false}
                   onClick={[Function]}
                   role="button"
@@ -546,7 +546,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
               <Component
                 aria-label="Bulk resolve issues"
                 autoFocus={true}
-                className="css-15f0jp2-StyledButton-getColors e17811v30"
+                className="css-1msljz8-StyledButton-getColors e17811v30"
                 data-test-id="confirm-modal"
                 disabled={false}
                 onClick={[Function]}
@@ -556,7 +556,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                 <button
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
-                  className="css-15f0jp2-StyledButton-getColors e17811v30"
+                  className="css-1msljz8-StyledButton-getColors e17811v30"
                   data-test-id="confirm-modal"
                   disabled={false}
                   onClick={[Function]}


### PR DESCRIPTION
In "Issue Ownership", the owners dropdown will now show all teams/members within the organization (but be disabled).

Teams will have a button to add the team to the project (as well as owners).

Members don't have anything actionable.

Depends on #8179 #8178 ~~#8145~~ 

![owners-input-list-all-teams](https://user-images.githubusercontent.com/79684/39225952-31706d24-4804-11e8-8245-38057fe2a221.gif)
