### PR TITLE
feat(identity): Added get_provider to Identity Model

### DIFF
--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -59,3 +59,7 @@ class Identity(Model):
         app_label = 'sentry'
         db_table = 'sentry_identity'
         unique_together = (('idp', 'external_id'), ('idp', 'user'))
+
+    def get_provider(self):
+        from sentry.identity import get
+        return get(self.idp.type)

--- a/tests/sentry/models/test_identity.py
+++ b/tests/sentry/models/test_identity.py
@@ -8,7 +8,7 @@ from sentry.testutils import TestCase
 
 
 class ProviderDummy(Provider):
-    name = 'tester'
+    name = 'Tester'
     key = 'tester'
 
     def build_identity(self, state):
@@ -22,11 +22,7 @@ class IdentityTestCase(TestCase):
             external_id='tester_id',
         )
 
-        pipeline_provider = ProviderDummy()
-        pipeline_provider.name = 'Tester'
-        pipeline_provider.key = 'tester'
-        register(pipeline_provider)
-
+        register(ProviderDummy)
         identity_model = Identity.objects.create(
             idp=provider_model,
             user=self.user,
@@ -34,5 +30,5 @@ class IdentityTestCase(TestCase):
         )
 
         provider = identity_model.get_provider()
-        assert provider.type == 'tester'
-        assert provider.external_id == 'tester_id'
+        assert provider.name == 'Tester'
+        assert provider.key == 'tester'

--- a/tests/sentry/models/test_identity.py
+++ b/tests/sentry/models/test_identity.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+
+from sentry.identity import register
+from sentry.identity.base import Provider
+from sentry.models import Identity, IdentityProvider
+from sentry.testutils import TestCase
+
+
+class ProviderDummy(Provider):
+    name = 'tester'
+    key = 'tester'
+
+    def build_identity(self, state):
+        pass
+
+
+class IdentityTestCase(TestCase):
+    def test_get_provider(self):
+        provider_model = IdentityProvider.objects.create(
+            type='tester',
+            external_id='tester_id',
+        )
+
+        pipeline_provider = ProviderDummy()
+        pipeline_provider.name = 'Tester'
+        pipeline_provider.key = 'tester'
+        register(pipeline_provider)
+
+        identity_model = Identity.objects.create(
+            idp=provider_model,
+            user=self.user,
+            external_id='identity_id',
+        )
+
+        provider = identity_model.get_provider()
+        assert provider.type == 'tester'
+        assert provider.external_id == 'tester_id'


### PR DESCRIPTION
Added method to be able to get the `Identity` model to give the  `IdentityProvider` object.