### PR TITLE
fix(ui): rename/simplify settings nav labels

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -208,7 +208,7 @@ class Sidebar extends React.Component {
                   {...sidebarItemProps}
                   onClick={this.hidePanel}
                   icon={<InlineSvg src="icon-star" />}
-                  label={t('Starred issues')}
+                  label={t('Bookmarked issues')}
                   to={`/organizations/${organization.slug}/issues/bookmarks/`}
                 />
                 <SidebarItem

--- a/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
@@ -52,7 +52,7 @@ class Dashboard extends React.Component {
             orgId={params.orgId}
             showBorder
             team={null}
-            title={t('Favorites')}
+            title={t('Bookmarked projects')}
             projects={favorites}
           />
         )}

--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
@@ -37,7 +37,7 @@ const ProjectNav = createReactClass({
         tooltip: t('You do not have permission to create new teams'),
       },
       {
-        title: t('Teammate'),
+        title: t('Member'),
         to: `settings/${org.slug}/members/new/`,
         disabled: !hasTeamWrite,
         tooltip: t('You do not have permission to manage teams'),

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -47,7 +47,7 @@ export default function getConfiguration({project}) {
         },
         {
           path: `${pathPrefix}/release-tracking/`,
-          title: t('Release Tracking'),
+          title: t('Releases'),
           show: ({access}) => access.has('project:write'),
         },
         {
@@ -67,7 +67,7 @@ export default function getConfiguration({project}) {
         },
         {
           path: `${pathPrefix}/debug-symbols/`,
-          title: t('Debug Information Files'),
+          title: t('Debug Files'),
         },
         {
           path: `${pathPrefix}/processing-issues/`,
@@ -81,7 +81,7 @@ export default function getConfiguration({project}) {
       ],
     },
     {
-      name: t('Data'),
+      name: t('Client'),
       items: [
         {
           path: `${pathPrefix}/install/`,

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -17,7 +17,7 @@ export default function getConfiguration({project}) {
         },
         {
           path: `${pathPrefix}/teams/`,
-          title: t('Teams'),
+          title: t('Project Teams'),
           description: t('Manage team access for a project'),
         },
         {

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -81,7 +81,7 @@ export default function getConfiguration({project}) {
       ],
     },
     {
-      name: t('Client'),
+      name: t('Data'),
       items: [
         {
           path: `${pathPrefix}/install/`,


### PR DESCRIPTION
fixes [APP-129](https://getsentry.atlassian.net/secure/RapidBoard.jspa?rapidView=11&projectKey=APP&view=planning&selectedIssue=APP-129) and [APP-182](https://getsentry.atlassian.net/secure/RapidBoard.jspa?rapidView=11&projectKey=APP&view=planning&selectedIssue=APP-182)

Are there other changes we want to make here? E.g. I think there is some confusion around having a **Teams** nav item at both the organization and project level. At the team level, should it say **Associated teams** or something a little more descriptive?

@benvinegar 