### PR TITLE
build(travis): Finishing Touches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,11 @@ script:
   - make travis-lint-$TEST_SUITE
   - make travis-test-$TEST_SUITE
   - make travis-scan-$TEST_SUITE
+  # installing codecov here ensures it gets cached in the virtualenv
+  # since after_success runs after travis `store build cache`
+  - pip install codecov
 
 after_success:
-  - pip install codecov
   - codecov -e TEST_SUITE
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ filter_secrets: false
 
 dist: trusty
 sudo: required
-group: deprecated-2017Q4
 language: python
 python: 2.7
 
 branches:
   only:
   - master
+  - build/finishing-touches
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,12 +110,12 @@ matrix:
         - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
       install:
+        - yarn install --pure-lockfile
         - pip install -e ".[dev,tests,optional]"
         - wget -N "http://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip" -P ~/
         - unzip ~/chromedriver_linux64.zip -d ~/
         - rm ~/chromedriver_linux64.zip
         - sudo install -m755 ~/chromedriver /usr/local/bin/
-        - yarn install --pure-lockfile
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -126,6 +126,7 @@ matrix:
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile
+        # TODO https://github.com/getsentry/sentry/issues/8451
         - pip install $(cat requirements*.txt | grep -E 'click|pycodestyle')
 
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-filter_secrets: false
-
 dist: trusty
 sudo: required
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ branches:
 cache:
   yarn: true
   directories:
-    - node_modules
     - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
-    - $HOME/google-cloud-sdk
+    - "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
+    - node_modules
+    - "${HOME}/google-cloud-sdk"
 
 addons:
   apt:
@@ -32,7 +33,7 @@ env:
     - SENTRY_SKIP_BACKEND_VALIDATION=1
     - SOUTH_TESTS_MIGRATE=1
     - DJANGO_VERSION=">=1.6.11,<1.7"
-    - NODE_VERSION="8.9.1"
+    # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
     - YARN_VERSION="1.3.2"
 
 script:
@@ -104,7 +105,7 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - nvm install "$NODE_VERSION"
+        - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - pip install -e ".[dev,tests,optional]"
@@ -119,7 +120,7 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=js
       before_install:
-        - nvm install "$NODE_VERSION"
+        - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile
@@ -189,8 +190,6 @@ matrix:
         - tar -xzf credentials.tar.gz
         # Use the decrypted service account credentials to authenticate the command line tool
         - gcloud auth activate-service-account --key-file client-secret.json
-        # Travis doesn't "inherit" steps like before_install in the build matrix, so we have to explicitly install our package managers
-        - nvm install "$NODE_VERSION"
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python: 2.7
 branches:
   only:
   - master
-  - build/finishing-touches
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,13 @@ after_failure:
 after_script:
   - npm install -g @zeus-ci/cli
   - zeus upload -t "text/xml+xunit" junit.xml
-  - zeus upload -t "text/xml+xunit" jest.junit.xml
-  - zeus upload -t "text/xml+coverage" coverage.xml
-  - zeus upload -t "text/xml+coverage" coverage/cobertura-coverage.xml
-  - zeus upload -t "text/html+pytest" pytest.html
-  - zeus upload -t "text/plain+pycodestyle" flake8.pycodestyle.log
-  - zeus upload -t "text/xml+checkstyle" eslint.checkstyle.xml
-  - zeus upload -t "application/webpack-stats+json" webpack-stats.json
+    -t "text/xml+xunit" jest.junit.xml
+    -t "text/xml+coverage" coverage.xml
+    -t "text/xml+coverage" coverage/cobertura-coverage.xml
+    -t "text/html+pytest" pytest.html
+    -t "text/plain+pycodestyle" flake8.pycodestyle.log
+    -t "text/xml+checkstyle" eslint.checkstyle.xml
+    -t "application/webpack-stats+json" webpack-stats.json
 
 # each job in the matrix inherits `env/global` and uses everything above,
 # but custom `services`, `before_install`, `install`, and `before_script` directives

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,10 @@ script:
   - make travis-lint-$TEST_SUITE
   - make travis-test-$TEST_SUITE
   - make travis-scan-$TEST_SUITE
-  # installing codecov here ensures it gets cached in the virtualenv
-  # since after_success runs after travis `store build cache`
+  # installing dependencies for after_* steps here ensures they get cached
+  # since those steps execute after travis runs `store build cache`
   - pip install codecov
+  - npm install -g @zeus-ci/cli
 
 after_success:
   - codecov -e TEST_SUITE
@@ -51,7 +52,6 @@ after_failure:
   - dmesg | tail -n 100
 
 after_script:
-  - npm install -g @zeus-ci/cli
   - zeus upload -t "text/xml+xunit" junit.xml
     -t "text/xml+xunit" jest.junit.xml
     -t "text/xml+coverage" coverage.xml

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ requests[security]>=2.18.4,<2.19.0
 selenium==3.11.0
 semaphore>=0.1.0,<0.2.0
 simplejson>=3.2.0,<3.9.0
-six>=1.10.0,<1.11.0
+six==1.11.0
 setproctitle>=1.1.7,<1.2.0
 statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7


### PR DESCRIPTION
Some finishing touches to the Travis config. The commit messages should be self-explanatory, but here's some elaboration:

* node is pinned by `.nvmrc` for real this time
* the pinned node has been added to cache, effectively caching pinned yarn and zeus cli as well, which saves around 10 seconds in total
* our builds work on the latest trusty image (its nice to upgrade)...
  * ...where the [preinstalled](https://docs.travis-ci.com/user/reference/trusty/#Pre-installed-pip-packages) `six` package appears to have been upgraded to 1.11.0, and our tests pass with that pinned, so I have pinned it in our requirements as well to avoid ContextualVersionConflicts.
* `filter_secrets` [is literally nowhere to be found in the modern travis documentation](https://github.com/travis-ci/docs-travis-ci-com/search?q=%22filter_secrets%22&unscoped_q=%22filter_secrets%22) and we don't need it anymore. Also it sounds scary @mattrobenolt , but turns out the function is harmless. Quoting @mitsuhiko in internal slack:

  > not sure if it still causes an issue but when we did not disable it, build would get stuck because travis' log parser did not have a large enough buffer size ... so if lots of stuff was printed it died with sigpipe