### PR TITLE
fix(ui): widen backfill notice so text fits on two lines again

### DIFF
--- a/src/sentry/static/sentry/app/components/projectHeader/backfillNotice.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/backfillNotice.jsx
@@ -57,7 +57,7 @@ const StyledCallout = styled.div`
   background-color: ${p => p.theme.offWhite2};
   border-radius: ${p => p.theme.borderRadius};
   animation: 0.5s ${slideInRight};
-  width: 305px;
+  width: 325px;
   padding: ${space(1)};
   position: absolute;
   right: calc(100% + ${space(2)});


### PR DESCRIPTION
Looks like this:
<img width="1202" alt="screen shot 2018-05-08 at 4 37 51 pm" src="https://user-images.githubusercontent.com/30713/39788215-3b767e50-52de-11e8-864c-97cbc2afc45f.png">
