### PR TITLE
feat(api): Include group/event for short/event id queries

### DIFF
--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -6,8 +6,9 @@ from rest_framework.response import Response
 
 from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.models import Project, Event, EventMapping
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.models import Project, Event, EventMapping
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -76,6 +77,10 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
                 'organizationSlug': organization.slug,
                 'projectSlug': project_slugs_by_id[event.project_id],
                 'groupId': six.text_type(event.group_id),
-                'eventId': six.text_type(event.id)
+                'eventId': six.text_type(event.id),
+                'event': serialize(
+                    event,
+                    request.user,
+                ),
             }
         )

--- a/src/sentry/api/endpoints/organization_shortid.py
+++ b/src/sentry/api/endpoints/organization_shortid.py
@@ -6,8 +6,9 @@ from rest_framework.response import Response
 
 from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.models import Group
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.models import Group
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -46,6 +47,10 @@ class ShortIdLookupEndpoint(OrganizationEndpoint):
                 'organizationSlug': organization.slug,
                 'projectSlug': group.project.slug,
                 'groupId': six.text_type(group.id),
+                'group': serialize(
+                    group,
+                    request.user,
+                ),
                 'shortId': group.qualified_short_id,
             }
         )

--- a/tests/sentry/api/endpoints/test_organization_eventid.py
+++ b/tests/sentry/api/endpoints/test_organization_eventid.py
@@ -29,6 +29,7 @@ class EventIdLookupEndpointTest(APITestCase):
         assert response.data['projectSlug'] == self.project.slug
         assert response.data['groupId'] == six.text_type(self.group.id)
         assert response.data['eventId'] == six.text_type(self.event.id)
+        assert response.data['event']['id'] == six.text_type(self.event.id)
 
     def test_missing_eventid(self):
         url = reverse(

--- a/tests/sentry/api/endpoints/test_organization_shortid.py
+++ b/tests/sentry/api/endpoints/test_organization_shortid.py
@@ -26,3 +26,4 @@ class ShortIdLookupEndpointTest(APITestCase):
         assert response.data['organizationSlug'] == org.slug
         assert response.data['projectSlug'] == project.slug
         assert response.data['groupId'] == six.text_type(group.id)
+        assert response.data['group']['id'] == six.text_type(group.id)


### PR DESCRIPTION
Include group for shortid queries and event for eventid queries. Note eventid queries are not guaranteed to have an event.