### PR TITLE
fix(snuba): Add limits to Search related DB queries

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -283,7 +283,7 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
             # pre-filtered candidates were *not* passed down to Snuba,
             # so we need to do post-filtering to verify Sentry DB predicates
             result_groups = []
-            for i, chunk in enumerate(chunked(snuba_groups.items(), MAX_POST_SNUBA_CHUNK)):
+            for i, chunk in enumerate(chunked(snuba_groups.items(), MAX_POST_SNUBA_CHUNK), 1):
                 filtered_group_ids = group_queryset.filter(
                     id__in=[gid for gid, _ in chunk]
                 ).values_list('id', flat=True)
@@ -293,7 +293,7 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                     for group_id in filtered_group_ids
                 )
 
-            metrics.timing('snuba.search.num_post_filters', i + 1)
+            metrics.timing('snuba.search.num_post_filters', i)
 
         paginator_results = SequencePaginator(
             [(score, id) for (id, score) in result_groups],

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -23,8 +23,8 @@ logger = logging.getLogger('sentry.search.snuba')
 datetime_format = '%Y-%m-%dT%H:%M:%S+00:00'
 
 
-MAX_PRE_SNUBA_CANDIDATES = 0
-MAX_POST_SNUBA_CHUNK = 1000
+MAX_PRE_SNUBA_CANDIDATES = 500
+MAX_POST_SNUBA_CHUNK = 10000
 
 
 # TODO: Would be nice if this was handled in the Snuba abstraction, but that
@@ -288,10 +288,6 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                     (group_id, snuba_groups[group_id])
                     for group_id in filtered_group_ids
                 )
-
-                # TODO: Reconcile this with Pagination, maybe pass a generator down instead?
-                # if len(result_groups) >= limit:
-                #     break
 
         paginator_results = SequencePaginator(
             [(score, id) for (id, score) in result_groups],

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -285,7 +285,7 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
             result_groups = []
             for i, chunk in enumerate(chunked(snuba_groups.items(), MAX_POST_SNUBA_CHUNK)):
                 filtered_group_ids = group_queryset.filter(
-                    id__in=list(gid for gid, _ in chunk)
+                    id__in=[gid for gid, _ in chunk]
                 ).values_list('id', flat=True)
 
                 result_groups.extend(

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -239,7 +239,7 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                 'hash', 'group_id'
             )[:MAX_PRE_SNUBA_CANDIDATES + 1]
         )
-        metrics.incr('snuba.search.num_candidates', len(candidate_hashes))
+        metrics.timing('snuba.search.num_candidates', len(candidate_hashes))
 
         if not candidate_hashes:
             # no matches could possibly be found from this point on
@@ -273,7 +273,7 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
             candidate_hashes=candidate_hashes,
             **parameters
         )
-        metrics.incr('snuba.search.num_snuba_results', len(snuba_groups))
+        metrics.timing('snuba.search.num_snuba_results', len(snuba_groups))
 
         if candidate_hashes:
             # pre-filtered candidates were passed down to Snuba,
@@ -293,7 +293,7 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                     for group_id in filtered_group_ids
                 )
 
-            metrics.incr('snuba.search.num_post_filters', i + 1)
+            metrics.timing('snuba.search.num_post_filters', i + 1)
 
         paginator_results = SequencePaginator(
             [(score, id) for (id, score) in result_groups],

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -790,7 +790,6 @@ class SnubaSearchTest(SnubaTestCase):
             'referrer': 'search',
             'groupby': ['primary_hash'],
             'conditions': [],
-            'limit': Any(int),
         }
 
         self.backend.query(self.project, query='foo')

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -835,3 +835,29 @@ class SnubaSearchTest(SnubaTestCase):
             having=[('first_seen', '>=', Any(int))],
             **common_args
         )
+
+    def test_pre_and_post_filtering(self):
+        from sentry.search.snuba import backend as snuba_search
+
+        prev_max_pre = snuba_search.MAX_PRE_SNUBA_CANDIDATES
+        prev_max_post = snuba_search.MAX_POST_SNUBA_CHUNK
+
+        snuba_search.MAX_PRE_SNUBA_CANDIDATES = 1
+        snuba_search.MAX_POST_SNUBA_CHUNK = 1
+        try:
+            # normal queries work as expected
+            results = self.backend.query(self.project, query='foo')
+            assert set(results) == set([self.group1])
+            results = self.backend.query(self.project, query='bar')
+            assert set(results) == set([self.group2])
+
+            # no candidate matches in Sentry, immediately return empty paginator
+            results = self.backend.query(self.project, query='NO MATCHES IN SENTRY')
+            assert set(results) == set()
+
+            # too many candidates, skip pre-filter, requires >1 postfilter queries
+            results = self.backend.query(self.project)
+            assert set(results) == set([self.group1, self.group2])
+        finally:
+            snuba_search.MAX_PRE_SNUBA_CANDIDATES = prev_max_pre
+            snuba_search.MAX_POST_SNUBA_CHUNK = prev_max_post


### PR DESCRIPTION
* Limits number of candidate hashes returned from Sentry (and thus also sent down to Snuba)
* Previously: queried Groups, then GroupHash. Now: combined into one query for GroupHash
* Previously: always queried GroupHash for Snuba results. Now: re-use GroupHash data (avoiding a query) if we sent down candidate hashes
* If more than the limit of hashes are returned from Sentry, they are thrown away and instead we do post filtering of Groups that come back from Snuba
* Generally cleaned up the Snuba search code function, return an OrderedDict of `{group_id: score, ...}` now for sanity
* If post filtering is required (too many candidates in the first step) it is done in batches so that the query size/time against Sentry is at least bounded

Fixes SNS-97