### PR TITLE
feat(ui): Add "empty state" to dropdowns in settings

### DIFF
--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -26,6 +26,10 @@ class AutoComplete extends React.Component {
     defaultHighlightedIndex: PropTypes.number,
     defaultInputValue: PropTypes.string,
     /**
+     * Resets autocomplete input when menu closes
+     */
+    resetInputOnClose: PropTypes.bool,
+    /**
      * Currently, this does not act as a "controlled" prop, only for initial state of dropdown
      */
     isOpen: PropTypes.bool,
@@ -197,14 +201,17 @@ class AutoComplete extends React.Component {
    * This is exposed to render function
    */
   closeMenu = (...args) => {
-    let {onClose} = this.props;
+    let {onClose, resetInputOnClose} = this.props;
     if (this.isControlled() && typeof onClose === 'function') {
       onClose(...args);
       return;
     }
 
-    this.setState({
-      isOpen: false,
+    this.setState(state => {
+      return {
+        isOpen: false,
+        inputValue: resetInputOnClose ? '' : state.inputValue,
+      };
     });
   };
 

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -300,10 +300,11 @@ const StyledMenu = styled(({isOpen, blendCorner, alignMenu, ...props}) => (
 `;
 
 const EmptyMessage = styled('div')`
-  opacity: 0.4;
+  color: ${p => p.theme.gray1};
   padding: ${space(1)} ${space(2)};
   text-align: center;
   font-size: 1.2em;
+  text-transform: none;
 `;
 
 export default DropdownAutoCompleteMenu;

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import _ from 'lodash';
 import styled from 'react-emotion';
 
+import {t} from 'app/locale';
 import AutoComplete from 'app/components/autoComplete';
 import Input from 'app/views/settings/components/forms/controls/input';
 import space from 'app/styles/space';
@@ -37,6 +38,16 @@ class DropdownAutoCompleteMenu extends React.Component {
     onSelect: PropTypes.func,
 
     /**
+     * Message to display when there are no items initially
+     */
+    emptyMessage: PropTypes.node,
+
+    /**
+     * Message to display when there are no items that match the search
+     */
+    noResultsMessage: PropTypes.node,
+
+    /**
      * Presentational properties
      */
 
@@ -62,6 +73,7 @@ class DropdownAutoCompleteMenu extends React.Component {
   static defaultProps = {
     onSelect: () => {},
     blendCorner: true,
+    emptyMessage: t('No items'),
   };
 
   filterItems = (items, inputValue) =>
@@ -107,6 +119,8 @@ class DropdownAutoCompleteMenu extends React.Component {
       menuProps,
       alignMenu,
       blendCorner,
+      emptyMessage,
+      noResultsMessage,
       style,
       menuHeader,
       menuFooter,
@@ -114,7 +128,12 @@ class DropdownAutoCompleteMenu extends React.Component {
     } = this.props;
 
     return (
-      <AutoComplete itemToString={item => ''} onSelect={onSelect} {...props}>
+      <AutoComplete
+        resetInputOnClose
+        itemToString={item => ''}
+        onSelect={onSelect}
+        {...props}
+      >
         {({
           getActorProps,
           getRootProps,
@@ -127,6 +146,13 @@ class DropdownAutoCompleteMenu extends React.Component {
           isOpen,
           actions,
         }) => {
+          // Only filter results if menu is open
+          let autoCompleteResults =
+            (isOpen && this.autoCompleteFilter(items, inputValue)) || [];
+          let hasItems = items && !!items.length;
+          let hasResults = !!autoCompleteResults.length;
+          let showNoResultsMessage = inputValue && hasItems && !hasResults;
+
           return (
             <AutoCompleteRoot {...getRootProps()}>
               {children({
@@ -153,7 +179,14 @@ class DropdownAutoCompleteMenu extends React.Component {
                   />
                   <div>
                     {menuHeader && <StyledLabel>{menuHeader}</StyledLabel>}
-                    {this.autoCompleteFilter(items, inputValue).map(
+
+                    {!hasItems && <EmptyMessage>{emptyMessage}</EmptyMessage>}
+                    {showNoResultsMessage && (
+                      <EmptyMessage>
+                        {noResultsMessage || `${emptyMessage} ${t('found')}`}
+                      </EmptyMessage>
+                    )}
+                    {autoCompleteResults.map(
                       ({index, ...item}) =>
                         item.groupLabel ? (
                           <StyledLabel key={item.value}>{item.label}</StyledLabel>
@@ -264,6 +297,13 @@ const StyledMenu = styled(({isOpen, blendCorner, alignMenu, ...props}) => (
 
   ${getMenuBorderRadius};
   ${({alignMenu}) => (alignMenu === 'left' ? 'left: 0;' : '')};
+`;
+
+const EmptyMessage = styled('div')`
+  opacity: 0.4;
+  padding: ${space(1)} ${space(2)};
+  text-align: center;
+  font-size: 1.2em;
 `;
 
 export default DropdownAutoCompleteMenu;

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -179,6 +179,7 @@ class ProjectTeams extends AsyncView {
         items={teamsToAdd}
         onSelect={this.handleAdd}
         menuHeader={menuHeader}
+        emptyMessage={t('No teams')}
       >
         {({isOpen, selectedItem}) => (
           <DropdownButton isOpen={isOpen} size="xsmall">

--- a/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
@@ -203,6 +203,7 @@ const TeamMembers = createReactClass({
         items={items}
         onSelect={this.addTeamMember}
         menuHeader={menuHeader}
+        emptyMessage={t('No members')}
       >
         {({isOpen, selectedItem}) => (
           <DropdownButton isOpen={isOpen} size="xsmall">

--- a/src/sentry/static/sentry/app/views/settings/team/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamProjects.jsx
@@ -133,6 +133,7 @@ const TeamProjects = createReactClass({
             <DropdownAutoComplete
               items={otherProjects}
               onSelect={this.handleProjectSelected}
+              emptyMessage={t('No projects')}
             >
               {({isOpen, selectedItem}) => (
                 <DropdownButton isOpen={isOpen} size="xsmall">

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
   isOpen={true}
   itemToString={[Function]}
   onSelect={[Function]}
+  resetInputOnClose={true}
 />
 `;
 
@@ -13,6 +14,7 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
   isOpen={true}
   itemToString={[Function]}
   onSelect={[Function]}
+  resetInputOnClose={true}
 />
 `;
 

--- a/tests/js/spec/components/autoComplete.spec.jsx
+++ b/tests/js/spec/components/autoComplete.spec.jsx
@@ -257,4 +257,19 @@ describe('AutoComplete', function() {
     expect(wrapper.instance().items.size).toBe(0);
     expect(wrapper.state('inputValue')).toBe('Pineapple');
   });
+
+  it('can reset input when menu closes', function() {
+    jest.useFakeTimers();
+    wrapper.setProps({resetInputOnClose: true});
+    input.simulate('focus');
+    expect(wrapper.state('isOpen')).toBe(true);
+
+    input.simulate('change', {target: {value: 'a'}});
+    expect(wrapper.state('inputValue')).toBe('a');
+
+    input.simulate('blur');
+    jest.runAllTimers();
+    expect(wrapper.state('isOpen')).toBe(false);
+    expect(wrapper.state('inputValue')).toBe('');
+  });
 });

--- a/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
@@ -99,6 +99,10 @@ describe('DropdownAutoCompleteMenu', function() {
 
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);
     expect(wrapper.find('EmptyMessage').text()).toBe('No items!');
+
+    // Should still be "no items" empty message even if search results return an empty set
+    wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
+    expect(wrapper.find('EmptyMessage').text()).toBe('No items!');
   });
 
   it('shows default empty results message when there are no items found in search', function() {

--- a/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
@@ -4,25 +4,23 @@ import {mount, shallow} from 'enzyme';
 import DropdownAutoCompleteMenu from 'app/components/dropdownAutoCompleteMenu';
 
 describe('DropdownAutoCompleteMenu', function() {
+  const items = [
+    {
+      value: 'apple',
+      label: <div>Apple</div>,
+    },
+    {
+      value: 'bacon',
+      label: <div>Bacon</div>,
+    },
+    {
+      value: 'corn',
+      label: <div>Corn</div>,
+    },
+  ];
   it('renders without a group', function() {
     const wrapper = shallow(
-      <DropdownAutoCompleteMenu
-        isOpen={true}
-        items={[
-          {
-            value: 'apple',
-            label: <div>Apple</div>,
-          },
-          {
-            value: 'bacon',
-            label: <div>Bacon</div>,
-          },
-          {
-            value: 'corn',
-            label: <div>Corn</div>,
-          },
-        ]}
-      >
+      <DropdownAutoCompleteMenu isOpen={true} items={items}>
         {() => 'Click Me!'}
       </DropdownAutoCompleteMenu>
     );
@@ -90,5 +88,44 @@ describe('DropdownAutoCompleteMenu', function() {
       .last()
       .simulate('click');
     expect(mock).toMatchSnapshot();
+  });
+
+  it('shows empty message when there are no items', function() {
+    const wrapper = mount(
+      <DropdownAutoCompleteMenu isOpen={true} items={[]} emptyMessage="No items!">
+        {({selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
+      </DropdownAutoCompleteMenu>
+    );
+
+    expect(wrapper.find('EmptyMessage')).toHaveLength(1);
+    expect(wrapper.find('EmptyMessage').text()).toBe('No items!');
+  });
+
+  it('shows default empty results message when there are no items found in search', function() {
+    const wrapper = mount(
+      <DropdownAutoCompleteMenu isOpen={true} items={items} emptyMessage="No items!">
+        {({selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
+      </DropdownAutoCompleteMenu>
+    );
+
+    wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
+    expect(wrapper.find('EmptyMessage')).toHaveLength(1);
+    expect(wrapper.find('EmptyMessage').text()).toBe('No items! found');
+  });
+
+  it('overrides default empty results message', function() {
+    const wrapper = mount(
+      <DropdownAutoCompleteMenu
+        isOpen={true}
+        items={items}
+        emptyMessage="No items!"
+        noResultsMessage="No search results"
+      >
+        {({selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
+      </DropdownAutoCompleteMenu>
+    );
+
+    wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
+    expect(wrapper.find('EmptyMessage').text()).toBe('No search results');
   });
 });

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -50,6 +50,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                     >
                       <DropdownAutoComplete
                         alignMenu="right"
+                        emptyMessage="No projects"
                         items={
                           Array [
                             Object {
@@ -66,6 +67,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         <DropdownAutoCompleteMenu
                           alignMenu="right"
                           blendCorner={true}
+                          emptyMessage="No projects"
                           items={
                             Array [
                               Object {
@@ -82,6 +84,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           <AutoComplete
                             itemToString={[Function]}
                             onSelect={[Function]}
+                            resetInputOnClose={true}
                           >
                             <DropdownMenu
                               isOpen={false}

--- a/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
@@ -39,6 +39,7 @@ exports[`ProjectTeams renders 1`] = `
         <div>
           <DropdownAutoComplete
             alignMenu="right"
+            emptyMessage="No teams"
             items={
               Array [
                 Object {

--- a/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
@@ -17,6 +17,7 @@ exports[`TeamMembers render() renders 1`] = `
     >
       <DropdownAutoComplete
         alignMenu="right"
+        emptyMessage="No members"
         items={Array []}
         menuHeader={
           <StyledMembersLabel>


### PR DESCRIPTION
Adds an empty state to dropdown menus in new settings when 1) there are no items and 2) when there are no search results.

Also add prop to clear input value when menu is closed.

![image](https://user-images.githubusercontent.com/79684/39593755-9793f6c2-4ebf-11e8-9f7a-f93d535836c3.png)

![image](https://user-images.githubusercontent.com/79684/39593761-9c2006d6-4ebf-11e8-8bb9-a547d49b0ab0.png)
