### PR TITLE
fix(ui): Remove `overflow: hidden` from new settings Content

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
@@ -75,9 +75,12 @@ const SidebarWrapper = styled(Box)`
   width: ${p => p.theme.settings.sidebarWidth};
 `;
 
+/**
+ * Note: `overflow: hidden` will cause some buttons in `SettingsPageHeader` to be cut off because it has negative margin.
+ * Will also cut off tooltips.
+ */
 const Content = styled(Box)`
   flex: 1;
-  overflow: hidden; /* We need this so that Content area does not overflow outside of max width */
 `;
 
 const SettingsSubheader = styled.div`


### PR DESCRIPTION
Overflow hidden on the main settings content wrapper causes issues with `SettingsPageHeader` because of negative margins, as well as tooltips.

I think most of our long form content gets wrapped now, so that we don't need this.

![image](https://user-images.githubusercontent.com/79684/39456011-748cf382-4c98-11e8-897b-fe7376921580.png)
