### PR TITLE
Update Avatar Icons On Releases Page

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
@@ -84,7 +84,7 @@ const CollapsedUsers = styled('div')`
   font-weight: 600;
   background-color: ${p => p.theme.borderLight};
   color: ${p => p.theme.gray2};
-  font-size: ${p => p.theme.fontSizeSmall};
+  font-size: ${p => Math.floor(p.size / 2.3)}px;
   width: ${p => p.size}px;
   height: ${p => p.size}px;
   ${Circle};

--- a/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
@@ -14,11 +14,13 @@ export default class AvatarList extends React.Component {
     maxVisibleAvatars: PropTypes.number,
     renderTooltip: PropTypes.func,
     tooltipOptions: PropTypes.object,
+    typeMembers: PropTypes.string,
   };
 
   static defaultProps = {
     avatarSize: 28,
     maxVisibleAvatars: 5,
+    typeMembers: 'users',
   };
 
   render() {
@@ -28,14 +30,14 @@ export default class AvatarList extends React.Component {
       maxVisibleAvatars,
       tooltipOptions,
       renderTooltip,
+      typeMembers,
     } = this.props;
     const visibleUsers = users.slice(0, maxVisibleAvatars);
     const numCollapsedUsers = users.length - visibleUsers.length;
-
     return (
       <Flex direction="row-reverse">
         {!!numCollapsedUsers && (
-          <Tooltip title={`${numCollapsedUsers} other users`}>
+          <Tooltip title={`${numCollapsedUsers} other ${typeMembers}`}>
             <CollapsedUsers size={avatarSize}>
               {numCollapsedUsers < 99 && <Plus>+</Plus>}
               {numCollapsedUsers}

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -76,7 +76,7 @@ const SeenInfo = createReactClass({
           <dd key={1}>
             <Tooltip title={this.getTooltipTitle} tooltipOptions={{html: true}}>
               <span>
-                <TimeSince date={date} />
+                <TimeSince className="dotted-underline" date={date} />
               </span>
             </Tooltip>
             <br />

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -32,7 +32,7 @@ const ReleaseStats = createReactClass({
       <div className="release-stats">
         <ReleaseSummaryHeading>{releaseSummary}</ReleaseSummaryHeading>
         <span style={{display: 'inline-block'}}>
-          <AvatarList users={release.authors} avatarSize={25} />
+          <AvatarList users={release.authors} avatarSize={25} typeMembers={'authors'} />
         </span>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -31,9 +31,7 @@ const ReleaseStats = createReactClass({
     return (
       <div className="release-stats">
         <ReleaseSummaryHeading>{releaseSummary}</ReleaseSummaryHeading>
-        <div className="avatar-grid">
-          <AvatarList users={release.authors} avatarSize={25} />
-        </div>
+        <AvatarList users={release.authors} avatarSize={25} />
       </div>
     );
   },

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -31,7 +31,9 @@ const ReleaseStats = createReactClass({
     return (
       <div className="release-stats">
         <ReleaseSummaryHeading>{releaseSummary}</ReleaseSummaryHeading>
-        <AvatarList users={release.authors} avatarSize={25} />
+        <span style={{display: 'inline-block'}}>
+          <AvatarList users={release.authors} avatarSize={25} />
+        </span>
       </div>
     );
   },

--- a/src/sentry/static/sentry/app/components/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
-import Avatar from 'app/components/avatar';
-import Tooltip from 'app/components/tooltip';
+import AvatarList from 'app/components/avatar/avatarList';
 import {t} from 'app/locale';
 
 const ReleaseStats = createReactClass({
@@ -33,15 +32,7 @@ const ReleaseStats = createReactClass({
       <div className="release-stats">
         <ReleaseSummaryHeading>{releaseSummary}</ReleaseSummaryHeading>
         <div className="avatar-grid">
-          {release.authors.map((author, i) => {
-            return (
-              <Tooltip key={i} title={`${author.name} ${author.email}`}>
-                <span className="avatar-grid-item">
-                  <Avatar user={author} />
-                </span>
-              </Tooltip>
-            );
-          })}
+          <AvatarList users={release.authors} avatarSize={25} />
         </div>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -171,6 +171,7 @@ const VersionHoverCard = createReactClass({
                 users={release.authors}
                 avatarSize={25}
                 tooltipOptions={{container: 'body'}}
+                typeMembers={'authors'}
               />
             </div>
           </div>

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -161,7 +161,7 @@ const VersionHoverCard = createReactClass({
               <div className="count-since">{release.newGroups}</div>
             </div>
             <div className="col-xs-8">
-              <h6>
+              <h6 style={{textAlign: 'right'}}>
                 {release.commitCount}{' '}
                 {release.commitCount !== 1 ? t('commits ') : t('commit ')} {t('by ')}{' '}
                 {release.authors.length}{' '}

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import _ from 'lodash';
 
-import Avatar from 'app/components/avatar';
+import AvatarList from 'app/components/avatar/avatarList';
 
 import LastCommit from 'app/components/lastCommit';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -106,7 +106,8 @@ const VersionHoverCard = createReactClass({
 
   toggleHovercard() {
     this.setState({
-      visible: !this.state.visible,
+      visible: true,
+      // visible: !this.state.visible,
     });
   },
 
@@ -166,19 +167,11 @@ const VersionHoverCard = createReactClass({
                 {release.authors.length}{' '}
                 {release.authors.length !== 1 ? t('authors') : t('author')}{' '}
               </h6>
-              <div className="avatar-grid">
-                {release.authors.map((author, idx) => {
-                  return (
-                    <span
-                      className="avatar-grid-item tip"
-                      title={author.name + ' ' + author.email}
-                      key={idx}
-                    >
-                      <Avatar user={author} />
-                    </span>
-                  );
-                })}
-              </div>
+              <AvatarList
+                users={release.authors}
+                avatarSize={25}
+                tooltipOptions={{container: 'body'}}
+              />
             </div>
           </div>
           {lastCommit && <LastCommit commit={lastCommit} headerClass="commit-heading" />}

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -341,7 +341,7 @@
     }
   }
 
-  .seen-info .tip {
+  .seen-info .dotted-underline {
     border-bottom: 1px dotted @trim;
   }
 

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -113,7 +113,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             title="1 other users"
           >
             <div
-              className="tip css-1831z2i-CollapsedUsers-Circle e1axh4r51"
+              className="tip css-17ychq3-CollapsedUsers-Circle e1axh4r51"
               size={28}
               title="1 other users"
             >

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -4,6 +4,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
 <AvatarList
   avatarSize={28}
   maxVisibleAvatars={5}
+  typeMembers="users"
   users={
     Array [
       Object {
@@ -698,6 +699,7 @@ exports[`AvatarList renders with user avatars 1`] = `
 <AvatarList
   avatarSize={28}
   maxVisibleAvatars={5}
+  typeMembers="users"
   users={
     Array [
       Object {


### PR DESCRIPTION
Switched out older component for AvatarList component on the releases page
[Resolves this ticket.](https://getsentry.atlassian.net/projects/APP/issues/APP-264?filter=myopenissues)

Before: sentry/project/releases overview
![screen shot 2018-05-24 at 2 52 13 pm](https://user-images.githubusercontent.com/10991288/40515732-cc36a420-5f62-11e8-964d-184ad5de2c74.png)
After:
![image](https://user-images.githubusercontent.com/10991288/40515754-de03a3b0-5f62-11e8-99b6-4f5d94e9a0c9.png)

Before: sentry/project/releases
![screen shot 2018-05-24 at 2 52 33 pm](https://user-images.githubusercontent.com/10991288/40515770-f026699c-5f62-11e8-8e61-7c27efced7db.png)
After:
![image](https://user-images.githubusercontent.com/10991288/40515783-009ed336-5f63-11e8-9670-853fc62d21bd.png)
