### PR TITLE
feat: Add referrer headers to snuba requests

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -344,6 +344,7 @@ def do_search(project_id, environment_id, tags, start, end,
         aggregations=aggregations,
         orderby='-' + sort,
         limit=limit,
+        referrer='search',
     )
 
     # {hash -> group_id, ...}

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -77,7 +77,7 @@ class SnubaTSDB(BaseTSDB):
         end = to_datetime(series[-1] + rollup)
 
         result = snuba.query(start, end, groupby, None, keys_map,
-                             aggregations, rollup)
+                             aggregations, rollup, referrer='tsdb')
 
         if group_on_time:
             keys_map['time'] = series

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -18,7 +18,7 @@ class SnubaError(Exception):
 
 def query(start, end, groupby, conditions=None, filter_keys=None,
           aggregations=None, rollup=None, arrayjoin=None, limit=None, orderby=None,
-          having=None):
+          having=None, referrer=None):
     """
     Sends a query to snuba.
 
@@ -93,8 +93,12 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
         'orderby': orderby,
     }) if v is not None}
 
+    headers = {}
+    if referrer:
+        headers['referer'] = referrer
+
     try:
-        response = requests.post(url, data=json.dumps(request))
+        response = requests.post(url, data=json.dumps(request), headers=headers)
         response.raise_for_status()
     except requests.RequestException as re:
         raise SnubaError(re)


### PR DESCRIPTION
So we can tell which backend (and in the case of tagstore, which method)
they come from.