### PR TITLE
ref(tagstore): Return set from `get_release_tags` too

### DIFF
--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -594,7 +594,7 @@ class LegacyTagStorage(TagStorage):
         return last_release.value
 
     def get_release_tags(self, project_ids, environment_id, versions):
-        return list(
+        return set(
             map(
                 transformers[models.TagValue],
                 models.TagValue.objects.filter(

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -867,7 +867,7 @@ class V2TagStorage(TagStorage):
 
         qs = self._add_environment_filter(qs, environment_id)
 
-        return list(
+        return set(
             map(
                 transformers[models.TagValue],
                 qs,

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -606,7 +606,7 @@ class TagStorage(TestCase):
             [self.proj1.id],
             self.proj1env1.id,
             ['1.0'],
-        ) == [transformers[models.TagValue](tv)]
+        ) == set([transformers[models.TagValue](tv)])
 
     def test_get_group_ids_for_users(self):
         from sentry.models import EventUser


### PR DESCRIPTION
Missed this one in GH-8311, turning in my badge and refactoring gun