### PR TITLE
feat: Opera Mini Filter

### DIFF
--- a/src/sentry/data/samples/javascript.json
+++ b/src/sentry/data/samples/javascript.json
@@ -222,7 +222,7 @@
         "headers": [
             [
                 "User-Agent",
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36 Opera/9.80"
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
             ]
         ]
     },

--- a/src/sentry/data/samples/javascript.json
+++ b/src/sentry/data/samples/javascript.json
@@ -222,7 +222,7 @@
         "headers": [
             [
                 "User-Agent",
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36 Opera/9.80"
             ]
         ]
     },

--- a/src/sentry/filters/legacy_browsers.py
+++ b/src/sentry/filters/legacy_browsers.py
@@ -19,13 +19,21 @@ MIN_VERSIONS = {
     'Edge': 0,
     'Opera': 15,
     'Android': 4,
+    'Opera Mini': 8
 }
 
 
 class LegacyBrowserFilterSerializer(serializers.Serializer):
     active = serializers.BooleanField()
     subfilters = MultipleChoiceField(
-        choices=['ie_pre_9', 'ie9', 'ie10', 'opera_pre_15', 'android_pre_4', 'safari_pre_6']
+        choices=[
+            'ie_pre_9',
+            'ie9',
+            'ie10',
+            'opera_pre_15',
+            'android_pre_4',
+            'safari_pre_6',
+            'opera_mini_pre_8']
     )
 
 
@@ -136,6 +144,20 @@ class LegacyBrowsersFilter(Filter):
             return False
 
         if major_browser_version < 4:
+            return True
+
+        return False
+
+    def filter_opera_mini_pre_8(self, browser):
+        if not browser['family'] == "Opera Mini":
+            return False
+
+        try:
+            major_browser_version = int(browser['major'])
+        except (TypeError, ValueError):
+            return False
+
+        if major_browser_version < 8:
             return True
 
         return False

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -31,15 +31,20 @@ const LEGACY_BROWSER_SUBFILTERS = {
     helpText: 'Version 10',
     title: 'Internet Explorer',
   },
+  safari_pre_6: {
+    icon: 'safari',
+    helpText: 'Version 5 and lower',
+    title: 'Safari',
+  },
   opera_pre_15: {
     icon: 'opera',
     helpText: 'Version 14 and lower',
     title: 'Opera',
   },
-  safari_pre_6: {
-    icon: 'safari',
-    helpText: 'Version 5 and lower',
-    title: 'Safari',
+  opera_mini_pre_8: {
+    icon: 'opera',
+    helpText: 'Version 8 and lower',
+    title: 'Opera Mini',
   },
   android_pre_4: {
     icon: 'android',
@@ -291,7 +296,7 @@ const FilterGridItem = styled.div`
 // We want this wrapper to maining 30% width
 const FilterGridItemWrapper = styled.div`
   padding: 12px;
-  flex: 1;
+  width: 50%;
 `;
 
 const FilterGridIcon = styled.div`

--- a/tests/js/spec/views/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectFilters.spec.jsx
@@ -124,7 +124,7 @@ describe('ProjectFilters', function() {
     let mock = createFilterMock(filter);
 
     // default stubs ie_pre_9 and ie9 selected (first 2 switches)
-    const Switch = wrapper.find('LegacyBrowserFilterRow Switch').at(3);
+    const Switch = wrapper.find('LegacyBrowserFilterRow Switch').at(4);
 
     // Toggle filter on
     Switch.simulate('click');
@@ -139,7 +139,7 @@ describe('ProjectFilters', function() {
     // Toggle filter off
     wrapper
       .find('LegacyBrowserFilterRow Switch')
-      .at(4)
+      .at(3)
       .simulate('click');
     expect(Array.from(mock.mock.calls[1][1].data.subfilters)).toEqual([
       'ie_pre_9',
@@ -179,8 +179,9 @@ describe('ProjectFilters', function() {
       'ie_pre_9',
       'ie9',
       'ie10',
-      'opera_pre_15',
       'safari_pre_6',
+      'opera_pre_15',
+      'opera_mini_pre_8',
       'android_pre_4',
     ]);
 


### PR DESCRIPTION
Sentry users can filter Opera Mini legacy browsers pre version 8.  
# Before
![screen shot 2018-05-24 at 1 36 07 pm](https://user-images.githubusercontent.com/25037561/40512493-dce38618-5f57-11e8-9a3c-908fa47f45d7.png)
# After
![screen shot 2018-05-24 at 1 35 20 pm](https://user-images.githubusercontent.com/25037561/40512481-d5e6a016-5f57-11e8-9b12-ebd28c938a4c.png)

