### PR TITLE
ref(integrations): Add error messaging github apps

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -15,21 +15,7 @@ from sentry.pipeline import PipelineProvider
 from .exceptions import (
     ApiHostError, ApiError, ApiUnauthorized, IntegrationError, UnsupportedResponseType
 )
-
-
-ERR_INTERNAL = (
-    'An internal error occurred with the integration and the Sentry team has'
-    ' been notified'
-)
-
-ERR_UNAUTHORIZED = (
-    'Unauthorized: either your access token was invalid or you do not have'
-    ' access'
-)
-
-ERR_UNSUPPORTED_RESPONSE_TYPE = (
-    'An unsupported response type was returned: {content_type}'
-)
+from .constants import ERR_UNAUTHORIZED, ERR_INTERNAL, ERR_UNSUPPORTED_RESPONSE_TYPE
 
 IntegrationMetadata = namedtuple('IntegrationMetadata', [
     'description',  # A markdown description of the integration
@@ -187,6 +173,9 @@ class Integration(object):
     def get_client(self):
         # Return the api client for a given provider
         raise NotImplementedError
+
+    def error_message_from_json(self, data):
+        return data.get('message', 'unknown error')
 
     def message_from_error(self, exc):
         if isinstance(exc, ApiUnauthorized):

--- a/src/sentry/integrations/constants.py
+++ b/src/sentry/integrations/constants.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+
+ERR_INTERNAL = (
+    'An internal error occurred with the integration and the Sentry team has'
+    ' been notified'
+)
+
+ERR_UNAUTHORIZED = (
+    'Unauthorized: either your access token was invalid or you do not have'
+    ' access'
+)
+
+ERR_UNSUPPORTED_RESPONSE_TYPE = (
+    'An unsupported response type was returned: {content_type}'
+)

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -60,7 +60,7 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
             try:
                 repo = client.get_repo(config['name'])
             except Exception as e:
-                self.raise_error(e)
+                installation.raise_error(e)
             else:
                 config['external_id'] = six.text_type(repo['id'])
                 config['integration_id'] = integration.id


### PR DESCRIPTION
* Removes the `ProviderMixin` from the `IntegrationRepositoryProvider`.
* Adds in the `handle_api_error`. 
* Customizes the error message for `GitHubIntegration`

![screen shot 2018-05-30 at 4 59 47 pm](https://user-images.githubusercontent.com/15368179/40754154-9d88a690-642c-11e8-9cd9-539dd9b9fd49.png)
