### PR TITLE
feat: Display Kernel version when no OS Version is available

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -56,6 +56,51 @@ class GenericSummary extends React.Component {
   }
 }
 
+export class OsSummary extends React.Component {
+  static propTypes = {
+    data: PropTypes.object.isRequired,
+  };
+
+  render() {
+    let data = this.props.data;
+
+    if (objectIsEmpty(data) || !data.name) {
+      return <NoSummary title={t('Unknown OS')} />;
+    }
+
+    let className = generateClassName(data.name);
+    let versionElement = null;
+
+    if (data.version) {
+      versionElement = (
+        <p>
+          <strong>{t('Version:')}</strong> {data.version}
+        </p>
+      );
+    } else if (data.kernel_version) {
+      versionElement = (
+        <p>
+          <strong>{t('Kernel:')}</strong> {data.kernel_version}
+        </p>
+      );
+    } else {
+      versionElement = (
+        <p>
+          <strong>{t('Version:')}</strong> {t('Unknown')}
+        </p>
+      );
+    }
+
+    return (
+      <div className={`context-item ${className}`}>
+        <span className="context-item-icon" />
+        <h3>{data.name}</h3>
+        {versionElement}
+      </div>
+    );
+  }
+}
+
 class UserSummary extends React.Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
@@ -146,7 +191,7 @@ const KNOWN_CONTEXTS = [
   {key: 'user', Component: UserSummary},
   {key: 'browser', Component: GenericSummary, unknownTitle: t('Unknown Browser')},
   {key: 'runtime', Component: GenericSummary, unknownTitle: t('Unknown Runtime')},
-  {key: 'os', Component: GenericSummary, unknownTitle: t('Unknown OS')},
+  {key: 'os', Component: OsSummary},
   {key: 'device', Component: DeviceSummary},
 ];
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -985,6 +985,7 @@
       }
     }
 
+    &.darwin,
     &.ios,
     &.macos,
     &.tvos,

--- a/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
@@ -72,7 +72,7 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
     key="runtime"
     unknownTitle="Unknown Runtime"
   />
-  <GenericSummary
+  <OsSummary
     data={
       Object {
         "build": "17E199",
@@ -83,7 +83,6 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
       }
     }
     key="os"
-    unknownTitle="Unknown OS"
   />
 </div>
 `;
@@ -103,7 +102,7 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
     key="runtime"
     unknownTitle="Unknown Runtime"
   />
-  <GenericSummary
+  <OsSummary
     data={
       Object {
         "build": "17E199",
@@ -114,7 +113,6 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
       }
     }
     key="os"
-    unknownTitle="Unknown OS"
   />
   <DeviceSummary
     data={
@@ -154,7 +152,7 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     key="runtime"
     unknownTitle="Unknown Runtime"
   />
-  <GenericSummary
+  <OsSummary
     data={
       Object {
         "build": "17E199",
@@ -165,7 +163,6 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
       }
     }
     key="os"
-    unknownTitle="Unknown OS"
   />
   <DeviceSummary
     data={
@@ -178,5 +175,65 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     }
     key="device"
   />
+</div>
+`;
+
+exports[`OsSummary render() should render the kernel version when no version 1`] = `
+<div
+  className="context-item mac-os-x"
+>
+  <span
+    className="context-item-icon"
+  />
+  <h3>
+    Mac OS X
+  </h3>
+  <p>
+    <strong>
+      Kernel:
+    </strong>
+     
+    17.5.0
+  </p>
+</div>
+`;
+
+exports[`OsSummary render() should render the version string 1`] = `
+<div
+  className="context-item mac-os-x"
+>
+  <span
+    className="context-item-icon"
+  />
+  <h3>
+    Mac OS X
+  </h3>
+  <p>
+    <strong>
+      Version:
+    </strong>
+     
+    10.13.4
+  </p>
+</div>
+`;
+
+exports[`OsSummary render() should render unknown when no version 1`] = `
+<div
+  className="context-item mac-os-x"
+>
+  <span
+    className="context-item-icon"
+  />
+  <h3>
+    Mac OS X
+  </h3>
+  <p>
+    <strong>
+      Version:
+    </strong>
+     
+    Unknown
+  </p>
 </div>
 `;

--- a/tests/js/spec/components/events/contextSummary.spec.jsx
+++ b/tests/js/spec/components/events/contextSummary.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import ContextSummary from 'app/components/events/contextSummary';
+import ContextSummary, {OsSummary} from 'app/components/events/contextSummary';
 
 const CONTEXT_USER = {
   email: 'mail@example.org',
@@ -128,6 +128,46 @@ describe('ContextSummary', function() {
       };
 
       const wrapper = shallow(<ContextSummary event={event} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});
+
+describe('OsSummary', function() {
+  describe('render()', function() {
+    it('should render the version string', () => {
+      const os = {
+        kernel_version: '17.5.0',
+        version: '10.13.4',
+        type: 'os',
+        build: '17E199',
+        name: 'Mac OS X',
+      };
+
+      const wrapper = shallow(<OsSummary data={os} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render the kernel version when no version', () => {
+      const os = {
+        kernel_version: '17.5.0',
+        type: 'os',
+        build: '17E199',
+        name: 'Mac OS X',
+      };
+
+      const wrapper = shallow(<OsSummary data={os} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render unknown when no version', () => {
+      const os = {
+        type: 'os',
+        build: '17E199',
+        name: 'Mac OS X',
+      };
+
+      const wrapper = shallow(<OsSummary data={os} />);
       expect(wrapper).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
To improve the experience of the .NET SDK, when reporting errors from both .NET Core and Mono on different platforms, the UI was changed to report the Kernel version when the OS version is not known.

Take for example an app compiled to .NET Framework 4.0 running on Mono on _macOS_. It'll report OS _Unix_ and its kernel version. When running on .NET Core 2, it'll return _Darwin_ and its kernel version.

We still need an icon when the OS reported is Unix:

![Unix](https://user-images.githubusercontent.com/1633368/39525185-8c0c38d6-4e1b-11e8-824f-60acae1a6ca7.png) 

This Unix value is more like _Unix-like_ as it could be Darwin, BSD, Linux or else.

But when the reported OS is Darwin:

![Darwin](https://user-images.githubusercontent.com/1633368/39525166-7e13578c-4e1b-11e8-8b4d-032db9b0efd9.png)
We at least know it's an apple device (i.e: macOS, iOS) so we show the Apple logo.
