### PR TITLE
fix(owners): Fix race condition when unmounting Owners view

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
@@ -249,6 +249,11 @@ export default class SelectOwners extends React.Component {
 
   queryMembers = debounce((query, cb) => {
     let {organization} = this.props;
+
+    // Because this function is debounced, the component can potentially be
+    // unmounted before this fires, in which case, `this.api` is null
+    if (!this.api) return null;
+
     return this.api
       .requestPromise(`/organizations/${organization.slug}/members/`, {
         query: {query},


### PR DESCRIPTION
There's a race condition because of a debounced query when you unmount
the Issue Owners view.

Fixes JAVASCRIPT-3TD