### PR TITLE
feat(ui): Add noTitleStyles prop for SettingsPageHeading

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
@@ -4,20 +4,33 @@ import styled from 'react-emotion';
 import {Flex, Box} from 'grid-emotion';
 import space from 'app/styles/space';
 
+const Heading = styled(Flex)`
+  margin: ${space(3)} 0;
+  flex: 1;
+`;
+
+const Title = styled(Heading)`
+  font-size: 20px;
+  font-weight: bold;
+`;
+
 class SettingsPageHeading extends React.Component {
   static propTypes = {
     icon: PropTypes.node,
     title: PropTypes.node,
     action: PropTypes.node,
     tabs: PropTypes.node,
+    noStyles: PropTypes.bool,
   };
 
   render() {
+    const StyledTitle = this.props.noStyles ? Heading : Title;
+
     return (
       <Wrapper tabs={this.props.tabs}>
         <Flex align="center">
           {this.props.icon && <Box pr={1}>{this.props.icon}</Box>}
-          {this.props.title && <Title>{this.props.title}</Title>}
+          {this.props.title && <StyledTitle>{this.props.title}</StyledTitle>}
           {this.props.action && <div>{this.props.action}</div>}
         </Flex>
 
@@ -31,13 +44,6 @@ const Wrapper = styled.div`
   font-size: 14px;
   box-shadow: inset 0 -1px 0 ${p => p.theme.borderLight};
   margin: -${space(3)} 0 ${space(3)};
-`;
-
-const Title = styled.div`
-  font-size: 20px;
-  font-weight: bold;
-  margin: ${space(3)} 0;
-  flex: 1;
 `;
 
 export default SettingsPageHeading;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
@@ -4,33 +4,24 @@ import styled from 'react-emotion';
 import {Flex, Box} from 'grid-emotion';
 import space from 'app/styles/space';
 
-const Heading = styled(Flex)`
-  margin: ${space(3)} 0;
-  flex: 1;
-`;
-
-const Title = styled(Heading)`
-  font-size: 20px;
-  font-weight: bold;
-`;
-
 class SettingsPageHeading extends React.Component {
   static propTypes = {
     icon: PropTypes.node,
     title: PropTypes.node,
     action: PropTypes.node,
     tabs: PropTypes.node,
-    noStyles: PropTypes.bool,
+    // Disables font styles in the title. Allows for more custom titles.
+    noTitleStyles: PropTypes.bool,
   };
 
   render() {
-    const StyledTitle = this.props.noStyles ? Heading : Title;
-
     return (
       <Wrapper tabs={this.props.tabs}>
         <Flex align="center">
           {this.props.icon && <Box pr={1}>{this.props.icon}</Box>}
-          {this.props.title && <StyledTitle>{this.props.title}</StyledTitle>}
+          {this.props.title && (
+            <Title styled={this.props.noTitleStyles}>{this.props.title}</Title>
+          )}
           {this.props.action && <div>{this.props.action}</div>}
         </Flex>
 
@@ -39,6 +30,16 @@ class SettingsPageHeading extends React.Component {
     );
   }
 }
+
+const Title = styled(Flex)`
+  ${p =>
+    !p.styled &&
+    `
+    font-size: 20px;
+    font-weight: bold;`};
+  margin: ${space(3)} 0;
+  flex: 1;
+`;
 
 const Wrapper = styled.div`
   font-size: 14px;

--- a/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
@@ -49,7 +49,7 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
         >
           <Wrapper>
             <div
-              className="css-12kovf2-Wrapper e1kblvez0"
+              className="css-12kovf2-Wrapper e1kblvez2"
             >
               <Flex
                 align="center"
@@ -63,11 +63,16 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
                     is={null}
                   >
                     <Title>
-                      <div
-                        className="css-zmdcxu-Title e1kblvez1"
+                      <Base
+                        className="css-19wrrzr-Heading-Title e1kblvez1"
                       >
-                        Subscriptions
-                      </div>
+                        <div
+                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          is={null}
+                        >
+                          Subscriptions
+                        </div>
+                      </Base>
                     </Title>
                   </div>
                 </Base>

--- a/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
@@ -49,7 +49,7 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
         >
           <Wrapper>
             <div
-              className="css-12kovf2-Wrapper e1kblvez2"
+              className="css-12kovf2-Wrapper e1kblvez1"
             >
               <Flex
                 align="center"
@@ -64,10 +64,10 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
                   >
                     <Title>
                       <Base
-                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        className="css-1mqcea-Title e1kblvez0"
                       >
                         <div
-                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          className="css-1mqcea-Title e1kblvez0"
                           is={null}
                         >
                           Subscriptions

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -83,7 +83,7 @@ exports[`projectAlertRules renders 1`] = `
           }
         >
           <div
-            className="css-1pnrn3o-Wrapper e1kblvez0"
+            className="css-1pnrn3o-Wrapper e1kblvez2"
           >
             <Flex
               align="center"
@@ -97,11 +97,16 @@ exports[`projectAlertRules renders 1`] = `
                   is={null}
                 >
                   <Title>
-                    <div
-                      className="css-zmdcxu-Title e1kblvez1"
+                    <Base
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
                     >
-                      Alerts
-                    </div>
+                      <div
+                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        is={null}
+                      >
+                        Alerts
+                      </div>
+                    </Base>
                   </Title>
                   <div>
                     <Button

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -83,7 +83,7 @@ exports[`projectAlertRules renders 1`] = `
           }
         >
           <div
-            className="css-1pnrn3o-Wrapper e1kblvez2"
+            className="css-1pnrn3o-Wrapper e1kblvez1"
           >
             <Flex
               align="center"
@@ -98,10 +98,10 @@ exports[`projectAlertRules renders 1`] = `
                 >
                   <Title>
                     <Base
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                     >
                       <div
-                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        className="css-1mqcea-Title e1kblvez0"
                         is={null}
                       >
                         Alerts

--- a/tests/js/spec/views/__snapshots__/projectDebugSymbols.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugSymbols.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`ProjectDebugSymbols renders 1`] = `
     >
       <Wrapper>
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez0"
+          className="css-1pnrn3o-Wrapper e1kblvez2"
         >
           <Flex
             align="center"
@@ -29,11 +29,16 @@ exports[`ProjectDebugSymbols renders 1`] = `
                 is={null}
               >
                 <Title>
-                  <div
-                    className="css-zmdcxu-Title e1kblvez1"
+                  <Base
+                    className="css-19wrrzr-Heading-Title e1kblvez1"
                   >
-                    Debug Information Files
-                  </div>
+                    <div
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      is={null}
+                    >
+                      Debug Information Files
+                    </div>
+                  </Base>
                 </Title>
               </div>
             </Base>
@@ -264,7 +269,7 @@ exports[`ProjectDebugSymbols renders 1`] = `
       >
         <Wrapper>
           <div
-            className="css-1pnrn3o-Wrapper e1kblvez0"
+            className="css-1pnrn3o-Wrapper e1kblvez2"
           >
             <Flex
               align="center"
@@ -278,11 +283,16 @@ exports[`ProjectDebugSymbols renders 1`] = `
                   is={null}
                 >
                   <Title>
-                    <div
-                      className="css-zmdcxu-Title e1kblvez1"
+                    <Base
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
                     >
-                      Unreferenced Debug Information Files
-                    </div>
+                      <div
+                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        is={null}
+                      >
+                        Unreferenced Debug Information Files
+                      </div>
+                    </Base>
                   </Title>
                 </div>
               </Base>

--- a/tests/js/spec/views/__snapshots__/projectDebugSymbols.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugSymbols.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`ProjectDebugSymbols renders 1`] = `
     >
       <Wrapper>
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez2"
+          className="css-1pnrn3o-Wrapper e1kblvez1"
         >
           <Flex
             align="center"
@@ -30,10 +30,10 @@ exports[`ProjectDebugSymbols renders 1`] = `
               >
                 <Title>
                   <Base
-                    className="css-19wrrzr-Heading-Title e1kblvez1"
+                    className="css-1mqcea-Title e1kblvez0"
                   >
                     <div
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                       is={null}
                     >
                       Debug Information Files
@@ -269,7 +269,7 @@ exports[`ProjectDebugSymbols renders 1`] = `
       >
         <Wrapper>
           <div
-            className="css-1pnrn3o-Wrapper e1kblvez2"
+            className="css-1pnrn3o-Wrapper e1kblvez1"
           >
             <Flex
               align="center"
@@ -284,10 +284,10 @@ exports[`ProjectDebugSymbols renders 1`] = `
                 >
                   <Title>
                     <Base
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                     >
                       <div
-                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        className="css-1mqcea-Title e1kblvez0"
                         is={null}
                       >
                         Unreferenced Debug Information Files

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -76,7 +76,7 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez0"
+          className="css-1pnrn3o-Wrapper e1kblvez2"
         >
           <Flex
             align="center"
@@ -90,11 +90,16 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
                 is={null}
               >
                 <Title>
-                  <div
-                    className="css-zmdcxu-Title e1kblvez1"
+                  <Base
+                    className="css-19wrrzr-Heading-Title e1kblvez1"
                   >
-                    Manage Environments
-                  </div>
+                    <div
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      is={null}
+                    >
+                      Manage Environments
+                    </div>
+                  </Base>
                 </Title>
               </div>
             </Base>
@@ -296,7 +301,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez0"
+          className="css-1pnrn3o-Wrapper e1kblvez2"
         >
           <Flex
             align="center"
@@ -310,11 +315,16 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                 is={null}
               >
                 <Title>
-                  <div
-                    className="css-zmdcxu-Title e1kblvez1"
+                  <Base
+                    className="css-19wrrzr-Heading-Title e1kblvez1"
                   >
-                    Manage Environments
-                  </div>
+                    <div
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      is={null}
+                    >
+                      Manage Environments
+                    </div>
+                  </Base>
                 </Title>
               </div>
             </Base>
@@ -962,7 +972,7 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez0"
+          className="css-1pnrn3o-Wrapper e1kblvez2"
         >
           <Flex
             align="center"
@@ -976,11 +986,16 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
                 is={null}
               >
                 <Title>
-                  <div
-                    className="css-zmdcxu-Title e1kblvez1"
+                  <Base
+                    className="css-19wrrzr-Heading-Title e1kblvez1"
                   >
-                    Manage Environments
-                  </div>
+                    <div
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      is={null}
+                    >
+                      Manage Environments
+                    </div>
+                  </Base>
                 </Title>
               </div>
             </Base>
@@ -1182,7 +1197,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez0"
+          className="css-1pnrn3o-Wrapper e1kblvez2"
         >
           <Flex
             align="center"
@@ -1196,11 +1211,16 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                 is={null}
               >
                 <Title>
-                  <div
-                    className="css-zmdcxu-Title e1kblvez1"
+                  <Base
+                    className="css-19wrrzr-Heading-Title e1kblvez1"
                   >
-                    Manage Environments
-                  </div>
+                    <div
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      is={null}
+                    >
+                      Manage Environments
+                    </div>
+                  </Base>
                 </Title>
               </div>
             </Base>

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -76,7 +76,7 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez2"
+          className="css-1pnrn3o-Wrapper e1kblvez1"
         >
           <Flex
             align="center"
@@ -91,10 +91,10 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
               >
                 <Title>
                   <Base
-                    className="css-19wrrzr-Heading-Title e1kblvez1"
+                    className="css-1mqcea-Title e1kblvez0"
                   >
                     <div
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                       is={null}
                     >
                       Manage Environments
@@ -301,7 +301,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez2"
+          className="css-1pnrn3o-Wrapper e1kblvez1"
         >
           <Flex
             align="center"
@@ -316,10 +316,10 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
               >
                 <Title>
                   <Base
-                    className="css-19wrrzr-Heading-Title e1kblvez1"
+                    className="css-1mqcea-Title e1kblvez0"
                   >
                     <div
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                       is={null}
                     >
                       Manage Environments
@@ -972,7 +972,7 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez2"
+          className="css-1pnrn3o-Wrapper e1kblvez1"
         >
           <Flex
             align="center"
@@ -987,10 +987,10 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
               >
                 <Title>
                   <Base
-                    className="css-19wrrzr-Heading-Title e1kblvez1"
+                    className="css-1mqcea-Title e1kblvez0"
                   >
                     <div
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                       is={null}
                     >
                       Manage Environments
@@ -1197,7 +1197,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
         }
       >
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez2"
+          className="css-1pnrn3o-Wrapper e1kblvez1"
         >
           <Flex
             align="center"
@@ -1212,10 +1212,10 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
               >
                 <Title>
                   <Base
-                    className="css-19wrrzr-Heading-Title e1kblvez1"
+                    className="css-1mqcea-Title e1kblvez0"
                   >
                     <div
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                       is={null}
                     >
                       Manage Environments

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -148,7 +148,7 @@ exports[`ProjectPluginDetails renders 1`] = `
           >
             <Wrapper>
               <div
-                className="css-1pnrn3o-Wrapper e1kblvez0"
+                className="css-1pnrn3o-Wrapper e1kblvez2"
               >
                 <Flex
                   align="center"
@@ -162,11 +162,16 @@ exports[`ProjectPluginDetails renders 1`] = `
                       is={null}
                     >
                       <Title>
-                        <div
-                          className="css-zmdcxu-Title e1kblvez1"
+                        <Base
+                          className="css-19wrrzr-Heading-Title e1kblvez1"
                         >
-                          Amazon SQS
-                        </div>
+                          <div
+                            className="css-19wrrzr-Heading-Title e1kblvez1"
+                            is={null}
+                          >
+                            Amazon SQS
+                          </div>
+                        </Base>
                       </Title>
                       <div>
                         <div

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -148,7 +148,7 @@ exports[`ProjectPluginDetails renders 1`] = `
           >
             <Wrapper>
               <div
-                className="css-1pnrn3o-Wrapper e1kblvez2"
+                className="css-1pnrn3o-Wrapper e1kblvez1"
               >
                 <Flex
                   align="center"
@@ -163,10 +163,10 @@ exports[`ProjectPluginDetails renders 1`] = `
                     >
                       <Title>
                         <Base
-                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          className="css-1mqcea-Title e1kblvez0"
                         >
                           <div
-                            className="css-19wrrzr-Heading-Title e1kblvez1"
+                            className="css-1mqcea-Title e1kblvez0"
                             is={null}
                           >
                             Amazon SQS

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`ProjectSavedSearches renders 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez2"
+              className="css-1pnrn3o-Wrapper e1kblvez1"
             >
               <Flex
                 align="center"
@@ -36,10 +36,10 @@ exports[`ProjectSavedSearches renders 1`] = `
                   >
                     <Title>
                       <Base
-                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        className="css-1mqcea-Title e1kblvez0"
                       >
                         <div
-                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          className="css-1mqcea-Title e1kblvez0"
                           is={null}
                         >
                           Saved Searches
@@ -907,7 +907,7 @@ exports[`ProjectSavedSearches renders empty 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez2"
+              className="css-1pnrn3o-Wrapper e1kblvez1"
             >
               <Flex
                 align="center"
@@ -922,10 +922,10 @@ exports[`ProjectSavedSearches renders empty 1`] = `
                   >
                     <Title>
                       <Base
-                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        className="css-1mqcea-Title e1kblvez0"
                       >
                         <div
-                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          className="css-1mqcea-Title e1kblvez0"
                           is={null}
                         >
                           Saved Searches

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`ProjectSavedSearches renders 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez0"
+              className="css-1pnrn3o-Wrapper e1kblvez2"
             >
               <Flex
                 align="center"
@@ -35,11 +35,16 @@ exports[`ProjectSavedSearches renders 1`] = `
                     is={null}
                   >
                     <Title>
-                      <div
-                        className="css-zmdcxu-Title e1kblvez1"
+                      <Base
+                        className="css-19wrrzr-Heading-Title e1kblvez1"
                       >
-                        Saved Searches
-                      </div>
+                        <div
+                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          is={null}
+                        >
+                          Saved Searches
+                        </div>
+                      </Base>
                     </Title>
                   </div>
                 </Base>
@@ -902,7 +907,7 @@ exports[`ProjectSavedSearches renders empty 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez0"
+              className="css-1pnrn3o-Wrapper e1kblvez2"
             >
               <Flex
                 align="center"
@@ -916,11 +921,16 @@ exports[`ProjectSavedSearches renders empty 1`] = `
                     is={null}
                   >
                     <Title>
-                      <div
-                        className="css-zmdcxu-Title e1kblvez1"
+                      <Base
+                        className="css-19wrrzr-Heading-Title e1kblvez1"
                       >
-                        Saved Searches
-                      </div>
+                        <div
+                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          is={null}
+                        >
+                          Saved Searches
+                        </div>
+                      </Base>
                     </Title>
                   </div>
                 </Base>

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`ProjectTags renders 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez0"
+              className="css-1pnrn3o-Wrapper e1kblvez2"
             >
               <Flex
                 align="center"
@@ -35,11 +35,16 @@ exports[`ProjectTags renders 1`] = `
                     is={null}
                   >
                     <Title>
-                      <div
-                        className="css-zmdcxu-Title e1kblvez1"
+                      <Base
+                        className="css-19wrrzr-Heading-Title e1kblvez1"
                       >
-                        Tags
-                      </div>
+                        <div
+                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          is={null}
+                        >
+                          Tags
+                        </div>
+                      </Base>
                     </Title>
                   </div>
                 </Base>

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`ProjectTags renders 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez2"
+              className="css-1pnrn3o-Wrapper e1kblvez1"
             >
               <Flex
                 align="center"
@@ -36,10 +36,10 @@ exports[`ProjectTags renders 1`] = `
                   >
                     <Title>
                       <Base
-                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        className="css-1mqcea-Title e1kblvez0"
                       >
                         <div
-                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          className="css-1mqcea-Title e1kblvez0"
                           is={null}
                         >
                           Tags

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -31,7 +31,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
     >
       <Wrapper>
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez0"
+          className="css-1pnrn3o-Wrapper e1kblvez2"
         >
           <Flex
             align="center"
@@ -45,11 +45,16 @@ exports[`CreateProject should render roles when available and allowed, and handl
                 is={null}
               >
                 <Title>
-                  <div
-                    className="css-zmdcxu-Title e1kblvez1"
+                  <Base
+                    className="css-19wrrzr-Heading-Title e1kblvez1"
                   >
-                    Add Member to Organization
-                  </div>
+                    <div
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      is={null}
+                    >
+                      Add Member to Organization
+                    </div>
+                  </Base>
                 </Title>
               </div>
             </Base>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -31,7 +31,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
     >
       <Wrapper>
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez2"
+          className="css-1pnrn3o-Wrapper e1kblvez1"
         >
           <Flex
             align="center"
@@ -46,10 +46,10 @@ exports[`CreateProject should render roles when available and allowed, and handl
               >
                 <Title>
                   <Base
-                    className="css-19wrrzr-Heading-Title e1kblvez1"
+                    className="css-1mqcea-Title e1kblvez0"
                   >
                     <div
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                       is={null}
                     >
                       Add Member to Organization

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -60,7 +60,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
     >
       <Wrapper>
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez0"
+          className="css-1pnrn3o-Wrapper e1kblvez2"
         >
           <Flex
             align="center"
@@ -74,11 +74,16 @@ exports[`OrganizationApiKeysList renders 1`] = `
                 is={null}
               >
                 <Title>
-                  <div
-                    className="css-zmdcxu-Title e1kblvez1"
+                  <Base
+                    className="css-19wrrzr-Heading-Title e1kblvez1"
                   >
-                    API Keys
-                  </div>
+                    <div
+                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      is={null}
+                    >
+                      API Keys
+                    </div>
+                  </Base>
                 </Title>
                 <div>
                   <Button

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -60,7 +60,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
     >
       <Wrapper>
         <div
-          className="css-1pnrn3o-Wrapper e1kblvez2"
+          className="css-1pnrn3o-Wrapper e1kblvez1"
         >
           <Flex
             align="center"
@@ -75,10 +75,10 @@ exports[`OrganizationApiKeysList renders 1`] = `
               >
                 <Title>
                   <Base
-                    className="css-19wrrzr-Heading-Title e1kblvez1"
+                    className="css-1mqcea-Title e1kblvez0"
                   >
                     <div
-                      className="css-19wrrzr-Heading-Title e1kblvez1"
+                      className="css-1mqcea-Title e1kblvez0"
                       is={null}
                     >
                       API Keys

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -32,7 +32,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez0"
+              className="css-1pnrn3o-Wrapper e1kblvez2"
             >
               <Flex
                 align="center"
@@ -46,11 +46,16 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                     is={null}
                   >
                     <Title>
-                      <div
-                        className="css-zmdcxu-Title e1kblvez1"
+                      <Base
+                        className="css-19wrrzr-Heading-Title e1kblvez1"
                       >
-                        Projects
-                      </div>
+                        <div
+                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          is={null}
+                        >
+                          Projects
+                        </div>
+                      </Base>
                     </Title>
                     <div>
                       <Button

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -32,7 +32,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
         >
           <Wrapper>
             <div
-              className="css-1pnrn3o-Wrapper e1kblvez2"
+              className="css-1pnrn3o-Wrapper e1kblvez1"
             >
               <Flex
                 align="center"
@@ -47,10 +47,10 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                   >
                     <Title>
                       <Base
-                        className="css-19wrrzr-Heading-Title e1kblvez1"
+                        className="css-1mqcea-Title e1kblvez0"
                       >
                         <div
-                          className="css-19wrrzr-Heading-Title e1kblvez1"
+                          className="css-1mqcea-Title e1kblvez0"
                           is={null}
                         >
                           Projects


### PR DESCRIPTION
Adds support to the settings page header for a custom title node

Used in the integrations configuration page:

![image](https://user-images.githubusercontent.com/1421724/41562694-3e09a504-7302-11e8-85ee-bdd2f31aeaf3.png)
