### PR TITLE
bug(ui): fix issue where long artifact urls break table

### DIFF
--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -126,7 +126,7 @@ const ReleaseArtifacts = createReactClass({
       <div>
         <Panel>
           <PanelHeader>
-            <Flex flex="7" pr="2">
+            <Flex flex="7" pr={2}>
               {t('Name')}
             </Flex>
             <Flex flex="2">{t('Distribution')}</Flex>
@@ -138,7 +138,7 @@ const ReleaseArtifacts = createReactClass({
                 <PanelItem key={file.id}>
                   <Flex
                     flex="7"
-                    pr="2"
+                    pr={2}
                     style={{wordWrap: 'break-word', wordBreak: 'break-all'}}
                   >
                     <strong>{file.name || '(empty)'}</strong>

--- a/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releaseArtifacts.jsx
@@ -126,7 +126,9 @@ const ReleaseArtifacts = createReactClass({
       <div>
         <Panel>
           <PanelHeader>
-            <Flex flex="7">{t('Name')}</Flex>
+            <Flex flex="7" pr="2">
+              {t('Name')}
+            </Flex>
             <Flex flex="2">{t('Distribution')}</Flex>
             <Flex flex="3">{t('Size')}</Flex>
           </PanelHeader>
@@ -134,7 +136,11 @@ const ReleaseArtifacts = createReactClass({
             {this.state.fileList.map(file => {
               return (
                 <PanelItem key={file.id}>
-                  <Flex flex="7" style={{wordWrap: 'break-word'}}>
+                  <Flex
+                    flex="7"
+                    pr="2"
+                    style={{wordWrap: 'break-word', wordBreak: 'break-all'}}
+                  >
                     <strong>{file.name || '(empty)'}</strong>
                   </Flex>
                   <Flex flex="2">


### PR DESCRIPTION
Long strings now wrap properly in the artifacts table:
<img width="915" alt="screen shot 2018-05-08 at 12 13 44 pm" src="https://user-images.githubusercontent.com/30713/39777784-6281f33c-52b9-11e8-91f6-473f5ede861b.png">
