### PR TITLE
feat(identity): Double write/read IDP and Identity

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -72,15 +72,14 @@ class IntegrationPipeline(Pipeline):
             # Create identity provider for this integration if necessary
             idp, created = IdentityProvider.objects.get_or_create(
                 external_id=data['external_id'],
-                organization_id=self.organization.id,
+                organization_id=0,
                 type=identity['type'],
                 defaults={'config': identity_config},
             )
-
             if created:
                 idp.update(config=identity_config)
 
-            identity, created = Identity.objects.get_or_create(
+            Identity.objects.get_or_create(
                 idp=idp,
                 user=self.request.user,
                 external_id=identity['external_id'],

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -217,22 +217,28 @@ class SlackActionEndpoint(Endpoint):
         try:
             identity = Identity.objects.get(
                 external_id=user_id,
-                idp__organization_id=group.organization.id,
+                idp__organization_id=0,
             )
         except Identity.DoesNotExist:
-            associate_url = build_linking_url(
-                integration,
-                group.organization,
-                user_id,
-                channel_id,
-                data.get('response_url')
-            )
+            try:
+                identity = Identity.objects.get(
+                    external_id=user_id,
+                    idp__organization_id=group.organization.id,
+                )
+            except Identity.DoesNotExist:
+                associate_url = build_linking_url(
+                    integration,
+                    group.organization,
+                    user_id,
+                    channel_id,
+                    data.get('response_url')
+                )
 
-            return self.respond({
-                'response_type': 'ephemeral',
-                'replace_original': False,
-                'text': LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
-            })
+                return self.respond({
+                    'response_type': 'ephemeral',
+                    'replace_original': False,
+                    'text': LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
+                })
 
         # Handle status dialog submission
         if data['type'] == 'dialog_submission' and 'resolve_type' in data['submission']:

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -241,6 +241,8 @@ class SlackActionEndpoint(Endpoint):
                 identity = Identity.objects.get(idp=idp, external_id=user_id)
             except Identity.DoesNotExist:
                 identity = None
+            else:
+                break
 
         if not identity:
             associate_url = build_linking_url(

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -50,20 +50,25 @@ class SlackLinkIdentitiyView(BaseView):
             raise Http404
 
         try:
-            idp = IdentityProvider.objects.get(
+            idp_new = IdentityProvider.objects.get(
                 external_id=integration.external_id,
                 type='slack',
                 organization_id=0,
             )
         except IdentityProvider.DoesNotExist:
-            try:
-                idp = IdentityProvider.objects.get(
-                    external_id=integration.external_id,
-                    type='slack',
-                    organization_id=organization.id,
-                )
-            except IdentityProvider.DoesNotExist:
-                raise Http404
+            idp_new = None
+
+        try:
+            idp_old = IdentityProvider.objects.get(
+                external_id=integration.external_id,
+                type='slack',
+                organization_id=organization.id,
+            )
+        except IdentityProvider.DoesNotExist:
+            idp_old = None
+
+        if not idp_new and not idp_old:
+            raise Http404
 
         if request.method != 'POST':
             return render_to_response('sentry/auth-link-identity.html', request=request, context={
@@ -76,40 +81,42 @@ class SlackLinkIdentitiyView(BaseView):
 
         # Link the user with the identity. Handle the case where the user is linked to a
         # different identity or the identity is linked to a different user.
-        try:
-            id_by_user = Identity.objects.get(user=request.user, idp=idp)
-        except Identity.DoesNotExist:
-            id_by_user = None
-        try:
-            id_by_external_id = Identity.objects.get(external_id=params['slack_id'], idp=idp)
-        except Identity.DoesNotExist:
-            id_by_external_id = None
+        # NOTE: during the IDP migration update both the old and new sets of identities.
+        for idp in filter(None, (idp_new, idp_old)):
+            try:
+                id_by_user = Identity.objects.get(user=request.user, idp=idp)
+            except Identity.DoesNotExist:
+                id_by_user = None
+            try:
+                id_by_external_id = Identity.objects.get(external_id=params['slack_id'], idp=idp)
+            except Identity.DoesNotExist:
+                id_by_external_id = None
 
-        if not id_by_user and not id_by_external_id:
-            Identity.objects.create(
-                user=request.user,
-                external_id=params['slack_id'],
-                idp=idp,
-                status=IdentityStatus.VALID,
-            )
-        elif id_by_user and not id_by_external_id:
-            # TODO(epurkhiser): In this case we probably want to prompt and
-            # warn them that they had a previous identity linked to slack.
-            id_by_user.update(
-                external_id=params['slack_id'],
-                status=IdentityStatus.VALID,
-            )
-        elif id_by_external_id and not id_by_user:
-            id_by_external_id.update(
-                user=request.user,
-                status=IdentityStatus.VALID,
-            )
-        else:
-            updates = {'status': IdentityStatus.VALID}
-            if id_by_user != id_by_external_id:
-                id_by_external_id.delete()
-                updates['external_id'] = params['slack_id']
-            id_by_user.update(**updates)
+            if not id_by_user and not id_by_external_id:
+                Identity.objects.create(
+                    user=request.user,
+                    external_id=params['slack_id'],
+                    idp=idp,
+                    status=IdentityStatus.VALID,
+                )
+            elif id_by_user and not id_by_external_id:
+                # TODO(epurkhiser): In this case we probably want to prompt and
+                # warn them that they had a previous identity linked to slack.
+                id_by_user.update(
+                    external_id=params['slack_id'],
+                    status=IdentityStatus.VALID,
+                )
+            elif id_by_external_id and not id_by_user:
+                id_by_external_id.update(
+                    user=request.user,
+                    status=IdentityStatus.VALID,
+                )
+            else:
+                updates = {'status': IdentityStatus.VALID}
+                if id_by_user != id_by_external_id:
+                    id_by_external_id.delete()
+                    updates['external_id'] = params['slack_id']
+                id_by_user.update(**updates)
 
         payload = {
             'replace_original': False,

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -76,8 +76,14 @@ class SlackLinkIdentitiyView(BaseView):
 
         # Link the user with the identity. Handle the case where the user is linked to a
         # different identity or the identity is linked to a different user.
-        id_by_user = Identity.objects.get(user=request.user, idp=idp)
-        id_by_external_id = Identity.objects.get(external_id=params['slack_id'], idp=idp)
+        try:
+            id_by_user = Identity.objects.get(user=request.user, idp=idp)
+        except Identity.DoesNotExist:
+            id_by_user = None
+        try:
+            id_by_external_id = Identity.objects.get(external_id=params['slack_id'], idp=idp)
+        except Identity.DoesNotExist:
+            id_by_external_id = None
 
         if not id_by_user and not id_by_external_id:
             Identity.objects.create(

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -99,8 +99,11 @@ class SlackLinkIdentitiyView(BaseView):
                 status=IdentityStatus.VALID,
             )
         else:
-            assert id_by_user == id_by_external_id
-            id_by_user.update(status=IdentityStatus.VALID)
+            updates = {'status': IdentityStatus.VALID}
+            if id_by_user != id_by_external_id:
+                id_by_external_id.delete()
+                updates['external_id'] = params['slack_id']
+            id_by_user.update(**updates)
 
         payload = {
             'replace_original': False,

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -106,12 +106,20 @@ def build_assigned_text(group, identity, assignee):
         try:
             assignee_ident = Identity.objects.get(
                 user=assigned_actor,
-                idp__organization_id=group.project.organization_id,
+                idp__organization_id=0,
                 idp__type='slack',
             )
             assignee_text = u'<@{}>'.format(assignee_ident.external_id)
         except Identity.DoesNotExist:
-            assignee_text = assigned_actor.get_display_name()
+            try:
+                assignee_ident = Identity.objects.get(
+                    user=assigned_actor,
+                    idp__organization_id=group.project.organization_id,
+                    idp__type='slack',
+                )
+                assignee_text = u'<@{}>'.format(assignee_ident.external_id)
+            except Identity.DoesNotExist:
+                assignee_text = assigned_actor.get_display_name()
     else:
         raise NotImplementedError
 

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -106,16 +106,18 @@ def build_assigned_text(group, identity, assignee):
         try:
             assignee_ident = Identity.objects.get(
                 user=assigned_actor,
-                idp__organization_id=0,
                 idp__type='slack',
+                idp__external_id=identity.idp.external_id,
+                idp__organization_id=0,
             )
             assignee_text = u'<@{}>'.format(assignee_ident.external_id)
         except Identity.DoesNotExist:
             try:
                 assignee_ident = Identity.objects.get(
                     user=assigned_actor,
-                    idp__organization_id=group.project.organization_id,
                     idp__type='slack',
+                    idp__external_id=identity.idp.external_id,
+                    idp__organization_id=group.project.organization_id,
                 )
                 assignee_text = u'<@{}>'.format(assignee_ident.external_id)
             except Identity.DoesNotExist:

--- a/src/sentry/web/frontend/account_identity.py
+++ b/src/sentry/web/frontend/account_identity.py
@@ -14,12 +14,19 @@ class AccountIdentityAssociateView(OrganizationView):
     def handle(self, request, organization, provider_key, external_id):
         try:
             provider_model = IdentityProvider.objects.get(
-                organization_id=organization.id,
+                organization_id=0,
                 type=provider_key,
                 external_id=external_id,
             )
         except IdentityProvider.DoesNotExist:
-            return self.redirect(reverse('sentry-account-settings-identities'))
+            try:
+                provider_model = IdentityProvider.objects.get(
+                    organization_id=organization.id,
+                    type=provider_key,
+                    external_id=external_id,
+                )
+            except IdentityProvider.DoesNotExist:
+                return self.redirect(reverse('sentry-account-settings-identities'))
 
         pipeline = IdentityProviderPipeline(
             organization=organization,

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -123,7 +123,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         idp = IdentityProvider.objects.get(
             type='github',
-            organization_id=self.organization.id,
+            organization_id=0,
         )
         identity = Identity.objects.get(
             idp=idp,

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -143,7 +143,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
 
         idp = IdentityProvider.objects.get(
             type='github-enterprise',
-            organization_id=self.organization.id,
+            organization_id=0,
         )
         identity = Identity.objects.get(
             idp=idp,

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -38,6 +38,7 @@ class BaseEventTest(APITestCase):
 
         self.idp = IdentityProvider.objects.create(
             type='slack',
+            external_id='TXXXXXXX1',
             organization_id=self.org.id,
             config={},
         )

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -94,7 +94,7 @@ class SlackIntegrationTest(IntegrationTestCase):
 
         idp = IdentityProvider.objects.get(
             type='slack',
-            organization_id=self.organization.id,
+            organization_id=0,
         )
         identity = Identity.objects.get(
             idp=idp,
@@ -122,7 +122,7 @@ class SlackIntegrationTest(IntegrationTestCase):
 
         idps = IdentityProvider.objects.filter(
             type='slack',
-            organization_id=self.organization.id,
+            organization_id=0,
         )
 
         assert idps.count() == 2

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -12,11 +12,12 @@ from sentry.integrations.slack.link_identity import build_linking_url
 class SlackIntegrationLinkIdentityTest(TestCase):
     def setUp(self):
         super(TestCase, self).setUp()
-        self.user = self.create_user(is_superuser=False)
+        self.user1 = self.create_user(is_superuser=False)
+        self.user2 = self.create_user(is_superuser=False)
         self.org = self.create_organization(owner=None)
-        self.team = self.create_team(organization=self.org, members=[self.user])
+        self.team = self.create_team(organization=self.org, members=[self.user1, self.user2])
 
-        self.login_as(self.user)
+        self.login_as(self.user1)
 
         self.integration = Integration.objects.create(
             provider='slack',
@@ -74,7 +75,7 @@ class SlackIntegrationLinkIdentityTest(TestCase):
 
         identity = Identity.objects.filter(
             external_id='new-slack-id',
-            user=self.user,
+            user=self.user1,
         )
 
         assert len(identity) == 1
@@ -84,18 +85,24 @@ class SlackIntegrationLinkIdentityTest(TestCase):
 
     @responses.activate
     @patch('sentry.integrations.slack.link_identity.unsign')
-    def test_overwrites_existing_external_id(self, unsign):
-        existing_identity = Identity.objects.create(
-            user=self.user,
+    def test_overwrites_existing_identities(self, unsign):
+        existing_id1 = Identity.objects.create(
+            user=self.user1,
             idp=self.idp,
-            external_id='old-slack-id',
+            external_id='slack-id1',
+            status=IdentityStatus.VALID,
+        )
+        existing_id2 = Identity.objects.create(
+            user=self.user2,
+            idp=self.idp,
+            external_id='slack-id2',
             status=IdentityStatus.VALID,
         )
 
         unsign.return_value = {
             'integration_id': self.integration.id,
             'organization_id': self.org.id,
-            'slack_id': 'new-slack-id',
+            'slack_id': 'slack-id2',
             'channel_id': 'my-channel',
             'response_url': 'http://example.slack.com/response_url',
         }
@@ -103,7 +110,7 @@ class SlackIntegrationLinkIdentityTest(TestCase):
         linking_url = build_linking_url(
             self.integration,
             self.org,
-            'new-slack-id',
+            'slack-id2',
             'my-channel',
             'http://example.slack.com/response_url'
         )
@@ -118,7 +125,9 @@ class SlackIntegrationLinkIdentityTest(TestCase):
         self.client.post(linking_url)
 
         assert Identity.objects.filter(
-            id=existing_identity.id,
-            external_id='new-slack-id',
-            user=self.user,
+            id=existing_id1.id,
+            external_id='slack-id2',
+            user=self.user1,
         ).exists()
+
+        assert not Identity.objects.filter(id=existing_id2.id).exists()


### PR DESCRIPTION
Step 2 of removing org from IdentityProvider.

- IDP get_or_create: replace with org=0
- IDP get: try org=0 first, then actual org
- Identity get_or_create: use whatever idp is given
- Identity get: try org=0 first, then actual org

This makes it so that new objects are created with org=0, and after bulk migrating the data to org=0 (using a script) all reads will go through org=0 objects.