### PR TITLE
feat(ui): platformicons 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "moment": "2.22.0",
     "moment-timezone": "0.5.4",
     "node-libs-browser": "0.5.3",
-    "platformicons": "0.1.1",
+    "platformicons": "2.0.1",
     "po-catalog-loader": "^1.2.0",
     "prop-types": "^15.6.0",
     "query-string": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7122,9 +7122,9 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-platformicons@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-0.1.1.tgz#ad4354d83940cbed9628b35538624fc0b920be2f"
+platformicons@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-2.0.1.tgz#6d29a3ca9b7d0634850accb924ae5b12a221990f"
 
 pluralize@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This imports the new svg-based platformicons for use on the new project dash (and eventually elsewhere).