### PR TITLE
chore(js): Upgrade react-dom to 16.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-autosize-textarea": "3.0.2",
     "react-bootstrap": "^0.32.0",
     "react-document-title": "2.0.3",
-    "react-dom": "16.2.0",
+    "react-dom": "16.3.2",
     "react-emotion": "9.1.2",
     "react-hot-loader": "^3.1.3",
     "react-icon-base": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "jest-junit": "^3.4.1",
     "mockdate": "2.0.2",
     "prettier": "1.7.4",
-    "react-test-renderer": "16.2.0",
+    "react-test-renderer": "16.3.2",
     "sinon": "1.17.2",
     "sinon-chai": "2.8.0",
     "stylelint": "9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7874,9 +7874,9 @@ react-document-title@2.0.3:
     prop-types "^15.5.6"
     react-side-effect "^1.0.2"
 
-react-dom@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7929,6 +7929,10 @@ react-inspector@^2.2.1:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
+react-is@^16.3.2:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.0.tgz#cc9fdc855ac34d2e7d9d2eb7059bbc240d35ffcf"
+
 react-keydown@^1.9.7:
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/react-keydown/-/react-keydown-1.9.7.tgz#cd168d4b0194b6ef71bca47e5c1cbc5d24ab5498"
@@ -8041,7 +8045,16 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@16.2.0, react-test-renderer@^16.0.0-0:
+react-test-renderer@16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
+
+react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:


### PR DESCRIPTION
Forgot to upgrade `react-dom` when `react` was upgraded here: https://github.com/getsentry/sentry/pull/8444