### PR TITLE
feat(dashboard): Fetch specific project details (APP-190)

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -89,6 +89,8 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 if key == 'query':
                     value = ' '.join(value)
                     queryset = queryset.filter(Q(name__icontains=value) | Q(slug__icontains=value))
+                elif key == 'id':
+                    queryset = queryset.filter(id__in=value)
                 else:
                     queryset = queryset.none()
 

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -32,7 +32,7 @@ describe('OrganizationDashboard', function() {
   describe('with projects', function() {
     beforeEach(function() {
       MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/projects/?statsPeriod=24h',
+        url: '/organizations/org-slug/projects/?statsPeriod=24h&query=id:2',
         body: [
           TestStubs.Project({
             teams: [TestStubs.Team()],
@@ -119,7 +119,8 @@ describe('OrganizationDashboard', function() {
       ];
 
       MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/projects/?statsPeriod=24h',
+        url:
+          '/organizations/org-slug/projects/?statsPeriod=24h&query=id:3 id:2 id:4 id:5 id:1 id:6',
         body: projects,
       });
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -66,3 +66,25 @@ class OrganizationProjectsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
+
+    def test_search_by_ids(self):
+        self.login_as(user=self.user)
+
+        org = self.create_organization(owner=self.user, name='baz')
+        team = self.create_team(organization=org)
+        project_bar = self.create_project(teams=[team], name='bar', slug='bar')
+        project_foo = self.create_project(teams=[team], name='foo', slug='foo')
+        self.create_project(teams=[team], name='baz', slug='baz')
+
+        path = '/api/0/organizations/{}/projects/?query=id:{}'.format(org.slug, project_foo.id)
+        response = self.client.get(path)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == six.text_type(project_foo.id)
+
+        path = '/api/0/organizations/{}/projects/?query=id:{} id:{}'.format(org.slug, project_bar.id, project_foo.id)
+        response = self.client.get(path)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2


### PR DESCRIPTION
Previously we were relying on users set of projects contained in
`/organizations/org/projects/` list, but this breaks down when an org
has > 100 projects because of pagination.

Instead, fetch stats using specific projects.

Fixes JAVASCRIPT-3S7