### PR TITLE
feat: add Calypso AppCrawler to WebCrawlersFilter

### DIFF
--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -36,6 +36,8 @@ CRAWLERS = re.compile(
             r'spider[\/\s\)\;]',
             # Slack - see https://api.slack.com/robots
             r'Slack',
+            # Calypso AppCrawler (Android/iOS)
+            r'Calypso AppCrawler',
         )
     ),
     re.I


### PR DESCRIPTION
This crawler scans Android (and iOS?) apps and crawls web pages accessed in web views. I get lots of unactionable Sentry reports from this crawler. I'm happy to share some privately with the team if necessary.

The full User Agent this crawler currently sends on Android is:
Mozilla/5.0 (Linux; Android 6.0.1; Calypso AppCrawler Build/MMB30Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36

I haven't seen an iOS UA for this crawler but Google says it exists there too.