### PR TITLE
fix(ui): Better `AsyncComponent` pagination

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -101,7 +101,7 @@ class AsyncComponent extends React.Component {
       let query = (params && params.query) || {};
       // If paginate option then pass entire `query` object to API call
       // It should only be expecting `query.cursor` for pagination
-      if (options.paginate) {
+      if (options.paginate || locationQuery.cursor) {
         query = {...locationQuery, ...query};
       }
 


### PR DESCRIPTION
Fix `AsyncComponent` requiring an option to paginate, it should more
intelligently detect when pagination is needed.