### PR TITLE
build(travis): Fix eslint wrapper not returning proper codes

### DIFF
--- a/bin/eslint-travis-wrapper
+++ b/bin/eslint-travis-wrapper
@@ -28,6 +28,6 @@ if (otherFormatterType) {
   const otherFormatter = cli.getFormatter(otherFormatterType);
 
   fs.writeFile('eslint.checkstyle.xml', otherFormatter(report.results), 'utf8', () => {
-    process.exit(0);
+    process.exit(report.errorCount);
   });
 }

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -111,7 +111,7 @@ const ProjectInstallPlatform = createReactClass({
 
   inInstallExperiment() {
     let {experimentPlatforms, integration} = this.state;
-    if (!integration || !integration.id) return;
+    if (!integration || !integration.id) return '';
 
     let currentPlatform = integration.id;
     let installExperiment =


### PR DESCRIPTION
`eslint-travis-wrapper` was always throwing a 0 status code regardless of lint errors 🙃

/cc @Chrissy 