### PR TITLE
ref(tagstore): Use non-model types for read methods

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import six
-
 from rest_framework.response import Response
 
 from sentry import tagstore
@@ -64,7 +62,6 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             group.project_id, group.id, environment_id, lookup_key, limit=9)
 
         data = {
-            'id': six.text_type(tag_key.id),
             'key': key,
             'name': tagstore.get_tag_key_label(tag_key.key),
             'uniqueValues': group_tag_key.values_seen,

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -8,6 +8,7 @@ from sentry.api.paginator import DateTimePaginator, Paginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.tagvalue import UserTagValueSerializer
 from sentry.models import Group, Environment
+from sentry.tagstore.types import GroupTagValue
 from sentry.utils.apidocs import scenario
 
 
@@ -74,5 +75,19 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint, EnvironmentMixin):
             queryset=queryset,
             order_by=order_by,
             paginator_cls=paginator_cls,
-            on_results=lambda x: serialize(x, request.user, serializer_cls),
+            on_results=lambda results: serialize(
+                map(  # XXX: This is a pretty big abstraction leak
+                    lambda instance: GroupTagValue(
+                        group_id=instance.group_id,
+                        key=instance.key,
+                        value=instance.value,
+                        times_seen=instance.times_seen,
+                        last_seen=instance.last_seen,
+                        first_seen=instance.first_seen,
+                    ),
+                    results,
+                ),
+                request.user,
+                serializer_cls,
+            ),
         )

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -66,7 +66,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint, EnvironmentMixin):
             paginator_cls = Paginator
 
         if key == 'user':
-            serializer_cls = UserTagValueSerializer()
+            serializer_cls = UserTagValueSerializer(group.project_id)
         else:
             serializer_cls = None
 

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import six
-
 from rest_framework.response import Response
 
 from sentry import tagstore
@@ -29,7 +27,6 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
         for tag_key in tag_keys:
             data.append(
                 {
-                    'id': six.text_type(tag_key.id),
                     'key': tagstore.get_standardized_key(tag_key.key),
                     'name': tagstore.get_tag_key_label(tag_key.key),
                     'uniqueValues': tag_key.values_seen,

--- a/src/sentry/api/serializers/models/tagvalue.py
+++ b/src/sentry/api/serializers/models/tagvalue.py
@@ -15,9 +15,12 @@ class EnvironmentTagValueSerializer(Serializer):
 
 
 class UserTagValueSerializer(Serializer):
+    def __init__(self, project_id):
+        self.project_id = project_id
+
     def get_attrs(self, item_list, user):
         users = EventUser.for_tags(
-            project_id=item_list[0].project_id,
+            project_id=self.project_id,
             values=[t.value for t in item_list],
         )
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -421,13 +421,7 @@ class LegacyTagStorage(TagStorage):
 
             if updated:
                 delete_tag_key_task.delay(object_id=tagkey.id, model=models.TagKey)
-                deleted.append(
-                    TagKey(
-                        key=tagkey.key,
-                        values_seen=tagkey.values_seen,
-                        status=tagkey.status,
-                    )
-                )
+                deleted.append(tagkey)
 
         return deleted
 

--- a/src/sentry/tagstore/legacy/models/grouptagkey.py
+++ b/src/sentry/tagstore/legacy/models/grouptagkey.py
@@ -7,11 +7,8 @@ sentry.tagstore.legacy.models.grouptagkey
 """
 from __future__ import absolute_import
 
-import six
-
 from django.db import models, router, transaction, DataError
 
-from sentry.api.serializers import Serializer, register
 from sentry.constants import MAX_TAG_KEY_LENGTH
 from sentry.db.models import (
     Model, BoundedPositiveIntegerField, BaseManager, sane_repr
@@ -57,27 +54,3 @@ class GroupTagKey(Model):
         except DataError:
             # it's possible to hit an out of range value for counters
             pass
-
-
-@register(GroupTagKey)
-class GroupTagKeySerializer(Serializer):
-    def get_attrs(self, item_list, user):
-        from sentry import tagstore
-
-        result = {}
-        for item in item_list:
-            key = tagstore.get_standardized_key(item.key)
-            result[item] = {
-                'name': tagstore.get_tag_key_label(item.key),
-                'key': key,
-            }
-
-        return result
-
-    def serialize(self, obj, attrs, user):
-        return {
-            'id': six.text_type(obj.id),
-            'name': attrs['name'],
-            'key': attrs['key'],
-            'uniqueValues': obj.values_seen,
-        }

--- a/src/sentry/tagstore/legacy/models/grouptagvalue.py
+++ b/src/sentry/tagstore/legacy/models/grouptagvalue.py
@@ -7,12 +7,9 @@ sentry.tagstore.legacy.models.grouptagvalue
 """
 from __future__ import absolute_import
 
-import six
-
 from django.db import models, router, transaction, DataError
 from django.utils import timezone
 
-from sentry.api.serializers import Serializer, register
 from sentry.constants import MAX_TAG_KEY_LENGTH, MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
     Model, BoundedPositiveIntegerField, BaseManager, sane_repr)
@@ -66,30 +63,3 @@ class GroupTagValue(Model):
         except DataError:
             # it's possible to hit an out of range value for counters
             pass
-
-
-@register(GroupTagValue)
-class GroupTagValueSerializer(Serializer):
-    def get_attrs(self, item_list, user):
-        from sentry import tagstore
-
-        result = {}
-        for item in item_list:
-            result[item] = {
-                'name': tagstore.get_tag_value_label(item.key, item.value),
-            }
-
-        return result
-
-    def serialize(self, obj, attrs, user):
-        from sentry import tagstore
-
-        return {
-            'id': six.text_type(obj.id),
-            'name': attrs['name'],
-            'key': tagstore.get_standardized_key(obj.key),
-            'value': obj.value,
-            'count': obj.times_seen,
-            'lastSeen': obj.last_seen,
-            'firstSeen': obj.first_seen,
-        }

--- a/src/sentry/tagstore/legacy/models/tagkey.py
+++ b/src/sentry/tagstore/legacy/models/tagkey.py
@@ -8,12 +8,9 @@ sentry.tagstore.legacy.models.tagkey
 
 from __future__ import absolute_import, print_function
 
-import six
-
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.api.serializers import Serializer, register
 from sentry.tagstore import TagKeyStatus
 from sentry.constants import MAX_TAG_KEY_LENGTH
 from sentry.db.models import (Model, BoundedPositiveIntegerField, sane_repr)
@@ -53,17 +50,4 @@ class TagKey(Model):
     def get_audit_log_data(self):
         return {
             'key': self.key,
-        }
-
-
-@register(TagKey)
-class TagKeySerializer(Serializer):
-    def serialize(self, obj, attrs, user):
-        from sentry import tagstore
-
-        return {
-            'id': six.text_type(obj.id),
-            'key': tagstore.get_standardized_key(obj.key),
-            'name': tagstore.get_tag_key_label(obj.key),
-            'uniqueValues': obj.values_seen,
         }

--- a/src/sentry/tagstore/legacy/models/tagvalue.py
+++ b/src/sentry/tagstore/legacy/models/tagvalue.py
@@ -7,12 +7,9 @@ sentry.tagstore.legacy.models.tagvalue
 """
 from __future__ import absolute_import, print_function
 
-import six
-
 from django.db import models
 from django.utils import timezone
 
-from sentry.api.serializers import Serializer, register
 from sentry.constants import MAX_TAG_KEY_LENGTH, MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
     Model, BoundedPositiveIntegerField, GzippedDictField, BaseManager, sane_repr
@@ -49,29 +46,3 @@ class TagValue(Model):
         from sentry import tagstore
 
         return tagstore.get_tag_value_label(self.key, self.value)
-
-
-@register(TagValue)
-class TagValueSerializer(Serializer):
-    def get_attrs(self, item_list, user):
-        from sentry import tagstore
-
-        result = {}
-        for item in item_list:
-            result[item] = {
-                'name': tagstore.get_tag_value_label(item.key, item.value),
-            }
-        return result
-
-    def serialize(self, obj, attrs, user):
-        from sentry import tagstore
-
-        return {
-            'id': six.text_type(obj.id),
-            'key': tagstore.get_standardized_key(obj.key),
-            'name': attrs['name'],
-            'value': obj.value,
-            'count': obj.times_seen,
-            'lastSeen': obj.last_seen,
-            'firstSeen': obj.first_seen,
-        }

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
+from sentry.tagstore.base import TagKeyStatus
 
 
 class TagKey(object):
-    def __init__(self, key, values_seen, status):
+    def __init__(self, key, values_seen, status=TagKeyStatus.VISIBLE):
         self.key = key
         self.values_seen = values_seen
         self.status = status

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import
+
+
+class TagKey(object):
+    def __init__(self, key, values_seen, status):
+        self.key = key
+        self.values_seen = values_seen
+        self.status = status
+
+
+class TagValue(object):
+    def __init__(self, key, value, times_seen, first_seen, last_seen):
+        self.key = key
+        self.value = value
+        self.times_seen = times_seen
+        self.first_seen = first_seen
+        self.last_seen = last_seen
+
+
+class GroupTagKey(object):
+    def __init__(self, group_id, key, values_seen):
+        self.group_id = group_id
+        self.key = key
+        self.values_seen = values_seen
+
+
+class GroupTagValue(object):
+    def __init__(self, group_id, key, value, times_seen, first_seen, last_seen):
+        self.group_id = group_id
+        self.key = key
+        self.value = value
+        self.times_seen = times_seen
+        self.first_seen = first_seen
+        self.last_seen = last_seen
+
+
+from sentry.api.serializers import Serializer, register
+
+
+@register(TagKey)
+class TagKeySerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        from sentry import tagstore
+
+        return {
+            'key': tagstore.get_standardized_key(obj.key),
+            'name': tagstore.get_tag_key_label(obj.key),
+            'uniqueValues': obj.values_seen,
+        }
+
+
+@register(TagValue)
+class TagValueSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        from sentry import tagstore
+
+        return {
+            'key': tagstore.get_standardized_key(obj.key),
+            'name': tagstore.get_tag_value_label(obj.key, obj.value),
+            'value': obj.value,
+            'count': obj.times_seen,
+            'lastSeen': obj.last_seen,
+            'firstSeen': obj.first_seen,
+        }
+
+
+@register(GroupTagKey)
+class GroupTagKeySerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        from sentry import tagstore
+
+        return {
+            'name': tagstore.get_tag_key_label(obj.key),
+            'key': tagstore.get_standardized_key(obj.key),
+            'uniqueValues': obj.values_seen,
+        }
+
+
+@register(GroupTagValue)
+class GroupTagValueSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        from sentry import tagstore
+
+        return {
+            'name': tagstore.get_tag_value_label(obj.key, obj.value),
+            'key': tagstore.get_standardized_key(obj.key),
+            'value': obj.value,
+            'count': obj.times_seen,
+            'lastSeen': obj.last_seen,
+            'firstSeen': obj.first_seen,
+        }

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -1,15 +1,35 @@
 from __future__ import absolute_import
+
 from sentry.tagstore.base import TagKeyStatus
 
 
-class TagKey(object):
+class TagType(object):
+    def __repr__(self):
+        return '<%s: %s>' % (
+            type(self).__name__,
+            ', '.join('%s=%r' % (name, getattr(self, name)) for name in self.__slots__),
+        )
+
+    def __hash__(self):
+        return hash(tuple([getattr(self, name) for name in self.__slots__]))
+
+    def __eq__(self, other):
+        return type(self) == type(other) and \
+            all(getattr(self, name) == getattr(other, name) for name in self.__slots__)
+
+
+class TagKey(TagType):
+    __slots__ = ['key', 'values_seen', 'status']
+
     def __init__(self, key, values_seen, status=TagKeyStatus.VISIBLE):
         self.key = key
         self.values_seen = values_seen
         self.status = status
 
 
-class TagValue(object):
+class TagValue(TagType):
+    __slots__ = ['key', 'value', 'times_seen', 'first_seen', 'last_seen']
+
     def __init__(self, key, value, times_seen, first_seen, last_seen):
         self.key = key
         self.value = value
@@ -18,14 +38,18 @@ class TagValue(object):
         self.last_seen = last_seen
 
 
-class GroupTagKey(object):
+class GroupTagKey(TagType):
+    __slots__ = ['group_id', 'key', 'values_seen']
+
     def __init__(self, group_id, key, values_seen):
         self.group_id = group_id
         self.key = key
         self.values_seen = values_seen
 
 
-class GroupTagValue(object):
+class GroupTagValue(TagType):
+    __slots__ = ['group_id', 'key', 'value', 'times_seen', 'first_seen', 'last_seen']
+
     def __init__(self, group_id, key, value, times_seen, first_seen, last_seen):
         self.group_id = group_id
         self.key = key

--- a/tests/sentry/api/endpoints/test_group_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_details.py
@@ -47,7 +47,6 @@ class GroupTagDetailsTest(APITestCase):
         url = '/api/0/issues/{}/tags/{}/'.format(group.id, tagkey.key)
         response = self.client.get(url, format='json')
         assert response.status_code == 200, response.content
-        assert response.data['id'] == six.text_type(tagkey.id)
         assert response.data['key'] == six.text_type(tagkey.key)
         assert response.data['uniqueValues'] == 1
         assert response.data['totalValues'] == 3

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import mock
-import six
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -35,7 +34,6 @@ class ProjectTagKeyDetailsTest(APITestCase):
         response = self.client.get(url)
 
         assert response.status_code == 200
-        assert response.data['id'] == six.text_type(tagkey.id)
         assert response.data['uniqueValues'] == tagkey.values_seen
 
 

--- a/tests/sentry/api/serializers/test_grouptagkey.py
+++ b/tests/sentry/api/serializers/test_grouptagkey.py
@@ -1,28 +1,19 @@
 from __future__ import absolute_import
 
-import six
-
-from sentry import tagstore
 from sentry.api.serializers import serialize
+from sentry.tagstore.types import GroupTagKey
 from sentry.testutils import TestCase
 
 
 class GroupTagKeySerializerTest(TestCase):
     def test(self):
         user = self.create_user()
-        project = self.create_project()
-        tagkey = tagstore.create_tag_key(
-            project_id=project.id,
-            environment_id=self.environment.id,
-            key='key'
-        )
-        grouptagkey = tagstore.create_group_tag_key(
-            project_id=project.id,
-            group_id=self.create_group(project=project).id,
-            environment_id=self.environment.id,
-            key=tagkey.key
+        grouptagkey = GroupTagKey(
+            group_id=0,
+            key='key',
+            values_seen=1,
         )
 
         result = serialize(grouptagkey, user)
-        assert result['id'] == six.text_type(grouptagkey.id)
         assert result['key'] == 'key'
+        assert result['uniqueValues'] == 1

--- a/tests/sentry/api/serializers/test_grouptagvalue.py
+++ b/tests/sentry/api/serializers/test_grouptagvalue.py
@@ -2,38 +2,26 @@
 
 from __future__ import absolute_import
 
-import six
+from datetime import datetime
 
-from sentry import tagstore
 from sentry.api.serializers import serialize
-from sentry.models import EventUser
+from sentry.tagstore.types import GroupTagValue
 from sentry.testutils import TestCase
 
 
 class GroupTagValueSerializerTest(TestCase):
     def test_with_user(self):
         user = self.create_user()
-        project = self.create_project()
-        euser = EventUser.objects.create(
-            project_id=project.id,
-            email='foo@example.com',
-        )
-        tagvalue = tagstore.create_tag_value(
-            project_id=project.id,
-            environment_id=self.environment.id,
+        grouptagvalue = GroupTagValue(
+            group_id=0,
             key='sentry:user',
-            value=euser.tag_value,
-        )
-        grouptagvalue = tagstore.create_group_tag_value(
-            project_id=project.id,
-            group_id=self.create_group(project=project).id,
-            environment_id=self.environment.id,
-            key=tagvalue.key,
-            value=tagvalue.value,
+            value='username:ted',
+            times_seen=1,
+            first_seen=datetime(2018, 1, 1),
+            last_seen=datetime(2018, 1, 1),
         )
 
         result = serialize(grouptagvalue, user)
-        assert result['id'] == six.text_type(grouptagvalue.id)
         assert result['key'] == 'user'
-        assert result['value'] == grouptagvalue.value
-        assert result['name'] == euser.get_label()
+        assert result['value'] == 'username:ted'
+        assert result['name'] == 'ted'

--- a/tests/sentry/api/serializers/test_tagvalue.py
+++ b/tests/sentry/api/serializers/test_tagvalue.py
@@ -2,63 +2,40 @@
 
 from __future__ import absolute_import
 
-import six
+from datetime import datetime
 
-from sentry import tagstore
 from sentry.api.serializers import serialize
-from sentry.models import EventUser
+from sentry.tagstore.types import TagValue
 from sentry.testutils import TestCase
 
 
 class TagValueSerializerTest(TestCase):
     def test_with_user(self):
         user = self.create_user()
-        project = self.create_project()
-        euser = EventUser.objects.create(
-            project_id=project.id,
-            email='foo@example.com',
-        )
-        tagvalue = tagstore.create_tag_value(
-            project_id=project.id,
-            environment_id=self.environment.id,
+        tagvalue = TagValue(
             key='sentry:user',
-            value=euser.tag_value,
+            value='username:ted',
+            times_seen=1,
+            first_seen=datetime(2018, 1, 1),
+            last_seen=datetime(2018, 1, 1),
         )
 
         result = serialize(tagvalue, user)
-        assert result['id'] == six.text_type(tagvalue.id)
         assert result['key'] == 'user'
-        assert result['value'] == tagvalue.value
-        assert result['name'] == euser.get_label()
-
-    def test_basic(self):
-        user = self.create_user()
-        project = self.create_project()
-        tagvalue = tagstore.create_tag_value(
-            project_id=project.id,
-            environment_id=self.environment.id,
-            key='sentry:user',
-            value='email:foo@example.com',
-        )
-
-        result = serialize(tagvalue, user)
-        assert result['id'] == six.text_type(tagvalue.id)
-        assert result['key'] == 'user'
-        assert result['value'] == tagvalue.value
-        assert result['name'] == tagvalue.get_label()
+        assert result['value'] == 'username:ted'
+        assert result['name'] == 'ted'
 
     def test_release(self):
         user = self.create_user()
-        project = self.create_project()
-        tagvalue = tagstore.create_tag_value(
-            project_id=project.id,
-            environment_id=self.environment.id,
+        tagvalue = TagValue(
             key='sentry:release',
             value='df84bccbb23ca15f2868be1f2a5f7c7a6464fadd',
+            times_seen=1,
+            first_seen=datetime(2018, 1, 1),
+            last_seen=datetime(2018, 1, 1),
         )
 
         result = serialize(tagvalue, user)
-        assert result['id'] == six.text_type(tagvalue.id)
         assert result['key'] == 'release'
-        assert result['value'] == tagvalue.value
-        assert result['name'] == tagvalue.get_label()
+        assert result['value'] == 'df84bccbb23ca15f2868be1f2a5f7c7a6464fadd'
+        assert result['name'] == 'df84bcc'

--- a/tests/sentry/manager/tests.py
+++ b/tests/sentry/manager/tests.py
@@ -20,16 +20,25 @@ class SentryManagerTest(TestCase):
         environment = self.create_environment()
 
         with self.tasks():
-            Group.objects.add_tags(group, environment, tags=(
-                ('foo', 'bar'), ('foo', 'baz'), ('biz', 'boz')))
+            Group.objects.add_tags(
+                group,
+                environment,
+                tags=[
+                    ('foo', 'bar'),
+                    ('foo', 'baz'),
+                    ('biz', 'boz'),
+                ],
+            )
 
         results = sorted(
             tagstore.get_group_tag_values(
                 group.project_id,
                 group.id,
                 environment_id=None,
-                key='foo'),
-            key=lambda x: x.id)
+                key='foo',
+            ),
+            key=lambda x: x.value,
+        )
         assert len(results) == 2
         res = results[0]
         self.assertEquals(res.value, 'bar')
@@ -38,13 +47,12 @@ class SentryManagerTest(TestCase):
         self.assertEquals(res.value, 'baz')
         self.assertEquals(res.times_seen, 1)
 
-        results = sorted(
-            tagstore.get_group_tag_values(
-                group.project_id,
-                group.id,
-                environment_id=None,
-                key='biz'),
-            key=lambda x: x.id)
+        results = tagstore.get_group_tag_values(
+            group.project_id,
+            group.id,
+            environment_id=None,
+            key='biz'
+        )
         assert len(results) == 1
         res = results[0]
         self.assertEquals(res.value, 'boz')


### PR DESCRIPTION
This updates the legacy tagstore backend to return the non-model types defined in `sentry.tagstore.types` rather than model instances from read methods (with the exception of methods that return a `QuerySet` instance for pagination.)

These methods are almost exclusively used to construct API responses, and changing the return type to a non-model type will allow simpler substitution for non-model-based backends (such as the Snuba backend.) This will also allow easier comparison of results between two different backends, since they'll be returning the same types and will be directly comparable without having to perform an intermediate translation.

Some changes worth noting:

- The serializers no longer include an `id` parameter, since `{,Group}Tag{Key,Value}` objects will be derived from the underlying data and not stored as independent rows.
- This also removes the legacy model API serializers to ensure that no model instances are leaking through to the API.