### PR TITLE
feat(snuba): Implement get_group_event_filter (formerly get_group_eve…

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -99,8 +99,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
                 tags,
             )
 
-            # HACK: Short-circuit filter responses like {'id__in': []}
-            if len(event_filter) == 1 and not event_filter.values()[0]:
+            if not event_filter:
                 return respond(events.none())
 
             events = events.filter(**event_filter)

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -43,7 +43,7 @@ class TagStorage(Service):
         'get_group_list_tag_value',
 
         'get_groups_user_counts',
-        'get_group_event_ids',
+        'get_group_event_filter',
         'get_group_tag_value_count',
         'get_top_group_tag_values',
         'get_first_release',
@@ -288,9 +288,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_event_ids(self, project_id, group_id, environment_id, tags):
+    def get_group_event_filter(self, project_id, group_id, environment_id, tags):
         """
-        >>> get_group_event_ids(1, 2, 3, {'key1': 'value1', 'key2': 'value2'})
+        >>> get_group_event_filter(1, 2, 3, {'key1': 'value1', 'key2': 'value2'})
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -439,7 +439,7 @@ class LegacyTagStorage(TagStorage):
                     },
                     extra=extra)
 
-    def get_group_event_ids(self, project_id, group_id, environment_id, tags):
+    def get_group_event_filter(self, project_id, group_id, environment_id, tags):
         tagkeys = dict(
             models.TagKey.objects.filter(
                 project_id=project_id,
@@ -464,7 +464,7 @@ class LegacyTagStorage(TagStorage):
         except KeyError:
             # one or more tags were invalid, thus the result should be an empty
             # set
-            return set()
+            return {'id__in': set()}
 
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -491,9 +491,9 @@ class LegacyTagStorage(TagStorage):
                 ).values_list('event_id', flat=True)[:1000]
             )
             if not matches:
-                return set()
+                return {'id__in': set()}
 
-        return set(matches)
+        return {'id__in': set(matches)}
 
     def get_groups_user_counts(self, project_id, group_ids, environment_id):
         qs = models.GroupTagKey.objects.filter(

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -464,7 +464,7 @@ class LegacyTagStorage(TagStorage):
         except KeyError:
             # one or more tags were invalid, thus the result should be an empty
             # set
-            return {'id__in': set()}
+            return None
 
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -491,7 +491,7 @@ class LegacyTagStorage(TagStorage):
                 ).values_list('event_id', flat=True)[:1000]
             )
             if not matches:
-                return {'id__in': set()}
+                return None
 
         return {'id__in': set(matches)}
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -398,22 +398,9 @@ class SnubaTagStorage(TagStorage):
 
         return {'event_id__in': set(result.keys())}
 
-    def get_group_tag_value_qs(self, project_id, group_id, environment_id, key, value=None):
-        # TODO: Implement
-        raise NotImplementedError
-
-    def get_event_tag_qs(self, project_id, environment_id, key, value):
-        # This method is not implemented because it is only used by the Django
-        # search backend.
-        raise NotImplementedError
-
     def get_group_ids_for_search_filter(
             self, project_id, environment_id, tags, candidates=None, limit=1000):
         # This method is not implemented since the `group.id` column doesn't
         # exist in Snuba. This logic is implemented in the search backend
         # instead.
         raise NotImplementedError
-
-    def update_group_for_events(self, project_id, event_ids, destination_id):
-        # Group updates are unncessary in Snuba, but we shouldn't throw an error.
-        pass

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -393,6 +393,9 @@ class SnubaTagStorage(TagStorage):
         result = snuba.query(start, end, groupby=['event_id'], conditions=conditions,
             filter_keys=filters, referrer='tagstore.get_group_event_filter')
 
+        if not result:
+            return None
+
         return {'event_id__in': set(result.keys())}
 
     def get_group_tag_value_qs(self, project_id, group_id, environment_id, key, value=None):

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -391,7 +391,7 @@ class SnubaTagStorage(TagStorage):
         conditions = [[['tags[{}]'.format(k), '=', v] for (k, v) in tags.items()]]
 
         result = snuba.query(start, end, groupby=['event_id'], conditions=conditions,
-            filter_keys=filters, referrer='tagstore.get_group_event_filter')
+            filter_keys=filters, limit=1000, referrer='tagstore.get_group_event_filter')
 
         if not result:
             return None

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -691,7 +691,7 @@ class V2TagStorage(TagStorage):
         except KeyError:
             # one or more tags were invalid, thus the result should be an empty
             # set
-            return {'id__in': set()}
+            return None
 
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -720,7 +720,7 @@ class V2TagStorage(TagStorage):
                 ).values_list('event_id', flat=True)[:1000]
             )
             if not matches:
-                return {'id__in': set()}
+                return None
 
         return {'id__in': set(matches)}
 

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -652,7 +652,7 @@ class V2TagStorage(TagStorage):
                         },
                         extra=extra)
 
-    def get_group_event_ids(self, project_id, group_id, environment_id, tags):
+    def get_group_event_filter(self, project_id, group_id, environment_id, tags):
         # NOTE: `environment_id=None` needs to be filtered differently in this method.
         # EventTag never has NULL `environment_id` fields (individual Events always have an environment),
         # and so `environment_id=None` needs to query EventTag for *all* environments (except, ironically
@@ -691,7 +691,7 @@ class V2TagStorage(TagStorage):
         except KeyError:
             # one or more tags were invalid, thus the result should be an empty
             # set
-            return set()
+            return {'id__in': set()}
 
         # Django doesnt support union, so we limit results and try to find
         # reasonable matches
@@ -720,9 +720,9 @@ class V2TagStorage(TagStorage):
                 ).values_list('event_id', flat=True)[:1000]
             )
             if not matches:
-                return set()
+                return {'id__in': set()}
 
-        return set(matches)
+        return {'id__in': set(matches)}
 
     def get_groups_user_counts(self, project_id, group_ids, environment_id):
         qs = models.GroupTagKey.objects.filter(
@@ -922,7 +922,7 @@ class V2TagStorage(TagStorage):
 
         # ANY matches should come last since they're the least specific and
         # will provide the largest range of matches
-        tag_lookups = sorted(six.iteritems(tags), key=lambda (k, v): v == ANY)
+        tag_lookups = sorted(six.iteritems(tags), key=lambda k_v: k_v[1] == ANY)
 
         # get initial matches to start the filter
         matches = candidates or []

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -423,7 +423,7 @@ class TagStorage(TestCase):
 
         assert models.GroupTagValue.objects.count() == 0
 
-    def test_get_group_event_ids(self):
+    def test_get_group_event_filter(self):
         tags = {
             'abc': 'xyz',
             'foo': 'bar',
@@ -455,12 +455,12 @@ class TagStorage(TestCase):
             tags=different_tags.items(),
         )
 
-        assert len(
-            self.ts.get_group_event_ids(
-                self.proj1.id,
-                self.proj1group1.id,
-                self.proj1env1.id,
-                tags)) == 2
+        assert self.ts.get_group_event_filter(
+            self.proj1.id,
+            self.proj1group1.id,
+            self.proj1env1.id,
+            tags
+        ) == {'id__in': set([1, 2])}
 
     def test_get_groups_user_counts(self):
         k1, _ = self.ts.get_or_create_group_tag_key(

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -460,7 +460,7 @@ class TagStorage(TestCase):
             self.proj1group1.id,
             self.proj1env1.id,
             tags
-        ) == {'id__in': set([1, 2])}
+        ) == {'id__in': set([self.proj1group1event1.id, self.proj1group1event2.id])}
 
     def test_get_groups_user_counts(self):
         k1, _ = self.ts.get_or_create_group_tag_key(

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -235,12 +235,12 @@ class IndexEventTagsTest(TestCase):
                 tags=[('foo', 'bar'), ('biz', 'baz')],
             )
 
-        assert tagstore.get_group_event_ids(
+        assert tagstore.get_group_event_filter(
             self.project.id,
             group.id,
             self.environment.id,
             {'foo': 'bar', 'biz': 'baz'},
-        ) == set([event.id])
+        ) == {'id__in': set([event.id])}
 
         # ensure it safely handles repeat runs
         with self.tasks():
@@ -253,9 +253,9 @@ class IndexEventTagsTest(TestCase):
                 tags=[('foo', 'bar'), ('biz', 'baz')],
             )
 
-        assert tagstore.get_group_event_ids(
+        assert tagstore.get_group_event_filter(
             self.project.id,
             group.id,
             self.environment.id,
             {'foo': 'bar', 'biz': 'baz'},
-        ) == set([event.id])
+        ) == {'id__in': set([event.id])}

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -301,17 +301,17 @@ class TagStorageTest(SnubaTestCase):
         assert tags[0].first_seen == one_second_ago
         assert tags[0].times_seen == 1
 
-    def test_get_group_event_ids(self):
-        assert set(self.ts.get_group_event_ids(
+    def test_get_group_event_filter(self):
+        assert self.ts.get_group_event_filter(
             self.proj1.id,
             self.proj1group1.id,
             self.proj1env1.id,
             {
                 'foo': 'bar',
             }
-        )) == set(["1" * 32, "2" * 32])
+        ) == {'event_id__in': set(["1" * 32, "2" * 32])}
 
-        assert set(self.ts.get_group_event_ids(
+        assert self.ts.get_group_event_filter(
             self.proj1.id,
             self.proj1group1.id,
             self.proj1env1.id,
@@ -319,22 +319,22 @@ class TagStorageTest(SnubaTestCase):
                 'foo': 'bar',  # OR
                 'release': '200'
             }
-        )) == set(["1" * 32, "2" * 32])
+        ) == {'event_id__in': set(["1" * 32, "2" * 32])}
 
-        assert set(self.ts.get_group_event_ids(
+        assert self.ts.get_group_event_filter(
             self.proj1.id,
             self.proj1group2.id,
             self.proj1env1.id,
             {
                 'browser': 'chrome'
             }
-        )) == set(["3" * 32])
+        ) == {'event_id__in': set(["3" * 32])}
 
-        assert set(self.ts.get_group_event_ids(
+        assert self.ts.get_group_event_filter(
             self.proj1.id,
             self.proj1group2.id,
             self.proj1env1.id,
             {
                 'browser': 'ie'
             }
-        )) == set([])
+        ) == {'event_id__in': set([])}

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -337,4 +337,4 @@ class TagStorageTest(SnubaTestCase):
             {
                 'browser': 'ie'
             }
-        ) == {'event_id__in': set([])}
+        ) is None


### PR DESCRIPTION
…nt_ids)

In order to hit Snuba to search tags within an event the tagstore
interface had to change slightly. This isn't a long term solution,
eventually we'll probably want Event search to be its own service
abstraction (like issue search) and all (or almost all) of the search
can be implemented in a single Snuba query.

For now this kicks the can down the road so we can continue comparison
testing.