### PR TITLE
feat(ui): Dropdown enhancements + fix add member to team search

### DIFF
--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -169,7 +169,7 @@ class AutoComplete extends React.Component {
     callIfFunction(onClick, item, e);
   };
 
-  handleMenuMouseDown = ({onClick} = {}, e) => {
+  handleMenuMouseDown = () => {
     // Cancel close menu from input blur (mouseDown event can occur before input blur :()
     setTimeout(() => this.blurTimer && clearTimeout(this.blurTimer));
   };

--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -124,6 +124,18 @@ class AutoComplete extends React.Component {
     }, 200);
   };
 
+  // Dropdown detected click outside, we should close
+  handleClickOutside = () => {
+    // Otherwise, it's possible that this gets fired multiple times
+    // e.g. click outside triggers closeMenu and at the same time input gets blurred, so
+    // a timer is set to close the menu
+    if (this.blurTimer) {
+      clearTimeout(this.blurTimer);
+    }
+
+    this.closeMenu();
+  };
+
   handleInputKeyDown = ({onKeyDown} = {}, e) => {
     let shouldSelectWithEnter =
       e.key === 'Enter' && this.items.size && this.items.has(this.state.highlightedIndex);
@@ -196,10 +208,11 @@ class AutoComplete extends React.Component {
    */
   openMenu = (...args) => {
     let {onOpen} = this.props;
-    if (this.isControlled() && typeof onOpen === 'function') {
-      onOpen(...args);
-      return;
-    }
+
+    callIfFunction(onOpen, ...args);
+
+    if (this.isControlled()) return;
+
     this.resetHighlightState();
     this.setState({
       isOpen: true,
@@ -213,10 +226,10 @@ class AutoComplete extends React.Component {
    */
   closeMenu = (...args) => {
     let {onClose, resetInputOnClose} = this.props;
-    if (this.isControlled() && typeof onClose === 'function') {
-      onClose(...args);
-      return;
-    }
+
+    callIfFunction(onClose, ...args);
+
+    if (this.isControlled()) return;
 
     this.setState(state => {
       return {
@@ -260,7 +273,7 @@ class AutoComplete extends React.Component {
     let isOpen = this.getOpenState();
 
     return (
-      <DropdownMenu isOpen={isOpen} onClickOutside={this.closeMenu}>
+      <DropdownMenu isOpen={isOpen} onClickOutside={this.handleClickOutside}>
         {dropdownMenuProps =>
           children({
             ...dropdownMenuProps,

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -1,13 +1,14 @@
-import {css} from 'emotion';
+import {Flex} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import styled from 'react-emotion';
+import styled, {css} from 'react-emotion';
 
 import {t} from 'app/locale';
 import AutoComplete from 'app/components/autoComplete';
 import Input from 'app/views/settings/components/forms/controls/input';
 import space from 'app/styles/space';
+import LoadingIndicator from 'app/components/loadingIndicator';
 
 class DropdownAutoCompleteMenu extends React.Component {
   static propTypes = {
@@ -35,7 +36,17 @@ class DropdownAutoCompleteMenu extends React.Component {
       ),
     ]),
     isOpen: PropTypes.bool,
+
+    /**
+     * Show loading indicator next to input
+     */
+    busy: PropTypes.bool,
+
     onSelect: PropTypes.func,
+    /**
+     * When AutoComplete input changes
+     */
+    onChange: PropTypes.func,
 
     /**
      * Message to display when there are no items initially
@@ -66,6 +77,7 @@ class DropdownAutoCompleteMenu extends React.Component {
      * Props to pass to menu component
      */
     menuProps: PropTypes.object,
+
     css: PropTypes.object,
     style: PropTypes.object,
   };
@@ -114,6 +126,7 @@ class DropdownAutoCompleteMenu extends React.Component {
   render() {
     let {
       onSelect,
+      onChange,
       children,
       items,
       menuProps,
@@ -124,6 +137,7 @@ class DropdownAutoCompleteMenu extends React.Component {
       style,
       menuHeader,
       menuFooter,
+      busy,
       ...props
     } = this.props;
 
@@ -132,6 +146,7 @@ class DropdownAutoCompleteMenu extends React.Component {
         resetInputOnClose
         itemToString={item => ''}
         onSelect={onSelect}
+        inputIsActor={false}
         {...props}
       >
         {({
@@ -167,16 +182,22 @@ class DropdownAutoCompleteMenu extends React.Component {
                   {...getMenuProps({
                     ...menuProps,
                     style,
+                    isStyled: true,
                     css: this.props.css,
                     blendCorner,
                     alignMenu,
                   })}
                 >
-                  <StyledInput
-                    autoFocus
-                    placeholder="Filter search"
-                    {...getInputProps()}
-                  />
+                  <Flex>
+                    <StyledInput
+                      autoFocus
+                      placeholder="Filter search"
+                      {...getInputProps({onChange})}
+                    />
+                    <InputLoadingWrapper>
+                      {busy && <LoadingIndicator size={16} mini />}
+                    </InputLoadingWrapper>
+                  </Flex>
                   <div>
                     {menuHeader && <StyledLabel>{menuHeader}</StyledLabel>}
 
@@ -240,10 +261,21 @@ const AutoCompleteRoot = styled(({isOpen, ...props}) => <div {...props} />)`
   display: inline-block;
 `;
 
+const InputLoadingWrapper = styled(Flex)`
+  align-items: center;
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+  flex-shrink: 0;
+  width: 30px;
+`;
+
 const StyledInput = styled(Input)`
+  flex: 1;
+
   &,
-  &:focus {
-    border: none;
+  &:focus,
+  &:active,
+  &:hover {
+    border: 1px solid transparent;
     border-bottom: 1px solid ${p => p.theme.borderLight};
     border-radius: 0;
     box-shadow: none;
@@ -281,9 +313,7 @@ const StyledLabel = styled('div')`
   }
 `;
 
-const StyledMenu = styled(({isOpen, blendCorner, alignMenu, ...props}) => (
-  <div {...props} />
-))`
+const StyledMenu = styled('div')`
   background: #fff;
   border: 1px solid ${p => p.theme.borderLight};
   position: absolute;

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -166,7 +166,9 @@ class DropdownAutoCompleteMenu extends React.Component {
             (isOpen && this.autoCompleteFilter(items, inputValue)) || [];
           let hasItems = items && !!items.length;
           let hasResults = !!autoCompleteResults.length;
-          let showNoResultsMessage = inputValue && hasItems && !hasResults;
+          let showNoItems = !busy && !inputValue && !hasItems;
+          // Results mean there was a search (i.e. inputValue)
+          let showNoResultsMessage = !busy && inputValue && !hasResults;
 
           return (
             <AutoCompleteRoot {...getRootProps()}>
@@ -201,27 +203,33 @@ class DropdownAutoCompleteMenu extends React.Component {
                   <div>
                     {menuHeader && <StyledLabel>{menuHeader}</StyledLabel>}
 
-                    {!hasItems && <EmptyMessage>{emptyMessage}</EmptyMessage>}
+                    {showNoItems && <EmptyMessage>{emptyMessage}</EmptyMessage>}
                     {showNoResultsMessage && (
                       <EmptyMessage>
                         {noResultsMessage || `${emptyMessage} ${t('found')}`}
                       </EmptyMessage>
                     )}
-                    {autoCompleteResults.map(
-                      ({index, ...item}) =>
-                        item.groupLabel ? (
-                          <StyledLabel key={item.value}>{item.label}</StyledLabel>
-                        ) : (
-                          <AutoCompleteItem
-                            key={`${item.value}-${index}`}
-                            index={index}
-                            highlightedIndex={highlightedIndex}
-                            {...getItemProps({item, index})}
-                          >
-                            {item.label}
-                          </AutoCompleteItem>
-                        )
+                    {busy && (
+                      <Flex justify="center" p={1}>
+                        <EmptyMessage>{t('Searching...')}</EmptyMessage>
+                      </Flex>
                     )}
+                    {!busy &&
+                      autoCompleteResults.map(
+                        ({index, ...item}) =>
+                          item.groupLabel ? (
+                            <StyledLabel key={item.value}>{item.label}</StyledLabel>
+                          ) : (
+                            <AutoCompleteItem
+                              key={`${item.value}-${index}`}
+                              index={index}
+                              highlightedIndex={highlightedIndex}
+                              {...getItemProps({item, index})}
+                            >
+                              {item.label}
+                            </AutoCompleteItem>
+                          )
+                      )}
                     {menuFooter && <StyledLabel>{menuFooter}</StyledLabel>}
                   </div>
                 </StyledMenu>

--- a/src/sentry/static/sentry/app/components/loadingIndicator.jsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.jsx
@@ -14,6 +14,7 @@ function LoadingIndicator(props) {
     className,
     style,
     relative,
+    size,
   } = props;
   let cx = classNames(className, {
     overlay,
@@ -29,9 +30,17 @@ function LoadingIndicator(props) {
     'load-complete': finished,
   });
 
+  let loadingStyle = {};
+  if (size) {
+    loadingStyle = {
+      width: size,
+      height: size,
+    };
+  }
+
   return (
     <div className={cx} style={style}>
-      <div className={loadingCx}>
+      <div className={loadingCx} style={loadingStyle}>
         {finished ? <div className="checkmark draw" /> : null}
       </div>
 
@@ -48,6 +57,7 @@ LoadingIndicator.propTypes = {
   finished: PropTypes.bool,
   relative: PropTypes.bool,
   hideMessage: PropTypes.bool,
+  size: PropTypes.number,
 };
 
 export default LoadingIndicator;

--- a/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
@@ -188,6 +188,7 @@ const TeamMembers = createReactClass({
  * @param {Event} e React Event when member filter input changes
  */
   handleMemberFilterChange(e) {
+    this.setState({dropdownBusy: true});
     this.debouncedFetchMembersRequest(e.target.value);
   },
 

--- a/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
@@ -241,6 +241,7 @@ const TeamMembers = createReactClass({
         emptyMessage={t('No members')}
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
+        onClose={() => this.debouncedFetchMembersRequest('')}
       >
         {({isOpen, selectedItem}) => (
           <DropdownButton isOpen={isOpen} size="xsmall">

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -35,7 +35,7 @@ class DashboardTest(AcceptanceTestCase):
         self.project.update(first_event=None)
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('new dashboard empty')
+        self.browser.snapshot('org dash no issues')
 
     def test_one_issue(self):
         event = create_sample_event(
@@ -57,3 +57,28 @@ class DashboardTest(AcceptanceTestCase):
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading-indicator')
         self.browser.snapshot('org dash one issue')
+
+
+class EmptyDashboardTest(AcceptanceTestCase):
+    def setUp(self):
+        super(EmptyDashboardTest, self).setUp()
+        self.user = self.create_user('foo@example.com')
+        self.org = self.create_organization(
+            name='Rowdy Tiger',
+            owner=None,
+        )
+        self.team = self.create_team(organization=self.org, name='Mariachi Band')
+        self.create_member(
+            user=self.user,
+            organization=self.org,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        self.path = '/{}/'.format(self.org.slug)
+
+    def test_new_dashboard_empty(self):
+        with self.feature('organizations:dashboard'):
+            self.browser.get(self.path)
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('new dashboard empty')

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
 <AutoComplete
+  inputIsActor={false}
   isOpen={true}
   itemToString={[Function]}
   onSelect={[Function]}
@@ -11,6 +12,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
 
 exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
 <AutoComplete
+  inputIsActor={false}
   isOpen={true}
   itemToString={[Function]}
   onSelect={[Function]}

--- a/tests/js/spec/components/autoComplete.spec.jsx
+++ b/tests/js/spec/components/autoComplete.spec.jsx
@@ -25,14 +25,16 @@ describe('AutoComplete', function() {
   let autoCompleteState = [];
   let mocks = {
     onSelect: jest.fn(),
+    onClose: jest.fn(),
+    onOpen: jest.fn(),
   };
 
-  beforeEach(() => {
+  const createWrapper = props => {
     autoCompleteState = [];
     Object.keys(mocks).forEach(key => mocks[key].mockReset());
 
     wrapper = mount(
-      <AutoComplete {...mocks} itemToString={item => item.name}>
+      <AutoComplete {...mocks} itemToString={item => item.name} {...props}>
         {injectedProps => {
           let {
             getRootProps,
@@ -98,178 +100,370 @@ describe('AutoComplete', function() {
     );
 
     input = wrapper.find('input');
+    return wrapper;
+  };
+
+  describe('Uncontrolled', function() {
+    beforeEach(() => {
+      wrapper = createWrapper();
+    });
+
+    it('shows dropdown menu when input has focus', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.find('li')).toHaveLength(3);
+    });
+
+    it('only tries to close once if input is blurred and click outside occurs', function() {
+      jest.useFakeTimers();
+      input.simulate('focus');
+      input.simulate('blur');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.find('li')).toHaveLength(3);
+      wrapper.find('DropdownMenu').prop('onClickOutside')();
+      jest.runAllTimers();
+      wrapper.update();
+
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('only calls onClose dropdown menu when input is blurred', function() {
+      jest.useFakeTimers();
+      input.simulate('focus');
+      input.simulate('blur');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.find('li')).toHaveLength(3);
+      jest.runAllTimers();
+      wrapper.update();
+
+      expect(wrapper.state('isOpen')).toBe(false);
+      expect(wrapper.find('li')).toHaveLength(0);
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('can close dropdown menu when Escape is pressed', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('keyDown', {key: 'Escape'});
+      expect(wrapper.state('isOpen')).toBe(false);
+    });
+
+    it('can open and close dropdown menu using injected actions', function() {
+      let [injectedProps] = autoCompleteState;
+      injectedProps.actions.open();
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(mocks.onOpen).toHaveBeenCalledTimes(1);
+
+      injectedProps.actions.close();
+      expect(wrapper.state('isOpen')).toBe(false);
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('reopens dropdown menu after Escape is pressed and input is changed', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('keyDown', {key: 'Escape'});
+      expect(wrapper.state('isOpen')).toBe(false);
+
+      input.simulate('change', {target: {value: 'a'}});
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.instance().items.size).toBe(3);
+    });
+
+    it('reopens dropdown menu after item is selected and then input is changed', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('change', {target: {value: 'eapp'}});
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.instance().items.size).toBe(1);
+      input.simulate('keyDown', {key: 'Enter'});
+      expect(wrapper.state('isOpen')).toBe(false);
+
+      input.simulate('change', {target: {value: 'app'}});
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.instance().items.size).toBe(2);
+    });
+
+    it('selects dropdown item by clicking and sets input to selected value', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.instance().items.size).toBe(3);
+
+      wrapper
+        .find('li')
+        .at(1)
+        .simulate('click');
+      expect(mocks.onSelect).toHaveBeenCalledWith(items[1]);
+
+      expect(wrapper.state('inputValue')).toBe('Pineapple');
+      expect(wrapper.instance().items.size).toBe(0);
+    });
+
+    it('can navigate dropdown items with keyboard and select with "Enter" keypress', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(2);
+
+      expect(wrapper.instance().items.size).toBe(3);
+      input.simulate('keyDown', {key: 'Enter'});
+
+      expect(mocks.onSelect).toHaveBeenCalledWith(items[2]);
+      expect(wrapper.instance().items.size).toBe(0);
+      expect(wrapper.state('inputValue')).toBe('Orange');
+    });
+
+    it('respects list bounds when navigating filtered items with arrow keys', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(2);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(2);
+
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
+
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+
+      expect(wrapper.instance().items.size).toBe(3);
+    });
+
+    it('can filter items and then navigate with keyboard', function() {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.instance().items.size).toBe(3);
+
+      input.simulate('change', {target: {value: 'a'}});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.state('inputValue')).toBe('a');
+      // Apple, pineapple, orange
+      expect(wrapper.instance().items.size).toBe(3);
+
+      input.simulate('change', {target: {value: 'ap'}});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.state('inputValue')).toBe('ap');
+      expect(autoCompleteState[autoCompleteState.length - 1].inputValue).toBe('ap');
+      // Apple, pineapple
+      expect(wrapper.instance().items.size).toBe(2);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
+      expect(wrapper.instance().items.size).toBe(2);
+
+      input.simulate('keyDown', {key: 'Enter'});
+      expect(mocks.onSelect).toHaveBeenCalledWith(items[1]);
+      expect(wrapper.instance().items.size).toBe(0);
+      expect(wrapper.state('inputValue')).toBe('Pineapple');
+    });
+
+    it('can reset input when menu closes', function() {
+      jest.useFakeTimers();
+      wrapper.setProps({resetInputOnClose: true});
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('change', {target: {value: 'a'}});
+      expect(wrapper.state('inputValue')).toBe('a');
+
+      input.simulate('blur');
+      jest.runAllTimers();
+      expect(wrapper.state('isOpen')).toBe(false);
+      expect(wrapper.state('inputValue')).toBe('');
+    });
   });
 
-  it('shows dropdown menu when input has focus', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.find('li')).toHaveLength(3);
-  });
+  describe('Controlled', function() {
+    beforeEach(function() {
+      wrapper = createWrapper({isOpen: true});
+    });
 
-  it('hides dropdown menu when input is blurred', function() {
-    jest.useFakeTimers();
-    input.simulate('focus');
-    input.simulate('blur');
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.find('li')).toHaveLength(3);
-    jest.runAllTimers();
-    wrapper.update();
+    it('has dropdown menu initially open', function() {
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.find('li')).toHaveLength(3);
+    });
 
-    expect(wrapper.state('isOpen')).toBe(false);
-    expect(wrapper.find('li')).toHaveLength(0);
-  });
+    it('closes when props change', function() {
+      wrapper.setProps({isOpen: false});
+      expect(wrapper.state('isOpen')).toBe(true);
+      wrapper.update();
 
-  it('can close dropdown menu when Escape is pressed', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
+      // Menu should be closed
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.find('li')).toHaveLength(0);
+    });
 
-    input.simulate('keyDown', {key: 'Escape'});
-    expect(wrapper.state('isOpen')).toBe(false);
-  });
+    it('remains closed when input is focused, but calls `onOpen`', function() {
+      wrapper = createWrapper({isOpen: false});
+      jest.useFakeTimers();
 
-  it('can open and close dropdown menu using injected actions', function() {
-    let [injectedProps] = autoCompleteState;
-    injectedProps.actions.open();
-    expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('isOpen')).toBe(false);
 
-    injectedProps.actions.close();
-    expect(wrapper.state('isOpen')).toBe(false);
-  });
+      input.simulate('focus');
+      jest.runAllTimers();
+      wrapper.update();
+      expect(wrapper.state('isOpen')).toBe(false);
+      expect(wrapper.find('li')).toHaveLength(0);
 
-  it('reopens dropdown menu after Escape is pressed and input is changed', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
+      expect(mocks.onOpen).toHaveBeenCalledTimes(1);
+    });
 
-    input.simulate('keyDown', {key: 'Escape'});
-    expect(wrapper.state('isOpen')).toBe(false);
+    it('remains open when input focus/blur events occur, but calls `onClose`', function() {
+      jest.useFakeTimers();
+      input.simulate('focus');
+      input.simulate('blur');
+      jest.runAllTimers();
+      wrapper.update();
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.find('li')).toHaveLength(3);
 
-    input.simulate('change', {target: {value: 'a'}});
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.instance().items.size).toBe(3);
-  });
+      // This still gets called even though menu is open
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
 
-  it('reopens dropdown menu after item is selectted and then input is changed', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
+    it('calls onClose when Escape is pressed', function() {
+      expect(wrapper.state('isOpen')).toBe(true);
 
-    input.simulate('change', {target: {value: 'eapp'}});
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.instance().items.size).toBe(1);
-    input.simulate('keyDown', {key: 'Enter'});
-    expect(wrapper.state('isOpen')).toBe(false);
+      input.simulate('keyDown', {key: 'Escape'});
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
 
-    input.simulate('change', {target: {value: 'app'}});
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.instance().items.size).toBe(2);
-  });
+    it('does not open and close dropdown menu using injected actions', function() {
+      let [injectedProps] = autoCompleteState;
+      injectedProps.actions.open();
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(mocks.onOpen).toHaveBeenCalledTimes(1);
 
-  it('selects dropdown item by clicking and sets input to selected value', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.instance().items.size).toBe(3);
+      injectedProps.actions.close();
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
 
-    wrapper
-      .find('li')
-      .at(1)
-      .simulate('click');
-    expect(mocks.onSelect).toHaveBeenCalledWith(items[1]);
+    it('onClose is called after item is selected', function() {
+      expect(wrapper.state('isOpen')).toBe(true);
 
-    expect(wrapper.state('inputValue')).toBe('Pineapple');
-    expect(wrapper.instance().items.size).toBe(0);
-  });
+      input.simulate('change', {target: {value: 'eapp'}});
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.instance().items.size).toBe(1);
+      input.simulate('keyDown', {key: 'Enter'});
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
 
-  it('can navigate dropdown items with keyboard and select with "Enter" keypress', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.state('highlightedIndex')).toBe(0);
+    it('selects dropdown item by clicking and sets input to selected value', function() {
+      expect(wrapper.instance().items.size).toBe(3);
 
-    input.simulate('keyDown', {key: 'ArrowDown'});
-    expect(wrapper.state('highlightedIndex')).toBe(1);
+      wrapper
+        .find('li')
+        .at(1)
+        .simulate('click');
+      expect(mocks.onSelect).toHaveBeenCalledWith(items[1]);
 
-    input.simulate('keyDown', {key: 'ArrowDown'});
-    expect(wrapper.state('highlightedIndex')).toBe(2);
+      expect(wrapper.state('inputValue')).toBe('Pineapple');
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
 
-    expect(wrapper.instance().items.size).toBe(3);
-    input.simulate('keyDown', {key: 'Enter'});
+    it('can navigate dropdown items with keyboard and select with "Enter" keypress', function() {
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
 
-    expect(mocks.onSelect).toHaveBeenCalledWith(items[2]);
-    expect(wrapper.instance().items.size).toBe(0);
-    expect(wrapper.state('inputValue')).toBe('Orange');
-  });
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
 
-  it('respects list bounds when navigating filtered items with arrow keys', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.state('highlightedIndex')).toBe(0);
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(2);
 
-    input.simulate('keyDown', {key: 'ArrowUp'});
-    expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.instance().items.size).toBe(3);
+      input.simulate('keyDown', {key: 'Enter'});
 
-    input.simulate('keyDown', {key: 'ArrowDown'});
-    expect(wrapper.state('highlightedIndex')).toBe(1);
+      expect(mocks.onSelect).toHaveBeenCalledWith(items[2]);
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+      expect(wrapper.state('inputValue')).toBe('Orange');
+    });
 
-    input.simulate('keyDown', {key: 'ArrowDown'});
-    expect(wrapper.state('highlightedIndex')).toBe(2);
+    it('respects list bounds when navigating filtered items with arrow keys', function() {
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
 
-    input.simulate('keyDown', {key: 'ArrowDown'});
-    expect(wrapper.state('highlightedIndex')).toBe(2);
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
 
-    input.simulate('keyDown', {key: 'ArrowUp'});
-    expect(wrapper.state('highlightedIndex')).toBe(1);
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
 
-    input.simulate('keyDown', {key: 'ArrowUp'});
-    expect(wrapper.state('highlightedIndex')).toBe(0);
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(2);
 
-    input.simulate('keyDown', {key: 'ArrowUp'});
-    expect(wrapper.state('highlightedIndex')).toBe(0);
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(2);
 
-    expect(wrapper.instance().items.size).toBe(3);
-  });
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
 
-  it('can filter items and then navigate with keyboard', function() {
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
-    expect(wrapper.state('highlightedIndex')).toBe(0);
-    expect(wrapper.instance().items.size).toBe(3);
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
 
-    input.simulate('change', {target: {value: 'a'}});
-    expect(wrapper.state('highlightedIndex')).toBe(0);
-    expect(wrapper.state('inputValue')).toBe('a');
-    // Apple, pineapple, orange
-    expect(wrapper.instance().items.size).toBe(3);
+      input.simulate('keyDown', {key: 'ArrowUp'});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
 
-    input.simulate('change', {target: {value: 'ap'}});
-    expect(wrapper.state('highlightedIndex')).toBe(0);
-    expect(wrapper.state('inputValue')).toBe('ap');
-    expect(autoCompleteState[autoCompleteState.length - 1].inputValue).toBe('ap');
-    // Apple, pineapple
-    expect(wrapper.instance().items.size).toBe(2);
+      expect(wrapper.instance().items.size).toBe(3);
+    });
 
-    input.simulate('keyDown', {key: 'ArrowDown'});
-    expect(wrapper.state('highlightedIndex')).toBe(1);
+    it('can filter items and then navigate with keyboard', function() {
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.instance().items.size).toBe(3);
 
-    input.simulate('keyDown', {key: 'ArrowDown'});
-    expect(wrapper.state('highlightedIndex')).toBe(1);
-    expect(wrapper.instance().items.size).toBe(2);
+      input.simulate('change', {target: {value: 'a'}});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.state('inputValue')).toBe('a');
+      // Apple, pineapple, orange
+      expect(wrapper.instance().items.size).toBe(3);
 
-    input.simulate('keyDown', {key: 'Enter'});
-    expect(mocks.onSelect).toHaveBeenCalledWith(items[1]);
-    expect(wrapper.instance().items.size).toBe(0);
-    expect(wrapper.state('inputValue')).toBe('Pineapple');
-  });
+      input.simulate('change', {target: {value: 'ap'}});
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.state('inputValue')).toBe('ap');
+      expect(autoCompleteState[autoCompleteState.length - 1].inputValue).toBe('ap');
+      // Apple, pineapple
+      expect(wrapper.instance().items.size).toBe(2);
 
-  it('can reset input when menu closes', function() {
-    jest.useFakeTimers();
-    wrapper.setProps({resetInputOnClose: true});
-    input.simulate('focus');
-    expect(wrapper.state('isOpen')).toBe(true);
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
 
-    input.simulate('change', {target: {value: 'a'}});
-    expect(wrapper.state('inputValue')).toBe('a');
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
+      expect(wrapper.instance().items.size).toBe(2);
 
-    input.simulate('blur');
-    jest.runAllTimers();
-    expect(wrapper.state('isOpen')).toBe(false);
-    expect(wrapper.state('inputValue')).toBe('');
+      input.simulate('keyDown', {key: 'Enter'});
+      expect(mocks.onSelect).toHaveBeenCalledWith(items[1]);
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+      expect(wrapper.state('inputValue')).toBe('Pineapple');
+    });
   });
 });

--- a/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
@@ -100,9 +100,11 @@ describe('DropdownAutoCompleteMenu', function() {
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);
     expect(wrapper.find('EmptyMessage').text()).toBe('No items!');
 
-    // Should still be "no items" empty message even if search results return an empty set
+    // Should be "No items! Found"  because there are no results and there is a search value
+    // This is for the case where items is an async result from an API endpoint that also does
+    // a string match query.
     wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
-    expect(wrapper.find('EmptyMessage').text()).toBe('No items!');
+    expect(wrapper.find('EmptyMessage').text()).toBe('No items! found');
   });
 
   it('shows default empty results message when there are no items found in search', function() {

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -82,6 +82,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           onSelect={[Function]}
                         >
                           <AutoComplete
+                            inputIsActor={false}
                             itemToString={[Function]}
                             onSelect={[Function]}
                             resetInputOnClose={true}

--- a/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
@@ -17,6 +17,7 @@ exports[`TeamMembers renders 1`] = `
     >
       <DropdownAutoComplete
         alignMenu="right"
+        busy={false}
         emptyMessage="No members"
         items={Array []}
         menuHeader={
@@ -29,6 +30,7 @@ exports[`TeamMembers renders 1`] = `
             </StyledCreateMemberLink>
           </StyledMembersLabel>
         }
+        onChange={[Function]}
         onSelect={[Function]}
       />
     </div>

--- a/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
@@ -31,6 +31,7 @@ exports[`TeamMembers renders 1`] = `
           </StyledMembersLabel>
         }
         onChange={[Function]}
+        onClose={[Function]}
         onSelect={[Function]}
       />
     </div>


### PR DESCRIPTION
* DropdownAutocomplete
  * no longer hide when trying to drag scrollbar
  * fixes bug where there were two actors (button + autocomplete input),
  can now have input not be an actor. Fixes JAVASCRIPT-381
  * adds a `busy` prop to <DropdownAutoCompleteMenu> to display a loading
  indicator next to search input

* Allows "Add Member to Team" dropdown to query API on every keypress
(debounced). This fixes a bug where it was only filtering the first 100
members only.
  * More performance optimizations need to be done here.

![add-team-members](https://user-images.githubusercontent.com/79684/39939249-7893e0e2-550a-11e8-9dcb-c3814c5b1a4a.gif)
