### PR TITLE
fix(snuba): Use `tags[sentry:user]` for `get_groups_user_counts`.

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -374,7 +374,7 @@ class SnubaTagStorage(TagStorage):
             'environment': [environment_id],
             'issue': group_ids,
         }
-        aggregations = [['uniq', 'user_id', 'count']]
+        aggregations = [['uniq', 'tags[sentry:user]', 'count']]
 
         result = snuba.query(start, end, ['issue'], None, filters, aggregations,
                              referrer='tagstore.get_groups_user_counts')

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -90,7 +90,7 @@ class TagStorage(TestCase):
             self.proj1env1.id,
         )
         tags = [r['key'] for r in result]
-        assert set(tags) == set(['foo', 'baz', 'environment', 'release'])
+        assert set(tags) == set(['foo', 'baz', 'environment', 'release', 'user'])
 
         result.sort(key=lambda r: r['key'])
         assert result[0]['key'] == 'baz'
@@ -151,12 +151,12 @@ class TagStorage(TestCase):
                 environment_id=self.proj1env1.id,
             )
         }
-        assert len(keys) == 4
-        assert set(keys) == set(['baz', 'environment', 'foo', 'sentry:release'])
+        assert set(keys) == set(['baz', 'environment', 'foo', 'sentry:release', 'sentry:user'])
         for k in keys.values():
-            if k.key != 'sentry:release':
+            if k.key not in set(['sentry:release', 'sentry:user']):
                 assert k.values_seen == 1, 'expected {!r} to have 1 unique value'.format(k.key)
-        assert keys['sentry:release'].values_seen == 2
+            else:
+                assert k.values_seen == 2
 
     def test_get_group_tag_value(self):
         with pytest.raises(GroupTagValueNotFound):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -53,6 +53,7 @@ class TagStorage(TestCase):
                     'baz': 'quux',
                     'environment': self.proj1env1.name,
                     'sentry:release': 100 * r,
+                    'sentry:user': "id:user{}".format(r),
                 },
                 'sentry.interfaces.User': {
                     'id': "user{}".format(r),
@@ -71,6 +72,7 @@ class TagStorage(TestCase):
                 'tags': {
                     'browser': 'chrome',
                     'environment': self.proj1env1.name,
+                    'sentry:user': "id:user1",
                 },
                 'sentry.interfaces.User': {
                     'id': "user1"


### PR DESCRIPTION
See GH-8546 for a similar issue in TSDB.

Reference/baseline implementation: https://github.com/getsentry/sentry/blob/e8f9ddd9bc2124babc4224db44b77f08ff765956/src/sentry/tagstore/legacy/backend.py#L498-L505