### PR TITLE
fix(badges): Fix user badge to support member or user

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/userAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/userAvatar.jsx
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 
 import {userDisplayName} from 'app/utils/formatters';
 import BaseAvatar from 'app/components/avatar/baseAvatar';
+import SentryTypes from 'app/proptypes';
 
 class UserAvatar extends React.Component {
   static propTypes = {
-    user: PropTypes.object,
+    user: SentryTypes.User,
     gravatar: PropTypes.bool,
     ...BaseAvatar.propTypes,
   };

--- a/src/sentry/static/sentry/app/components/idBadge/index.jsx
+++ b/src/sentry/static/sentry/app/components/idBadge/index.jsx
@@ -17,11 +17,12 @@ export default class IdBadge extends React.Component {
     team: SentryTypes.Team,
     project: SentryTypes.Project,
     organization: SentryTypes.Organization,
+    member: SentryTypes.Member,
     user: SentryTypes.User,
   };
 
   render() {
-    let {organization, project, team, user} = this.props;
+    let {organization, project, team, user, member} = this.props;
 
     if (organization) {
       return <OrganizationBadge {...this.props} />;
@@ -29,12 +30,12 @@ export default class IdBadge extends React.Component {
       return <ProjectBadge {...this.props} />;
     } else if (team) {
       return <TeamBadge {...this.props} />;
-    } else if (user) {
+    } else if (member || user) {
       return <UserBadge useLink={false} {...this.props} />;
     }
 
     throw new Error(
-      'IdBadge: required property missing (organization, project, team, user)'
+      'IdBadge: required property missing (organization, project, team, member, user)'
     );
   }
 }

--- a/src/sentry/static/sentry/app/components/idBadge/userBadge.jsx
+++ b/src/sentry/static/sentry/app/components/idBadge/userBadge.jsx
@@ -5,29 +5,34 @@ import Avatar from 'app/components/avatar';
 import Link from 'app/components/link';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
+import SentryTypes from 'app/proptypes';
 
 const UserBadge = ({
   displayName,
   displayEmail,
   user,
+  member,
   orgId,
   avatarSize,
   useLink,
   hideEmail,
   ...props
 }) => {
+  let userFromPropsOrMember = user || (member && member.user);
   return (
     <StyledUserBadge {...props}>
-      <StyledAvatar user={user} size={avatarSize} />
+      <StyledAvatar user={userFromPropsOrMember} size={avatarSize} />
       <StyledNameAndEmail>
         <StyledName
-          useLink={useLink && orgId}
+          useLink={useLink && orgId && member}
           hideEmail={hideEmail}
-          to={`/settings/${orgId}/members/${user.id}/`}
+          to={member && orgId && `/settings/${orgId}/members/${member.id}/`}
         >
-          {displayName || user.name || user.email}
+          {displayName || userFromPropsOrMember.name || userFromPropsOrMember.email}
         </StyledName>
-        {!hideEmail && <StyledEmail>{displayEmail || user.email}</StyledEmail>}
+        {!hideEmail && (
+          <StyledEmail>{displayEmail || userFromPropsOrMember.email}</StyledEmail>
+        )}
       </StyledNameAndEmail>
     </StyledUserBadge>
   );
@@ -37,7 +42,15 @@ UserBadge.propTypes = {
   displayName: PropTypes.node,
   displayEmail: PropTypes.node,
   avatarSize: PropTypes.number,
-  user: PropTypes.object,
+  /**
+   * Sometimes we may not have the member object (i.e. the current user, `ConfigStore.get('user')`,
+   * is an user, not a member)
+   */
+  user: SentryTypes.User,
+  /**
+   * This is a Sentry member (not the user object that is a child of the member object)
+   */
+  member: SentryTypes.Member,
   orgId: PropTypes.string,
   useLink: PropTypes.bool,
   hideEmail: PropTypes.bool,

--- a/src/sentry/static/sentry/app/components/search/searchResult.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResult.jsx
@@ -61,7 +61,7 @@ class SearchResult extends React.Component {
           displayEmail={highlightedDescription}
           userLink={false}
           orgId={params.orgId}
-          user={model}
+          member={model}
           avatarSize={32}
         />
       );

--- a/src/sentry/static/sentry/app/proptypes.jsx
+++ b/src/sentry/static/sentry/app/proptypes.jsx
@@ -9,12 +9,36 @@ export const Metadata = PropTypes.shape({
   uri: PropTypes.string,
 });
 
+const Avatar = PropTypes.shape({
+  avatarType: PropTypes.oneOf(['letter_avatar', 'upload', 'gravatar']),
+  avatarUuid: PropTypes.string,
+});
+
 /**
  * A User is someone that has registered on Sentry
  *
  */
 export const User = PropTypes.shape({
+  avatar: Avatar,
+  avatarUrl: PropTypes.string,
+  dateJoined: PropTypes.string,
+  email: PropTypes.string,
+  emails: PropTypes.arrayOf(
+    PropTypes.shape({
+      is_verified: PropTypes.bool,
+      id: PropTypes.string,
+      email: PropTypes.string,
+    })
+  ),
+  has2fa: PropTypes.bool,
+  hasPasswordAuth: PropTypes.bool,
   id: PropTypes.string.isRequired,
+  identities: PropTypes.array,
+  isActive: PropTypes.bool,
+  isManaged: PropTypes.bool,
+  lastActive: PropTypes.string,
+  lastLogin: PropTypes.string,
+  username: PropTypes.string,
 });
 
 export const Config = PropTypes.shape({
@@ -46,11 +70,17 @@ export const Config = PropTypes.shape({
  * not have registered for an account yet
  */
 export const Member = PropTypes.shape({
-  id: PropTypes.string.isRequired,
+  dateCreated: PropTypes.string,
   email: PropTypes.string.isRequired,
+  flags: PropTypes.shape({
+    'sso:linked': PropTypes.bool,
+    'sso:invalid': PropTypes.bool,
+  }),
+  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  roleName: PropTypes.string.isRequired,
   pending: PropTypes.bool,
+  role: PropTypes.string.isRequired,
+  roleName: PropTypes.string.isRequired,
   user: User,
 });
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
@@ -81,9 +81,9 @@ export default class SelectOwners extends React.Component {
     }
   }
 
-  renderUserBadge = user => (
-    <IdBadge avatarSize={24} user={user} hideEmail useLink={false} />
-  );
+  renderUserBadge = user => {
+    return <IdBadge avatarSize={24} user={user} hideEmail useLink={false} />;
+  };
 
   createMentionableUser = user => {
     return {

--- a/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/team/teamMembers.jsx
@@ -283,12 +283,7 @@ const TeamMembers = createReactClass({
         {this.state.teamMemberList.length ? (
           this.state.teamMemberList.map(member => (
             <StyledMemberContainer key={member.id}>
-              <IdBadge
-                avatarSize={36}
-                user={member.user || member}
-                useLink
-                orgId={params.orgId}
-              />
+              <IdBadge avatarSize={36} member={member} useLink orgId={params.orgId} />
               {access.has('org:write') && this.removeButton(member)}
             </StyledMemberContainer>
           ))

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -530,25 +530,21 @@ window.TestStubs = {
     url: 'https://status.sentry.io',
   }),
 
-  Members: () => [
-    {
-      id: '1',
-      email: 'sentry1@test.com',
-      name: 'Sentry 1 Name',
-      role: '',
-      roleName: '',
-      pending: false,
-      flags: {
-        'sso:linked': false,
-      },
-      user: {
-        id: '1',
-        has2fa: false,
-        name: 'Sentry 1 Name',
-        email: 'sentry1@test.com',
-        username: 'Sentry 1 Username',
-      },
+  Member: params => ({
+    id: '1',
+    email: 'sentry1@test.com',
+    name: 'Sentry 1 Name',
+    role: '',
+    roleName: '',
+    pending: false,
+    flags: {
+      'sso:linked': false,
     },
+    user: TestStubs.User(),
+    ...params,
+  }),
+  Members: () => [
+    TestStubs.Member(),
     {
       id: '2',
       name: 'Sentry 2 Name',

--- a/tests/js/spec/components/idBadge/userBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/userBadge.spec.jsx
@@ -4,15 +4,25 @@ import {mount, shallow} from 'enzyme';
 import UserBadge from 'app/components/idBadge/userBadge';
 
 describe('UserBadge', function() {
+  let member = TestStubs.Member();
   let user = TestStubs.User();
 
-  it('renders', function() {
-    let wrapper = mount(<UserBadge user={user} orgId="orgId" />);
+  it('renders with link when member is supplied', function() {
+    let wrapper = mount(<UserBadge member={member} orgId="orgId" />);
 
     expect(wrapper.find('StyledUserBadge')).toHaveLength(1);
     expect(wrapper.find('StyledName').prop('children')).toBe('Foo Bar');
     expect(wrapper.find('StyledEmail').prop('children')).toBe('foo@example.com');
     expect(wrapper.find('StyledName Link')).toHaveLength(1);
+  });
+
+  it('renders with no link when user is supplied', function() {
+    let wrapper = mount(<UserBadge user={user} orgId="orgId" />);
+
+    expect(wrapper.find('StyledUserBadge')).toHaveLength(1);
+    expect(wrapper.find('StyledName').prop('children')).toBe('Foo Bar');
+    expect(wrapper.find('StyledEmail').prop('children')).toBe('foo@example.com');
+    expect(wrapper.find('StyledName Link')).toHaveLength(0);
   });
 
   it('can display alternate display names/emails', function() {

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -757,13 +757,11 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                         >
                           <StyledName
                             hideEmail={false}
-                            to="/settings/undefined/members/1/"
                             useLink={false}
                           >
                             <Component
                               className="css-12fcmnb-StyledName ev46mzr3"
                               hideEmail={false}
-                              to="/settings/undefined/members/1/"
                               useLink={false}
                             >
                               <span
@@ -1769,13 +1767,11 @@ exports[`Sidebar renders without org and router 1`] = `
                         >
                           <StyledName
                             hideEmail={false}
-                            to="/settings/undefined/members/1/"
                             useLink={false}
                           >
                             <Component
                               className="css-12fcmnb-StyledName ev46mzr3"
                               hideEmail={false}
-                              to="/settings/undefined/members/1/"
                               useLink={false}
                             >
                               <span

--- a/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
@@ -41,17 +41,35 @@ exports[`TeamMembers renders 1`] = `
   >
     <IdBadge
       avatarSize={36}
-      orgId="org-slug"
-      useLink={true}
-      user={
+      member={
         Object {
           "email": "sentry1@test.com",
-          "has2fa": false,
+          "flags": Object {
+            "sso:linked": false,
+          },
           "id": "1",
           "name": "Sentry 1 Name",
-          "username": "Sentry 1 Username",
+          "pending": false,
+          "role": "",
+          "roleName": "",
+          "user": Object {
+            "email": "foo@example.com",
+            "flags": Object {
+              "newsletter_consent_prompt": false,
+            },
+            "hasPasswordAuth": true,
+            "id": "1",
+            "isAuthenticated": true,
+            "name": "Foo Bar",
+            "options": Object {
+              "timezone": "UTC",
+            },
+            "username": "foo@example.com",
+          },
         }
       }
+      orgId="org-slug"
+      useLink={true}
     />
     <Button
       disabled={false}
@@ -75,17 +93,28 @@ exports[`TeamMembers renders 1`] = `
   >
     <IdBadge
       avatarSize={36}
-      orgId="org-slug"
-      useLink={true}
-      user={
+      member={
         Object {
           "email": "sentry2@test.com",
-          "has2fa": false,
+          "flags": Object {
+            "sso:linked": false,
+          },
           "id": "2",
           "name": "Sentry 2 Name",
-          "username": "Sentry 2 Username",
+          "pending": true,
+          "role": "",
+          "roleName": "",
+          "user": Object {
+            "email": "sentry2@test.com",
+            "has2fa": false,
+            "id": "2",
+            "name": "Sentry 2 Name",
+            "username": "Sentry 2 Username",
+          },
         }
       }
+      orgId="org-slug"
+      useLink={true}
     />
     <Button
       disabled={false}
@@ -109,17 +138,28 @@ exports[`TeamMembers renders 1`] = `
   >
     <IdBadge
       avatarSize={36}
-      orgId="org-slug"
-      useLink={true}
-      user={
+      member={
         Object {
           "email": "sentry3@test.com",
-          "has2fa": true,
+          "flags": Object {
+            "sso:linked": true,
+          },
           "id": "3",
           "name": "Sentry 3 Name",
-          "username": "Sentry 3 Username",
+          "pending": false,
+          "role": "owner",
+          "roleName": "Owner",
+          "user": Object {
+            "email": "sentry3@test.com",
+            "has2fa": true,
+            "id": "3",
+            "name": "Sentry 3 Name",
+            "username": "Sentry 3 Username",
+          },
         }
       }
+      orgId="org-slug"
+      useLink={true}
     />
     <Button
       disabled={false}
@@ -143,17 +183,28 @@ exports[`TeamMembers renders 1`] = `
   >
     <IdBadge
       avatarSize={36}
-      orgId="org-slug"
-      useLink={true}
-      user={
+      member={
         Object {
           "email": "sentry4@test.com",
-          "has2fa": true,
+          "flags": Object {
+            "sso:linked": true,
+          },
           "id": "4",
           "name": "Sentry 4 Name",
-          "username": "Sentry 4 Username",
+          "pending": false,
+          "role": "owner",
+          "roleName": "Owner",
+          "user": Object {
+            "email": "sentry4@test.com",
+            "has2fa": true,
+            "id": "4",
+            "name": "Sentry 4 Name",
+            "username": "Sentry 4 Username",
+          },
         }
       }
+      orgId="org-slug"
+      useLink={true}
     />
     <Button
       disabled={false}

--- a/tests/js/spec/views/groupActivity/index.spec.jsx
+++ b/tests/js/spec/views/groupActivity/index.spec.jsx
@@ -15,7 +15,7 @@ describe('GroupActivity', function() {
     sandbox
       .stub(ConfigStore, 'get')
       .withArgs('user')
-      .returns({});
+      .returns({id: '123'});
   });
 
   afterEach(function() {

--- a/tests/js/spec/views/groupDetails/seenBy.spec.jsx
+++ b/tests/js/spec/views/groupDetails/seenBy.spec.jsx
@@ -34,8 +34,8 @@ describe('GroupSeenBy', function() {
         context: {
           group: TestStubs.Group({
             seenBy: [
-              {id: 1, email: 'jane@example.com'},
-              {id: 2, email: 'john@example.com'},
+              {id: '1', email: 'jane@example.com'},
+              {id: '2', email: 'john@example.com'},
             ],
           }),
           project: TestStubs.Project(),


### PR DESCRIPTION
This fixes incorrect links being generated on Team Members settings page where it was using `user.id` instead of `member.id` to link to the members details page.