### PR TITLE
fix: Alert Rules Conditions and Actions

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -57,7 +57,8 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             data=request.DATA,
             partial=True
         )
-        if request.DATA['conditions'] == []:
+
+        if request.DATA['conditions'] == [] or request.DATA['actions'] == []:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         if serializer.is_valid():

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -59,7 +59,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
         )
 
         if request.DATA['conditions'] == [] or request.DATA['actions'] == []:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         if serializer.is_valid():
             rule = serializer.save(rule=rule)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -58,9 +58,6 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             partial=True
         )
 
-        if request.DATA['conditions'] == [] or request.DATA['actions'] == []:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
-
         if serializer.is_valid():
             rule = serializer.save(rule=rule)
             self.create_audit_entry(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -57,6 +57,8 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             data=request.DATA,
             partial=True
         )
+        if request.DATA['conditions'] == []:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         if serializer.is_valid():
             rule = serializer.save(rule=rule)

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -89,13 +89,15 @@ class RuleSerializer(serializers.Serializer):
         return attrs
 
     def validate_conditions(self, attrs, source):
-        if attrs['conditions'] == []:
+        name = attrs.get(source)
+        if not name:
             raise serializers.ValidationError(u'Must select a condition')
 
         return attrs
 
     def validate_actions(self, attrs, source):
-        if attrs['actions'] == []:
+        name = attrs.get(source)
+        if not name:
             raise serializers.ValidationError(u'Must select an action')
 
         return attrs

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -88,6 +88,18 @@ class RuleSerializer(serializers.Serializer):
 
         return attrs
 
+    def validate_conditions(self, attrs, source):
+        if attrs['conditions'] == []:
+            raise serializers.ValidationError(u'Must select a condition')
+
+        return attrs
+
+    def validate_actions(self, attrs, source):
+        if attrs['actions'] == []:
+            raise serializers.ValidationError(u'Must select an action')
+
+        return attrs
+
     def save(self, rule):
         rule.project = self.context['project']
         if 'environment' in self.data:


### PR DESCRIPTION
Users are notified with a 400 error when they are missing a condition or action when updating their alert rules.

https://getsentry.atlassian.net/browse/SE-54