### PR TITLE
fix(rules): Correct rule key computations

### DIFF
--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -139,7 +139,7 @@ class RuleProcessor(object):
                 continue
 
             for future in results:
-                key = future.key is not None or future.callback
+                key = future.key if future.key is not None else future.callback
                 rule_future = RuleFuture(rule=rule, kwargs=future.kwargs)
 
                 if key not in self.grouped_futures:


### PR DESCRIPTION
The key would always just end up being a boolean, grouping all the actions together.