### PR TITLE
fix(environment): Show error message if API request fails

### DIFF
--- a/src/sentry/static/sentry/app/views/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/projectEnvironments.jsx
@@ -139,7 +139,7 @@ const ProjectEnvironments = createReactClass({
           );
         },
         error: err => {
-          addSuccessMessage(
+          addErrorMessage(
             tct('Unable to update [environment]', {
               environment: env.displayName,
             })


### PR DESCRIPTION
Previously this was showing the success variation of the indicator on a failed request

Came up in ISSUE-24