### PR TITLE
feat(settings): Allow access to Release Tracking for all

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -48,7 +48,6 @@ export default function getConfiguration({project}) {
         {
           path: `${pathPrefix}/release-tracking/`,
           title: t('Releases'),
-          show: ({access}) => access.has('project:write'),
         },
         {
           path: `${pathPrefix}/ownership/`,


### PR DESCRIPTION
Previously we would hide the link from the settings menu if you did not
have `project:write` access, however the release tracking settings page
was being linked from other sources.

The API returns a 403 if you do not have write access, so users would
see an error message when trying to access the page.

Instead, lets allow the API request to fail on 403s, and render the page
with placeholder values for token and webhook URL.

![image](https://user-images.githubusercontent.com/79684/41614377-36f1e546-73ad-11e8-86ff-b0456f2b72a5.png)

Fixes JAVASCRIPT-3VW