### PR TITLE
chore(react): Upgrade to react@16.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prop-types": "^15.6.0",
     "query-string": "2.4.2",
     "raven-js": "3.23.2",
-    "react": "16.2.0",
+    "react": "16.3.2",
     "react-addons-css-transition-group": "15.6.2",
     "react-autosize-textarea": "3.0.2",
     "react-bootstrap": "^0.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8087,9 +8087,9 @@ react-treebeard@^2.0.3:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
I think this is pretty safe to upgrade, features include:

* `createRef` API - we could update our string refs with this more easily than the callback API
* `forwardRef` API - this would be useful when dealing with styled and functional components when you want a ref to reference a specific child component.
* `getDerivedStateFromProps` - replaces some of our usage of `cWRP` 
* new Context API
