### PR TITLE
fix(filestore): seek back to zero before gcs upload

### DIFF
--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import os
 import mimetypes
 import posixpath
 from tempfile import SpooledTemporaryFile
@@ -207,6 +208,7 @@ class GoogleCloudStorage(Storage):
         content.name = cleaned_name
         encoded_name = self._encode_name(name)
         file = GoogleCloudFile(encoded_name, 'w', self)
+        content.seek(0, os.SEEK_SET)
         file.blob.upload_from_file(content, size=content.size,
                                    content_type=file.mime_type)
         return cleaned_name


### PR DESCRIPTION
GCS uploads need upload contents to be seeked back to the beginning, like in [`_save_content`](https://github.com/getsentry/sentry/blob/master/src/sentry/filestore/s3.py#L521) in `s3.py`.

Ref: #8708 