### PR TITLE
fix(native): Fix symbolserver lookup for windows symbols

### DIFF
--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -186,7 +186,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             # similar we need to skip.
             try:
                 uuid.UUID(obj.id)
-            except ValueError:
+            except (ValueError, TypeError):
                 continue
 
             to_lookup.append(


### PR DESCRIPTION
Fixes [SENTRY-6CQ](https://sentry.io/sentry/sentry/issues/527067739)