### PR TITLE
feat(ui): Use FormFields without wrapping in Form

### DIFF
--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -17,6 +17,7 @@ import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlide
 import Form from 'app/views/settings/components/forms/form';
 import FormField from 'app/views/settings/components/forms/formField';
 import TextField from 'app/views/settings/components/forms/textField';
+import Switch from 'app/components/switch';
 
 class UndoButton extends React.Component {
   static contextTypes = {
@@ -185,4 +186,35 @@ storiesOf('Forms/Fields/New', module)
         />
       </div>
     ))
+  )
+  .add(
+    'Without a parent Form',
+    withInfo('New form fields used withing having a parent Form')(() => {
+      return (
+        <div>
+          <TextField
+            name="simpletextfield"
+            label="Simple Text Field"
+            placeholder="Simple Text Field"
+            onChange={action('TextField onChange')}
+          />
+          <NewBooleanField
+            name="field"
+            label="New Boolean Field"
+            onChange={action('BooleanField onChange')}
+          />
+          <RadioField
+            name="radio"
+            label="Radio Field"
+            onChange={action('RadioField onChange')}
+            choices={[
+              ['choice_one', 'Choice One'],
+              ['choice_two', 'Choice Two'],
+              ['choice_three', 'Choice Three'],
+            ]}
+          />
+          <Switch id="test" />
+        </div>
+      );
+    })
   );

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -134,6 +134,31 @@ class ControlState extends React.Component {
   }
 }
 
+// MockedModel that returns values from props
+// Disables a lot of functionality but allows you to use fields
+// without wrapping them in a Form
+class MockModel {
+  constructor(props) {
+    this.props = props;
+
+    this.initialData = {
+      [props.name]: props.value,
+    };
+  }
+  setValue() {}
+  setFieldDescriptor() {}
+  handleBlurField() {}
+  getValue() {
+    return this.props.value;
+  }
+  getError() {
+    return this.props.error;
+  }
+  getFieldState() {
+    return false;
+  }
+}
+
 class FormField extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
@@ -203,7 +228,7 @@ class FormField extends React.Component {
 
   getModel() {
     if (this.context.form === undefined) {
-      throw new Error('Make sure to wrap your fields into <Form/>');
+      return new MockModel(this.props);
     }
     return this.context.form;
   }


### PR DESCRIPTION
So we can use new Form Fields without having a parent `Form`