### PR TITLE
build(vscode): Fix jsconfig paths

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,12 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "allowSyntheticDefaultImports": false,
+    "target": "esnext",
+    "jsx": "preserve",
+    "checkJs": false,
+    "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "baseUrl": "./src/sentry/static/sentry",
+    "baseUrl": ".",
     "paths": {
       "app/*": ["src/sentry/static/sentry/app/*"]
     }
   },
-  "include": ["tests/js/**/*", "src/sentry/static/sentry/app/**/*"]
+  "include": ["src/sentry/static/sentry/app/**/*"]
 }


### PR DESCRIPTION
This fixes import pathname intellisense and goto definition (as well as other stuff probably).

I didn't reload conf between edits 