### PR TITLE
fix(ui): Use old sidebar for old django views

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -32,8 +32,8 @@ class SidebarDropdown extends React.Component {
 
   render() {
     let {org, orientation, collapsed, config, user, onClick} = this.props;
-    let hasOrgWrite = org.access.indexOf('org:write') > -1;
-    let hasMemberRead = org.access.indexOf('member:read') > -1;
+    let hasOrgWrite = org && org.access && org.access.indexOf('org:write') > -1;
+    let hasMemberRead = org && org.access && org.access.indexOf('member:read') > -1;
 
     return (
       <DropdownMenu>

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -157,7 +157,9 @@ export default {
     ProjectSelector: require('app/components/projectHeader/projectSelector').default,
     SettingsPageHeader: require('app/views/settings/components/settingsPageHeader')
       .default,
-    Sidebar: require('app/components/sidebar').default,
+
+    // #NEW-SETTINGS #SIDEBAR -- need to update this when we remove old sidebar
+    Sidebar: require('app/components/sidebar.old').default,
     StackedBarChart: require('app/components/stackedBarChart').default,
     TextBlock: require('app/views/settings/components/text/textBlock').default,
     TimeSince: require('app/components/timeSince').default,


### PR DESCRIPTION
`/account/notifications/unsubscribe/`  routes seem to be throwing emotion errors. New Sidebar is being exported, change it to export old sidebar.

Fixes JAVASCRIPT-3QW
Fixes JAVASCRIPT-3QS