### PR TITLE
feat(ui): Allow sidebar to render w/o org/router

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -43,14 +43,14 @@ class SidebarDropdown extends React.Component {
     let hasOrgWrite = org && org.access && org.access.indexOf('org:write') > -1;
     let hasMemberRead = org && org.access && org.access.indexOf('member:read') > -1;
 
-    // Avatar to use (Sentry avatar if no org exists)
+    // Avatar to use: Organization --> user --> Sentry
     const avatar =
       hasOrganization || hasUser ? (
         <StyledAvatar
           onClick={onClick}
           collapsed={collapsed}
           organization={org}
-          user={user}
+          user={!org ? user : null}
           size={32}
         />
       ) : (

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -6,6 +6,7 @@ import {t} from 'app/locale';
 import Avatar from 'app/components/avatar';
 import DropdownMenu from 'app/components/dropdownMenu';
 import Hook from 'app/components/hook';
+import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/link';
 import SentryTypes from 'app/proptypes';
 import TextOverflow from 'app/components/textOverflow';
@@ -33,8 +34,30 @@ class SidebarDropdown extends React.Component {
 
   render() {
     let {org, orientation, collapsed, config, user, onClick} = this.props;
+    let hasOrganization = !!org;
+    let hasUser = !!user;
+
+    // If there is no org in context, we use an org from `withLatestContext`
+    // (which uses an org from organizations index endpoint versus details endpoint)
+    // and does not have `access`
     let hasOrgWrite = org && org.access && org.access.indexOf('org:write') > -1;
     let hasMemberRead = org && org.access && org.access.indexOf('member:read') > -1;
+
+    // Avatar to use (Sentry avatar if no org exists)
+    const avatar =
+      hasOrganization || hasUser ? (
+        <StyledAvatar
+          onClick={onClick}
+          collapsed={collapsed}
+          organization={org}
+          user={user}
+          size={32}
+        />
+      ) : (
+        <SentryLink to="/">
+          <InlineSvg css={{fontSize: 32}} src="icon-sentry" />
+        </SentryLink>
+      );
 
     return (
       <DropdownMenu>
@@ -46,13 +69,9 @@ class SidebarDropdown extends React.Component {
                 {...getActorProps({isStyled: true})}
               >
                 <div style={{display: 'flex', alignItems: 'flex-start'}}>
-                  <StyledAvatar
-                    onClick={onClick}
-                    collapsed={collapsed}
-                    organization={org}
-                    size={32}
-                  />
-                  {!collapsed &&
+                  {avatar}
+                  {hasOrganization &&
+                    !collapsed &&
                     orientation !== 'top' && (
                       <NameAndOrgWrapper>
                         <DropdownOrgName>
@@ -66,54 +85,62 @@ class SidebarDropdown extends React.Component {
 
               {isOpen && (
                 <OrgAndUserMenu {...getMenuProps({isStyled: true, org})}>
-                  <SidebarOrgSummary organization={org} />
-                  {hasOrgWrite && (
-                    <SidebarMenuItem to={`/settings/${org.slug}/`}>
-                      {t('Organization settings')}
-                    </SidebarMenuItem>
+                  {hasOrganization && (
+                    <React.Fragment>
+                      <SidebarOrgSummary organization={org} />
+                      {hasOrgWrite && (
+                        <SidebarMenuItem to={`/settings/${org.slug}/`}>
+                          {t('Organization settings')}
+                        </SidebarMenuItem>
+                      )}
+                      {hasMemberRead && (
+                        <SidebarMenuItem to={`/settings/${org.slug}/members/`}>
+                          {t('Members')}
+                        </SidebarMenuItem>
+                      )}
+
+                      <Hook
+                        name="sidebar:organization-dropdown-menu"
+                        organization={org}
+                        Components={{SidebarMenuItem}}
+                      />
+
+                      {config.isOnPremise && (
+                        <SidebarMenuItem href="https://forum.sentry.io/">
+                          {t('Support forum')}
+                        </SidebarMenuItem>
+                      )}
+
+                      <SidebarMenuItem>
+                        <SwitchOrganization canCreateOrganization={hasOrgWrite} />
+                      </SidebarMenuItem>
+
+                      <Divider />
+                    </React.Fragment>
                   )}
-                  {hasMemberRead && (
-                    <SidebarMenuItem to={`/settings/${org.slug}/members/`}>
-                      {t('Members')}
-                    </SidebarMenuItem>
+
+                  {!!user && (
+                    <React.Fragment>
+                      <UserSummary to="/settings/account/details/">
+                        <UserBadgeNoOverflow user={user} avatarSize={32} />
+                      </UserSummary>
+
+                      <div>
+                        <SidebarMenuItem to="/settings/account/">
+                          {t('User settings')}
+                        </SidebarMenuItem>
+                        <SidebarMenuItem to={'/settings/account/api/'}>
+                          {t('API keys')}
+                        </SidebarMenuItem>
+                        {user.isSuperuser && (
+                          <SidebarMenuItem to={'/manage/'}>{t('Admin')}</SidebarMenuItem>
+                        )}
+                        <SidebarMenuItem href="/auth/logout/">
+                          {t('Sign out')}
+                        </SidebarMenuItem>
+                      </div>
+                    </React.Fragment>
                   )}
-
-                  <Hook
-                    name="sidebar:organization-dropdown-menu"
-                    organization={org}
-                    Components={{SidebarMenuItem}}
-                  />
-
-                  {config.isOnPremise && (
-                    <SidebarMenuItem href="https://forum.sentry.io/">
-                      {t('Support forum')}
-                    </SidebarMenuItem>
-                  )}
-
-                  <SidebarMenuItem>
-                    <SwitchOrganization canCreateOrganization={hasOrgWrite} />
-                  </SidebarMenuItem>
-
-                  <Divider />
-
-                  <UserSummary to="/settings/account/details/">
-                    <UserBadgeNoOverflow user={user} avatarSize={32} />
-                  </UserSummary>
-
-                  <div>
-                    <SidebarMenuItem to="/settings/account/">
-                      {t('User settings')}
-                    </SidebarMenuItem>
-                    <SidebarMenuItem to={'/settings/account/api/'}>
-                      {t('API keys')}
-                    </SidebarMenuItem>
-                    {user.isSuperuser && (
-                      <SidebarMenuItem to={'/manage/'}>{t('Admin')}</SidebarMenuItem>
-                    )}
-                    <SidebarMenuItem href="/auth/logout/">
-                      {t('Sign out')}
-                    </SidebarMenuItem>
-                  </div>
                 </OrgAndUserMenu>
               )}
             </SidebarDropdownRoot>
@@ -125,6 +152,13 @@ class SidebarDropdown extends React.Component {
 }
 
 export default SidebarDropdown;
+
+const SentryLink = styled(Link)`
+  color: ${p => p.theme.white};
+  &:hover {
+    color: ${p => p.theme.white};
+  }
+`;
 
 const UserSummary = styled(Link)`
   display: flex;

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -156,7 +156,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
   }
 >
   <div
-    className="css-1d11loe-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw8"
+    className="css-1d11loe-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -483,17 +483,17 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
       to="/settings/account/details/"
     >
       <Link
-        className="css-1fpw0f9-UserSummary e1fowdfw0"
+        className="css-1fpw0f9-UserSummary e1fowdfw1"
         to="/settings/account/details/"
       >
         <Link
-          className="css-1fpw0f9-UserSummary e1fowdfw0"
+          className="css-1fpw0f9-UserSummary e1fowdfw1"
           onlyActiveOnIndex={false}
           style={Object {}}
           to="/settings/account/details/"
         >
           <a
-            className="css-1fpw0f9-UserSummary e1fowdfw0"
+            className="css-1fpw0f9-UserSummary e1fowdfw1"
             onClick={[Function]}
             style={Object {}}
           >
@@ -519,7 +519,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
             >
               <IdBadge
                 avatarSize={32}
-                className="css-1tz319h-UserBadgeNoOverflow e1fowdfw1"
+                className="css-1tz319h-UserBadgeNoOverflow e1fowdfw2"
                 user={
                   Object {
                     "email": "foo@example.com",
@@ -540,7 +540,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
               >
                 <UserBadge
                   avatarSize={32}
-                  className="css-1tz319h-UserBadgeNoOverflow e1fowdfw1"
+                  className="css-1tz319h-UserBadgeNoOverflow e1fowdfw2"
                   hideEmail={false}
                   useLink={false}
                   user={
@@ -562,10 +562,10 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                   }
                 >
                   <StyledUserBadge
-                    className="css-1tz319h-UserBadgeNoOverflow e1fowdfw1"
+                    className="css-1tz319h-UserBadgeNoOverflow e1fowdfw2"
                   >
                     <div
-                      className="e1fowdfw1 css-1dpgz1o-StyledUserBadge-UserBadgeNoOverflow ev46mzr0"
+                      className="e1fowdfw2 css-1dpgz1o-StyledUserBadge-UserBadgeNoOverflow ev46mzr0"
                     >
                       <StyledAvatar
                         size={32}
@@ -1475,4 +1475,396 @@ exports[`Sidebar can have onboarding feature 1`] = `
     </Component>
   </StyledSidebarPanel>
 </SidebarPanel>
+`;
+
+exports[`Sidebar renders without org and router 1`] = `
+<OrgAndUserMenu
+  innerRef={[Function]}
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  org={null}
+>
+  <div
+    className="css-1d11loe-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <UserSummary
+      to="/settings/account/details/"
+    >
+      <Link
+        className="css-1fpw0f9-UserSummary e1fowdfw1"
+        to="/settings/account/details/"
+      >
+        <Link
+          className="css-1fpw0f9-UserSummary e1fowdfw1"
+          onlyActiveOnIndex={false}
+          style={Object {}}
+          to="/settings/account/details/"
+        >
+          <a
+            className="css-1fpw0f9-UserSummary e1fowdfw1"
+            onClick={[Function]}
+            style={Object {}}
+          >
+            <UserBadgeNoOverflow
+              avatarSize={32}
+              user={
+                Object {
+                  "email": "foo@example.com",
+                  "flags": Object {
+                    "newsletter_consent_prompt": false,
+                  },
+                  "hasPasswordAuth": true,
+                  "id": "1",
+                  "isAuthenticated": true,
+                  "name": "Foo Bar",
+                  "options": Object {
+                    "timezone": "UTC",
+                  },
+                  "permissions": Set {},
+                  "username": "foo@example.com",
+                }
+              }
+            >
+              <IdBadge
+                avatarSize={32}
+                className="css-1tz319h-UserBadgeNoOverflow e1fowdfw2"
+                user={
+                  Object {
+                    "email": "foo@example.com",
+                    "flags": Object {
+                      "newsletter_consent_prompt": false,
+                    },
+                    "hasPasswordAuth": true,
+                    "id": "1",
+                    "isAuthenticated": true,
+                    "name": "Foo Bar",
+                    "options": Object {
+                      "timezone": "UTC",
+                    },
+                    "permissions": Set {},
+                    "username": "foo@example.com",
+                  }
+                }
+              >
+                <UserBadge
+                  avatarSize={32}
+                  className="css-1tz319h-UserBadgeNoOverflow e1fowdfw2"
+                  hideEmail={false}
+                  useLink={false}
+                  user={
+                    Object {
+                      "email": "foo@example.com",
+                      "flags": Object {
+                        "newsletter_consent_prompt": false,
+                      },
+                      "hasPasswordAuth": true,
+                      "id": "1",
+                      "isAuthenticated": true,
+                      "name": "Foo Bar",
+                      "options": Object {
+                        "timezone": "UTC",
+                      },
+                      "permissions": Set {},
+                      "username": "foo@example.com",
+                    }
+                  }
+                >
+                  <StyledUserBadge
+                    className="css-1tz319h-UserBadgeNoOverflow e1fowdfw2"
+                  >
+                    <div
+                      className="e1fowdfw2 css-1dpgz1o-StyledUserBadge-UserBadgeNoOverflow ev46mzr0"
+                    >
+                      <StyledAvatar
+                        size={32}
+                        user={
+                          Object {
+                            "email": "foo@example.com",
+                            "flags": Object {
+                              "newsletter_consent_prompt": false,
+                            },
+                            "hasPasswordAuth": true,
+                            "id": "1",
+                            "isAuthenticated": true,
+                            "name": "Foo Bar",
+                            "options": Object {
+                              "timezone": "UTC",
+                            },
+                            "permissions": Set {},
+                            "username": "foo@example.com",
+                          }
+                        }
+                      >
+                        <Component
+                          className="css-1u6j7yz-StyledAvatar ev46mzr4"
+                          size={32}
+                          user={
+                            Object {
+                              "email": "foo@example.com",
+                              "flags": Object {
+                                "newsletter_consent_prompt": false,
+                              },
+                              "hasPasswordAuth": true,
+                              "id": "1",
+                              "isAuthenticated": true,
+                              "name": "Foo Bar",
+                              "options": Object {
+                                "timezone": "UTC",
+                              },
+                              "permissions": Set {},
+                              "username": "foo@example.com",
+                            }
+                          }
+                        >
+                          <Avatar
+                            className="css-1u6j7yz-StyledAvatar ev46mzr4"
+                            hasTooltip={false}
+                            size={32}
+                            user={
+                              Object {
+                                "email": "foo@example.com",
+                                "flags": Object {
+                                  "newsletter_consent_prompt": false,
+                                },
+                                "hasPasswordAuth": true,
+                                "id": "1",
+                                "isAuthenticated": true,
+                                "name": "Foo Bar",
+                                "options": Object {
+                                  "timezone": "UTC",
+                                },
+                                "permissions": Set {},
+                                "username": "foo@example.com",
+                              }
+                            }
+                          >
+                            <UserAvatar
+                              className="css-1u6j7yz-StyledAvatar ev46mzr4"
+                              gravatar={true}
+                              hasTooltip={false}
+                              size={32}
+                              user={
+                                Object {
+                                  "email": "foo@example.com",
+                                  "flags": Object {
+                                    "newsletter_consent_prompt": false,
+                                  },
+                                  "hasPasswordAuth": true,
+                                  "id": "1",
+                                  "isAuthenticated": true,
+                                  "name": "Foo Bar",
+                                  "options": Object {
+                                    "timezone": "UTC",
+                                  },
+                                  "permissions": Set {},
+                                  "username": "foo@example.com",
+                                }
+                              }
+                            >
+                              <BaseAvatar
+                                className="css-1u6j7yz-StyledAvatar ev46mzr4"
+                                gravatarId="foo@example.com"
+                                hasTooltip={false}
+                                letterId="foo@example.com"
+                                size={32}
+                                style={Object {}}
+                                title="Foo Bar"
+                                tooltip="Foo Bar (foo@example.com)"
+                                type="gravatar"
+                              >
+                                <Tooltip
+                                  disabled={true}
+                                  title="Foo Bar (foo@example.com)"
+                                >
+                                  <StyledBaseAvatar
+                                    className="avatar css-1u6j7yz-StyledAvatar ev46mzr4"
+                                    style={
+                                      Object {
+                                        "height": "32px",
+                                        "width": "32px",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="avatar ev46mzr4 css-1dbvbxh-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                                      style={
+                                        Object {
+                                          "height": "32px",
+                                          "width": "32px",
+                                        }
+                                      }
+                                    >
+                                      <img
+                                        onError={[Function]}
+                                        onLoad={[Function]}
+                                        src="undefined/avatar/b48def645758b95537d4424c84d1a9ff?d=blank&s=32"
+                                      />
+                                    </span>
+                                  </StyledBaseAvatar>
+                                </Tooltip>
+                              </BaseAvatar>
+                            </UserAvatar>
+                          </Avatar>
+                        </Component>
+                      </StyledAvatar>
+                      <StyledNameAndEmail>
+                        <div
+                          className="css-9l6b2w-StyledNameAndEmail ev46mzr1"
+                        >
+                          <StyledName
+                            hideEmail={false}
+                            to="/settings/undefined/members/1/"
+                            useLink={false}
+                          >
+                            <Component
+                              className="css-12fcmnb-StyledName ev46mzr3"
+                              hideEmail={false}
+                              to="/settings/undefined/members/1/"
+                              useLink={false}
+                            >
+                              <span
+                                className="css-12fcmnb-StyledName ev46mzr3"
+                              >
+                                Foo Bar
+                              </span>
+                            </Component>
+                          </StyledName>
+                          <StyledEmail>
+                            <div
+                              className="css-3w2sfq-StyledEmail ev46mzr2"
+                            >
+                              foo@example.com
+                            </div>
+                          </StyledEmail>
+                        </div>
+                      </StyledNameAndEmail>
+                    </div>
+                  </StyledUserBadge>
+                </UserBadge>
+              </IdBadge>
+            </UserBadgeNoOverflow>
+          </a>
+        </Link>
+      </Link>
+    </UserSummary>
+    <div>
+      <SidebarMenuItem
+        to="/settings/account/"
+      >
+        <MenuItemLink
+          to="/settings/account/"
+        >
+          <Component
+            className="css-1vsrn4x-MenuItemLink ebifsjx1"
+            to="/settings/account/"
+          >
+            <Link
+              className="css-1vsrn4x-MenuItemLink ebifsjx1"
+              to="/settings/account/"
+            >
+              <Link
+                className="css-1vsrn4x-MenuItemLink ebifsjx1"
+                onlyActiveOnIndex={false}
+                style={Object {}}
+                to="/settings/account/"
+              >
+                <a
+                  className="css-1vsrn4x-MenuItemLink ebifsjx1"
+                  onClick={[Function]}
+                  style={Object {}}
+                >
+                  <MenuItemLabel
+                    hasMenu={false}
+                  >
+                    <span
+                      className="css-3xcmix-MenuItemLabel-MenuItemLabel ebifsjx0"
+                    >
+                      User settings
+                    </span>
+                  </MenuItemLabel>
+                </a>
+              </Link>
+            </Link>
+          </Component>
+        </MenuItemLink>
+      </SidebarMenuItem>
+      <SidebarMenuItem
+        to="/settings/account/api/"
+      >
+        <MenuItemLink
+          to="/settings/account/api/"
+        >
+          <Component
+            className="css-1vsrn4x-MenuItemLink ebifsjx1"
+            to="/settings/account/api/"
+          >
+            <Link
+              className="css-1vsrn4x-MenuItemLink ebifsjx1"
+              to="/settings/account/api/"
+            >
+              <Link
+                className="css-1vsrn4x-MenuItemLink ebifsjx1"
+                onlyActiveOnIndex={false}
+                style={Object {}}
+                to="/settings/account/api/"
+              >
+                <a
+                  className="css-1vsrn4x-MenuItemLink ebifsjx1"
+                  onClick={[Function]}
+                  style={Object {}}
+                >
+                  <MenuItemLabel
+                    hasMenu={false}
+                  >
+                    <span
+                      className="css-3xcmix-MenuItemLabel-MenuItemLabel ebifsjx0"
+                    >
+                      API keys
+                    </span>
+                  </MenuItemLabel>
+                </a>
+              </Link>
+            </Link>
+          </Component>
+        </MenuItemLink>
+      </SidebarMenuItem>
+      <SidebarMenuItem
+        href="/auth/logout/"
+      >
+        <MenuItemLink
+          href="/auth/logout/"
+        >
+          <Component
+            className="css-1vsrn4x-MenuItemLink ebifsjx1"
+            href="/auth/logout/"
+          >
+            <Link
+              className="css-1vsrn4x-MenuItemLink ebifsjx1"
+              href="/auth/logout/"
+            >
+              <a
+                className="css-1vsrn4x-MenuItemLink ebifsjx1"
+                href="/auth/logout/"
+              >
+                <MenuItemLabel
+                  hasMenu={false}
+                >
+                  <span
+                    className="css-3xcmix-MenuItemLabel-MenuItemLabel ebifsjx0"
+                  >
+                    Sign out
+                  </span>
+                </MenuItemLabel>
+              </a>
+            </Link>
+          </Component>
+        </MenuItemLink>
+      </SidebarMenuItem>
+    </div>
+  </div>
+</OrgAndUserMenu>
 `;

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -43,6 +43,16 @@ describe('Sidebar', function() {
     expect(wrapper.find('StyledSidebar')).toHaveLength(1);
   });
 
+  it('renders without org and router', function() {
+    wrapper = createWrapper({
+      organization: null,
+      router: null,
+    });
+
+    wrapper.find('SidebarDropdownActor').simulate('click');
+    expect(wrapper.find('OrgAndUserMenu')).toMatchSnapshot();
+  });
+
   it('can toggle collapsed state', async function() {
     wrapper = mount(
       <SidebarContainer organization={organization} user={user} router={router} />,


### PR DESCRIPTION
If there is no org in scope, show user avatar + dropdown.

If there is no user, show Sentry logo with a link back to index page.

This fixes new sidebar when it is rendered inside of a django view where there is no router in scope. Also fixes when there is no org in scope.