### PR TITLE
fix(brew): remove npm, add pkgconfig

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
 brew 'python@2'
-brew 'npm'
+brew 'pkgconfig'
 brew 'libxmlsec1'
 brew 'openssl'
 brew 'redis@3.2', restart_service: true


### PR DESCRIPTION
`npm` is removed because we use `nvm` to pin the node version in `.nvmrc`. See #8364, #8453.

Also, `pkgconfig` was added because I found it necessary while setting up @ayesha-omarali's machine. Still unclear on this, but `pkgconfig` is a system dependency which is wrapped by pip package `pkg-config` which is a requirement of pip package `xmlsec`. CC @MaxBittker who was having the same issue but resolved by installing/updating Xcode command line utilities.