### PR TITLE
fix(settings): Fix unhandled XHR error in Project Settings

### DIFF
--- a/src/sentry/static/sentry/app/utils/handleXhrErrorResponse.jsx
+++ b/src/sentry/static/sentry/app/utils/handleXhrErrorResponse.jsx
@@ -1,0 +1,31 @@
+import Raven from 'raven-js';
+
+export default function handleXhrErrorResponse(message) {
+  return resp => {
+    if (!resp) return;
+    if (!resp.responseJSON) return;
+
+    let {responseJSON} = resp;
+
+    // If this is a string then just capture it as error
+    if (typeof responseJSON.detail === 'string') {
+      Raven.captureException(new Error(message), {
+        status: resp.status,
+        detail: responseJSON.detail,
+      });
+      return;
+    }
+
+    // Ignore sudo-required errors
+    if (responseJSON.detail.code === 'sudo-required') return;
+
+    if (typeof responseJSON.detail.message === 'string') {
+      Raven.captureException(new Error(message), {
+        status: resp.status,
+        detail: responseJSON.detail.message,
+        code: responseJSON.detail.code,
+      });
+      return;
+    }
+  };
+}

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -18,6 +18,7 @@ import Confirm from 'app/components/confirm';
 import Field from 'app/views/settings/components/forms/field';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
+import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 import {Panel, PanelAlert, PanelHeader} from 'app/components/panels';
 import ProjectsStore from 'app/stores/projectsStore';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
@@ -61,7 +62,7 @@ class ProjectGeneralSettings extends AsyncView {
     removeProject(this.api, orgId, project).then(() => {
       // Need to hard reload because lots of components do not listen to Projects Store
       window.location.assign('/');
-    });
+    }, handleXhrErrorResponse('Unable to remove project'));
   };
 
   handleTransferProject = () => {
@@ -73,7 +74,7 @@ class ProjectGeneralSettings extends AsyncView {
     transferProject(this.api, orgId, project, this._form.email).then(() => {
       // Need to hard reload because lots of components do not listen to Projects Store
       window.location.assign('/');
-    });
+    }, handleXhrErrorResponse('Unable to transfer project'));
   };
 
   renderRemoveProject() {

--- a/tests/js/spec/utils/handleXhrErrorResponse.spec.jsx
+++ b/tests/js/spec/utils/handleXhrErrorResponse.spec.jsx
@@ -1,0 +1,53 @@
+import Raven from 'raven-js';
+import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
+
+jest.mock('raven-js', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('handleXhrErrorResponse', function() {
+  const stringError = {responseJSON: {detail: 'Error'}, status: 400};
+  const objError = {
+    status: 400,
+    responseJSON: {detail: {code: 'api-err-code', message: 'Error message'}},
+  };
+  beforeEach(function() {
+    Raven.captureException.mockReset();
+  });
+
+  it('does nothing if we have invalid response', function() {
+    handleXhrErrorResponse('')(null);
+    expect(Raven.captureException).not.toHaveBeenCalled();
+    handleXhrErrorResponse('')({});
+    expect(Raven.captureException).not.toHaveBeenCalled();
+  });
+
+  it('captures an exception to raven when `resp.detail` is a string', function() {
+    handleXhrErrorResponse('String error')(stringError);
+    expect(Raven.captureException).toHaveBeenCalledWith(new Error('String error'), {
+      status: 400,
+      detail: 'Error',
+    });
+  });
+
+  it('captures an exception to raven when `resp.detail` is an object', function() {
+    handleXhrErrorResponse('Object error')(objError);
+    expect(Raven.captureException).toHaveBeenCalledWith(new Error('Object error'), {
+      status: 400,
+      detail: 'Error message',
+      code: 'api-err-code',
+    });
+  });
+  it('ignores `sudo-required` errors', function() {
+    handleXhrErrorResponse('Sudo required error')({
+      status: 401,
+      responseJSON: {
+        detail: {
+          code: 'sudo-required',
+          detail: 'Sudo required',
+        },
+      },
+    });
+    expect(Raven.captureException).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes JAVASCRIPT-3C0 (partially)

Ignore 401s due to sudo requires, but log everything else if we can.
This only partially addresses the error because there's other views/actionCreators that use api promises that are unhandled.