### PR TITLE
Sentry 9 dashboard polish

### DIFF
--- a/src/sentry/static/sentry/app/components/buttons/button.jsx
+++ b/src/sentry/static/sentry/app/components/buttons/button.jsx
@@ -162,6 +162,10 @@ const getColors = ({priority, disabled, theme}) => {
     background-color: ${background};
     border: 1px solid ${border || 'transparent'};
 
+    &:hover {
+      color: ${color};
+    }
+
     &:hover,
     &:focus,
     &:active {

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -157,6 +157,7 @@ const NameAndOrgWrapper = styled('div')`
 `;
 const DropdownOrgName = styled(TextOverflow)`
   font-size: 16px;
+  line-height: 1.2;
   font-weight: bold;
   color: ${p => p.theme.white};
   text-shadow: 0 0 6px rgba(255, 255, 255, 0);
@@ -179,7 +180,7 @@ const SidebarDropdownActor = styled('div')`
     }
     /* stylelint-disable-next-line no-duplicate-selectors */
     ${DropdownUserName} {
-      color: ${p => p.theme.gray3};
+      color: ${p => p.theme.gray1};
     }
   }
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -115,7 +115,9 @@ const getActiveStyle = ({active, theme}) => {
   return css`
     color: ${theme.white};
 
-    &:focus {
+    &:active,
+    &:focus,
+    &:hover {
       color: ${theme.white};
     }
 

--- a/src/sentry/static/sentry/app/views/organizationDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/chart.jsx
@@ -18,7 +18,7 @@ export default class Chart extends React.Component {
 
     return (
       <div>
-        <StyledBarChart points={data} label="events" height={80} />
+        <StyledBarChart points={data} label="events" height={60} />
       </div>
     );
   }
@@ -26,12 +26,11 @@ export default class Chart extends React.Component {
 
 const StyledBarChart = styled(BarChart)`
   a {
-    background-color: rgba(175, 163, 187, 0.2);
     &:not(:first-child) {
-      border-left: 2px solid white;
+      border-left: 2px solid transparent;
     }
     &:not(:last-child) {
-      border-right: 2px solid white;
+      border-right: 2px solid transparent;
     }
     > span {
       left: 0;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
@@ -60,14 +60,14 @@ class Dashboard extends AsyncComponent {
       <React.Fragment>
         {favorites.length > 0 && (
           <div data-test-id="favorites">
-            <TeamSection>
+            <TeamSection showBorder>
               <TeamTitleBar>
                 <TeamName>{t('Favorites')}</TeamName>
               </TeamTitleBar>
+              <ProjectCards>
+                {favorites.map(project => this.renderProjectCard(project))}
+              </ProjectCards>
             </TeamSection>
-            <ProjectCards>
-              {favorites.map(project => this.renderProjectCard(project))}
-            </ProjectCards>
           </div>
         )}
 

--- a/src/sentry/static/sentry/app/views/organizationDashboard/noEvents.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/noEvents.jsx
@@ -24,9 +24,8 @@ const Container = styled.div`
 `;
 
 const EmptyText = styled(Flex)`
-  background-color: rgba(175, 163, 187, 0.2);
   margin-left: 4px;
   margin-right: 4px;
-  height: 80px;
+  height: 68px;
   color: ${p => p.theme.gray2};
 `;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
@@ -7,6 +7,7 @@ import {Flex} from 'grid-emotion';
 import SentryTypes from 'app/proptypes';
 import {Client} from 'app/api';
 import Link from 'app/components/link';
+import space from 'app/styles/space';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import {update} from 'app/actionCreators/projects';
@@ -68,6 +69,8 @@ class ProjectCard extends React.Component {
 
 const ChartContainer = styled.div`
   position: relative;
+  background: ${p => p.theme.offWhite};
+  padding-top: ${space(1)};
 `;
 
 const StyledLink = styled(Link)`

--- a/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
@@ -89,6 +89,7 @@ const Percentage = styled(
   margin-top: ${space(0.25)};
   color: ${p => p.theme.gray2};
   font-size: 12px;
+  line-height: 1.2;
 `;
 
 export default ProjectTable;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1158,6 +1158,8 @@ table.integrations {
   h3 {
     font-size: 20px;
     margin: 0;
+    position: relative;
+    top: 2px;
 
     a {
       color: @gray-dark;

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -981,7 +981,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
             >
               <Component
                 aria-label="Learn more"
-                className="css-dvpz5-StyledButton-getColors e17811v30"
+                className="css-o6814l-StyledButton-getColors e17811v30"
                 disabled={false}
                 external={true}
                 href="https://status.sentry.io"
@@ -991,7 +991,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
               >
                 <ExternalLink
                   aria-label="Learn more"
-                  className="css-dvpz5-StyledButton-getColors e17811v30"
+                  className="css-o6814l-StyledButton-getColors e17811v30"
                   disabled={false}
                   href="https://status.sentry.io"
                   onClick={[Function]}
@@ -1002,7 +1002,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                 >
                   <a
                     aria-label="Learn more"
-                    className="css-dvpz5-StyledButton-getColors e17811v30"
+                    className="css-o6814l-StyledButton-getColors e17811v30"
                     disabled={false}
                     href="https://status.sentry.io"
                     onClick={[Function]}

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -416,7 +416,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                           >
                             <Component
                               aria-label="Compare"
-                              className="css-1hb4mqw-StyledButton-getColors e17811v30"
+                              className="css-n5jzh7-StyledButton-getColors e17811v30"
                               disabled={true}
                               href={null}
                               onClick={[Function]}
@@ -431,7 +431,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             >
                               <button
                                 aria-label="Compare"
-                                className="css-1hb4mqw-StyledButton-getColors e17811v30"
+                                className="css-n5jzh7-StyledButton-getColors e17811v30"
                                 disabled={true}
                                 href={null}
                                 onClick={[Function]}
@@ -503,7 +503,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                           >
                             <Component
                               aria-label="Collapse All"
-                              className="toggle-collapse-all css-dvpz5-StyledButton-getColors e17811v30"
+                              className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               role="button"
@@ -511,7 +511,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                             >
                               <button
                                 aria-label="Collapse All"
-                                className="toggle-collapse-all css-dvpz5-StyledButton-getColors e17811v30"
+                                className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -1880,7 +1880,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                           >
                             <Component
                               aria-label="Compare"
-                              className="css-1hb4mqw-StyledButton-getColors e17811v30"
+                              className="css-n5jzh7-StyledButton-getColors e17811v30"
                               disabled={true}
                               href={null}
                               onClick={[Function]}
@@ -1895,7 +1895,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             >
                               <button
                                 aria-label="Compare"
-                                className="css-1hb4mqw-StyledButton-getColors e17811v30"
+                                className="css-n5jzh7-StyledButton-getColors e17811v30"
                                 disabled={true}
                                 href={null}
                                 onClick={[Function]}
@@ -1967,7 +1967,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                           >
                             <Component
                               aria-label="Collapse All"
-                              className="toggle-collapse-all css-dvpz5-StyledButton-getColors e17811v30"
+                              className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               role="button"
@@ -1975,7 +1975,7 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                             >
                               <button
                                 aria-label="Collapse All"
-                                className="toggle-collapse-all css-dvpz5-StyledButton-getColors e17811v30"
+                                className="toggle-collapse-all css-o6814l-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"

--- a/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -97,7 +97,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                     >
                       <Component
                         aria-label="New API Key"
-                        className="css-1ri5bky-StyledButton-getColors e17811v30"
+                        className="css-1oc9q3a-StyledButton-getColors e17811v30"
                         disabled={false}
                         onClick={[Function]}
                         priority="primary"
@@ -106,7 +106,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                       >
                         <button
                           aria-label="New API Key"
-                          className="css-1ri5bky-StyledButton-getColors e17811v30"
+                          className="css-1oc9q3a-StyledButton-getColors e17811v30"
                           disabled={false}
                           onClick={[Function]}
                           priority="primary"

--- a/tests/js/spec/views/__snapshots__/organizationIntegrationConfig.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationIntegrationConfig.spec.jsx.snap
@@ -150,14 +150,14 @@ exports[`OrganizationIntegrationConfig render() with one integration renders 1`]
                                   size="xsmall"
                                 >
                                   <Component
-                                    className="css-dvpz5-StyledButton-getColors e17811v30"
+                                    className="css-o6814l-StyledButton-getColors e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
                                     size="xsmall"
                                   >
                                     <button
-                                      className="css-dvpz5-StyledButton-getColors e17811v30"
+                                      className="css-o6814l-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
@@ -318,14 +318,14 @@ exports[`OrganizationIntegrationConfig render() with one integration renders 1`]
                                     size="small"
                                   >
                                     <Component
-                                      className="css-dvpz5-StyledButton-getColors e17811v30"
+                                      className="css-o6814l-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
                                     >
                                       <button
-                                        className="css-dvpz5-StyledButton-getColors e17811v30"
+                                        className="css-o6814l-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         role="button"

--- a/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationProjects.spec.jsx.snap
@@ -71,7 +71,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                         >
                           <Component
                             aria-label="Create Project"
-                            className="css-1ri5bky-StyledButton-getColors e17811v30"
+                            className="css-1oc9q3a-StyledButton-getColors e17811v30"
                             disabled={false}
                             onClick={[Function]}
                             priority="primary"
@@ -81,7 +81,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                           >
                             <Link
                               aria-label="Create Project"
-                              className="css-1ri5bky-StyledButton-getColors e17811v30"
+                              className="css-1oc9q3a-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               onlyActiveOnIndex={false}
@@ -93,7 +93,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                             >
                               <a
                                 aria-label="Create Project"
-                                className="css-1ri5bky-StyledButton-getColors e17811v30"
+                                className="css-1oc9q3a-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 priority="primary"
@@ -562,7 +562,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                   >
                                     <Component
                                       aria-label="View Issues"
-                                      className="css-dvpz5-StyledButton-getColors e17811v30"
+                                      className="css-o6814l-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
@@ -571,7 +571,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                     >
                                       <Link
                                         aria-label="View Issues"
-                                        className="css-dvpz5-StyledButton-getColors e17811v30"
+                                        className="css-o6814l-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         onlyActiveOnIndex={false}
@@ -582,7 +582,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                       >
                                         <a
                                           aria-label="View Issues"
-                                          className="css-dvpz5-StyledButton-getColors e17811v30"
+                                          className="css-o6814l-StyledButton-getColors e17811v30"
                                           disabled={false}
                                           onClick={[Function]}
                                           role="button"

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -127,14 +127,14 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                 size="xsmall"
                                               >
                                                 <Component
-                                                  className="e1yghndz1 css-1v9frub-StyledButton-getColors-StyledButton e17811v30"
+                                                  className="e1yghndz1 css-a0wrx4-StyledButton-getColors-StyledButton e17811v30"
                                                   disabled={false}
                                                   onClick={[Function]}
                                                   role="button"
                                                   size="xsmall"
                                                 >
                                                   <button
-                                                    className="e1yghndz1 css-1v9frub-StyledButton-getColors-StyledButton e17811v30"
+                                                    className="e1yghndz1 css-a0wrx4-StyledButton-getColors-StyledButton e17811v30"
                                                     disabled={false}
                                                     onClick={[Function]}
                                                     role="button"
@@ -495,14 +495,14 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           size="small"
                         >
                           <Component
-                            className="css-dvpz5-StyledButton-getColors e17811v30"
+                            className="css-o6814l-StyledButton-getColors e17811v30"
                             disabled={false}
                             onClick={[Function]}
                             role="button"
                             size="small"
                           >
                             <button
-                              className="css-dvpz5-StyledButton-getColors e17811v30"
+                              className="css-o6814l-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               role="button"

--- a/tests/js/spec/views/__snapshots__/organizationTeamsProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamsProjects.spec.jsx.snap
@@ -246,7 +246,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                       >
                                         <Component
                                           aria-label="Manage Project"
-                                          className="css-dvpz5-StyledButton-getColors e17811v30"
+                                          className="css-o6814l-StyledButton-getColors e17811v30"
                                           disabled={false}
                                           onClick={[Function]}
                                           role="button"
@@ -255,7 +255,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                         >
                                           <Link
                                             aria-label="Manage Project"
-                                            className="css-dvpz5-StyledButton-getColors e17811v30"
+                                            className="css-o6814l-StyledButton-getColors e17811v30"
                                             disabled={false}
                                             onClick={[Function]}
                                             onlyActiveOnIndex={false}
@@ -266,7 +266,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                           >
                                             <a
                                               aria-label="Manage Project"
-                                              className="css-dvpz5-StyledButton-getColors e17811v30"
+                                              className="css-o6814l-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -103,7 +103,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
             <p>
               <button
                 aria-label="Restore Organization"
-                class="css-1a9yqga-StyledButton-getColors e17811v30"
+                class="css-15f0jp2-StyledButton-getColors e17811v30"
                 priority="primary"
                 role="button"
               >

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -694,7 +694,7 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
               size="zero"
             >
               <Component
-                className="e1hyuoc79 css-11tjqo2-StyledButton-getColors-RuleAddButton e17811v30"
+                className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"
@@ -702,7 +702,7 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
                 size="zero"
               >
                 <button
-                  className="e1hyuoc79 css-11tjqo2-StyledButton-getColors-RuleAddButton e17811v30"
+                  className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
                   disabled={false}
                   onClick={[Function]}
                   priority="primary"
@@ -867,7 +867,7 @@ url:http://example.com/settings/* #product"
           >
             <Component
               aria-label="Save Changes"
-              className="css-1ri5bky-StyledButton-getColors e17811v30"
+              className="css-1oc9q3a-StyledButton-getColors e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"
@@ -876,7 +876,7 @@ url:http://example.com/settings/* #product"
             >
               <button
                 aria-label="Save Changes"
-                className="css-1ri5bky-StyledButton-getColors e17811v30"
+                className="css-1oc9q3a-StyledButton-getColors e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -440,7 +440,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           type="button"
                                         >
                                           <Component
-                                            className="css-dvpz5-StyledButton-getColors e17811v30"
+                                            className="css-o6814l-StyledButton-getColors e17811v30"
                                             disabled={false}
                                             onClick={[Function]}
                                             role="button"
@@ -449,7 +449,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                             type="button"
                                           >
                                             <button
-                                              className="css-dvpz5-StyledButton-getColors e17811v30"
+                                              className="css-o6814l-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
@@ -712,7 +712,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           type="button"
                                         >
                                           <Component
-                                            className="css-dvpz5-StyledButton-getColors e17811v30"
+                                            className="css-o6814l-StyledButton-getColors e17811v30"
                                             disabled={false}
                                             onClick={[Function]}
                                             role="button"
@@ -721,7 +721,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                             type="button"
                                           >
                                             <button
-                                              className="css-dvpz5-StyledButton-getColors e17811v30"
+                                              className="css-o6814l-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
@@ -987,7 +987,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             >
                               <Component
                                 aria-label="Cancel"
-                                className="elb7f1e1 css-8du0gd-StyledButton-getColors-CancelButton e17811v30"
+                                className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -995,7 +995,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               >
                                 <Link
                                   aria-label="Cancel"
-                                  className="elb7f1e1 css-8du0gd-StyledButton-getColors-CancelButton e17811v30"
+                                  className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   onlyActiveOnIndex={false}
@@ -1005,7 +1005,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 >
                                   <a
                                     aria-label="Cancel"
-                                    className="elb7f1e1 css-8du0gd-StyledButton-getColors-CancelButton e17811v30"
+                                    className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -1052,7 +1052,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                           >
                             <Component
                               aria-label="Save Rule"
-                              className="css-1a9yqga-StyledButton-getColors e17811v30"
+                              className="css-15f0jp2-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               priority="primary"
@@ -1060,7 +1060,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             >
                               <button
                                 aria-label="Save Rule"
-                                className="css-1a9yqga-StyledButton-getColors e17811v30"
+                                className="css-15f0jp2-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 priority="primary"
@@ -1857,7 +1857,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                             >
                               <Component
                                 aria-label="Cancel"
-                                className="elb7f1e1 css-8du0gd-StyledButton-getColors-CancelButton e17811v30"
+                                className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -1865,7 +1865,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               >
                                 <Link
                                   aria-label="Cancel"
-                                  className="elb7f1e1 css-8du0gd-StyledButton-getColors-CancelButton e17811v30"
+                                  className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   onlyActiveOnIndex={false}
@@ -1875,7 +1875,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 >
                                   <a
                                     aria-label="Cancel"
-                                    className="elb7f1e1 css-8du0gd-StyledButton-getColors-CancelButton e17811v30"
+                                    className="elb7f1e1 css-9klyok-StyledButton-getColors-CancelButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -1922,7 +1922,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                           >
                             <Component
                               aria-label="Save Rule"
-                              className="css-1a9yqga-StyledButton-getColors e17811v30"
+                              className="css-15f0jp2-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               priority="primary"
@@ -1930,7 +1930,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                             >
                               <button
                                 aria-label="Save Rule"
-                                className="css-1a9yqga-StyledButton-getColors e17811v30"
+                                className="css-15f0jp2-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 priority="primary"

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -122,7 +122,7 @@ exports[`projectAlertRules renders 1`] = `
                       >
                         <Component
                           aria-label="New Alert Rule"
-                          className="css-1ri5bky-StyledButton-getColors e17811v30"
+                          className="css-1oc9q3a-StyledButton-getColors e17811v30"
                           disabled={false}
                           onClick={[Function]}
                           priority="primary"
@@ -132,7 +132,7 @@ exports[`projectAlertRules renders 1`] = `
                         >
                           <Link
                             aria-label="New Alert Rule"
-                            className="css-1ri5bky-StyledButton-getColors e17811v30"
+                            className="css-1oc9q3a-StyledButton-getColors e17811v30"
                             disabled={false}
                             onClick={[Function]}
                             onlyActiveOnIndex={false}
@@ -144,7 +144,7 @@ exports[`projectAlertRules renders 1`] = `
                           >
                             <a
                               aria-label="New Alert Rule"
-                              className="css-1ri5bky-StyledButton-getColors e17811v30"
+                              className="css-1oc9q3a-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
                               priority="primary"
@@ -418,7 +418,7 @@ exports[`projectAlertRules renders 1`] = `
                                 >
                                   <Component
                                     aria-label="Edit Rule"
-                                    className="css-dvpz5-StyledButton-getColors e17811v30"
+                                    className="css-o6814l-StyledButton-getColors e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -432,7 +432,7 @@ exports[`projectAlertRules renders 1`] = `
                                   >
                                     <Link
                                       aria-label="Edit Rule"
-                                      className="css-dvpz5-StyledButton-getColors e17811v30"
+                                      className="css-o6814l-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       onlyActiveOnIndex={false}
@@ -447,7 +447,7 @@ exports[`projectAlertRules renders 1`] = `
                                     >
                                       <a
                                         aria-label="Edit Rule"
-                                        className="css-dvpz5-StyledButton-getColors e17811v30"
+                                        className="css-o6814l-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         role="button"
@@ -510,14 +510,14 @@ exports[`projectAlertRules renders 1`] = `
                                     size="small"
                                   >
                                     <Component
-                                      className="css-dvpz5-StyledButton-getColors e17811v30"
+                                      className="css-o6814l-StyledButton-getColors e17811v30"
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
                                     >
                                       <button
-                                        className="css-dvpz5-StyledButton-getColors e17811v30"
+                                        className="css-o6814l-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         role="button"

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -489,7 +489,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Set as default"
-                                  className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -497,7 +497,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Set as default"
-                                    className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -621,7 +621,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Set as default"
-                                  className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -629,7 +629,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Set as default"
-                                    className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -688,7 +688,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Hide"
-                                  className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -696,7 +696,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Hide"
-                                    className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -833,7 +833,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                               >
                                 <Component
                                   aria-label="Hide"
-                                  className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -841,7 +841,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 >
                                   <button
                                     aria-label="Hide"
-                                    className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
@@ -1392,7 +1392,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                               >
                                 <Component
                                   aria-label="Show"
-                                  className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                  className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -1400,7 +1400,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                 >
                                   <button
                                     aria-label="Show"
-                                    className="ezuela50 css-6f9oti-StyledButton-getColors-EnvironmentButton e17811v30"
+                                    className="ezuela50 css-wfgtbj-StyledButton-getColors-EnvironmentButton e17811v30"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -194,7 +194,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                             >
                               <Component
                                 aria-label="Enable Plugin"
-                                className="css-133e1g3-StyledButton-getColors e17811v30"
+                                className="css-1w79b6l-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
@@ -206,7 +206,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                               >
                                 <button
                                   aria-label="Enable Plugin"
-                                  className="css-133e1g3-StyledButton-getColors e17811v30"
+                                  className="css-1w79b6l-StyledButton-getColors e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"
@@ -254,14 +254,14 @@ exports[`ProjectPluginDetails renders 1`] = `
                             >
                               <Component
                                 aria-label="Reset Configuration"
-                                className="css-133e1g3-StyledButton-getColors e17811v30"
+                                className="css-1w79b6l-StyledButton-getColors e17811v30"
                                 disabled={false}
                                 onClick={[Function]}
                                 role="button"
                               >
                                 <button
                                   aria-label="Reset Configuration"
-                                  className="css-133e1g3-StyledButton-getColors e17811v30"
+                                  className="css-1w79b6l-StyledButton-getColors e17811v30"
                                   disabled={false}
                                   onClick={[Function]}
                                   role="button"

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -359,14 +359,14 @@ exports[`ProjectSavedSearches renders 1`] = `
                                             size="small"
                                           >
                                             <Component
-                                              className="css-dvpz5-StyledButton-getColors e17811v30"
+                                              className="css-o6814l-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
                                               size="small"
                                             >
                                               <button
-                                                className="css-dvpz5-StyledButton-getColors e17811v30"
+                                                className="css-o6814l-StyledButton-getColors e17811v30"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
@@ -644,14 +644,14 @@ exports[`ProjectSavedSearches renders 1`] = `
                                             size="small"
                                           >
                                             <Component
-                                              className="css-dvpz5-StyledButton-getColors e17811v30"
+                                              className="css-o6814l-StyledButton-getColors e17811v30"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
                                               size="small"
                                             >
                                               <button
-                                                className="css-dvpz5-StyledButton-getColors e17811v30"
+                                                className="css-o6814l-StyledButton-getColors e17811v30"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 role="button"

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -768,7 +768,7 @@ exports[`RuleBuilder render() renders 1`] = `
             size="zero"
           >
             <Component
-              className="e1hyuoc79 css-11tjqo2-StyledButton-getColors-RuleAddButton e17811v30"
+              className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"
@@ -776,7 +776,7 @@ exports[`RuleBuilder render() renders 1`] = `
               size="zero"
             >
               <button
-                className="e1hyuoc79 css-11tjqo2-StyledButton-getColors-RuleAddButton e17811v30"
+                className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"
@@ -2072,7 +2072,7 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
             size="zero"
           >
             <Component
-              className="e1hyuoc79 css-11tjqo2-StyledButton-getColors-RuleAddButton e17811v30"
+              className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"
@@ -2080,7 +2080,7 @@ exports[`RuleBuilder renders with suggestions renders 1`] = `
               size="zero"
             >
               <button
-                className="e1hyuoc79 css-11tjqo2-StyledButton-getColors-RuleAddButton e17811v30"
+                className="e1hyuoc79 css-nbmdxi-StyledButton-getColors-RuleAddButton e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -525,7 +525,7 @@ exports[`CreateProject render() should render roles when available and allowed, 
           <Component
             aria-label="Add Member"
             busy={false}
-            className="invite-member-submit css-1a9yqga-StyledButton-getColors e17811v30"
+            className="invite-member-submit css-15f0jp2-StyledButton-getColors e17811v30"
             disabled={false}
             onClick={[Function]}
             priority="primary"
@@ -533,7 +533,7 @@ exports[`CreateProject render() should render roles when available and allowed, 
           >
             <button
               aria-label="Add Member"
-              className="invite-member-submit css-1a9yqga-StyledButton-getColors e17811v30"
+              className="invite-member-submit css-15f0jp2-StyledButton-getColors e17811v30"
               disabled={false}
               onClick={[Function]}
               priority="primary"

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -256,7 +256,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                             >
                                               <Component
                                                 aria-label="Full Documentation"
-                                                className="css-dvpz5-StyledButton-getColors e17811v30"
+                                                className="css-o6814l-StyledButton-getColors e17811v30"
                                                 disabled={false}
                                                 external={true}
                                                 href="https://docs.getsentry.com/hosted/clients/csharp/"
@@ -266,7 +266,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                               >
                                                 <ExternalLink
                                                   aria-label="Full Documentation"
-                                                  className="css-dvpz5-StyledButton-getColors e17811v30"
+                                                  className="css-o6814l-StyledButton-getColors e17811v30"
                                                   disabled={false}
                                                   href="https://docs.getsentry.com/hosted/clients/csharp/"
                                                   onClick={[Function]}
@@ -277,7 +277,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                                 >
                                                   <a
                                                     aria-label="Full Documentation"
-                                                    className="css-dvpz5-StyledButton-getColors e17811v30"
+                                                    className="css-o6814l-StyledButton-getColors e17811v30"
                                                     disabled={false}
                                                     href="https://docs.getsentry.com/hosted/clients/csharp/"
                                                     onClick={[Function]}

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -293,11 +293,11 @@ exports[`ProjectCard renders 1`] = `
                 >
                   <Base
                     align="center"
-                    className="css-1qof738-EmptyText eks1zeg1"
+                    className="css-k1bbsy-EmptyText eks1zeg1"
                     justify="center"
                   >
                     <div
-                      className="css-1qof738-EmptyText eks1zeg1"
+                      className="css-k1bbsy-EmptyText eks1zeg1"
                       is={null}
                     >
                       No activity yet.

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -99,7 +99,7 @@ exports[`ProjectCard renders 1`] = `
       </Flex>
       <ChartContainer>
         <div
-          className="css-l3ron9-ChartContainer efesc7i0"
+          className="css-1s8o1vf-ChartContainer efesc7i0"
         >
           <Chart
             noEvents={true}
@@ -118,7 +118,7 @@ exports[`ProjectCard renders 1`] = `
           >
             <div>
               <StyledBarChart
-                height={80}
+                height={60}
                 label="events"
                 points={
                   Array [
@@ -134,8 +134,8 @@ exports[`ProjectCard renders 1`] = `
                 }
               >
                 <BarChart
-                  className="css-fcxdqz-StyledBarChart e1wib7610"
-                  height={80}
+                  className="css-h6aoq0-StyledBarChart e1wib7610"
+                  height={60}
                   label="events"
                   points={
                     Array [
@@ -156,8 +156,8 @@ exports[`ProjectCard renders 1`] = `
                         "chart-bar",
                       ]
                     }
-                    className="css-fcxdqz-StyledBarChart e1wib7610"
-                    height={80}
+                    className="css-h6aoq0-StyledBarChart e1wib7610"
+                    height={60}
                     label="events"
                     markers={Array []}
                     points={
@@ -180,10 +180,10 @@ exports[`ProjectCard renders 1`] = `
                     width={null}
                   >
                     <figure
-                      className="css-fcxdqz-StyledBarChart e1wib7610 barchart"
+                      className="css-h6aoq0-StyledBarChart e1wib7610 barchart"
                       style={
                         Object {
-                          "height": 80,
+                          "height": 60,
                           "width": null,
                         }
                       }

--- a/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
@@ -165,7 +165,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
             >
               <Component
                 aria-label="Cancel"
-                className="css-133e1g3-StyledButton-getColors e17811v30"
+                className="css-1w79b6l-StyledButton-getColors e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 role="button"
@@ -177,7 +177,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
               >
                 <button
                   aria-label="Cancel"
-                  className="css-133e1g3-StyledButton-getColors e17811v30"
+                  className="css-1w79b6l-StyledButton-getColors e17811v30"
                   disabled={false}
                   onClick={[Function]}
                   role="button"
@@ -232,7 +232,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
               <Component
                 aria-label="Bulk resolve issues"
                 autoFocus={true}
-                className="css-1a9yqga-StyledButton-getColors e17811v30"
+                className="css-15f0jp2-StyledButton-getColors e17811v30"
                 data-test-id="confirm-modal"
                 disabled={false}
                 onClick={[Function]}
@@ -242,7 +242,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                 <button
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
-                  className="css-1a9yqga-StyledButton-getColors e17811v30"
+                  className="css-15f0jp2-StyledButton-getColors e17811v30"
                   data-test-id="confirm-modal"
                   disabled={false}
                   onClick={[Function]}
@@ -479,7 +479,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
             >
               <Component
                 aria-label="Cancel"
-                className="css-133e1g3-StyledButton-getColors e17811v30"
+                className="css-1w79b6l-StyledButton-getColors e17811v30"
                 disabled={false}
                 onClick={[Function]}
                 role="button"
@@ -491,7 +491,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
               >
                 <button
                   aria-label="Cancel"
-                  className="css-133e1g3-StyledButton-getColors e17811v30"
+                  className="css-1w79b6l-StyledButton-getColors e17811v30"
                   disabled={false}
                   onClick={[Function]}
                   role="button"
@@ -546,7 +546,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
               <Component
                 aria-label="Bulk resolve issues"
                 autoFocus={true}
-                className="css-1a9yqga-StyledButton-getColors e17811v30"
+                className="css-15f0jp2-StyledButton-getColors e17811v30"
                 data-test-id="confirm-modal"
                 disabled={false}
                 onClick={[Function]}
@@ -556,7 +556,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                 <button
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
-                  className="css-1a9yqga-StyledButton-getColors e17811v30"
+                  className="css-15f0jp2-StyledButton-getColors e17811v30"
                   data-test-id="confirm-modal"
                   disabled={false}
                   onClick={[Function]}


### PR DESCRIPTION
Addresses the initial round of design feedback:

- [x] Stats padding/margin in stats table (reduce line-height on percentages)
- [x] Project cards graph fixes… background fill, lighten gray, shorter (60px) bars.
- [x] Org dropdown hover state https://d3vv6lp55qjaqc.cloudfront.net/items/0N3d093E1C3k1d0z2D0m/Screen%20Shot%202018-05-02%20at%2011.00.08%20AM.png?X-CloudApp-Visitor-Id=17234
- [x] hovering active sidebar item shouldn’t affect active state color
- [x] fix button hover state
- [x] org-level header should have 30px horizontal margin instead of 20 https://cl.ly/1M0j2f141p0i
- [x] favorite cards should have bottom border
- [x] make 'no activity yet' easier to read