### PR TITLE
ref(ingest): Remove unused regression_signal

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -35,7 +35,7 @@ from sentry.models import (
     Project, Release, ReleaseEnvironment, ReleaseProject, ReleaseProjectEnvironment, UserReport
 )
 from sentry.plugins import plugins
-from sentry.signals import event_discarded, event_saved, first_event_received, regression_signal
+from sentry.signals import event_discarded, event_saved, first_event_received
 from sentry.tasks.merge import merge_group
 from sentry.tasks.post_process import post_process_group
 from sentry.utils import metrics
@@ -945,10 +945,6 @@ class EventManager(object):
             )
         else:
             self.logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
-
-        # TODO: move this to the queue
-        if is_regression and not raw:
-            regression_signal.send_robust(sender=Group, instance=group)
 
         metrics.timing(
             'events.latency',

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -53,7 +53,6 @@ class BetterSignal(Signal):
         return responses
 
 
-regression_signal = BetterSignal(providing_args=["instance"])
 buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra", "result"])
 event_accepted = BetterSignal(providing_args=["ip", "data", "project"])
 event_discarded = BetterSignal(providing_args=["project"])

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -78,16 +78,6 @@ class EventManagerTest(TransactionTestCase):
         assert event1.transaction == 'bar'
         assert event1.culprit == 'bar'
 
-    @mock.patch('sentry.signals.regression_signal.send')
-    def test_broken_regression_signal(self, send):
-        send.side_effect = Exception()
-
-        manager = EventManager(self.make_event())
-        event = manager.save(1)
-
-        assert event.message == 'foo'
-        assert event.project_id == 1
-
     @mock.patch('sentry.event_manager.should_sample')
     def test_saves_event_mapping_when_sampled(self, should_sample):
         should_sample.return_value = True


### PR DESCRIPTION
Ran across this while doing some research into SNS-78.

The last usage of this was removed with d0f35f1a1e8e4bff0487f84d63150e34c8b4b6b7.