### PR TITLE
fix loop logic in BgTask.run

### DIFF
--- a/src/sentry/bgtasks/api.py
+++ b/src/sentry/bgtasks/api.py
@@ -38,17 +38,18 @@ class BgTask(object):
     def run(self):
         if self.running:
             return
+        self.running = True
 
         next_run = time.time() + self.interval * random.random()
         while self.running:
-            started = time.time()
-            if next_run >= started:
+            now = time.time()
+            if now >= next_run:
                 try:
                     self.callback()
                 except Exception:
                     logging.error('bgtask.failed', exc_info=True,
                                   extra=dict(task_name=self.name))
-                next_run = started + self.interval
+                next_run = now + self.interval
             time.sleep(1.0)
 
     def reconfigure(self, cfg):


### PR DESCRIPTION
The threads that get spawned by spawn_bgtasks(role) currently immediately exit as the BgTask.running flag never gets set to True. Also, there's an issue with the value of next_run after the first callback execution.