### PR TITLE
api: Hide "No Environment" environment from project environments

### DIFF
--- a/src/sentry/api/endpoints/project_environments.py
+++ b/src/sentry/api/endpoints/project_environments.py
@@ -18,6 +18,14 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
     def get(self, request, project):
         queryset = EnvironmentProject.objects.filter(
             project=project,
+        ).exclude(
+            # HACK(mattrobenolt): We don't want to surface the
+            # "No Environment" environment to the UI since it
+            # doesn't really exist. This might very likely change
+            # with new tagstore backend in the future, but until
+            # then, we're hiding it since it causes more problems
+            # than it's worth.
+            environment__name='',
         ).select_related('environment').order_by('environment__name')
 
         visibility = request.GET.get('visibility', 'visible')


### PR DESCRIPTION
I'm not sure if this will cause any other ramifications, but this seemed to be fine locally.