### PR TITLE
ref(group): Group sidebar only uses group from props

### DIFF
--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -8,7 +8,7 @@ import ApiMixin from 'app/mixins/apiMixin';
 import SuggestedOwners from 'app/components/group/suggestedOwners';
 import GroupParticipants from 'app/components/group/participants';
 import GroupReleaseStats from 'app/components/group/releaseStats';
-import GroupState from 'app/mixins/groupState';
+import ProjectState from 'app/mixins/projectState';
 import HookStore from 'app/stores/hookStore';
 import IndicatorStore from 'app/stores/indicatorStore';
 import TagDistributionMeter from 'app/components/group/tagDistributionMeter';
@@ -19,7 +19,7 @@ const GroupSidebar = createReactClass({
   displayName: 'GroupSidebar',
 
   propTypes: {
-    group: PropTypes.object,
+    group: PropTypes.object.isRequired,
     event: PropTypes.object,
   },
 
@@ -27,7 +27,7 @@ const GroupSidebar = createReactClass({
     location: PropTypes.object,
   },
 
-  mixins: [ApiMixin, GroupState],
+  mixins: [ApiMixin, ProjectState],
 
   getInitialState() {
     // Allow injection via getsentry et all
@@ -44,7 +44,7 @@ const GroupSidebar = createReactClass({
   },
 
   componentWillMount() {
-    let group = this.props.group;
+    let {group} = this.props;
     this.api.request(`/issues/${group.id}/participants/`, {
       success: data => {
         this.setState({
@@ -58,7 +58,7 @@ const GroupSidebar = createReactClass({
         });
       },
     });
-    // Fetch group data for all environments since the one in GroupState is filtered for the selected environment
+    // Fetch group data for all environments since the one passed in props is filtered for the selected environment
     // The charts rely on having all environment data as well as the data for the selected env
     this.api.request(`/issues/${group.id}/`, {
       success: data => {
@@ -155,11 +155,11 @@ const GroupSidebar = createReactClass({
   },
 
   canChangeSubscriptionState() {
-    return !(this.getGroup().subscriptionDetails || {disabled: false}).disabled;
+    return !(this.props.group.subscriptionDetails || {disabled: false}).disabled;
   },
 
   getNotificationText() {
-    let group = this.getGroup();
+    let {group} = this.props;
 
     if (group.isSubscribed) {
       let result = t(
@@ -208,10 +208,10 @@ const GroupSidebar = createReactClass({
   },
 
   render() {
+    let {group} = this.props;
     let project = this.getProject();
     let projectId = project.slug;
     let orgId = this.getOrganization().slug;
-    let group = this.getGroup();
 
     return (
       <div className="group-stats">


### PR DESCRIPTION
We should not use group from context since it is the same as the one being passed as a prop to this component