### PR TITLE
fix(ui): Project Dropdown Alignment

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1207,7 +1207,8 @@ table.integrations {
     max-width: 500px;
     width: auto;
     padding-bottom: 0;
-    left: 30px;
+    left: 0;
+    top: 100%;
     .clearfix;
     overflow: auto;
     max-height: 500px;


### PR DESCRIPTION
This fixes the weird spacing in project dropdown
Before:
![](https://cl.ly/3u36081J3k3P/download/Image%202018-06-19%20at%2012.27.37%20PM.png)

After:
![](https://cl.ly/0v2q3H0e3b1l/download/Image%202018-06-19%20at%2012.26.08%20PM.png)