### PR TITLE
fix(tests): Don't assume local Postgres is accessible over Unix socket

### DIFF
--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -51,6 +51,7 @@ def pytest_configure(config):
                     'ENGINE': 'sentry.db.postgres',
                     'USER': 'postgres',
                     'NAME': 'sentry',
+                    'HOST': '127.0.0.1',
                 }
             )
             # postgres requires running full migration all the time


### PR DESCRIPTION
This should be no change in behavior for anyone that does use a unix
socket, since it should also be bound to 127.0.0.1. But for those of us
that do not have a unix socket, it should make tests actually work.