### PR TITLE
build(travis): travis cache and nvm install hotfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,11 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"/n*
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin" || true
         - which npm || true
         - nvm install
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"
+        - which npm || true
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile
@@ -124,9 +126,11 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=js
       before_install:
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"/n*
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin" || true
         - which npm || true
         - nvm install
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"
+        - which npm || true
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python: 2.7
 branches:
   only:
   - master
+  - build/nvm-hotfix
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python: 2.7
 branches:
   only:
   - master
-  - build/nvm-hotfix
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,10 +107,10 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin" || true
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)" || true
         - which npm || true
         - nvm install
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
         - which npm || true
         - npm install -g "yarn@${YARN_VERSION}"
       install:
@@ -126,10 +126,10 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=js
       before_install:
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin" || true
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)" || true
         - which npm || true
         - nvm install
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
         - which npm || true
         - npm install -g "yarn@${YARN_VERSION}"
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   yarn: true
   directories:
     - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
-    - "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
+    - "$NODE_DIR"
     - node_modules
     - "${HOME}/google-cloud-sdk"
 
@@ -33,8 +33,8 @@ env:
     - SOUTH_TESTS_MIGRATE=1
     - DJANGO_VERSION=">=1.6.11,<1.7"
     # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
+    - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - YARN_VERSION="1.3.2"
-    - PATH="${PATH}:${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"
 
 script:
   - make travis-lint-$TEST_SUITE
@@ -107,11 +107,8 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)" || true
-        - which npm || true
+        - find "$NODE_DIR" -type d -empty -delete
         - nvm install
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
-        - which npm || true
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile
@@ -126,11 +123,8 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=js
       before_install:
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)" || true
-        - which npm || true
+        - find "$NODE_DIR" -type d -empty -delete
         - nvm install
-        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
-        - which npm || true
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   yarn: true
   directories:
     - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
-    - "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
+    - "${HOME}/.nvm/versions/node/v${NODE_VERSION}"
     - node_modules
     - "${HOME}/google-cloud-sdk"
 
@@ -32,7 +32,7 @@ env:
     - SENTRY_SKIP_BACKEND_VALIDATION=1
     - SOUTH_TESTS_MIGRATE=1
     - DJANGO_VERSION=">=1.6.11,<1.7"
-    # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
+    - NODE_VERSION="$(< .nvmrc)"
     - YARN_VERSION="1.3.2"
 
 script:
@@ -106,7 +106,7 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - nvm install
+        - nvm install "$NODE_VERSION"
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile
@@ -121,7 +121,7 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=js
       before_install:
-        - nvm install
+        - nvm install "$NODE_VERSION"
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   yarn: true
   directories:
     - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
-    - "${HOME}/.nvm/versions/node/v${NODE_VERSION}"
+    - "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - node_modules
     - "${HOME}/google-cloud-sdk"
 
@@ -32,8 +32,9 @@ env:
     - SENTRY_SKIP_BACKEND_VALIDATION=1
     - SOUTH_TESTS_MIGRATE=1
     - DJANGO_VERSION=">=1.6.11,<1.7"
-    - NODE_VERSION="$(< .nvmrc)"
+    # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
     - YARN_VERSION="1.3.2"
+    - PATH="${PATH}:${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"
 
 script:
   - make travis-lint-$TEST_SUITE
@@ -106,7 +107,9 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - nvm install "$NODE_VERSION"
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"/n*
+        - which npm || true
+        - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile
@@ -121,7 +124,9 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=js
       before_install:
-        - nvm install "$NODE_VERSION"
+        - ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)/bin"/n*
+        - which npm || true
+        - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
       install:
         - yarn install --pure-lockfile


### PR DESCRIPTION
Well, this is interesting. The nvm/node-related changes introduced in #8617 made master fail when merged (but not in the PR). This seems to be a combination of issues with travis cache purging and nvm doing poor version presence checking.

What's happening is with travis uncached `"${HOME}/.nvm/versions/node/v$(< .nvmrc)"`:

```
$ nvm install
v8.9.1 is already installed.
Now using node v8.9.1
```

Notice how `(npm v...)` is not present. That comes from this:

```
nvm_print_npm_version () {
	if nvm_has "npm"
	then
		command printf " (npm v$(npm --version 2>/dev/null))"
	fi
}
```

`npm_has` is just `type "${1-}" > /dev/null 2>&1`. So `npm` isn't there, which is correct, since travis cache is empty. Or is it?

Why would `nvm install` report 8.9.1 (from our `.nvmrc`) already installed?

```
nvm_is_version_installed () {
	[ -n "${1-}" ] && [ -d "$(nvm_version_path "${1-}" 2> /dev/null)" ]
}
```

It's just a directory exist check. But it's empty: 

```
$ nvm install
Found '/home/travis/build/getsentry/sentry/.nvmrc' with version <8.9.1>
v8.9.1 is already installed.
Now using node v8.9.1
$ ls -lah "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
total 8.0K
drwxrwxr-x 2 travis travis 4.0K May 31 21:41 .
drwxr-xr-x 5 travis travis 4.0K May 31 21:41 ..
```

And `nvm` isn't warning against this. Instead it happily reports `node` is installed and doesn't do anything else. It _should_ be checking for an executable `${HOME}/.nvm/versions/node/v8.9.1/bin/node` instead.

Clearing the cache should in theory remove the entire `"${HOME}/.nvm/versions/node/v$(< .nvmrc)"`. But despite purging travis cache via the web UI, this empty folder still persists.

**The temporary hotfix is to remove that dir if it's empty so `nvm install` can populate the cache.**

If `nvm install` is changed so that it better detects the presence of a node version as suggested above, then we don't need this hotfix.