### PR TITLE
fix(ui): Cleanup autocomplete empty message sizing

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -339,9 +339,8 @@ const StyledMenu = styled('div')`
 
 const EmptyMessage = styled('div')`
   color: ${p => p.theme.gray1};
-  padding: ${space(1)} ${space(2)};
+  padding: ${space(2)};
   text-align: center;
-  font-size: 1.2em;
   text-transform: none;
 `;
 


### PR DESCRIPTION
Maybe a little oppinionative but.. Just gives things a little more room to breath

![image](https://user-images.githubusercontent.com/1421724/41561108-d87d22fa-72fd-11e8-8a33-ebea0cce2f14.png)

versus the old

![image](https://user-images.githubusercontent.com/1421724/41561174-fd55fe3a-72fd-11e8-931b-5368c175f558.png)