### PR TITLE
ref(ui): more informative empty messages for org-level views

### DIFF
--- a/src/sentry/static/sentry/app/components/issueList.jsx
+++ b/src/sentry/static/sentry/app/components/issueList.jsx
@@ -6,6 +6,7 @@ import createReactClass from 'create-react-class';
 import {Panel, PanelBody} from 'app/components/panels';
 import ApiMixin from 'app/mixins/apiMixin';
 import CompactIssue from 'app/components/compactIssue';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
@@ -16,6 +17,7 @@ const IssueList = createReactClass({
 
   propTypes: {
     endpoint: PropTypes.string.isRequired,
+    emptyText: PropTypes.string,
     query: PropTypes.object,
     pagination: PropTypes.bool,
     renderEmpty: PropTypes.func,
@@ -132,7 +134,15 @@ const IssueList = createReactClass({
   },
 
   renderEmpty() {
-    return <div className="box empty">{t('Nothing to show here, move along.')}</div>;
+    const {emptyText} = this.props;
+
+    return (
+      <Panel>
+        <EmptyMessage icon="icon-circle-exclamation">
+          {emptyText ? emptyText : t('Nothing to show here, move along.')}
+        </EmptyMessage>
+      </Panel>
+    );
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -11,6 +11,7 @@ class OrganizationIssueList extends React.Component {
   static propTypes = {
     title: PropTypes.string,
     endpoint: PropTypes.string.isRequired,
+    emptyText: PropTypes.string,
     pageSize: PropTypes.number,
   };
 
@@ -63,6 +64,7 @@ class OrganizationIssueList extends React.Component {
         <h3>{this.props.title}</h3>
         <IssueList
           endpoint={this.props.endpoint}
+          emptyText={this.props.emptyText}
           query={{
             status: this.state.status,
             statsPeriod: '24h',

--- a/src/sentry/static/sentry/app/views/myIssues/assignedToMe.jsx
+++ b/src/sentry/static/sentry/app/views/myIssues/assignedToMe.jsx
@@ -17,6 +17,7 @@ class AssignedToMe extends React.Component {
       <OrganizationIssueList
         title={this.getTitle()}
         endpoint={this.getEndpoint()}
+        emptyText={t('No issues currently assigned to you.')}
         {...this.props}
       />
     );

--- a/src/sentry/static/sentry/app/views/myIssues/bookmarked.jsx
+++ b/src/sentry/static/sentry/app/views/myIssues/bookmarked.jsx
@@ -17,6 +17,7 @@ class Bookmarked extends React.Component {
       <OrganizationIssueList
         title={this.getTitle()}
         endpoint={this.getEndpoint()}
+        emptyText={t('You have not bookmarked any issues.')}
         {...this.props}
       />
     );

--- a/src/sentry/static/sentry/app/views/myIssues/viewed.jsx
+++ b/src/sentry/static/sentry/app/views/myIssues/viewed.jsx
@@ -17,6 +17,7 @@ class Viewed extends React.Component {
       <OrganizationIssueList
         title={this.getTitle()}
         endpoint={this.getEndpoint()}
+        emptyText={t('No recently viewed issues.')}
         {...this.props}
       />
     );


### PR DESCRIPTION
Moves away from 'Nothing to see here, move along' in favor of more specific empty messages:

<img width="823" alt="screen shot 2018-05-06 at 12 23 32 pm" src="https://user-images.githubusercontent.com/30713/39676974-6138bb60-5128-11e8-8c0d-6c90dba7f78f.png">
