### PR TITLE
feat(ui): Use SelectControl in Context Picker Modal

### DIFF
--- a/src/sentry/static/sentry/app/components/globalModal.jsx
+++ b/src/sentry/static/sentry/app/components/globalModal.jsx
@@ -38,6 +38,12 @@ class GlobalModal extends React.Component {
       options.onClose();
     }
 
+    // Focus this to get hotkeys to keep working
+    let containerEl = document.querySelector('.main-container');
+    if (containerEl) {
+      containerEl.focus();
+    }
+
     // Action creator
     closeModal();
   };

--- a/src/sentry/static/sentry/app/components/globalModal.jsx
+++ b/src/sentry/static/sentry/app/components/globalModal.jsx
@@ -24,6 +24,13 @@ class GlobalModal extends React.Component {
       modalClassName: PropTypes.string,
     }),
     visible: PropTypes.bool,
+    /**
+     * Note this is the callback for the main App container and
+     * NOT the calling component.  GlobalModal is never used directly,
+     * but is controlled via stores. To access the onClose callback from
+     * the component, you must specify it when using the action creator.
+     */
+    onClose: PropTypes.func,
   };
 
   static defaultProps = {
@@ -32,20 +39,20 @@ class GlobalModal extends React.Component {
   };
 
   handleCloseModal = () => {
-    let {options} = this.props;
+    let {options, onClose} = this.props;
 
+    // onClose callback for calling component
     if (typeof options.onClose === 'function') {
       options.onClose();
     }
 
-    // Focus this to get hotkeys to keep working
-    let containerEl = document.querySelector('.main-container');
-    if (containerEl) {
-      containerEl.focus();
-    }
-
     // Action creator
     closeModal();
+
+    // Read description in propTypes
+    if (typeof onClose === 'function') {
+      onClose();
+    }
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -161,6 +161,14 @@ const App = createReactClass({
     });
   },
 
+  handleGlobalModalClose() {
+    if (!this.mainContainerRef) return;
+    if (typeof this.mainContainerRef.focus !== 'function') return;
+
+    // Focus the main container to get hotkeys to keep working after modal closes
+    this.mainContainerRef.focus();
+  },
+
   renderBody() {
     let {needsUpgrade, newsletterConsentPrompt} = this.state;
     if (needsUpgrade) {
@@ -185,8 +193,12 @@ const App = createReactClass({
 
     return (
       <ThemeProvider theme={theme}>
-        <div className="main-container" tabIndex="-1">
-          <GlobalModal />
+        <div
+          className="main-container"
+          tabIndex="-1"
+          ref={ref => (this.mainContainerRef = ref)}
+        >
+          <GlobalModal onClose={this.handleGlobalModalClose} />
           <Alerts className="messages-container" />
           <Indicators className="indicators-container" />
           <ErrorBoundary>{this.renderBody()}</ErrorBoundary>


### PR DESCRIPTION
Use new SelectControl in Context Picker Modal.
Fix hot keys not working after closing modal.

![image](https://user-images.githubusercontent.com/79684/41126367-21eba7fe-6a5c-11e8-914b-0ffcaf5909f7.png)
