### PR TITLE
ref(integrations): Added finish_integration to bitbucket.

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -50,10 +50,19 @@ class BitbucketIntegrationProvider(IntegrationProvider):
                     'base_url': state['baseApiUrl'],
                     'domain_name': principal_data['links']['html']['href'].replace('https://', ''),
                     'icon': principal_data['links']['avatar']['href'],
+                    'uuid': state['uuid'],
+                    'type': state['type'],  # team or user account
                 },
             }
         return {
             'provider': 'bitbucket',
             'external_id': state['identity']['bitbucket_client_key'],
             'expect_exists': True,
+            'has_callback': True,
         }
+
+    def finish_integration(self, state, integration):
+        # Because clientKey appears to be temporary for this connection,
+        # it is fine for the unique case of bitbucket, but should be switched
+        # at the end to have a persistent external_id
+        integration.update(external_id=integration.metadata['uuid'])

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -91,6 +91,9 @@ class IntegrationPipeline(Pipeline):
                 },
             )
 
+        if 'has_callback' in data:
+            self.provider.finish_integration(data, integration)
+
         return self._dialog_response(serialize(integration, self.request.user), True)
 
     def _dialog_response(self, data, success):

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -198,12 +198,15 @@ def register_extensions():
     plugins.register(TestIssuePlugin2)
 
     from sentry import integrations
+    from sentry.integrations.bitbucket import BitbucketIntegrationProvider
     from sentry.integrations.example import ExampleIntegrationProvider
     from sentry.integrations.github import GitHubIntegrationProvider
     from sentry.integrations.github_enterprise import GitHubEnterpriseIntegrationProvider
     from sentry.integrations.jira import JiraIntegrationProvider
     from sentry.integrations.slack import SlackIntegrationProvider
     from sentry.integrations.vsts import VSTSIntegrationProvider
+
+    integrations.register(BitbucketIntegrationProvider)
     integrations.register(ExampleIntegrationProvider)
     integrations.register(GitHubIntegrationProvider)
     integrations.register(GitHubEnterpriseIntegrationProvider)

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+from sentry.testutils import IntegrationTestCase
+from sentry.models import Integration
+from sentry.integrations.bitbucket.integration import BitbucketIntegrationProvider
+
+
+class BitbucketIntegrationProviderTestCase(IntegrationTestCase):
+    provider = BitbucketIntegrationProvider
+
+    def test_finish_integration(self):
+        client_key = 'client:12345'
+        uuid = '1234567890'
+        Integration.objects.create(
+            provider=self.provider.key,
+            name='tester',
+            metadata={'uuid': uuid},
+            external_id=client_key,
+        )
+
+        self.pipeline.state.data = {'identity': {'bitbucket_client_key': client_key}}
+        self.pipeline.finish_pipeline()
+        assert Integration.objects.filter(
+            provider=self.provider.key,
+            external_id=uuid,
+        ).exists()
+        assert not Integration.objects.filter(
+            provider=self.provider.key,
+            external_id=client_key,
+        ).exists()


### PR DESCRIPTION
Realized that `uuid` rather than `clientKey` is a more appropriate `external_id`. The easiest way to implement this change has been to allow `clientKey` to be the temporary `external_id` and to give the `IntegrationProvider` an option at the end to add any additional changes to the integration. In Bitbucket's case I changed the `external_id` to the `uuid`.

TODO: Add in docs