### PR TITLE
fix(integrations): Add empty state for external issue dropdown

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssues.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssues.jsx
@@ -169,11 +169,19 @@ class ExternalIssueActionList extends AsyncComponent {
     });
   };
 
+  renderEmpty() {
+    // TODO(jess): This should link to org integrations page
+    return <MenuItem>{t('No integrations configured')}</MenuItem>;
+  }
+
   renderBody() {
-    let {selectedIntegration, action} = this.state;
+    let {action, selectedIntegration, integrations} = this.state;
+    if (!integrations || !integrations.length) {
+      return this.renderEmpty();
+    }
     return (
       <React.Fragment>
-        {this.state.integrations.map(integration => {
+        {integrations.map(integration => {
           return (
             <React.Fragment key={integration.id}>
               <MenuItem noAnchor={true}>

--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -306,6 +306,7 @@ const GroupDetailsActions = createReactClass({
               href={`/${this.getOrganization().slug}/${this.getProject()
                 .slug}/settings/issue-tracking/`}
               className={'btn btn-default btn-sm btn-config-issue-tracking'}
+              style={{marginRight: '5px'}}
             >
               {t('Link Issue Tracker')}
             </a>

--- a/tests/js/spec/views/groupDetails/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/actions.spec.jsx.snap
@@ -104,6 +104,11 @@ exports[`GroupActions render() renders correctly 1`] = `
     <a
       className="btn btn-default btn-sm btn-config-issue-tracking"
       href="/org/project/settings/issue-tracking/"
+      style={
+        Object {
+          "marginRight": "5px",
+        }
+      }
     >
       Link Issue Tracker
     </a>


### PR DESCRIPTION
We're going to change the UI for this based on some designs from Chrissy, so just did a super simple solution for now.

<img width="403" alt="screenshot 2018-06-05 12 36 32" src="https://user-images.githubusercontent.com/5026776/40998717-78181202-68bd-11e8-9cc2-7ba95c845f05.png">
