### PR TITLE
fix(integrations): Reparent identity on install

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -96,10 +96,13 @@ class IntegrationPipeline(Pipeline):
                 )
             except IntegrityError:
                 # If the external_id is already used for a different user or
-                # the user already has a different external_id, reparent it
+                # the user already has a different external_id remove those
+                # identities and recreate it.
                 lookup = Q(external_id=identity['external_id']) | Q(user=self.request.user)
+                Identity.objects.filter(lookup, idp=idp).delete()
 
-                Identity.objects.filter(lookup, idp=idp).update(
+                Identity.objects.create(
+                    idp=idp,
                     user=self.request.user,
                     external_id=identity['external_id'],
                     **identity_data

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -129,3 +129,13 @@ class SlackIntegrationTest(IntegrationTestCase):
         assert identities.count() == 2
         assert identities[0].external_id != identities[1].external_id
         assert identities[0].idp != identities[1].idp
+
+    @responses.activate
+    def test_reassign_user(self):
+        self.assert_setup_flow()
+        identity = Identity.objects.get()
+        assert identity.external_id == 'UXXXXXXX1'
+
+        self.assert_setup_flow(authorizing_user_id='UXXXXXXX2')
+        identity = Identity.objects.get()
+        assert identity.external_id == 'UXXXXXXX2'


### PR DESCRIPTION
When installing an integration, if an identity was already linked to the identity provider for the user or external ID of the installer, the integration would fail to install. This corrects that by simply reparenting the identity to that user + external_id

Fixes [SENTRY-6J3](https://sentry.io/sentry/sentry/issues/540779618/)