### PR TITLE
fix(dashboard): Fix platform list spacing

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/platformList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/platformList.jsx
@@ -85,11 +85,12 @@ const StyledPlatformIcon = styled.span`
 const PlatformText = styled.div`
   color: ${p => p.theme.gray2};
   font-size: 13px;
+  line-height: 13px;
 `;
 
 const NoPlatforms = styled(Flex)`
   color: ${p => p.theme.gray2};
-  height: 70px;
+  height: 66px;
 `;
 
 export default withRouter(PlatformList);

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -419,7 +419,7 @@ exports[`ProjectCard renders 1`] = `
                 </div>
                 <PlatformText>
                   <div
-                    className="css-12aj0sd-PlatformText e1mca4c62"
+                    className="css-1oyd7ep-PlatformText e1mca4c62"
                   >
                     javascript
                   </div>


### PR DESCRIPTION
Improve spacing for platform text that spans multiple lines

Height of empty platform section matches the others