### PR TITLE
fix(bulk delete) Display correct message in modal for bulk actions

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -54,6 +54,18 @@ const getConfirm = (numIssues, allInQuerySelected, query, queryCount) => {
           numIssues
         );
 
+    let message =
+      action == 'delete'
+        ? tct(
+            'Bulk deletion is only recommended for junk data. To clear your stream, consider resolving or ignoring. [link:When should I delete events?]',
+            {
+              link: (
+                <Link to="https://help.sentry.io/hc/en-us/articles/360003443113-When-should-I-delete-events-" />
+              ),
+            }
+          )
+        : t('This action cannot be undone.');
+
     return (
       <div>
         <p style={{marginBottom: '20px'}}>
@@ -64,18 +76,7 @@ const getConfirm = (numIssues, allInQuerySelected, query, queryCount) => {
           query={query}
           queryCount={queryCount}
         />
-        {!canBeUndone && (
-          <p>
-            {tct(
-              'Bulk deletion is only recommended for junk data. To clear your stream, consider resolving or ignoring. [link:When should I delete events?]',
-              {
-                link: (
-                  <Link to="https://help.sentry.io/hc/en-us/articles/360003443113-When-should-I-delete-events-" />
-                ),
-              }
-            )}
-          </p>
-        )}
+        {!canBeUndone && <p>{message}</p>}
       </div>
     );
   };


### PR DESCRIPTION
If the action is bulk delete, it shows a specific message now, if it's another bulk action, shows another message.

Gif of behavior: 
https://cl.ly/311E163F0a1m