### PR TITLE
Fixed URL Routing for settings/notifications and account/notifications

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
@@ -32,7 +32,6 @@ let NewSettingsWarning = ({location = {}}) => {
   let oldLocation;
 
   if (isAccount) {
-    console.log(location.pathname);
     oldLocation = location.pathname
       .replace('settings/account/notifications/alerts', 'account/settings/notifications')
       .replace(accountRegex, '/account/settings/$1/')

--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
@@ -32,7 +32,9 @@ let NewSettingsWarning = ({location = {}}) => {
   let oldLocation;
 
   if (isAccount) {
+    console.log(location.pathname);
     oldLocation = location.pathname
+      .replace('settings/account/notifications/alerts', 'account/settings/notifications')
       .replace(accountRegex, '/account/settings/$1/')
       .replace('details/', '')
       .replace('settings/close-account/', 'remove/')

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
@@ -89,8 +89,7 @@ export default class ProjectAlertSettings extends AsyncView {
             </ul>
           }
         />
-        {/* TODO(ckj): change 'href' to 'to' when new settings is launched #NEW-SETTINGS */}
-        <AlertLink href={'/account/settings/notifications/'} icon="icon-mail">
+        <AlertLink to={'/settings/account/notifications/'} icon="icon-mail">
           {t(
             'Looking to fine-tune your personal notification preferences? Visit your Account Settings'
           )}

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -45,8 +45,8 @@ exports[`ProjectAlertSettings render() renders 1`] = `
       title="Alerts"
     />
     <AlertLink
-      href="/account/settings/notifications/"
       icon="icon-mail"
+      to="/settings/account/notifications/"
     >
       Looking to fine-tune your personal notification preferences? Visit your Account Settings
     </AlertLink>


### PR DESCRIPTION
Did the todo for AlertLink rerouting in project alerts 
` {/* TODO(ckj): change 'href' to 'to' when new settings is launched #NEW-SETTINGS */}`

Updated settings to go to new account/settings/notifications page instead of settings/account/notifications/alert.