### PR TITLE
fix(slack): Use authorizing_user_id over installer_user_id

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -97,7 +97,7 @@ class SlackIntegration(Integration):
             },
             'user_identity': {
                 'type': 'slack',
-                'external_id': data['installer_user_id'],
+                'external_id': data['authorizing_user_id'],
                 'scopes': [],
                 'data': {},
             },

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -13,7 +13,7 @@ from sentry.testutils import IntegrationTestCase
 class SlackIntegrationTest(IntegrationTestCase):
     provider = SlackIntegration
 
-    def assert_setup_flow(self, team_id='TXXXXXXX1', installer_user_id='UXXXXXXX1'):
+    def assert_setup_flow(self, team_id='TXXXXXXX1', authorizing_user_id='UXXXXXXX1'):
         responses.reset()
 
         resp = self.client.get(self.init_path)
@@ -36,11 +36,10 @@ class SlackIntegrationTest(IntegrationTestCase):
             responses.POST, 'https://slack.com/api/oauth.token',
             json={
                 'ok': True,
-                'user_id': installer_user_id,
                 'access_token': 'xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
                 'team_id': team_id,
                 'team_name': 'Example',
-                'installer_user_id': installer_user_id,
+                'authorizing_user_id': authorizing_user_id,
             }
         )
 
@@ -107,7 +106,7 @@ class SlackIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_multiple_integrations(self):
         self.assert_setup_flow()
-        self.assert_setup_flow(team_id='TXXXXXXX2', installer_user_id='UXXXXXXX2')
+        self.assert_setup_flow(team_id='TXXXXXXX2', authorizing_user_id='UXXXXXXX2')
 
         integrations = Integration.objects.filter(provider=self.provider.key)
 


### PR DESCRIPTION
When associating the users identity after the app install flow we were incorrectly using the `installer_user_id` to identify the *current* installing user, `installer_user_id` returns the *original* installer, when really we should have been using the `authorizing_user_id` to retrieve their identity.

Slack defines the difference as ([documented here](https://api.slack.com/methods/oauth.token#oauth.token_response_field_guide)):

 * `installer_user_id` - This is the user ID of the user that originally installed this app.
 * `authorizing_user_id` - This user ID belongs to the user currently undergoing the authorization process.

Relates to [SENTRY-6J3](https://sentry.io/share/issue/b96770b4432748d386364a2e08ac233a/) but doesn't completely fix it.