### PR TITLE
fix(commits): limit total displayed

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventCause.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCause.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import {uniqBy, flatMap} from 'lodash';
 
 import ApiMixin from 'app/mixins/apiMixin';
 import GroupState from 'app/mixins/groupState';
@@ -59,24 +60,30 @@ export default createReactClass({
     );
   },
 
+  getUniqueCommitsWithAuthors() {
+    let {committers} = this.state;
+
+    //get a list of commits with author information attached
+    let commitsWithAuthors = flatMap(committers, ({commits, author}) =>
+      commits.map(commit => ({
+        ...commit,
+        author,
+      }))
+    );
+    //remove duplicate commits
+    let uniqueCommitsWithAuthors = uniqBy(commitsWithAuthors, commit => commit.id);
+    return uniqueCommitsWithAuthors;
+  },
+
   render() {
     if (!(this.state.committers && this.state.committers.length)) {
       return null;
     }
 
-    let commits = [];
-    let commitSet = new Set();
-    this.state.committers.forEach(committer => {
-      committer.commits.forEach(commit => {
-        if (!commitSet.has(commit.id)) {
-          commitSet.add(commit.id);
-          commits.push({
-            ...commit,
-            author: committer.author,
-          });
-        }
-      });
-    });
+    let commits = this.getUniqueCommitsWithAuthors();
+    //limit to 5 commits maximum
+    commits = commits.slice(0, 5);
+
     return (
       <div className="box">
         <div className="box-header">

--- a/src/sentry/static/sentry/app/components/events/eventCause.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCause.jsx
@@ -62,7 +62,6 @@ export default createReactClass({
 
   getUniqueCommitsWithAuthors() {
     let {committers} = this.state;
-
     //get a list of commits with author information attached
     let commitsWithAuthors = flatMap(committers, ({commits, author}) =>
       commits.map(commit => ({
@@ -70,6 +69,7 @@ export default createReactClass({
         author,
       }))
     );
+
     //remove duplicate commits
     let uniqueCommitsWithAuthors = uniqBy(commitsWithAuthors, commit => commit.id);
     return uniqueCommitsWithAuthors;

--- a/tests/js/spec/components/events/eventCause.spec.jsx
+++ b/tests/js/spec/components/events/eventCause.spec.jsx
@@ -19,18 +19,41 @@ describe('EventCause', function() {
       method: 'GET',
       url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
       body: {
-        committers: {
-          commits: [
-            {
-              message:
-                'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
-              score: 4,
-              id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-              repository: TestStubs.Repository(),
-              dateCreated: '2018-03-02T18:30:26Z',
-            },
-          ],
-        },
+        committers: [
+          {
+            author: {name: 'Max Bittker', id: '1'},
+            commits: [
+              {
+                message:
+                  'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
+                score: 4,
+                id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+                repository: TestStubs.Repository(),
+                dateCreated: '2018-03-02T18:30:26Z',
+              },
+              {
+                message:
+                  'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
+                score: 4,
+                id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+                repository: TestStubs.Repository(),
+                dateCreated: '2018-03-02T18:30:26Z',
+              },
+            ],
+          },
+          {
+            author: {name: 'Somebody else', id: '2'},
+            commits: [
+              {
+                message: 'fix: Make things less broken',
+                score: 2,
+                id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
+                repository: TestStubs.Repository(),
+                dateCreated: '2018-03-02T16:30:26Z',
+              },
+            ],
+          },
+        ],
       },
     });
 
@@ -50,7 +73,7 @@ describe('EventCause', function() {
     wrapper.update();
 
     setTimeout(() => {
-      expect(wrapper.find('.commit-list').children).toHaveLength(1);
+      expect(wrapper.find('CommitRow')).toHaveLength(2);
       done();
     });
   });


### PR DESCRIPTION
limits a hard cap of 5 suspect commits displayed.

sorting by score or date beforehand would let us make a more intelligent choice, but people having that many commits is an edge case.

we could also indicate that there were omitted values (currently the count could be misleading)