### PR TITLE
fix(pagination): Fix pagination when searching in settings list views

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -110,15 +110,7 @@ class AsyncComponent extends React.Component {
         ...params,
         query,
         success: (data, _, jqXHR) => {
-          this.setState(prevState => {
-            return {
-              [stateKey]: data,
-              // TODO(billy): This currently fails if this request is retried by SudoModal
-              [`${stateKey}PageLinks`]: jqXHR && jqXHR.getResponseHeader('Link'),
-              remainingRequests: prevState.remainingRequests - 1,
-              loading: prevState.remainingRequests > 1,
-            };
-          });
+          this.handleRequestSuccess({stateKey, data, jqXHR}, true);
         },
         error: error => {
           // Allow endpoints to fail
@@ -129,6 +121,23 @@ class AsyncComponent extends React.Component {
           this.handleError(error, [stateKey, endpoint, params, options]);
         },
       });
+    });
+  };
+
+  handleRequestSuccess = ({stateKey, data, jqXHR}, initialRequest) => {
+    this.setState(prevState => {
+      let state = {
+        [stateKey]: data,
+        // TODO(billy): This currently fails if this request is retried by SudoModal
+        [`${stateKey}PageLinks`]: jqXHR && jqXHR.getResponseHeader('Link'),
+      };
+
+      if (initialRequest) {
+        state.remainingRequests = prevState.remainingRequests - 1;
+        state.loading = prevState.remainingRequests > 1;
+      }
+
+      return state;
     });
   };
 

--- a/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/members/organizationMembersView.jsx
@@ -221,8 +221,8 @@ class OrganizationMembersView extends AsyncView {
 
     this.api.request(`/organizations/${orgId}/members/?query=${searchQuery}`, {
       method: 'GET',
-      success: data => {
-        this.setState({members: data});
+      success: (data, _, jqXHR) => {
+        this.handleRequestSuccess({stateKey: 'members', data, jqXHR});
       },
     });
   }, 200);

--- a/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/projects/organizationProjectsView.jsx
@@ -82,8 +82,8 @@ export default class OrganizationProjectsView extends AsyncView {
 
     this.api.request(`/organizations/${orgId}/projects/?query=${searchQuery}`, {
       method: 'GET',
-      success: data => {
-        this.setState({projectList: data});
+      success: (data, _, jqXHR) => {
+        this.handleRequestSuccess({stateKey: 'projectList', data, jqXHR});
       },
     });
   }, 200);

--- a/tests/js/spec/views/projectPlugins/index.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/index.spec.jsx
@@ -24,6 +24,11 @@ describe('ProjectPluginsContainer', function() {
     };
 
     MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/`,
+      method: 'GET',
+      body: org,
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/config/integrations/`,
       method: 'GET',
       body: {providers: [TestStubs.GitHubIntegrationProvider()]},


### PR DESCRIPTION
Since we re-query API during searches, the pagination data does not get updated in state after a query. This fixes this for Organization->Projects and Members views.

cc @saragilford 