### PR TITLE
ref: Truncate float fingerprints

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -85,7 +85,7 @@ def md5_from_hash(hash_bits):
 
 def get_fingerprint_for_event(event):
     fingerprint = event.data.get('fingerprint')
-    if not fingerprint:
+    if fingerprint is None:
         return ['{{ default }}']
     return fingerprint
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -333,7 +333,7 @@ class EventManager(object):
 
         def stringify(f):
             if isinstance(f, float):
-                return text(int(f)) if f < (1 << 53) else None
+                return text(int(f)) if abs(f) < (1 << 53) else None
             return text(f)
 
         casts = {

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -495,7 +495,7 @@ class ValidateDataTest(BaseAPITest):
         assert len(data['errors']) == 0
 
         data = self.validate_and_normalize({
-            'fingerprint': ['{{default}}', 1e100, 1e10],
+            'fingerprint': ['{{default}}', 1e100, -1e100, 1e10],
         })
         assert data.get('fingerprint') == ['{{default}}', '10000000000']
         assert len(data['errors']) == 0

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -489,9 +489,15 @@ class ValidateDataTest(BaseAPITest):
         assert data['errors'][0]['name'] == 'fingerprint'
 
         data = self.validate_and_normalize({
-            'fingerprint': ['{{default}}', 1, 'bar', 4.5],
+            'fingerprint': ['{{default}}', 1, 'bar', 4.5, -2.7],
         })
-        assert data.get('fingerprint') == ['{{default}}', '1', 'bar', '4.5']
+        assert data.get('fingerprint') == ['{{default}}', '1', 'bar', '4', '-2']
+        assert len(data['errors']) == 0
+
+        data = self.validate_and_normalize({
+            'fingerprint': ['{{default}}', 1e100, 1e10],
+        })
+        assert data.get('fingerprint') == ['{{default}}', '10000000000']
         assert len(data['errors']) == 0
 
     def test_messages(self):

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -500,6 +500,12 @@ class ValidateDataTest(BaseAPITest):
         assert data.get('fingerprint') == ['{{default}}', '10000000000']
         assert len(data['errors']) == 0
 
+        data = self.validate_and_normalize({
+            'fingerprint': [],
+        })
+        assert data.get('fingerprint') == []
+        assert len(data['errors']) == 0
+
     def test_messages(self):
         # Just 'message': wrap it in interface
         data = self.validate_and_normalize({

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -489,9 +489,9 @@ class ValidateDataTest(BaseAPITest):
         assert data['errors'][0]['name'] == 'fingerprint'
 
         data = self.validate_and_normalize({
-            'fingerprint': ['{{default}}', 1, 'bar', 4.5, -2.7],
+            'fingerprint': ['{{default}}', 1, 'bar', 4.5, -2.7, True],
         })
-        assert data.get('fingerprint') == ['{{default}}', '1', 'bar', '4', '-2']
+        assert data.get('fingerprint') == ['{{default}}', '1', 'bar', '4', '-2', 'True']
         assert len(data['errors']) == 0
 
         data = self.validate_and_normalize({


### PR DESCRIPTION
**WARNING**: This might break grouping behavior in some cases!

This updates the behavior for fingerprints to align it with semaphore. It basically stays the same, except that it truncates floats. To be more precise:

- Fingerprints must either be `null` / missing, or an array. All other types will be rejected. This means no auto-boxing into arrays for top-level strings.
- The default for fingerprints if they are missing completely is `['{{ default }}']`. Empty arrays stay empty.
- Each value in the fingerprint can be `bool`, `int`, `float` or `string`. All other values will reject the entire fingerprint, add a processing error and reset it to the default.
- Ints are directly stringified; strings say the same.
- Booleans are converted to `"True"` or `"False"`.
- **BREAKING**: Floats are truncated and stringified if there is a safe bidirectional conversion to int (53 bits or less without exponent). All other floats are silently swallowed.

**Examples** (first line input, second line normalization):

```json
{ "fingerprint": ["{{default}}", "bar", 1, 4.5, -2.7, 1e100, true] }
{ "fingerprint": ["{{default}}", "bar", "1", "4", "-2", "True"] }
```

```json
{ "fingerprint": [] }
{ "fingerprint": [] }
```

```json
{ }
{ "fingerprint": ["{{ default }}"] }
```