### PR TITLE
feat(ui): Add `Hook` component

### DIFF
--- a/src/sentry/static/sentry/app/components/hook.jsx
+++ b/src/sentry/static/sentry/app/components/hook.jsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+
+import HookStore from 'app/stores/hookStore';
+
+/**
+ * Instead of accessing the HookStore directly, use this.
+ *
+ * If the hook slot needs to perform anything w/ the hooks, you can pass a function as a child and you will receive an object with a `hooks` key
+ *
+ * example:
+ *
+ * <Hook name="my-hook">
+ * {({hooks}) => hooks.map(hook => (
+ *  <Wrapper>
+ *    {hook}
+ * </Wrapper>
+ * ))}
+ * </Hook>
+ *
+ */
+const Hook = createReactClass({
+  displayName: 'Hook',
+  propTypes: {
+    name: PropTypes.string.isRequired,
+  },
+  mixins: [Reflux.listenTo(HookStore, 'handleHooks')],
+
+  getInitialState() {
+    let {name, ...props} = this.props;
+
+    return {
+      hooks: HookStore.get(name).map(cb => cb(props)),
+    };
+  },
+
+  handleHooks(name, hooks) {
+    // Make sure that the incoming hook update matches this component's hook name
+    if (name !== this.props.name) return;
+
+    this.setState(state => ({
+      hooks: hooks.map(cb => cb(this.props)),
+    }));
+  },
+
+  render() {
+    let {children} = this.props;
+
+    if (typeof children === 'function') {
+      return children({hooks: this.state.hooks});
+    }
+
+    return this.state.hooks;
+  },
+});
+
+export default Hook;

--- a/src/sentry/static/sentry/app/components/hook.jsx
+++ b/src/sentry/static/sentry/app/components/hook.jsx
@@ -35,12 +35,14 @@ const Hook = createReactClass({
     };
   },
 
-  handleHooks(name, hooks) {
+  handleHooks(hookName, hooks) {
+    let {name, ...props} = this.props;
+
     // Make sure that the incoming hook update matches this component's hook name
-    if (name !== this.props.name) return;
+    if (hookName !== name) return;
 
     this.setState(state => ({
-      hooks: hooks.map(cb => cb(this.props)),
+      hooks: hooks.map(cb => cb(props)),
     }));
   },
 

--- a/src/sentry/static/sentry/app/components/hook.jsx
+++ b/src/sentry/static/sentry/app/components/hook.jsx
@@ -47,6 +47,8 @@ const Hook = createReactClass({
   render() {
     let {children} = this.props;
 
+    if (!this.state.hooks || !this.state.hooks.length) return null;
+
     if (typeof children === 'function') {
       return children({hooks: this.state.hooks});
     }

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -36,7 +36,7 @@ const HookStore = Reflux.createStore({
       this.hooks[hookName] = [];
     }
     this.hooks[hookName].push(callback);
-    this.trigger(hookName, [callback]);
+    this.trigger(hookName, this.hooks[hookName]);
   },
 
   remove(hookName, callback) {

--- a/src/sentry/static/sentry/app/views/settings/organization/organizationSettingsNavigation.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/organizationSettingsNavigation.jsx
@@ -28,7 +28,7 @@ const OrganizationSettingsNavigation = createReactClass({
     let org = this.getOrganization();
     if (name !== 'settings:organization-navigation-config') return;
     this.setState(state => ({
-      hookConfigs: [...state.hookConfigs, ...hooks.map(cb => cb(org))],
+      hookConfigs: hooks.map(cb => cb(org)),
     }));
   },
 

--- a/tests/js/spec/components/hook.spec.jsx
+++ b/tests/js/spec/components/hook.spec.jsx
@@ -25,7 +25,7 @@ describe('Hook', function() {
     HookStore.init();
   });
 
-  it('can render component from a hook', function() {
+  it('renders component from a hook', function() {
     let wrapper = mount(
       <div>
         <Hook name="footer" organization={TestStubs.Organization()} />
@@ -36,6 +36,18 @@ describe('Hook', function() {
     expect(HookStore.hooks.footer).toHaveLength(1);
     expect(wrapper.find('Wrapper')).toHaveLength(1);
     expect(wrapper.find('Wrapper').prop('organization').slug).toBe('org-slug');
+  });
+
+  it('renders an invalid hook', function() {
+    let wrapper = mount(
+      <div>
+        <Hook name="invalid-hook" organization={TestStubs.Organization()} />
+      </div>,
+      routerContext
+    );
+
+    expect(wrapper.find('Wrapper')).toHaveLength(0);
+    expect(wrapper.find('div')).toHaveLength(1);
   });
 
   it('can re-render when hooks get after initial render', function() {

--- a/tests/js/spec/components/hook.spec.jsx
+++ b/tests/js/spec/components/hook.spec.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import Hook from 'app/components/hook';
+import HookStore from 'app/stores/hookStore';
+
+describe('Hook', function() {
+  const Wrapper = function Wrapper(props) {
+    return <div {...props} />;
+  };
+  const routerContext = TestStubs.routerContext();
+
+  beforeEach(function() {
+    HookStore.add('footer', ({organization} = {}) => {
+      return (
+        <Wrapper key="initial" organization={organization}>
+          {organization.slug}
+        </Wrapper>
+      );
+    });
+  });
+
+  afterEach(function() {
+    // Clear HookStore
+    HookStore.init();
+  });
+
+  it('can render component from a hook', function() {
+    let wrapper = mount(
+      <div>
+        <Hook name="footer" organization={TestStubs.Organization()} />
+      </div>,
+      routerContext
+    );
+
+    expect(HookStore.hooks.footer).toHaveLength(1);
+    expect(wrapper.find('Wrapper')).toHaveLength(1);
+    expect(wrapper.find('Wrapper').prop('organization').slug).toBe('org-slug');
+  });
+
+  it('can re-render when hooks get after initial render', function() {
+    let wrapper = mount(
+      <div>
+        <Hook name="footer" organization={TestStubs.Organization()} />
+      </div>,
+      routerContext
+    );
+
+    expect(wrapper.find('Wrapper')).toHaveLength(1);
+
+    HookStore.add('footer', ({organization} = {}) => {
+      return (
+        <Wrapper key="new" organization={null}>
+          New Hook
+        </Wrapper>
+      );
+    });
+
+    wrapper.update();
+
+    expect(HookStore.hooks.footer).toHaveLength(2);
+    expect(wrapper.find('Wrapper')).toHaveLength(2);
+    expect(
+      wrapper
+        .find('Wrapper')
+        .at(1)
+        .prop('organization')
+    ).toEqual(null);
+  });
+
+  it('can use children as a render prop', function() {
+    let wrapper = mount(
+      <div>
+        <Hook name="footer" organization={TestStubs.Organization()}>
+          {({hooks}) => hooks.map((hook, i) => <Wrapper key={i}>{hook}</Wrapper>)}
+        </Hook>
+      </div>,
+      routerContext
+    );
+
+    HookStore.add('footer', ({organization} = {}) => {
+      return (
+        <Wrapper key="new" organization={null}>
+          New Hook
+        </Wrapper>
+      );
+    });
+
+    wrapper.update();
+
+    // Has 2 Wrappers from store, and each is wrapped by another Wrapper
+    expect(wrapper.find('Wrapper')).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
This will make HookStore a bit easier to use in our components. It also handles the case where hooks are added after the parent component is rendered.

All properties passed to the `Hook` component will be forwarded to the hook source.

**Note** this is currently **NOT** compatible with existing hooks.

Example:

```javascript
render() {
  return (
    <div>
     <Hook name="footer" organization={organization} project={project} />
    </div>
  );
}
```

Or if you need your own rendering:
```javascript
render() {
  return (
    <div>
     <Hook name="footer" organization={organization} project={project}>
       {({hooks}) => hooks.map(hook => (
         <Wrapper>{hook}</Wrapper>
       ))}
     </Hook>
    </div>
  );
}
```

or see this for real world usage: https://github.com/getsentry/sentry/pull/8263/files#diff-5024521501cf983c6228c59e305c91a7R80