### PR TITLE
ref(storybook): Use "app" alias for imports

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,8 +10,6 @@ const staticPath = path.resolve(
   'sentry',
   'app'
 );
-const componentPath = path.resolve(staticPath, 'components');
-const newSettingsPath = path.resolve(staticPath, 'views', 'settings', 'components');
 
 const sentryConfig = require('../webpack.config');
 const appConfig = sentryConfig[0];
@@ -83,9 +81,7 @@ module.exports = {
   resolve: {
     extensions: appConfig.resolve.extensions,
     alias: Object.assign({}, appConfig.resolve.alias, {
-      'sentry-ui': componentPath,
-      'settings-ui': newSettingsPath,
-      'application-root': staticPath,
+      app: staticPath,
     }),
   },
 };

--- a/docs-ui/components/alertLink.stories.js
+++ b/docs-ui/components/alertLink.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import AlertLink from 'sentry-ui/alertLink';
+import AlertLink from 'app/components/alertLink';
 
 storiesOf('Links/AlertLink', module)
   .add(

--- a/docs-ui/components/alertMessage.stories.js
+++ b/docs-ui/components/alertMessage.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import AlertMessage from 'sentry-ui/alertMessage';
+import AlertMessage from 'app/components/alertMessage';
 
 storiesOf('AlertMessage', module)
   .add(

--- a/docs-ui/components/autoComplete.stories.js
+++ b/docs-ui/components/autoComplete.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import AutoComplete from 'sentry-ui/autoComplete';
+import AutoComplete from 'app/components/autoComplete';
 
 const items = [
   {

--- a/docs-ui/components/avatar.stories.js
+++ b/docs-ui/components/avatar.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import Avatar from 'sentry-ui/avatar';
+import Avatar from 'app/components/avatar';
 
 const USER = {
   id: 1,

--- a/docs-ui/components/badge.stories.js
+++ b/docs-ui/components/badge.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import Badge from 'sentry-ui/badge';
+import Badge from 'app/components/badge';
 
 storiesOf('Badge', module).add(
   'default',

--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -5,8 +5,8 @@ import {withInfo} from '@storybook/addon-info';
 import {action} from '@storybook/addon-actions';
 import {boolean} from '@storybook/addon-knobs';
 
-import Button from 'sentry-ui/buttons/button';
-import DropdownButton from 'sentry-ui/dropdownButton';
+import Button from 'app/components/buttons/button';
+import DropdownButton from 'app/components/dropdownButton';
 
 const Item = styled('span')`
   padding: 12px;

--- a/docs-ui/components/circleIndicator.stories.js
+++ b/docs-ui/components/circleIndicator.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {number, boolean} from '@storybook/addon-knobs';
 
-import CircleIndicator from 'sentry-ui/circleIndicator';
+import CircleIndicator from 'app/components/circleIndicator';
 
 storiesOf('CircleIndicator', module).add(
   'default',

--- a/docs-ui/components/clipboard.stories.js
+++ b/docs-ui/components/clipboard.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import Clipboard from 'sentry-ui/clipboard';
+import Clipboard from 'app/components/clipboard';
 
 storiesOf('Clipboard', module).add(
   'default',

--- a/docs-ui/components/clippedBox.stories.js
+++ b/docs-ui/components/clippedBox.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import ClippedBox from 'sentry-ui/clippedBox';
+import ClippedBox from 'app/components/clippedBox';
 
 storiesOf('ClippedBox', module).add(
   'default',

--- a/docs-ui/components/confirm.stories.js
+++ b/docs-ui/components/confirm.stories.js
@@ -3,8 +3,8 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {action} from '@storybook/addon-actions';
 
-import Confirm from 'sentry-ui/confirm';
-import Button from 'sentry-ui/buttons/button';
+import Confirm from 'app/components/confirm';
+import Button from 'app/components/buttons/button';
 
 storiesOf('Confirm/Confirm', module).add(
   'default',

--- a/docs-ui/components/contextData.stories.js
+++ b/docs-ui/components/contextData.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import ContextData from 'sentry-ui/contextData';
+import ContextData from 'app/components/contextData';
 
 storiesOf('ContextData', module).add(
   'strings',

--- a/docs-ui/components/detailedError.stories.js
+++ b/docs-ui/components/detailedError.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import DetailedError from 'sentry-ui/errors/detailedError';
+import DetailedError from 'app/components/errors/detailedError';
 
 // eslint-disable-next-line
 storiesOf('DetailedError', module)

--- a/docs-ui/components/dropdownAutoComplete.stories.js
+++ b/docs-ui/components/dropdownAutoComplete.stories.js
@@ -2,9 +2,9 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import Button from 'sentry-ui/buttons/button';
-import DropdownAutoComplete from 'sentry-ui/dropdownAutoComplete';
-import DropdownButton from 'sentry-ui/dropdownButton';
+import Button from 'app/components/buttons/button';
+import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
+import DropdownButton from 'app/components/dropdownButton';
 
 const items = [
   {

--- a/docs-ui/components/dropdownLink.stories.js
+++ b/docs-ui/components/dropdownLink.stories.js
@@ -3,8 +3,8 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import DropdownLink from 'sentry-ui/dropdownLink';
-import MenuItem from 'sentry-ui/menuItem';
+import DropdownLink from 'app/components/dropdownLink';
+import MenuItem from 'app/components/menuItem';
 
 storiesOf('Links/DropdownLink', module)
   .add(

--- a/docs-ui/components/dynamicWrapper.stories.js
+++ b/docs-ui/components/dynamicWrapper.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import DynamicWrapper from 'sentry-ui/dynamicWrapper';
+import DynamicWrapper from 'app/components/dynamicWrapper';
 
 storiesOf('DynamicWrapper', module).add(
   'default',

--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -2,10 +2,10 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import {Panel, PanelHeader} from 'sentry-ui/panels';
-import EmptyMessage from 'settings-ui/emptyMessage';
+import {Panel, PanelHeader} from 'app/components/panels';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
-import Button from 'sentry-ui/buttons/button';
+import Button from 'app/components/buttons/button';
 
 storiesOf('EmptyMessage', module)
   .add(

--- a/docs-ui/components/emptyStateWarning.stories.js
+++ b/docs-ui/components/emptyStateWarning.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import EmptyStateWarning from 'sentry-ui/emptyStateWarning';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
 
 storiesOf('EmptyStateWarning', module).add(
   'default',

--- a/docs-ui/components/externalLink.stories.js
+++ b/docs-ui/components/externalLink.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import ExternalLink from 'sentry-ui/externalLink';
+import ExternalLink from 'app/components/externalLink';
 
 storiesOf('Links/ExternalLink', module).add(
   'default',

--- a/docs-ui/components/flowLayout.stories.js
+++ b/docs-ui/components/flowLayout.stories.js
@@ -3,8 +3,8 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import FlowLayout from 'sentry-ui/flowLayout';
-import SpreadLayout from 'sentry-ui/spreadLayout';
+import FlowLayout from 'app/components/flowLayout';
+import SpreadLayout from 'app/components/spreadLayout';
 
 storiesOf('ComponentLayouts/FlowLayout', module)
   .add(

--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -9,14 +9,14 @@ import {
   TextField as LegacyTextField,
   PasswordField,
   BooleanField,
-} from 'sentry-ui/forms';
-import NewBooleanField from 'settings-ui/forms/booleanField';
-import RadioField from 'settings-ui/forms/radioField';
-import RadioGroup from 'settings-ui/forms/controls/radioGroup';
-import RangeSlider from 'settings-ui/forms/controls/rangeSlider';
-import Form from 'settings-ui/forms/form';
-import FormField from 'settings-ui/forms/formField';
-import TextField from 'settings-ui/forms/textField';
+} from 'app/components/forms';
+import NewBooleanField from 'app/views/settings/components/forms/booleanField';
+import RadioField from 'app/views/settings/components/forms/radioField';
+import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
+import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
+import Form from 'app/views/settings/components/forms/form';
+import FormField from 'app/views/settings/components/forms/formField';
+import TextField from 'app/views/settings/components/forms/textField';
 
 class UndoButton extends React.Component {
   static contextTypes = {

--- a/docs-ui/components/formatters.stories.js
+++ b/docs-ui/components/formatters.stories.js
@@ -3,10 +3,10 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import FileSize from 'sentry-ui/fileSize';
-import Duration from 'sentry-ui/duration';
-import DateTime from 'sentry-ui/dateTime';
-import Count from 'sentry-ui/count';
+import FileSize from 'app/components/fileSize';
+import Duration from 'app/components/duration';
+import DateTime from 'app/components/dateTime';
+import Count from 'app/components/count';
 
 storiesOf('Formatters', module)
   .add(

--- a/docs-ui/components/globalModal.stories.js
+++ b/docs-ui/components/globalModal.stories.js
@@ -2,9 +2,9 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import GlobalModal from 'sentry-ui/globalModal';
-import Button from 'sentry-ui/buttons/button';
-import {openModal} from 'application-root/actionCreators/modal';
+import GlobalModal from 'app/components/globalModal';
+import Button from 'app/components/buttons/button';
+import {openModal} from 'app/actionCreators/modal';
 
 storiesOf('GlobalModal', module).add(
   'default',

--- a/docs-ui/components/hovercard.stories.js
+++ b/docs-ui/components/hovercard.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {text} from '@storybook/addon-knobs';
 
-import Hovercard from 'sentry-ui/hovercard';
+import Hovercard from 'app/components/hovercard';
 
 storiesOf('Hovercard', module).add(
   'default',

--- a/docs-ui/components/indicators.stories.js
+++ b/docs-ui/components/indicators.stories.js
@@ -3,14 +3,14 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {select} from '@storybook/addon-knobs';
 
-import IndicatorContainer, {Indicators} from 'sentry-ui/indicators';
-import IndicatorStore from 'application-root/stores/indicatorStore';
+import IndicatorContainer, {Indicators} from 'app/components/indicators';
+import IndicatorStore from 'app/stores/indicatorStore';
 import {
   addSuccessMessage,
   addErrorMessage,
   addMessage,
-} from 'application-root/actionCreators/indicator';
-import Button from 'sentry-ui/buttons/button';
+} from 'app/actionCreators/indicator';
+import Button from 'app/components/buttons/button';
 
 const stories = storiesOf('Toast Indicators', module);
 stories

--- a/docs-ui/components/lazyLoad.stories.js
+++ b/docs-ui/components/lazyLoad.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import LazyLoad from 'sentry-ui/lazyLoad';
+import LazyLoad from 'app/components/lazyLoad';
 
 storiesOf('LazyLoad', module).add(
   'default',

--- a/docs-ui/components/linkWithConfirmation.stories.js
+++ b/docs-ui/components/linkWithConfirmation.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import LinkWithConfirmation from 'sentry-ui/linkWithConfirmation';
+import LinkWithConfirmation from 'app/components/linkWithConfirmation';
 
 storiesOf('Links/LinkWithConfirmation', module).add(
   'default',

--- a/docs-ui/components/loadingError.stories.js
+++ b/docs-ui/components/loadingError.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import LoadingError from 'sentry-ui/loadingError';
+import LoadingError from 'app/components/loadingError';
 
 // eslint-disable-next-line
 storiesOf('LoadingError', module)

--- a/docs-ui/components/loadingIndicator.stories.js
+++ b/docs-ui/components/loadingIndicator.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import LoadingIndicator from 'sentry-ui/loadingIndicator';
+import LoadingIndicator from 'app/components/loadingIndicator';
 
 storiesOf('LoadingIndicator', module)
   .add(

--- a/docs-ui/components/multipleCheckbox.stories.js
+++ b/docs-ui/components/multipleCheckbox.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {action} from '@storybook/addon-actions';
 
-import MultipleCheckbox from 'application-root/views/settings/components/forms/controls/multipleCheckbox';
+import MultipleCheckbox from 'app/views/settings/components/forms/controls/multipleCheckbox';
 
 storiesOf('Forms/Fields', module).add(
   'MultipleCheckbox',

--- a/docs-ui/components/mutedBox.stories.js
+++ b/docs-ui/components/mutedBox.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import MutedBox from 'sentry-ui/mutedBox';
+import MutedBox from 'app/components/mutedBox';
 
 storiesOf('Muted Box', module)
   .add('default', withInfo('Default')(() => <MutedBox statusDetails={{}} />))

--- a/docs-ui/components/narrowLayout.stories.js
+++ b/docs-ui/components/narrowLayout.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import NarrowLayout from 'sentry-ui/narrowLayout';
+import NarrowLayout from 'app/components/narrowLayout';
 
 storiesOf('NarrowLayout', module).add(
   'default',

--- a/docs-ui/components/panels.stories.js
+++ b/docs-ui/components/panels.stories.js
@@ -2,14 +2,9 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import Button from 'sentry-ui/buttons/button';
-import {
-  Panel,
-  PanelHeader,
-  PanelBody,
-  PanelItem,
-} from 'application-root/components/panels';
-import Field from 'application-root/views/settings/components/forms/field';
+import Button from 'app/components/buttons/button';
+import {Panel, PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
+import Field from 'app/views/settings/components/forms/field';
 
 storiesOf('New Settings/Panel', module)
   .add(

--- a/docs-ui/components/pills.stories.js
+++ b/docs-ui/components/pills.stories.js
@@ -2,8 +2,8 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import Pills from 'sentry-ui/pills';
-import Pill from 'sentry-ui/pill';
+import Pills from 'app/components/pills';
+import Pill from 'app/components/pill';
 
 // eslint-disable-next-line
 storiesOf('Pills', module).add(

--- a/docs-ui/components/projectLabel.stories.js
+++ b/docs-ui/components/projectLabel.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import ProjectLabel from 'sentry-ui/projectLabel';
+import ProjectLabel from 'app/components/projectLabel';
 
 storiesOf('ProjectLabel', module).add(
   'default',

--- a/docs-ui/components/qrcode.stories.js
+++ b/docs-ui/components/qrcode.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import Qrcode from 'sentry-ui/qrcode';
+import Qrcode from 'app/components/qrcode';
 
 storiesOf('Qrcode', module).add(
   'default',

--- a/docs-ui/components/scoreBar.stories.js
+++ b/docs-ui/components/scoreBar.stories.js
@@ -4,7 +4,7 @@ import {withInfo} from '@storybook/addon-info';
 import {number, boolean, array, color} from '@storybook/addon-knobs';
 // import {action} from '@storybook/addon-actions';
 
-import ScoreBar from 'sentry-ui/scoreBar';
+import ScoreBar from 'app/components/scoreBar';
 
 const stories = storiesOf('ScoreBar', module);
 stories

--- a/docs-ui/components/similarSpectrum.stories.js
+++ b/docs-ui/components/similarSpectrum.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import SimilarSpectrum from 'sentry-ui/similarSpectrum';
+import SimilarSpectrum from 'app/components/similarSpectrum';
 
 storiesOf('SimilarSpectrum', module).add(
   'default',

--- a/docs-ui/components/splitDiff.stories.js
+++ b/docs-ui/components/splitDiff.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import SplitDiff from 'sentry-ui/splitDiff';
+import SplitDiff from 'app/components/splitDiff';
 
 const base = `RangeError: Invalid array length
   at Constructor.render(./app/components/scoreBar.jsx:73:0)

--- a/docs-ui/components/splitLayout.stories.js
+++ b/docs-ui/components/splitLayout.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import SplitLayout from 'sentry-ui/splitLayout';
+import SplitLayout from 'app/components/splitLayout';
 
 storiesOf('ComponentLayouts/SplitLayout', module).add(
   'default',

--- a/docs-ui/components/spreadLayout.stories.js
+++ b/docs-ui/components/spreadLayout.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import SpreadLayout from 'sentry-ui/spreadLayout';
+import SpreadLayout from 'app/components/spreadLayout';
 
 storiesOf('ComponentLayouts/SpreadLayout', module)
   .add(

--- a/docs-ui/components/stackedBarChart.stories.js
+++ b/docs-ui/components/stackedBarChart.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
-import StackedBarChart from 'sentry-ui/stackedBarChart';
+import StackedBarChart from 'app/components/stackedBarChart';
 
 storiesOf('StackedBarChart', module).add(
   'default',

--- a/docs-ui/components/tag.stories.js
+++ b/docs-ui/components/tag.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import Tag from 'settings-ui/tag';
+import Tag from 'app/views/settings/components/tag';
 
 storiesOf('Tags', module)
   .add(

--- a/docs-ui/components/teamBadge.stories.js
+++ b/docs-ui/components/teamBadge.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import TeamBadge from 'sentry-ui/teamBadge';
+import TeamBadge from 'app/components/teamBadge';
 
 storiesOf('TeamBadge', module).add(
   'default',

--- a/docs-ui/components/text.stories.js
+++ b/docs-ui/components/text.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import Text from 'sentry-ui/text';
+import Text from 'app/components/text';
 
 storiesOf('Text', module).add(
   'default',

--- a/docs-ui/components/textCopyInput.stories.js
+++ b/docs-ui/components/textCopyInput.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {action} from '@storybook/addon-actions';
 
-import TextCopyInput from 'application-root/views/settings/components/forms/textCopyInput';
+import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 
 storiesOf('TextCopyInput', module).add(
   'default',

--- a/docs-ui/components/textLink.stories.js
+++ b/docs-ui/components/textLink.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import TextLink from 'sentry-ui/textLink';
+import TextLink from 'app/components/textLink';
 
 storiesOf('Links/TextLink', module).add(
   'default',

--- a/docs-ui/components/textOverflow.stories.js
+++ b/docs-ui/components/textOverflow.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import TextOverflow from 'sentry-ui/textOverflow';
+import TextOverflow from 'app/components/textOverflow';
 
 storiesOf('TextOverflow', module).add(
   'default',

--- a/docs-ui/components/toolbar.stories.js
+++ b/docs-ui/components/toolbar.stories.js
@@ -3,9 +3,9 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 // import {action} from '@storybook/addon-actions';
 
-import Toolbar from 'sentry-ui/toolbar';
-import ToolbarHeader from 'sentry-ui/toolbarHeader';
-import SpreadLayout from 'sentry-ui/spreadLayout';
+import Toolbar from 'app/components/toolbar';
+import ToolbarHeader from 'app/components/toolbarHeader';
+import SpreadLayout from 'app/components/spreadLayout';
 
 storiesOf('Toolbar', module).add(
   'default',

--- a/docs-ui/components/tooltip.stories.js
+++ b/docs-ui/components/tooltip.stories.js
@@ -3,8 +3,8 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {text, boolean} from '@storybook/addon-knobs';
 
-import Tooltip from 'sentry-ui/tooltip';
-import Button from 'sentry-ui/buttons/button';
+import Tooltip from 'app/components/tooltip';
+import Button from 'app/components/buttons/button';
 
 storiesOf('Tooltip', module).add(
   'default',

--- a/docs-ui/components/userBadge.stories.js
+++ b/docs-ui/components/userBadge.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import UserBadge from 'sentry-ui/userBadge';
+import UserBadge from 'app/components/userBadge';
 
 const user = {
   name: 'Chrissy',


### PR DESCRIPTION
This changes storybook stories to use the same "app" alias as the rest of the app.