### PR TITLE
fix(environments): Use null to represent all environments in project details

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -88,7 +88,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     securityToken = serializers.RegexField(r'^[-a-zA-Z0-9+/=\s]+$', max_length=255)
     securityTokenHeader = serializers.RegexField(r'^[a-zA-Z0-9_\-]+$', max_length=20)
     verifySSL = serializers.BooleanField(required=False)
-    defaultEnvironment = serializers.CharField(required=False)
+    defaultEnvironment = serializers.CharField(required=False, allow_none=True)
     dataScrubber = serializers.BooleanField(required=False)
     dataScrubberDefaults = serializers.BooleanField(required=False)
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
@@ -350,8 +350,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if result.get('subjectTemplate'):
             project.update_option('mail:subject_template',
                                   result['subjectTemplate'])
-        if result.get('defaultEnvironment') is not None:
-            project.update_option('sentry:default_environment', result['defaultEnvironment'])
         if result.get('scrubIPAddresses') is not None:
             project.update_option('sentry:scrub_ip_address', result['scrubIPAddresses'])
         if result.get('securityToken') is not None:
@@ -368,6 +366,11 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             project.update_option('sentry:sensitive_fields', result['sensitiveFields'])
         if result.get('safeFields') is not None:
             project.update_option('sentry:safe_fields', result['safeFields'])
+        if 'defaultEnvironment' in result:
+            if result['defaultEnvironment'] is None:
+                project.delete_option('sentry:default_environment')
+            else:
+                project.update_option('sentry:default_environment', result['defaultEnvironment'])
         # resolveAge can be None
         if 'resolveAge' in result:
             if project.update_option(

--- a/src/sentry/static/sentry/app/stores/environmentStore.jsx
+++ b/src/sentry/static/sentry/app/stores/environmentStore.jsx
@@ -7,14 +7,6 @@ import EnvironmentActions from 'app/actions/environmentActions';
 import {setActiveEnvironment} from 'app/actionCreators/environments';
 import {ALL_ENVIRONMENTS_KEY} from 'app/constants';
 
-const PRODUCTION_ENV_NAMES = new Set([
-  'production',
-  'prod',
-  'release',
-  'master',
-  'trunk',
-]);
-
 const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
 const DEFAULT_EMPTY_ROUTING_NAME = 'none';
 
@@ -90,9 +82,7 @@ const EnvironmentStore = Reflux.createStore({
 
     let defaultEnv = allEnvs.find(e => e.name === this.defaultEnvironment);
 
-    let prodEnv = allEnvs.find(e => PRODUCTION_ENV_NAMES.has(e.name));
-
-    return defaultEnv || prodEnv || null;
+    return defaultEnv || null;
   },
 });
 

--- a/src/sentry/static/sentry/app/views/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/projectEnvironments.jsx
@@ -152,7 +152,10 @@ const ProjectEnvironments = createReactClass({
 
   // Change "Default Environment"
   handleSetAsDefault(env) {
-    const data = {defaultEnvironment: env.name};
+    const defaultEnvironment = env.name === ALL_ENVIRONMENTS_KEY ? null : env.name;
+
+    const data = {defaultEnvironment};
+
     const oldProject = this.state.project;
 
     // Optimistically update state
@@ -212,8 +215,7 @@ const ProjectEnvironments = createReactClass({
     if (this.state.isHidden) return null;
     let {project} = this.state;
 
-    let isAllEnvironmentsDefault =
-      project && project.defaultEnvironment === ALL_ENVIRONMENTS_KEY;
+    let isAllEnvironmentsDefault = project && project.defaultEnvironment === null;
 
     return (
       <EnvironmentRow
@@ -237,8 +239,7 @@ const ProjectEnvironments = createReactClass({
     if (this.state.isHidden) return null;
     let {environments, project} = this.state;
     // Default environment that is not a valid environment
-    let isAllEnvironmentsDefault =
-      project && project.defaultEnvironment === ALL_ENVIRONMENTS_KEY;
+    let isAllEnvironmentsDefault = project && project.defaultEnvironment === null;
 
     let hasOtherDefaultEnvironment =
       project &&

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -444,12 +444,12 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem eo8n7lk0"
+                      className="css-qcergp-StyledPanelItem css-q9h14u0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem eo8n7lk0"
+                        className="css-qcergp-StyledPanelItem css-q9h14u0"
                         is={null}
                       >
                         <Flex
@@ -573,12 +573,12 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem eo8n7lk0"
+                      className="css-qcergp-StyledPanelItem css-q9h14u0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem eo8n7lk0"
+                        className="css-qcergp-StyledPanelItem css-q9h14u0"
                         is={null}
                       >
                         <Flex
@@ -772,12 +772,12 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem eo8n7lk0"
+                      className="css-qcergp-StyledPanelItem css-q9h14u0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem eo8n7lk0"
+                        className="css-qcergp-StyledPanelItem css-q9h14u0"
                         is={null}
                       >
                         <Flex
@@ -803,7 +803,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                   priority="success"
                                 >
                                   <span
-                                    className="css-giy4xh-TagTextStyled e6q9yfr0"
+                                    className="css-giy4xh-TagTextStyled css-3x95g0"
                                   >
                                     Default
                                   </span>
@@ -1344,12 +1344,12 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem eo8n7lk0"
+                      className="css-qcergp-StyledPanelItem css-q9h14u0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem eo8n7lk0"
+                        className="css-qcergp-StyledPanelItem css-q9h14u0"
                         is={null}
                       >
                         <Flex

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -444,12 +444,12 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem css-q9h14u0"
+                      className="css-qcergp-StyledPanelItem eo8n7lk0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem css-q9h14u0"
+                        className="css-qcergp-StyledPanelItem eo8n7lk0"
                         is={null}
                       >
                         <Flex
@@ -573,12 +573,12 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem css-q9h14u0"
+                      className="css-qcergp-StyledPanelItem eo8n7lk0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem css-q9h14u0"
+                        className="css-qcergp-StyledPanelItem eo8n7lk0"
                         is={null}
                       >
                         <Flex
@@ -772,12 +772,12 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem css-q9h14u0"
+                      className="css-qcergp-StyledPanelItem eo8n7lk0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem css-q9h14u0"
+                        className="css-qcergp-StyledPanelItem eo8n7lk0"
                         is={null}
                       >
                         <Flex
@@ -803,7 +803,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                   priority="success"
                                 >
                                   <span
-                                    className="css-giy4xh-TagTextStyled css-3x95g0"
+                                    className="css-giy4xh-TagTextStyled e6q9yfr0"
                                   >
                                     Default
                                   </span>
@@ -1344,12 +1344,12 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                   >
                     <Base
                       align="center"
-                      className="css-qcergp-StyledPanelItem css-q9h14u0"
+                      className="css-qcergp-StyledPanelItem eo8n7lk0"
                       justify="space-between"
                       p={2}
                     >
                       <div
-                        className="css-qcergp-StyledPanelItem css-q9h14u0"
+                        className="css-qcergp-StyledPanelItem eo8n7lk0"
                         is={null}
                       >
                         <Flex

--- a/tests/js/spec/views/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/projectEnvironments.spec.jsx
@@ -163,7 +163,7 @@ describe('ProjectEnvironments', function() {
         expect.anything(),
         expect.objectContaining({
           data: {
-            defaultEnvironment: ALL_ENVIRONMENTS_KEY,
+            defaultEnvironment: null,
           },
         })
       );


### PR DESCRIPTION
Use a null value instead of `__all_environments__` to represent all environments

Fixes APP-147