### PR TITLE
fix(tests): Remove validateDOMNesting warning

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -397,8 +397,8 @@ const StreamActions = createReactClass({
                   >
                     {t('Add to Bookmarks')}
                   </ActionLink>
-                  <MenuItem divider={true} className={'hidden-md hidden-lg hidden-xl'} />
                 </MenuItem>
+                <MenuItem divider={true} className={'hidden-md hidden-lg hidden-xl'} />
                 <MenuItem noAnchor={true}>
                   <ActionLink
                     className="action-remove-bookmark"


### PR DESCRIPTION
remove `Warning: validateDOMNesting(...): <li> cannot appear as a descendant of <li>` in stream/actions.spec.jsx