### PR TITLE
fix(sidebar): Fix jumpy icons on collapse

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -208,8 +208,8 @@ const SidebarDropdownActor = styled('div')`
 `;
 
 const StyledAvatar = styled(Avatar)`
-  margin-top: 1px;
-  margin-bottom: 1px;
+  margin-top: 2px;
+  margin-bottom: 2px;
   margin-right: ${p => (p.collapsed ? '0' : '12px')};
 `;
 


### PR DESCRIPTION
When sidebar was expanded, text content height was > avatar, so when it collapsed, it caused the rest of the content to move up a few pixels