### PR TITLE
ref(services): Keep full traceback object in executors

### DIFF
--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import sys
 import threading
 from Queue import Full, PriorityQueue
 from concurrent.futures import Future
@@ -121,8 +122,8 @@ class SynchronousExecutor(Executor):
         assert future.set_running_or_notify_cancel()
         try:
             result = callable()
-        except Exception as error:
-            future.set_exception(error)
+        except Exception:
+            future.set_exception_info(*sys.exc_info()[1:])
         else:
             future.set_result(result)
         return future
@@ -154,8 +155,8 @@ class ThreadedExecutor(Executor):
                 continue
             try:
                 result = function()
-            except Exception as error:
-                future.set_exception(error)
+            except Exception:
+                future.set_exception_info(*sys.exc_info()[1:])
             else:
                 future.set_result(result)
             queue.task_done()


### PR DESCRIPTION
This allows stitching together the full traceback across the calling and executor thread: https://gist.github.com/tkaemming/616090aabf1098096f8880d0a51ed196

This mirrors the `concurrent.futures` implementation: https://github.com/agronholm/pythonfutures/blob/5edbc65401fd578e195c2f0e2e8d3a6b5404f6bc/concurrent/futures/thread.py#L62-L68