### PR TITLE
feat(integrations): Add JIRA issue search endpoint

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import datetime
 import jwt
+import re
 from six.moves.urllib.parse import urlparse
 
 from sentry.http import build_session
@@ -15,6 +16,7 @@ JIRA_KEY = '%s.jira' % (urlparse(absolute_uri()).hostname, )
 class JiraApiClient(object):
     COMMENT_URL = '/rest/api/2/issue/%s/comment'
     ISSUE_URL = '/rest/api/2/issue/%s'
+    SEARCH_URL = '/rest/api/2/search/'
 
     def __init__(self, base_url, shared_secret):
         self.base_url = base_url
@@ -47,6 +49,14 @@ class JiraApiClient(object):
 
     def get_issue(self, issue_id):
         return self.request('GET', self.ISSUE_URL % (issue_id,))
+
+    def search_issues(self, query):
+        # check if it looks like an issue id
+        if re.search(r'^[A-Za-z]+-\d+$', query):
+            jql = 'id="%s"' % query.replace('"', '\\"')
+        else:
+            jql = 'text ~ "%s"' % query.replace('"', '\\"')
+        return self.request('GET', self.SEARCH_URL, params={'jql': jql})
 
     def create_comment(self, issue_key, comment):
         return self.request('POST', self.COMMENT_URL % issue_key, data={'body': comment})

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -45,6 +45,9 @@ class JiraIntegration(Integration):
     def create_comment(self, issue_id, comment):
         return self.get_client().create_comment(issue_id, comment)
 
+    def search_issues(self, query):
+        return self.get_client().search_issues(query)
+
 
 class JiraIntegrationProvider(IntegrationProvider):
     key = 'jira'

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models import Integration
+
+
+class JiraSearchEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationPermission, )
+
+    def get(self, request, organization, integration_id):
+        try:
+            integration = Integration.objects.get(
+                organizations=organization,
+                id=integration_id,
+                provider='jira',
+            )
+        except Integration.DoesNotExist:
+            return Response(status=404)
+
+        field = request.GET.get('field')
+        query = request.GET.get('query')
+        if field is None:
+            return Response({'detail': 'field is a required parameter'}, status=400)
+        if not query:
+            return Response({'detail': 'query is a required parameter'}, status=400)
+
+        installation = integration.get_installation()
+
+        if field == 'issue_id':
+            resp = installation.search_issues(query)
+            return Response([{
+                'text': '(%s) %s' % (i['key'], i['fields']['summary']),
+                'id': i['key']
+            } for i in resp.get('issues', [])])
+
+        # TODO(jess): handle other autocomplete urls
+        return Response(status=400)

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import patterns, url
 from .configure import JiraConfigureView
 from .descriptor import JiraDescriptorEndpoint
 from .installed import JiraInstalledEndpoint
+from .search import JiraSearchEndpoint
 
 
 urlpatterns = patterns(
@@ -12,4 +13,8 @@ urlpatterns = patterns(
     url(r'^configure/$', JiraConfigureView.as_view()),
     url(r'^descriptor/$', JiraDescriptorEndpoint.as_view()),
     url(r'^installed/$', JiraInstalledEndpoint.as_view()),
+    url(r'^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>[^\/]+)/$',
+        JiraSearchEndpoint.as_view(),
+        name='sentry-extensions-jira-search'
+        ),
 )

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -200,11 +200,13 @@ def register_extensions():
     from sentry import integrations
     from sentry.integrations.example import ExampleIntegrationProvider
     from sentry.integrations.github import GitHubIntegrationProvider
+    from sentry.integrations.jira import JiraIntegrationProvider
     from sentry.integrations.slack import SlackIntegrationProvider
     from sentry.integrations.vsts import VSTSIntegrationProvider
     integrations.register(ExampleIntegrationProvider)
-    integrations.register(SlackIntegrationProvider)
     integrations.register(GitHubIntegrationProvider)
+    integrations.register(JiraIntegrationProvider)
+    integrations.register(SlackIntegrationProvider)
     integrations.register(VSTSIntegrationProvider)
 
     from sentry.plugins import bindings

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+import json
+
+from mock import patch
+
+from django.core.urlresolvers import reverse
+
+from sentry.integrations.jira import JiraIntegration
+from sentry.models import Integration
+from sentry.testutils import APITestCase
+
+
+SAMPLE_SEARCH_RESPONSE = """
+{
+  "expand": "names,schema",
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 1,
+  "issues": [
+    {
+      "expand": "",
+      "id": "10001",
+      "self": "http://www.example.com/jira/rest/api/2/issue/10001",
+      "key": "HSP-1",
+      "fields": {
+        "summary": "this is a test issue summary"
+      }
+    }
+  ],
+  "warningMessages": [
+    "The value 'splat' does not exist for the field 'Foo'."
+  ]
+}
+"""
+
+
+class JiraSearchEndpointTest(APITestCase):
+    @patch.object(JiraIntegration, 'search_issues',
+                  return_value=json.loads(SAMPLE_SEARCH_RESPONSE.strip()))
+    def test_simple(self, mock_search_issues):
+        org = self.organization
+        self.login_as(self.user)
+
+        integration = Integration.objects.create(
+            provider='jira',
+            name='Example JIRA',
+        )
+        integration.add_organization(org.id)
+
+        path = reverse('sentry-extensions-jira-search', args=[org.slug, integration.id])
+
+        resp = self.client.get('%s?field=issue_id&query=test' % (path,))
+        assert resp.data == [
+            {'text': '(HSP-1) this is a test issue summary', 'id': 'HSP-1'}
+        ]
+        mock_search_issues.assert_called_with('test')


### PR DESCRIPTION
related to https://github.com/getsentry/sentry/pull/8384 but not dependent on it

this is so that we can return an autocomplete url as part of the link issue config fields ([example here](https://github.com/getsentry/sentry/pull/8384/files#diff-3a5bf2096b34e34ae242b48be34d6b56R47))