### PR TITLE
fix(settings): Fix searching of select fields

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -215,7 +215,10 @@ class FormField extends React.Component {
 
       if (hash !== `#${this.props.name}`) return;
 
-      ref.focus();
+      // Not all form fields have this (e.g. Select fields)
+      if (typeof ref.focus === 'function') {
+        ref.focus();
+      }
     }
 
     this.input = ref;


### PR DESCRIPTION
Navigating to a search result of a setting that was a Select field would break
because there is no `focus` method on the Select field.

Fixes JAVASCRIPT-3V3