### PR TITLE
feat(command-palette): Event ID Endpoint for Command Palette

### DIFF
--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+
+import six
+
+from rest_framework.response import Response
+
+from sentry.api.base import DocSection
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models import Project, Event, EventMapping
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.utils.apidocs import scenario, attach_scenarios
+
+
+@scenario('ResolveEventId')
+def resolve_event_id_scenario(runner):
+    event = Event.objects.filter(project=runner.default_project).first()
+    runner.request(
+        method='GET',
+        path='/organizations/%s/eventids/%s/' % (runner.org.slug, event.event_id, )
+    )
+
+
+class EventIdLookupEndpoint(OrganizationEndpoint):
+    doc_section = DocSection.ORGANIZATIONS
+
+    @attach_scenarios([resolve_event_id_scenario])
+    def get(self, request, organization, event_id):
+        """
+        Resolve a Event ID
+        ``````````````````
+
+        This resolves a event ID to the project slug and internal issue ID and internal event ID.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          event ID should be looked up in.
+        :param string event_id: the event ID to look up.
+        :auth: required
+        """
+
+        # Largely copied from ProjectGroupIndexEndpoint
+        if len(event_id) != 32:
+            return Response({'detail': 'Event ID must be 32 characters.'}, status=400)
+
+        project_ids = Project.objects.filter(organization=organization).values_list('id', flat=True)
+
+        try:
+            event = Event.objects.filter(event_id=event_id, project_id__in=project_ids).get()
+        except Event.DoesNotExist:
+            try:
+                EventMapping.objects.filter(event_id=event_id, project_id__in=project_ids).get()
+            except EventMapping.DoesNotExist:
+                raise ResourceDoesNotExist()
+
+        return Response(
+            {
+                'organizationSlug': organization.slug,
+                'projectSlug': event.group.project.slug,
+                'groupId': six.text_type(event.group_id),
+                'eventId': event.id,
+            }
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -49,6 +49,7 @@ from .endpoints.organization_auth_provider_send_reminders import OrganizationAut
 from .endpoints.organization_avatar import OrganizationAvatarEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
 from .endpoints.organization_shortid import ShortIdLookupEndpoint
+from .endpoints.organization_eventid import EventIdLookupEndpoint
 from .endpoints.organization_slugs import SlugsUpdateEndpoint
 from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
 from .endpoints.organization_member_details import OrganizationMemberDetailsEndpoint
@@ -313,6 +314,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/shortids/(?P<short_id>[^\/]+)/$',
         ShortIdLookupEndpoint.as_view(),
         name='sentry-api-0-short-id-lookup'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/eventids/(?P<event_id>[^\/]+)/$',
+        EventIdLookupEndpoint.as_view(),
+        name='sentry-api-0-event-id-lookup'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/slugs/$',

--- a/tests/sentry/api/endpoints/test_organization_eventid.py
+++ b/tests/sentry/api/endpoints/test_organization_eventid.py
@@ -8,22 +8,35 @@ from sentry.testutils import APITestCase
 
 
 class EventIdLookupEndpointTest(APITestCase):
-    def test_simple(self):
-        org = self.create_organization(owner=self.user)
-        project = self.create_project(organization=org)
-        group = self.create_group(checksum='a' * 32, project=project)
-        event = self.create_event('b' * 32, group=group)
+    def setUp(self):
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.group = self.create_group(checksum='a' * 32, project=self.project)
+        self.event = self.create_event('b' * 32, group=self.group)
         self.login_as(user=self.user)
+
+    def test_simple(self):
         url = reverse(
             'sentry-api-0-event-id-lookup', kwargs={
-                'organization_slug': org.slug,
-                'event_id': event.event_id,
+                'organization_slug': self.org.slug,
+                'event_id': self.event.event_id,
             }
         )
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
-        assert response.data['organizationSlug'] == org.slug
-        assert response.data['projectSlug'] == project.slug
-        assert response.data['groupId'] == six.text_type(group.id)
-        assert response.data['eventId'] == six.text_type(event.id)
+        assert response.data['organizationSlug'] == self.org.slug
+        assert response.data['projectSlug'] == self.project.slug
+        assert response.data['groupId'] == six.text_type(self.group.id)
+        assert response.data['eventId'] == six.text_type(self.event.id)
+
+    def test_missing_eventid(self):
+        url = reverse(
+            'sentry-api-0-event-id-lookup', kwargs={
+                'organization_slug': self.org.slug,
+                'event_id': 'c' * 32,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 404, response.content

--- a/tests/sentry/api/endpoints/test_organization_eventid.py
+++ b/tests/sentry/api/endpoints/test_organization_eventid.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+import six
+
+from sentry.testutils import APITestCase
+
+
+class EventIdLookupEndpointTest(APITestCase):
+    def test_simple(self):
+        org = self.create_organization(owner=self.user)
+        project = self.create_project(organization=org)
+        group = self.create_group(checksum='a' * 32, project=project)
+        event = self.create_event('b' * 32, group=group)
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-event-id-lookup', kwargs={
+                'organization_slug': org.slug,
+                'event_id': event.event_id,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['organizationSlug'] == org.slug
+        assert response.data['projectSlug'] == project.slug
+        assert response.data['groupId'] == six.text_type(group.id)
+        assert response.data['eventId'] == event.id

--- a/tests/sentry/api/endpoints/test_organization_eventid.py
+++ b/tests/sentry/api/endpoints/test_organization_eventid.py
@@ -26,4 +26,4 @@ class EventIdLookupEndpointTest(APITestCase):
         assert response.data['organizationSlug'] == org.slug
         assert response.data['projectSlug'] == project.slug
         assert response.data['groupId'] == six.text_type(group.id)
-        assert response.data['eventId'] == event.id
+        assert response.data['eventId'] == six.text_type(event.id)

--- a/tests/sentry/api/endpoints/test_organization_shortid.py
+++ b/tests/sentry/api/endpoints/test_organization_shortid.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+import six
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+
+class ShortIdLookupEndpointTest(APITestCase):
+    def test_simple(self):
+        org = self.create_organization(owner=self.user)
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project, short_id=project.next_short_id())
+
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-short-id-lookup', kwargs={
+                'organization_slug': org.slug,
+                'short_id': group.qualified_short_id,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['organizationSlug'] == org.slug
+        assert response.data['projectSlug'] == project.slug
+        assert response.data['groupId'] == six.text_type(group.id)


### PR DESCRIPTION
A proposed endpoint for letting command palette GOTO events.

@billyvg the short_id endpoint [already exists](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/organization_shortid.py).

Will add tests if it's useful.