### PR TITLE
Revert "ref(services): Add `internal:optin` handler for explicitly sending to Sentry (#8170)"

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -623,11 +623,6 @@ LOGGING = {
             'filters': ['sentry:internal'],
             'class': 'raven.contrib.django.handlers.SentryHandler',
         },
-        'internal:optin': {
-            'level': 'WARNING',
-            'filters': ['sentry:internal'],
-            'class': 'raven.contrib.django.handlers.SentryHandler',
-        },
         'metrics': {
             'level': 'WARNING',
             'filters': ['important_django_request'],
@@ -673,10 +668,6 @@ LOGGING = {
         },
         'sentry.rules': {
             'handlers': ['console'],
-            'propagate': False,
-        },
-        'sentry.utils.services': {
-            'handlers': ['internal:optin'],
             'propagate': False,
         },
         'multiprocessing': {


### PR DESCRIPTION
This reverts commit 703f968461c02cdfaba77d0b348928f35001ee88.