### PR TITLE
fix(issues): Clean up various components in issue details

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -58,11 +58,6 @@ class EventSerializer(Serializer):
             sdk_interface = item.interfaces.get('sdk')
             if sdk_interface:
                 sdk_data = sdk_interface.get_api_context()
-                # we restrict SDK information to superusers due to the nature of
-                # privacy laws and IP sensitivity
-                # TODO(dcramer): make this respect 'enhanced privacy' org flag
-                if not user.is_superuser:
-                    sdk_data.pop('clientIP', None)
             else:
                 sdk_data = None
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -502,9 +502,6 @@ class EventManager(object):
         elif client_ip and (is_public or data.get('platform') in add_ip_platforms):
             data.setdefault('sentry.interfaces.User', {}).setdefault('ip_address', client_ip)
 
-        if client_ip and data.get('sdk'):
-            data['sdk']['client_ip'] = client_ip
-
         # Trim values
         data['logger'] = trim(data['logger'].strip(), 64)
         trim_dict(data['extra'], max_size=settings.SENTRY_MAX_EXTRA_VARIABLE_SIZE)

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -57,7 +57,6 @@ class Sdk(Interface):
         kwargs = {
             'name': trim(name, 128),
             'version': trim(version, 128),
-            'client_ip': data.get('client_ip'),
             'integrations': integrations,
         }
         return cls(**kwargs)
@@ -82,7 +81,6 @@ class Sdk(Interface):
         return {
             'name': self.name,
             'version': self.version,
-            'clientIP': self.client_ip,
             'upstream': {
                 'name': newest_name,
                 # when this is correct we can make it available

--- a/src/sentry/static/sentry/app/components/events/eventCause.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCause.jsx
@@ -16,8 +16,8 @@ import {Panel} from 'app/components/panels';
 const ExpandButton = styled.span`
   cursor: pointer;
   position: absolute;
-  right: ${p => p.theme.grid}px;
-  top: 1px;
+  right: 0;
+  top: 7px;
 `;
 
 export default createReactClass({
@@ -98,17 +98,19 @@ export default createReactClass({
         <div className="box-header">
           <h3>
             {t('Suspect Commits')} ({commits.length})
-            <ExpandButton onClick={() => this.setState({expanded: !expanded})}>
-              {expanded ? (
-                <React.Fragment>
-                  show less <InlineSvg src="icon-circle-subtract" size="16px" />
-                </React.Fragment>
-              ) : (
-                <React.Fragment>
-                  show more <InlineSvg src="icon-circle-add" size="16px" />
-                </React.Fragment>
-              )}
-            </ExpandButton>
+            {commits.length > 1 && (
+              <ExpandButton onClick={() => this.setState({expanded: !expanded})}>
+                {expanded ? (
+                  <React.Fragment>
+                    {t('Show less')} <InlineSvg src="icon-circle-subtract" size="16px" />
+                  </React.Fragment>
+                ) : (
+                  <React.Fragment>
+                    {t('Show more')} <InlineSvg src="icon-circle-add" size="16px" />
+                  </React.Fragment>
+                )}
+              </ExpandButton>
+            )}
           </h3>
           <Panel>
             {commits.slice(0, expanded ? 100 : 1).map(commit => {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -132,21 +132,6 @@ const EventEntries = createReactClass({
             issueId={group.id}
           />
         )}
-        {!utils.objectIsEmpty(event.sdk) &&
-          event.sdk.upstream.isNewer && (
-            <div className="alert-block alert-info box">
-              <span className="icon-exclamation" />
-              {t(
-                'This event was reported with an old version of the %s SDK.',
-                event.platform
-              )}
-              {event.sdk.upstream.url && (
-                <a href={event.sdk.upstream.url} className="btn btn-sm btn-default">
-                  {t('Learn More')}
-                </a>
-              )}
-            </div>
-          )}
         {hasContext && <EventContextSummary group={group} event={event} />}
         <EventTags group={group} event={event} orgId={orgId} projectId={project.slug} />
         {entries}
@@ -161,6 +146,21 @@ const EventEntries = createReactClass({
           <EventDevice group={group} event={event} />
         )}
         {!utils.objectIsEmpty(event.sdk) && <EventSdk group={group} event={event} />}
+        {!utils.objectIsEmpty(event.sdk) &&
+          event.sdk.upstream.isNewer && (
+            <div className="alert-block alert-info box">
+              <span className="icon-exclamation" />
+              {t(
+                'This event was reported with an old version of the %s SDK.',
+                event.platform
+              )}
+              {event.sdk.upstream.url && (
+                <a href={event.sdk.upstream.url} className="btn btn-sm btn-default">
+                  {t('Learn More')}
+                </a>
+              )}
+            </div>
+          )}{' '}
       </div>
     );
   },

--- a/src/sentry/static/sentry/app/components/events/sdk.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdk.jsx
@@ -36,14 +36,6 @@ class EventSdk extends React.Component {
                 <pre>{data.version}</pre>
               </td>
             </tr>
-            {data.clientIP && (
-              <tr key="clientIP">
-                <td className="key">{t('Client IP')}</td>
-                <td className="value">
-                  <pre>{data.clientIP}</pre>
-                </td>
-              </tr>
-            )}
           </tbody>
         </table>
       </GroupEventDataSection>

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -618,7 +618,6 @@ class StoreViewTest(TestCase):
         assert call_data['sdk'] == {
             'name': '_postWithHeader',
             'version': '0.0.0',
-            'client_ip': '127.0.0.1',
         }
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database', Mock())


### PR DESCRIPTION
- Dont show expand action on Suspect Commits with only 1 value
- Correct alignment on expand action on Suspect Commits
- Completely remove clientIP from SDK interface
- Move outdated SDK warning to footer of issue details