### PR TITLE
build(travis): revert travis cache and nvm install hotfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   yarn: true
   directories:
     - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
-    - "$NODE_DIR"
+    - "${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - node_modules
     - "${HOME}/google-cloud-sdk"
 
@@ -32,7 +32,6 @@ env:
     - SOUTH_TESTS_MIGRATE=1
     - DJANGO_VERSION=">=1.6.11,<1.7"
     # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
-    - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - YARN_VERSION="1.3.2"
 
 script:
@@ -106,7 +105,6 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - find "$NODE_DIR" -type d -empty -delete
         - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
       install:
@@ -122,7 +120,6 @@ matrix:
     - python: 2.7
       env: TEST_SUITE=js
       before_install:
-        - find "$NODE_DIR" -type d -empty -delete
         - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
       install:


### PR DESCRIPTION
This reverts #8623 now that I've gotten the appropriate changes merged into `nvm` here: https://github.com/creationix/nvm/pull/1824

To recap, nvm's `nvm_is_version_installed` has been made stricter and no longer assumes a node version is installed if the directory is merely present. See #8623 for a more detailed explanation.