### PR TITLE
perf: Add timing stats to the snuba client.

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1,19 +1,31 @@
 from __future__ import absolute_import
 
+from contextlib import contextmanager
 from dateutil.parser import parse as parse_datetime
 from itertools import chain
 import json
 import requests
 import six
+import time
 
 from django.conf import settings
 
 from sentry.models import Group, GroupHash, Environment, Release, ReleaseProject
+from sentry.utils import metrics
 from sentry.utils.dates import to_timestamp
 
 
 class SnubaError(Exception):
     pass
+
+
+@contextmanager
+def timer(name, prefix='snuba.client'):
+    t = time.time()
+    try:
+        yield
+    finally:
+        metrics.timing('{}.{}'.format(prefix, name), time.time() - t)
 
 
 def query(start, end, groupby, conditions=None, filter_keys=None,
@@ -44,10 +56,11 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
     filter_keys = filter_keys or {}
 
     # Forward and reverse translation maps from model ids to snuba keys, per column
-    snuba_map = {col: get_snuba_map(col, keys) for col, keys in six.iteritems(filter_keys)}
-    snuba_map = {k: v for k, v in six.iteritems(snuba_map) if k is not None and v is not None}
-    rev_snuba_map = {col: dict(reversed(i) for i in keys.items())
-                     for col, keys in six.iteritems(snuba_map)}
+    with timer('get_snuba_map'):
+        snuba_map = {col: get_snuba_map(col, keys) for col, keys in six.iteritems(filter_keys)}
+        snuba_map = {k: v for k, v in six.iteritems(snuba_map) if k is not None and v is not None}
+        rev_snuba_map = {col: dict(reversed(i) for i in keys.items())
+                         for col, keys in six.iteritems(snuba_map)}
 
     for col, keys in six.iteritems(filter_keys):
         keys = [k for k in keys if k is not None]
@@ -61,8 +74,9 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
         project_ids = filter_keys['project_id']
     elif filter_keys:
         # Otherwise infer the project_ids from any related models
-        ids = [get_related_project_ids(k, filter_keys[k]) for k in filter_keys]
-        project_ids = list(set.union(*map(set, ids)))
+        with timer('get_related_project_ids'):
+            ids = [get_related_project_ids(k, filter_keys[k]) for k in filter_keys]
+            project_ids = list(set.union(*map(set, ids)))
     else:
         project_ids = []
 
@@ -75,7 +89,8 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
     condition_cols = [c[0] for c in flat_conditions(conditions)]
     all_cols = groupby + aggregate_cols + condition_cols
     get_issues = 'issue' in all_cols
-    issues = get_project_issues(project_ids, filter_keys.get('issue')) if get_issues else None
+    with timer('get_project_issues'):
+        issues = get_project_issues(project_ids, filter_keys.get('issue')) if get_issues else None
 
     url = '{0}/query'.format(settings.SENTRY_SNUBA)
     request = {k: v for k, v in six.iteritems({
@@ -98,7 +113,8 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
         headers['referer'] = referrer
 
     try:
-        response = requests.post(url, data=json.dumps(request), headers=headers)
+        with timer('snuba_query'):
+            response = requests.post(url, data=json.dumps(request), headers=headers)
         response.raise_for_status()
     except requests.RequestException as re:
         raise SnubaError(re)
@@ -115,14 +131,14 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
 
     assert expected_cols == got_cols
 
-    for d in response['data']:
-        if 'time' in d:
-            d['time'] = int(to_timestamp(parse_datetime(d['time'])))
-        for col in rev_snuba_map:
-            if col in d:
-                d[col] = rev_snuba_map[col][d[col]]
-
-    return nest_groups(response['data'], groupby, aggregate_cols)
+    with timer('process_result'):
+        for d in response['data']:
+            if 'time' in d:
+                d['time'] = int(to_timestamp(parse_datetime(d['time'])))
+            for col in rev_snuba_map:
+                if col in d:
+                    d[col] = rev_snuba_map[col][d[col]]
+        return nest_groups(response['data'], groupby, aggregate_cols)
 
 
 def nest_groups(data, groups, aggregate_cols):


### PR DESCRIPTION
Collect timing around the db calls we make to retrieve project issues
and other mappings, as well as the actual Snuba API query time from the
client perspective, and the time to post-process the data.