### PR TITLE
fix(ui): Fix Context Picker modal overflow

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/navigation.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/navigation.jsx
@@ -10,19 +10,24 @@ export function navigateTo(to, router) {
   let needProject = to.indexOf(':projectId') > -1;
 
   if (needOrg || needProject) {
-    openModal(({closeModal, Header, Body}) => (
-      <ContextPickerModal
-        Header={Header}
-        Body={Body}
-        nextPath={to}
-        needOrg={needOrg}
-        needProject={needProject}
-        onFinish={path => {
-          closeModal();
-          router.push(path);
-        }}
-      />
-    ));
+    openModal(
+      ({closeModal, Header, Body}) => (
+        <ContextPickerModal
+          Header={Header}
+          Body={Body}
+          nextPath={to}
+          needOrg={needOrg}
+          needProject={needProject}
+          onFinish={path => {
+            closeModal();
+            router.push(path);
+          }}
+        />
+      ),
+      {
+        modalClassName: 'context-picker-modal',
+      }
+    );
   } else {
     router.push(to);
   }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2776,6 +2776,12 @@ ul.radio-inputs {
   }
 }
 
+.context-picker-modal.modal {
+  .modal-content {
+    overflow: visible;
+  }
+}
+
 // Broadcast Modal
 
 .modal-broadcast {


### PR DESCRIPTION
Currently the Context Picker Modal body has `overflow: hidden`, it can hide `react-select` dropdowns.