### PR TITLE
fix(auth): Handle passwordless SSO flows

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -429,7 +429,8 @@ class Fixtures(object):
         kwargs.setdefault('is_superuser', False)
 
         user = User(email=email, **kwargs)
-        user.set_password('admin')
+        if not kwargs.get('password'):
+            user.set_password('admin')
         user.save()
 
         # UserEmail is created by a signal


### PR DESCRIPTION
This changes SSO auto-link behavior to:

- Remove the Sentry-verified check. This exposes the ability for accounts to be auto merged on typos, but is considered a low risk tradeoff.
- Remove login checks if the user doesn't have a password (and thus could never authenticate).
- Send verification email for new users

Note: we'll likely need to revisit the "has_usable_password" check to become "can_login_at_all" if/when we support "login with Google"