### PR TITLE
feat(assistant): Remove close icon from last step

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/guideDrawer.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideDrawer.jsx
@@ -11,7 +11,9 @@ import AssistantContainer from 'app/components/assistant/assistantContainer';
 // GuideDrawer is what slides up when the user clicks on a guide cue.
 export default class GuideDrawer extends React.Component {
   static propTypes = {
+    // `guide` must be a valid guide.
     guide: PropTypes.object.isRequired,
+    // `step` must be > 0.
     step: PropTypes.number.isRequired,
     onFinish: PropTypes.func.isRequired,
     onDismiss: PropTypes.func.isRequired,
@@ -42,13 +44,15 @@ export default class GuideDrawer extends React.Component {
         <StyledAssistantInputRow>
           <CueIcon hasGuide={true} />
           <StyledTitle>{this.props.guide.steps[this.props.step - 1].title}</StyledTitle>
-          <div
-            className="close-button"
-            style={{display: 'flex'}}
-            onClick={this.props.onDismiss}
-          >
-            <CloseIcon />
-          </div>
+          {this.props.step < this.props.guide.steps.length && (
+            <div
+              className="close-button"
+              style={{display: 'flex'}}
+              onClick={this.props.onDismiss}
+            >
+              <CloseIcon />
+            </div>
+          )}
         </StyledAssistantInputRow>
         <StyledContent>
           <div

--- a/tests/js/spec/components/assistant/__snapshots__/guideDrawer.spec.jsx.snap
+++ b/tests/js/spec/components/assistant/__snapshots__/guideDrawer.spec.jsx.snap
@@ -61,17 +61,6 @@ exports[`GuideDrawer renders next step 1`] = `
     <StyledTitle>
       2. Title 2
     </StyledTitle>
-    <div
-      className="close-button"
-      onClick={[MockFunction]}
-      style={
-        Object {
-          "display": "flex",
-        }
-      }
-    >
-      <CloseIcon />
-    </div>
   </StyledAssistantInputRow>
   <StyledContent>
     <div


### PR DESCRIPTION
On the last step of the guide we ask the user to answer if the guide was useful. This doubles as a dismiss so we don't need to show the dismiss icon, which forces the user to give feedback.