### PR TITLE
feat(integrations): Add support for atlassian connect for JIRA

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -33,6 +33,7 @@ petname>=2.0,<2.1
 Pillow>=3.2.0,<=4.2.1
 progressbar2>=3.10,<3.11
 psycopg2>=2.6.0,<2.8.0
+PyJWT>=1.5.0,<1.6.0
 pytest>=3.5.0,<3.6.0
 pytest-django>=2.9.1,<2.10.0
 pytest-html>=1.9.0,<1.10.0

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -19,6 +19,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
                     'name': provider.name,
                     'metadata': metadata,
                     'config': provider.get_config(),
+                    'canAdd': provider.can_add,
                     'setupDialog': dict(
                         url='/organizations/{}/integrations/{}/setup/'.format(
                             organization.slug,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1236,6 +1236,7 @@ SENTRY_USE_X_FORWARDED_FOR = True
 
 SENTRY_DEFAULT_INTEGRATIONS = (
     'sentry.integrations.slack.SlackIntegration',
+    'sentry.integrations.jira.JiraIntegration',
 )
 
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -37,7 +37,7 @@ class Integration(PipelineProvider):
     # a human readable name (e.g. 'Slack')
     name = None
 
-    # an IntegrationMetadata object, used to provider extra details in the
+    # an IntegrationMetadata object, used to provide extra details in the
     # configuration interface of the integration.
     metadata = None
 
@@ -46,6 +46,9 @@ class Integration(PipelineProvider):
         'width': 600,
         'height': 600,
     }
+
+    # whether or not the integration installation be initiated from Sentry
+    can_add = True
 
     def get_logger(self):
         return logging.getLogger('sentry.integration.%s' % (self.key, ))

--- a/src/sentry/integrations/jira/__init__.py
+++ b/src/sentry/integrations/jira/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/integrations/jira/__init__.py
+++ b/src/sentry/integrations/jira/__init__.py
@@ -1,1 +1,5 @@
 from __future__ import absolute_import
+
+from sentry.utils.imports import import_submodules
+
+import_submodules(globals(), __name__, __path__)

--- a/src/sentry/integrations/jira/configure.py
+++ b/src/sentry/integrations/jira/configure.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+from django.db import IntegrityError, transaction
+from django import forms
+
+from .utils import get_integration_from_request, JiraValidationError
+from sentry.models import OrganizationIntegration
+from sentry.web.frontend.base import BaseView
+from sentry.web.helpers import render_to_response
+
+
+# TODO(jess): support linking a single JIRA instance to multiple orgs
+class JiraConfigForm(forms.Form):
+    organization = forms.ChoiceField(
+        label='Sentry Organization',
+        choices=tuple(),
+        widget=forms.Select(attrs={'class': 'select'})
+    )
+
+    def __init__(self, organizations, *args, **kwargs):
+        super(JiraConfigForm, self).__init__(*args, **kwargs)
+        self.fields['organization'].choices = organizations
+
+
+class JiraConfigureView(BaseView):
+
+    def get_response(self, context):
+        context['ac_js_src'] = '%s%s%s' % (
+            self.request.GET['xdm_e'], self.request.GET.get('cp', ''),
+            '/atlassian-connect/all.js'
+        )
+        res = render_to_response('sentry/jira-configure.html', context, self.request)
+        res['X-Frame-Options'] = 'ALLOW-FROM %s' % self.request.GET['xdm_e']
+        return res
+
+    def handle(self, request):
+        try:
+            integration = get_integration_from_request(request)
+        except JiraValidationError:
+            return self.get_response({'error_message': 'Unable to verify installation.'})
+
+        # TODO(jess): restrict to org owners?
+        org_choices = [(o.id, o.name) for o in request.user.get_orgs()]
+
+        if request.method == 'GET':
+            form = JiraConfigForm(org_choices)
+        else:
+            form = JiraConfigForm(org_choices, request.POST)
+            if form.is_valid():
+                organization_id = form.cleaned_data['organization']
+                try:
+                    with transaction.atomic():
+                        OrganizationIntegration.objects.create(
+                            organization_id=organization_id,
+                            integration=integration,
+                        )
+                except IntegrityError:
+                    return self.get_response({
+                        'error_message': 'That Sentry organization is already linked.',
+                        'form': form,
+                    })
+
+        return self.get_response({'form': form})

--- a/src/sentry/integrations/jira/configure.py
+++ b/src/sentry/integrations/jira/configure.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
 
-from django.db import IntegrityError, transaction
 from django import forms
 
 from .utils import get_integration_from_request, JiraValidationError
-from sentry.models import OrganizationIntegration
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
@@ -25,10 +23,10 @@ class JiraConfigForm(forms.Form):
 class JiraConfigureView(BaseView):
 
     def get_response(self, context):
-        context['ac_js_src'] = '%s%s%s' % (
-            self.request.GET['xdm_e'], self.request.GET.get('cp', ''),
-            '/atlassian-connect/all.js'
-        )
+        context['ac_js_src'] = '%(base_url)s%(context_path)s/atlassian-connect/all.js' % {
+            'base_url': self.request.GET['xdm_e'],
+            'context_path': self.request.GET.get('cp', ''),
+        }
         res = render_to_response('sentry/jira-configure.html', context, self.request)
         res['X-Frame-Options'] = 'ALLOW-FROM %s' % self.request.GET['xdm_e']
         return res
@@ -48,13 +46,8 @@ class JiraConfigureView(BaseView):
             form = JiraConfigForm(org_choices, request.POST)
             if form.is_valid():
                 organization_id = form.cleaned_data['organization']
-                try:
-                    with transaction.atomic():
-                        OrganizationIntegration.objects.create(
-                            organization_id=organization_id,
-                            integration=integration,
-                        )
-                except IntegrityError:
+                added = integration.add_organization(organization_id)
+                if not added:
                     return self.get_response({
                         'error_message': 'That Sentry organization is already linked.',
                         'form': form,

--- a/src/sentry/integrations/jira/descriptor.py
+++ b/src/sentry/integrations/jira/descriptor.py
@@ -32,7 +32,15 @@ class JiraDescriptorEndpoint(Endpoint):
                     'uninstalled': '/extensions/jira/uninstalled/',
                 },
                 'apiVersion': 1,
-                'modules': {},
+                'modules': {
+                    'configurePage': {
+                        'url': '/extensions/jira/configure',
+                        'name': {
+                            'value': 'Configure Sentry Add-on'
+                        },
+                        'key': 'configure-sentry'
+                    },
+                },
                 'scopes': [
                     'read',
                     'write',

--- a/src/sentry/integrations/jira/descriptor.py
+++ b/src/sentry/integrations/jira/descriptor.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+
+from six.moves.urllib.parse import urlparse
+
+from sentry.api.base import Endpoint
+from sentry.utils.http import absolute_uri
+
+
+JIRA_KEY = '%s.jira' % (urlparse(absolute_uri()).hostname, )
+
+
+class JiraDescriptorEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    def get(self, request):
+        return self.respond(
+            {
+                'name': 'Sentry',
+                'description': 'Sentry',
+                'key': JIRA_KEY,
+                'baseUrl': absolute_uri(),
+                'vendor': {
+                    'name': 'Sentry',
+                    'url': 'https://sentry.io'
+                },
+                'authentication': {
+                    'type': 'jwt'
+                },
+                'lifecycle': {
+                    'installed': '/extensions/jira/installed/',
+                    'uninstalled': '/extensions/jira/uninstalled/',
+                },
+                'apiVersion': 1,
+                'modules': {},
+                'scopes': [
+                    'read',
+                    'write',
+                    'act_as_user',
+                ]
+            }
+        )

--- a/src/sentry/integrations/jira/installed.py
+++ b/src/sentry/integrations/jira/installed.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+
+from django.db import IntegrityError, transaction
+from django.views.decorators.csrf import csrf_exempt
+
+from sentry.api.base import Endpoint
+from sentry.models import Integration
+
+
+class JiraInstalledEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        return super(JiraInstalledEndpoint, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        data = request.DATA
+
+        try:
+            with transaction.atomic():
+                Integration.objects.create(
+                    provider='jira',
+                    external_id=data['clientKey'],
+                    metadata={
+                        'oauth_client_id': data['oauthClientId'],
+                        # public key is possibly deprecated, so we can maybe remove this
+                        'public_key': data['publicKey'],
+                        'shared_secret': data['sharedSecret'],
+                        'base_url': data['baseUrl'],
+                    }
+                )
+        except IntegrityError:
+            pass
+
+        return self.respond()

--- a/src/sentry/integrations/jira/installed.py
+++ b/src/sentry/integrations/jira/installed.py
@@ -18,7 +18,7 @@ class JiraInstalledEndpoint(Endpoint):
 
     def post(self, request, *args, **kwargs):
         data = request.DATA
-
+        # TODO(jess): Handle updating existing integration
         try:
             with transaction.atomic():
                 Integration.objects.create(

--- a/src/sentry/integrations/jira/installed.py
+++ b/src/sentry/integrations/jira/installed.py
@@ -24,6 +24,7 @@ class JiraInstalledEndpoint(Endpoint):
                 Integration.objects.create(
                     provider='jira',
                     external_id=data['clientKey'],
+                    name=data['baseUrl'],
                     metadata={
                         'oauth_client_id': data['oauthClientId'],
                         # public key is possibly deprecated, so we can maybe remove this

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -3,13 +3,21 @@ from __future__ import absolute_import
 
 from sentry.integrations import Integration, IntegrationMetadata
 
+alert_link = {
+    'text': 'Visit the **Atlassian Marketplace** to install this integration.',
+    # TODO(jess): update this when we have our app listed on the
+    # atlassian marketplace
+    'link': 'https://marketplace.atlassian.com/',
+}
 
 metadata = IntegrationMetadata(
-    description='Sync Sentry and JIRA issues. This integration must be installed from the JIRA app store.',
+    description='Sync Sentry and JIRA issues.',
     author='The Sentry Team',
     issue_url='https://github.com/getsentry/sentry/issues/new?title=JIRA%20Integration:%20&labels=Component%3A%20Integrations',
     source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/jira',
-    aspects={},
+    aspects={
+        'alert_link': alert_link,
+    },
 )
 
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+
+from sentry.integrations import Integration, IntegrationMetadata
+
+
+metadata = IntegrationMetadata(
+    description='Sync Sentry and JIRA issues. This integration must be installed from the JIRA app store.',
+    author='The Sentry Team',
+    issue_url='https://github.com/getsentry/sentry/issues/new?title=JIRA%20Integration:%20&labels=Component%3A%20Integrations',
+    source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/jira',
+    aspects={},
+)
+
+
+class JiraIntegration(Integration):
+    key = 'jira'
+    name = 'JIRA'
+    metadata = metadata
+
+    can_add = False
+
+    def get_pipeline_views(self):
+        return []

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -2,12 +2,14 @@ from __future__ import absolute_import, print_function
 
 from django.conf.urls import patterns, url
 
+from .configure import JiraConfigureView
 from .descriptor import JiraDescriptorEndpoint
 from .installed import JiraInstalledEndpoint
 
 
 urlpatterns = patterns(
     '',
+    url(r'^configure/$', JiraConfigureView.as_view()),
     url(r'^descriptor/$', JiraDescriptorEndpoint.as_view()),
     url(r'^installed/$', JiraInstalledEndpoint.as_view()),
 )

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, print_function
+
+from django.conf.urls import patterns, url
+
+from .descriptor import JiraDescriptorEndpoint
+from .installed import JiraInstalledEndpoint
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^descriptor/$', JiraDescriptorEndpoint.as_view()),
+    url(r'^installed/$', JiraInstalledEndpoint.as_view()),
+)

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+
+import hashlib
+import jwt
+
+from six.moves.urllib.parse import quote
+
+from sentry.models import Integration
+
+
+class JiraValidationError(Exception):
+    pass
+
+
+def percent_encode(val):
+    # see https://en.wikipedia.org/wiki/Percent-encoding
+    return quote(val.encode('utf8', errors='replace')).replace('%7E', '~').replace('/', '%2F')
+
+
+def get_query_hash(uri, method, query_params=None):
+    # see
+    # https://developer.atlassian.com/static/connect/docs/latest/concepts/understanding-jwt.html#qsh
+    uri = uri.rstrip('/')
+    method = method.upper()
+    if query_params is None:
+        query_params = {}
+
+    sorted_query = []
+    for k, v in sorted(query_params.items()):
+        # don't include jwt query param
+        if k != 'jwt':
+            if isinstance(v, list):
+                param_val = [percent_encode(val) for val in v].join(',')
+            else:
+                param_val = percent_encode(v)
+            sorted_query.append('%s=%s' % (percent_encode(k), param_val))
+
+    query_string = '%s&%s&%s' % (method, uri, '&'.join(sorted_query))
+    return hashlib.sha256(query_string.encode('utf8')).hexdigest()
+
+
+def get_integration_from_request(request):
+    # https://developer.atlassian.com/static/connect/docs/latest/concepts/authentication.html
+    # Extract the JWT token from the request's jwt query
+    # parameter or the authorization header.
+    token = request.GET.get('jwt')
+    if token is None:
+        raise JiraValidationError('No token parameter')
+    # Decode the JWT token, without verification. This gives
+    # you a header JSON object, a claims JSON object, and a signature.
+    decoded = jwt.decode(token, verify=False)
+    # Extract the issuer ('iss') claim from the decoded, unverified
+    # claims object. This is the clientKey for the tenant - an identifier
+    # for the Atlassian application making the call
+    issuer = decoded['iss']
+    # Look up the sharedSecret for the clientKey, as stored
+    # by the add-on during the installation handshake
+    try:
+        integration = Integration.objects.get(
+            provider='jira',
+            external_id=issuer,
+        )
+    except Integration.DoesNotExist:
+        raise JiraValidationError('No integration found')
+    # Verify the signature with the sharedSecret and
+    # the algorithm specified in the header's alg field.
+    decoded_verified = jwt.decode(token, integration.metadata['shared_secret'])
+    # Verify the query has not been tampered by Creating a Query Hash
+    # and comparing it against the qsh claim on the verified token.
+
+    qsh = get_query_hash(request.path, 'GET', request.GET)
+    if qsh != decoded_verified['qsh']:
+        raise JiraValidationError('Query hash mismatch')
+
+    return integration

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -3,18 +3,12 @@ from __future__ import absolute_import
 import hashlib
 import jwt
 
-from six.moves.urllib.parse import quote
-
 from sentry.models import Integration
+from sentry.utils.http import percent_encode
 
 
 class JiraValidationError(Exception):
     pass
-
-
-def percent_encode(val):
-    # see https://en.wikipedia.org/wiki/Percent-encoding
-    return quote(val.encode('utf8', errors='replace')).replace('%7E', '~').replace('/', '%2F')
 
 
 def get_query_hash(uri, method, query_params=None):

--- a/src/sentry/static/sentry/app/views/organizationIntegrationConfig.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrationConfig.jsx
@@ -200,8 +200,10 @@ export default class OrganizationIntegrationConfig extends AsyncView {
       link = link.replace(`{${key}}`, this.props.params[key]);
     }
 
+    let props = link.startsWith('http') ? {href: link} : {to: link};
+
     return (
-      <AlertLink to={link}>
+      <AlertLink {...props}>
         <span dangerouslySetInnerHTML={{__html: linkHtml}} />
       </AlertLink>
     );

--- a/src/sentry/static/sentry/app/views/organizationIntegrationConfig.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrationConfig.jsx
@@ -223,11 +223,13 @@ export default class OrganizationIntegrationConfig extends AsyncView {
     const header = (
       <PanelHeader disablePadding hasButtons>
         <Box px={2}>{t('Workspaces')}</Box>
-        <Box mr={1}>
-          <Button size="xsmall" onClick={() => this.handleAddIntegration(provider)}>
-            <span className="icon icon-add" /> {t('Add Workspace')}
-          </Button>
-        </Box>
+        {provider.canAdd && (
+          <Box mr={1}>
+            <Button size="xsmall" onClick={() => this.handleAddIntegration(provider)}>
+              <span className="icon icon-add" /> {t('Add Workspace')}
+            </Button>
+          </Box>
+        )}
       </PanelHeader>
     );
 

--- a/src/sentry/static/sentry/app/views/projectPlugins/organizationIntegrations.jsx
+++ b/src/sentry/static/sentry/app/views/projectPlugins/organizationIntegrations.jsx
@@ -30,38 +30,49 @@ export default class OrganizationIntegrations extends AsyncComponent {
 
   getEndpoints() {
     let {orgId} = this.props;
-    return [['config', `/organizations/${orgId}/config/integrations/`]];
+    return [
+      ['config', `/organizations/${orgId}/config/integrations/`],
+      ['organization', `/organizations/${orgId}/`],
+    ];
   }
 
   renderBody() {
     let {orgId, projectId} = this.props;
+    let orgFeatures = new Set(this.state.organization.features);
+    let internalIntegrations = new Set(['jira']);
 
-    const integrations = this.state.config.providers.map(provider => (
-      <PanelItem key={provider.key} align="center">
-        <Box>
-          <PluginIcon size={32} pluginId={provider.key} />
-        </Box>
-        <Box px={2} flex={1}>
-          <ProviderName>
-            <Link
+    const integrations = this.state.config.providers
+      .filter(provider => {
+        return (
+          orgFeatures.has('internal-catchall') || !internalIntegrations.has(provider.key)
+        );
+      })
+      .map(provider => (
+        <PanelItem key={provider.key} align="center">
+          <Box>
+            <PluginIcon size={32} pluginId={provider.key} />
+          </Box>
+          <Box px={2} flex={1}>
+            <ProviderName>
+              <Link
+                to={`/settings/${orgId}/${projectId}/integrations/${provider.key}/`}
+                css={{color: theme.gray5}}
+              >
+                {provider.name}
+              </Link>
+            </ProviderName>
+            <TeamName>{provider.metadata.author}</TeamName>
+          </Box>
+          <Box>
+            <Button
+              size="small"
               to={`/settings/${orgId}/${projectId}/integrations/${provider.key}/`}
-              css={{color: theme.gray5}}
             >
-              {provider.name}
-            </Link>
-          </ProviderName>
-          <TeamName>{provider.metadata.author}</TeamName>
-        </Box>
-        <Box>
-          <Button
-            size="small"
-            to={`/settings/${orgId}/${projectId}/integrations/${provider.key}/`}
-          >
-            {t('Configure')}
-          </Button>
-        </Box>
-      </PanelItem>
-    ));
+              {t('Configure')}
+            </Button>
+          </Box>
+        </PanelItem>
+      ));
 
     return (
       <Panel>

--- a/src/sentry/templates/sentry/jira-configure.html
+++ b/src/sentry/templates/sentry/jira-configure.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script src="{{ ac_js_src }}"></script>
+</head>
+<body class="">
+  <section id="content" role="main">
+    {% if error_message %}
+        <div>{{ error_message }}</div>
+    {% endif %}
+
+    <div class="description">Choose a Sentry Organization to link to JIRA</div>
+    <form class="aui" action="" method="post">
+      {% csrf_token %}
+      {% for field in form %}
+        <div class="field-group">
+          {{ field.errors }}
+          {{ field.label_tag }} {{ field }}
+        </div>
+      {% endfor %}
+      <div class="field-group">
+        <button class="aui-button aui-button-primary" type="submit">
+            Configure Integration
+        </button>
+      </div>
+    </form>
+  </section>
+</body>
+</html>

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -11,7 +11,7 @@ import six
 
 from collections import namedtuple
 from django.conf import settings
-from six.moves.urllib.parse import parse_qs, urlencode, urljoin, urlparse
+from six.moves.urllib.parse import parse_qs, quote, urlencode, urljoin, urlparse
 from functools import partial
 
 from sentry import options
@@ -256,3 +256,8 @@ def heuristic_decode(data, possible_content_type=None):
             continue
 
     return (data, inferred_content_type)
+
+
+def percent_encode(val):
+    # see https://en.wikipedia.org/wiki/Percent-encoding
+    return quote(val.encode('utf8', errors='replace')).replace('%7E', '~').replace('/', '%2F')

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -489,6 +489,7 @@ urlpatterns += patterns(
     url(r'^extensions/(?P<provider_id>[\w_-]+)/setup/$',
         IntegrationSetupView.as_view()),
     url(r'^extensions/cloudflare/', include('sentry.integrations.cloudflare.urls')),
+    url(r'^extensions/jira/', include('sentry.integrations.jira.urls')),
     url(r'^extensions/slack/', include('sentry.integrations.slack.urls')),
 
     url(r'^plugins/', include('sentry.plugins.base.urls')),

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -461,6 +461,7 @@ window.TestStubs = {
     return {
       key: 'github',
       name: 'GitHub',
+      canAdd: true,
       config: [],
       setupDialog: {
         url: '/github-integration-setup-uri/',

--- a/tests/js/spec/views/projectPlugins/pluginNavigation.integration.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/pluginNavigation.integration.spec.jsx
@@ -22,6 +22,11 @@ describe('PluginNavigation Integration', function() {
       body: {providers: [TestStubs.GitHubIntegrationProvider()]},
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/`,
+      method: 'GET',
+      body: org,
+    });
+    MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/plugins/`,
       method: 'GET',
       body: plugins,


### PR DESCRIPTION
this is pretty bare bones, but I think it's at a point where it's worth getting in

it adds:
- the "descriptor" endpoint (how we define our app to JIRA) 
- a handler for the installation hook from JIRA
- a (really crappy looking) configuration page that is iframed in JIRA

a lot of this came from https://github.com/getsentry/sentry-plugins/tree/master/src/sentry_plugins/jira_ac

cc @MaxBittker @lauryndbrown @MeredithAnya 