### PR TITLE
ref(integrations): Moved Vsts default_project to the config form

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -24,7 +24,7 @@ class IntegrationSerializer(Serializer):
 
 
 class IntegrationConfigSerializer(IntegrationSerializer):
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, organization_id=None):
         data = super(IntegrationConfigSerializer, self).serialize(obj, attrs, user)
 
         data.update({
@@ -33,7 +33,7 @@ class IntegrationConfigSerializer(IntegrationSerializer):
         })
 
         try:
-            install = obj.get_installation()
+            install = obj.get_installation(organization_id)
         except NotImplementedError:
             # The integration may not implement a Installed Integration object
             # representation.
@@ -73,7 +73,12 @@ class OrganizationIntegrationSerializer(Serializer):
         # we're using the IntegrationConfigSerializer which pulls in the
         # integration installation config object which very well may be making
         # API request for config options.
-        integration = serialize(obj.integration, user, IntegrationConfigSerializer())
+        integration = serialize(
+            objects=obj.integration,
+            user=user,
+            serializer=IntegrationConfigSerializer(),
+            organization_id=obj.organization.id
+        )
         integration.update({
             'configData': obj.config,
             'configDataProjects': attrs['project_configs'],

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -24,7 +24,10 @@ class IntegrationSerializer(Serializer):
 
 
 class IntegrationConfigSerializer(IntegrationSerializer):
-    def serialize(self, obj, attrs, user, organization_id=None):
+    def __init__(self, organization_id=None):
+        self.organization_id = organization_id
+
+    def serialize(self, obj, attrs, user):
         data = super(IntegrationConfigSerializer, self).serialize(obj, attrs, user)
 
         data.update({
@@ -33,7 +36,7 @@ class IntegrationConfigSerializer(IntegrationSerializer):
         })
 
         try:
-            install = obj.get_installation(organization_id)
+            install = obj.get_installation(self.organization_id)
         except NotImplementedError:
             # The integration may not implement a Installed Integration object
             # representation.
@@ -76,8 +79,7 @@ class OrganizationIntegrationSerializer(Serializer):
         integration = serialize(
             objects=obj.integration,
             user=user,
-            serializer=IntegrationConfigSerializer(),
-            organization_id=obj.organization.id
+            serializer=IntegrationConfigSerializer(obj.organization.id),
         )
         integration.update({
             'configData': obj.config,

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from time import time
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 from sentry.integrations import Integration, IntegrationProvider, IntegrationMetadata
 from .client import VstsApiClient
 from sentry.pipeline import NestedPipelineView
@@ -44,8 +44,13 @@ class VstsIntegration(Integration):
         project_choices = [(project['id'], project['name']) for project in projects['value']]
         default_project = self.org_integration.config.get('default_project')
 
-        # TODO(LB): This is only saving the id. That might work... but really I'd
-        # want to save the name. Help? Maybe name and id?
+        initial_project = ('', '')
+        if default_project is not None:
+            for project_id, project_name in project_choices:
+                if default_project == project_id:
+                    initial_project = (project_id, project_name)
+                    break
+
         return [
             {
                 'name': 'default_project',
@@ -53,13 +58,10 @@ class VstsIntegration(Integration):
                 'allowEmpty': True,
                 'required': True,
                 'choices': project_choices,
-                'initial': (default_project['id'], default_project['name']) if default_project is not None else ('', ''),
-                # TODO(LB): Tried using ugettext_lazy but got <django.utils.functional.__proxy__ object at 0x107fb5110> is not JSON serializable
-                # this was during the installation flow; decided to just move on instead
-                # of worrying about it
-                'label': 'Default Project Name',
-                'placeholder': 'MyProject',
-                'help': 'Enter the Visual Studio Team Services project name that you wish to use as a default for new work items',
+                'initial': initial_project,
+                'label': _('Default Project Name'),
+                'placeholder': _('MyProject'),
+                'help': _('Enter the Visual Studio Team Services project name that you wish to use as a default for new work items'),
             }
         ]
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -88,7 +88,7 @@ class VstsIntegration(Integration):
             {
                 'name': 'default_project',
                 'label': 'Default Project Name',
-                'type': 'text',
+                'type': 'string',
                 'placeholder': 'MyProject',
                 'required': True,
                 'help': (

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -44,6 +44,8 @@ class VstsIntegration(Integration):
         project_choices = [(project['id'], project['name']) for project in projects['value']]
         default_project = self.org_integration.config.get('default_project')
 
+        # TODO(LB): This is only saving the id. That might work... but really I'd
+        # want to save the name. Help? Maybe name and id?
         return [
             {
                 'name': 'default_project',

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -53,7 +53,7 @@ class VstsIntegration(Integration):
         else:
             project_choices = [(project['id'], project['name']) for project in projects['value']]
 
-        default_project = self.org_integration.config.get('default_project')
+        default_project = self.project_integration.config.get('default_project')
         initial_project = ('', '')
         if default_project is not None:
             for project_id, project_name in project_choices:
@@ -149,17 +149,3 @@ class VstsIntegrationProvider(IntegrationProvider):
             VstsRepositoryProvider,
             id='integrations:vsts',
         )
-
-
-def get_projects(instance, access_token):
-    session = http.build_session()
-    url = 'https://%s/DefaultCollection/_apis/projects' % instance
-    response = session.get(
-        url,
-        headers={
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer %s' % access_token,
-        }
-    )
-    response.raise_for_status()
-    return response.json()

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -83,6 +83,21 @@ class VstsIntegration(Integration):
             raise ValueError('Identity missing access token')
         return VstsApiClient(access_token)
 
+    def get_organization_config(self):
+        return [
+            {
+                'name': 'default_project',
+                'label': 'Default Project Name',
+                'type': 'text',
+                'placeholder': 'MyProject',
+                'required': True,
+                'help': (
+                    'Enter the Visual Studio Team Services project name that you wish '
+                    'to use as a default for new work items'
+                ),
+            },
+        ]
+
 
 class VstsIntegrationProvider(IntegrationProvider):
     key = 'vsts'
@@ -118,23 +133,27 @@ class VstsIntegrationProvider(IntegrationProvider):
     def build_integration(self, state):
         data = state['identity']['data']
         account = state['identity']['account']
-        instance = state['identity']['instance']
         project = state['project']
 
         scopes = sorted(VSTSIdentityProvider.oauth_scopes)
         return {
-            'name': project['name'],
-            'external_id': project['id'],
+            'name': account['AccountName'],
+            'external_id': account['AccountId'],
             'metadata': {
-                'domain_name': instance,
                 'scopes': scopes,
-                # icon doesn't appear to be possible
             },
+            # TODO(LB): Change this to a Microsoft account as opposed to a VSTS workspace
             'user_identity': {
                 'type': 'vsts',
                 'external_id': account['AccountId'],
                 'scopes': [],
                 'data': self.get_oauth_data(data),
+            },
+            'config': {
+                'default_project': {
+                    'name': project['name'],
+                    'id': project['id'],
+                }
             }
         }
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -41,13 +41,15 @@ class VstsIntegration(Integration):
 
     def get_project_config(self):
         client = self.get_client()
+        disabled = False
         try:
             projects = client.get_projects(self.model.metadata['domain_name'])
         except ApiError:
-            # TODO(LB): This is an issue... what should happen if the client fails?
+            # TODO(LB): Disable for now. Need to decide what to do with this in the future
             # should a message be shown to the user?
             # Should we try refreshing the token? For VSTS that often clears up the problem
             project_choices = []
+            disabled = True
         else:
             project_choices = [(project['id'], project['name']) for project in projects['value']]
 
@@ -64,13 +66,14 @@ class VstsIntegration(Integration):
                 'name': 'default_project',
                 'type': 'choice',
                 'allowEmpty': True,
+                'disabled': disabled,
                 'required': True,
                 'choices': project_choices,
                 'initial': initial_project,
                 'label': _('Default Project Name'),
                 'placeholder': _('MyProject'),
                 'help': _('Enter the Visual Studio Team Services project name that you wish to use as a default for new work items'),
-            }
+            },
         ]
 
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -53,7 +53,14 @@ class VstsIntegration(Integration):
         else:
             project_choices = [(project['id'], project['name']) for project in projects['value']]
 
-        default_project = self.project_integration.config.get('default_project')
+        try:
+            # TODO(LB): Will not work in the UI until the serliazer sends a `project_id` to get_installation()
+            # serializers and UI are being refactored and it's not worth trying to fix
+            # the old system. Revisit
+            default_project = self.project_integration.config.get('default_project')
+        except Exception:
+            default_project = None
+
         initial_project = ('', '')
         if default_project is not None:
             for project_id, project_name in project_choices:

--- a/src/sentry/static/sentry/app/views/organizationIntegration/installedIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegration/installedIntegration.jsx
@@ -144,7 +144,7 @@ export default class InstalledIntegration extends React.Component {
             <Box mr={1}>
               <Button
                 size="small"
-                disabled={!this.isEnabledForProject() && provider.canAddProject}
+                disabled={!this.isEnabledForProject()}
                 priority={this.state.configuring ? 'primary' : undefined}
                 onClick={this.onConfigure}
               >
@@ -168,10 +168,7 @@ export default class InstalledIntegration extends React.Component {
         <div
           style={{
             display:
-              this.state.configuring &&
-              (this.isEnabledForProject() || !provider.canAddProject)
-                ? 'block'
-                : 'none',
+              this.state.configuring && this.isEnabledForProject() ? 'block' : 'none',
           }}
         >
           {this.renderConfiguration()}

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider
 from sentry.identity.vsts import VSTSIdentityProvider
 from sentry.models import Integration, Identity, IdentityProvider
-from sentry.testutils import TestCase
+from sentry.testutils import APITestCase, TestCase
 
 
 class VSTSIntegrationTest(TestCase):
@@ -40,11 +40,11 @@ class VSTSIntegrationTest(TestCase):
         assert integration_dict['user_identity']['data']['token_type'] == 'jwt-bearer'
 
 
-class VstsIntegrationTest(TestCase):
-    def test_get_client(self):
+class VstsIntegrationTest(APITestCase):
+    def setUp(self):
         user = self.create_user()
         organization = self.create_organization()
-        access_token = '1234567890'
+        self.access_token = '1234567890'
         model = Integration.objects.create(
             provider='integrations:vsts',
             external_id='vsts_external_id',
@@ -59,11 +59,12 @@ class VstsIntegrationTest(TestCase):
             user=user,
             external_id='vsts_id',
             data={
-                'access_token': access_token
+                'access_token': self.access_token
             }
         )
         model.add_organization(organization.id, identity.id)
-        integration = VstsIntegration(model, organization.id)
-        client = integration.get_client()
+        self.integration = VstsIntegration(model, organization.id)
 
-        assert client.access_token == access_token
+    def test_get_client(self):
+        client = self.integration.get_client()
+        assert client.access_token == self.access_token

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -1,68 +1,10 @@
 from __future__ import absolute_import
 
-import responses
 
-from mock import Mock
-from django.http import HttpRequest
-
-from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider, ProjectConfigView, ProjectForm, get_projects
+from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider
 from sentry.identity.vsts import VSTSIdentityProvider
 from sentry.models import Integration, Identity, IdentityProvider
 from sentry.testutils import TestCase
-
-
-class ProjectConfigViewTest(TestCase):
-    def setUp(self):
-        self.instance = 'example.visualstudio.com'
-        self.projects = [
-            {
-                'id': 'first-project-id',
-                'name': 'First Project',
-                        'url': 'https://myfirstproject.visualstudio.com/DefaultCollection/_apis/projects/xxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx',
-                        'description': 'My First Project!',
-            },
-            {
-                'id': 'second-project-id',
-                'name': 'Second Project',
-                        'url': 'https://mysecondproject.visualstudio.com/DefaultCollection/_apis/projects/xxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxz',
-                        'description': 'Not My First Project!',
-            }
-        ]
-        responses.add(
-            responses.GET,
-            'https://{}/DefaultCollection/_apis/projects'.format(self.instance),
-            json={
-                'value': self.projects,
-                'count': 2,
-            },
-        )
-
-    @responses.activate
-    def test_get_projects(self):
-        result = get_projects(self.instance, 'access-token')
-        assert result['count'] == 2
-        assert result['value'][0]['name'] == 'First Project'
-        assert result['value'][1]['name'] == 'Second Project'
-
-    def test_project_form(self):
-        project_form = ProjectForm(self.projects)
-        assert project_form.fields['project'].choices == [
-            ('first-project-id', 'First Project'), ('second-project-id', 'Second Project')]
-
-    def test_dispatch(self):
-        view = ProjectConfigView()
-        request = HttpRequest()
-        request.POST = {'project': 'first-project-id'}
-
-        pipeline = Mock()
-        pipeline.state = {'projects': self.projects}
-        pipeline.fetch_state = lambda key: pipeline.state[key]
-        pipeline.bind_state = lambda name, value: pipeline.state.update({name: value})
-
-        view.dispatch(request, pipeline)
-
-        assert pipeline.fetch_state(key='project') == self.projects[0]
-        assert pipeline.next_step.call_count == 1
 
 
 class VSTSIntegrationTest(TestCase):
@@ -81,11 +23,10 @@ class VSTSIntegrationTest(TestCase):
                 'account': {'AccountName': 'sentry', 'AccountId': '123435'},
                 'instance': 'sentry.visualstudio.com',
             },
-            'project': {'name': 'My Project', 'id': 'my-project-id'},
         }
         integration_dict = self.integration.build_integration(state)
-        assert integration_dict['name'] == 'My Project'
-        assert integration_dict['external_id'] == 'my-project-id'
+        assert integration_dict['name'] == 'sentry'
+        assert integration_dict['external_id'] == '123435'
         assert integration_dict['metadata']['scopes'] == list(VSTSIdentityProvider.oauth_scopes)
         assert integration_dict['metadata']['domain_name'] == 'sentry.visualstudio.com'
 

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -44,6 +44,7 @@ class VstsIntegrationTest(APITestCase):
     def setUp(self):
         user = self.create_user()
         organization = self.create_organization()
+        project = self.create_project(organization=organization)
         self.access_token = '1234567890'
         model = Integration.objects.create(
             provider='integrations:vsts',
@@ -66,7 +67,8 @@ class VstsIntegrationTest(APITestCase):
             }
         )
         self.org_integration = model.add_organization(organization.id, identity.id)
-        self.integration = VstsIntegration(model, organization.id)
+        self.project_integration = model.add_project(project.id)
+        self.integration = VstsIntegration(model, organization.id, project.id)
         self.projects = [
             ('eb6e4656-77fc-42a1-9181-4c6d8e9da5d1', 'ProjectB'),
             ('6ce954b1-ce1f-45d1-b94d-e6bf2464ba2c', 'ProjectA')
@@ -108,7 +110,8 @@ class VstsIntegrationTest(APITestCase):
 
     @responses.activate
     def test_get_project_config_initial(self):
-        self.org_integration.update(config={'default_project': 'ProjectA'})
+        self.integration.project_integration.config = {'default_project': self.projects[1][0]}
+        self.integration.project_integration.save()
         fields = self.integration.get_project_config()
         assert len(fields) == 1
         project_field = fields[0]


### PR DESCRIPTION
Gives Vsts a `default_project` as a project-level configuration.  As is, this will not work in the UI until the relevant serliazers send a `project_id` to get_installation().  Serializers and UI are being refactored and it's not worth trying to fix the old system. Todo is noted in code. 