### PR TITLE
feat(dashboard): Add state when waiting for first event

### DIFF
--- a/src/sentry/static/sentry/app/components/errorRobot.jsx
+++ b/src/sentry/static/sentry/app/components/errorRobot.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Link, browserHistory} from 'react-router';
 import createReactClass from 'create-react-class';
+import styled from 'react-emotion';
 
 import ApiMixin from 'app/mixins/apiMixin';
 import {t} from 'app/locale';
@@ -94,11 +95,10 @@ const ErrorRobot = createReactClass({
         );
     }
     return (
-      <div
+      <ErrorRobotWrapper
+        data-test-id="awaiting-events"
         className="awaiting-events"
-        style={
-          gradient && {backgroundImage: 'linear-gradient(to bottom, #F8F9FA, #ffffff)'}
-        }
+        gradient={gradient}
       >
         <div className="wrap">
           <div className="robot">
@@ -125,9 +125,20 @@ const ErrorRobot = createReactClass({
           </p>
           {sampleLink}
         </div>
-      </div>
+      </ErrorRobotWrapper>
     );
   },
 });
 
 export default ErrorRobot;
+
+const ErrorRobotWrapper = styled('div')`
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
+  border-radius: 0 0 3px 3px;
+  ${p =>
+    p.gradient
+      ? `
+          background-image: linear-gradient(to bottom, #F8F9FA, #ffffff);
+         `
+      : ''};
+`;

--- a/src/sentry/static/sentry/app/components/resourceCard.jsx
+++ b/src/sentry/static/sentry/app/components/resourceCard.jsx
@@ -5,6 +5,7 @@ import styled from 'react-emotion';
 import analytics from 'app/utils/analytics';
 import ConfigStore from 'app/stores/configStore';
 import ExternalLink from 'app/components/externalLink';
+import {Panel} from 'app/components/panels';
 
 export default class ResourceCard extends React.Component {
   static propTypes = {
@@ -23,7 +24,7 @@ export default class ResourceCard extends React.Component {
     let {title, link, imgUrl} = this.props;
 
     return (
-      <ResourceCardWrapper className="box" onClick={this.recordClick}>
+      <ResourceCardWrapper onClick={this.recordClick}>
         <StyledLink href={link}>
           <div className="m-b-1">
             <img src={mediaUrl + imgUrl} alt={title} />
@@ -42,7 +43,7 @@ const StyledTitle = styled('div')`
   font-weight: bold;
 `;
 
-const ResourceCardWrapper = styled('div')`
+const ResourceCardWrapper = styled(Panel)`
   display: flex;
   flex: 1;
   align-items: center;

--- a/src/sentry/static/sentry/app/components/resourceCard.jsx
+++ b/src/sentry/static/sentry/app/components/resourceCard.jsx
@@ -6,13 +6,6 @@ import analytics from 'app/utils/analytics';
 import ConfigStore from 'app/stores/configStore';
 import ExternalLink from 'app/components/externalLink';
 
-const StyledTitle = styled('div')`
-  color: #493e54;
-  font-size: 16px;
-  text-align: center;
-  font-weight: bold;
-`;
-
 export default class ResourceCard extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
@@ -30,18 +23,33 @@ export default class ResourceCard extends React.Component {
     let {title, link, imgUrl} = this.props;
 
     return (
-      <div
-        className="flex box p-x-2 p-y-1"
-        style={{flexGrow: 1, alignItems: 'center'}}
-        onClick={this.recordClick}
-      >
-        <ExternalLink href={link}>
+      <ResourceCardWrapper className="box" onClick={this.recordClick}>
+        <StyledLink href={link}>
           <div className="m-b-1">
             <img src={mediaUrl + imgUrl} alt={title} />
           </div>
           <StyledTitle>{title}</StyledTitle>
-        </ExternalLink>
-      </div>
+        </StyledLink>
+      </ResourceCardWrapper>
     );
   }
 }
+
+const StyledTitle = styled('div')`
+  color: #493e54;
+  font-size: 16px;
+  text-align: center;
+  font-weight: bold;
+`;
+
+const ResourceCardWrapper = styled('div')`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  padding: 20px;
+  margin-bottom: 0;
+`;
+
+const StyledLink = styled(ExternalLink)`
+  flex: 1;
+`;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
@@ -20,6 +20,7 @@ import OldDashboard from './oldDashboard';
 import ProjectNav from './projectNav';
 import TeamSection from './teamSection';
 import EmptyState from './emptyState';
+import Resources from './resources';
 
 class Dashboard extends React.Component {
   static propTypes = {
@@ -87,6 +88,10 @@ class Dashboard extends React.Component {
         {teamSlugs.length === 0 &&
           favorites.length === 0 && (
             <EmptyState projects={projects} teams={teams} organization={organization} />
+          )}
+        {projects.length === 1 &&
+          !projects[0].firstEvent && (
+            <Resources org={organization} project={projects[0]} />
           )}
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/organizationDashboard/resources.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/resources.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Flex} from 'grid-emotion';
+import styled from 'react-emotion';
 
 import analytics from 'app/utils/analytics';
 import ResourceCard from 'app/components/resourceCard';
@@ -20,11 +21,11 @@ export default class Resources extends React.Component {
 
   render() {
     return (
-      <React.Fragment>
-        <Panel>
+      <ResourcesWrapper>
+        <RobotPanel>
           <ErrorRobot org={this.props.org} project={this.props.project} />
-        </Panel>
-        <div>
+        </RobotPanel>
+        <ResourcesSection>
           <h4>{t('Resources')}</h4>
           <Flex justify={'space-between'}>
             <Flex width={3 / 10}>
@@ -49,8 +50,20 @@ export default class Resources extends React.Component {
               />
             </Flex>
           </Flex>
-        </div>
-      </React.Fragment>
+        </ResourcesSection>
+      </ResourcesWrapper>
     );
   }
 }
+
+const ResourcesWrapper = styled('div')`
+  border-top: 1px solid ${p => p.theme.borderLight};
+`;
+
+const RobotPanel = styled(Panel)`
+  margin: 30px 30px 20px 30px;
+`;
+
+const ResourcesSection = styled('div')`
+  padding: 0 30px 20px 30px;
+`;

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -497,11 +497,7 @@
  */
 
 .awaiting-events {
-  border-radius: 0;
   padding: 10px 20px 30px;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
-  border-radius: 0 0 3px 3px;
-
   .wrap {
     position: relative;
     max-width: 740px;

--- a/tests/acceptance/test_project_issues.py
+++ b/tests/acceptance/test_project_issues.py
@@ -26,7 +26,7 @@ class ProjectIssuesTest(AcceptanceTestCase):
         # TODO(dcramer): we should add basic assertions around "i wanted this
         # URL but was sent somewhere else"
         self.browser.get(self.path)
-        self.browser.wait_until('.awaiting-events')
+        self.browser.wait_until('[data-test-id="awaiting-events"]')
         self.browser.snapshot('project issues not configured')
 
     def test_with_issues(self):

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -191,6 +191,7 @@ describe('OrganizationDashboard', function() {
           teams: [],
           isBookmarked: true,
           stats: [],
+          firstEvent: true,
         }),
       ];
       MockApiClient.addMockResponse({

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -50,7 +50,7 @@ describe('OrganizationDashboard', function() {
   describe('empty state', function() {
     beforeEach(function() {});
 
-    it('renders', function() {
+    it('renders with no projects', function() {
       const projects = [];
 
       const wrapper = shallow(
@@ -64,6 +64,30 @@ describe('OrganizationDashboard', function() {
       );
       const emptyState = wrapper.find('EmptyState');
       expect(emptyState).toHaveLength(1);
+    });
+
+    it('renders with 1 project, with no first event', function() {
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/issues/',
+        body: [{id: 'sampleIssueId'}],
+      });
+      const projects = [TestStubs.Project()];
+
+      const wrapper = mount(
+        <Dashboard
+          teams={teams}
+          projects={projects}
+          organization={TestStubs.Organization()}
+          params={{orgId: 'org-slug'}}
+        />,
+        TestStubs.routerContext()
+      );
+      const emptyState = wrapper.find('ErrorRobot');
+      expect(emptyState).toHaveLength(1);
+
+      expect(
+        wrapper.find('Link[to="/org-slug/project-slug/issues/sampleIssueId/?sample"]')
+      ).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
This re-adds the robot + resources cards to dashboard when there is exactly 1 project and it does not have a first event.

Not exactly sure where to put the Project Card in this scenario, might be better at the bottom. I think it's a bit confusing if we don't show it at all.