### PR TITLE
fix(search): `has:x` queries should not take precedence over `x:value` queries

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -364,7 +364,9 @@ def parse_query(project, query, user):
                     value = 'sentry:user'
                 elif value == 'release':
                     value = 'sentry:release'
-                results['tags'][value] = ANY
+                # `has:x` query should not take precedence over `x:value` queries
+                if value not in results['tags']:
+                    results['tags'][value] = ANY
             elif key in ('age', 'firstSeen'):
                 results.update(get_date_params(value, 'age_from', 'age_to'))
             elif key in ('last_seen', 'lastSeen'):

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -404,6 +404,9 @@ class ParseQueryTest(TestCase):
         result = self.parse_query('has:foo')
         assert result['tags']['foo'] == ANY
 
+        result = self.parse_query('has:foo foo:value')
+        assert result['tags']['foo'] == 'value'
+
     def test_has_user(self):
         result = self.parse_query('has:user')
         assert result['tags']['sentry:user'] == ANY


### PR DESCRIPTION
Fixes SENTRY-6NX