### PR TITLE
fix: Limit the number of issues we lookup for Snuba

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -279,6 +279,8 @@ def do_search(project_id, environment_id, tags, start, end,
         filters['environment'] = [environment_id]
 
     if candidates is not None:
+        # TODO remove this when Snuba accepts more than 500 issues
+        candidates = candidates[:500]
         hashes = list(
             GroupHash.objects.filter(
                 group_id__in=candidates

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -176,14 +176,14 @@ def get_snuba_map(column, ids):
 def get_project_issues(project_ids, issue_ids=None):
     """
     Get a list of issues and associated fingerprint hashes for a list of
-    project ids. If issue_ids is also set, then also restrict to only those
-    issues as well.
+    project ids. If issue_ids is set, then return only those issues.
 
     Returns a list: [(issue_id: [hash1, hash2, ...]), ...]
     """
-    hashes = GroupHash.objects.filter(project__in=project_ids)
     if issue_ids:
-        hashes = hashes.filter(group_id__in=issue_ids)
+        hashes = GroupHash.objects.filter(group_id__in=issue_ids[:500])
+    else:
+        hashes = GroupHash.objects.filter(project__in=project_ids)
     result = {}
     for gid, hsh in hashes.values_list('group_id', 'hash'):
         result.setdefault(gid, []).append(hsh)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -181,7 +181,9 @@ def get_project_issues(project_ids, issue_ids=None):
     Returns a list: [(issue_id: [hash1, hash2, ...]), ...]
     """
     if issue_ids:
-        hashes = GroupHash.objects.filter(group_id__in=issue_ids[:500])
+        # TODO remove this when Snuba accepts more than 500 issues
+        issue_ids = issue_ids[:500]
+        hashes = GroupHash.objects.filter(group_id__in=issue_ids)
     else:
         hashes = GroupHash.objects.filter(project__in=project_ids)
     result = {}


### PR DESCRIPTION
We already reject requests with more than 500 issue ids at the Snuba API
so killing Postgres with a giant lookup across thousands of groups is
futile.

Also, if issue_ids are specified, only filter on those, as they are
strictly more selective than project_ids and including issues and
projects in the query forces postgres to do a slow join of the indexes
for issue and project.