### PR TITLE
fix(ui): resolve scoping issue with dropdownButton in production css

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownButton.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.jsx
@@ -29,7 +29,7 @@ const StyledButton = styled(({isOpen, ...props}) => <Button {...props} />)`
     border-bottom-left-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
     position: relative;
     z-index: 2;
-    box-shadow: none;
+    box-shadow: ${p => (p.isOpen ? 'none' : p.theme.dropShadowLight)};
 
     &,
     &:hover {

--- a/src/sentry/static/sentry/app/components/dropdownButton.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.jsx
@@ -24,15 +24,17 @@ const StyledChevronDown = styled(props => (
 `;
 
 const StyledButton = styled(({isOpen, ...props}) => <Button {...props} />)`
-  border-bottom-right-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
-  border-bottom-left-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
-  position: relative;
-  z-index: 2;
-  box-shadow: none;
+  &.button {
+    border-bottom-right-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
+    border-bottom-left-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
+    position: relative;
+    z-index: 2;
+    box-shadow: none;
 
-  &,
-  &:hover {
-    border-bottom-color: ${p => (p.isOpen ? 'transparent' : p.theme.borderDark)};
+    &,
+    &:hover {
+      border-bottom-color: ${p => (p.isOpen ? 'transparent' : p.theme.borderDark)};
+    }
   }
 `;
 

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -110,17 +110,17 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                           size="xsmall"
                                         >
                                           <Component
-                                            className="css-2og6h6-StyledButton css-fx03i91"
+                                            className="css-1jpufvo-StyledButton css-1txqzk1"
                                             isOpen={false}
                                             size="xsmall"
                                           >
                                             <Button
-                                              className="css-2og6h6-StyledButton css-fx03i91"
+                                              className="css-1jpufvo-StyledButton css-1txqzk1"
                                               disabled={false}
                                               size="xsmall"
                                             >
                                               <button
-                                                className="css-2og6h6-StyledButton css-fx03i91 button button-default button-xs"
+                                                className="css-1jpufvo-StyledButton css-1txqzk1 button button-default button-xs"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
@@ -140,20 +140,20 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                       Add Project
                                                       <StyledChevronDown>
                                                         <Component
-                                                          className="css-17v3tc-StyledChevronDown css-fx03i90"
+                                                          className="css-17v3tc-StyledChevronDown css-1txqzk0"
                                                         >
                                                           <InlineSvg
-                                                            className="css-17v3tc-StyledChevronDown css-fx03i90"
+                                                            className="css-17v3tc-StyledChevronDown css-1txqzk0"
                                                             src="icon-chevron-down"
                                                           >
                                                             <StyledSvg
-                                                              className="css-17v3tc-StyledChevronDown css-fx03i90"
+                                                              className="css-17v3tc-StyledChevronDown css-1txqzk0"
                                                               height="1em"
                                                               viewBox={Object {}}
                                                               width="1em"
                                                             >
                                                               <svg
-                                                                className="css-fx03i90 css-1vk3ljv-StyledSvg css-adkcw30"
+                                                                className="css-1txqzk0 css-1vk3ljv-StyledSvg css-adkcw30"
                                                                 height="1em"
                                                                 viewBox={Object {}}
                                                                 width="1em"

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -110,17 +110,17 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                           size="xsmall"
                                         >
                                           <Component
-                                            className="css-ngzubs-StyledButton css-1pig06q1"
+                                            className="css-2og6h6-StyledButton css-fx03i91"
                                             isOpen={false}
                                             size="xsmall"
                                           >
                                             <Button
-                                              className="css-ngzubs-StyledButton css-1pig06q1"
+                                              className="css-2og6h6-StyledButton css-fx03i91"
                                               disabled={false}
                                               size="xsmall"
                                             >
                                               <button
-                                                className="css-ngzubs-StyledButton css-1pig06q1 button button-default button-xs"
+                                                className="css-2og6h6-StyledButton css-fx03i91 button button-default button-xs"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
@@ -140,20 +140,20 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                       Add Project
                                                       <StyledChevronDown>
                                                         <Component
-                                                          className="css-17v3tc-StyledChevronDown css-1pig06q0"
+                                                          className="css-17v3tc-StyledChevronDown css-fx03i90"
                                                         >
                                                           <InlineSvg
-                                                            className="css-17v3tc-StyledChevronDown css-1pig06q0"
+                                                            className="css-17v3tc-StyledChevronDown css-fx03i90"
                                                             src="icon-chevron-down"
                                                           >
                                                             <StyledSvg
-                                                              className="css-17v3tc-StyledChevronDown css-1pig06q0"
+                                                              className="css-17v3tc-StyledChevronDown css-fx03i90"
                                                               height="1em"
                                                               viewBox={Object {}}
                                                               width="1em"
                                                             >
                                                               <svg
-                                                                className="css-1pig06q0 css-1vk3ljv-StyledSvg css-adkcw30"
+                                                                className="css-fx03i90 css-1vk3ljv-StyledSvg css-adkcw30"
                                                                 height="1em"
                                                                 viewBox={Object {}}
                                                                 width="1em"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/435981/39266720-a8b31e1a-487f-11e8-908c-3eadde15ad59.png)

![image](https://user-images.githubusercontent.com/435981/39266735-b740dfb2-487f-11e8-9f13-3ab5f3659c30.png)

fwiw I did some serious due diligence trying to fix this the *right* way (converting `Button` to styled components). I've noticed this has been causing problems in several other places as well, and it will likely continue to create bugs because production css is in a different order than development css.

Moving forward, I'm gonna try to be on my toes about css compilation order and it's ability to cause annoying regressions in any feature that mixes styled components with global classes.

Anyways, here is the cheap fix for now don't judge me!

