### PR TITLE
fix(analytics): Remove user_id requirement

### DIFF
--- a/src/sentry/analytics/events/project_issue_searched.py
+++ b/src/sentry/analytics/events/project_issue_searched.py
@@ -7,7 +7,7 @@ class ProjectIssueSearchEvent(analytics.Event):
     type = 'project_issue.searched'
 
     attributes = (
-        analytics.Attribute('user_id'),
+        analytics.Attribute('user_id', required=False),
         analytics.Attribute('organization_id'),
         analytics.Attribute('project_id'),
         analytics.Attribute('query'),


### PR DESCRIPTION
project_group_index endpoint can be hit without an authenticated user. Removing user_id requirement

fixes SENTRY-6PG