### PR TITLE
fix(dashboard): Check for bookmarks before rendering empty state

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
@@ -78,9 +78,10 @@ class Dashboard extends React.Component {
             </LazyLoad>
           );
         })}
-        {!teamSlugs.length & !favorites.length && (
-          <EmptyState projects={projects} teams={teams} organization={organization} />
-        )}
+        {teamSlugs.length === 0 &&
+          favorites.length === 0 && (
+            <EmptyState projects={projects} teams={teams} organization={organization} />
+          )}
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
@@ -78,7 +78,7 @@ class Dashboard extends React.Component {
             </LazyLoad>
           );
         })}
-        {!teamSlugs.length && (
+        {!teamSlugs.length & !favorites.length && (
           <EmptyState projects={projects} teams={teams} organization={organization} />
         )}
       </React.Fragment>

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -182,6 +182,37 @@ describe('OrganizationDashboard', function() {
       expect(projectCards.at(4).prop('data-test-id')).toBe('m');
       expect(projectCards.at(5).prop('data-test-id')).toBe('z');
     });
+
+    it('renders favorited projects if there is any, even if team list is empty', function() {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/projects/?statsPeriod=24h',
+        body: [
+          TestStubs.Project({
+            teams: [],
+            stats: [[1517281200, 2], [1517310000, 1]],
+          }),
+        ],
+      });
+
+      const teams = [];
+      const projects = [TestStubs.Project({teams, isBookmarked: true})];
+
+      const wrapper = shallow(
+        <Dashboard
+          teams={teams}
+          projects={projects}
+          organization={TestStubs.Organization()}
+          params={{orgId: 'org-slug'}}
+        />,
+        TestStubs.routerContext()
+      );
+      const projectCard = wrapper.find('ProjectCardWrapper');
+
+      expect(projectCard).toHaveLength(1);
+
+      const emptyState = wrapper.find('EmptyState');
+      expect(emptyState).toHaveLength(0);
+    });
   });
 
   describe('ProjectsStatsStore', function() {

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -184,32 +184,33 @@ describe('OrganizationDashboard', function() {
     });
 
     it('renders favorited projects if there is any, even if team list is empty', function() {
+      const projects = [
+        TestStubs.Project({
+          id: '1',
+          slug: 'm',
+          teams: [],
+          isBookmarked: true,
+          stats: [],
+        }),
+      ];
       MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/projects/?statsPeriod=24h',
-        body: [
-          TestStubs.Project({
-            teams: [],
-            stats: [[1517281200, 2], [1517310000, 1]],
-          }),
-        ],
+        url: '/organizations/org-slug/projects/',
+        body: projects,
       });
 
-      const teams = [];
-      const projects = [TestStubs.Project({teams, isBookmarked: true})];
-
-      const wrapper = shallow(
+      const wrapper = mount(
         <Dashboard
-          teams={teams}
+          teams={[]}
           projects={projects}
           organization={TestStubs.Organization()}
           params={{orgId: 'org-slug'}}
         />,
-        TestStubs.routerContext()
+        routerContext
       );
-      const projectCard = wrapper.find('ProjectCardWrapper');
 
-      expect(projectCard).toHaveLength(1);
-
+      expect(wrapper.find('TeamSection')).toHaveLength(1);
+      const projectCards = wrapper.find('ProjectCard');
+      expect(projectCards).toHaveLength(1);
       const emptyState = wrapper.find('EmptyState');
       expect(emptyState).toHaveLength(0);
     });


### PR DESCRIPTION
This is because projects can be bookmarked without the user necessarily being in a team with that project

In this case, we'll show the favorites bar and skip the empty state