### PR TITLE
fix(snuba): Add no-op implementation of tagstore.update_group_for_events

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -391,3 +391,7 @@ class SnubaTagStorage(TagStorage):
         # exist in Snuba. This logic is implemented in the search backend
         # instead.
         raise NotImplementedError
+
+    def update_group_for_events(self, project_id, event_ids, destination_id):
+        # Group updates are unncessary in Snuba, but we shouldn't throw an error.
+        pass


### PR DESCRIPTION
This is called in `unmerge` but is a safe no-op for Snuba, because `GroupHash`es are updated separately:

https://github.com/getsentry/sentry/blob/7bfee4b5909c20906da365e01bb22e4f75de9c87/src/sentry/tasks/unmerge.py#L223-L227