### PR TITLE
fix(api): Avoid doing extra/invalid queries in OrganizationUserIssuesSearchEndpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_user_issues_search.py
+++ b/src/sentry/api/endpoints/organization_user_issues_search.py
@@ -30,18 +30,21 @@ class OrganizationUserIssuesSearchEndpoint(OrganizationEndpoint, EnvironmentMixi
             ).values_list('id', flat=True)[:1000]
         )
 
-        event_users = EventUser.objects.filter(
+        event_users = list(EventUser.objects.filter(
             email=email,
             project_id__in=project_ids,
-        )[:1000]
+        )[:1000])
 
-        project_ids = list(set([e.project_id for e in event_users]))
-
-        group_ids = tagstore.get_group_ids_for_users(project_ids, event_users, limit=limit)
-
-        groups = Group.objects.filter(
-            id__in=group_ids,
-        ).order_by('-last_seen')[:limit]
+        if event_users:
+            groups = Group.objects.filter(
+                id__in=tagstore.get_group_ids_for_users(
+                    project_ids=list(set([e.project_id for e in event_users])),
+                    event_users=event_users,
+                    limit=limit,
+                ),
+            ).order_by('-last_seen')[:limit]
+        else:
+            groups = []
 
         context = serialize(list(groups), request.user, GroupSerializer(
             environment_func=self._get_environment_func(


### PR DESCRIPTION
`tagstore.get_group_ids_for_users` is often being called with `{'event_users': [], 'limit': u'6', 'project_ids': []}` which doesn't return any results under legacy or v2 tagstore and fails under snuba due to the lack of project qualifiers.