### PR TITLE
fix: Project Chooser for Onboarding Wizard

### DIFF
--- a/src/sentry/static/sentry/app/views/projectChooser.jsx
+++ b/src/sentry/static/sentry/app/views/projectChooser.jsx
@@ -36,15 +36,15 @@ const ProjectChooser = createReactClass({
   redirectNoMultipleProjects() {
     let org = this.getOrganization();
     let projects = org.projects;
-    let task = TodoList.TASKS.filter(
+    let tasks = TodoList.TASKS.filter(
       task_inst => task_inst.task == this.props.location.query.task
-    )[0];
+    );
 
     if (projects.length === 0) {
       browserHistory.push(`/organizations/${org.slug}/projects/new/`);
-    } else if (projects.length === 1) {
+    } else if (projects.length === 1 && tasks.length === 1) {
       let project = projects[0];
-      browserHistory.push(`/${org.slug}/${project.slug}/${task.location}`);
+      browserHistory.push(`/${org.slug}/${project.slug}/${tasks[0].location}`);
     }
   },
 


### PR DESCRIPTION
Fixes so the `redirectNoMultipleProjects` does not error, but instead lets this corner case
(where user has intentionally typed in this url and not included task_id) fall back to the
render method, where we gracefully handle it.

```js
// line 59 of projectChooser.jsx
if (task.featureLocation != 'project') {
  throw new Error('User arrived on project chooser without a valid task id.');
}
```

Fixes JAVASCRIPT-33G