### PR TITLE
fix: Use dynamic project_id in Snuba optimized search aggregate test 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test-network:
 
 test-snuba:
 	@echo "--> Running snuba tests"
-	py.test tests/snuba --cov . --cov-report="xml:coverage.xml" --junit-xml="junit.xml"
+	py.test tests/snuba -vv --cov . --cov-report="xml:coverage.xml" --junit-xml="junit.xml"
 	@echo ""
 
 test-acceptance: build-platform-assets

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -784,7 +784,7 @@ class SnubaSearchTest(SnubaTestCase):
             'start': Any(datetime),
             'end': Any(datetime),
             'filter_keys': {
-                'project_id': [2],
+                'project_id': [self.project.id],
                 'primary_hash': [u'513772ee53011ad9f4dc374b2d34d0e9']
             },
             'groupby': ['primary_hash'],


### PR DESCRIPTION
Also leaving Snuba tests on verbose so we can see the actual assertion
diffs on Travis.

---

This test is silenced for now anyway but it was failing and I didn't want to throw us off.