### PR TITLE
fix(urls): Update members URL + redirect old (APP-214)

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -397,6 +397,11 @@ urlpatterns += patterns(
     ),
     url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/members/$',
+        RedirectView.as_view(pattern_name="sentry-organization-members", permanent=False),
+        name='sentry-organization-members-old'
+    ),
+    url(
+        r'^settings/(?P<organization_slug>[\w_-]+)/members/$',
         react_page_view,
         name='sentry-organization-members'
     ),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -420,6 +420,8 @@ urlpatterns += patterns(
         react_page_view,
         name='sentry-organization-stats'
     ),
+
+    # TODO REMOVEME #NEW-SETTINGS, redirect to team settings?
     url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/teams/(?P<team_slug>[\w_-]+)/remove/$',
         RemoveTeamView.as_view(),
@@ -448,11 +450,13 @@ urlpatterns += patterns(
         react_page_view,
         name='sentry-manage-project'
     ),
+    # TODO REMOVEME #NEW-SETTINGS, redirect to project settings?
     url(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/settings/remove/$',
         RemoveProjectView.as_view(),
         name='sentry-remove-project'
     ),
+    # TODO REMOVEME #NEW-SETTINGS, redirect to project settings?
     url(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/settings/transfer/$',
         TransferProjectView.as_view(),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -365,6 +365,21 @@ urlpatterns += patterns(
 
     url(r'^accept-transfer/$', react_page_view, name='sentry-accept-project-transfer'),
     url(r'^settings/', react_page_view),
+    url(
+        r'^settings/(?P<organization_slug>[\w_-]+)/members/$',
+        react_page_view,
+        name='sentry-organization-members'
+    ),
+    url(
+        r'^settings/(?P<organization_slug>[\w_-]+)/members/new/$',
+        react_page_view,
+        name='sentry-create-organization-member'
+    ),
+    url(
+        r'^settings/(?P<organization_slug>[\w_-]+)/members/(?P<member_id>\d+)/$',
+        react_page_view,
+        name='sentry-organization-member-settings'
+    ),
 
     # Organizations
     url(r'^(?P<organization_slug>[\w_-]+)/$',
@@ -401,19 +416,14 @@ urlpatterns += patterns(
         name='sentry-organization-members-old'
     ),
     url(
-        r'^settings/(?P<organization_slug>[\w_-]+)/members/$',
-        react_page_view,
-        name='sentry-organization-members'
-    ),
-    url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/members/new/$',
-        react_page_view,
-        name='sentry-create-organization-member'
+        RedirectView.as_view(pattern_name="sentry-create-organization-member", permanent=False),
+        name='sentry-create-organization-member-old'
     ),
     url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/members/(?P<member_id>\d+)/$',
-        react_page_view,
-        name='sentry-organization-member-settings'
+        RedirectView.as_view(pattern_name="sentry-organization-member-settings", permanent=False),
+        name='sentry-organization-member-settings-old'
     ),
     url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/stats/$',

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -534,8 +534,8 @@ window.TestStubs = {
     id: '1',
     email: 'sentry1@test.com',
     name: 'Sentry 1 Name',
-    role: '',
-    roleName: '',
+    role: 'member',
+    roleName: 'Member',
     pending: false,
     flags: {
       'sso:linked': false,
@@ -549,8 +549,8 @@ window.TestStubs = {
       id: '2',
       name: 'Sentry 2 Name',
       email: 'sentry2@test.com',
-      role: '',
-      roleName: '',
+      role: 'member',
+      roleName: 'Member',
       pending: true,
       flags: {
         'sso:linked': false,

--- a/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
@@ -47,6 +47,7 @@ exports[`ResolutionBox render() handles inNextRelease with actor 1`] = `
           user={
             Object {
               "email": "david@sentry.io",
+              "id": "111",
               "name": "David Cramer",
             }
           }
@@ -125,6 +126,7 @@ exports[`ResolutionBox render() handles inRelease with actor 1`] = `
           user={
             Object {
               "email": "david@sentry.io",
+              "id": "111",
               "name": "David Cramer",
             }
           }

--- a/tests/js/spec/components/resolutionBox.spec.jsx
+++ b/tests/js/spec/components/resolutionBox.spec.jsx
@@ -19,7 +19,7 @@ describe('ResolutionBox', function() {
         <ResolutionBox
           statusDetails={{
             inNextRelease: true,
-            actor: {name: 'David Cramer', email: 'david@sentry.io'},
+            actor: {id: '111', name: 'David Cramer', email: 'david@sentry.io'},
           }}
           params={{orgId: 'org', projectId: 'project'}}
         />
@@ -42,7 +42,7 @@ describe('ResolutionBox', function() {
         <ResolutionBox
           statusDetails={{
             inRelease: '1.0',
-            actor: {name: 'David Cramer', email: 'david@sentry.io'},
+            actor: {id: '111', name: 'David Cramer', email: 'david@sentry.io'},
           }}
           params={{orgId: 'org', projectId: 'project'}}
         />

--- a/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
@@ -50,8 +50,8 @@ exports[`TeamMembers renders 1`] = `
           "id": "1",
           "name": "Sentry 1 Name",
           "pending": false,
-          "role": "",
-          "roleName": "",
+          "role": "member",
+          "roleName": "Member",
           "user": Object {
             "email": "foo@example.com",
             "flags": Object {
@@ -102,8 +102,8 @@ exports[`TeamMembers renders 1`] = `
           "id": "2",
           "name": "Sentry 2 Name",
           "pending": true,
-          "role": "",
-          "roleName": "",
+          "role": "member",
+          "roleName": "Member",
           "user": Object {
             "email": "sentry2@test.com",
             "has2fa": false,

--- a/tests/js/spec/views/organizationAccessRequests.spec.jsx
+++ b/tests/js/spec/views/organizationAccessRequests.spec.jsx
@@ -29,6 +29,7 @@ describe('OrganizationAccessRequests', function() {
               id: 'memberid',
               email: '',
               name: '',
+              role: '',
               roleName: '',
               user: {
                 id: '',
@@ -58,6 +59,7 @@ describe('OrganizationAccessRequests', function() {
               id: 'memberid',
               email: '',
               name: '',
+              role: '',
               roleName: '',
               user: {
                 id: '',
@@ -93,6 +95,7 @@ describe('OrganizationAccessRequests', function() {
               id: 'memberid',
               email: '',
               name: '',
+              role: '',
               roleName: '',
               user: {
                 id: '',

--- a/tests/js/spec/views/organizationMemberRow.spec.jsx
+++ b/tests/js/spec/views/organizationMemberRow.spec.jsx
@@ -11,6 +11,7 @@ describe('OrganizationMemberRow', function() {
     id: '1',
     email: '',
     name: '',
+    role: '',
     roleName: '',
     pending: false,
     flags: {

--- a/tests/js/spec/views/organizationMembersView.spec.jsx
+++ b/tests/js/spec/views/organizationMembersView.spec.jsx
@@ -55,6 +55,7 @@ describe('OrganizationMembersView', function() {
             id: 'pending-member-id',
             email: '',
             name: '',
+            role: '',
             roleName: '',
             user: {
               id: '',


### PR DESCRIPTION
Updates djangos routes to have the named `sentry-organization-members`
 route to go to the new org settings. Keep the old route in place so it
 redirects to new settings.