### PR TITLE
fix(js): Dont log when receiving 403 on member invite

### DIFF
--- a/src/sentry/static/sentry/app/views/inviteMember/inviteMember.jsx
+++ b/src/sentry/static/sentry/app/views/inviteMember/inviteMember.jsx
@@ -156,7 +156,7 @@ const InviteMember = createReactClass({
         error: err => {
           if (err.status === 403) {
             addErrorMessage(t("You aren't allowed to invite members."));
-            reject(err.responseJSON);
+            resolve();
           } else if (err.status === 409) {
             addErrorMessage(`User already exists: ${email}`);
             resolve();


### PR DESCRIPTION
Rejecting this promise here will lead to the rejection handler in `submit` to log this into sentry. Since we display an error message on 403s, this should be considered a known + handled error.