### PR TITLE
ref(search): Make Cursor.__repr__ less ... weird

### DIFF
--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -31,7 +31,7 @@ class Cursor(object):
 
     def __repr__(self):
         return '<%s: value=%s offset=%s is_prev=%s>' % (
-            type(self), self.value, self.offset, int(self.is_prev)
+            type(self).__name__, self.value, self.offset, int(self.is_prev)
         )
 
     def __nonzero__(self):


### PR DESCRIPTION
```
<<class 'sentry.utils.cursors.Cursor'>: value=1526667588000 offset=0 is_prev=0>
```

lol