### PR TITLE
WIP: Responsiveness Adjusted Unresolved Issues (Merge button, tooltip)

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.jsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.jsx
@@ -124,7 +124,7 @@ export default class IgnoreActions extends React.Component {
             className={linkClassName}
             onAction={() => onUpdate({status: 'ignored'})}
           >
-            <span className="icon-ban" style={{marginRight: 5}} />
+            <span className="icon-ban hidden-xs" style={{marginRight: 5}} />
             <GuideAnchor target="ignore_delete_discard" type="text" />
             {t('Ignore')}
           </ActionLink>

--- a/src/sentry/static/sentry/app/components/actions/resolve.jsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.jsx
@@ -130,7 +130,7 @@ export default class ResolveActions extends React.Component {
             className={buttonClass}
             onAction={() => onUpdate({status: 'resolved'})}
           >
-            <span className="icon-checkmark" style={{marginRight: 5}} />
+            <span className="icon-checkmark hidden-xs" style={{marginRight: 5}} />
             <GuideAnchor target="resolve" type="text" />
             {t('Resolve')}
           </ActionLink>

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -352,7 +352,7 @@ const StreamActions = createReactClass({
             </div>
             <div className="btn-group hidden-xs">
               <ActionLink
-                className={'btn btn-default btn-sm action-bookmark'}
+                className={'btn btn-default btn-sm action-bookmark hidden-sm hidden-xs'}
                 onAction={() => this.onUpdate({isBookmarked: true})}
                 shouldConfirm={this.shouldConfirm('bookmark')}
                 message={confirm('bookmark', false)}
@@ -368,9 +368,37 @@ const StreamActions = createReactClass({
                 key="actions"
                 btnGroup={true}
                 caret={false}
-                className="btn btn-sm btn-default hidden-xs action-more"
+                className="btn btn-sm btn-default action-more"
                 title={<span className="icon-ellipsis" />}
               >
+                <MenuItem noAnchor={true}>
+                  <ActionLink
+                    className={'action-merge hidden-md hidden-lg hidden-xl'}
+                    disabled={!multiSelected}
+                    onAction={this.onMerge}
+                    shouldConfirm={this.shouldConfirm('merge')}
+                    message={confirm('merge', false)}
+                    confirmLabel={label('merge')}
+                    title={t('Merge Selected Issues')}
+                  >
+                    {t('Merge')}
+                  </ActionLink>
+                </MenuItem>
+                <MenuItem divider={true} className={'hidden-md hidden-lg hidden-xl'} />
+                <MenuItem noAnchor={true}>
+                  <ActionLink
+                    className={'action-bookmark hidden-md hidden-lg hidden-xl'}
+                    disabled={!anySelected}
+                    onAction={() => this.onUpdate({isBookmarked: true})}
+                    shouldConfirm={this.shouldConfirm('bookmark')}
+                    message={confirm('bookmark', false)}
+                    confirmLabel={label('bookmark')}
+                    title={t('Add to Bookmarks')}
+                  >
+                    {t('Add to Bookmarks')}
+                  </ActionLink>
+                  <MenuItem divider={true} className={'hidden-md hidden-lg hidden-xl'} />
+                </MenuItem>
                 <MenuItem noAnchor={true}>
                   <ActionLink
                     className="action-remove-bookmark"

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -446,6 +446,7 @@ const StreamActions = createReactClass({
                   '%s real-time updates',
                   realtimeActive ? t('Pause') : t('Enable')
                 )}
+                tooltipOptions={{container: 'body'}}
               >
                 <a
                   className="btn btn-default btn-sm hidden-xs realtime-control"

--- a/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
@@ -256,7 +256,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
           >
              
             <span
-              className="icon-ban"
+              className="icon-ban hidden-xs"
               style={
                 Object {
                   "marginRight": 5,
@@ -5290,7 +5290,7 @@ exports[`IgnoreActions without confirmation renders 1`] = `
           onClick={[Function]}
         >
           <span
-            className="icon-ban"
+            className="icon-ban hidden-xs"
             style={
               Object {
                 "marginRight": 5,

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -105,7 +105,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
           >
              
             <span
-              className="icon-checkmark"
+              className="icon-checkmark hidden-xs"
               style={
                 Object {
                   "marginRight": 5,
@@ -545,7 +545,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
           onClick={[Function]}
         >
           <span
-            className="icon-checkmark"
+            className="icon-checkmark hidden-xs"
             style={
               Object {
                 "marginRight": 5,


### PR DESCRIPTION
In response to: https://github.com/getsentry/sentry/issues/8336

- Kept ellipses dropdown in mobile responsiveness
- Added merge button and bookmark button to ellipses dropdown
- Remove Resolve and Ignore button icons while in mobile
- Used bootstrap responsiveness utilities to accomplish above-mentioned objectives.
- Fixed tooltip presentation (shown in screenshots). 

Mobile:
![image](https://user-images.githubusercontent.com/10991288/40394372-07349190-5dd8-11e8-89da-62d29568a63a.png)
Desktop:
![image](https://user-images.githubusercontent.com/10991288/40394387-1b96e5d4-5dd8-11e8-89a3-35e658d4c1cf.png)

Tooltip before:
![screen shot 2018-05-22 at 11 33 59 am](https://user-images.githubusercontent.com/10991288/40453186-4204d1ba-5e99-11e8-8fd3-613d81782e49.png)
Tooltip After:
![image](https://user-images.githubusercontent.com/10991288/40453215-5bd9e3f0-5e99-11e8-80d8-9364f0269602.png)

