### PR TITLE
fix(cleanup): remove old nodestore values although silent

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -242,13 +242,13 @@ def cleanup(days, project, concurrency, max_procs, silent, model, router, timed)
     else:
         if not silent:
             click.echo("Removing old NodeStore values")
-        else:
-            cutoff = timezone.now() - timedelta(days=days)
-            try:
-                nodestore.cleanup(cutoff)
-            except NotImplementedError:
-                click.echo(
-                    "NodeStore backend does not support cleanup operation", err=True)
+
+        cutoff = timezone.now() - timedelta(days=days)
+        try:
+            nodestore.cleanup(cutoff)
+        except NotImplementedError:
+            click.echo(
+                "NodeStore backend does not support cleanup operation", err=True)
 
     for bqd in BULK_QUERY_DELETES:
         if len(bqd) == 4:


### PR DESCRIPTION
It's a terrible mistake that, if not silent, `cleanup` does not remove old nodestore values.

This makes nodestore_node grows uncontrollable big.