### PR TITLE
fix: Don't use team names in org member details anymore

### DIFF
--- a/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
@@ -4,8 +4,8 @@ import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 import Checkbox from 'app/components/checkbox';
+import IdBadge from 'app/components/idBadge';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
-import TeamBadge from 'app/components/idBadge/teamBadge';
 
 const TeamItem = styled.div`
   width: 25%;
@@ -43,7 +43,7 @@ class TeamSelect extends React.Component {
                     }}
                     style={{marginTop: 0}}
                   />
-                  <TeamBadge team={team} hideAvatar />
+                  <IdBadge team={team} hideAvatar />
                 </label>
               </TeamItem>
             ))}

--- a/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
@@ -5,6 +5,7 @@ import styled from 'react-emotion';
 import {t} from 'app/locale';
 import Checkbox from 'app/components/checkbox';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import TeamBadge from 'app/components/idBadge/teamBadge';
 
 const TeamItem = styled.div`
   width: 25%;
@@ -30,19 +31,19 @@ class TeamSelect extends React.Component {
 
         <PanelBody className="grouping-controls team-choices">
           <PanelItem css={{flexWrap: 'wrap'}}>
-            {teams.map(({slug, name}, i) => (
-              <TeamItem key={slug}>
+            {teams.map(team => (
+              <TeamItem key={team.slug}>
                 <label className="checkbox">
                   <Checkbox
-                    id={slug}
+                    id={team.slug}
                     disabled={disabled}
-                    checked={selectedTeams.has(slug)}
+                    checked={selectedTeams.has(team.slug)}
                     onChange={e => {
-                      toggleTeam(slug);
+                      toggleTeam(team.slug);
                     }}
                     style={{marginTop: 0}}
                   />
-                  <span>{slug}</span>
+                  <TeamBadge team={team} hideAvatar />
                 </label>
               </TeamItem>
             ))}

--- a/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
@@ -40,9 +40,9 @@ class TeamSelect extends React.Component {
                     onChange={e => {
                       toggleTeam(slug);
                     }}
+                    style={{marginTop: 0}}
                   />
-                  <span>{name}</span>
-                  <span className="team-slug">{slug}</span>
+                  <span>{slug}</span>
                 </label>
               </TeamItem>
             ))}

--- a/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/teamSelect.jsx
@@ -41,7 +41,7 @@ class TeamSelect extends React.Component {
                     onChange={e => {
                       toggleTeam(team.slug);
                     }}
-                    style={{marginTop: 0}}
+                    style={{marginTop: '1px'}}
                   />
                   <IdBadge team={team} hideAvatar />
                 </label>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -443,21 +443,26 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                   checked={false}
                                   id="bar"
                                   onChange={[Function]}
+                                  style={
+                                    Object {
+                                      "marginTop": 0,
+                                    }
+                                  }
                                 >
                                   <input
                                     checked={false}
                                     className="chk-select"
                                     id="bar"
                                     onChange={[Function]}
+                                    style={
+                                      Object {
+                                        "marginTop": 0,
+                                      }
+                                    }
                                     type="checkbox"
                                   />
                                 </Checkbox>
                                 <span>
-                                  bar
-                                </span>
-                                <span
-                                  className="team-slug"
-                                >
                                   bar
                                 </span>
                               </label>
@@ -476,21 +481,26 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                   checked={false}
                                   id="foo"
                                   onChange={[Function]}
+                                  style={
+                                    Object {
+                                      "marginTop": 0,
+                                    }
+                                  }
                                 >
                                   <input
                                     checked={false}
                                     className="chk-select"
                                     id="foo"
                                     onChange={[Function]}
+                                    style={
+                                      Object {
+                                        "marginTop": 0,
+                                      }
+                                    }
                                     type="checkbox"
                                   />
                                 </Checkbox>
                                 <span>
-                                  foo
-                                </span>
-                                <span
-                                  className="team-slug"
-                                >
                                   foo
                                 </span>
                               </label>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -445,7 +445,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                   onChange={[Function]}
                                   style={
                                     Object {
-                                      "marginTop": 0,
+                                      "marginTop": "1px",
                                     }
                                   }
                                 >
@@ -456,7 +456,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     onChange={[Function]}
                                     style={
                                       Object {
-                                        "marginTop": 0,
+                                        "marginTop": "1px",
                                       }
                                     }
                                     type="checkbox"
@@ -556,7 +556,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                   onChange={[Function]}
                                   style={
                                     Object {
-                                      "marginTop": 0,
+                                      "marginTop": "1px",
                                     }
                                   }
                                 >
@@ -567,7 +567,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     onChange={[Function]}
                                     style={
                                       Object {
-                                        "marginTop": 0,
+                                        "marginTop": "1px",
                                       }
                                     }
                                     type="checkbox"

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -462,10 +462,8 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     type="checkbox"
                                   />
                                 </Checkbox>
-                                <TeamBadge
-                                  avatarSize={24}
+                                <IdBadge
                                   hideAvatar={true}
-                                  hideOverflow={true}
                                   team={
                                     Object {
                                       "hasAccess": true,
@@ -475,17 +473,10 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     }
                                   }
                                 >
-                                  <BaseBadge
+                                  <TeamBadge
                                     avatarSize={24}
-                                    displayName={
-                                      <BadgeDisplayName
-                                        hideOverflow={true}
-                                      >
-                                        #
-                                        bar
-                                      </BadgeDisplayName>
-                                    }
                                     hideAvatar={true}
+                                    hideOverflow={true}
                                     team={
                                       Object {
                                         "hasAccess": true,
@@ -495,37 +486,58 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                       }
                                     }
                                   >
-                                    <Flex
-                                      align="center"
-                                    >
-                                      <Base
-                                        align="center"
-                                        className="css-5ipae5"
-                                      >
-                                        <div
-                                          className="css-5ipae5"
-                                          is={null}
+                                    <BaseBadge
+                                      avatarSize={24}
+                                      displayName={
+                                        <BadgeDisplayName
+                                          hideOverflow={true}
                                         >
-                                          <BadgeDisplayName
-                                            hideOverflow={true}
+                                          #
+                                          bar
+                                        </BadgeDisplayName>
+                                      }
+                                      hideAvatar={true}
+                                      team={
+                                        Object {
+                                          "hasAccess": true,
+                                          "id": "1",
+                                          "name": "bar",
+                                          "slug": "bar",
+                                        }
+                                      }
+                                    >
+                                      <Flex
+                                        align="center"
+                                      >
+                                        <Base
+                                          align="center"
+                                          className="css-5ipae5"
+                                        >
+                                          <div
+                                            className="css-5ipae5"
+                                            is={null}
                                           >
-                                            <Component
-                                              className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                            <BadgeDisplayName
                                               hideOverflow={true}
                                             >
-                                              <span
+                                              <Component
                                                 className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                hideOverflow={true}
                                               >
-                                                #
-                                                bar
-                                              </span>
-                                            </Component>
-                                          </BadgeDisplayName>
-                                        </div>
-                                      </Base>
-                                    </Flex>
-                                  </BaseBadge>
-                                </TeamBadge>
+                                                <span
+                                                  className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                >
+                                                  #
+                                                  bar
+                                                </span>
+                                              </Component>
+                                            </BadgeDisplayName>
+                                          </div>
+                                        </Base>
+                                      </Flex>
+                                    </BaseBadge>
+                                  </TeamBadge>
+                                </IdBadge>
                               </label>
                             </div>
                           </TeamItem>
@@ -561,10 +573,8 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     type="checkbox"
                                   />
                                 </Checkbox>
-                                <TeamBadge
-                                  avatarSize={24}
+                                <IdBadge
                                   hideAvatar={true}
-                                  hideOverflow={true}
                                   team={
                                     Object {
                                       "hasAccess": false,
@@ -574,17 +584,10 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     }
                                   }
                                 >
-                                  <BaseBadge
+                                  <TeamBadge
                                     avatarSize={24}
-                                    displayName={
-                                      <BadgeDisplayName
-                                        hideOverflow={true}
-                                      >
-                                        #
-                                        foo
-                                      </BadgeDisplayName>
-                                    }
                                     hideAvatar={true}
+                                    hideOverflow={true}
                                     team={
                                       Object {
                                         "hasAccess": false,
@@ -594,37 +597,58 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                       }
                                     }
                                   >
-                                    <Flex
-                                      align="center"
-                                    >
-                                      <Base
-                                        align="center"
-                                        className="css-5ipae5"
-                                      >
-                                        <div
-                                          className="css-5ipae5"
-                                          is={null}
+                                    <BaseBadge
+                                      avatarSize={24}
+                                      displayName={
+                                        <BadgeDisplayName
+                                          hideOverflow={true}
                                         >
-                                          <BadgeDisplayName
-                                            hideOverflow={true}
+                                          #
+                                          foo
+                                        </BadgeDisplayName>
+                                      }
+                                      hideAvatar={true}
+                                      team={
+                                        Object {
+                                          "hasAccess": false,
+                                          "id": "2",
+                                          "name": "foo",
+                                          "slug": "foo",
+                                        }
+                                      }
+                                    >
+                                      <Flex
+                                        align="center"
+                                      >
+                                        <Base
+                                          align="center"
+                                          className="css-5ipae5"
+                                        >
+                                          <div
+                                            className="css-5ipae5"
+                                            is={null}
                                           >
-                                            <Component
-                                              className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                            <BadgeDisplayName
                                               hideOverflow={true}
                                             >
-                                              <span
+                                              <Component
                                                 className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                hideOverflow={true}
                                               >
-                                                #
-                                                foo
-                                              </span>
-                                            </Component>
-                                          </BadgeDisplayName>
-                                        </div>
-                                      </Base>
-                                    </Flex>
-                                  </BaseBadge>
-                                </TeamBadge>
+                                                <span
+                                                  className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                >
+                                                  #
+                                                  foo
+                                                </span>
+                                              </Component>
+                                            </BadgeDisplayName>
+                                          </div>
+                                        </Base>
+                                      </Flex>
+                                    </BaseBadge>
+                                  </TeamBadge>
+                                </IdBadge>
                               </label>
                             </div>
                           </TeamItem>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -462,9 +462,70 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     type="checkbox"
                                   />
                                 </Checkbox>
-                                <span>
-                                  bar
-                                </span>
+                                <TeamBadge
+                                  avatarSize={24}
+                                  hideAvatar={true}
+                                  hideOverflow={true}
+                                  team={
+                                    Object {
+                                      "hasAccess": true,
+                                      "id": "1",
+                                      "name": "bar",
+                                      "slug": "bar",
+                                    }
+                                  }
+                                >
+                                  <BaseBadge
+                                    avatarSize={24}
+                                    displayName={
+                                      <BadgeDisplayName
+                                        hideOverflow={true}
+                                      >
+                                        #
+                                        bar
+                                      </BadgeDisplayName>
+                                    }
+                                    hideAvatar={true}
+                                    team={
+                                      Object {
+                                        "hasAccess": true,
+                                        "id": "1",
+                                        "name": "bar",
+                                        "slug": "bar",
+                                      }
+                                    }
+                                  >
+                                    <Flex
+                                      align="center"
+                                    >
+                                      <Base
+                                        align="center"
+                                        className="css-5ipae5"
+                                      >
+                                        <div
+                                          className="css-5ipae5"
+                                          is={null}
+                                        >
+                                          <BadgeDisplayName
+                                            hideOverflow={true}
+                                          >
+                                            <Component
+                                              className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                              hideOverflow={true}
+                                            >
+                                              <span
+                                                className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                              >
+                                                #
+                                                bar
+                                              </span>
+                                            </Component>
+                                          </BadgeDisplayName>
+                                        </div>
+                                      </Base>
+                                    </Flex>
+                                  </BaseBadge>
+                                </TeamBadge>
                               </label>
                             </div>
                           </TeamItem>
@@ -500,9 +561,70 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                     type="checkbox"
                                   />
                                 </Checkbox>
-                                <span>
-                                  foo
-                                </span>
+                                <TeamBadge
+                                  avatarSize={24}
+                                  hideAvatar={true}
+                                  hideOverflow={true}
+                                  team={
+                                    Object {
+                                      "hasAccess": false,
+                                      "id": "2",
+                                      "name": "foo",
+                                      "slug": "foo",
+                                    }
+                                  }
+                                >
+                                  <BaseBadge
+                                    avatarSize={24}
+                                    displayName={
+                                      <BadgeDisplayName
+                                        hideOverflow={true}
+                                      >
+                                        #
+                                        foo
+                                      </BadgeDisplayName>
+                                    }
+                                    hideAvatar={true}
+                                    team={
+                                      Object {
+                                        "hasAccess": false,
+                                        "id": "2",
+                                        "name": "foo",
+                                        "slug": "foo",
+                                      }
+                                    }
+                                  >
+                                    <Flex
+                                      align="center"
+                                    >
+                                      <Base
+                                        align="center"
+                                        className="css-5ipae5"
+                                      >
+                                        <div
+                                          className="css-5ipae5"
+                                          is={null}
+                                        >
+                                          <BadgeDisplayName
+                                            hideOverflow={true}
+                                          >
+                                            <Component
+                                              className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                              hideOverflow={true}
+                                            >
+                                              <span
+                                                className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                              >
+                                                #
+                                                foo
+                                              </span>
+                                            </Component>
+                                          </BadgeDisplayName>
+                                        </div>
+                                      </Base>
+                                    </Flex>
+                                  </BaseBadge>
+                                </TeamBadge>
                               </label>
                             </div>
                           </TeamItem>


### PR DESCRIPTION
before:
![screenshot 2018-05-11 16 12 18](https://user-images.githubusercontent.com/5026776/39950467-1ad21f92-5536-11e8-8ad3-a05e09402b88.png)

after:
![screenshot 2018-05-11 16 18 03](https://user-images.githubusercontent.com/5026776/39950598-1919b9c0-5537-11e8-8364-abc543a86a58.png)

