### PR TITLE
fix(dashboard): Render project card without link if no access

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
@@ -44,7 +44,6 @@ class Dashboard extends React.Component {
     const teamSlugs = Object.keys(projectsByTeam).sort();
     const favorites = projects.filter(project => project.isBookmarked);
     const access = new Set(organization.access);
-    const hasTeamAccess = access.has('team:read');
     const teamsMap = new Map(teams.map(teamObj => [teamObj.slug, teamObj]));
 
     return (
@@ -57,6 +56,7 @@ class Dashboard extends React.Component {
             team={null}
             title={t('Bookmarked projects')}
             projects={favorites}
+            access={access}
           />
         )}
 
@@ -68,7 +68,6 @@ class Dashboard extends React.Component {
               <TeamSection
                 orgId={params.orgId}
                 team={team}
-                hasTeamAccess={hasTeamAccess}
                 showBorder={showBorder}
                 title={
                   <TeamLink to={`/settings/${organization.slug}/teams/${team.slug}/`}>
@@ -76,6 +75,7 @@ class Dashboard extends React.Component {
                   </TeamLink>
                 }
                 projects={projectsByTeam[slug]}
+                access={access}
               />
             </LazyLoad>
           );

--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
@@ -26,6 +26,7 @@ class ProjectCard extends React.Component {
   static propTypes = {
     project: SentryTypes.Project.isRequired,
     params: PropTypes.object,
+    hasProjectAccess: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -54,7 +55,7 @@ class ProjectCard extends React.Component {
   };
 
   render() {
-    const {project, params} = this.props;
+    const {project, hasProjectAccess, params} = this.props;
     const {firstEvent, isBookmarked, stats, slug} = project;
 
     const bookmarkText = isBookmarked
@@ -69,9 +70,15 @@ class ProjectCard extends React.Component {
               <Box ml={2}>
                 <StyledPlatformicon size="24" platform={project.platform || 'generic'} />
               </Box>
-              <StyledLink to={`/${params.orgId}/${slug}/`}>
-                <strong>{slug}</strong>
-              </StyledLink>
+              <StyledTitle>
+                {hasProjectAccess ? (
+                  <Link to={`/${params.orgId}/${slug}/`}>
+                    <strong>{slug}</strong>
+                  </Link>
+                ) : (
+                  <div>{slug}</div>
+                )}
+              </StyledTitle>
               <Tooltip title={bookmarkText}>
                 <Star
                   active={isBookmarked}
@@ -145,7 +152,7 @@ const ChartContainer = styled.div`
   padding-top: ${space(1)};
 `;
 
-const StyledLink = styled(Link)`
+const StyledTitle = styled.div`
   ${overflowEllipsis};
   padding: 16px 8px;
 `;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/teamSection.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/teamSection.jsx
@@ -14,13 +14,16 @@ class TeamSection extends React.Component {
     team: SentryTypes.Team,
     orgId: PropTypes.string,
     showBorder: PropTypes.bool,
-    hasTeamAccess: PropTypes.bool,
+    access: PropTypes.object,
     title: PropTypes.node,
     projects: PropTypes.array,
   };
 
   render() {
-    const {team, projects, title, showBorder, orgId, hasTeamAccess} = this.props;
+    const {team, projects, title, showBorder, orgId, access} = this.props;
+
+    const hasTeamAccess = access.has('team:read');
+    const hasProjectAccess = access.has('project:read');
 
     return (
       <TeamSectionWrapper data-test-id="team" showBorder={showBorder}>
@@ -34,6 +37,7 @@ class TeamSection extends React.Component {
               data-test-id={project.slug}
               key={project.slug}
               project={project}
+              hasProjectAccess={hasProjectAccess}
             />
           ))}
         </ProjectCards>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -113,31 +113,15 @@ exports[`ProjectCard renders 1`] = `
                       </div>
                     </Base>
                   </Box>
-                  <StyledLink
-                    to="/org-slug/project-slug/"
-                  >
-                    <Link
-                      className="css-1c2wmv-StyledLink efesc7i2"
-                      to="/org-slug/project-slug/"
+                  <StyledTitle>
+                    <div
+                      className="css-zq8dzg-StyledTitle efesc7i2"
                     >
-                      <Link
-                        className="css-1c2wmv-StyledLink efesc7i2"
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to="/org-slug/project-slug/"
-                      >
-                        <a
-                          className="css-1c2wmv-StyledLink efesc7i2"
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          <strong>
-                            project-slug
-                          </strong>
-                        </a>
-                      </Link>
-                    </Link>
-                  </StyledLink>
+                      <div>
+                        project-slug
+                      </div>
+                    </div>
+                  </StyledTitle>
                   <Tooltip
                     title="Add to bookmarks"
                   >


### PR DESCRIPTION
If the user does not have project:read access, render static text instead of a link
on the org dashboard project card

Fixes ISSUE-17