### PR TITLE
feat(2fa): Unblock require 2fa across organization

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -125,7 +125,7 @@ class OrganizationSerializer(serializers.Serializer):
         has_2fa = Authenticator.objects.user_has_2fa(user)
         if value and not has_2fa:
             raise serializers.ValidationError(
-                'Cannot require two-factor authentication without two-factor enabled.')
+                'Cannot require two-factor authentication without personal two-factor enabled.')
         return attrs
 
     def validate(self, attrs):

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -125,7 +125,7 @@ class OrganizationSerializer(serializers.Serializer):
         has_2fa = Authenticator.objects.user_has_2fa(user)
         if value and not has_2fa:
             raise serializers.ValidationError(
-                'User setting two-factor authentication enforcement without two-factor authentication enabled.')
+                'Cannot require two-factor authentication without two-factor enabled.')
         return attrs
 
     def validate(self, attrs):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -50,6 +50,7 @@ class OrganizationSerializer(Serializer):
             'name': obj.name or obj.slug,
             'dateCreated': obj.date_added,
             'isEarlyAdopter': bool(obj.flags.early_adopter),
+            'require2FA': bool(obj.flags.require_2fa),
             'avatar': avatar,
         }
 

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -375,7 +375,7 @@ class Organization(Model):
             if not Authenticator.objects.user_has_2fa(user):
                 context = {
                     'user': user,
-                    'url': absolute_uri(reverse('sentry-account-settings-2fa')),
+                    'url': absolute_uri(reverse('sentry-account-settings-security')),
                     'organization': self
                 }
                 message = MessageBuilder(

--- a/src/sentry/static/sentry/app/components/modals/recoveryOptionsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/recoveryOptionsModal.jsx
@@ -47,12 +47,12 @@ class RecoveryOptionsModal extends AsyncComponent {
     return (
       <React.Fragment>
         <Header closeButton onHide={closeModal}>
-          {t('Two Factor Authentication Enabled')}
+          {t('Two-Factor Authentication Enabled')}
         </Header>
 
         <Body>
           <TextBlock>
-            {t(`Two factor authentication via ${authenticatorName} has been enabled.`)}
+            {t(`Two-factor authentication via ${authenticatorName} has been enabled.`)}
           </TextBlock>
           <TextBlock>
             {t('You should now set up recovery options to secure your account.')}
@@ -68,7 +68,7 @@ class RecoveryOptionsModal extends AsyncComponent {
             <Alert type="warning">
               {t(
                 `Recovery codes are the only way to access your account if you lose
-                  your device and cannot receive two factor authentication codes.`
+                  your device and cannot receive two-factor authentication codes.`
               )}
             </Alert>
           )}

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
@@ -31,13 +31,21 @@ class TwoFactorRequired extends AsyncComponent {
     return (
       <div>
         {multipleOrgs ? (
-          <StyledAlert type="error" icon="icon-circle-exclamation">
+          <StyledAlert
+            className="require-2fa"
+            type="error"
+            icon="icon-circle-exclamation"
+          >
             {`The ${formattedNames} organizations require all members to enable
               two-factor authentication. You need to enable two-factor
               authentication to access projects under these organizations.`}
           </StyledAlert>
         ) : (
-          <StyledAlert type="error" icon="icon-circle-exclamation">
+          <StyledAlert
+            className="require-2fa"
+            type="error"
+            icon="icon-circle-exclamation"
+          >
             {`The ${formattedNames} organization requires all members to enable
               two-factor authentication. You need to enable two-factor
               authentication to access projects under this organization.`}

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import {capitalize} from 'lodash';
+import Alert from 'app/components/alert';
+import AsyncComponent from 'app/components/asyncComponent';
+import space from 'app/styles/space';
+
+let StyledAlert = styled(Alert)`
+  margin: ${space(3)} 0;
+`;
+
+class TwoFactorRequired extends AsyncComponent {
+  getEndpoints() {
+    return [['organizations', '/organizations/']];
+  }
+
+  renderBody() {
+    let orgsRequire2FA = this.state.organizations
+      .filter(org => org.require2FA === true)
+      .map(({name}) => {
+        return capitalize(name);
+      });
+    let multipleOrgs = orgsRequire2FA.length > 1;
+    let formattedNames = orgsRequire2FA.join(', ').replace(/,(?!.*,)/gim, ' and');
+
+    if (!orgsRequire2FA.length) {
+      return null;
+    }
+
+    return (
+      <div>
+        {multipleOrgs ? (
+          <StyledAlert type="error" icon="icon-circle-exclamation">
+            {`The ${formattedNames} organizations require all members to enable
+              two-factor authentication. You need to enable two-factor
+              authentication to access projects under these organizations.`}
+          </StyledAlert>
+        ) : (
+          <StyledAlert type="error" icon="icon-circle-exclamation">
+            {`The ${formattedNames} organization requires all members to enable
+              two-factor authentication. You need to enable two-factor
+              authentication to access projects under this organization.`}
+          </StyledAlert>
+        )}
+      </div>
+    );
+  }
+}
+
+export default TwoFactorRequired;

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
@@ -16,42 +16,30 @@ class TwoFactorRequired extends AsyncComponent {
   }
 
   renderBody() {
-    let orgsRequire2FA = this.state.organizations
-      .filter(org => org.require2FA === true)
-      .map(({name}) => {
-        return capitalize(name);
-      });
-    let multipleOrgs = orgsRequire2FA.length > 1;
-    let formattedNames = orgsRequire2FA.join(', ').replace(/,(?!.*,)/gim, ' and');
+    let orgsRequire2fa = this.state.organizations
+      .filter(org => org.require2FA)
+      .map(({name}) => capitalize(name));
 
-    if (!orgsRequire2FA.length) {
+    if (!orgsRequire2fa.length) {
       return null;
     }
 
+    // singular vs plural message
+    let plural = orgsRequire2fa.length > 1;
+
+    let organizationNames = [
+      orgsRequire2fa.slice(0, -1).join(', '),
+      orgsRequire2fa.slice(-1)[0],
+    ].join(plural ? ' and ' : '');
+
+    let require = plural ? 'organizations require' : 'organization requires';
+    let organizations = plural ? 'these organizations' : 'this organization';
+
     return (
-      <div>
-        {multipleOrgs ? (
-          <StyledAlert
-            className="require-2fa"
-            type="error"
-            icon="icon-circle-exclamation"
-          >
-            {`The ${formattedNames} organizations require all members to enable
-              two-factor authentication. You need to enable two-factor
-              authentication to access projects under these organizations.`}
-          </StyledAlert>
-        ) : (
-          <StyledAlert
-            className="require-2fa"
-            type="error"
-            icon="icon-circle-exclamation"
-          >
-            {`The ${formattedNames} organization requires all members to enable
-              two-factor authentication. You need to enable two-factor
-              authentication to access projects under this organization.`}
-          </StyledAlert>
-        )}
-      </div>
+      <StyledAlert className="require-2fa" type="error" icon="icon-circle-exclamation">
+        {`The ${organizationNames} ${require} all members to enable two-factor authentication.
+          You need to enable two-factor authentication to access projects under ${organizations}.`}
+      </StyledAlert>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {capitalize} from 'lodash';
+import {t} from 'app/locale';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import space from 'app/styles/space';
@@ -32,13 +33,18 @@ class TwoFactorRequired extends AsyncComponent {
       orgsRequire2fa.slice(-1)[0],
     ].join(plural ? ' and ' : '');
 
-    let require = plural ? 'organizations require' : 'organization requires';
-    let organizations = plural ? 'these organizations' : 'this organization';
+    let require = plural ? t('organizations require') : t('organization requires');
+    let organizations = plural ? t('these organizations') : t('this organization');
 
     return (
       <StyledAlert className="require-2fa" type="error" icon="icon-circle-exclamation">
-        {`The ${organizationNames} ${require} all members to enable two-factor authentication.
-          You need to enable two-factor authentication to access projects under ${organizations}.`}
+        {t(
+          'The %s %s all members to enable two-factor authentication.' +
+            'You need to enable two-factor authentication to access projects under %s',
+          organizationNames,
+          require,
+          organizations
+        )}
       </StyledAlert>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
@@ -14,6 +14,7 @@ import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
+import TwoFactorRequired from 'app/views/settings/account/accountSecurity/components/twoFactorRequired';
 import RemoveConfirm from 'app/views/settings/account/accountSecurity/components/removeConfirm';
 import PasswordForm from 'app/views/settings/account/passwordForm';
 
@@ -52,17 +53,23 @@ class AccountSecurity extends AsyncView {
   };
 
   renderBody() {
-    let isEmpty = !this.state.authenticators.length;
+    let authenticators = this.state.authenticators;
+    let isEmpty = !authenticators.length;
+    let twoFactorEnrolled = authenticators.some(({isEnrolled}) => {
+      return isEnrolled === true;
+    });
 
     return (
       <div>
         <SettingsPageHeader title="Security" />
 
+        {!isEmpty && !twoFactorEnrolled && <TwoFactorRequired />}
+
         <PasswordForm />
 
         <Panel>
           <PanelHeader>
-            <Box>{t('Two Factor Authentication')}</Box>
+            <Box>{t('Two-Factor Authentication')}</Box>
           </PanelHeader>
 
           {isEmpty && (
@@ -71,7 +78,7 @@ class AccountSecurity extends AsyncView {
 
           <PanelBody>
             {!isEmpty &&
-              this.state.authenticators.map(auth => {
+              authenticators.map(auth => {
                 let {
                   id,
                   authId,

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
@@ -53,10 +53,10 @@ class AccountSecurity extends AsyncView {
   };
 
   renderBody() {
-    let authenticators = this.state.authenticators;
+    let {authenticators} = this.state;
     let isEmpty = !authenticators.length;
     let twoFactorEnrolled = authenticators.some(({isEnrolled}) => {
-      return isEnrolled === true;
+      return isEnrolled;
     });
 
     return (

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -384,7 +384,7 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
 class TwoFactorAPITestCase(APITestCase):
     @fixture
     def path_2fa(self):
-        return reverse('sentry-account-settings-2fa')
+        return reverse('sentry-account-settings-security')
 
     def enable_org_2fa(self, organization):
         organization.flags.require_2fa = True

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -269,7 +269,7 @@ class BaseView(View, OrganizationMixin):
         return reverse('sentry-login')
 
     def get_not_2fa_compliant_url(self, request, *args, **kwargs):
-        return reverse('sentry-account-settings-2fa')
+        return reverse('sentry-account-settings-security')
 
     def get_context_data(self, request, **kwargs):
         context = csrf(request)

--- a/src/sentry/web/frontend/debug/debug_setup_2fa_email.py
+++ b/src/sentry/web/frontend/debug/debug_setup_2fa_email.py
@@ -13,7 +13,7 @@ class DebugSetup2faEmailView(View):
     def get(self, request):
         context = {
             'user': request.user,
-            'url': absolute_uri(reverse('sentry-account-settings-2fa')),
+            'url': absolute_uri(reverse('sentry-account-settings-security')),
             'organization': Organization(
                 id=1,
                 slug='organization',

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -364,6 +364,8 @@ urlpatterns += patterns(
     url(r'^out/$', OutView.as_view()),
 
     url(r'^accept-transfer/$', react_page_view, name='sentry-accept-project-transfer'),
+    url(r'^settings/account/security', generic_react_page_view, name='sentry-account-settings-security'),
+    url(r'^settings/account/', generic_react_page_view),
     url(r'^settings/', react_page_view),
     url(
         r'^settings/(?P<organization_slug>[\w_-]+)/members/$',

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -364,7 +364,9 @@ urlpatterns += patterns(
     url(r'^out/$', OutView.as_view()),
 
     url(r'^accept-transfer/$', react_page_view, name='sentry-accept-project-transfer'),
-    url(r'^settings/account/security', generic_react_page_view, name='sentry-account-settings-security'),
+    # User settings use generic_react_page_view, while any view
+    # acting on behalf of an organization should use react_page_view
+    url(r'^settings/account/security/$', generic_react_page_view, name='sentry-account-settings-security'),
     url(r'^settings/account/', generic_react_page_view),
     url(r'^settings/', react_page_view),
     url(

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -639,9 +639,9 @@ window.TestStubs = {
     return [
       {
         id: '1',
-        name: 'test',
-        slug: 'test',
-        require2FA: true,
+        name: 'test 1',
+        slug: 'test 1',
+        require2FA: false,
         status: {
           id: 'active',
           name: 'active',
@@ -652,17 +652,6 @@ window.TestStubs = {
         id: '2',
         name: 'test 2',
         slug: 'test 2',
-        require2FA: true,
-        status: {
-          id: 'active',
-          name: 'active',
-        },
-        ...params,
-      },
-      {
-        id: '3',
-        name: 'test 3',
-        slug: 'test 3',
         require2FA: false,
         status: {
           id: 'active',

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -326,7 +326,7 @@ window.TestStubs = {
         lastUsedAt: null,
         enrollButton: 'Activate',
         description:
-          'Recovery codes are the only way to access your account if you lose your device and cannot receive two factor authentication codes.',
+          'Recovery codes are the only way to access your account if you lose your device and cannot receive two-factor authentication codes.',
         isEnrolled: true,
         removeButton: null,
         id: 'recovery',
@@ -633,6 +633,44 @@ window.TestStubs = {
       projects: [],
       ...params,
     };
+  },
+
+  Organizations: params => {
+    return [
+      {
+        id: '1',
+        name: 'test',
+        slug: 'test',
+        require2FA: true,
+        status: {
+          id: 'active',
+          name: 'active',
+        },
+        ...params,
+      },
+      {
+        id: '2',
+        name: 'test 2',
+        slug: 'test 2',
+        require2FA: true,
+        status: {
+          id: 'active',
+          name: 'active',
+        },
+        ...params,
+      },
+      {
+        id: '3',
+        name: 'test 3',
+        slug: 'test 3',
+        require2FA: false,
+        status: {
+          id: 'active',
+          name: 'active',
+        },
+        ...params,
+      },
+    ];
   },
 
   Plugin: params => {

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -5,6 +5,7 @@ import {Client} from 'app/api';
 import AccountSecurity from 'app/views/settings/account/accountSecurity';
 
 const ENDPOINT = '/users/me/authenticators/';
+const ORG_ENDPOINT = '/organizations/';
 
 describe('AccountSecurity', function() {
   beforeEach(function() {
@@ -26,6 +27,10 @@ describe('AccountSecurity', function() {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({configureButton: 'Info'})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations(),
     });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
@@ -54,6 +59,10 @@ describe('AccountSecurity', function() {
           configureButton: 'Info',
         }),
       ],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations(),
     });
 
     let deleteMock = Client.addMockResponse({
@@ -87,6 +96,10 @@ describe('AccountSecurity', function() {
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
     });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations(),
+    });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
 
@@ -106,6 +119,10 @@ describe('AccountSecurity', function() {
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations(),
+    });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
 
@@ -120,6 +137,10 @@ describe('AccountSecurity', function() {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: true})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations(),
     });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
@@ -140,6 +161,10 @@ describe('AccountSecurity', function() {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: [],
     });
     let url = '/users/me/password/';
     let mock = Client.addMockResponse({
@@ -177,6 +202,10 @@ describe('AccountSecurity', function() {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations(),
     });
     let url = '/users/me/password/';
     let mock = Client.addMockResponse({

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -21,6 +21,7 @@ describe('AccountSecurity', function() {
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
 
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(0);
   });
 
   it('renders a primary interface that is enrolled', function() {
@@ -48,6 +49,8 @@ describe('AccountSecurity', function() {
     // Remove button
     expect(wrapper.find('Button .icon-trash')).toHaveLength(1);
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(true);
+
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(0);
   });
 
   it('can delete enrolled authenticator', function() {
@@ -89,6 +92,8 @@ describe('AccountSecurity', function() {
       wrapper.update();
       expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(false);
     }, 1);
+    // still has another 2fa method
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(0);
   });
 
   it('renders a primary interface that is not enrolled', function() {
@@ -112,6 +117,8 @@ describe('AccountSecurity', function() {
         .prop('children')
     ).toBe('Add');
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(false);
+    // user is not 2fa enrolled
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
   });
 
   it('renders a backup interface that is not enrolled', function() {
@@ -131,6 +138,8 @@ describe('AccountSecurity', function() {
     // There should be an View Codes button
     expect(wrapper.find('Button')).toHaveLength(0);
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(false);
+    // user is not 2fa enrolled
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
   });
 
   it('renders a backup interface that is enrolled', function() {
@@ -155,6 +164,8 @@ describe('AccountSecurity', function() {
         .prop('children')
     ).toBe('View Codes');
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(true);
+
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(0);
   });
 
   it('can change password', function() {
@@ -196,6 +207,8 @@ describe('AccountSecurity', function() {
         },
       })
     );
+    // user is not 2fa enrolled
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
   });
 
   it('requires current password to be entered', function() {
@@ -224,5 +237,7 @@ describe('AccountSecurity', function() {
     wrapper.find('PasswordForm form').simulate('submit');
 
     expect(mock).not.toHaveBeenCalled();
+    // user is not 2fa enrolled
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
   });
 });

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -10,6 +10,10 @@ const ORG_ENDPOINT = '/organizations/';
 describe('AccountSecurity', function() {
   beforeEach(function() {
     Client.clearMockResponses();
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations(),
+    });
   });
 
   it('renders empty', function() {
@@ -28,10 +32,6 @@ describe('AccountSecurity', function() {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({configureButton: 'Info'})],
-    });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations(),
     });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
@@ -62,10 +62,6 @@ describe('AccountSecurity', function() {
           configureButton: 'Info',
         }),
       ],
-    });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations(),
     });
 
     let deleteMock = Client.addMockResponse({
@@ -101,10 +97,6 @@ describe('AccountSecurity', function() {
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
     });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations(),
-    });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
 
@@ -126,10 +118,6 @@ describe('AccountSecurity', function() {
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations(),
-    });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
 
@@ -146,10 +134,6 @@ describe('AccountSecurity', function() {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: true})],
-    });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations(),
     });
 
     let wrapper = shallow(<AccountSecurity />, TestStubs.routerContext());
@@ -173,10 +157,7 @@ describe('AccountSecurity', function() {
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: [],
-    });
+
     let url = '/users/me/password/';
     let mock = Client.addMockResponse({
       url,
@@ -215,10 +196,6 @@ describe('AccountSecurity', function() {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
-    });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations(),
     });
     let url = '/users/me/password/';
     let mock = Client.addMockResponse({

--- a/tests/js/spec/views/twoFactorRequired.spec.jsx
+++ b/tests/js/spec/views/twoFactorRequired.spec.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import {Client} from 'app/api';
+import TwoFactorRequired from 'app/views/settings/account/accountSecurity/';
+
+const ENDPOINT = '/users/me/authenticators/';
+const ORG_ENDPOINT = '/organizations/';
+
+describe('TwoFactorRequired', function() {
+  beforeEach(function() {
+    Client.clearMockResponses();
+  });
+
+  it('renders empty', function() {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: [],
+    });
+
+    let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
+    expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
+    expect(wrapper.find('StyledAlert[className="require-2fa"]')).toHaveLength(0);
+  });
+
+  it('does not render when 2FA is not required, not 2FA enrolled', function() {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations({require2FA: false}),
+    });
+
+    let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
+    expect(wrapper.find('StyledAlert[className="require-2fa"]')).toHaveLength(0);
+  });
+
+  it('does not render when 2FA is not required, 2FA is enrolled', function() {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [TestStubs.Authenticators().Totp({isEnrolled: true})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations({require2FA: false}),
+    });
+
+    let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
+    expect(wrapper.find('StyledAlert[className="require-2fa"]')).toHaveLength(0);
+  });
+
+  it('does not render when 2FA is required, 2FA is enrolled', function() {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [TestStubs.Authenticators().Totp({isEnrolled: true})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations({require2FA: true}),
+    });
+
+    let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
+    expect(wrapper.find('StyledAlert[className="require-2fa"]')).toHaveLength(0);
+  });
+
+  it('renders when 2FA is required for multiple orgs, 2FA is not enrolled', function() {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations({require2FA: true}),
+    });
+
+    let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
+    expect(wrapper.find('StyledAlert[className="require-2fa"]')).toHaveLength(1);
+    expect(wrapper.find('StyledAlert[className="require-2fa"]').text()).toEqual(
+      expect.stringContaining('Test 1 and Test 2 organizations')
+    );
+  });
+
+  it('renders when 2FA is required for one org, 2FA is not enrolled', function() {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
+    });
+    Client.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: [
+        {
+          id: '1',
+          name: 'test 1',
+          require2FA: true,
+        },
+      ],
+    });
+
+    let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
+    expect(wrapper.find('StyledAlert[className="require-2fa"]')).toHaveLength(1);
+    expect(wrapper.find('StyledAlert[className="require-2fa"]').text()).toEqual(
+      expect.stringContaining('Test 1 organization')
+    );
+  });
+});

--- a/tests/js/spec/views/twoFactorRequired.spec.jsx
+++ b/tests/js/spec/views/twoFactorRequired.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import {Client} from 'app/api';
 import TwoFactorRequired from 'app/views/settings/account/accountSecurity/';
 
 const ENDPOINT = '/users/me/authenticators/';
@@ -9,15 +8,20 @@ const ORG_ENDPOINT = '/organizations/';
 
 describe('TwoFactorRequired', function() {
   beforeEach(function() {
-    Client.clearMockResponses();
-  });
+    MockApiClient.clearMockResponses();
 
-  it('renders empty', function() {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
+      url: ORG_ENDPOINT,
+      body: TestStubs.Organizations({require2FA: false}),
+    });
+  });
+
+  it('renders empty', function() {
+    MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: [],
     });
@@ -28,27 +32,14 @@ describe('TwoFactorRequired', function() {
   });
 
   it('does not render when 2FA is not required, not 2FA enrolled', function() {
-    Client.addMockResponse({
-      url: ENDPOINT,
-      body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
-    });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations({require2FA: false}),
-    });
-
     let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
     expect(wrapper.find('StyledAlert[className="require-2fa"]')).toHaveLength(0);
   });
 
   it('does not render when 2FA is not required, 2FA is enrolled', function() {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: true})],
-    });
-    Client.addMockResponse({
-      url: ORG_ENDPOINT,
-      body: TestStubs.Organizations({require2FA: false}),
     });
 
     let wrapper = mount(<TwoFactorRequired />, TestStubs.routerContext());
@@ -56,11 +47,11 @@ describe('TwoFactorRequired', function() {
   });
 
   it('does not render when 2FA is required, 2FA is enrolled', function() {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: true})],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: TestStubs.Organizations({require2FA: true}),
     });
@@ -70,11 +61,7 @@ describe('TwoFactorRequired', function() {
   });
 
   it('renders when 2FA is required for multiple orgs, 2FA is not enrolled', function() {
-    Client.addMockResponse({
-      url: ENDPOINT,
-      body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
-    });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: TestStubs.Organizations({require2FA: true}),
     });
@@ -87,11 +74,7 @@ describe('TwoFactorRequired', function() {
   });
 
   it('renders when 2FA is required for one org, 2FA is not enrolled', function() {
-    Client.addMockResponse({
-      url: ENDPOINT,
-      body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
-    });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: [
         {


### PR DESCRIPTION
When an organization requires 2FA, redirect users without 2FA enabled to `/settings/account/security/`, and add a warning explaining what they need to do.

<img width="1159" alt="screen shot 2018-06-07 at 12 16 25 pm" src="https://user-images.githubusercontent.com/16394317/41250191-0cf76fec-6d6b-11e8-8fe7-dbd567d1e898.png">
