### PR TITLE
fix(api): Fix org-members query API

### DIFF
--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -63,11 +63,13 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             tokens = tokenize_query(query)
             for key, value in six.iteritems(tokens):
                 if key == 'email':
-                    queryset = queryset.filter(Q(user__email__in=value) |
+                    queryset = queryset.filter(Q(email__in=value) |
+                                               Q(user__email__in=value) |
                                                Q(user__emails__email__in=value))
                 elif key == 'query':
                     value = ' '.join(value)
-                    queryset = queryset.filter(Q(user__email__icontains=value) |
+                    queryset = queryset.filter(Q(email__icontains=value) |
+                                               Q(user__email__icontains=value) |
                                                Q(user__name__icontains=value))
                 else:
                     queryset = queryset.none()

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -42,6 +42,21 @@ class OrganizationMemberListTest(APITestCase):
         assert response.data[0]['email'] == self.user_2.email
         assert response.data[1]['email'] == self.owner_user.email
 
+    def test_query(self):
+        response = self.client.get(self.url + "?query=bar")
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]['email'] == "bar@localhost"
+
+    def test_query_null_user(self):
+        OrganizationMember.objects.create(email="billy@localhost", organization=self.org)
+        response = self.client.get(self.url + "?query=bill")
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]['email'] == "billy@localhost"
+
     def test_email_query(self):
         response = self.client.get(self.url + "?query=email:foo@localhost")
 


### PR DESCRIPTION
`OrganizationMember.user` can be null if user has been invited to org but they have not accepted the invite and registered an account. When using the `query` GET param, the query only searched for `OrganizationMember.user.email`(/`name`) of the `user` model and not `OrganizationMember.email`.