### PR TITLE
fix: Revert to Old Config for New Project

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -77,7 +77,7 @@ const ProjectInstallPlatform = createReactClass({
   },
 
   isGettingStarted() {
-    return location.href.indexOf('getting-started') > 0;
+    return this.inInstallExperiment && location.href.indexOf('getting-started') > 0;
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -198,6 +198,7 @@ const ProjectInstallPlatform = createReactClass({
               priority="primary"
               size="large"
               to={`/${orgId}/${projectId}/#welcome`}
+              style={{marginTop: 20}}
             >
               {t('Got it! Take me to the Issue Stream.')}
             </Button>

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -77,7 +77,7 @@ const ProjectInstallPlatform = createReactClass({
   },
 
   isGettingStarted() {
-    return this.inInstallExperiment && location.href.indexOf('getting-started') > 0;
+    return location.href.indexOf('getting-started') > 0;
   },
 
   fetchData() {
@@ -110,6 +110,7 @@ const ProjectInstallPlatform = createReactClass({
   },
 
   inInstallExperiment() {
+    return true;
     let {experimentPlatforms} = this.state;
     let currentPlatform = this.state.integration.id;
     let installExperiment =
@@ -211,6 +212,7 @@ const ProjectInstallPlatform = createReactClass({
   renderTestBody() {
     let {integration, platform} = this.state;
     let {dsnPublic} = this.props.platformData;
+    let {orgId, projectId} = this.props.params;
 
     if (!integration || !platform) {
       return <NotFound />;
@@ -232,6 +234,16 @@ const ProjectInstallPlatform = createReactClass({
             <LoadingError onRetry={this.fetchData} />
           ) : (
             <InstallReactTest dsn={dsnPublic} />
+          )}
+          {this.isGettingStarted() && (
+            <Button
+              priority="primary"
+              size="large"
+              to={`/${orgId}/${projectId}/#welcome`}
+              style={{marginTop: 20}}
+            >
+              {t('Got it! Take me to the Issue Stream.')}
+            </Button>
           )}
         </PanelBody>
       </Panel>

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -110,7 +110,6 @@ const ProjectInstallPlatform = createReactClass({
   },
 
   inInstallExperiment() {
-    return true;
     let {experimentPlatforms} = this.state;
     let currentPlatform = this.state.integration.id;
     let installExperiment =


### PR DESCRIPTION
New React config instructions didn't have CTA. This will add it back in. We'll work on a better system for experimentation in the future.

![image](https://user-images.githubusercontent.com/279398/40329708-42304566-5cff-11e8-93d9-810031bd3911.png)
