### PR TITLE
feat(integration): Added OrganizationIntegraiton and ProjectIntegration to Integration base

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -160,7 +160,14 @@ class Integration(object):
 
     def __init__(self, model, organization_id=None, project_id=None):
         self.model = model
-        self.organization_id = organization_id
+        if organization_id is not None:
+            self.org_integration = OrganizationIntegration.objects.get(
+                organization_id=organization_id,
+                integration_id=model.id,
+            )
+        else:
+            self.org_integration = None
+
         if project_id is not None:
             self.project_integration = ProjectIntegration.objects.get(
                 project_id=project_id,
@@ -194,15 +201,10 @@ class Integration(object):
         """
         For Integrations that rely solely on user auth for authentication
         """
-        if self.organization_id is None:
-            raise NotImplementedError
+        if self.org_integration is None:
+            raise NotImplementedError('%s requires an organization_id' % self.name)
 
-        org_integration = OrganizationIntegration.objects.get(
-            organization_id=self.organization_id,
-            integration_id=self.model.id,
-        )
-        identity = Identity.objects.get(id=org_integration.default_auth_id)
-
+        identity = Identity.objects.get(id=self.org_integration.default_auth_id)
         return identity
 
     def error_message_from_json(self, data):

--- a/tests/sentry/integrations/test_base.py
+++ b/tests/sentry/integrations/test_base.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+import pytest
+
+from sentry.models import Integration as IntegrationModel, Identity, IdentityProvider
+from sentry.integrations import Integration
+from sentry.testutils import TestCase
+
+
+class IntegrationTestCase(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.organization = self.create_organization()
+        self.project = self.create_project()
+
+        self.model = IntegrationModel.objects.create(
+            provider='integrations:base',
+            external_id='base_external_id',
+            name='base_name',
+        )
+
+        self.identity = Identity.objects.create(
+            idp=IdentityProvider.objects.create(
+                type='base',
+                config={}
+            ),
+            user=self.user,
+            external_id='base_id',
+            data={
+                'access_token': '11234567'
+            }
+        )
+        self.org_integration = self.model.add_organization(self.organization.id, self.identity.id)
+        self.project_integration = self.model.add_project(self.project.id)
+
+    def test_no_context(self):
+        integration = Integration(self.model)
+        integration.name = 'Base'
+
+        assert integration.org_integration is None
+        assert integration.project_integration is None
+
+        with pytest.raises(NotImplementedError):
+            integration.get_default_identity()
+
+    def test_with_context(self):
+        integration = Integration(self.model, self.organization.id, self.project.id)
+
+        assert integration.model == self.model
+        assert integration.org_integration == self.org_integration
+        assert integration.project_integration == self.project_integration
+        assert integration.get_default_identity() == self.identity


### PR DESCRIPTION
Changed the `IntegrationProvider` to accept a `project_id`. Modified the pre-existing code so that the base Integration class saves an `OrganizationIntegration` object rather than an `organization_id`. And saved a `ProjectIntegration` object as well. Lastly, updated the `get_default_identity` to account for the change in how the org id is used.