### PR TITLE
feat(integrations): Add API to config Project & Org Integrations

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -94,6 +94,15 @@ class RelaxedSearchPermission(ProjectPermission):
     }
 
 
+class ProjectIntegrationsPermission(ProjectPermission):
+    scope_map = {
+        'GET': ['project:read', 'project:write', 'project:admin', 'project:integrations'],
+        'POST': ['project:write', 'project:admin', 'project:integrations'],
+        'PUT': ['project:write', 'project:admin', 'project:integrations'],
+        'DELETE': ['project:write', 'project:admin', 'project:integrations'],
+    }
+
+
 class ProjectEndpoint(Endpoint):
     permission_classes = (ProjectPermission, )
 

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -4,27 +4,42 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint, OrganizationIntegrationsPermission
 )
 from sentry.api.serializers import serialize
-from sentry.models import Integration, OrganizationIntegration
+from sentry.models import OrganizationIntegration, ProjectIntegration
 
 
 class OrganizationIntegrationDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission, )
 
     def get(self, request, organization, integration_id):
-        integration = Integration.objects.get(
-            organizations=organization,
-            id=integration_id,
+        integration = OrganizationIntegration.objects.get(
+            integration_id=integration_id,
+            organization=organization,
         )
 
         return self.respond(serialize(integration, request.user))
 
     def delete(self, request, organization, integration_id):
-        integration = Integration.objects.get(
-            organizations=organization,
-            id=integration_id,
-        )
+        # Removing the integration removes both the organization and project
+        # integration.
         OrganizationIntegration.objects.filter(
-            integration=integration,
+            integration_id=integration_id,
             organization=organization,
         ).delete()
+        ProjectIntegration.objects.filter(
+            integration_id=integration_id,
+            project__organization=organization,
+        ).delete()
+
         return self.respond(status=204)
+
+    def post(self, request, organization, integration_id):
+        integration = OrganizationIntegration.objects.get(
+            integration_id=integration_id,
+            organization=organization,
+        )
+
+        config = integration.config
+        config.update(request.DATA)
+        integration.update(config=config)
+
+        return self.respond(status=200)

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from django.http import Http404
+
 from sentry.api.bases.organization import (
     OrganizationEndpoint, OrganizationIntegrationsPermission
 )
@@ -11,10 +13,13 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission, )
 
     def get(self, request, organization, integration_id):
-        integration = OrganizationIntegration.objects.get(
-            integration_id=integration_id,
-            organization=organization,
-        )
+        try:
+            integration = OrganizationIntegration.objects.get(
+                integration_id=integration_id,
+                organization=organization,
+            )
+        except OrganizationIntegration.DoesNotExist:
+            raise Http404
 
         return self.respond(serialize(integration, request.user))
 
@@ -33,10 +38,13 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationEndpoint):
         return self.respond(status=204)
 
     def post(self, request, organization, integration_id):
-        integration = OrganizationIntegration.objects.get(
-            integration_id=integration_id,
-            organization=organization,
-        )
+        try:
+            integration = OrganizationIntegration.objects.get(
+                integration_id=integration_id,
+                organization=organization,
+            )
+        except OrganizationIntegration.DoesNotExist:
+            raise Http404
 
         config = integration.config
         config.update(request.DATA)

--- a/src/sentry/api/endpoints/organization_integrations.py
+++ b/src/sentry/api/endpoints/organization_integrations.py
@@ -5,22 +5,24 @@ from sentry.api.bases.organization import (
 )
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import Integration
+from sentry.models import OrganizationIntegration
 
 
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission, )
 
     def get(self, request, organization):
-        integrations = Integration.objects.filter(organizations=organization)
+        integrations = OrganizationIntegration.objects.filter(organization=organization)
 
         if 'provider_key' in request.GET:
-            integrations = integrations.filter(provider=request.GET['provider_key'])
+            integrations = integrations.filter(
+                integration__provider=request.GET['provider_key']
+            )
 
         return self.paginate(
             queryset=integrations,
             request=request,
-            order_by='name',
+            order_by='integration__name',
             on_results=lambda x: serialize(x, request.user),
             paginator_cls=OffsetPaginator,
         )

--- a/src/sentry/api/endpoints/project_integration_details.py
+++ b/src/sentry/api/endpoints/project_integration_details.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+
+from sentry.api.bases.project import ProjectEndpoint, ProjectIntegrationsPermission
+from sentry.api.serializers import serialize
+from sentry.models import ProjectIntegration, Integration
+
+
+class ProjectIntegrationDetailsEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectIntegrationsPermission, )
+
+    def get(self, request, project, integration_id):
+        integration = ProjectIntegration.objects.get(
+            project=project,
+            integration_id=integration_id,
+        )
+
+        return self.respond(serialize(integration, request.user))
+
+    def put(self, request, project, integration_id):
+        # Integrations can only be added to a project if they are already
+        # configured for the organization themselves.
+        try:
+            integration = Integration.objects.get(
+                id=integration_id,
+                organizations=project.organization_id,
+            )
+        except Integration.DoesNotExist:
+            return self.respond(status=404)
+
+        created = integration.add_project(project.id)
+
+        return self.respond(status=(201 if created else 204))
+
+    def delete(self, request, project, integration_id):
+        ProjectIntegration.objects.filter(
+            integration__id=integration_id,
+            project=project,
+        ).delete()
+        return self.respond(status=204)
+
+    def post(self, request, project, integration_id):
+        try:
+            integration = ProjectIntegration.objects.get(
+                integration__id=integration_id,
+                project=project,
+            )
+        except ProjectIntegration.DoesNotExist:
+            return self.respond(status=404)
+
+        config = integration.config
+        config.update(request.DATA)
+        integration.update(config=config)
+
+        return self.respond(status=200)

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -34,14 +34,15 @@ class IntegrationConfigSerializer(IntegrationSerializer):
 
         try:
             install = obj.get_installation()
-            data.update({
-                'config_organization': install.get_organization_config(),
-                'config_project': install.get_project_config(),
-            })
         except NotImplementedError:
             # The integration may not implement a Installed Integration object
             # representation.
             pass
+        else:
+            data.update({
+                'config_organization': install.get_organization_config(),
+                'config_project': install.get_project_config(),
+            })
 
         return data
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -69,6 +69,10 @@ class OrganizationIntegrationSerializer(Serializer):
         }
 
     def serialize(self, obj, attrs, user, organization=None, project=None):
+        # XXX(epurkhiser): This is O(n) for integrations, especially since
+        # we're using the IntegrationConfigSerializer which pulls in the
+        # integration installation config object which very well may be making
+        # API request for config options.
         integration = serialize(obj.integration, user, IntegrationConfigSerializer())
         integration.update({
             'config_data': obj.config,

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -57,16 +57,13 @@ class OrganizationIntegrationSerializer(Serializer):
                 project__organization_id__in=[i.organization_id for i in item_list],
             )
 
-        project_integrations_by_org = defaultdict(list)
+        project_integrations_by_org = defaultdict(dict)
         for pi in project_integrations:
-            project_integrations_by_org[pi.project.organization_id].append({
-                'project_id': pi.project_id,
-                'config_data': pi.config,
-            })
+            project_integrations_by_org[pi.project.organization_id][pi.project_id] = pi.config
 
         return {
             i: {
-                'project_integrations': project_integrations_by_org.get(i.organization_id, [])
+                'project_configs': project_integrations_by_org.get(i.organization_id, {})
             } for i in item_list
         }
 
@@ -74,7 +71,7 @@ class OrganizationIntegrationSerializer(Serializer):
         integration = serialize(obj.integration, user, IntegrationConfigSerializer())
         integration.update({
             'config_data': obj.config,
-            'project_integrations': attrs['project_integrations'],
+            'config_data_projects': attrs['project_configs'],
         })
 
         return integration

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -59,7 +59,7 @@ class OrganizationIntegrationSerializer(Serializer):
 
         project_integrations_by_org = defaultdict(dict)
         for pi in project_integrations:
-            project_integrations_by_org[pi.project.organization_id][pi.project_id] = pi.config
+            project_integrations_by_org[pi.project.organization_id][pi.project.slug] = pi.config
 
         return {
             i: {

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -93,6 +93,7 @@ from .endpoints.project_docs import ProjectDocsEndpoint
 from .endpoints.project_docs_platform import ProjectDocsPlatformEndpoint
 from .endpoints.project_environments import ProjectEnvironmentsEndpoint
 from .endpoints.project_environment_details import ProjectEnvironmentDetailsEndpoint
+from .endpoints.project_integration_details import ProjectIntegrationDetailsEndpoint
 from .endpoints.project_platforms import ProjectPlatformsEndpoint
 from .endpoints.project_events import ProjectEventsEndpoint
 from .endpoints.project_event_details import ProjectEventDetailsEndpoint
@@ -626,6 +627,11 @@ urlpatterns = patterns(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/environments/(?P<environment>[^/]+)/$',
         ProjectEnvironmentDetailsEndpoint.as_view(),
         name='sentry-api-0-project-environment-details'
+    ),
+    url(
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/integrations/(?P<integration_id>[^/]+)/$',
+        ProjectIntegrationDetailsEndpoint.as_view(),
+        name='sentry-api-0-project-integration-details'
     ),
     url(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/platforms/$',

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1055,6 +1055,7 @@ SENTRY_SCOPES = set(
         'project:write',
         'project:admin',
         'project:releases',
+        'project:integrations',
         'event:read',
         'event:write',
         'event:admin',
@@ -1068,6 +1069,7 @@ SENTRY_SCOPE_SETS = (
         ('org:read', 'Read access to organization details.'),
     ), (
         ('org:integrations', 'Read, write, and admin access to organization integrations.'),
+        ('project:integrations', 'Read, write, and admin access to project integrations.'),
     ), (
         ('member:admin', 'Read, write, and admin access to organization members.'),
         ('member:write', 'Read and write access to organization members.'),
@@ -1126,6 +1128,7 @@ SENTRY_ROLES = (
                 'project:write',
                 'project:admin',
                 'project:releases',
+                'project:integrations'
                 'team:read',
                 'team:write',
                 'team:admin',
@@ -1149,6 +1152,7 @@ SENTRY_ROLES = (
                 'project:write',
                 'project:admin',
                 'project:releases',
+                'project:integrations'
                 'team:read',
                 'team:write',
                 'team:admin',

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -154,6 +154,23 @@ class Integration(object):
     def __init__(self, model):
         self.model = model
 
+    def get_organization_config(self):
+        """
+        Returns a list of JSONForm configuration object descriptors used to
+        configure the integration per-organization. This simply represents the
+        configuration structure.
+
+        See the JSONForm react component for structure details.
+        """
+        return []
+
+    def get_project_config(self):
+        """
+        Provides configuration for the integration on a per-project
+        level. See ``get_config_organization``.
+        """
+        return []
+
     def get_client(self):
         # Return the api client for a given provider
         raise NotImplementedError

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -96,10 +96,15 @@ class Integration(Model):
         Returns True if the ProjectIntegration was created
         """
         from sentry.models import Project
-        if not OrganizationIntegration.objects.filter(
-            organization_id=Project.objects.get(id=project_id).organization_id,
+        org_id_queryset = Project.objects \
+            .filter(id=project_id) \
+            .values_list('organization_id', flat=True)
+        org_integration = OrganizationIntegration.objects.filter(
+            organization_id=org_id_queryset,
             integration=self,
-        ).exists():
+        )
+
+        if not org_integration.exists():
             return False
 
         try:

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -2,43 +2,67 @@ from __future__ import absolute_import
 
 import six
 
-from sentry.models import Integration, OrganizationIntegration
+from sentry.models import Integration, OrganizationIntegration, ProjectIntegration
 from sentry.testutils import APITestCase
 
 
 class OrganizationIntegrationDetailsTest(APITestCase):
-    def test_simple(self):
+    def setUp(self):
+        super(OrganizationIntegrationDetailsTest, self).setUp()
+
         self.login_as(user=self.user)
-        org = self.create_organization(owner=self.user, name='baz')
-        integration = Integration.objects.create(
+        self.org = self.create_organization(owner=self.user, name='baz')
+        self.integration = Integration.objects.create(
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
-        path = '/api/0/organizations/{}/integrations/{}/'.format(org.slug, integration.id)
+        self.integration.add_organization(self.org.id, config={'setting': 'value'})
 
-        response = self.client.get(path, format='json')
+        self.path = '/api/0/organizations/{}/integrations/{}/'.format(self.org.slug, self.integration.id)
+
+    def test_simple(self):
+        response = self.client.get(self.path, format='json')
 
         assert response.status_code == 200, response.content
-        assert response.data['id'] == six.text_type(integration.id)
+        assert response.data['id'] == six.text_type(self.integration.id)
+        assert response.data['config_data'] == {'setting': 'value'}
 
+    def test_removal(self):
+        team = self.create_team(organization=self.org, name='Mariachi Band')
+        project1 = self.create_project(teams=[team], name='project-1')
+        project2 = self.create_project(teams=[team], name='project-2')
 
-class OrganizationIntegrationDeleteTest(APITestCase):
-    def test_simple(self):
-        self.login_as(user=self.user)
-        org = self.create_organization(owner=self.user, name='baz')
-        integration = Integration.objects.create(
-            provider='example',
-            name='Example',
-        )
-        integration.add_organization(org.id)
-        path = '/api/0/organizations/{}/integrations/{}/'.format(org.slug, integration.id)
+        # Setup projects to ensure the projects are removed along with the organization integration
+        assert self.integration.add_project(project1.id)
+        assert self.integration.add_project(project2.id)
 
-        response = self.client.delete(path, format='json')
+        response = self.client.delete(self.path, format='json')
 
         assert response.status_code == 204, response.content
-        assert Integration.objects.filter(id=integration.id).exists()
+        assert Integration.objects.filter(id=self.integration.id).exists()
+
+        # Ensure both Organization *and* Project integrations are removed
         assert not OrganizationIntegration.objects.filter(
-            id=integration.id,
-            organization=org,
+            id=self.integration.id,
+            organization=self.org,
         ).exists()
+        assert not ProjectIntegration.objects.filter(
+            project__organization=self.org
+        ).exists()
+
+    def test_update_config(self):
+        config = {
+            'setting': 'new_value',
+            'setting2': 'baz',
+        }
+
+        response = self.client.post(self.path, format='json', data=config)
+
+        assert response.status_code == 200, response.content
+
+        org_integration = OrganizationIntegration.objects.get(
+            id=self.integration.id,
+            organization=self.org,
+        )
+
+        assert org_integration.config == config

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -43,7 +43,7 @@ class OrganizationIntegrationDetailsTest(APITestCase):
 
         # Ensure both Organization *and* Project integrations are removed
         assert not OrganizationIntegration.objects.filter(
-            id=self.integration.id,
+            integration=self.integration,
             organization=self.org,
         ).exists()
         assert not ProjectIntegration.objects.filter(
@@ -61,7 +61,7 @@ class OrganizationIntegrationDetailsTest(APITestCase):
         assert response.status_code == 200, response.content
 
         org_integration = OrganizationIntegration.objects.get(
-            id=self.integration.id,
+            integration=self.integration,
             organization=self.org,
         )
 

--- a/tests/sentry/api/endpoints/test_project_integration_details.py
+++ b/tests/sentry/api/endpoints/test_project_integration_details.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.models import Integration, ProjectIntegration
+from sentry.testutils import APITestCase
+
+
+class ProjectIntegrationDetailsTest(APITestCase):
+    def setUp(self):
+        super(ProjectIntegrationDetailsTest, self).setUp()
+
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user, name='baz')
+
+        team = self.create_team(organization=self.org, name='Mariachi Band')
+        self.project = self.create_project(teams=[team], name='bar-project')
+
+        self.integration = Integration.objects.create(
+            provider='example',
+            name='Example',
+        )
+        self.integration.add_organization(self.org.id)
+
+        self.path = '/api/0/projects/{}/{}/integrations/{}/'.format(
+            self.org.slug,
+            self.project.slug,
+            self.integration.id,
+        )
+
+    def test_simple(self):
+        config = {'setting': 'value'}
+        assert self.integration.add_project(self.project.id, config=config)
+
+        response = self.client.get(self.path, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == six.text_type(self.integration.id)
+        assert response.data['config_data'] == config
+
+    def test_enable(self):
+        response = self.client.put(self.path, format='json')
+        assert response.status_code == 201, response.content
+
+        assert ProjectIntegration.objects.filter(
+            project=self.project,
+            integration=self.integration
+        ).exists()
+
+        # Object has already been created, 204
+        response = self.client.put(self.path, format='json')
+        assert response.status_code == 204, response.content
+
+    def test_remove(self):
+        assert self.integration.add_project(self.project.id)
+
+        response = self.client.delete(self.path, format='json')
+        assert response.status_code == 204, response.content
+
+        assert not ProjectIntegration.objects.filter(
+            project=self.project,
+            integration=self.integration
+        ).exists()
+
+    def test_update_config(self):
+        config = {'setting': 'value'}
+        assert self.integration.add_project(self.project.id, config=config)
+
+        config = {
+            'setting': 'new_value',
+            'setting2': 'baz',
+        }
+        response = self.client.post(self.path, format='json', data=config)
+
+        assert response.status_code == 200, response.content
+
+        project_integration = ProjectIntegration.objects.get(
+            project=self.project,
+            integration=self.integration,
+        )
+
+        assert project_integration.config == config


### PR DESCRIPTION
* Adds API endpoints for to configure the `OrganizationIntegration` with arbitratry organization-specific configuration for an integration.

 * Adds API endpoints to create, configure, and disable (at the moment remove) Project level (`ProjectIntegration`) integrations.

   Uses `PUT` to create the project level integration

Both API endpoints use `POST` to update the configuration

This also adds the `project:integration` permission scope.