### PR TITLE
feat(integrations): Add sentry to external issue assignee sync core

### DIFF
--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -62,7 +62,7 @@ class ExampleIntegration(Integration, IssueSyncMixin):
             'description': 'This is a test external issue description',
         }
 
-    def sync_assignee_outbound(self, external_issue, user, **kwargs):
+    def sync_assignee_outbound(self, external_issue, user, action, **kwargs):
         pass
 
 

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -62,6 +62,9 @@ class ExampleIntegration(Integration, IssueSyncMixin):
             'description': 'This is a test external issue description',
         }
 
+    def sync_assignee_outbound(self, external_issue, user, **kwargs):
+        pass
+
 
 class ExampleIntegrationProvider(IntegrationProvider):
     """

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -62,7 +62,7 @@ class ExampleIntegration(Integration, IssueSyncMixin):
             'description': 'This is a test external issue description',
         }
 
-    def sync_assignee_outbound(self, external_issue, user, action, **kwargs):
+    def sync_assignee_outbound(self, external_issue, user, assign=True, **kwargs):
         pass
 
 

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -97,3 +97,10 @@ class IssueSyncMixin(object):
         >>>     }
         """
         raise NotImplementedError
+
+    def sync_assignee_outbound(self, external_issue, user, **kwargs):
+        """
+        Propagate a sentry issue's assignee to a linked issue's assignee.
+        If user is None, assume the issue has been unassigned
+        """
+        raise NotImplementedError

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -98,7 +98,7 @@ class IssueSyncMixin(object):
         """
         raise NotImplementedError
 
-    def sync_assignee_outbound(self, external_issue, user, action, **kwargs):
+    def sync_assignee_outbound(self, external_issue, user, assign=True, **kwargs):
         """
         Propagate a sentry issue's assignee to a linked issue's assignee.
         If user is None, assume the issue has been unassigned

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -98,7 +98,7 @@ class IssueSyncMixin(object):
         """
         raise NotImplementedError
 
-    def sync_assignee_outbound(self, external_issue, user, **kwargs):
+    def sync_assignee_outbound(self, external_issue, user, action, **kwargs):
         """
         Propagate a sentry issue's assignee to a linked issue's assignee.
         If user is None, assume the issue has been unassigned

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -18,7 +18,7 @@ from sentry.models.activity import Activity
 from sentry.signals import issue_assigned
 
 
-def sync_group_assignee(group, user_id, action):
+def sync_group_assignee(group, user_id, assign=True):
     from sentry.tasks.integrations import sync_assignee_outbound
     from sentry.models import GroupLink
     external_issue_ids = GroupLink.objects.filter(
@@ -32,7 +32,7 @@ def sync_group_assignee(group, user_id, action):
             kwargs={
                 'external_issue_id': external_issue_id,
                 'user_id': user_id,
-                'action': action,
+                'assign': assign,
             }
         )
 
@@ -98,7 +98,7 @@ class GroupAssigneeManager(BaseManager):
         # sync Sentry assignee to external issues
         if assignee_type == 'user' and features.has(
                 'organizations:internal-catchall', group.organization, actor=acting_user):
-            sync_group_assignee(group, assigned_to.id, 'assign')
+            sync_group_assignee(group, assigned_to.id, assign=True)
 
     def deassign(self, group, acting_user=None):
         from sentry import features
@@ -120,7 +120,7 @@ class GroupAssigneeManager(BaseManager):
 
         # sync Sentry assignee to external issues
         if features.has('organizations:internal-catchall', group.organization, actor=acting_user):
-            sync_group_assignee(group, None, 'deassign')
+            sync_group_assignee(group, None, assign=False)
 
 
 class GroupAssignee(Model):

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -39,7 +39,7 @@ def sync_metadata(installation):
     max_retries=5
 )
 @retry(exclude=(ExternalIssue.DoesNotExist, Integration.DoesNotExist, User.DoesNotExist))
-def sync_assignee_outbound(external_issue_id, user_id, action, **kwargs):
+def sync_assignee_outbound(external_issue_id, user_id, assign, **kwargs):
     # sync Sentry assignee to an external issue
     external_issue = ExternalIssue.objects.get(id=external_issue_id)
     integration = Integration.objects.get(id=external_issue.integration_id)
@@ -48,4 +48,4 @@ def sync_assignee_outbound(external_issue_id, user_id, action, **kwargs):
         user = None
     else:
         user = User.objects.get(id=user_id)
-    integration.get_installation().sync_assignee_outbound(external_issue, user, action)
+    integration.get_installation().sync_assignee_outbound(external_issue, user, assign=assign)

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -39,7 +39,7 @@ def sync_metadata(installation):
     max_retries=5
 )
 @retry(exclude=(ExternalIssue.DoesNotExist, Integration.DoesNotExist, User.DoesNotExist))
-def sync_assignee_outbound(external_issue_id, user_id, **kwargs):
+def sync_assignee_outbound(external_issue_id, user_id, action, **kwargs):
     # sync Sentry assignee to an external issue
     external_issue = ExternalIssue.objects.get(id=external_issue_id)
     integration = Integration.objects.get(id=external_issue.integration_id)
@@ -48,4 +48,4 @@ def sync_assignee_outbound(external_issue_id, user_id, **kwargs):
         user = None
     else:
         user = User.objects.get(id=user_id)
-    integration.get_installation().sync_assignee_outbound(external_issue, user)
+    integration.get_installation().sync_assignee_outbound(external_issue, user, action)

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -128,7 +128,7 @@ class GroupAssigneeTestCase(TestCase):
             with self.tasks():
                 GroupAssignee.objects.assign(self.group, self.user)
 
-                mock_sync_assignee_outbound.assert_called_with(external_issue, self.user)
+                mock_sync_assignee_outbound.assert_called_with(external_issue, self.user, 'assign')
 
                 assert GroupAssignee.objects.filter(
                     project=self.group.project,
@@ -174,7 +174,7 @@ class GroupAssigneeTestCase(TestCase):
         with self.feature('organizations:internal-catchall'):
             with self.tasks():
                 GroupAssignee.objects.deassign(self.group)
-                mock_sync_assignee_outbound.assert_called_with(external_issue, None)
+                mock_sync_assignee_outbound.assert_called_with(external_issue, None, 'deassign')
 
                 assert not GroupAssignee.objects.filter(
                     project=self.group.project,

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -128,7 +128,8 @@ class GroupAssigneeTestCase(TestCase):
             with self.tasks():
                 GroupAssignee.objects.assign(self.group, self.user)
 
-                mock_sync_assignee_outbound.assert_called_with(external_issue, self.user, 'assign')
+                mock_sync_assignee_outbound.assert_called_with(
+                    external_issue, self.user, assign=True)
 
                 assert GroupAssignee.objects.filter(
                     project=self.group.project,
@@ -174,7 +175,7 @@ class GroupAssigneeTestCase(TestCase):
         with self.feature('organizations:internal-catchall'):
             with self.tasks():
                 GroupAssignee.objects.deassign(self.group)
-                mock_sync_assignee_outbound.assert_called_with(external_issue, None, 'deassign')
+                mock_sync_assignee_outbound.assert_called_with(external_issue, None, assign=False)
 
                 assert not GroupAssignee.objects.filter(
                     project=self.group.project,

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 
+import mock
 import pytest
 import six
 
+from sentry.integrations.example.integration import ExampleIntegration
+from sentry.models import GroupAssignee, Activity, Integration, GroupLink, ExternalIssue
 from sentry.testutils import TestCase
-from sentry.models import GroupAssignee, Activity
 
 
 class GroupAssigneeTestCase(TestCase):
@@ -99,3 +101,90 @@ class GroupAssigneeTestCase(TestCase):
         assert activity[1].data['assignee'] == six.text_type(self.team.id)
         assert activity[1].data['assigneeEmail'] is None
         assert activity[1].data['assigneeType'] == 'team'
+
+    @mock.patch.object(ExampleIntegration, 'sync_assignee_outbound')
+    def test_assignee_sync_outbound_assign(self, mock_sync_assignee_outbound):
+        group = self.group
+        integration = Integration.objects.create(
+            provider='example',
+            external_id='123456',
+        )
+
+        external_issue = ExternalIssue.objects.create(
+            organization_id=group.organization.id,
+            integration_id=integration.id,
+            key='APP-123',
+        )
+
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+        )
+
+        with self.feature('organizations:internal-catchall'):
+            with self.tasks():
+                GroupAssignee.objects.assign(self.group, self.user)
+
+                mock_sync_assignee_outbound.assert_called_with(external_issue, self.user)
+
+                assert GroupAssignee.objects.filter(
+                    project=self.group.project,
+                    group=self.group,
+                    user=self.user,
+                    team__isnull=True,
+                ).exists()
+
+                activity = Activity.objects.get(
+                    project=self.group.project,
+                    group=self.group,
+                    type=Activity.ASSIGNED,
+                )
+
+                assert activity.data['assignee'] == six.text_type(self.user.id)
+                assert activity.data['assigneeEmail'] == self.user.email
+                assert activity.data['assigneeType'] == 'user'
+
+    @mock.patch.object(ExampleIntegration, 'sync_assignee_outbound')
+    def test_assignee_sync_outbound_unassign(self, mock_sync_assignee_outbound):
+        group = self.group
+        integration = Integration.objects.create(
+            provider='example',
+            external_id='123456',
+        )
+
+        external_issue = ExternalIssue.objects.create(
+            organization_id=group.organization.id,
+            integration_id=integration.id,
+            key='APP-123',
+        )
+
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+        )
+
+        GroupAssignee.objects.assign(self.group, self.user)
+
+        with self.feature('organizations:internal-catchall'):
+            with self.tasks():
+                GroupAssignee.objects.deassign(self.group)
+                mock_sync_assignee_outbound.assert_called_with(external_issue, None)
+
+                assert not GroupAssignee.objects.filter(
+                    project=self.group.project,
+                    group=self.group,
+                    user=self.user,
+                    team__isnull=True,
+                ).exists()
+
+                assert Activity.objects.filter(
+                    project=self.group.project,
+                    group=self.group,
+                    type=Activity.UNASSIGNED,
+                ).exists()


### PR DESCRIPTION
Adds core functionality for syncing assignee from sentry to JIRA/VSTS/etc (will have a follow up PR implementing for JIRA)


cc @EvanPurkhiser @MeredithAnya @lauryndbrown 