### PR TITLE
feat(errors): Add better `RouteError` context + fingerprint

### DIFF
--- a/src/sentry/static/sentry/app/utils/getRouteStringFromRoutes.jsx
+++ b/src/sentry/static/sentry/app/utils/getRouteStringFromRoutes.jsx
@@ -1,0 +1,21 @@
+/**
+ * Creates a route string from an array of `routes` from react-router
+ * Note this is currently only used for error context logging. It does
+ * not attempt to do anything smart (e.g. absolute vs relative paths in the list)
+ *
+ * @param {Array<{}>} routes An array of route objects from react-router
+ * @return String Returns a route path
+ */
+export default function getRouteStringFromRoutes(routes) {
+  if (!Array.isArray(routes)) return '';
+
+  // Strip the first route (path: '/') since the subsequent children routes
+  // are all absolute paths
+  return (
+    routes
+      .splice(1)
+      .filter(({path}) => path)
+      .map(({path}) => path)
+      .join('') || ''
+  );
+}

--- a/src/sentry/static/sentry/app/views/permissionDenied.jsx
+++ b/src/sentry/static/sentry/app/views/permissionDenied.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {t, tct} from 'app/locale';
 import ExternalLink from 'app/components/externalLink';
 import LoadingError from 'app/components/loadingError';
+import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
 const ERROR_NAME = 'Permission Denied';
 
@@ -24,14 +25,7 @@ class PermissionDenied extends React.Component {
     let {routes} = this.props;
     let {organization, project} = this.context;
 
-    let route =
-      (Array.isArray(routes) &&
-        routes
-          .filter(({path}) => path)
-          .map(({path}) => path)
-          .join('')) ||
-      '';
-
+    let route = getRouteStringFromRoutes(routes);
     Raven.captureException(new Error(ERROR_NAME), {
       fingerprint: [ERROR_NAME, route],
       extraInfo: {

--- a/tests/js/spec/utils/getRouteStringFromRoutes.spec.jsx
+++ b/tests/js/spec/utils/getRouteStringFromRoutes.spec.jsx
@@ -1,0 +1,23 @@
+import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
+
+describe('getRouteStringFromRoutes', function() {
+  const routes = [
+    {path: '/'},
+    {path: '/:orgId/'},
+    {name: 'this should be skipped'},
+    {path: '/organizations/:orgId/'},
+    {path: 'api-keys/', name: 'API Key'},
+  ];
+  it('can get a route string from routes array and skips routes that do not have a path', function() {
+    expect(getRouteStringFromRoutes(routes)).toBe(
+      '/:orgId//organizations/:orgId/api-keys/'
+    );
+  });
+
+  it('handles invalid `routes` values', function() {
+    expect(getRouteStringFromRoutes(null)).toBe('');
+    expect(getRouteStringFromRoutes('')).toBe('');
+    expect(getRouteStringFromRoutes({})).toBe('');
+    expect(getRouteStringFromRoutes(false)).toBe('');
+  });
+});

--- a/tests/js/spec/views/projectPlugins/projectPlugins.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/projectPlugins.spec.jsx
@@ -42,7 +42,7 @@ describe('ProjectPlugins', function() {
       routerContext
     );
 
-    expect(wrapper.find('RouteError')).toHaveLength(1);
+    expect(wrapper.dive().find('RouteError')).toHaveLength(1);
   });
 
   it('has error state when plugins=[]', function() {
@@ -55,7 +55,6 @@ describe('ProjectPlugins', function() {
       />,
       routerContext
     );
-
-    expect(wrapper.find('RouteError')).toHaveLength(1);
+    expect(wrapper.dive().find('RouteError')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
This generates a route string without route params, so that we can use it for fingerprinting (as well as giving more context when logging errors)