### PR TITLE
fix: Create ReleaseProjectEnvironment if not present on deploy creation

### DIFF
--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -119,13 +119,14 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
                 last_deploy_id=deploy.id,
             )
 
-            ReleaseProjectEnvironment.objects.filter(
-                release=release,
-                environment=env,
-                project__in=projects,
-            ).update(
-                last_deploy_id=deploy.id,
-            )
+            for project in projects:
+                ReleaseProjectEnvironment.get_or_create(
+                    release=release,
+                    environment=env,
+                    project=project,
+                ).update(
+                    last_deploy_id=deploy.id
+                )
 
             Deploy.notify_if_ready(deploy.id)
 

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -120,12 +120,13 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
             )
 
             for project in projects:
-                ReleaseProjectEnvironment.get_or_create(
+                ReleaseProjectEnvironment.objects.create_or_update(
                     release=release,
                     environment=env,
                     project=project,
-                ).update(
-                    last_deploy_id=deploy.id
+                    values={
+                        'last_deploy_id': deploy.id,
+                    }
                 )
 
             Deploy.notify_if_ready(deploy.id)

--- a/tests/sentry/api/endpoints/test_release_deploys.py
+++ b/tests/sentry/api/endpoints/test_release_deploys.py
@@ -6,7 +6,7 @@ import datetime
 
 from django.core.urlresolvers import reverse
 
-from sentry.models import Deploy, Environment, Release
+from sentry.models import Deploy, Environment, Release, ReleaseProjectEnvironment
 from sentry.testutils import APITestCase
 
 
@@ -106,3 +106,8 @@ class ReleaseDeploysCreateTest(APITestCase):
         release = Release.objects.get(id=release.id)
         assert release.total_deploys == 1
         assert release.last_deploy_id == deploy.id
+
+        rpe = ReleaseProjectEnvironment.objects.get(
+            project=project, release=release, environment=environment
+        )
+        assert rpe.last_deploy_id == deploy.id


### PR DESCRIPTION
Create ReleaseProjectEnvironment objects if they do not exist when a release deploy is created