### PR TITLE
tests: New pytest utils!

### DIFF
--- a/bin/pytest-utils/generate-report
+++ b/bin/pytest-utils/generate-report
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import sys
 import json
@@ -13,7 +13,7 @@ if __name__ == '__main__':
         'logfile',
         metavar='LOGFILE',
         nargs='?',
-        type=argparse.FileType('r', encoding='UTF-8'),
+        type=argparse.FileType('r'),
         default=sys.stdin,
         help='The logfile to read. If empty, stdin is used.',
     )
@@ -21,7 +21,7 @@ if __name__ == '__main__':
         'reportfile',
         metavar='REPORT',
         nargs='?',
-        type=argparse.FileType('w', encoding='UTF-8'),
+        type=argparse.FileType('w'),
         default=sys.stdout,
         help='The filepath to write the report to. If empty, stdout is used.',
     )

--- a/bin/pytest-utils/generate-report
+++ b/bin/pytest-utils/generate-report
@@ -25,10 +25,14 @@ if __name__ == '__main__':
         default=sys.stdout,
         help='The filepath to write the report to. If empty, stdout is used.',
     )
+    parser.add_argument('-p', '--pretty', action='store_true', help='write pretty JSON')
     args = parser.parse_args()
 
     with args.logfile as infile, args.reportfile as outfile:
         report = dict()
         for path, duration in extract_tests(infile.readlines()):
             report['/'.join(path)] = duration
-        json.dump(report, outfile, separators=(',', ':'))
+        if args.pretty:
+            json.dump(report, outfile, indent=4, sort_keys=True)
+        else:
+            json.dump(report, outfile, separators=(',', ':'))

--- a/bin/pytest-utils/generate-report
+++ b/bin/pytest-utils/generate-report
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import argparse
+
+from parse import extract_tests
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Generates a JSON-serialized test duration REPORT file from a `pytest --durations=0` LOGFILE.')
+    parser.add_argument(
+        'logfile',
+        metavar='LOGFILE',
+        nargs='?',
+        type=argparse.FileType('r', encoding='UTF-8'),
+        default=sys.stdin,
+        help='The logfile to read. If empty, stdin is used.',
+    )
+    parser.add_argument(
+        'reportfile',
+        metavar='REPORT',
+        nargs='?',
+        type=argparse.FileType('w', encoding='UTF-8'),
+        default=sys.stdout,
+        help='The filepath to write the report to. If empty, stdout is used.',
+    )
+    args = parser.parse_args()
+
+    with args.logfile as infile, args.reportfile as outfile:
+        report = dict()
+        for path, duration in extract_tests(infile.readlines()):
+            report['/'.join(path)] = duration
+        json.dump(report, outfile, separators=(',', ':'))

--- a/bin/pytest-utils/parse.py
+++ b/bin/pytest-utils/parse.py
@@ -1,0 +1,22 @@
+import re
+
+TESTLINE = re.compile(r"(?P<duration>\d+.\d+?)s\s+?(?P<type>\w+?)\s+?(?P<path>[\w/:.]+)")
+
+
+def _split_path(test_path):
+    dirs = test_path.split('/')
+    trace = dirs.pop().split('::')
+    return dirs + trace
+
+
+def extract_tests(lines):
+    # lines should be the output of py.test --durations=0
+    for l in lines:
+        m = TESTLINE.match(l)
+        if m:
+            d = m.groupdict()
+            # call times are a much more consistent and reliable metric
+            # than setup or teardown times, which vary depending on what
+            # tests are called and how pytest caches fixtures and such
+            if float(d['duration']) > 0.0 and d['type'] == 'call':
+                yield _split_path(d.pop('path')), float(d['duration'])

--- a/bin/pytest-utils/parse.py
+++ b/bin/pytest-utils/parse.py
@@ -18,5 +18,5 @@ def extract_tests(lines):
             # call times are a much more consistent and reliable metric
             # than setup or teardown times, which vary depending on what
             # tests are called and how pytest caches fixtures and such
-            if float(d['duration']) > 0.0 and d['type'] == 'call':
+            if d['type'] == 'call':
                 yield _split_path(d.pop('path')), float(d['duration'])

--- a/bin/pytest-utils/print-tree
+++ b/bin/pytest-utils/print-tree
@@ -1,5 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import sys
 import fileinput
 

--- a/bin/pytest-utils/print-tree
+++ b/bin/pytest-utils/print-tree
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import sys
+import fileinput
+
+from parse import extract_tests
+
+# only colorize tests that take longer than this (seconds)
+COLOR_THRESHOLD = 1.0
+
+
+def _usage():
+    sys.exit('''USAGE: py.test --durations=0 path/to/tests | {bin}\n
+Alternatively, you can pass in a filepath:\n
+py.test --durations=0 path/to/tests > pytest-log
+{bin} pytest-log'''.format(bin=sys.argv[0]))
+
+
+class Node(object):
+
+    def __init__(self, pathpart, duration=0.0, parent=None):
+        self.pathpart = pathpart
+        self.duration = duration
+        self.children = []
+        self.parent = parent
+
+    def pretty_duration(self):
+        # pretty print duration, time severity coloring is calculated relative to siblings
+        ansi_seq = '\033[1;30m'  # dark grey: default
+        if self.duration > COLOR_THRESHOLD:
+            ratio = self.duration / sum([n.duration for n in self.parent.children])
+            if 0.33 <= ratio < 0.5:
+                ansi_seq = '\033[1;33m'  # yellow
+            if 0.5 <= ratio < 1.0:  # if ratio is 1, then ignore because its the only child
+                ansi_seq = '\033[1;31m'  # red
+        return ansi_seq + '({:.2f}s)\033[0m'.format(self.duration)
+
+
+class Tree(object):
+
+    def __init__(self):
+        self.root = Node('')
+
+    def insert(self, path, duration):
+        cur = self.root
+        while path:
+            pathpart = path.pop(0)
+            found = False
+            for c in cur.children:
+                if c.pathpart == pathpart:
+                    c.duration += duration
+                    cur, found = c, True
+                    break
+            if not found:
+                n = Node(pathpart, duration, cur)
+                cur.children.append(n)
+                cur = n
+
+    def display(self):
+        def preorder(node, fullpath=None):
+            if not fullpath:
+                fullpath = node.pathpart
+            else:
+                fullpath += ' │ ' + node.pathpart
+            if not node:
+                return
+            if node.pathpart:  # ignore the fake root node
+                time_label_prefix = '┌─ ' if node.children else ''
+                print('{} {}{}'.format(fullpath, time_label_prefix, node.pretty_duration()))
+            for c in node.children:
+                preorder(c, fullpath)
+        preorder(self.root)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] in ('-h', '--help'):
+        _usage()
+    t = Tree()
+    try:
+        for path, duration in extract_tests(fileinput.input()):
+           t.insert(path, duration)
+    except FileNotFoundError as e:
+        print('File {} not found.\n'.format(sys.argv[1]))
+        _usage()
+    t.display()

--- a/bin/pytest-utils/report-diff
+++ b/bin/pytest-utils/report-diff
@@ -21,23 +21,20 @@ if __name__ == '__main__':
     parser.add_argument(
         'filea',
         metavar='A',
-        nargs=1,
         type=argparse.FileType('r', encoding='UTF-8'),
         help='Path to report file to compare B to.',
     )
     parser.add_argument(
         'fileb',
         metavar='B',
-        nargs=1,
-        type=argparse.FileType('w', encoding='UTF-8'),
+        type=argparse.FileType('r', encoding='UTF-8'),
         help='Path to report file to compare with A.',
     )
     parser.add_argument('-s', '--sensitivity', type=float, help='sensitivity threshold in seconds (float)', default=0.1)
     args = parser.parse_args()
 
     with args.filea as filea, args.fileb as fileb:
-        a = json.load(a)
-        b = json.load(b)
+        a, b = json.load(filea), json.load(fileb)
 
     added, faster, slower = dict(), dict(), dict()
 

--- a/bin/pytest-utils/report-diff
+++ b/bin/pytest-utils/report-diff
@@ -1,6 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
-import sys
+from __future__ import print_function
 import json
 import argparse
 from operator import itemgetter
@@ -22,13 +22,13 @@ if __name__ == '__main__':
     parser.add_argument(
         'filea',
         metavar='A',
-        type=argparse.FileType('r', encoding='UTF-8'),
+        type=argparse.FileType('r'),
         help='Path to report file to compare B to.',
     )
     parser.add_argument(
         'fileb',
         metavar='B',
-        type=argparse.FileType('r', encoding='UTF-8'),
+        type=argparse.FileType('r'),
         help='Path to report file to compare with A.',
     )
     parser.add_argument('-s', '--sensitivity', type=float, help='sensitivity threshold in seconds (float)', default=0.1)

--- a/bin/pytest-utils/report-diff
+++ b/bin/pytest-utils/report-diff
@@ -12,7 +12,7 @@ def _humanize(mode, tests_dict):
     if not tests_dict:
         print('Nothing to see here.\n')
         return
-    for testpath, duration in sorted(tests_dict.items(), key=itemgetter(1), reverse=(mode=='slower')):
+    for testpath, duration in sorted(tests_dict.items(), key=itemgetter(1), reverse=(mode!='faster')):
         print('({:+.2f}s) '.format(duration) if duration else '', testpath, sep='')
     print('\n')
 

--- a/bin/pytest-utils/report-diff
+++ b/bin/pytest-utils/report-diff
@@ -3,6 +3,7 @@
 import sys
 import json
 import argparse
+from operator import itemgetter
 
 
 def _humanize(mode, tests_dict):
@@ -11,7 +12,7 @@ def _humanize(mode, tests_dict):
     if not tests_dict:
         print('Nothing to see here.\n')
         return
-    for testpath, duration in sorted(tests_dict.items(), reverse=(mode=='slower')):
+    for testpath, duration in sorted(tests_dict.items(), key=itemgetter(1), reverse=(mode=='slower')):
         print('({:+.2f}s) '.format(duration) if duration else '', testpath, sep='')
     print('\n')
 

--- a/bin/pytest-utils/report-diff
+++ b/bin/pytest-utils/report-diff
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import argparse
+
+
+def _humanize(mode, tests_dict):
+    assert mode in ('added', 'removed', 'faster', 'slower')
+    print('=== tests: {} ===\n'.format(mode))
+    if not tests_dict:
+        print('Nothing to see here.\n')
+        return
+    for testpath, duration in sorted(tests_dict.items(), reverse=(mode=='slower')):
+        print('({:+.2f}s) '.format(duration) if duration else '', testpath, sep='')
+    print('\n')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Compares `generate-report`-generated pytest report file B to A.')
+    parser.add_argument(
+        'filea',
+        metavar='A',
+        nargs=1,
+        type=argparse.FileType('r', encoding='UTF-8'),
+        help='Path to report file to compare B to.',
+    )
+    parser.add_argument(
+        'fileb',
+        metavar='B',
+        nargs=1,
+        type=argparse.FileType('w', encoding='UTF-8'),
+        help='Path to report file to compare with A.',
+    )
+    parser.add_argument('-s', '--sensitivity', type=float, help='sensitivity threshold in seconds (float)', default=0.1)
+    args = parser.parse_args()
+
+    with args.filea as filea, args.fileb as fileb:
+        a = json.load(a)
+        b = json.load(b)
+
+    added, faster, slower = dict(), dict(), dict()
+
+    for testpath, duration in b.items():
+        a_duration = a.pop(testpath, None)
+        if a_duration is None:
+            added[testpath] = duration
+        else:
+            delta = duration - a_duration
+            if delta > args.sensitivity:
+                slower[testpath] = delta
+            elif delta < -args.sensitivity:
+                faster[testpath] = delta
+
+    removed = { t: None for t in a.keys() }
+
+    _humanize('added', added)
+    _humanize('removed', removed)
+    _humanize('slower', slower)
+    _humanize('faster', faster)
+


### PR DESCRIPTION
These new utilities are the beginning of an effort to understand how Sentry's python tests change over time and per-pull-request. Here's a short demonstration:

```
$ py.test --cache-clear --durations=0 tests/sentry/plugins/ | tee $(tty) | bin/pytest-utils/generate-report -p > one.json
============================= test session starts ==============================
platform darwin -- Python 2.7.15, pytest-3.5.1, py-1.5.3, pluggy-0.6.0
rootdir: /Users/josh/sentry/sentry, inifile: setup.cfg
plugins: xdist-1.18.2, timeout-1.2.1, profiling-1.3.0, html-1.9.0, django-2.9.1, cov-2.5.1
collected 68 items

tests/sentry/plugins/test_config.py ..                                   [  2%]
tests/sentry/plugins/test_repository_provider.py ....                    [  8%]
tests/sentry/plugins/base/test.py ....                                   [ 14%]

-- snip --

============================ slowest test durations ============================
2.88s setup    tests/sentry/plugins/test_config.py::ConfigTest::test_get_config
2.01s call     tests/sentry/plugins/mail/tests.py::MailPluginOwnersTest::test_notify_users_with_owners
1.42s teardown tests/sentry/plugins/useragents/tests.py::UserAgentPlugins::test_plugins
1.15s call     tests/sentry/plugins/mail/activity/test_release.py::ReleaseTestCase::test_simple
0.56s call     tests/sentry/plugins/mail/tests.py::MailPluginSignalsTest::test_user_feedback
0.52s call     tests/sentry/plugins/bases/test_issue2.py::IssuePlugin2GroupActionTest::test_get_create

-- snip --
```

```
$ py.test --cache-clear --durations=0 tests/sentry/plugins/ | tee $(tty) | bin/pytest-utils/generate-report -p > two.json
============================= test session starts ==============================
platform darwin -- Python 2.7.15, pytest-3.5.1, py-1.5.3, pluggy-0.6.0
rootdir: /Users/josh/sentry/sentry, inifile: setup.cfg
plugins: xdist-1.18.2, timeout-1.2.1, profiling-1.3.0, html-1.9.0, django-2.9.1, cov-2.5.1
collected 68 items

tests/sentry/plugins/test_config.py ..                                   [  2%]
tests/sentry/plugins/test_repository_provider.py ....                    [  8%]
tests/sentry/plugins/base/test.py ....                                   [ 14%]

-- snip --

============================ slowest test durations ============================
2.55s setup    tests/sentry/plugins/test_config.py::ConfigTest::test_get_config
1.77s call     tests/sentry/plugins/mail/tests.py::MailPluginOwnersTest::test_notify_users_with_owners
1.47s teardown tests/sentry/plugins/useragents/tests.py::UserAgentPlugins::test_plugins
1.16s call     tests/sentry/plugins/mail/activity/test_release.py::ReleaseTestCase::test_simple
0.53s call     tests/sentry/plugins/mail/tests.py::MailPluginSignalsTest::test_user_feedback
0.51s call     tests/sentry/plugins/bases/test_issue2.py::IssuePlugin2GroupActionTest::test_get_create

-- snip --
```

```
$ bin/pytest-utils/report-diff --sensitivity 0.01 one.json two.json
=== tests: added ===

Nothing to see here.

=== tests: removed ===

Nothing to see here.

=== tests: slower ===

(+0.01s) tests/sentry/plugins/mail/activity/test_release.py/ReleaseTestCase/test_simple
(+0.01s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_assignment


=== tests: faster ===

(-0.24s) tests/sentry/plugins/mail/tests.py/MailPluginOwnersTest/test_notify_users_with_owners
(-0.08s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_note
(-0.06s) tests/sentry/plugins/bases/test_issue2.py/IssuePlugin2GroupActionTest/test_get_unlink_valid
(-0.05s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_notify_users_with_utf8_subject
(-0.05s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_notify_with_suspect_commits
(-0.04s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_multiline_error
(-0.03s) tests/sentry/plugins/mail/tests.py/MailPluginSignalsTest/test_user_feedback
(-0.03s) tests/sentry/plugins/bases/test_issue2.py/IssuePlugin2GroupActionTest/test_get_unlink_invalid
(-0.03s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_assignment_team
(-0.02s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_notify_digest_subject_prefix
(-0.02s) tests/sentry/plugins/mail/tests.py/MailPluginTest/test_simple_notification
(-0.02s) tests/sentry/plugins/bases/test_issue2.py/IssuePlugin2GroupActionTest/test_no_group_events
(-0.01s) tests/sentry/plugins/base/test.py/test_load_plugin_urls
(-0.01s) tests/sentry/plugins/bases/test_issue2.py/IssuePlugin2GroupActionTest/test_get_create
(-0.01s) tests/sentry/plugins/interfaces/test_releasehook.py/SetCommitsTest/test_minimal
(-0.01s) tests/sentry/plugins/mail/tests.py/ActivityEmailTestCase/test_get_participants_without_actor
(-0.01s) tests/sentry/plugins/mail/tests.py/MailPluginOwnersTest/test_get_send_to_with_fallthrough
```