### PR TITLE
fix(github-app): Rename config keys to avoid conflicts

### DIFF
--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -28,10 +28,10 @@ class GitHubIdentityProvider(OAuth2Provider):
     oauth_scopes = ()
 
     def get_oauth_client_id(self):
-        return options.get('github.client-id')
+        return options.get('github-app.client-id')
 
     def get_oauth_client_secret(self):
-        return options.get('github.client-secret')
+        return options.get('github-app.client-secret')
 
     def build_identity(self, data):
         data = data['data']

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -106,7 +106,7 @@ class GitHubIntegration(Integration):
 
 class GitHubInstallationRedirect(PipelineView):
     def get_app_url(self):
-        name = options.get('github.app-name')
+        name = options.get('github-app.name')
         return 'https://github.com/apps/%s' % name
 
     def dispatch(self, request, pipeline):

--- a/src/sentry/integrations/github/payload.py
+++ b/src/sentry/integrations/github/payload.py
@@ -27,7 +27,7 @@ class GitHubAppsEndpoint(Endpoint):
         return super(GitHubAppsEndpoint, self).dispatch(request, *args, **kwargs)
 
     def get_secret(self):
-        return options.get('github.webhook-secret')
+        return options.get('github-app.webhook-secret')
 
     def is_valid_signature(self, method, body, secret, signature):
         if method != 'sha1':

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -18,7 +18,7 @@ def get_jwt():
         # JWT expiration time (10 minute maximum)
         'exp': exp,
         # Integration's GitHub identifier
-        'iss': options.get('github.app-id'),
+        'iss': options.get('github-app.id'),
     }
 
-    return jwt.encode(payload, options.get('github.private-key'), algorithm='RS256')
+    return jwt.encode(payload, options.get('github-app.private-key'), algorithm='RS256')

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -123,12 +123,13 @@ register('slack.client-secret', flags=FLAG_PRIORITIZE_DISK)
 register('slack.verification-token', flags=FLAG_PRIORITIZE_DISK)
 
 # Github Integration
-register('github.app-id', default=0)
-register('github.app-name', default='')
-register('github.webhook-secret', default='')
-register('github.private-key', default='')
-register('github.client-id', flags=FLAG_PRIORITIZE_DISK)
-register('github.client-secret', flags=FLAG_PRIORITIZE_DISK)
+register('github-app.id', default=0)
+register('github-app.name', default='')
+register('github-app.webhook-secret', default='')
+register('github-app.private-key', default='')
+register('github-app.client-id', flags=FLAG_PRIORITIZE_DISK)
+register('github-app.client-secret', flags=FLAG_PRIORITIZE_DISK)
+
 # VSTS Integration
 register('vsts.client-id', flags=FLAG_PRIORITIZE_DISK)
 register('vsts.client-secret', flags=FLAG_PRIORITIZE_DISK)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -146,9 +146,9 @@ def pytest_configure(config):
             'slack.client-secret': 'slack-client-secret',
             'slack.verification-token': 'slack-verification-token',
 
-            'github.app-name': 'sentry-test-app',
-            'github.client-id': 'github-client-id',
-            'github.client-secret': 'github-client-secret',
+            'github-app.name': 'sentry-test-app',
+            'github-app.client-id': 'github-client-id',
+            'github-app.client-secret': 'github-client-secret',
 
             'vsts.client-id': 'vsts-client-id',
             'vsts.client-secret': 'vsts-client-secret',


### PR DESCRIPTION
We already have a marketplace app in getsentry that uses the app-id key.