### PR TITLE
fix(settings): Disable alert rules for no write access

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
@@ -11,6 +11,7 @@ import {
   addLoadingMessage,
   removeIndicator,
 } from 'app/actionCreators/indicator';
+import {conditionalGuideAnchor} from 'app/components/assistant/guideAnchor';
 import {t, tct} from 'app/locale';
 import ApiMixin from 'app/mixins/apiMixin';
 import AsyncView from 'app/views/asyncView';
@@ -20,11 +21,10 @@ import Duration from 'app/components/duration';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import EnvironmentStore from 'app/stores/environmentStore';
 import ListLink from 'app/components/listLink';
-import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import SentryTypes from 'app/proptypes';
+import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Tooltip from 'app/components/tooltip';
 import recreateRoute from 'app/utils/recreateRoute';
-import {conditionalGuideAnchor} from 'app/components/assistant/guideAnchor';
 
 const TextColorLink = styled(Link)`
   color: ${p => p.theme.gray3};
@@ -111,7 +111,7 @@ const RuleRow = createReactClass({
           <div>
             <Tooltip
               disabled={canEdit}
-              title={t('You do not have permission to view rule configuration.')}
+              title={t('You do not have permission to edit alert rules.')}
             >
               <Button
                 data-test-id="edit-rule"
@@ -124,12 +124,18 @@ const RuleRow = createReactClass({
               </Button>
             </Tooltip>
 
-            <Confirm
-              message={t('Are you sure you want to remove this rule?')}
-              onConfirm={this.onDelete}
+            <Tooltip
+              disabled={canEdit}
+              title={t('You do not have permission to edit alert rules.')}
             >
-              <Button size="small" icon="icon-trash" />
-            </Confirm>
+              <Confirm
+                message={t('Are you sure you want to remove this rule?')}
+                onConfirm={this.onDelete}
+                disabled={!canEdit}
+              >
+                <Button size="small" icon="icon-trash" />
+              </Confirm>
+            </Tooltip>
           </div>
         </PanelHeader>
 
@@ -254,20 +260,28 @@ class ProjectAlertRules extends AsyncView {
 
   renderBody() {
     let {ruleList} = this.state;
+    let {organization} = this.context;
+    let canEditRule = organization.access.includes('project:write');
 
     return (
       <React.Fragment>
         <SettingsPageHeader
           title={t('Alerts')}
           action={
-            <Button
-              to={recreateRoute('new/', this.props)}
-              priority="primary"
-              size="small"
-              icon="icon-circle-add"
+            <Tooltip
+              disabled={canEditRule}
+              title={t('You do not have permission to edit alert rules.')}
             >
-              {t('New Alert Rule')}
-            </Button>
+              <Button
+                disabled={!canEditRule}
+                to={recreateRoute('new/', this.props)}
+                priority="primary"
+                size="small"
+                icon="icon-circle-add"
+              >
+                {t('New Alert Rule')}
+              </Button>
+            </Tooltip>
           }
           tabs={
             <ul className="nav nav-tabs" style={{borderBottom: '1px solid #ddd'}}>

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {PanelAlert} from 'app/components/panels';
+import {fields} from 'app/data/forms/projectAlerts';
 import {t} from 'app/locale';
 import AlertLink from 'app/components/alertLink';
 import AsyncView from 'app/views/asyncView';
@@ -7,11 +9,10 @@ import Button from 'app/components/buttons/button';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import ListLink from 'app/components/listLink';
-import {PanelAlert} from 'app/components/panels';
 import PluginList from 'app/components/pluginList';
 import SentryTypes from 'app/proptypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
-import {fields} from 'app/data/forms/projectAlerts';
+import Tooltip from 'app/components/tooltip';
 import recreateRoute from 'app/utils/recreateRoute';
 
 export default class ProjectAlertSettings extends AsyncView {
@@ -65,20 +66,27 @@ export default class ProjectAlertSettings extends AsyncView {
   renderBody() {
     let {orgId, projectId} = this.props.params;
     let {organization} = this.props;
+    let canEditRule = organization.access.includes('project:write');
 
     return (
       <React.Fragment>
         <SettingsPageHeader
           title={t('Alerts')}
           action={
-            <Button
-              to={recreateRoute('rules/new/', this.props)}
-              priority="primary"
-              size="small"
-              icon="icon-circle-add"
+            <Tooltip
+              disabled={canEditRule}
+              title={t('You do not have permission to edit alert rules.')}
             >
-              {t('New Alert Rule')}
-            </Button>
+              <Button
+                to={recreateRoute('rules/new/', this.props)}
+                disabled={!canEditRule}
+                priority="primary"
+                size="small"
+                icon="icon-circle-add"
+              >
+                {t('New Alert Rule')}
+              </Button>
+            </Tooltip>
           }
           tabs={
             <ul className="nav nav-tabs" style={{borderBottom: '1px solid #ddd'}}>

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -18,15 +18,20 @@ exports[`projectAlertRules renders 1`] = `
     >
       <SettingsPageHeading
         action={
-          <Button
-            disabled={false}
-            icon="icon-circle-add"
-            priority="primary"
-            size="small"
-            to="new/"
+          <Tooltip
+            disabled={true}
+            title="You do not have permission to edit alert rules."
           >
-            New Alert Rule
-          </Button>
+            <Button
+              disabled={false}
+              icon="icon-circle-add"
+              priority="primary"
+              size="small"
+              to="new/"
+            >
+              New Alert Rule
+            </Button>
+          </Tooltip>
         }
         tabs={
           <ul
@@ -109,25 +114,19 @@ exports[`projectAlertRules renders 1`] = `
                     </Base>
                   </Title>
                   <div>
-                    <Button
-                      disabled={false}
-                      icon="icon-circle-add"
-                      priority="primary"
-                      size="small"
-                      to="new/"
+                    <Tooltip
+                      disabled={true}
+                      title="You do not have permission to edit alert rules."
                     >
-                      <StyledButton
-                        aria-label="New Alert Rule"
+                      <Button
                         disabled={false}
-                        onClick={[Function]}
+                        icon="icon-circle-add"
                         priority="primary"
-                        role="button"
                         size="small"
                         to="new/"
                       >
-                        <Component
+                        <StyledButton
                           aria-label="New Alert Rule"
-                          className="css-zvpqlo-StyledButton-getColors e17811v30"
                           disabled={false}
                           onClick={[Function]}
                           priority="primary"
@@ -135,117 +134,128 @@ exports[`projectAlertRules renders 1`] = `
                           size="small"
                           to="new/"
                         >
-                          <Link
+                          <Component
                             aria-label="New Alert Rule"
                             className="css-zvpqlo-StyledButton-getColors e17811v30"
                             disabled={false}
                             onClick={[Function]}
-                            onlyActiveOnIndex={false}
                             priority="primary"
                             role="button"
                             size="small"
-                            style={Object {}}
                             to="new/"
                           >
-                            <a
+                            <Link
                               aria-label="New Alert Rule"
                               className="css-zvpqlo-StyledButton-getColors e17811v30"
                               disabled={false}
                               onClick={[Function]}
+                              onlyActiveOnIndex={false}
                               priority="primary"
                               role="button"
                               size="small"
                               style={Object {}}
+                              to="new/"
                             >
-                              <ButtonLabel
+                              <a
+                                aria-label="New Alert Rule"
+                                className="css-zvpqlo-StyledButton-getColors e17811v30"
+                                disabled={false}
+                                onClick={[Function]}
+                                priority="primary"
+                                role="button"
                                 size="small"
+                                style={Object {}}
                               >
-                                <Component
-                                  className="css-19bmqb3-ButtonLabel e17811v31"
+                                <ButtonLabel
                                   size="small"
                                 >
-                                  <Flex
-                                    align="center"
+                                  <Component
                                     className="css-19bmqb3-ButtonLabel e17811v31"
                                     size="small"
                                   >
-                                    <Base
+                                    <Flex
                                       align="center"
-                                      className="e17811v31 css-1eblpyp-ButtonLabel"
+                                      className="css-19bmqb3-ButtonLabel e17811v31"
                                       size="small"
                                     >
-                                      <div
+                                      <Base
+                                        align="center"
                                         className="e17811v31 css-1eblpyp-ButtonLabel"
-                                        is={null}
                                         size="small"
                                       >
-                                        <Icon
-                                          hasChildren={true}
+                                        <div
+                                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                                          is={null}
                                           size="small"
                                         >
-                                          <Component
-                                            className="css-1vdnsie-Icon e17811v32"
+                                          <Icon
                                             hasChildren={true}
                                             size="small"
                                           >
-                                            <Box
+                                            <Component
                                               className="css-1vdnsie-Icon e17811v32"
+                                              hasChildren={true}
                                               size="small"
                                             >
-                                              <Base
-                                                className="e17811v32 css-nk081r-Icon"
+                                              <Box
+                                                className="css-1vdnsie-Icon e17811v32"
                                                 size="small"
                                               >
-                                                <div
+                                                <Base
                                                   className="e17811v32 css-nk081r-Icon"
-                                                  is={null}
                                                   size="small"
                                                 >
-                                                  <StyledInlineSvg
-                                                    size="12px"
-                                                    src="icon-circle-add"
+                                                  <div
+                                                    className="e17811v32 css-nk081r-Icon"
+                                                    is={null}
+                                                    size="small"
                                                   >
-                                                    <InlineSvg
-                                                      className="css-1ov3rcq-StyledInlineSvg e17811v33"
+                                                    <StyledInlineSvg
                                                       size="12px"
                                                       src="icon-circle-add"
                                                     >
-                                                      <StyledSvg
+                                                      <InlineSvg
                                                         className="css-1ov3rcq-StyledInlineSvg e17811v33"
-                                                        height="12px"
-                                                        viewBox={Object {}}
-                                                        width="12px"
+                                                        size="12px"
+                                                        src="icon-circle-add"
                                                       >
-                                                        <svg
-                                                          className="e17811v33 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                        <StyledSvg
+                                                          className="css-1ov3rcq-StyledInlineSvg e17811v33"
                                                           height="12px"
                                                           viewBox={Object {}}
                                                           width="12px"
                                                         >
-                                                          <use
-                                                            href="#test"
-                                                            xlinkHref="#test"
-                                                          />
-                                                        </svg>
-                                                      </StyledSvg>
-                                                    </InlineSvg>
-                                                  </StyledInlineSvg>
-                                                </div>
-                                              </Base>
-                                            </Box>
-                                          </Component>
-                                        </Icon>
-                                        New Alert Rule
-                                      </div>
-                                    </Base>
-                                  </Flex>
-                                </Component>
-                              </ButtonLabel>
-                            </a>
-                          </Link>
-                        </Component>
-                      </StyledButton>
-                    </Button>
+                                                          <svg
+                                                            className="e17811v33 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                            height="12px"
+                                                            viewBox={Object {}}
+                                                            width="12px"
+                                                          >
+                                                            <use
+                                                              href="#test"
+                                                              xlinkHref="#test"
+                                                            />
+                                                          </svg>
+                                                        </StyledSvg>
+                                                      </InlineSvg>
+                                                    </StyledInlineSvg>
+                                                  </div>
+                                                </Base>
+                                              </Box>
+                                            </Component>
+                                          </Icon>
+                                          New Alert Rule
+                                        </div>
+                                      </Base>
+                                    </Flex>
+                                  </Component>
+                                </ButtonLabel>
+                              </a>
+                            </Link>
+                          </Component>
+                        </StyledButton>
+                      </Button>
+                    </Tooltip>
                   </div>
                 </div>
               </Base>
@@ -401,7 +411,7 @@ exports[`projectAlertRules renders 1`] = `
                             <div>
                               <Tooltip
                                 disabled={true}
-                                title="You do not have permission to view rule configuration."
+                                title="You do not have permission to edit alert rules."
                               >
                                 <Button
                                   data-test-id="edit-rule"
@@ -507,156 +517,137 @@ exports[`projectAlertRules renders 1`] = `
                                   </StyledButton>
                                 </Button>
                               </Tooltip>
-                              <Confirm
-                                cancelText="Cancel"
-                                confirmText="Confirm"
-                                message="Are you sure you want to remove this rule?"
-                                onConfirm={[Function]}
-                                priority="primary"
+                              <Tooltip
+                                disabled={true}
+                                title="You do not have permission to edit alert rules."
                               >
-                                <Button
+                                <Confirm
+                                  cancelText="Cancel"
+                                  confirmText="Confirm"
                                   disabled={false}
-                                  icon="icon-trash"
-                                  onClick={[Function]}
-                                  size="small"
+                                  message="Are you sure you want to remove this rule?"
+                                  onConfirm={[Function]}
+                                  priority="primary"
                                 >
-                                  <StyledButton
+                                  <Button
                                     disabled={false}
+                                    icon="icon-trash"
                                     onClick={[Function]}
-                                    role="button"
                                     size="small"
                                   >
-                                    <Component
-                                      className="css-dkprmi-StyledButton-getColors e17811v30"
+                                    <StyledButton
                                       disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
                                     >
-                                      <button
+                                      <Component
                                         className="css-dkprmi-StyledButton-getColors e17811v30"
                                         disabled={false}
                                         onClick={[Function]}
                                         role="button"
                                         size="small"
                                       >
-                                        <ButtonLabel
+                                        <button
+                                          className="css-dkprmi-StyledButton-getColors e17811v30"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="button"
                                           size="small"
                                         >
-                                          <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                          <ButtonLabel
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
+                                            <Component
                                               className="css-19bmqb3-ButtonLabel e17811v31"
                                               size="small"
                                             >
-                                              <Base
+                                              <Flex
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                className="css-19bmqb3-ButtonLabel e17811v31"
                                                 size="small"
                                               >
-                                                <div
+                                                <Base
+                                                  align="center"
                                                   className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                  is={null}
                                                   size="small"
                                                 >
-                                                  <Icon
-                                                    hasChildren={false}
+                                                  <div
+                                                    className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                    is={null}
                                                     size="small"
                                                   >
-                                                    <Component
-                                                      className="css-ljhpxy-Icon e17811v32"
+                                                    <Icon
                                                       hasChildren={false}
                                                       size="small"
                                                     >
-                                                      <Box
+                                                      <Component
                                                         className="css-ljhpxy-Icon e17811v32"
+                                                        hasChildren={false}
                                                         size="small"
                                                       >
-                                                        <Base
-                                                          className="e17811v32 css-7mohvl-Icon"
+                                                        <Box
+                                                          className="css-ljhpxy-Icon e17811v32"
                                                           size="small"
                                                         >
-                                                          <div
+                                                          <Base
                                                             className="e17811v32 css-7mohvl-Icon"
-                                                            is={null}
                                                             size="small"
                                                           >
-                                                            <StyledInlineSvg
-                                                              size="12px"
-                                                              src="icon-trash"
+                                                            <div
+                                                              className="e17811v32 css-7mohvl-Icon"
+                                                              is={null}
+                                                              size="small"
                                                             >
-                                                              <InlineSvg
-                                                                className="css-1ov3rcq-StyledInlineSvg e17811v33"
+                                                              <StyledInlineSvg
                                                                 size="12px"
                                                                 src="icon-trash"
                                                               >
-                                                                <StyledSvg
+                                                                <InlineSvg
                                                                   className="css-1ov3rcq-StyledInlineSvg e17811v33"
-                                                                  height="12px"
-                                                                  viewBox={Object {}}
-                                                                  width="12px"
+                                                                  size="12px"
+                                                                  src="icon-trash"
                                                                 >
-                                                                  <svg
-                                                                    className="e17811v33 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                  <StyledSvg
+                                                                    className="css-1ov3rcq-StyledInlineSvg e17811v33"
                                                                     height="12px"
                                                                     viewBox={Object {}}
                                                                     width="12px"
                                                                   >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </StyledSvg>
-                                                              </InlineSvg>
-                                                            </StyledInlineSvg>
-                                                          </div>
-                                                        </Base>
-                                                      </Box>
-                                                    </Component>
-                                                  </Icon>
-                                                </div>
-                                              </Base>
-                                            </Flex>
-                                          </Component>
-                                        </ButtonLabel>
-                                      </button>
-                                    </Component>
-                                  </StyledButton>
-                                </Button>
-                                <Modal
-                                  animation={false}
-                                  autoFocus={true}
-                                  backdrop={true}
-                                  bsClass="modal"
-                                  dialogComponentClass={[Function]}
-                                  enforceFocus={true}
-                                  keyboard={true}
-                                  manager={
-                                    ModalManager {
-                                      "add": [Function],
-                                      "containers": Array [],
-                                      "data": Array [],
-                                      "handleContainerOverflow": true,
-                                      "hideSiblingNodes": true,
-                                      "isTopModal": [Function],
-                                      "modals": Array [],
-                                      "remove": [Function],
-                                    }
-                                  }
-                                  onHide={[Function]}
-                                  renderBackdrop={[Function]}
-                                  restoreFocus={true}
-                                  show={false}
-                                >
+                                                                    <svg
+                                                                      className="e17811v33 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                      height="12px"
+                                                                      viewBox={Object {}}
+                                                                      width="12px"
+                                                                    >
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </div>
+                                                          </Base>
+                                                        </Box>
+                                                      </Component>
+                                                    </Icon>
+                                                  </div>
+                                                </Base>
+                                              </Flex>
+                                            </Component>
+                                          </ButtonLabel>
+                                        </button>
+                                      </Component>
+                                    </StyledButton>
+                                  </Button>
                                   <Modal
+                                    animation={false}
                                     autoFocus={true}
                                     backdrop={true}
-                                    backdropClassName="modal-backdrop"
-                                    containerClassName="modal-open"
+                                    bsClass="modal"
+                                    dialogComponentClass={[Function]}
                                     enforceFocus={true}
                                     keyboard={true}
                                     manager={
@@ -671,15 +662,40 @@ exports[`projectAlertRules renders 1`] = `
                                         "remove": [Function],
                                       }
                                     }
-                                    onEntering={[Function]}
-                                    onExited={[Function]}
                                     onHide={[Function]}
                                     renderBackdrop={[Function]}
                                     restoreFocus={true}
                                     show={false}
-                                  />
-                                </Modal>
-                              </Confirm>
+                                  >
+                                    <Modal
+                                      autoFocus={true}
+                                      backdrop={true}
+                                      backdropClassName="modal-backdrop"
+                                      containerClassName="modal-open"
+                                      enforceFocus={true}
+                                      keyboard={true}
+                                      manager={
+                                        ModalManager {
+                                          "add": [Function],
+                                          "containers": Array [],
+                                          "data": Array [],
+                                          "handleContainerOverflow": true,
+                                          "hideSiblingNodes": true,
+                                          "isTopModal": [Function],
+                                          "modals": Array [],
+                                          "remove": [Function],
+                                        }
+                                      }
+                                      onEntering={[Function]}
+                                      onExited={[Function]}
+                                      onHide={[Function]}
+                                      renderBackdrop={[Function]}
+                                      restoreFocus={true}
+                                      show={false}
+                                    />
+                                  </Modal>
+                                </Confirm>
+                              </Tooltip>
                             </div>
                           </div>
                         </Base>

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -7,15 +7,20 @@ exports[`ProjectAlertSettings render() renders 1`] = `
   <React.Fragment>
     <SettingsPageHeading
       action={
-        <Button
-          disabled={false}
-          icon="icon-circle-add"
-          priority="primary"
-          size="small"
-          to="rules/new/"
+        <Tooltip
+          disabled={true}
+          title="You do not have permission to edit alert rules."
         >
-          New Alert Rule
-        </Button>
+          <Button
+            disabled={false}
+            icon="icon-circle-add"
+            priority="primary"
+            size="small"
+            to="rules/new/"
+          >
+            New Alert Rule
+          </Button>
+        </Tooltip>
       }
       tabs={
         <ul


### PR DESCRIPTION
Disable buttons for Alert rules that require write access (add, edit, delete), otherwise users will click and get an ugly permission denied error.

Fixes JAVASCRIPT-3VQ