### PR TITLE
fix: Filter out GroupHashes with no Group

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -18,6 +18,10 @@ from sentry.utils import metrics
 from sentry.utils.dates import to_timestamp
 from functools import reduce
 
+# TODO remove this when Snuba accepts more than 500 issues
+MAX_ISSUES = 500
+MAX_HASHES = 5000
+
 
 class SnubaError(Exception):
     pass
@@ -294,14 +298,15 @@ def get_project_issues(project_ids, issue_ids=None):
     Returns a list: [(issue_id: [hash1, hash2, ...]), ...]
     """
     if issue_ids:
-        # TODO remove this when Snuba accepts more than 500 issues
-        issue_ids = issue_ids[:500]
-        hashes = GroupHash.objects.filter(group_id__in=issue_ids)
+        issue_ids = issue_ids[:MAX_ISSUES]
+        hashes = GroupHash.objects.filter(
+            group_id__in=issue_ids
+        )[:MAX_HASHES]
     else:
         hashes = GroupHash.objects.filter(
             project__in=project_ids,
             group_id__isnull=False,
-        )[:500]
+        )[:MAX_HASHES]
 
     hashes = [h for h in hashes if HASH_RE.match(h.hash)]
     if not hashes:
@@ -328,7 +333,7 @@ def get_project_issues(project_ids, issue_ids=None):
         tombstone_date = tombstones_by_project.get(h.project_id, {}).get(h.hash, None)
         pair = (h.hash, tombstone_date.strftime("%Y-%m-%d %H:%M:%S") if tombstone_date else None)
         result.setdefault(h.group_id, []).append(pair)
-    return list(result.items())
+    return list(result.items())[:MAX_ISSUES]
 
 
 def get_related_project_ids(column, ids):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -298,7 +298,10 @@ def get_project_issues(project_ids, issue_ids=None):
         issue_ids = issue_ids[:500]
         hashes = GroupHash.objects.filter(group_id__in=issue_ids)
     else:
-        hashes = GroupHash.objects.filter(project__in=project_ids)
+        hashes = GroupHash.objects.filter(
+            project__in=project_ids,
+            group_id__isnull=False,
+        )[:500]
 
     hashes = [h for h in hashes if HASH_RE.match(h.hash)]
     if not hashes:

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -60,6 +60,15 @@ class SnubaTest(SnubaTestCase):
         assert snuba.get_project_issues([self.project], [self.group.id]) == \
             [(self.group.id, [('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', None)])]
 
+        # GroupHash without a group_id, should not be included in get_project_issues
+        GroupHash.objects.create(
+            project=self.project,
+            hash='0' * 32,
+        )
+
+        assert self.group.id in dict(snuba.get_project_issues([self.project]))
+        assert None not in dict(snuba.get_project_issues([self.project]))
+
     def test_project_issues_with_tombstones(self):
         base_time = datetime.utcnow()
         a_hash = 'a' * 32
@@ -94,7 +103,8 @@ class SnubaTest(SnubaTestCase):
         GroupHash.objects.create(
             project=self.project,
             group=group1,
-            hash=a_hash)
+            hash=a_hash
+        )
         assert snuba.get_project_issues([self.project], [group1.id]) == \
             [(group1.id, [('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', None)])]
 


### PR DESCRIPTION
Don't send these to Snuba as the group_id is null. Also limit down
the set of GroupHashes to 500 in the case where we want all of them
from a project. (This will mess with result accuracy until we have
a better solution to the "All Issues" problem.)