### PR TITLE
ref(settings): Use `react-select` in new settings

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -19,9 +19,26 @@ export default class SelectControl extends React.Component {
   }
 }
 
-const StyledSelect = styled(
-  ({async, ...props}) => (async ? <Async {...props} /> : <ReactSelect {...props} />)
-)`
+// We're making this class because we pass `innerRef` from `FormField`
+// And react yells at us if this picker is a stateless function component
+// (since you can't attach refs to them)
+class SelectPicker extends React.Component {
+  static propTypes = {
+    async: PropTypes.bool,
+  };
+
+  render() {
+    let {async, ...props} = this.props;
+
+    if (async) {
+      return <Async {...props} />;
+    }
+
+    return <ReactSelect {...props} />;
+  }
+}
+
+const StyledSelect = styled(SelectPicker)`
   font-size: 15px;
 
   .Select-control,

--- a/tests/js/spec/components/forms/__snapshots__/selectField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/selectField.spec.jsx.snap
@@ -67,7 +67,7 @@ exports[`SelectField render() renders with form context 1`] = `
           required={false}
           value="a"
         >
-          <Component
+          <SelectPicker
             arrowRenderer={[Function]}
             className="css-lrye9l-StyledSelect eho28m20"
             clearable={true}
@@ -279,7 +279,7 @@ exports[`SelectField render() renders with form context 1`] = `
                 </div>
               </div>
             </Select>
-          </Component>
+          </SelectPicker>
         </StyledSelect>
       </SelectControl>
     </div>
@@ -355,7 +355,7 @@ exports[`SelectField render() renders without form context 1`] = `
           required={false}
           value="a"
         >
-          <Component
+          <SelectPicker
             arrowRenderer={[Function]}
             className="css-lrye9l-StyledSelect eho28m20"
             clearable={true}
@@ -567,7 +567,7 @@ exports[`SelectField render() renders without form context 1`] = `
                 </div>
               </div>
             </Select>
-          </Component>
+          </SelectPicker>
         </StyledSelect>
       </SelectControl>
     </div>

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -195,7 +195,7 @@ exports[`Project Ownership Input renders 1`] = `
                     required={false}
                     value="path"
                   >
-                    <Component
+                    <SelectPicker
                       arrowRenderer={[Function]}
                       className="css-16280ey-StyledSelect eho28m20"
                       clearable={false}
@@ -389,7 +389,7 @@ exports[`Project Ownership Input renders 1`] = `
                           </div>
                         </div>
                       </Select>
-                    </Component>
+                    </SelectPicker>
                   </StyledSelect>
                 </SelectControl>
               </div>
@@ -534,7 +534,7 @@ exports[`Project Ownership Input renders 1`] = `
                       value={Array []}
                       valueComponent={[Function]}
                     >
-                      <Component
+                      <SelectPicker
                         arrowRenderer={[Function]}
                         async={true}
                         cache={false}
@@ -722,7 +722,7 @@ exports[`Project Ownership Input renders 1`] = `
                             </div>
                           </Select>
                         </Async>
-                      </Component>
+                      </SelectPicker>
                     </StyledSelect>
                   </SelectControl>
                 </MultiSelectControl>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -164,7 +164,7 @@ exports[`RuleBuilder renders 1`] = `
                   required={false}
                   value="path"
                 >
-                  <Component
+                  <SelectPicker
                     arrowRenderer={[Function]}
                     className="css-16280ey-StyledSelect eho28m20"
                     clearable={false}
@@ -358,7 +358,7 @@ exports[`RuleBuilder renders 1`] = `
                         </div>
                       </div>
                     </Select>
-                  </Component>
+                  </SelectPicker>
                 </StyledSelect>
               </SelectControl>
             </div>
@@ -510,7 +510,7 @@ exports[`RuleBuilder renders 1`] = `
                     value={Array []}
                     valueComponent={[Function]}
                   >
-                    <Component
+                    <SelectPicker
                       arrowRenderer={[Function]}
                       async={true}
                       cache={false}
@@ -698,7 +698,7 @@ exports[`RuleBuilder renders 1`] = `
                           </div>
                         </Select>
                       </Async>
-                    </Component>
+                    </SelectPicker>
                   </StyledSelect>
                 </SelectControl>
               </MultiSelectControl>
@@ -1215,7 +1215,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                   required={false}
                   value="path"
                 >
-                  <Component
+                  <SelectPicker
                     arrowRenderer={[Function]}
                     className="css-16280ey-StyledSelect eho28m20"
                     clearable={false}
@@ -1409,7 +1409,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         </div>
                       </div>
                     </Select>
-                  </Component>
+                  </SelectPicker>
                 </StyledSelect>
               </SelectControl>
             </div>
@@ -1713,7 +1713,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                     }
                     valueComponent={[Function]}
                   >
-                    <Component
+                    <SelectPicker
                       arrowRenderer={[Function]}
                       async={true}
                       cache={false}
@@ -2175,7 +2175,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           </div>
                         </Select>
                       </Async>
-                    </Component>
+                    </SelectPicker>
                   </StyledSelect>
                 </SelectControl>
               </MultiSelectControl>

--- a/tests/js/spec/views/accountDetail.spec.jsx
+++ b/tests/js/spec/views/accountDetail.spec.jsx
@@ -42,6 +42,8 @@ describe('AccountDetails', function() {
   });
 
   describe('Managed User', function() {
+    // I don't think this test expectation is accurate
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip('does not have password fields', function() {
       mockUserDetails({isManaged: true});
       let wrapper = mount(<AccountDetails location={{}} />, TestStubs.routerContext());

--- a/tests/js/spec/views/accountDetail.spec.jsx
+++ b/tests/js/spec/views/accountDetail.spec.jsx
@@ -27,7 +27,7 @@ describe('AccountDetails', function() {
     expect(wrapper.find('input[name="name"]')).toHaveLength(1);
 
     // Stacktrace order, language, timezone
-    expect(wrapper.find('select')).toHaveLength(3);
+    expect(wrapper.find('SelectControl')).toHaveLength(3);
 
     expect(wrapper.find('BooleanField')).toHaveLength(1);
     expect(wrapper.find('RadioGroup')).toHaveLength(1);


### PR DESCRIPTION
Use new `SelectControl` instead of select2. This only replaces the `Select2Field` component that is used in new settings.

![image](https://user-images.githubusercontent.com/79684/40092302-7a5322b6-5871-11e8-9382-2b1bf1f0175b.png)
