### PR TITLE
feat(onboarding): Add split test for enriched fe in install instructions

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -40,6 +40,7 @@ default_manager.add('projects:discard-groups', ProjectFeature)  # NOQA
 default_manager.add('projects:custom-inbound-filters', ProjectFeature)  # NOQA
 default_manager.add('projects:minidump', ProjectFeature)  # NOQA
 default_manager.add('user:assistant')
+default_manager.add('user:install-experiment')
 
 # expose public api
 add = default_manager.add

--- a/src/sentry/static/sentry/app/views/planout/installReact.jsx
+++ b/src/sentry/static/sentry/app/views/planout/installReact.jsx
@@ -5,10 +5,10 @@ import createReactClass from 'create-react-class';
 import {t} from 'app/locale';
 
 const InstallReactTest = createReactClass({
-  displayName: 'ProjectInstallPlatform',
+  displayName: 'InstallReactTest',
 
   propTypes: {
-    dsn: PropTypes.str,
+    dsn: PropTypes.string,
   },
 
   getInitialState(props) {

--- a/src/sentry/static/sentry/app/views/planout/installReact.jsx
+++ b/src/sentry/static/sentry/app/views/planout/installReact.jsx
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+
+import {t} from 'app/locale';
+
+const InstallReactTest = createReactClass({
+  displayName: 'ProjectInstallPlatform',
+
+  propTypes: {
+    dsn: PropTypes.str,
+  },
+
+  getInitialState(props) {
+    return {
+      loading: true,
+      error: false,
+    };
+  },
+
+  render() {
+    let dsn = this.props.dsn;
+
+    return (
+      <div>
+        <h2> Installation </h2>
+        <p>
+          {' '}
+          Start by adding the <span className="pre"> raven.js </span> script tag to your
+          page. It should be loaded as early as possible, before your main javascript
+          bundle.{' '}
+        </p>
+        <pre>
+          <span style={{color: '#111111'}}>{'<'}</span>
+          <span style={{color: '#2eb0f7'}}>script </span>
+          <span style={{color: '#a47ac6'}}>src</span>
+          <span style={{color: '#111111'}}>=</span>
+          <span style={{color: '#e8535a'}}>
+            "https://cdn.ravenjs.com/3.24.0/raven.min.js"
+          </span>
+          <br />
+          <span style={{color: '#a47ac6'}}> crossorigin</span>
+          <span style={{color: '#111111'}}>=</span>
+          <span style={{color: '#e8535a'}}>{'anonymous'}</span>
+          <span style={{color: '#111111'}}>{'>'}</span>
+          <span style={{color: '#111111'}}>{'</'}</span>
+          <span style={{color: '#2eb0f7'}}>script</span>
+          <span style={{color: '#111111'}}>{'>'}</span>
+        </pre>
+
+        <h2> Basic Configuration </h2>
+        <p>{t('Next configure Raven.js to use your Sentry DSN: ')}</p>
+
+        <pre>
+          <span style={{color: '#111111'}}>{'Raven.config('}</span>
+          <span style={{color: '#e8535a'}}>{"'"}</span>
+          <span style={{color: '#e8535a'}}>{dsn}</span>
+          <span style={{color: '#111111'}}>{"', {"}</span>
+          <br />
+
+          <span style={{color: '#111111'}}>{'   release: '}</span>
+          <span style={{color: '#e8535a'}}>{'test-1-2-3'}</span>
+          <span style={{color: '#111111'}}>{','}</span>
+          <br />
+          <span style={{color: '#111111'}}>{'   environment: '}</span>
+          <span style={{color: '#e8535a'}}>{'development'}</span>
+          <span style={{color: '#111111'}}>{','}</span>
+          <br />
+          <span style={{color: '#111111'}}>{'}).install()'}</span>
+        </pre>
+        <p>Congrats! Raven is now ready to capture any uncaught exceptions</p>
+      </div>
+    );
+  },
+});
+
+export default InstallReactTest;

--- a/src/sentry/static/sentry/app/views/planout/installReact.jsx
+++ b/src/sentry/static/sentry/app/views/planout/installReact.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 import createReactClass from 'create-react-class';
 
 import {t} from 'app/locale';
@@ -25,26 +26,24 @@ const InstallReactTest = createReactClass({
       <div>
         <h3> Installation </h3>
         <p>
-          {' '}
-          Start by adding the <span className="pre"> raven.js </span> script tag to your
+          {t('Start by adding the')}
+          <span className="pre"> raven.js </span>{' '}
+          {t(`script tag to your
           page. It should be loaded as early as possible, before your main javascript
-          bundle.{' '}
+          bundle.`)}
         </p>
         <pre>
           <span>{'<'}</span>
-          <span className="script">script </span>
-          <span className="attribute">src</span>
+          <ScriptSpan>script </ScriptSpan>
+          <AttributeSpan>src</AttributeSpan>
           <span>=</span>
-          <span className="value-text">
-            "https://cdn.ravenjs.com/3.24.0/raven.min.js"
-          </span>
+          <ValueSpan>{t('https://cdn.ravenjs.com/3.24.0/raven.min.js')}</ValueSpan>
           <br />
-          <span className="attribute"> crossorigin</span>
+          <AttributeSpan> crossorigin</AttributeSpan>
           <span>=</span>
-          <span className="value-text">{'anonymous'}</span>
-          <span>{'>'}</span>
-          <span>{'</'}</span>
-          <span className="script">script</span>
+          <ValueSpan>{'anonymous'}</ValueSpan>
+          <span>{'></'}</span>
+          <ScriptSpan>script</ScriptSpan>
           <span>{'>'}</span>
         </pre>
 
@@ -53,17 +52,17 @@ const InstallReactTest = createReactClass({
 
         <pre>
           <span>{'Raven.config('}</span>
-          <span className="value-text">{"'"}</span>
-          <span className="value-text">{dsn}</span>
+          <ValueSpan>{"'"}</ValueSpan>
+          <ValueSpan>{dsn}</ValueSpan>
           <span>{"', {"}</span>
           <br />
 
           <span>{'   release: '}</span>
-          <span className="value-text">{'test-1-2-3'}</span>
+          <ValueSpan>{'0-0-0'}</ValueSpan>
           <span>{','}</span>
           <br />
           <span>{'   environment: '}</span>
-          <span className="value-text">{'development'}</span>
+          <ValueSpan>{'development'}</ValueSpan>
           <span>{','}</span>
           <br />
           <span>{'}).install()'}</span>
@@ -73,5 +72,15 @@ const InstallReactTest = createReactClass({
     );
   },
 });
+
+const ScriptSpan = styled('span')`
+  color: #2eb0f7;
+`;
+const AttributeSpan = styled('span')`
+  color: #a47ac6;
+`;
+const ValueSpan = styled('span')`
+  color: #e8535a;
+`;
 
 export default InstallReactTest;

--- a/src/sentry/static/sentry/app/views/planout/installReact.jsx
+++ b/src/sentry/static/sentry/app/views/planout/installReact.jsx
@@ -23,7 +23,7 @@ const InstallReactTest = createReactClass({
 
     return (
       <div>
-        <h2> Installation </h2>
+        <h3> Installation </h3>
         <p>
           {' '}
           Start by adding the <span className="pre"> raven.js </span> script tag to your
@@ -31,42 +31,42 @@ const InstallReactTest = createReactClass({
           bundle.{' '}
         </p>
         <pre>
-          <span style={{color: '#111111'}}>{'<'}</span>
-          <span style={{color: '#2eb0f7'}}>script </span>
-          <span style={{color: '#a47ac6'}}>src</span>
-          <span style={{color: '#111111'}}>=</span>
-          <span style={{color: '#e8535a'}}>
+          <span>{'<'}</span>
+          <span className="script">script </span>
+          <span className="attribute">src</span>
+          <span>=</span>
+          <span className="value-text">
             "https://cdn.ravenjs.com/3.24.0/raven.min.js"
           </span>
           <br />
-          <span style={{color: '#a47ac6'}}> crossorigin</span>
-          <span style={{color: '#111111'}}>=</span>
-          <span style={{color: '#e8535a'}}>{'anonymous'}</span>
-          <span style={{color: '#111111'}}>{'>'}</span>
-          <span style={{color: '#111111'}}>{'</'}</span>
-          <span style={{color: '#2eb0f7'}}>script</span>
-          <span style={{color: '#111111'}}>{'>'}</span>
+          <span className="attribute"> crossorigin</span>
+          <span>=</span>
+          <span className="value-text">{'anonymous'}</span>
+          <span>{'>'}</span>
+          <span>{'</'}</span>
+          <span className="script">script</span>
+          <span>{'>'}</span>
         </pre>
 
-        <h2> Basic Configuration </h2>
+        <h3> Basic Configuration </h3>
         <p>{t('Next configure Raven.js to use your Sentry DSN: ')}</p>
 
         <pre>
-          <span style={{color: '#111111'}}>{'Raven.config('}</span>
-          <span style={{color: '#e8535a'}}>{"'"}</span>
-          <span style={{color: '#e8535a'}}>{dsn}</span>
-          <span style={{color: '#111111'}}>{"', {"}</span>
+          <span>{'Raven.config('}</span>
+          <span className="value-text">{"'"}</span>
+          <span className="value-text">{dsn}</span>
+          <span>{"', {"}</span>
           <br />
 
-          <span style={{color: '#111111'}}>{'   release: '}</span>
-          <span style={{color: '#e8535a'}}>{'test-1-2-3'}</span>
-          <span style={{color: '#111111'}}>{','}</span>
+          <span>{'   release: '}</span>
+          <span className="value-text">{'test-1-2-3'}</span>
+          <span>{','}</span>
           <br />
-          <span style={{color: '#111111'}}>{'   environment: '}</span>
-          <span style={{color: '#e8535a'}}>{'development'}</span>
-          <span style={{color: '#111111'}}>{','}</span>
+          <span>{'   environment: '}</span>
+          <span className="value-text">{'development'}</span>
+          <span>{','}</span>
           <br />
-          <span style={{color: '#111111'}}>{'}).install()'}</span>
+          <span>{'}).install()'}</span>
         </pre>
         <p>Congrats! Raven is now ready to capture any uncaught exceptions</p>
       </div>

--- a/src/sentry/static/sentry/app/views/planout/installReact.jsx
+++ b/src/sentry/static/sentry/app/views/planout/installReact.jsx
@@ -48,25 +48,45 @@ const InstallReactTest = createReactClass({
         </pre>
 
         <h3> Basic Configuration </h3>
-        <p>{t('Next configure Raven.js to use your Sentry DSN: ')}</p>
+        <p>
+          {t(`Next configure Raven.js to use your Sentry DSN. Sending release and environment data both provide valuable
+          context e.g. when an issue was first seen. Learn more about `)}
+          <a href="https://docs.sentry.io/clients/javascript/config/">
+            {' '}
+            configuration options{' '}
+          </a>here.
+        </p>
 
         <pre>
-          <span>{'Raven.config('}</span>
-          <ValueSpan>{"'"}</ValueSpan>
-          <ValueSpan>{dsn}</ValueSpan>
-          <span>{"', {"}</span>
+          <span>
+            {'<'}
+            <ScriptSpan>script</ScriptSpan>
+            {'>'}
+          </span>
+          <br />
+          <span>{' Raven.config('}</span>
+          <ValueSpan>'{dsn}'</ValueSpan>
+          <span>{', {'}</span>
           <br />
 
           <span>{'   release: '}</span>
-          <ValueSpan>{'0-0-0'}</ValueSpan>
+          <ValueSpan>{"'0-0-0'"}</ValueSpan>
           <span>{','}</span>
           <br />
           <span>{'   environment: '}</span>
-          <ValueSpan>{'development'}</ValueSpan>
+          <ValueSpan>{"'development-test'"}</ValueSpan>
           <span>{','}</span>
           <br />
-          <span>{'}).install()'}</span>
+          <span>{' }).install()'}</span>
+          <br />
+          <span>
+            {'</'}
+            <ScriptSpan>script</ScriptSpan>
+            {'>'}
+          </span>
+          <br />
         </pre>
+
         <p>Congrats! Raven is now ready to capture any uncaught exceptions</p>
       </div>
     );

--- a/src/sentry/static/sentry/less/type.less
+++ b/src/sentry/static/sentry/less/type.less
@@ -6,6 +6,9 @@
 @baseFontSize: 13px;
 @font-family-base: 'Lato', 'Avenir Next', 'Helvetica Neue', sans-serif;
 @font-family-code: Monaco, Consolas, 'Courier New', monospace;
+@script-blue: #2eb0f7;
+@attribute-purple: #a47ac6;
+@link-red: #e8535a;
 
 /**
  * Links
@@ -181,6 +184,16 @@ pre {
   word-break: keep-all;
   word-wrap: normal;
   padding: 10px;
+
+  .script {
+    color: @script-blue;
+  }
+  .attribute {
+    color: @attribute-purple;
+  }
+  .value-text {
+    color: @link-red;
+  }
 }
 
 /**

--- a/src/sentry/static/sentry/less/type.less
+++ b/src/sentry/static/sentry/less/type.less
@@ -6,9 +6,6 @@
 @baseFontSize: 13px;
 @font-family-base: 'Lato', 'Avenir Next', 'Helvetica Neue', sans-serif;
 @font-family-code: Monaco, Consolas, 'Courier New', monospace;
-@script-blue: #2eb0f7;
-@attribute-purple: #a47ac6;
-@link-red: #e8535a;
 
 /**
  * Links
@@ -184,16 +181,6 @@ pre {
   word-break: keep-all;
   word-wrap: normal;
   padding: 10px;
-
-  .script {
-    color: @script-blue;
-  }
-  .attribute {
-    color: @attribute-purple;
-  }
-  .value-text {
-    color: @link-red;
-  }
 }
 
 /**

--- a/src/sentry/templatetags/sentry_react.py
+++ b/src/sentry/templatetags/sentry_react.py
@@ -103,6 +103,8 @@ def get_react_config(context):
         enabled_features.append('auth:register')
     if features.has('user:assistant', actor=user):
         enabled_features.append('assistant')
+    if features.has('user:install-experiment', actor=user):
+        enabled_features.append('install-experiment')
 
     version_info = _get_version_info()
 

--- a/tests/js/spec/views/projectInstall/platform.spec.jsx
+++ b/tests/js/spec/views/projectInstall/platform.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {Client} from 'app/api';
+import ConfigStore from 'app/stores/configStore';
 import ProjectInstallPlatform from 'app/views/projectInstall/platform';
 
 describe('ProjectInstallPlatform', function() {
@@ -29,6 +30,16 @@ describe('ProjectInstallPlatform', function() {
               {
                 id: 'csharp',
                 type: 'language',
+              },
+            ],
+          },
+          {
+            id: 'javascript',
+            name: 'JavaScript',
+            integrations: [
+              {
+                id: 'javascript-react',
+                type: 'framework',
               },
             ],
           },
@@ -78,6 +89,61 @@ describe('ProjectInstallPlatform', function() {
       });
 
       expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
+    });
+
+    // TO-DO(Dena): Remove next three tests after experiment
+    it('should render experiment if selected react and in treatment', function() {
+      // Assignment in treatment or control lives in the configstore
+      ConfigStore.set('features', new Set(['install-experiment']));
+      let props = {
+        ...baseProps,
+        params: {
+          platform: 'javascript-react',
+        },
+      };
+      let wrapper = shallow(<ProjectInstallPlatform {...props} />, {
+        disableLifecycleMethods: false,
+        organization: {id: '1337'},
+      });
+
+      wrapper.setState({loading: false});
+      expect(wrapper.find('InstallReactTest')).toHaveLength(1);
+    });
+
+    it('should not render experiment if selected react and in control', function() {
+      // Assignment in treatment or control lives in the configstore
+      ConfigStore.set('features', new Set());
+      let props = {
+        ...baseProps,
+        params: {
+          platform: 'javascript-react',
+        },
+      };
+      let wrapper = shallow(<ProjectInstallPlatform {...props} />, {
+        disableLifecycleMethods: false,
+        organization: {id: '1337'},
+      });
+
+      wrapper.setState({loading: false});
+      expect(wrapper.find('InstallReactTest')).toHaveLength(0);
+    });
+
+    it('should not render experiment if did not select react and in treatment', function() {
+      // Assignment in treatment or control lives in the configstore
+      ConfigStore.set('features', new Set(['install-experiment']));
+      let props = {
+        ...baseProps,
+        params: {
+          platform: 'node-connect',
+        },
+      };
+      let wrapper = shallow(<ProjectInstallPlatform {...props} />, {
+        disableLifecycleMethods: false,
+        organization: {id: '1337'},
+      });
+
+      wrapper.setState({loading: false});
+      expect(wrapper.find('InstallReactTest')).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Goal: Test if adding releases and environment to first event config in install instructions (i.e. introducing the concepts from the beginning) will improve adoption of features in new users

To Do
- [x] clean up css
- [x] Reload event [PR](https://github.com/getsentry/reload/pull/26)
- [x] Tests
See [paper doc](https://paper.dropbox.com/doc/Enriched-First-Event-suiXd8H7gsEYb2nXDYiAy) for more details and screenshots.