### PR TITLE
fix(mocks): Prevent occasional unbound local error in load-mocks

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -79,7 +79,7 @@ def create_sample_event(*args, **kwargs):
 
 def generate_commits(user):
     commits = []
-    for i in range(random.randint(0, 20)):
+    for i in range(random.randint(1, 20)):
         if i == 1:
             filename = 'raven/base.py'
         else:


### PR DESCRIPTION
fixes:
```python
Traceback (most recent call last):
  File "bin/load-mocks", line 666, in <module>
    extra_events=options.extra_events,
  File "bin/load-mocks", line 484, in main
    last_commit_id=commit.id,
UnboundLocalError: local variable 'commit' referenced before assignment
```