### PR TITLE
fix(api): Cast limit to int in `OrganizationUserIssuesSearchEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/organization_user_issues_search.py
+++ b/src/sentry/api/endpoints/organization_user_issues_search.py
@@ -17,7 +17,7 @@ class OrganizationUserIssuesSearchEndpoint(OrganizationEndpoint, EnvironmentMixi
         if email is None:
             return Response(status=400)
 
-        limit = request.GET.get('limit', 100)
+        limit = int(request.GET.get('limit', 100))
 
         # limit to only teams user has opted into
         project_ids = list(


### PR DESCRIPTION
Snuba doesn't like it when you do things that don't make sense, so make this make more sense