### PR TITLE
fix(sidebar): Apply max height to org selector  (APP-184)

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
@@ -81,6 +81,7 @@ class SwitchOrganization extends React.Component {
 }
 const SwitchOrganizationContainer = withOrganizations(SwitchOrganization);
 
+export {SwitchOrganization};
 export default SwitchOrganizationContainer;
 
 const AddIcon = styled(InlineSvg)`

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
@@ -47,14 +47,16 @@ class SwitchOrganization extends React.Component {
                   data-test-id="sidebar-switch-org-menu"
                   {...getMenuProps({isStyled: true})}
                 >
-                  {organizations.map(organization => (
-                    <SidebarMenuItem
-                      key={organization.slug}
-                      to={`/${organization.slug}/`}
-                    >
-                      <SidebarOrgSummary organization={organization} />
-                    </SidebarMenuItem>
-                  ))}
+                  <OrganizationList>
+                    {organizations.map(organization => (
+                      <SidebarMenuItem
+                        key={organization.slug}
+                        to={`/${organization.slug}/`}
+                      >
+                        <SidebarOrgSummary organization={organization} />
+                      </SidebarMenuItem>
+                    ))}
+                  </OrganizationList>
                   {hasOrganizations && canCreateOrganization && <Divider />}
                   {canCreateOrganization && (
                     <SidebarMenuItem
@@ -117,4 +119,9 @@ const SwitchOrganizationMenu = styled('div')`
   ${SidebarDropdownMenu};
   top: 0;
   left: 256px;
+`;
+
+const OrganizationList = styled('div')`
+  max-height: 350px;
+  overflow-y: auto;
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
@@ -57,7 +57,8 @@ class SwitchOrganization extends React.Component {
                       </SidebarMenuItem>
                     ))}
                   </OrganizationList>
-                  {hasOrganizations && canCreateOrganization && <Divider />}
+                  {hasOrganizations &&
+                    canCreateOrganization && <Divider css={{marginTop: 0}} />}
                   {canCreateOrganization && (
                     <SidebarMenuItem
                       to={'/organizations/new/'}

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
@@ -61,6 +61,7 @@ class SwitchOrganization extends React.Component {
                     canCreateOrganization && <Divider css={{marginTop: 0}} />}
                   {canCreateOrganization && (
                     <SidebarMenuItem
+                      data-test-id="sidebar-create-org"
                       to={'/organizations/new/'}
                       style={{alignItems: 'center'}}
                     >

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -21,6 +21,7 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
       />
     </OrganizationList>
     <SidebarMenuItem
+      data-test-id="sidebar-create-org"
       style={
         Object {
           "alignItems": "center",
@@ -29,6 +30,7 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
       to="/organizations/new/"
     >
       <MenuItemLink
+        data-test-id="sidebar-create-org"
         style={
           Object {
             "alignItems": "center",
@@ -38,6 +40,7 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
       >
         <Component
           className="css-1vsrn4x-MenuItemLink ebifsjx1"
+          data-test-id="sidebar-create-org"
           style={
             Object {
               "alignItems": "center",
@@ -47,6 +50,7 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
         >
           <Link
             className="css-1vsrn4x-MenuItemLink ebifsjx1"
+            data-test-id="sidebar-create-org"
             style={
               Object {
                 "alignItems": "center",
@@ -56,6 +60,7 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
           >
             <Link
               className="css-1vsrn4x-MenuItemLink ebifsjx1"
+              data-test-id="sidebar-create-org"
               onlyActiveOnIndex={false}
               style={
                 Object {
@@ -66,6 +71,7 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
             >
               <a
                 className="css-1vsrn4x-MenuItemLink ebifsjx1"
+                data-test-id="sidebar-create-org"
                 onClick={[Function]}
                 style={
                   Object {

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -15,6 +15,11 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
+    <OrganizationList>
+      <div
+        className="css-1qovpib-OrganizationList ejspo4a5"
+      />
+    </OrganizationList>
     <SidebarMenuItem
       style={
         Object {

--- a/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
+++ b/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
@@ -7,7 +7,7 @@ describe('SwitchOrganization', function() {
   let routerContext = TestStubs.routerContext();
   let {organization} = routerContext.context;
 
-  it('can list organizations', async function() {
+  it('can list organizations', function() {
     jest.useFakeTimers();
     let wrapper = mount(
       <SwitchOrganization
@@ -16,11 +16,49 @@ describe('SwitchOrganization', function() {
       routerContext
     );
 
-    wrapper.find('span[data-test-id="sidebar-switch-org"]').simulate('mouseEnter');
+    wrapper.find('SwitchOrganizationMenuActor').simulate('mouseEnter');
     jest.advanceTimersByTime(500);
     wrapper.update();
     expect(wrapper.find('OrganizationList')).toHaveLength(1);
     expect(wrapper.find('OrganizationList SidebarMenuItem')).toHaveLength(2);
+    jest.useRealTimers();
+  });
+
+  it('shows "Create an Org" if they have permission', function() {
+    jest.useFakeTimers();
+    let wrapper = mount(
+      <SwitchOrganization
+        organizations={[organization, TestStubs.Organization({slug: 'org2'})]}
+        canCreateOrganization
+      />,
+      routerContext
+    );
+
+    wrapper.find('SwitchOrganizationMenuActor').simulate('mouseEnter');
+    jest.advanceTimersByTime(500);
+    wrapper.update();
+    expect(
+      wrapper.find('SidebarMenuItem[data-test-id="sidebar-create-org"]')
+    ).toHaveLength(1);
+    jest.useRealTimers();
+  });
+
+  it('does not have "Create an Org" if they do not have permission', function() {
+    jest.useFakeTimers();
+    let wrapper = mount(
+      <SwitchOrganization
+        organizations={[organization, TestStubs.Organization({slug: 'org2'})]}
+        canCreateOrganization={false}
+      />,
+      routerContext
+    );
+
+    wrapper.find('SwitchOrganizationMenuActor').simulate('mouseEnter');
+    jest.advanceTimersByTime(500);
+    wrapper.update();
+    expect(
+      wrapper.find('SidebarMenuItem[data-test-id="sidebar-create-org"]')
+    ).toHaveLength(0);
     jest.useRealTimers();
   });
 });

--- a/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
+++ b/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import {mount} from 'enzyme';
+import {SwitchOrganization} from 'app/components/sidebar/sidebarDropdown/switchOrganization';
+
+describe('SwitchOrganization', function() {
+  let routerContext = TestStubs.routerContext();
+  let {organization} = routerContext.context;
+
+  it('can list organizations', async function() {
+    jest.useFakeTimers();
+    let wrapper = mount(
+      <SwitchOrganization
+        organizations={[organization, TestStubs.Organization({slug: 'org2'})]}
+      />,
+      routerContext
+    );
+
+    wrapper.find('span[data-test-id="sidebar-switch-org"]').simulate('mouseEnter');
+    jest.advanceTimersByTime(500);
+    wrapper.update();
+    expect(wrapper.find('OrganizationList')).toHaveLength(1);
+    expect(wrapper.find('OrganizationList SidebarMenuItem')).toHaveLength(2);
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
Instead of text filter like in #8402, just apply a max height. About 99% of users have < 10 orgs.

![image](https://user-images.githubusercontent.com/79684/39897972-80ff3a0c-5469-11e8-93fa-d44cf5acd67e.png)
