### PR TITLE
ref(tagstore): Consider `get_group_ids_for_users` result as unordered

### DIFF
--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -606,7 +606,7 @@ class LegacyTagStorage(TagStorage):
         )
 
     def get_group_ids_for_users(self, project_ids, event_users, limit=100):
-        return list(
+        return set(
             models.GroupTagValue.objects.filter(
                 key='sentry:user',
                 value__in=[eu.tag_value for eu in event_users],

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -330,7 +330,7 @@ class SnubaTagStorage(TagStorage):
         result = snuba.query(start, end, ['issue'], conditions, filters,
                              aggregations, limit=limit, orderby='-seen',
                              referrer='tagstore.get_group_ids_for_users')
-        return result.keys()
+        return set(result.keys())
 
     def get_group_tag_values_for_users(self, event_users, limit=100):
         start, end = self.get_time_range()

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -875,7 +875,7 @@ class V2TagStorage(TagStorage):
         )
 
     def get_group_ids_for_users(self, project_ids, event_users, limit=100):
-        return list(models.GroupTagValue.objects.filter(
+        return set(models.GroupTagValue.objects.filter(
             project_id__in=project_ids,
             _key__project_id__in=project_ids,
             _key__environment_id=AGGREGATE_ENVIRONMENT_ID,

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -622,7 +622,7 @@ class TagStorage(TestCase):
 
         assert self.ts.get_group_ids_for_users(
             [self.proj1.id],
-            [eu]) == [self.proj1group1.id]
+            [eu]) == set([self.proj1group1.id])
 
     @xfail_if_mysql
     def test_get_group_tag_values_for_users(self):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -239,15 +239,15 @@ class TagStorageTest(SnubaTestCase):
         ) is None
 
     def test_get_group_ids_for_users(self):
-        assert set(self.ts.get_group_ids_for_users(
+        assert self.ts.get_group_ids_for_users(
             [self.proj1.id],
             [EventUser(project_id=self.proj1.id, ident='user1')]
-        )) == set([self.proj1group1.id, self.proj1group2.id])
+        ) == set([self.proj1group1.id, self.proj1group2.id])
 
-        assert set(self.ts.get_group_ids_for_users(
+        assert self.ts.get_group_ids_for_users(
             [self.proj1.id],
             [EventUser(project_id=self.proj1.id, ident='user2')]
-        )) == set([self.proj1group1.id])
+        ) == set([self.proj1group1.id])
 
     def test_get_group_tag_values_for_users(self):
         result = self.ts.get_group_tag_values_for_users(


### PR DESCRIPTION
This has an internal limit and sort order but should be considered
unordered by callers. Returning a set rather than a list will make
comparison results more accurate.

Fixes SNS-110