### PR TITLE
feat(ui): Add <Feature> component

### DIFF
--- a/src/sentry/static/sentry/app/components/feature.jsx
+++ b/src/sentry/static/sentry/app/components/feature.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SentryTypes from 'app/proptypes';
+
+/**
+ * Interface to handle feature tags as well as user's organization access levels
+ */
+class Feature extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization,
+    project: SentryTypes.Project,
+    /**
+     * List of required feature tags
+     */
+    feature: PropTypes.arrayOf(PropTypes.string),
+    /**
+     * List of required access levels
+     */
+    access: PropTypes.arrayOf(PropTypes.string),
+    /**
+     * If children is a function then will be treated as a render prop and passed this object:
+     * {
+     *   hasFeature: bool,
+     *   hasAccess: bool,
+     * }
+     *
+     * The other interface is more simple, only show `children` if org/project has
+     * all the required feature AND access tags
+     */
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  };
+
+  render() {
+    let {children, organization, project, feature, access} = this.props;
+    let allFeatures = []
+      .concat((organization && organization.features) || [])
+      .concat((project && project.features) || []);
+    let {access: orgAccess} = organization || {access: []};
+    let hasFeature = !feature || feature.every(feat => allFeatures.includes(feat));
+    let hasAccess = !access || access.every(acc => orgAccess.includes(acc));
+
+    if (typeof children === 'function') {
+      return children({
+        hasFeature,
+        hasAccess,
+      });
+    }
+
+    // if children is NOT a function,
+    // then only render `children` iff `features` and `access` passes
+    if (hasFeature && hasAccess) {
+      return children;
+    }
+
+    return null;
+  }
+}
+
+export default class FeatureContainer extends React.Component {
+  static contextTypes = {
+    organization: SentryTypes.Organization,
+    project: SentryTypes.Project,
+  };
+
+  render() {
+    return (
+      <Feature
+        organization={this.context.organization}
+        project={this.context.project}
+        {...this.props}
+      />
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/components/feature.jsx
+++ b/src/sentry/static/sentry/app/components/feature.jsx
@@ -49,18 +49,18 @@ class Feature extends React.Component {
   };
 
   hasFeature = (feature, features) => {
-    let shouldMatchOnlyProject = /^project:/.test(feature);
-    let shouldMatchOnlyOrg = /^organization:/.test(feature);
+    let shouldMatchOnlyProject = feature.match(/^project:(\w+)/);
+    let shouldMatchOnlyOrg = feature.match(/^organization:(\w+)/);
 
     // Array of feature strings
     let {config, organization, project} = features;
 
     if (shouldMatchOnlyProject) {
-      return project.includes(feature);
+      return project.includes(shouldMatchOnlyProject[1]);
     }
 
     if (shouldMatchOnlyOrg) {
-      return organization.includes(feature);
+      return organization.includes(shouldMatchOnlyOrg[1]);
     }
 
     // default, check all feature arrays

--- a/tests/js/spec/components/feature.spec.jsx
+++ b/tests/js/spec/components/feature.spec.jsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import Feature from 'app/components/feature';
+
+describe('Feature', function() {
+  const organization = TestStubs.Organization({
+    features: ['org-foo', 'org-bar'],
+    access: ['project:write', 'project:read'],
+  });
+  const project = TestStubs.Project({
+    features: ['project-foo', 'project-bar'],
+  });
+  const routerContext = TestStubs.routerContext([
+    {
+      organization,
+      project,
+    },
+  ]);
+
+  describe('as render prop', function() {
+    let childrenMock = jest.fn().mockReturnValue(null);
+    beforeEach(function() {
+      childrenMock.mockClear();
+    });
+
+    it('has feature (has access because optional)', function() {
+      mount(
+        <Feature feature={['org-foo', 'project-foo']}>{childrenMock}</Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: true,
+        hasAccess: true,
+      });
+    });
+
+    it('has accesss (has feature because optional)', function() {
+      mount(
+        <Feature access={['project:write', 'project:read']}>{childrenMock}</Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: true,
+        hasAccess: true,
+      });
+    });
+
+    it('has feature and access', function() {
+      mount(
+        <Feature
+          feature={['org-foo', 'project-foo']}
+          access={['project:write', 'project:read']}
+        >
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: true,
+        hasAccess: true,
+      });
+    });
+
+    it('has feature but no access', function() {
+      mount(
+        <Feature feature={['org-foo', 'project-foo']} access={['org:write']}>
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: true,
+        hasAccess: false,
+      });
+    });
+
+    it('has access but no feature', function() {
+      mount(
+        <Feature feature={['org-baz']} access={['project:write']}>
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: false,
+        hasAccess: true,
+      });
+    });
+
+    it('has no access and no feature', function() {
+      mount(
+        <Feature feature={['org-baz']} access={['org:write']}>
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: false,
+        hasAccess: false,
+      });
+    });
+
+    it('can specify org from props', function() {
+      mount(
+        <Feature
+          organization={TestStubs.Organization({access: ['org:write']})}
+          access={['org:write']}
+        >
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: true,
+        hasAccess: true,
+      });
+    });
+
+    it('can specify project from props', function() {
+      mount(
+        <Feature
+          project={TestStubs.Project({features: ['project-baz']})}
+          feature={['project-baz']}
+        >
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: true,
+        hasAccess: true,
+      });
+    });
+
+    it('handles no org/project', function() {
+      mount(
+        <Feature
+          organization={null}
+          project={null}
+          access={['org:write']}
+          feature={['org-foo', 'project-foo']}
+        >
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: false,
+        hasAccess: false,
+      });
+    });
+  });
+
+  describe('as React node', function() {
+    let wrapper;
+
+    it('has features and access', function() {
+      wrapper = mount(
+        <Feature feature={['org-bar']} access={['project:write']}>
+          <div>The Child</div>
+        </Feature>,
+        routerContext
+      );
+
+      expect(wrapper.find('Feature div').text()).toBe('The Child');
+    });
+
+    it('has no features or no access', function() {
+      wrapper = mount(
+        <Feature feature={['org-baz']} access={['org:write']}>
+          <div>The Child</div>
+        </Feature>,
+        routerContext
+      );
+
+      expect(wrapper.find('Feature div')).toHaveLength(0);
+    });
+  });
+});

--- a/tests/js/spec/components/feature.spec.jsx
+++ b/tests/js/spec/components/feature.spec.jsx
@@ -5,7 +5,7 @@ import Feature from 'app/components/feature';
 
 describe('Feature', function() {
   const organization = TestStubs.Organization({
-    features: ['org-foo', 'org-bar'],
+    features: ['org-foo', 'org-bar', 'bar'],
     access: ['project:write', 'project:read'],
   });
   const project = TestStubs.Project({
@@ -157,6 +157,36 @@ describe('Feature', function() {
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
         hasAccess: false,
+      });
+    });
+
+    it('handles features prefixed with org/project', function() {
+      mount(
+        <Feature
+          organization={organization}
+          project={project}
+          feature={['organization:bar']}
+        >
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: true,
+        hasAccess: true,
+      });
+
+      mount(
+        <Feature organization={organization} project={project} feature={['project:bar']}>
+          {childrenMock}
+        </Feature>,
+        routerContext
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: false,
+        hasAccess: true,
       });
     });
   });


### PR DESCRIPTION
This adds a <Feature> component with two interfaces for `children`:

1) render prop: `({hasAccess: bool, hasFeature: bool}) => Component`
   Calls `children` as a function with this object `{hasAccess,
   hasFeature}`.

2) react node: if both `feature` and `access` check pass, simply render
   `children`.

Does not consider undefined `feature` or `access` as required.

I think this is more appropriate than a HoC because this component is
very closely tied to rendering logic, so it would be more helpful to
have it in the parent's `render` method. With a HoC, your
feature/access props would be moved to the bottom of the file, and
organizationally, gets separated from your main `render`.

/cc @denamwangi - I think we could also build on top of this for planout.