### PR TITLE
feat(gdpr): Prompt new SSO users for marketing consent

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError, transaction
+from django.db.models import F
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -386,6 +387,9 @@ class AuthHelper(object):
             email=identity['email'],
             name=identity.get('name', '')[:200],
         )
+
+        if settings.TERMS_URL and settings.PRIVACY_URL:
+            user.update(flags=F('flags').bitor(User.flags.newsletter_consent_prompt))
 
         try:
             with transaction.atomic():

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -60,7 +60,8 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, 'sentry/auth-confirm-identity.html')
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {'op': 'newuser'})
+        with self.settings(TERMS_URL='https://example.com/terms', PRIVACY_URL='https://example.com/privacy'):
+            resp = self.client.post(path, {'op': 'newuser'})
 
         assert resp.status_code == 302
         assert resp['Location'] == 'http://testserver' + reverse('sentry-login')
@@ -73,6 +74,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert user.email == 'foo@example.com'
         assert not user.has_usable_password()
         assert not user.is_managed
+        assert user.flags.newsletter_consent_prompt
 
         member = OrganizationMember.objects.get(
             organization=organization,

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -191,6 +191,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert user.email == 'bar@example.com'
         assert new_user != user
 
+        # Without settings.TERMS_URL and settings.PRIVACY_URL, this should be
+        # unset following new user creation
+        assert not new_user.flags.newsletter_consent_prompt
+
         member = OrganizationMember.objects.get(
             organization=organization,
             user=new_user,


### PR DESCRIPTION
If `TERMS_URL` and `PRIVACY_URL` are set, prompt for consent on subsequent
successful login.

Refs: BIZ-65