### PR TITLE
fix(dropdown): Keep sidebar dropdown open when "Switch Organization" is clicked

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
@@ -33,7 +33,18 @@ class SwitchOrganization extends React.Component {
             <React.Fragment>
               <SwitchOrganizationMenuActor
                 data-test-id="sidebar-switch-org"
-                {...getActorProps()}
+                {...getActorProps({
+                  isStyled: true,
+                })}
+                onClick={e => {
+                  // This overwrites `DropdownMenu.getActorProps.onClick` which normally handles clicks on actor
+                  // to toggle visibility of menu. Instead, do nothing because it is nested and we only want it
+                  // to appear when hovered on. Will also stop menu from closing when clicked on (which seems to be common
+                  // behavior);
+
+                  // Stop propagation so that dropdown menu doesn't close here
+                  e.stopPropagation();
+                }}
               >
                 {t('Switch organization')}
 

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -493,6 +493,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                     >
                       <SwitchOrganizationMenuActor
                         data-test-id="sidebar-switch-org"
+                        innerRef={[Function]}
                         onClick={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}


### PR DESCRIPTION
This changes the behavior in the sidebar so that it does not close when the submenu: "Switch Organization" is clicked. This also fixes an error when it was clicked. Based on the number of errors, it seems like this is common behavior to click it.

Fixes JAVASCRIPT-381