### PR TITLE
fix(teams): Fix adding team to project after creating team

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -145,7 +145,7 @@ class ProjectTeams extends AsyncView {
       project,
       organization,
       onClose: data => {
-        addTeamToProject(this.api, organization.slug, project.slug, data.slug).then(
+        addTeamToProject(this.api, organization.slug, project.slug, data).then(
           this.remountComponent,
           this.remountComponent
         );
@@ -154,7 +154,11 @@ class ProjectTeams extends AsyncView {
   };
 
   renderAddTeamToProject() {
+    let {organization} = this.props;
     let projectTeams = new Set(this.state.projectTeams.map(team => team.slug));
+    let canCreateTeams = getOrganizationState(organization)
+      .getAccess()
+      .has('project:admin');
     let teamsToAdd = this.state.allTeams
       .filter(team => {
         return team.hasAccess && !projectTeams.has(team.slug);
@@ -168,9 +172,11 @@ class ProjectTeams extends AsyncView {
     let menuHeader = (
       <StyledTeamsLabel>
         {t('Teams')}
-        <StyledCreateTeamLink onClick={this.handleCreateTeam}>
-          {t('Create Team')}
-        </StyledCreateTeamLink>
+        {canCreateTeams && (
+          <StyledCreateTeamLink onClick={this.handleCreateTeam}>
+            {t('Create Team')}
+          </StyledCreateTeamLink>
+        )}
       </StyledTeamsLabel>
     );
 
@@ -220,31 +226,12 @@ class ProjectTeams extends AsyncView {
     if (this.state.projectTeams.length > 0) body = this.renderResults();
     else body = this.renderEmpty();
 
-    let {organization, params} = this.props;
-    let canCreateTeams = getOrganizationState(organization)
-      .getAccess()
-      .has('project:admin');
+    let {params} = this.props;
 
     return (
       <div>
         <SettingsPageHeader
           title={tct('[projectId] Teams', {projectId: params.projectId})}
-          action={
-            <Button
-              priority="primary"
-              size="small"
-              disabled={!canCreateTeams}
-              title={
-                !canCreateTeams
-                  ? t('You do not have permission to create teams')
-                  : undefined
-              }
-              onClick={this.handleCreateTeam}
-              icon="icon-circle-add"
-            >
-              {t('Create Team')}
-            </Button>
-          }
         />
         <Panel>
           <PanelHeader hasButtons={true}>

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -104,10 +104,7 @@ class ProjectTeams extends AsyncView {
     let {organization} = this.props;
     let access = getOrganizationState(organization).getAccess();
     return (
-      access.has('org:write') &&
-      access.has('team:write') &&
-      access.has('project:write') &&
-      false
+      access.has('org:write') && access.has('team:write') && access.has('project:write')
     );
   };
 

--- a/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
@@ -42,11 +42,22 @@ exports[`ProjectTeams renders 1`] = `
             menuHeader={
               <StyledTeamsLabel>
                 Teams
-                <StyledCreateTeamLink
-                  onClick={[Function]}
+                <Tooltip
+                  disabled={true}
+                  title="You do not have access to create teams."
+                  tooltipOptions={
+                    Object {
+                      "placement": "top",
+                    }
+                  }
                 >
-                  Create Team
-                </StyledCreateTeamLink>
+                  <StyledCreateTeamLink
+                    disabled={false}
+                    onClick={[Function]}
+                  >
+                    Create Team
+                  </StyledCreateTeamLink>
+                </Tooltip>
               </StyledTeamsLabel>
             }
             onSelect={[Function]}

--- a/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
@@ -6,18 +6,6 @@ exports[`ProjectTeams renders 1`] = `
 >
   <div>
     <SettingsPageHeading
-      action={
-        <Button
-          disabled={false}
-          icon="icon-circle-add"
-          onClick={[Function]}
-          priority="primary"
-          size="small"
-          title={undefined}
-        >
-          Create Team
-        </Button>
-      }
       title={
         <span>
           <span>

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -155,32 +155,6 @@ describe('ProjectTeams', function() {
     );
   });
 
-  it('opens "create team modal" when creating a new team from header', function() {
-    let wrapper = mount(
-      <ProjectTeams
-        params={{orgId: org.slug, projectId: project.slug}}
-        project={project}
-        organization={org}
-      />,
-      TestStubs.routerContext()
-    );
-
-    // Click "Create Team" in Panel Header
-    wrapper.find('SettingsPageHeading Button').simulate('click');
-
-    // action creator to open "create team modal" is called
-    expect(openCreateTeamModal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        project: expect.objectContaining({
-          slug: project.slug,
-        }),
-        organization: expect.objectContaining({
-          slug: org.slug,
-        }),
-      })
-    );
-  });
-
   it('opens "create team modal" when creating a new team from dropdown', function() {
     let wrapper = mount(
       <ProjectTeams


### PR DESCRIPTION
This happened in during @denamwangi 's user-testing. If you created a team using
the "Add team to project" dropdown, it would fail to add to project.

This also removes the "Create Team" from header (this was from feedback from our earlier user tests).