### PR TITLE
fix(snuba): Trim unneeded results from Snuba TSDB

### DIFF
--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -290,10 +290,6 @@ class SnubaTSDBTest(TestCase):
         }
 
     def test_frequency_series(self):
-        # Technically while we request both releases for group1
-        # and only release 1 on group2, that distinction is lost
-        # in the snuba query, and we return a frequency series for
-        # both releases * both groups
         dts = [self.now + timedelta(hours=i) for i in range(4)]
         assert self.db.get_frequency_series(
             TSDBModel.frequent_releases_by_group,

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -325,19 +325,15 @@ class SnubaTSDBTest(TestCase):
             self.proj1group2.id: [
                 (timestamp(dts[0]), {
                     self.release1.id: 0,
-                    self.release2.id: 0,
                 }),
                 (timestamp(dts[1]), {
                     self.release1.id: 3,
-                    self.release2.id: 0,
                 }),
                 (timestamp(dts[2]), {
                     self.release1.id: 0,
-                    self.release2.id: 3,
                 }),
                 (timestamp(dts[3]), {
                     self.release1.id: 0,
-                    self.release2.id: 0,
                 }),
             ],
         }


### PR DESCRIPTION
This is a pretty hacky function, but works to trim TSDB keys where
the client doesn't expect them.