### PR TITLE
Fixed Alert Rules Labels With Respect to 'Issue' vs 'Event'

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -91,7 +91,7 @@ class BaseEventFrequencyCondition(EventCondition):
 
 
 class EventFrequencyCondition(BaseEventFrequencyCondition):
-    label = 'An event is seen more than {value} times in {interval}'
+    label = 'An issue is seen more than {value} times in {interval}'
 
     def query(self, event, start, end, environment_id):
         return self.tsdb.get_sums(
@@ -104,7 +104,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
 
 
 class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
-    label = 'An event is seen by more than {value} users in {interval}'
+    label = 'An issue is seen by more than {value} users in {interval}'
 
     def query(self, event, start, end, environment_id):
         return self.tsdb.get_distinct_counts_totals(

--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -12,7 +12,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class FirstSeenEventCondition(EventCondition):
-    label = 'An event is first seen'
+    label = 'An issue is first seen'
 
     def passes(self, event, state):
         if self.rule.environment_id is None:

--- a/src/sentry/rules/conditions/regression_event.py
+++ b/src/sentry/rules/conditions/regression_event.py
@@ -12,7 +12,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class RegressionEventCondition(EventCondition):
-    label = 'An event changes state from resolved to unresolved'
+    label = 'An issue changes state from resolved to unresolved'
 
     def passes(self, event, state):
         return state.is_regression

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -162,7 +162,7 @@ class UpdateProjectRuleTest(APITestCase):
                       'interval': '1h',
                       'id': 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
                       'value': 666,
-                      'name': 'An event is seen more than 30 times in 1m'
+                      'name': 'An issue is seen more than 30 times in 1m'
                   }],
                   'id': rule.id,
                   'actions': [{
@@ -173,7 +173,7 @@ class UpdateProjectRuleTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data['conditions'][0]['name'] == 'An event is seen more than 666 times in 1h'
+        assert response.data['conditions'][0]['name'] == 'An issue is seen more than 666 times in 1h'
 
     def test_with_environment(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Fixes this [ticket](https://getsentry.atlassian.net/browse/APP-219?filter=myopenissues)
Before it was all just "event" and not using "issue" at all
![image](https://user-images.githubusercontent.com/10991288/40683714-2b05dc66-6344-11e8-9aa0-fd01484f3bad.png)
