### PR TITLE
build(travis): directly cache virtualenv instead of pip wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
         - riak
         - redis-server
       install:
-        - pip install -e ".[dev,tests,optional]"
+        - pip install ".[dev,tests,optional]"
 
     - python: 2.7
       env: TEST_SUITE=postgres DB=postgres
@@ -81,7 +81,7 @@ matrix:
         - redis-server
         - postgresql
       install:
-        - pip install -e ".[dev,tests,optional]"
+        - pip install ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -92,7 +92,7 @@ matrix:
         - mysql
         - redis-server
       install:
-        - pip install -e ".[dev,tests,optional]"
+        - pip install ".[dev,tests,optional]"
         - pip install mysqlclient
       before_script:
         - mysql -u root -e 'create database sentry;'
@@ -107,7 +107,7 @@ matrix:
         - nvm install "$NODE_VERSION"
         - npm install -g "yarn@${YARN_VERSION}"
       install:
-        - pip install -e ".[dev,tests,optional]"
+        - pip install ".[dev,tests,optional]"
         - wget -N "http://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip" -P ~/
         - unzip ~/chromedriver_linux64.zip -d ~/
         - rm ~/chromedriver_linux64.zip
@@ -131,7 +131,7 @@ matrix:
         - postgresql
         - redis-server
       install:
-        - pip install -e .
+        - pip install .
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -145,7 +145,7 @@ matrix:
         - redis-server
         - postgresql
       install:
-        - pip install -e ".[dev,tests,optional]"
+        - pip install ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -157,7 +157,7 @@ matrix:
         - redis-server
         - postgresql
       install:
-        - pip install -e ".[dev,tests,optional]"
+        - pip install ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -174,7 +174,7 @@ matrix:
         - docker run -d --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=clickhouse-server:9000 --name snuba -p 1218:1218 --link clickhouse-server:clickhouse-server getsentry/snuba
         - docker ps -a
       install:
-        - pip install -e ".[dev,tests,optional]"
+        - pip install ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   yarn: true
   directories:
     - node_modules
-    - "${HOME}/virtualenv/python"$(python -c 'import platform; print(platform.python_version())')""
+    - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
     - $HOME/google-cloud-sdk
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ script:
   - make travis-test-$TEST_SUITE
   - make travis-scan-$TEST_SUITE
 
-before_cache:
-  - find "${HOME}/virtualenv" -type f -iname '*.egg-link' -print -delete
-
 after_success:
   - pip install codecov
   - codecov -e TEST_SUITE
@@ -74,6 +71,8 @@ matrix:
         - memcached
         - riak
         - redis-server
+      before_install:
+        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
 
@@ -83,6 +82,8 @@ matrix:
         - memcached
         - redis-server
         - postgresql
+      before_install:
+        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
       before_script:
@@ -94,6 +95,8 @@ matrix:
         - memcached
         - mysql
         - redis-server
+      before_install:
+        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
         - pip install mysqlclient
@@ -107,6 +110,7 @@ matrix:
         - redis-server
         - postgresql
       before_install:
+        - pip uninstall -y mock
         - nvm install "$NODE_VERSION"
         - npm install -g "yarn@${YARN_VERSION}"
       install:
@@ -133,6 +137,8 @@ matrix:
       services:
         - postgresql
         - redis-server
+      before_install:
+        - pip uninstall -y mock
       install:
         - pip install -e .
       before_script:
@@ -147,6 +153,8 @@ matrix:
         - memcached
         - redis-server
         - postgresql
+      before_install:
+        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
       before_script:
@@ -159,6 +167,8 @@ matrix:
         - memcached
         - redis-server
         - postgresql
+      before_install:
+        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
       before_script:
@@ -173,6 +183,7 @@ matrix:
         - redis-server
         - postgresql
       before_install:
+        - pip uninstall -y mock
         - docker run -d --name clickhouse-server -p 9000:9000 -p 9009:9009 -p 8123:8123 --ulimit nofile=262144:262144 yandex/clickhouse-server
         - docker run -d --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=clickhouse-server:9000 --name snuba -p 1218:1218 --link clickhouse-server:clickhouse-server getsentry/snuba
         - docker ps -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ branches:
   - master
 
 cache:
-  pip: true
   yarn: true
   directories:
     - node_modules
+    - $HOME/virtualenv/python2.7.13
     - $HOME/google-cloud-sdk
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   yarn: true
   directories:
     - node_modules
-    - $HOME/virtualenv/python2.7.13
+    - "${HOME}/virtualenv/python"$(python -c 'import platform; print(platform.python_version())')""
     - $HOME/google-cloud-sdk
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - make travis-scan-$TEST_SUITE
 
 before_cache:
-  - find -type f -iname '*.egg-link' -delete
+  - find "${HOME}/virtualenv" -type f -iname '*.egg-link' -print -delete
 
 after_success:
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
         - riak
         - redis-server
       install:
-        - pip install ".[dev,tests,optional]"
+        - pip install -e ".[dev,tests,optional]"
 
     - python: 2.7
       env: TEST_SUITE=postgres DB=postgres
@@ -84,7 +84,7 @@ matrix:
         - redis-server
         - postgresql
       install:
-        - pip install ".[dev,tests,optional]"
+        - pip install -e ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -95,7 +95,7 @@ matrix:
         - mysql
         - redis-server
       install:
-        - pip install ".[dev,tests,optional]"
+        - pip install -e ".[dev,tests,optional]"
         - pip install mysqlclient
       before_script:
         - mysql -u root -e 'create database sentry;'
@@ -110,7 +110,7 @@ matrix:
         - nvm install "$NODE_VERSION"
         - npm install -g "yarn@${YARN_VERSION}"
       install:
-        - pip install ".[dev,tests,optional]"
+        - pip install -e ".[dev,tests,optional]"
         - wget -N "http://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip" -P ~/
         - unzip ~/chromedriver_linux64.zip -d ~/
         - rm ~/chromedriver_linux64.zip
@@ -134,7 +134,7 @@ matrix:
         - postgresql
         - redis-server
       install:
-        - pip install .
+        - pip install -e .
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -148,7 +148,7 @@ matrix:
         - redis-server
         - postgresql
       install:
-        - pip install ".[dev,tests,optional]"
+        - pip install -e ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -160,7 +160,7 @@ matrix:
         - redis-server
         - postgresql
       install:
-        - pip install ".[dev,tests,optional]"
+        - pip install -e ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -177,7 +177,7 @@ matrix:
         - docker run -d --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=clickhouse-server:9000 --name snuba -p 1218:1218 --link clickhouse-server:clickhouse-server getsentry/snuba
         - docker ps -a
       install:
-        - pip install ".[dev,tests,optional]"
+        - pip install -e ".[dev,tests,optional]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ script:
   - make travis-test-$TEST_SUITE
   - make travis-scan-$TEST_SUITE
 
+before_cache:
+  - find -type f -iname '*.egg-link' -delete
+
 after_success:
   - pip install codecov
   - codecov -e TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,6 @@ matrix:
         - memcached
         - riak
         - redis-server
-      before_install:
-        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
 
@@ -82,8 +80,6 @@ matrix:
         - memcached
         - redis-server
         - postgresql
-      before_install:
-        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
       before_script:
@@ -95,8 +91,6 @@ matrix:
         - memcached
         - mysql
         - redis-server
-      before_install:
-        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
         - pip install mysqlclient
@@ -110,7 +104,6 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - pip uninstall -y mock
         - nvm install "$NODE_VERSION"
         - npm install -g "yarn@${YARN_VERSION}"
       install:
@@ -137,8 +130,6 @@ matrix:
       services:
         - postgresql
         - redis-server
-      before_install:
-        - pip uninstall -y mock
       install:
         - pip install -e .
       before_script:
@@ -153,8 +144,6 @@ matrix:
         - memcached
         - redis-server
         - postgresql
-      before_install:
-        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
       before_script:
@@ -167,8 +156,6 @@ matrix:
         - memcached
         - redis-server
         - postgresql
-      before_install:
-        - pip uninstall -y mock
       install:
         - pip install -e ".[dev,tests,optional]"
       before_script:
@@ -183,7 +170,6 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - pip uninstall -y mock
         - docker run -d --name clickhouse-server -p 9000:9000 -p 9009:9009 -p 8123:8123 --ulimit nofile=262144:262144 yandex/clickhouse-server
         - docker run -d --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=clickhouse-server:9000 --name snuba -p 1218:1218 --link clickhouse-server:clickhouse-server getsentry/snuba
         - docker ps -a

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifneq "$(wildcard /usr/local/opt/openssl/lib)" ""
 	LDFLAGS += -L/usr/local/opt/openssl/lib
 endif
 
-PIP = LDFLAGS="$(LDFLAGS)" pip -q
+PIP = LDFLAGS="$(LDFLAGS)" pip
 WEBPACK = NODE_ENV=production ./node_modules/.bin/webpack
 
 test: develop lint test-js test-python test-cli
@@ -81,7 +81,7 @@ locale: build-js-po
 	cd src/sentry && sentry django compilemessages
 
 update-transifex: build-js-po
-	pip install -q transifex-client
+	$(PIP) install transifex-client
 	cd src/sentry && sentry django makemessages -i static -l en
 	./bin/merge-catalogs en
 	tx push -s
@@ -146,12 +146,6 @@ lint-js:
 	bin/lint --js --parseable
 	@echo ""
 
-scan-python:
-	@echo "--> Running Python vulnerability scanner"
-	python -m pip install -q safety
-	bin/scan
-	@echo ""
-
 publish:
 	python setup.py sdist bdist_wheel upload
 
@@ -186,6 +180,12 @@ travis-test-dist:
 	@ls -lh dist/
 
 # Scan steps
+scan-python:
+	@echo "--> Running Python vulnerability scanner"
+	$(PIP) install safety
+	bin/scan
+	@echo ""
+
 travis-scan-sqlite: scan-python
 travis-scan-postgres: scan-python
 travis-scan-mysql: scan-python

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -25,7 +25,7 @@ ipaddress>=1.0.16,<1.1.0
 loremipsum>=1.0.5,<1.1.0
 jsonschema==2.6.0
 lxml>=3.4.1
-mock>=0.8.0,<1.1
+mock==2.0.0
 mmh3>=2.3.1,<2.4
 oauth2>=1.5.167
 parsimonious==0.8.0

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -85,7 +85,7 @@ class RedisBufferTest(TestCase):
             'e+foo': "S'bar'\np1\n.",
             'f': "(dp1\nS'pk'\np2\nI1\ns.",
             'i+times_seen': '1',
-            'm': 'mock.Mock',
+            'm': 'mock.mock.Mock',
         }
         pending = client.zrange('b:p', 0, -1)
         assert pending == ['foo']
@@ -95,7 +95,7 @@ class RedisBufferTest(TestCase):
             'e+foo': "S'bar'\np1\n.",
             'f': "(dp1\nS'pk'\np2\nI1\ns.",
             'i+times_seen': '2',
-            'm': 'mock.Mock',
+            'm': 'mock.mock.Mock',
         }
         pending = client.zrange('b:p', 0, -1)
         assert pending == ['foo']


### PR DESCRIPTION
The issues this PR fixes is twofold:

On Travis CI, `pip` places direct wheel downloads (which it prefers by default - I tried forcing pip to build Sentry deps from source but we need to pull in more toolchains like rust to build semaphore, which is not preferable) into hash-named directories inside of `~/.cache/pip/http`. Part of what goes into the hash are HTTP(s) request headers, which contain cache control and thus files that are cached there are invalidated every X minutes or so. Near the end of the build, Travis CI will spend some time (usually around 15-30 secs) appending those invalidated wheels to the cache.

Deserializing and installing wheels into a virtualenv takes a considerable amount of time given Sentry's many dependencies - almost a full minute, usually, even if most/all of the wheels are already cached.

---

Directly caching the virtualenv Travis CI uses saves all the time mentioned above. Some important notes:

* need to explicitly cache `$HOME/virtualenv/python2.7.13`; `$HOME/virtualenv/python2.7` is a symlink and Travis CI's caching mechanism refuses to follow them.
* pip editable installs (`-e`) were disabled because we don't actually need that and it was resulting in `ContextualVersionConflict` with `mock`:

```
--snip--
File "/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 859, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
ContextualVersionConflict: (mock 2.0.0 (/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages), Requirement.parse('mock<1.1,>=0.8.0'), set(['sentry']))
```