### PR TITLE
test(js): Throw on unmocked API endpoint

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -79,18 +79,10 @@ class Client {
     let [response, mock] = Client.findMockResponse(url, options) || [];
 
     if (!response) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'No mocked response found for request.',
-        url,
-        options.method || 'GET'
+      // Endpoints need to be mocked
+      throw new Error(
+        `No mocked response found for request:\n\t${options.method || 'GET'} ${url}`
       );
-      let resp = {
-        status: 404,
-        responseText: 'HTTP 404',
-        responseJSON: null,
-      };
-      respond(Client.mockAsync, options.error, resp);
     } else {
       // has mocked response
 

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectHpkpReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectHpkpReports.spec.jsx.snap
@@ -4,272 +4,125 @@ exports[`ProjectHpkpReports renders 1`] = `
 <SideEffect(DocumentTitle)
   title="Sentry"
 >
-  <RouteError
-    component={
-      ProjectHpkpReports {
-        "api": Client {},
-        "context": Object {
-          "location": Object {
-            "pathame": "/mock-pathname/",
-            "query": Object {},
-          },
-          "organization": Object {
-            "access": Array [
-              "org:read",
-              "org:write",
-              "org:admin",
-              "project:read",
-              "project:write",
-              "project:admin",
-              "team:read",
-              "team:write",
-              "team:admin",
-            ],
-            "features": Array [],
-            "id": "3",
-            "name": "Organization Name",
-            "onboardingTasks": Array [],
-            "projects": Array [],
-            "slug": "org-slug",
-            "status": Object {
-              "id": "active",
-              "name": "active",
-            },
-            "teams": Array [],
-          },
-          "project": Object {
-            "hasAccess": true,
-            "id": "2",
-            "isBookmarked": false,
-            "isMember": true,
-            "name": "Project Name",
-            "slug": "project-slug",
-            "teams": Array [],
-          },
-          "router": Object {
-            "createHref": [MockFunction],
-            "go": [MockFunction],
-            "goBack": [MockFunction],
-            "goForward": [MockFunction],
-            "isActive": [MockFunction],
-            "location": Object {
-              "query": Object {},
-            },
-            "push": [MockFunction],
-            "replace": [MockFunction],
-            "setRouteLeaveHook": [MockFunction],
-          },
-        },
-        "fetchData": [Function],
-        "props": Object {
-          "location": Object {
-            "pathame": "/mock-pathname/",
-            "pathname": "/projects/org-slug/project-slug/hpkp/",
-            "query": Object {},
-          },
-          "organization": Object {
-            "access": Array [
-              "org:read",
-              "org:write",
-              "org:admin",
-              "project:read",
-              "project:write",
-              "project:admin",
-              "team:read",
-              "team:write",
-              "team:admin",
-            ],
-            "features": Array [],
-            "id": "3",
-            "name": "Organization Name",
-            "onboardingTasks": Array [],
-            "projects": Array [],
-            "slug": "org-slug",
-            "status": Object {
-              "id": "active",
-              "name": "active",
-            },
-            "teams": Array [],
-          },
-          "params": Object {
-            "orgId": "org-slug",
-            "projectId": "project-slug",
-          },
-          "project": Object {
-            "hasAccess": true,
-            "id": "2",
-            "isBookmarked": false,
-            "isMember": true,
-            "name": "Project Name",
-            "slug": "project-slug",
-            "teams": Array [],
-          },
-          "routes": Array [],
-          "setProjectNavSection": [Function],
-          "stepBack": [Function],
-        },
-        "refs": Object {},
-        "remountComponent": [Function],
-        "render": [Function],
-        "state": Object {
-          "error": true,
-          "errors": Object {
-            "project": Object {
-              "responseJSON": null,
-              "responseText": "HTTP 404",
-              "status": 404,
-            },
-          },
-          "keyList": Array [],
-          "keyListPageLinks": undefined,
-          "loading": false,
-          "project": null,
-          "remainingRequests": 0,
-        },
-        "updater": Updater {
-          "_callbacks": Array [],
-          "_renderer": ReactShallowRenderer {
-            "_context": Object {
-              "location": Object {
-                "pathame": "/mock-pathname/",
-                "query": Object {},
-              },
-              "organization": Object {
-                "access": Array [
-                  "org:read",
-                  "org:write",
-                  "org:admin",
-                  "project:read",
-                  "project:write",
-                  "project:admin",
-                  "team:read",
-                  "team:write",
-                  "team:admin",
-                ],
-                "features": Array [],
-                "id": "3",
-                "name": "Organization Name",
-                "onboardingTasks": Array [],
-                "projects": Array [],
-                "slug": "org-slug",
-                "status": Object {
-                  "id": "active",
-                  "name": "active",
-                },
-                "teams": Array [],
-              },
-              "project": Object {
-                "hasAccess": true,
-                "id": "2",
-                "isBookmarked": false,
-                "isMember": true,
-                "name": "Project Name",
-                "slug": "project-slug",
-                "teams": Array [],
-              },
-              "router": Object {
-                "createHref": [MockFunction],
-                "go": [MockFunction],
-                "goBack": [MockFunction],
-                "goForward": [MockFunction],
-                "isActive": [MockFunction],
-                "location": Object {
-                  "query": Object {},
-                },
-                "push": [MockFunction],
-                "replace": [MockFunction],
-                "setRouteLeaveHook": [MockFunction],
-              },
-            },
-            "_element": <ProjectHpkpReports
-              location={
-                Object {
-                  "pathame": "/mock-pathname/",
-                  "pathname": "/projects/org-slug/project-slug/hpkp/",
-                  "query": Object {},
-                }
-              }
-              organization={
-                Object {
-                  "access": Array [
-                    "org:read",
-                    "org:write",
-                    "org:admin",
-                    "project:read",
-                    "project:write",
-                    "project:admin",
-                    "team:read",
-                    "team:write",
-                    "team:admin",
-                  ],
-                  "features": Array [],
-                  "id": "3",
-                  "name": "Organization Name",
-                  "onboardingTasks": Array [],
-                  "projects": Array [],
-                  "slug": "org-slug",
-                  "status": Object {
-                    "id": "active",
-                    "name": "active",
-                  },
-                  "teams": Array [],
-                }
-              }
-              params={
-                Object {
-                  "orgId": "org-slug",
-                  "projectId": "project-slug",
-                }
-              }
-              project={
-                Object {
-                  "hasAccess": true,
-                  "id": "2",
-                  "isBookmarked": false,
-                  "isMember": true,
-                  "name": "Project Name",
-                  "slug": "project-slug",
-                  "teams": Array [],
-                }
-              }
-              routes={Array []}
-              setProjectNavSection={[Function]}
-              stepBack={[Function]}
-            />,
-            "_forcedUpdate": false,
-            "_instance": [Circular],
-            "_newState": Object {
-              "error": true,
-              "errors": Object {
-                "project": Object {
-                  "responseJSON": null,
-                  "responseText": "HTTP 404",
-                  "status": 404,
-                },
-              },
-              "keyList": Array [],
-              "keyListPageLinks": undefined,
-              "loading": false,
-              "project": null,
-              "remainingRequests": 0,
-            },
-            "_rendered": <SideEffect(DocumentTitle)
-              title="Sentry"
-            >
-              <RouteError
-                component={[Circular]}
-                error={[Error: Unable to load all required endpoints]}
-                onRetry={[Function]}
-              />
-            </SideEffect(DocumentTitle)>,
-            "_rendering": false,
-            "_updater": [Circular],
-          },
-        },
+  <div>
+    <SettingsPageHeading
+      title="HTTP Public Key Pinning"
+    />
+    <PreviewFeature />
+    <ReportUri
+      keyList={Array []}
+      params={
+        Object {
+          "orgId": "org-slug",
+          "projectId": "project-slug",
+        }
       }
-    }
-    error={[Error: Unable to load all required endpoints]}
-    onRetry={[Function]}
-  />
+    />
+    <Panel>
+      <PanelHeader>
+        About
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={false}
+        flex={false}
+      >
+        <TextBlock>
+          <span
+            key="4"
+          >
+            <ExternalLink
+              href="https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning"
+              key="1"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              <span
+                key="0"
+              >
+                HTTP Public Key Pinning
+              </span>
+            </ExternalLink>
+            <span
+              key="2"
+            >
+              
+              (HPKP) is a security feature that tells a web client to associate a specific
+              cryptographic public key with a certain web server to decrease the risk of MITM
+              attacks with forged certificates. It's enforced by browser vendors, and Sentry
+              supports capturing violations using the standard reporting hooks.
+            </span>
+          </span>
+        </TextBlock>
+        <TextBlock>
+          To configure HPKP reports
+              in Sentry, you'll need to send a header from your server describing your
+              policy, as well specifying the authenticated Sentry endpoint.
+        </TextBlock>
+        <TextBlock
+          noMargin={true}
+        >
+          For example, in Python you might achieve this via a simple web middleware
+        </TextBlock>
+        <CodeBlock>
+          def middleware(request, response):
+    response['Public-Key-Pins'] = \\
+        'pin-sha256="cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs="; ' \\
+        'pin-sha256="M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE="; ' \\
+        'max-age=5184000; includeSubDomains; ' \\
+        'report-uri="https://sentry.example.com/api/security-report/"' 
+    return response
+
+        </CodeBlock>
+        <TextBlock
+          noMargin={true}
+        >
+          Alternatively you can setup HPKP reports to simply send reports rather than
+              actually enforcing the policy
+        </TextBlock>
+        <CodeBlock>
+          def middleware(request, response):
+    response['Public-Key-Pins-Report-Only'] = \\
+        'pin-sha256="cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs="; ' \\
+        'pin-sha256="M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE="; ' \\
+        'max-age=5184000; includeSubDomains; ' \\
+        'report-uri="https://sentry.example.com/api/security-report/"' 
+    return response
+
+        </CodeBlock>
+        <TextBlock
+          className="css-46b038"
+          noMargin={true}
+        >
+          <span
+            key="5"
+          >
+            <span
+              key="0"
+            >
+              We recommend setting this up to only run on a percentage of requests, as
+              otherwise you may find that you've quickly exhausted your quota. For more
+              information, take a look at 
+            </span>
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning"
+              key="2"
+            >
+              <span
+                key="1"
+              >
+                the documentation on MDN
+              </span>
+            </a>
+            <span
+              key="3"
+            >
+              .
+            </span>
+          </span>
+        </TextBlock>
+      </PanelBody>
+    </Panel>
+  </div>
 </SideEffect(DocumentTitle)>
 `;

--- a/tests/js/spec/views/projectSecurityHeaders/projectHpkpReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectHpkpReports.spec.jsx
@@ -13,6 +13,11 @@ describe('ProjectHpkpReports', function() {
   beforeEach(function() {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/keys/`,
       method: 'GET',
       body: [],


### PR DESCRIPTION
Unmocked APIs will now throw and cause a test failure instead of only printing to console. This should eliminate tests that incorrectly snapshot errors.