### PR TITLE
fix(ui): Refetch plugins when project changes

### DIFF
--- a/src/sentry/static/sentry/app/utils/withPlugins.jsx
+++ b/src/sentry/static/sentry/app/utils/withPlugins.jsx
@@ -19,7 +19,27 @@ const withPlugins = WrappedComponent =>
       project: SentryTypes.Project,
     },
     mixins: [ProjectState, Reflux.connect(PluginsStore, 'store')],
+
     componentDidMount() {
+      this.fetchPlugins();
+    },
+
+    componentDidUpdate(prevProps) {
+      let organization = this.props.organization || this.getOrganization();
+      let project = this.props.project || this.getProject();
+
+      if (
+        (typeof prevProps.organization === 'undefined' ||
+          prevProps.organization.slug === organization.slug) &&
+        (typeof prevProps.project === 'undefined' ||
+          prevProps.project.slug === project.slug)
+      )
+        return;
+
+      this.fetchPlugins();
+    },
+
+    fetchPlugins() {
       let organization = this.props.organization || this.getOrganization();
       let project = this.props.project || this.getProject();
 
@@ -27,6 +47,7 @@ const withPlugins = WrappedComponent =>
 
       fetchPlugins({projectId: project.slug, orgId: organization.slug});
     },
+
     render() {
       return <WrappedComponent {...this.props} plugins={this.state.store} />;
     },

--- a/tests/js/spec/views/projectReleaseTracking.spec.jsx
+++ b/tests/js/spec/views/projectReleaseTracking.spec.jsx
@@ -106,5 +106,12 @@ describe('ProjectReleaseTracking', function() {
         projectId: 'new-project',
       })
     );
+
+    fetchPlugins.mockClear();
+
+    // Does not call fetchPlugins if slug is the same
+    wrapper.setProps({...wrapper.props(), project: {...project, slug: 'new-project'}});
+    wrapper.update();
+    expect(fetchPlugins).not.toHaveBeenCalled();
   });
 });

--- a/tests/js/spec/views/projectReleaseTracking.spec.jsx
+++ b/tests/js/spec/views/projectReleaseTracking.spec.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
-
 import {mount} from 'enzyme';
-import {ProjectReleaseTracking} from 'app/views/settings/project/projectReleaseTracking';
+
+import ProjectReleaseTrackingContainer, {
+  ProjectReleaseTracking,
+} from 'app/views/settings/project/projectReleaseTracking';
+import {fetchPlugins} from 'app/actionCreators/plugins';
+
+jest.mock('app/actionCreators/plugins', () => ({
+  fetchPlugins: jest.fn(),
+}));
 
 describe('ProjectReleaseTracking', function() {
   let org = TestStubs.Organization();
@@ -75,5 +82,29 @@ describe('ProjectReleaseTracking', function() {
       );
       done();
     }, 1);
+  });
+
+  it('fetches new plugins when project changes', function() {
+    let wrapper = mount(
+      <ProjectReleaseTrackingContainer
+        organization={org}
+        project={project}
+        params={{orgId: org.slug, projectId: project.slug}}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(fetchPlugins).toHaveBeenCalled();
+
+    fetchPlugins.mockClear();
+
+    // For example, this happens when we switch to a new project using settings breadcrumb
+    wrapper.setProps({...wrapper.props(), project: {...project, slug: 'new-project'}});
+    wrapper.update();
+
+    expect(fetchPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'new-project',
+      })
+    );
   });
 });


### PR DESCRIPTION
This happens in settings (e.g. Release Tracking), when you switch projects using the breadcrumb, the current view gets updated with new project slug, but `withPlugins` HoC only fetches plugins on `DidMount` and not `DidUpdate`

Fixes APP-339