### PR TITLE
ref(search): Sort candidates prior to limiting

### DIFF
--- a/src/sentry/search/django/backend.py
+++ b/src/sentry/search/django/backend.py
@@ -326,6 +326,7 @@ class DjangoSearchBackend(SearchBackend):
                     id__in=list(event_queryset.distinct().values_list('group_id', flat=True)[:1000])
                 )
 
+            _, group_queryset_sort_clause = sort_strategies[sort_by]
             group_queryset = QuerySetBuilder({
                 'first_release': CallbackCondition(
                     lambda queryset, version: queryset.extra(
@@ -425,7 +426,7 @@ class DjangoSearchBackend(SearchBackend):
                     tables=[GroupEnvironment._meta.db_table],
                 ),
                 parameters,
-            )
+            ).order_by(group_queryset_sort_clause)
 
             get_sort_expression, sort_value_to_cursor_value = environment_sort_strategies[sort_by]
 


### PR DESCRIPTION
Assuming that the sort orders are relatively consistent between environments*, this should encourage more relevant candidates to be included in the limited candidate set introduced in GH-8579 at the cost of introducing an (indexed) sort on the query.

References ISSUE-21, ISSUE-31, ISSUE-39

\* I'm not sure how accurate this assumption is, but it has to be better than the way things are being ordered now