### PR TITLE
chore(tests): Don't snapshot test txt versions of emails

### DIFF
--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+import os.path
+
 from six.moves.urllib.parse import urlencode
+from os.path import join, dirname
 
 from sentry.testutils import AcceptanceTestCase
 
@@ -31,6 +34,18 @@ EMAILS = (
 )
 
 
+def read_txt_email_fixture(name):
+    # "sso unlinked without password"
+    # => "sso_unlinked_without_password.txt"
+    filename = name.replace(' ', '_') + '.txt'
+    path = join(dirname(__file__), os.pardir, 'fixtures', 'emails', filename)
+
+    fixture = None
+    with open(path, 'r') as f:
+        fixture = f.read()
+    return fixture
+
+
 class EmailTestCase(AcceptanceTestCase):
     def setUp(self):
         super(EmailTestCase, self).setUp()
@@ -48,6 +63,16 @@ class EmailTestCase(AcceptanceTestCase):
 
     def test_emails(self):
         for url, name in EMAILS:
+            # HTML output is captured as a snapshot
             self.browser.get(self.build_url(url, 'html'))
             self.browser.wait_until('#preview')
             self.browser.snapshot('{} email html'.format(name))
+
+            # Text output is asserted against static fixture files
+            self.browser.get(self.build_url(url, 'txt'))
+            self.browser.wait_until('#preview')
+            elem = self.browser.find_element_by_css_selector('#preview pre')
+            text_src = elem.get_attribute('innerHTML')
+
+            fixture_src = read_txt_email_fixture(name)
+            assert fixture_src == text_src

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -51,7 +51,3 @@ class EmailTestCase(AcceptanceTestCase):
             self.browser.get(self.build_url(url, 'html'))
             self.browser.wait_until('#preview')
             self.browser.snapshot('{} email html'.format(name))
-
-            self.browser.get(self.build_url(url, 'txt'))
-            self.browser.wait_until('#preview')
-            self.browser.snapshot('{} email txt'.format(name))

--- a/tests/fixtures/emails/alert.txt
+++ b/tests/fixtures/emails/alert.txt
@@ -1,0 +1,49 @@
+Details
+-------
+
+http://example.com/link
+
+
+Suspect Commits
+---------------
+
+* feat: Do something to raven/base.py
+  1b17483 - dcramer@gmail.com
+
+
+Tags
+----
+
+* logger = javascript
+* environment = prod
+* level = error
+* device = Other
+
+
+Stacktrace
+-----------
+
+
+
+
+Template
+-----------
+
+
+
+
+Request
+-----------
+
+
+
+
+User
+-----------
+
+
+
+
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/assigned.txt
+++ b/tests/fixtures/emails/assigned.txt
@@ -1,0 +1,13 @@
+# Assigned
+
+foo@example.com assigned an issue to foo@example.com
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/assigned_self.txt
+++ b/tests/fixtures/emails/assigned_self.txt
@@ -1,0 +1,13 @@
+# Assigned
+
+foo@example.com assigned an issue to themselves
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/digest.txt
+++ b/tests/fixtures/emails/digest.txt
@@ -1,0 +1,26 @@
+Notifications for example
+June 8, 2016, 7:25 a.m. UTC to July 4, 2016, 2:11 p.m. UTC
+
+Rule #1
+
+* CursusError: nibh curabitur (9729 events, 5901 users)
+  http://testserver/example/example/issues/9/
+
+* CuraeError: pulvinar fames suspendisse erat integer ad magna (7555 events, 4549 users)
+  http://testserver/example/example/issues/15/
+
+* erat pellentesque enim imperdiet tortor (3180 events, 276 users)
+  http://testserver/example/example/issues/16/
+
+* NecVivamusError: consequat ipsum proin gravida inceptos scelerisque inceptos iaculis libero vulputate (2824 events, 1188 users)
+  http://testserver/example/example/issues/14/
+
+* LectusDapibusTacitiError: semper porta curae luctus fermentum molestie praesent ac auctor (2358 events, 7906 users)
+  http://testserver/example/example/issues/2/
+
+* VelTorquentError: porttitor praesent ridiculus (562 events, 8950 users)
+  http://testserver/example/example/issues/13/
+
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/invalid_identity.txt
+++ b/tests/fixtures/emails/invalid_identity.txt
@@ -1,0 +1,8 @@
+Action Required
+---------------
+
+An identity with a third party service provider (dummy) failed to authenticate and has been removed.
+
+You will need to associate your account with dummy to continue using the integration.
+
+http://testserver/account/settings/social/associate/dummy/

--- a/tests/fixtures/emails/invitation.txt
+++ b/tests/fixtures/emails/invitation.txt
@@ -1,0 +1,9 @@
+Welcome to Sentry
+
+Your teammates over at Example have already been using Sentry without you, but the good news is that you've been invited to join them.
+
+Join your team by visiting the following url:
+
+    http://testserver/accept/1/None/
+
+If you'd like to learn more about Sentry before diving head-first, check out our website, https://sentry.io/

--- a/tests/fixtures/emails/mfa_added.txt
+++ b/tests/fixtures/emails/mfa_added.txt
@@ -1,0 +1,20 @@
+Security Notice
+---------------
+
+An authenticator has been added to your Sentry account.
+
+
+Details
+-------
+
+Account: foo@example.com
+IP: 127.0.0.1
+When: Jan. 20, 2017, 9:39 p.m. UTC
+
+Authenticator: U2F (Universal 2nd Factor)
+
+
+Don't recognize this activity?
+------------------------------
+
+If you didn't trigger this action, we recommend you immediately review your account security, including changing your password. If you determine that this activity is malicious please contact .

--- a/tests/fixtures/emails/mfa_removed.txt
+++ b/tests/fixtures/emails/mfa_removed.txt
@@ -1,0 +1,20 @@
+Security Notice
+---------------
+
+An authenticator has been removed from your Sentry account.
+
+
+Details
+-------
+
+Account: foo@example.com
+IP: 127.0.0.1
+When: Jan. 20, 2017, 9:39 p.m. UTC
+
+Authenticator: U2F (Universal 2nd Factor)
+
+
+Don't recognize this activity?
+------------------------------
+
+If you didn't trigger this action, we recommend you immediately review your account security, including changing your password. If you determine that this activity is malicious please contact .

--- a/tests/fixtures/emails/note.txt
+++ b/tests/fixtures/emails/note.txt
@@ -1,0 +1,14 @@
+# New Comment
+
+foo@example.com left a new comment:
+
+metus volutpat
+
+
+## Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/activity/
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/password_changed.txt
+++ b/tests/fixtures/emails/password_changed.txt
@@ -1,0 +1,18 @@
+Security Notice
+---------------
+
+The password to your Sentry account was changed.
+
+
+Details
+-------
+
+Account: foo@example.com
+IP: 127.0.0.1
+When: Jan. 20, 2017, 9:39 p.m. UTC
+
+
+Don't recognize this activity?
+------------------------------
+
+If you didn't trigger this action, we recommend you immediately review your account security, including changing your password. If you determine that this activity is malicious please contact .

--- a/tests/fixtures/emails/regression.txt
+++ b/tests/fixtures/emails/regression.txt
@@ -1,0 +1,13 @@
+# Regression
+
+Sentry marked an issue as a regression
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/regression_with_version.txt
+++ b/tests/fixtures/emails/regression_with_version.txt
@@ -1,0 +1,13 @@
+# Regression
+
+Sentry marked an issue as a regression in abcdef
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/release.txt
+++ b/tests/fixtures/emails/release.txt
@@ -1,0 +1,9 @@
+Version 6c998f7 was deployed to production on Oct. 12, 2016, 3:39 p.m.
+
+
+    http://testserver/organization/project/releases/6c998f755f304593a4713abd123eaf8833a2de5e/
+
+    http://testserver/organization/another-project/releases/6c998f755f304593a4713abd123eaf8833a2de5e/
+
+    http://testserver/organization/yet-another-project/releases/6c998f755f304593a4713abd123eaf8833a2de5e/
+

--- a/tests/fixtures/emails/resolved.txt
+++ b/tests/fixtures/emails/resolved.txt
@@ -1,0 +1,13 @@
+# Resolved Issue
+
+Sentry marked an issue as resolved
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved_in_release.txt
+++ b/tests/fixtures/emails/resolved_in_release.txt
@@ -1,0 +1,13 @@
+# Resolved Issue
+
+Sentry marked an issue as resolved in abcdef
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved_in_release_upcoming.txt
+++ b/tests/fixtures/emails/resolved_in_release_upcoming.txt
@@ -1,0 +1,13 @@
+# Resolved Issue
+
+Sentry marked an issue as resolved in an upcoming release
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/sso_linked.txt
+++ b/tests/fixtures/emails/sso_linked.txt
@@ -1,0 +1,7 @@
+Dummy Single Sign-On has been configured for the My Company organization.
+
+Link your Sentry account to enable signing on with your Dummy account by visiting the following url:
+
+
+
+SSO link request invoked by foo@example.com

--- a/tests/fixtures/emails/sso_unlinked.txt
+++ b/tests/fixtures/emails/sso_unlinked.txt
@@ -1,0 +1,9 @@
+Dummy Single Sign-On has been disabled for the My Company organization.
+
+
+You can now login using your email , and password. If you forgot your password you can always reset it by visiting the following url:
+
+
+
+
+SSO was disabled by foo@example.com

--- a/tests/fixtures/emails/sso_unlinked_without_password.txt
+++ b/tests/fixtures/emails/sso_unlinked_without_password.txt
@@ -1,0 +1,9 @@
+Dummy Single Sign-On has been disabled for the My Company organization.
+
+
+You can now login using your email , however you'll first have to set a password for your account by visiting the following url:
+
+
+
+
+SSO was disabled by foo@example.com

--- a/tests/fixtures/emails/unable_to_delete_repo.txt
+++ b/tests/fixtures/emails/unable_to_delete_repo.txt
@@ -1,0 +1,7 @@
+Unable to Delete Repo
+---------------------
+
+We were unable to delete webhooks in Example for your repository (<em>getsentry/sentry</em>) due to the following error:
+An internal server error occurred
+
+You will need to remove these webhooks manually in Example in order to stop sending commit data to Sentry.

--- a/tests/fixtures/emails/unable_to_fetch_commits.txt
+++ b/tests/fixtures/emails/unable_to_fetch_commits.txt
@@ -1,0 +1,6 @@
+Unable to Fetch Commits
+-----------------------
+
+We were unable to fetch the commit log for your release (abcdef) due to the following error:
+
+An internal server error occurred

--- a/tests/fixtures/emails/unassigned.txt
+++ b/tests/fixtures/emails/unassigned.txt
@@ -1,0 +1,13 @@
+# Unassigned
+
+foo@example.com unassigned an issue
+
+
+## Issue Details
+
+ornare elit pulvinar nisl integer cum ad massa
+
+http://testserver/organization/project/issues/1/
+
+
+Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");


### PR DESCRIPTION
Doesn't make sense to do a full browser snapshot of plain text output and then continually monitor them in a tool like Percy.