### PR TITLE
fix(search): Use email when username is UUID

### DIFF
--- a/src/sentry/static/sentry/app/stores/tagStore.jsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.jsx
@@ -4,8 +4,16 @@ import _ from 'lodash';
 import TagActions from 'app/actions/tagActions';
 import MemberListStore from 'app/stores/memberListStore';
 
+const uuidPattern = /[0-9a-f]{32}$/;
+
 const getUsername = ({isManaged, username, email}) => {
-  return !isManaged && username ? username : email;
+  // Users created via SAML receive unique UUID usernames. Use
+  // their email in these cases, instead.
+  if (username && uuidPattern.test(username)) {
+    return email;
+  } else {
+    return !isManaged && username ? username : email;
+  }
 };
 
 const getMemberListStoreUsernames = () => {

--- a/tests/js/spec/stores/tagStore.spec.jsx
+++ b/tests/js/spec/stores/tagStore.spec.jsx
@@ -34,6 +34,17 @@ describe('TagStore', function() {
       TagStore.onMemberListStoreChange();
       expect(TagStore.tags.assigned.values).toEqual(['me', 'janesmith@example.org']);
     });
+
+    it('should fall back to email when the username is a UUID', () => {
+      sandbox.stub(MemberListStore, 'getAll').returns([
+        {
+          username: '8f5c6478172d4389930c12841f45dc18',
+          email: 'janesmith@example.org',
+        },
+      ]);
+      TagStore.onMemberListStoreChange();
+      expect(TagStore.tags.assigned.values).toEqual(['me', 'janesmith@example.org']);
+    });
   });
 
   describe('onLoadTagsSuccess()', () => {


### PR DESCRIPTION
When users are created via SAML, we use an UUID as the username, to ensure uniqueness.

Places in the UI, like the "Assigned" filter in the search sidebar, use that username as choices in dropdowns.

Instead of displaying the UUID, this will fall back to the email address.