### PR TITLE
ref(store): Always copy data in EventManager

### DIFF
--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -500,14 +500,13 @@ class LazyData(MutableMapping):
         data['key_id'] = self._key.id
         data['sdk'] = data.get('sdk') or helper.parse_client_as_sdk(auth.client)
 
-        # mutates data
+        # does not mutate data, must use return value of normalize
         manager = EventManager(data, version=auth.version)
-        manager.normalize(request_env={
+        self._data = manager.normalize(request_env={
             'client_ip': self._client_ip,
             'auth': self._auth,
         })
 
-        self._data = data
         self._decoded = True
 
     def __getitem__(self, name):

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -613,8 +613,7 @@ class EnsureHasIpTest(BaseAPITest):
                 },
             },
         }
-        out = inp.copy()
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.Http']['env']['REMOTE_ADDR'] == '192.168.0.1'
 
     def test_with_user_ip(self):
@@ -623,29 +622,28 @@ class EnsureHasIpTest(BaseAPITest):
                 'ip_address': '192.168.0.1',
             },
         }
-        out = inp.copy()
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.User']['ip_address'] == '192.168.0.1'
 
     def test_with_user_auto_ip(self):
-        out = {
+        inp = {
             'sentry.interfaces.User': {
                 'ip_address': '{{auto}}',
             },
         }
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.User']['ip_address'] == '127.0.0.1'
 
-        out = {
+        inp = {
             'user': {
                 'ip_address': '{{auto}}',
             },
         }
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.User']['ip_address'] == '127.0.0.1'
 
     def test_without_ip_values(self):
-        out = {
+        inp = {
             'platform': 'javascript',
             'sentry.interfaces.User': {},
             'sentry.interfaces.Http': {
@@ -653,18 +651,18 @@ class EnsureHasIpTest(BaseAPITest):
                 'env': {},
             },
         }
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.User']['ip_address'] == '127.0.0.1'
 
     def test_without_any_values(self):
-        out = {
+        inp = {
             'platform': 'javascript',
         }
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.User']['ip_address'] == '127.0.0.1'
 
     def test_with_http_auto_ip(self):
-        out = {
+        inp = {
             'sentry.interfaces.Http': {
                 'url': 'http://example.com/',
                 'env': {
@@ -672,11 +670,11 @@ class EnsureHasIpTest(BaseAPITest):
                 },
             },
         }
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.Http']['env']['REMOTE_ADDR'] == '127.0.0.1'
 
     def test_with_all_auto_ip(self):
-        out = {
+        inp = {
             'sentry.interfaces.User': {
                 'ip_address': '{{auto}}',
             },
@@ -687,7 +685,7 @@ class EnsureHasIpTest(BaseAPITest):
                 },
             },
         }
-        self.validate_and_normalize(out, {'client_ip': '127.0.0.1'})
+        out = self.validate_and_normalize(inp, {'client_ip': '127.0.0.1'})
         assert out['sentry.interfaces.Http']['env']['REMOTE_ADDR'] == '127.0.0.1'
         assert out['sentry.interfaces.User']['ip_address'] == '127.0.0.1'
 


### PR DESCRIPTION
This makes the EventManager side-effect free, so that we do not rely on its mutating behavior anymore. It will allow us a cleaner implementation of the canonical key rename.