### PR TITLE
docs: Update help text for reprocessing

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -417,9 +417,9 @@ const ProjectProcessingIssues = createReactClass({
             `
           For some platforms the event processing requires configuration or
           manual action.  If a misconfiguration happens or some necessary
-          steps are skipped issues can occur during processing.  In these
-          cases you can see all the problems here with guides of how to correct
-          them.
+          steps are skipped, issues can occur during processing. (The most common
+          reason for this is missing debug symbols.) In these cases you can see
+          all the problems here with guides of how to correct them.
         `
           )}
         </TextBlock>


### PR DESCRIPTION
Add a sentence explaining that reprocessing most commonly (right now only)
happens because of missing debug symbols, per
https://getsentry.atlassian.net/browse/SE-31 .