### PR TITLE
ref(services): Allow sharing additional context across threads

### DIFF
--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -138,20 +138,20 @@ class ServiceDelegator(Service):
         # ... etc ...
 
     The backends used for a method call are determined by a selector function
-    which is provided with the method name (as a string) and arguments (in the
-    form returned by ``inspect.getcallargs``) and expected to return a list of
-    strings which correspond to names in the backend mapping. (This list should
-    contain at least one member.) The first item in the result list is
-    considered the "primary backend". The remainder of the items in the result
-    list are considered "secondary backends". The result value of the primary
-    backend will be the result value of the delegated method (to callers, this
-    appears as a synchronous method call.) The secondary backends are called
-    asynchronously in the background.  (To receive the result values of these
-    method calls, provide a callback_func, described below.) If the primary
-    backend name returned by the selector function doesn't correspond to any
-    registered backend, the function will raise a ``InvalidBackend`` exception.
-    If any referenced secondary backends are not registered names, they will be
-    discarded and logged.
+    which is provided with the current context, the method name (as a string)
+    and arguments (in the form returned by ``inspect.getcallargs``) and
+    expected to return a list of strings which correspond to names in the
+    backend mapping. (This list should contain at least one member.) The first
+    item in the result list is considered the "primary backend". The remainder
+    of the items in the result list are considered "secondary backends". The
+    result value of the primary backend will be the result value of the
+    delegated method (to callers, this appears as a synchronous method call.)
+    The secondary backends are called asynchronously in the background.  (To
+    receive the result values of these method calls, provide a callback_func,
+    described below.) If the primary backend name returned by the selector
+    function doesn't correspond to any registered backend, the function will
+    raise a ``InvalidBackend`` exception.  If any referenced secondary backends
+    are not registered names, they will be discarded and logged.
 
     The members and ordering of the selector function result (and thus the
     primary and secondary backends for a method call) may vary from call to
@@ -189,6 +189,7 @@ class ServiceDelegator(Service):
       attempting to retrieve the result.)
     - The ``callback_func`` is called after all futures have completed, either
       successfully or unsuccessfully. The function parameters are:
+      - the context,
       - the method name (as a string),
       - the calling arguments (as returned by ``inspect.getcallargs``),
       - the backend names (as returned by the selector function),


### PR DESCRIPTION
- Implements a `Context` object that is instantiated when calling a delegated method and subsequently propagated across the different threads of execution downstream of that method.
- Allows access to the request object and active backends in the selector and callback functions via the `Context` object.