### PR TITLE
fix(ui): Avatar should never shrink when inside flexbox

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
@@ -144,6 +144,8 @@ class BaseAvatar extends React.Component {
 
 export default BaseAvatar;
 
+// Note: Avatar will not always be a child of a flex layout, but this seems like a
+// sensible default.
 const StyledBaseAvatar = styled('span')`
   flex-shrink: 0;
 `;


### PR DESCRIPTION
There are a few PRs in the works that depend on this behavior