### PR TITLE
fix(api): Add list of reserved project slug names

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -18,6 +18,7 @@ from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import DetailedProjectSerializer
 from sentry.api.serializers.rest_framework import ListField, OriginField
+from sentry.constants import RESERVED_PROJECT_SLUGS
 from sentry.models import (
     AuditLogEntryEvent, Group, GroupStatus, Project, ProjectBookmark, ProjectRedirect,
     ProjectStatus, ProjectTeam, UserOption, Team,
@@ -129,6 +130,10 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
 
     def validate_slug(self, attrs, source):
         slug = attrs[source]
+        if slug in RESERVED_PROJECT_SLUGS:
+            raise serializers.ValidationError(
+                'The slug "%s" is reserved and not allowed.' %
+                (slug, ))
         project = self.context['project']
         other = Project.objects.filter(
             slug=slug,

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -91,6 +91,11 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
     )
 )
 
+RESERVED_PROJECT_SLUGS = frozenset((
+    'api-keys', 'audit-log', 'auth', 'members', 'projects',
+    'rate-limits', 'repos', 'settings', 'teams',
+))
+
 LOG_LEVELS = {
     logging.NOTSET: 'sample',
     logging.DEBUG: 'debug',

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -21,7 +21,7 @@ from django.utils.functional import cached_property
 
 from sentry import roles
 from sentry.app import locks
-from sentry.constants import RESERVED_ORGANIZATION_SLUGS
+from sentry.constants import RESERVED_ORGANIZATION_SLUGS, RESERVED_PROJECT_SLUGS
 from sentry.db.models import (BaseManager, BoundedPositiveIntegerField, Model, sane_repr)
 from sentry.db.models.utils import slugify_instance
 from sentry.utils.http import absolute_uri
@@ -283,7 +283,11 @@ class Organization(Model):
                 with transaction.atomic():
                     project.update(organization=to_org)
             except IntegrityError:
-                slugify_instance(project, project.name, organization=to_org)
+                slugify_instance(
+                    project,
+                    project.name,
+                    organization=to_org,
+                    reserved=RESERVED_PROJECT_SLUGS)
                 project.update(
                     organization=to_org,
                     slug=project.slug,

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -20,7 +20,7 @@ from django.utils.translation import ugettext_lazy as _
 from uuid import uuid1
 
 from sentry.app import locks
-from sentry.constants import ObjectStatus
+from sentry.constants import ObjectStatus, RESERVED_PROJECT_SLUGS
 from sentry.db.models import (
     BaseManager, BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
 )
@@ -134,7 +134,11 @@ class Project(Model):
         if not self.slug:
             lock = locks.get('slug:project', duration=5)
             with TimedRetryPolicy(10)(lock.acquire):
-                slugify_instance(self, self.name, organization=self.organization)
+                slugify_instance(
+                    self,
+                    self.name,
+                    organization=self.organization,
+                    reserved=RESERVED_PROJECT_SLUGS)
             super(Project, self).save(*args, **kwargs)
         else:
             super(Project, self).save(*args, **kwargs)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -5,6 +5,7 @@ import six
 
 from django.core.urlresolvers import reverse
 
+from sentry.constants import RESERVED_PROJECT_SLUGS
 from sentry.models import Project, ProjectBookmark, ProjectStatus, UserOption, DeletedProject, ProjectRedirect, AuditLogEntry, AuditLogEntryEvent
 from sentry.testutils import APITestCase
 
@@ -215,6 +216,12 @@ class ProjectUpdateTest(APITestCase):
         assert resp.status_code == 400
         project = Project.objects.get(id=self.project.id)
         assert project.slug != new_project.slug
+
+    def test_reserved_slug(self):
+        resp = self.client.put(self.path, data={
+            'slug': list(RESERVED_PROJECT_SLUGS)[0],
+        })
+        assert resp.status_code == 400, resp.content
 
     def test_platform(self):
         resp = self.client.put(self.path, data={


### PR DESCRIPTION
Bad names may conflict with routing urls in the frontend within settings
pages, etc.

cc @billyvg I need a list of slugs that you know will conflict in whatever pages you can think of. I just added two obvious ones.