### PR TITLE
fix(environments): Prevent environment change triggering double fetch

### DIFF
--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -50,7 +50,10 @@ const ProjectReleases = createReactClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.location.search !== this.props.location.search) {
+    const queryHasChanged =
+      nextProps.location.query.query !== this.props.location.query.query;
+
+    if (queryHasChanged) {
       let queryParams = nextProps.location.query;
       this.setState(
         {


### PR DESCRIPTION
Since changing the environment was updated in the URL as well, a change of environment was inadvertantly causing the API to fetch data twice