### PR TITLE
fix(ui): Wrong tooltip for expanding sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -276,7 +276,7 @@ class Sidebar extends React.Component {
                 data-test-id="sidebar-collapse"
                 {...sidebarItemProps}
                 icon={<StyledInlineSvg src="icon-collapse" collapsed={collapsed} />}
-                label={t('Collapse')}
+                label={t('Expand')}
                 onClick={this.toggleSidebar}
               />
             </SidebarSection>

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -276,7 +276,7 @@ class Sidebar extends React.Component {
                 data-test-id="sidebar-collapse"
                 {...sidebarItemProps}
                 icon={<StyledInlineSvg src="icon-collapse" collapsed={collapsed} />}
-                label={t('Expand')}
+                label={collapsed ? t('Expand') : t('Collapse')}
                 onClick={this.toggleSidebar}
               />
             </SidebarSection>


### PR DESCRIPTION
Was "collapse" when it should be "expand"