### PR TITLE
fix(ui): Only reset search string when changed from outside

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -130,7 +130,7 @@ const SearchBar = createReactClass({
 
   componentWillReceiveProps(nextProps) {
     // query was updated by another source (e.g. sidebar filters)
-    if (nextProps.query !== this.state.query) {
+    if (nextProps.query !== this.props.query) {
       this.setState({
         query: nextProps.query,
       });

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -35,6 +35,34 @@ describe('SearchBar', function() {
     sandbox.restore();
   });
 
+  describe('componentWillReceiveProps()', function() {
+    it('should update state.query if props.query is updated from outside', function() {
+      let searchBar = shallow(<SearchBar query="one" />, options);
+
+      searchBar.setProps({query: 'two'});
+
+      expect(searchBar.state().query).toEqual('two');
+    });
+
+    it('should not reset user input if a noop props change happens', function() {
+      let searchBar = shallow(<SearchBar query="one" />, options);
+      searchBar.setState({query: 'two'});
+
+      searchBar.setProps({query: 'one'});
+
+      expect(searchBar.state().query).toEqual('two');
+    });
+
+    it('should reset user input if a meaningful props change happens', function() {
+      let searchBar = shallow(<SearchBar query="one" />, options);
+      searchBar.setState({query: 'two'});
+
+      searchBar.setProps({query: 'three'});
+
+      expect(searchBar.state().query).toEqual('three');
+    });
+  });
+
   describe('getQueryTerms()', function() {
     it('should extract query terms from a query string', function() {
       let query = 'tagname: ';


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/8503 

To reproduce when developing, I alternated between 
```
$ bin/mock-event sentry/internal python
$ bin/mock-event sentry/internal javascript
```
and waited for the list ordering to update, while I had something in my search box. Changing the filters via the right hand side seems to work and tab completion seems to still work.