### PR TITLE
fix(auditlog): Properly display org.restore in audit log

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -309,14 +309,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         'model': Organization.__name__,
                     }
                 )
-            else:
-                self.create_audit_entry(
-                    request=request,
-                    organization=organization,
-                    target_object=organization.id,
-                    event=AuditLogEntryEvent.ORG_EDIT,
-                    data=changed_data
-                )
 
             return self.respond(
                 serialize(

--- a/src/sentry/static/sentry/app/views/settings/organizationAuditLog/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuditLog/index.jsx
@@ -25,6 +25,7 @@ const EVENT_TYPES = [
   'project.set-private',
   'org.create',
   'org.edit',
+  'org.restore',
   'org.remove',
   'tagkey.remove',
   'projectkey.create',

--- a/tests/js/spec/views/settings/__snapshots__/auditLogView.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/auditLogView.spec.jsx.snap
@@ -188,6 +188,7 @@ exports[`OrganizationAuditLog renders 1`] = `
         "org.create",
         "org.edit",
         "org.remove",
+        "org.restore",
         "project.create",
         "project.edit",
         "project.remove",


### PR DESCRIPTION
This should now properly display in the audit log when an organization is restored.

JIRA ticket: https://getsentry.atlassian.net/browse/SE-15