### PR TITLE
fix(ui): sentry 9 polish pass #2

### DIFF
--- a/src/sentry/static/sentry/app/components/projectHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/index.jsx
@@ -60,7 +60,7 @@ class ProjectHeader extends React.Component {
 
     return (
       <div className="sub-header flex flex-container flex-vertically-centered">
-        <div className="project-header p-t-1">
+        <div className="project-header">
           <div className="project-header-main">
             <div className="project-select-wrapper">
               <ProjectSelector organization={org} projectId={project.slug} />

--- a/src/sentry/static/sentry/app/components/projectHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/index.jsx
@@ -123,6 +123,7 @@ class ProjectHeader extends React.Component {
                   <MenuItem
                     onClick={clearActiveEnvironment}
                     className={activeEnvironment === null && 'active'}
+                    linkClassName="truncate"
                   >
                     {allEnvironmentsLabel}
                   </MenuItem>
@@ -135,6 +136,7 @@ class ProjectHeader extends React.Component {
                         activeEnvironment.name === env.name &&
                         'active'
                       }
+                      linkClassName="truncate"
                     >
                       {env.displayName}
                     </MenuItem>

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -272,11 +272,7 @@ const ProjectSelector = createReactClass({
     let orgId = org.slug;
     let projectId = project.slug;
 
-    return (
-      <span>
-        <Link to={`/${orgId}/${projectId}/`}>{label}</Link>
-      </span>
-    );
+    return <Link to={`/${orgId}/${projectId}/`}>{label}</Link>;
   },
 
   renderProjectList({organization: org, projects, filter, hasProjectWrite}) {

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -219,6 +219,8 @@ const StyledAvatar = styled(Avatar)`
   margin-top: 2px;
   margin-bottom: 2px;
   margin-right: ${p => (p.collapsed ? '0' : '12px')};
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
 `;
 
 const OrgAndUserMenu = styled('div')`

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -268,6 +268,7 @@ body.auth {
 
     + .dropdown-menu {
       z-index: @zindex-sticky-bar + 2;
+      width: 172px;
     }
   }
 

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -229,6 +229,8 @@ body.auth {
 
   .project-header {
     display: flex;
+    margin-top: 18px;
+
     &-main {
       flex-grow: 1;
     }
@@ -240,6 +242,7 @@ body.auth {
         font-weight: normal;
         display: block;
         margin-top: 8px;
+        margin-bottom: 8px;
       }
     }
   }
@@ -251,7 +254,7 @@ body.auth {
 
   .project-select-bookmark {
     border-left: 1px solid @gray-lightest;
-    padding-left: 10px;
+    padding-left: 15px;
     margin-left: 10px;
     color: @40;
     &.active {
@@ -294,14 +297,14 @@ body.auth {
       z-index: 2;
 
       a {
-        padding-bottom: 13px;
+        padding-bottom: 10px;
       }
     }
   }
 
   .project-select-wrapper + .nav-tabs,
   #blk_projectselect + .nav-tabs {
-    margin-top: 10px;
+    margin-top: 12px;
   }
 
   .align-right {

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1158,8 +1158,8 @@ table.integrations {
   h3 {
     font-size: 20px;
     margin: 0;
-    position: relative;
-    top: 2px;
+    display: flex;
+    align-items: center;
 
     a {
       color: @gray-dark;
@@ -1188,6 +1188,7 @@ table.integrations {
 
 .project-dropdown {
   position: static;
+  height: 24px;
 
   .dropdown-toggle {
     height: 23px;
@@ -2419,7 +2420,7 @@ header + .alert {
       margin: 0;
       border: 0;
       background: none;
-      color: @gray;
+      color: @60;
       min-width: 30px;
       text-align: center;
 

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -989,7 +989,6 @@
 */
 
 .stream-header {
-  margin-top: -2px;
   margin-bottom: 15px;
 }
 

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -940,10 +940,10 @@
 
   .dropdown-toggle {
     .btn-default;
-    width: 168px;
+    width: 176px;
     font-size: 14px;
     border: 1px solid lighten(@gray-lighter, 7);
-    padding: 6px 12px;
+    padding: 6px 8px;
     border-radius: 3px;
 
     display: block;

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -896,7 +896,7 @@
 
   .dropdown-menu {
     max-width: 350px;
-    min-width: 250px;
+    min-width: 275px;
 
     .row {
       margin: 8px 5px 5px;


### PR DESCRIPTION
here's another quick polish pass, most of which can be seen here:

<img width="1434" alt="screen shot 2018-05-09 at 4 24 19 pm" src="https://user-images.githubusercontent.com/30713/39844572-9a20b282-53a5-11e8-97bc-9e9d260c224f.png">

- fixes padding/alignment issues in project header
- adds a dropshadow below org avatar
- fixes margins around 'Manage environments' button
- truncates long environment names in the environment dropdown
