### PR TITLE
ref(tagstore): Return sets for any collections that are not explicitly ordered

### DIFF
--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -464,7 +464,7 @@ class LegacyTagStorage(TagStorage):
         except KeyError:
             # one or more tags were invalid, thus the result should be an empty
             # set
-            return []
+            return set()
 
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -491,7 +491,7 @@ class LegacyTagStorage(TagStorage):
                 ).values_list('event_id', flat=True)[:1000]
             )
             if not matches:
-                return []
+                return set()
 
         return set(matches)
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -304,7 +304,7 @@ class LegacyTagStorage(TagStorage):
         if status is not None:
             qs = qs.filter(status=status)
 
-        return list(map(transformers[models.TagKey], qs))
+        return set(map(transformers[models.TagKey], qs))
 
     def get_tag_value(self, project_id, environment_id, key, value):
         from sentry.tagstore.exceptions import TagValueNotFound
@@ -326,7 +326,7 @@ class LegacyTagStorage(TagStorage):
             key=key,
         )
 
-        return list(map(transformers[models.TagValue], qs))
+        return set(map(transformers[models.TagValue], qs))
 
     def get_group_tag_key(self, project_id, group_id, environment_id, key):
         from sentry.tagstore.exceptions import GroupTagKeyNotFound
@@ -347,7 +347,7 @@ class LegacyTagStorage(TagStorage):
         if limit is not None:
             qs = qs[:limit]
 
-        return list(map(transformers[models.GroupTagKey], qs))
+        return set(map(transformers[models.GroupTagKey], qs))
 
     def get_group_tag_value(self, project_id, group_id, environment_id, key, value):
         from sentry.tagstore.exceptions import GroupTagValueNotFound
@@ -371,7 +371,7 @@ class LegacyTagStorage(TagStorage):
             key=key,
         )
 
-        return list(map(transformers[models.GroupTagValue], qs))
+        return set(map(transformers[models.GroupTagValue], qs))
 
     def get_group_list_tag_value(self, project_id, group_id_list, environment_id, key, value):
         qs = models.GroupTagValue.objects.filter(
@@ -493,7 +493,7 @@ class LegacyTagStorage(TagStorage):
             if not matches:
                 return []
 
-        return matches
+        return set(matches)
 
     def get_groups_user_counts(self, project_id, group_ids, environment_id):
         qs = models.GroupTagKey.objects.filter(
@@ -667,7 +667,7 @@ class LegacyTagStorage(TagStorage):
             if not matches:
                 return []
 
-        return matches
+        return set(matches)
 
     def update_group_tag_key_values_seen(self, project_id, group_ids):
         gtk_qs = models.GroupTagKey.objects.filter(

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -445,7 +445,7 @@ class V2TagStorage(TagStorage):
         if status is not None:
             qs = qs.filter(status=status)
 
-        return list(
+        return set(
             map(
                 transformers[models.TagKey],
                 qs,
@@ -480,7 +480,7 @@ class V2TagStorage(TagStorage):
 
         qs = self._add_environment_filter(qs, environment_id)
 
-        return list(
+        return set(
             map(
                 transformers[models.TagValue],
                 qs,
@@ -518,7 +518,7 @@ class V2TagStorage(TagStorage):
         if limit is not None:
             qs = qs[:limit]
 
-        return list(
+        return set(
             map(
                 transformers[models.GroupTagKey],
                 qs,
@@ -691,7 +691,7 @@ class V2TagStorage(TagStorage):
         except KeyError:
             # one or more tags were invalid, thus the result should be an empty
             # set
-            return []
+            return set()
 
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -720,9 +720,9 @@ class V2TagStorage(TagStorage):
                 ).values_list('event_id', flat=True)[:1000]
             )
             if not matches:
-                return []
+                return set()
 
-        return matches
+        return set(matches)
 
     def get_groups_user_counts(self, project_id, group_ids, environment_id):
         qs = models.GroupTagKey.objects.filter(

--- a/tests/sentry/manager/tests.py
+++ b/tests/sentry/manager/tests.py
@@ -54,7 +54,7 @@ class SentryManagerTest(TestCase):
             key='biz'
         )
         assert len(results) == 1
-        res = results[0]
+        res = list(results)[0]
         self.assertEquals(res.value, 'boz')
         self.assertEquals(res.times_seen, 1)
 

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -52,7 +52,7 @@ class TagStorage(TestCase):
         assert self.ts.get_tag_keys(
             project_id=self.proj1.id,
             environment_id=self.proj1env1.id,
-        ) == []
+        ) == set()
 
         tk = self.ts.create_tag_key(
             project_id=self.proj1.id,
@@ -69,7 +69,7 @@ class TagStorage(TestCase):
         assert self.ts.get_tag_keys(
             project_id=self.proj1.id,
             environment_id=self.proj1env1.id,
-        ) == [transformers[models.TagKey](tk)]
+        ) == set([transformers[models.TagKey](tk)])
 
         assert models.TagKey.objects.all().count() == 1
 
@@ -108,7 +108,7 @@ class TagStorage(TestCase):
             project_id=self.proj1.id,
             environment_id=self.proj1env1.id,
             key=self.key1,
-        ) == []
+        ) == set()
 
         tv = self.ts.create_tag_value(
             project_id=self.proj1.id,
@@ -128,7 +128,7 @@ class TagStorage(TestCase):
             project_id=self.proj1.id,
             environment_id=self.proj1env1.id,
             key=self.key1,
-        ) == [transformers[models.TagValue](tv)]
+        ) == set([transformers[models.TagValue](tv)])
 
         assert models.TagKey.objects.all().count() == 1
         assert models.TagValue.objects.all().count() == 1
@@ -179,7 +179,7 @@ class TagStorage(TestCase):
             project_id=self.proj1.id,
             group_id=self.proj1group1.id,
             environment_id=self.proj1env1.id,
-        ) == []
+        ) == set()
 
         gtk = self.ts.create_group_tag_key(
             project_id=self.proj1.id,

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -240,7 +240,7 @@ class IndexEventTagsTest(TestCase):
             group.id,
             self.environment.id,
             {'foo': 'bar', 'biz': 'baz'},
-        ) == [event.id]
+        ) == set([event.id])
 
         # ensure it safely handles repeat runs
         with self.tasks():
@@ -258,4 +258,4 @@ class IndexEventTagsTest(TestCase):
             group.id,
             self.environment.id,
             {'foo': 'bar', 'biz': 'baz'},
-        ) == [event.id]
+        ) == set([event.id])


### PR DESCRIPTION
See GH-8270 and GH-8306 and SNS-3.

This will make it more straightforward to compare results from different backends that are returning unordered results since the equality comparison will work as expected and not take order into account.