### PR TITLE
ref(js): Refactor `analytics:event` into a function

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/guides.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/guides.jsx
@@ -1,6 +1,6 @@
 import {Client} from 'app/api';
 import GuideActions from 'app/actions/guideActions';
-import HookStore from 'app/stores/hookStore';
+import analytics from 'app/utils/analytics';
 
 const api = new Client();
 
@@ -38,12 +38,10 @@ export function recordFinish(guideId, useful) {
       useful,
     },
   });
-  HookStore.get('analytics:event').forEach(cb =>
-    cb('assistant.guide_finished', {
-      guide: guideId,
-      useful,
-    })
-  );
+  analytics('assistant.guide_finished', {
+    guide: guideId,
+    useful,
+  });
 }
 
 export function recordDismiss(guideId, step) {
@@ -54,10 +52,8 @@ export function recordDismiss(guideId, step) {
       status: 'dismissed',
     },
   });
-  HookStore.get('analytics:event').forEach(cb =>
-    cb('assistant.guide_dismissed', {
-      guide: guideId,
-      step,
-    })
-  );
+  analytics('assistant.guide_dismissed', {
+    guide: guideId,
+    step,
+  });
 }

--- a/src/sentry/static/sentry/app/components/assistant/supportDrawer.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/supportDrawer.jsx
@@ -5,6 +5,7 @@ import createReactClass from 'create-react-class';
 import $ from 'jquery';
 import styled from 'react-emotion';
 import {t} from 'app/locale';
+import analytics from 'app/utils/analytics';
 import ExternalLink from 'app/components/externalLink';
 import HookStore from 'app/stores/hookStore';
 import CueIcon from 'app/components/assistant/cueIcon';
@@ -64,9 +65,7 @@ const SupportDrawer = createReactClass({
       },
     });
 
-    HookStore.get('analytics:event').forEach(cb =>
-      cb('assistant.search', {query: this.state.inputVal})
-    );
+    analytics('assistant.search', {query: this.state.inputVal});
   }, 300),
 
   handleChange(evt) {

--- a/src/sentry/static/sentry/app/components/resourceCard.jsx
+++ b/src/sentry/static/sentry/app/components/resourceCard.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
+import analytics from 'app/utils/analytics';
 import ConfigStore from 'app/stores/configStore';
 import ExternalLink from 'app/components/externalLink';
-import HookStore from 'app/stores/hookStore';
 
 const StyledTitle = styled('div')`
   color: #493e54;
@@ -22,9 +22,7 @@ export default class ResourceCard extends React.Component {
 
   recordClick = () => {
     let {link, title} = this.props;
-    HookStore.get('analytics:event').forEach(cb =>
-      cb('orgdash.resource_clicked', {link, title})
-    );
+    analytics('orgdash.resource_clicked', {link, title});
   };
 
   render() {
@@ -34,7 +32,7 @@ export default class ResourceCard extends React.Component {
     return (
       <div
         className="flex box p-x-2 p-y-1"
-        style={{flexGrow: '1', alignItems: 'center'}}
+        style={{flexGrow: 1, alignItems: 'center'}}
         onClick={this.recordClick}
       >
         <ExternalLink href={link}>

--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -3,9 +3,11 @@ import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
+import {debounce} from 'lodash';
 
 import {navigateTo} from 'app/actionCreators/navigation';
 import {t} from 'app/locale';
+import analytics from 'app/utils/analytics';
 import AutoComplete from 'app/components/autoComplete';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import SearchResult from 'app/components/search/searchResult';
@@ -68,6 +70,8 @@ class Search extends React.Component {
     navigateTo(nextPath, router);
   };
 
+  saveQueryMetrics = debounce(query => analytics('omnisearch.query', {query}), 200);
+
   renderItem = ({resultObj, index, highlightedIndex, getItemProps}) => {
     // resultObj is a fuse.js result object with {item, matches, score}
     let {renderItem} = this.props;
@@ -125,6 +129,8 @@ class Search extends React.Component {
         }) => {
           let searchQuery = inputValue.toLowerCase();
           let isValidSearch = inputValue.length >= minSearch;
+
+          this.saveQueryMetrics(searchQuery);
 
           return (
             <SearchWrapper>

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -1,8 +1,8 @@
 import Reflux from 'reflux';
 import $ from 'jquery';
 import GuideActions from 'app/actions/guideActions';
-import HookStore from 'app/stores/hookStore';
 import OrganizationsActions from 'app/actions/organizationsActions';
+import analytics from 'app/utils/analytics';
 
 const GuideStore = Reflux.createStore({
   init() {
@@ -68,11 +68,9 @@ const GuideStore = Reflux.createStore({
     this.state.currentStep += 1;
     this.trigger(this.state);
     if (this.state.currentGuide && this.state.currentStep == 1) {
-      HookStore.get('analytics:event').forEach(cb =>
-        cb('assistant.guide_opened', {
-          guide: this.state.currentGuide.id,
-        })
-      );
+      analytics('assistant.guide_opened', {
+        guide: this.state.currentGuide.id,
+      });
     }
   },
 
@@ -87,12 +85,10 @@ const GuideStore = Reflux.createStore({
   },
 
   recordCue(id, cue) {
-    HookStore.get('analytics:event').forEach(cb =>
-      cb('assistant.guide_cued', {
-        guide: id,
-        cue,
-      })
-    );
+    analytics('assistant.guide_cued', {
+      guide: id,
+      cue,
+    });
   },
 
   updatePrevGuide(bestGuide) {

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -55,4 +55,3 @@ const HookStore = Reflux.createStore({
 });
 
 export default HookStore;
-window.hook = HookStore;

--- a/src/sentry/static/sentry/app/utils/analytics.jsx
+++ b/src/sentry/static/sentry/app/utils/analytics.jsx
@@ -1,5 +1,12 @@
 import HookStore from 'app/stores/hookStore';
 
+/**
+ * Note, you will need to add the event `name` to the inclusion list in redash
+ * See: https://github.com/getsentry/reload/blob/master/reload_app/app.py#L20
+ *
+ * @param {String} name The name of the event
+ * @param {Object} data Additional event data to record
+ */
 export default function analytics(name, data) {
   HookStore.get('analytics:event').forEach(cb => cb(name, data));
 }

--- a/src/sentry/static/sentry/app/utils/analytics.jsx
+++ b/src/sentry/static/sentry/app/utils/analytics.jsx
@@ -1,0 +1,5 @@
+import HookStore from 'app/stores/hookStore';
+
+export default function analytics(name, data) {
+  HookStore.get('analytics:event').forEach(cb => cb(name, data));
+}

--- a/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/configure/index.jsx
@@ -3,6 +3,7 @@ import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import Raven from 'raven-js';
 
+import analytics from 'app/utils/analytics';
 import Waiting from 'app/views/onboarding/configure/waiting';
 import ApiMixin from 'app/mixins/apiMixin';
 import ProjectContext from 'app/views/projects/projectContext';
@@ -86,9 +87,7 @@ const Configure = createReactClass({
 
   submit() {
     HookStore.get('analytics:onboarding-complete').forEach(cb => cb());
-    HookStore.get('analytics:event').forEach(cb =>
-      cb('onboarding.complete', {project: this.props.params.projectId})
-    );
+    analytics('onboarding.complete', {project: this.props.params.projectId});
     this.redirectUrl();
   },
 

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
+import analytics from 'app/utils/analytics';
 import PlatformPicker from 'app/views/onboarding/project/platformpicker';
 import PlatformiconTile from 'app/views/onboarding/project/platformiconTile';
 import SelectField from 'app/components/forms/selectField';
 import {t} from 'app/locale';
-import HookStore from 'app/stores/hookStore';
 
 class OnboardingProject extends React.Component {
   static propTypes = {
@@ -42,7 +42,7 @@ class OnboardingProject extends React.Component {
   submit = () => {
     this.setWarning(this.props.name);
     if (this.props.name) {
-      HookStore.get('analytics:event').forEach(cb => cb('platformpicker.create_project'));
+      analytics('platformpicker.create_project');
       this.props.next();
     }
   };

--- a/src/sentry/static/sentry/app/views/onboarding/project/platformpicker.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/platformpicker.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 import classnames from 'classnames';
 import _ from 'lodash';
 
+import analytics from 'app/utils/analytics';
 import ListLink from 'app/components/listLink';
 import {flattenedPlatforms, categoryList} from 'app/views/onboarding/utils';
 import PlatformCard from 'app/views/onboarding/project/platformCard';
 import {t} from 'app/locale';
-import HookStore from 'app/stores/hookStore';
 
 const allCategories = categoryList.concat({id: 'all', name: t('All')});
 
@@ -30,12 +30,10 @@ class PlatformPicker extends React.Component {
 
   logSearch = _.debounce(() => {
     if (this.state.filter) {
-      HookStore.get('analytics:event').forEach(cb =>
-        cb('platformpicker.search', {
-          query: this.state.filter.toLowerCase(),
-          num_results: this.getPlatformList().length,
-        })
-      );
+      analytics('platformpicker.search', {
+        query: this.state.filter.toLowerCase(),
+        num_results: this.getPlatformList().length,
+      });
     }
   }, 300);
 
@@ -85,9 +83,7 @@ class PlatformPicker extends React.Component {
               <ListLink
                 key={id}
                 onClick={e => {
-                  HookStore.get('analytics:event').forEach(cb =>
-                    cb('platformpicker.select_tab', {tab: id})
-                  );
+                  analytics('platformpicker.select_tab', {tab: id});
                   this.setState({tab: id, filter: ''});
                   e.preventDefault();
                 }}
@@ -110,9 +106,7 @@ class PlatformPicker extends React.Component {
                   })}
                   key={platform.id}
                   onClick={e => {
-                    HookStore.get('analytics:event').forEach(cb =>
-                      cb('platformpicker.select_platform', {platform: platform.id})
-                    );
+                    analytics('platformpicker.select_platform', {platform: platform.id});
                     this.props.setPlatform(platform.id);
                     e.preventDefault();
                   }}

--- a/src/sentry/static/sentry/app/views/organizationDashboard/resources.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/resources.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import {Flex} from 'grid-emotion';
+
+import analytics from 'app/utils/analytics';
 import ResourceCard from 'app/components/resourceCard';
 import SentryTypes from 'app/proptypes';
 import ErrorRobot from 'app/components/errorRobot';
 import {Panel} from 'app/components/panels';
 import {t} from 'app/locale';
-import HookStore from 'app/stores/hookStore';
 
 export default class Resources extends React.Component {
   static propTypes = {
@@ -14,7 +15,7 @@ export default class Resources extends React.Component {
   };
 
   componentDidMount() {
-    HookStore.get('analytics:event').forEach(cb => cb('orgdash.resources_shown'));
+    analytics('orgdash.resources_shown');
   }
 
   render() {

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -8,12 +8,12 @@ import classNames from 'classnames';
 import qs from 'query-string';
 import {omit, isEqual} from 'lodash';
 
+import analytics from 'app/utils/analytics';
 import SentryTypes from 'app/proptypes';
 import ApiMixin from 'app/mixins/apiMixin';
 import ConfigStore from 'app/stores/configStore';
 import GroupStore from 'app/stores/groupStore';
 import EnvironmentStore from 'app/stores/environmentStore';
-import HookStore from 'app/stores/hookStore';
 import ErrorRobot from 'app/components/errorRobot';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -495,13 +495,11 @@ const Stream = createReactClass({
     // Ignore saved searches
     if (this.state.savedSearchList.map(s => s.query == this.state.query).length > 0) {
       let {orgId, projectId} = this.props.params;
-      HookStore.get('analytics:event').forEach(cb =>
-        cb('issue.search', {
-          query: this.state.query,
-          organization_id: orgId,
-          project_id: projectId,
-        })
-      );
+      analytics('issue.search', {
+        query: this.state.query,
+        organization_id: orgId,
+        project_id: projectId,
+      });
     }
   },
 


### PR DESCRIPTION
Abstracted this into a function so you don't have to use HookStore directly

To use:

```javascript
import analytics from 'app/utils/analytics';

analytics('assistant.guide_finished', {
   guide: guideId,
});
```