### PR TITLE
fix(ui): Fix sidebar being too jumpy on load

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -56,6 +56,7 @@ class Sidebar extends React.Component {
     this.routerListener = this.props.router.listen(() => {
       $('.tooltip').tooltip('hide');
     });
+    this.doCollapse(this.props.collapsed);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -69,11 +70,7 @@ class Sidebar extends React.Component {
 
     if (collapsed === nextProps.collapsed) return;
 
-    if (nextProps.collapsed) {
-      jQuery(document.body).addClass('collapsed');
-    } else {
-      jQuery(document.body).removeClass('collapsed');
-    }
+    this.doCollapse(nextProps.collapsed);
   }
 
   componentWillUnmount() {
@@ -88,6 +85,14 @@ class Sidebar extends React.Component {
     // Unlisten to router changes
     if (this.routerListener) {
       this.routerListener();
+    }
+  }
+
+  doCollapse(collapsed) {
+    if (collapsed) {
+      jQuery(document.body).addClass('collapsed');
+    } else {
+      jQuery(document.body).removeClass('collapsed');
     }
   }
 

--- a/src/sentry/static/sentry/app/main.jsx
+++ b/src/sentry/static/sentry/app/main.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import {Router, browserHistory} from 'react-router';
+
 import routes from 'app/routes';
+import {loadSidebarState} from 'app/actionCreators/sidebar';
 
 export default class Main extends React.Component {
+  componentDidMount() {
+    loadSidebarState();
+  }
+
   render() {
     return <Router history={browserHistory}>{routes()}</Router>;
   }

--- a/src/sentry/static/sentry/app/views/organizationDashboard/emptyState.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/emptyState.jsx
@@ -22,7 +22,7 @@ export default class EmptyState extends React.Component {
             <h2>{t('Remain calm.')}</h2>
             <p>{t("Sentry's got you covered.")}</p>
             <div>
-              <Button priority="primary" to={`organizations/${orgId}/projects/new/`}>
+              <Button priority="primary" to={`/organizations/${orgId}/projects/new/`}>
                 {t('Create project')}
               </Button>
             </div>


### PR DESCRIPTION
* also fixes create project link on dashboard empty state

This loads sidebar state (currently via cookies) before Sidebar renders (i.e. when we render our main component) so that when Sidebar renders, it renders in the correct collapsed state. This should fix Sidebar being jumpy (by default it loads in expanded state and if your cookie is in collapsed state, you'll end up seeing the sidebar resized).