### PR TITLE
fix: Sort breadcrumbs on timestamp before rendering

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
@@ -68,6 +68,7 @@ class BreadcrumbsInterface extends React.Component {
     // reverse array to get consistent idx between collapsed/expanded state
     // (indexes begin and increment from last breadcrumb)
     return crumbs
+      .sort((a, b) => a.timestamp > b.timestamp)
       .reverse()
       .map((item, idx) => {
         return <Breadcrumb key={idx} crumb={item} />;


### PR DESCRIPTION
Reference: https://forum.sentry.io/t/bad-sorting-of-manual-breadcrumbs/3630

At first, I fixed it in the JS SDK https://github.com/getsentry/raven-js/pull/1308, however, after rethinking it, I believe we should do this here, so it's fixed for every SDK instead.

It's out of order, because `timestamp` is one of the parameters that can be passed to `captureBreadcrumb`, yet we push them at the end of the breadcrumbs array as they happen.