### PR TITLE
build(storybook): Dont snapshot storybook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,6 @@ travis-test-network: test-network
 travis-test-snuba: test-snuba
 travis-test-js:
 	$(MAKE) test-js
-	$(MAKE) test-styleguide
 travis-test-cli: test-cli
 travis-test-dist:
 	SENTRY_BUILD=$(TRAVIS_COMMIT) SENTRY_LIGHT_BUILD=0 python setup.py sdist bdist_wheel


### PR DESCRIPTION
Storing storybook snapshots in percy has limited value right now, so let's remove it