### PR TITLE
fix(snuba): Explicitly qualify sentry:release as tag instead of field

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -265,7 +265,7 @@ class SnubaTagStorage(TagStorage):
         aggregations = [['min' if first else 'max', SEEN_COLUMN, 'seen']]
         orderby = 'seen' if first else '-seen'
 
-        result = snuba.query(start, end, ['sentry:release'], conditions, filters,
+        result = snuba.query(start, end, ['tags[sentry:release]'], conditions, filters,
                              aggregations, limit=1, orderby=orderby,
                              referrer='tagstore.__get_release')
         if not result:

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -259,7 +259,7 @@ class SnubaTagStorage(TagStorage):
         filters = {
             'project_id': [project_id],
         }
-        conditions = [['sentry:release', 'IS NOT NULL', None]]
+        conditions = [['tags[sentry:release]', 'IS NOT NULL', None]]
         if group_id is not None:
             filters['issue'] = [group_id]
         aggregations = [['min' if first else 'max', SEEN_COLUMN, 'seen']]
@@ -288,7 +288,7 @@ class SnubaTagStorage(TagStorage):
         # NB we add release as a condition rather than a filter because
         # this method is already dealing with version strings rather than
         # release ids which would need to be translated by the snuba util.
-        key = 'sentry:release'
+        key = 'tags[sentry:release]'
         conditions = [[key, 'IN', versions]]
         aggregations = [
             ['count()', '', 'times_seen'],

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -25,11 +25,11 @@ class SnubaTSDB(BaseTSDB):
     model_columns = {
         TSDBModel.project: ('project_id', None),
         TSDBModel.group: ('issue', None),
-        TSDBModel.release: ('sentry:release', None),
+        TSDBModel.release: ('tags[sentry:release]', None),
         TSDBModel.users_affected_by_group: ('issue', 'user_id'),
         TSDBModel.users_affected_by_project: ('project_id', 'user_id'),
         TSDBModel.frequent_environments_by_group: ('issue', 'environment'),
-        TSDBModel.frequent_releases_by_group: ('issue', 'sentry:release'),
+        TSDBModel.frequent_releases_by_group: ('issue', 'tags[sentry:release]'),
         TSDBModel.frequent_issues_by_project: ('project_id', 'issue'),
     }
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -169,7 +169,7 @@ def get_snuba_map(column, ids):
     """
     mappings = {
         'environment': (Environment, 'name'),
-        'sentry:release': (Release, 'version'),
+        'tags[sentry:release]': (Release, 'version'),
     }
     if column in mappings and ids:
         model, field = mappings[column]

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -203,7 +203,7 @@ def get_related_project_ids(column, ids):
     mappings = {
         'environment': (Environment, 'id', 'project_id'),
         'issue': (Group, 'id', 'project_id'),
-        'sentry:release': (ReleaseProject, 'release_id', 'project_id'),
+        'tags[sentry:release]': (ReleaseProject, 'release_id', 'project_id'),
     }
     if ids:
         if column == "project_id":

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -169,11 +169,11 @@ class SnubaTSDBRequestsTest(TestCase):
                 body = json.loads(request.body)
                 assert body['aggregations'] == [['count()', None, 'aggregate']]
                 assert body['project'] == [project.id]
-                assert body['groupby'] == ['sentry:release', 'time']
-                assert ['sentry:release', 'IN', ['version X']] in body['conditions']
+                assert body['groupby'] == ['tags[sentry:release]', 'time']
+                assert ['tags[sentry:release]', 'IN', ['version X']] in body['conditions']
                 return (200, {}, json.dumps({
-                    'data': [{'sentry:release': 'version X', 'time': '2018-03-09T01:00:00Z', 'aggregate': 100}],
-                    'meta': [{'name': 'sentry:release'}, {'name': 'time'}, {'name': 'aggregate'}]
+                    'data': [{'tags[sentry:release]': 'version X', 'time': '2018-03-09T01:00:00Z', 'aggregate': 100}],
+                    'meta': [{'name': 'tags[sentry:release]'}, {'name': 'time'}, {'name': 'aggregate'}]
                 }))
 
             rsps.add_callback(


### PR DESCRIPTION
See GH-8496, this basically continues further down the path started there.