### PR TITLE
fix(snuba): Ignore legacy (non-MD5) hashes

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -12,6 +12,7 @@ import urllib3
 from django.conf import settings
 from django.db.models import Q
 
+from sentry.event_manager import HASH_RE
 from sentry.models import Group, GroupHash, GroupHashTombstone, Environment, Release, ReleaseProject
 from sentry.utils import metrics
 from sentry.utils.dates import to_timestamp
@@ -226,7 +227,7 @@ def get_project_issues(project_ids, issue_ids=None):
     else:
         hashes = GroupHash.objects.filter(project__in=project_ids)
 
-    hashes = list(hashes)
+    hashes = [h for h in hashes if HASH_RE.match(h.hash)]
     if not hashes:
         return []
 

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -47,6 +47,19 @@ class SnubaTest(SnubaTestCase):
                 groupby=[")("],
             )
 
+    def test_project_issues_with_legacy_hash(self):
+        a_hash = 'a' * 32
+
+        for h in [a_hash, 'A' * 8]:
+            GroupHash.objects.create(
+                project=self.project,
+                group=self.group,
+                hash=h,
+            )
+
+        assert snuba.get_project_issues([self.project], [self.group.id]) == \
+            [(self.group.id, [('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', None)])]
+
     def test_project_issues_with_tombstones(self):
         base_time = datetime.utcnow()
         a_hash = 'a' * 32


### PR DESCRIPTION
These have been written as MD5 hashes since https://github.com/getsentry/sentry/commit/9373db79b968afac80d975579c1f4dcd5c640600, so the non-MD5 form can be ignored.

Fixes SNS-99.