### PR TITLE
feat(api): Handle project redirect in API client

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -129,7 +129,7 @@ class ProjectEndpoint(Endpoint):
 
                 # Resource was moved/renamed if the requested url is different than the new url
                 if requested_url != new_url:
-                    raise ResourceMoved(new_url)
+                    raise ResourceMoved(new_url, redirect.project.slug)
 
                 # otherwise project doesn't exist
                 raise ResourceDoesNotExist
@@ -153,7 +153,10 @@ class ProjectEndpoint(Endpoint):
 
     def handle_exception(self, request, exc):
         if isinstance(exc, ResourceMoved):
-            response = Response({}, status=exc.status_code)
+            response = Response({
+                'slug': exc.detail['extra']['slug'],
+                'detail': exc.detail
+            }, status=exc.status_code)
             response['Location'] = exc.detail['extra']['url']
             return response
         return super(ProjectEndpoint, self).handle_exception(request, exc)

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -121,7 +121,7 @@ class ProjectEndpoint(Endpoint):
                     redirect_slug=project_slug
                 )
 
-                raise ResourceMoved(detail={'slug': redirect.project.slug})
+                raise ResourceMoved(redirect.project.slug)
             except ProjectRedirect.DoesNotExist:
                 raise ResourceDoesNotExist
 

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -9,10 +9,6 @@ class ResourceDoesNotExist(APIException):
     status_code = status.HTTP_404_NOT_FOUND
 
 
-class ResourceMoved(APIException):
-    status_code = status.HTTP_302_FOUND
-
-
 class SentryAPIException(APIException):
     code = ''
     message = ''
@@ -26,6 +22,17 @@ class SentryAPIException(APIException):
             }
 
         super(SentryAPIException, self).__init__(detail=detail)
+
+
+class ResourceMoved(SentryAPIException):
+    status_code = status.HTTP_302_FOUND
+    code = 'project-moved'
+    message = 'Project slug was renamed'
+
+    def __init__(self, new_slug):
+        super(ResourceMoved, self).__init__(
+            slug=new_slug
+        )
 
 
 class SsoRequired(SentryAPIException):

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -25,13 +25,14 @@ class SentryAPIException(APIException):
 
 
 class ResourceMoved(SentryAPIException):
-    status_code = status.HTTP_302_FOUND
-    code = 'project-moved'
-    message = 'Project slug was renamed'
+    status_code = status.HTTP_307_TEMPORARY_REDIRECT
+    # code/message currently don't get used
+    code = 'resource-moved'
+    message = 'Resource has been moved'
 
-    def __init__(self, new_slug):
+    def __init__(self, new_url):
         super(ResourceMoved, self).__init__(
-            slug=new_slug
+            url=new_url
         )
 
 

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -25,14 +25,15 @@ class SentryAPIException(APIException):
 
 
 class ResourceMoved(SentryAPIException):
-    status_code = status.HTTP_307_TEMPORARY_REDIRECT
+    status_code = status.HTTP_302_FOUND
     # code/message currently don't get used
     code = 'resource-moved'
     message = 'Resource has been moved'
 
-    def __init__(self, new_url):
+    def __init__(self, new_url, slug):
         super(ResourceMoved, self).__init__(
-            url=new_url
+            url=new_url,
+            slug=slug,
         )
 
 

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -24,14 +24,14 @@ class SentryAPIException(APIException):
         super(SentryAPIException, self).__init__(detail=detail)
 
 
-class ResourceMoved(SentryAPIException):
+class ProjectMoved(SentryAPIException):
     status_code = status.HTTP_302_FOUND
     # code/message currently don't get used
     code = 'resource-moved'
     message = 'Resource has been moved'
 
     def __init__(self, new_url, slug):
-        super(ResourceMoved, self).__init__(
+        super(ProjectMoved, self).__init__(
             url=new_url,
             slug=slug,
         )

--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -62,7 +62,10 @@ class Client {
   }
 
   wrapCallback(id, error) {
-    return (...args) => respond(Client.mockAsync, error, ...args);
+    return (...args) => {
+      if (this.hasProjectBeenRenamed(...args)) return;
+      respond(Client.mockAsync, error, ...args);
+    };
   }
 
   requestPromise(url, options) {
@@ -125,5 +128,7 @@ Client.prototype.uniqueId = RealClient.Client.prototype.uniqueId;
 Client.prototype.bulkUpdate = RealClient.Client.prototype.bulkUpdate;
 Client.prototype._chain = RealClient.Client.prototype._chain;
 Client.prototype._wrapRequest = RealClient.Client.prototype._wrapRequest;
+Client.prototype.hasProjectBeenRenamed =
+  RealClient.Client.prototype.hasProjectBeenRenamed;
 
 export {Client};

--- a/src/sentry/static/sentry/app/actionCreators/modal.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.jsx
@@ -100,3 +100,11 @@ export function openIntegrationDetails(options = {}) {
       });
     });
 }
+
+export function redirectToProject(newProjectSlug) {
+  import(/* webpackChunkName: "RedirectToProjectModal" */ 'app/components/modals/redirectToProject')
+    .then(mod => mod.default)
+    .then(Modal => {
+      openModal(deps => <Modal {...deps} slug={newProjectSlug} />, {});
+    });
+}

--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -64,6 +64,9 @@ export class Client {
    */
   hasProjectBeenRenamed(response) {
     let code = response && idx(response, _ => _.responseJSON.detail.code);
+
+    // XXX(billy): This actually will never happen because we can't intercept the 302
+    // jQuery ajax will follow the redirect by default...
     if (code !== PROJECT_MOVED) return false;
 
     let slug = response && idx(response, _ => _.responseJSON.detail.extra.slug);

--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -2,7 +2,12 @@ import $ from 'jquery';
 import {isUndefined, isNil} from 'lodash';
 import idx from 'idx';
 
-import {openSudo} from 'app/actionCreators/modal';
+import {
+  PROJECT_MOVED,
+  SUDO_REQUIRED,
+  SUPERUSER_REQUIRED,
+} from 'app/constants/apiErrorCodes';
+import {openSudo, redirectToProject} from 'app/actionCreators/modal';
 import GroupActions from 'app/actions/groupActions';
 
 export class Request {
@@ -53,6 +58,20 @@ export class Client {
     return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
   }
 
+  /**
+   * Check if the API response says project has been renamed.
+   * If so, redirect user to new project slug
+   */
+  hasProjectBeenRenamed(response) {
+    let code = response && idx(response, _ => _.responseJSON.detail.code);
+    if (code !== PROJECT_MOVED) return false;
+
+    let slug = response && idx(response, _ => _.responseJSON.detail.extra.slug);
+
+    redirectToProject(slug);
+    return true;
+  }
+
   wrapCallback(id, func, cleanup) {
     /*eslint consistent-return:0*/
     if (isUndefined(func)) {
@@ -65,6 +84,11 @@ export class Client {
         delete this.activeRequests[id];
       }
       if (req && req.alive) {
+        // Check if API response is a 302 -- means project slug was renamed and user
+        // needs to be redirected
+        if (this.hasProjectBeenRenamed(...args)) return;
+
+        // Call success callback
         return func.apply(req, args);
       }
     };
@@ -81,12 +105,12 @@ export class Client {
 
   handleRequestError({id, path, requestOptions}, response, ...responseArgs) {
     let code = response && idx(response, _ => _.responseJSON.detail.code);
-    let isSudoRequired = code === 'sudo-required' || code === 'superuser-required';
+    let isSudoRequired = code === SUDO_REQUIRED || code === SUPERUSER_REQUIRED;
 
     if (isSudoRequired) {
       openSudo({
-        superuser: code === 'superuser-required',
-        sudo: code === 'sudo-required',
+        superuser: code === SUPERUSER_REQUIRED,
+        sudo: code === SUDO_REQUIRED,
         retryRequest: () => {
           return this.requestPromise(path, requestOptions)
             .then((...args) => {

--- a/src/sentry/static/sentry/app/components/modals/redirectToProject.jsx
+++ b/src/sentry/static/sentry/app/components/modals/redirectToProject.jsx
@@ -1,0 +1,94 @@
+import {Flex} from 'grid-emotion';
+import {withRouter} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import {t, tct} from 'app/locale';
+import Button from 'app/components/buttons/button';
+import Text from 'app/components/text';
+import recreateRoute from 'app/utils/recreateRoute';
+
+class RedirectToProjectModal extends React.Component {
+  static propTypes = {
+    /**
+     * New slug to redirect to
+     */
+    slug: PropTypes.string.isRequired,
+
+    Header: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+    Body: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      timer: 5,
+    };
+  }
+
+  componentDidMount() {
+    setInterval(() => {
+      if (this.state.timer <= 1) {
+        window.location.assign(this.getNewPath());
+        return;
+      }
+
+      this.setState(state => ({
+        timer: state.timer - 1,
+      }));
+    }, 1000);
+  }
+
+  getNewPath() {
+    let {params, slug} = this.props;
+
+    return recreateRoute('', {
+      ...this.props,
+      params: {
+        ...params,
+        projectId: slug,
+      },
+    });
+  }
+
+  render() {
+    let {slug, Header, Body} = this.props;
+    return (
+      <React.Fragment>
+        <Header>{t('Redirecting to New Project...')}</Header>
+
+        <Body>
+          <div>
+            <Text>
+              <p>{t('The project slug has been changed.')}</p>
+
+              <p>
+                {tct(
+                  'You will be redirected to the new project [project] in [timer] seconds...',
+                  {
+                    project: <strong>{slug}</strong>,
+                    timer: `${this.state.timer}`,
+                  }
+                )}
+              </p>
+              <ButtonWrapper>
+                <Button priority="primary" href={this.getNewPath()}>
+                  {t('Continue to %s', slug)}
+                </Button>
+              </ButtonWrapper>
+            </Text>
+          </div>
+        </Body>
+      </React.Fragment>
+    );
+  }
+}
+
+export default withRouter(RedirectToProjectModal);
+export {RedirectToProjectModal};
+
+const ButtonWrapper = styled(Flex)`
+  justify-content: flex-end;
+`;

--- a/src/sentry/static/sentry/app/constants/apiErrorCodes.jsx
+++ b/src/sentry/static/sentry/app/constants/apiErrorCodes.jsx
@@ -1,0 +1,3 @@
+export const SUDO_REQUIRED = 'sudo-required';
+export const SUPERUSER_REQUIRED = 'superuser-required';
+export const PROJECT_MOVED = 'project-moved';

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -44,7 +44,6 @@ const ProjectContext = createReactClass({
     projectId: PropTypes.string,
     orgId: PropTypes.string,
     location: PropTypes.object,
-    router: PropTypes.object,
   },
 
   childContextTypes: {
@@ -197,31 +196,16 @@ const ProjectContext = createReactClass({
         errorType: ERROR_TYPES.MISSING_MEMBERSHIP,
       });
     } else {
-      // The project may have been renamed, attempt to lookup the project, if
-      // we 302 we will receive the moved project slug and can update update
-      // our route accordingly.
-      const lookupHandler = resp => {
-        const {status, responseJSON} = resp;
-
-        if (status !== 302 || !responseJSON || !responseJSON.detail) {
+      // The request is a 404 or other error
+      this.api.request(`/projects/${orgId}/${projectId}/`, {
+        error: () => {
           this.setState({
             loading: false,
             error: true,
             errorType: ERROR_TYPES.PROJECT_NOT_FOUND,
           });
-          return;
-        }
-
-        this.props.router.replace(
-          recreateRoute('', {
-            ...this.props,
-            params: {...this.props.params, projectId: responseJSON.detail.slug},
-          })
-        );
-      };
-
-      // The request ill 404 or 302
-      this.api.request(`/projects/${orgId}/${projectId}/`, {error: lookupHandler});
+        },
+      });
     }
   },
 

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -15,7 +15,6 @@ import MemberListStore from 'app/stores/memberListStore';
 import MissingProjectMembership from 'app/components/missingProjectMembership';
 import OrganizationState from 'app/mixins/organizationState';
 import ProjectsStore from 'app/stores/projectsStore';
-import recreateRoute from 'app/utils/recreateRoute';
 import SentryTypes from 'app/sentryTypes';
 import withProjects from 'app/utils/withProjects';
 
@@ -138,6 +137,7 @@ const ProjectContext = createReactClass({
     let {orgId, projectId, location, skipReload} = this.props;
     // we fetch core access/information from the global organization data
     let activeProject = this.identifyProject();
+    let hasAccess = activeProject && activeProject.hasAccess;
 
     this.setState(state => ({
       // if `skipReload` is true, then don't change loading state
@@ -146,53 +146,66 @@ const ProjectContext = createReactClass({
       project: activeProject,
     }));
 
-    setActiveProject(null);
-    const projectRequest = this.api.requestPromise(`/projects/${orgId}/${projectId}/`);
+    if (activeProject && hasAccess) {
+      setActiveProject(null);
+      const projectRequest = this.api.requestPromise(`/projects/${orgId}/${projectId}/`);
 
-    const environmentRequest = this.api.requestPromise(this.getEnvironmentListEndpoint());
+      const environmentRequest = this.api.requestPromise(
+        this.getEnvironmentListEndpoint()
+      );
 
-    Promise.all([projectRequest, environmentRequest]).then(
-      ([project, envs]) => {
-        this.setState({
-          loading: false,
-          project,
-          error: false,
-          errorType: null,
-        });
+      Promise.all([projectRequest, environmentRequest]).then(
+        ([project, envs]) => {
+          this.setState({
+            loading: false,
+            project,
+            error: false,
+            errorType: null,
+          });
 
-        // assuming here that this means the project is considered the active project
-        setActiveProject(project);
+          // assuming here that this means the project is considered the active project
+          setActiveProject(project);
 
-        // If an environment is specified in the query string, load it instead of default
-        const queryEnv = location.query.environment;
-        // The default environment cannot be "" (No Environment)
-        const {defaultEnvironment} = project;
-        const envName = typeof queryEnv === 'undefined' ? defaultEnvironment : queryEnv;
-        loadEnvironments(envs, envName);
-
-        // TODO(dcramer): move member list to organization level
-        this.api.request(this.getMemberListEndpoint(), {
-          success: data => {
-            MemberListStore.loadInitialData(data.filter(m => m.user).map(m => m.user));
-          },
-        });
-      },
-      resp => {
-        let errorType = ERROR_TYPES.UNKNOWN;
-
-        if (resp.status === 404) {
-          errorType = ERROR_TYPES.PROJECT_NOT_FOUND;
-        } else if (activeProject && !activeProject.isMember) {
-          errorType = ERROR_TYPES.MISSING_MEMBERSHIP;
+          // If an environment is specified in the query string, load it instead of default
+          const queryEnv = location.query.environment;
+          // The default environment cannot be "" (No Environment)
+          const {defaultEnvironment} = project;
+          const envName = typeof queryEnv === 'undefined' ? defaultEnvironment : queryEnv;
+          loadEnvironments(envs, envName);
+        },
+        () => {
+          this.setState({
+            loading: false,
+            error: false,
+            errorType: ERROR_TYPES.UNKNOWN,
+          });
         }
+      );
 
-        this.setState({
-          loading: false,
-          error: true,
-          errorType,
-        });
-      }
-    );
+      // TODO(dcramer): move member list to organization level
+      this.api.request(this.getMemberListEndpoint(), {
+        success: data => {
+          MemberListStore.loadInitialData(data.filter(m => m.user).map(m => m.user));
+        },
+      });
+    } else if (activeProject && !activeProject.isMember) {
+      this.setState({
+        loading: false,
+        error: true,
+        errorType: ERROR_TYPES.MISSING_MEMBERSHIP,
+      });
+    } else {
+      // The request is a 404 or other error
+      this.api.request(`/projects/${orgId}/${projectId}/`, {
+        error: () => {
+          this.setState({
+            loading: false,
+            error: true,
+            errorType: ERROR_TYPES.PROJECT_NOT_FOUND,
+          });
+        },
+      });
+    }
   },
 
   getEnvironmentListEndpoint() {

--- a/tests/js/spec/api.spec.jsx
+++ b/tests/js/spec/api.spec.jsx
@@ -1,6 +1,8 @@
 import $ from 'jquery';
+
 import {Client, Request, paramsToQueryArgs} from 'app/api';
 import GroupActions from 'app/actions/groupActions';
+import {PROJECT_MOVED} from 'app/constants/apiErrorCodes';
 
 jest.unmock('app/api');
 
@@ -90,6 +92,23 @@ describe('api', function() {
         expect(req2.xhr.abort.calledOnce).toBeTruthy();
       });
     });
+  });
+
+  it('does not call success callback if 302 was returned because of a project slug change', function() {
+    let successCb = jest.fn();
+    api.activeRequests = {id: {alive: true}};
+    api.wrapCallback('id', successCb)({
+      responseJSON: {
+        detail: {
+          code: PROJECT_MOVED,
+          message: '...',
+          extra: {
+            slug: 'new-slug',
+          },
+        },
+      },
+    });
+    expect(successCb).not.toHaveBeenCalled();
   });
 
   it('handles error callback', function() {

--- a/tests/js/spec/components/modals/redirectToProject.spec.jsx
+++ b/tests/js/spec/components/modals/redirectToProject.spec.jsx
@@ -1,0 +1,43 @@
+import {Modal} from 'react-bootstrap';
+import React from 'react';
+
+import {RedirectToProjectModal} from 'app/components/modals/redirectToProject';
+import {mount} from 'enzyme';
+
+jest.unmock('app/utils/recreateRoute');
+describe('RedirectToProjectModal', function() {
+  jest.useFakeTimers();
+  const routes = [
+    {path: '/', childRoutes: []},
+    {name: 'Organizations', path: ':orgId/', childRoutes: []},
+    {name: 'Projects', path: ':projectId/', childRoutes: []},
+  ];
+
+  beforeEach(function() {
+    sinon.stub(window.location, 'assign');
+  });
+
+  afterEach(function() {
+    window.location.assign.restore();
+  });
+
+  it('has timer to redirect to new slug after mounting', function() {
+    mount(
+      <RedirectToProjectModal
+        routes={routes}
+        params={{orgId: 'org-slug', projectId: 'project-slug'}}
+        slug="new-slug"
+        Header={Modal.Header}
+        Body={Modal.Body}
+      />,
+      TestStubs.routerContext()
+    );
+
+    jest.advanceTimersByTime(4900);
+    expect(window.location.assign.calledOnce).toBe(false);
+
+    jest.advanceTimersByTime(200);
+    expect(window.location.assign.calledOnce).toBe(true);
+    expect(window.location.assign.calledWith('/org-slug/new-slug/')).toBe(true);
+  });
+});

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -91,6 +91,7 @@ exports[`Configure should render correctly render() should render platform docs 
                 "hasAccess": true,
                 "id": "testProject",
                 "isBookmarked": false,
+                "isMember": true,
                 "name": "Test Project",
                 "slug": "project-slug",
                 "teams": Array [
@@ -123,6 +124,7 @@ exports[`Configure should render correctly render() should render platform docs 
                   "hasAccess": true,
                   "id": "testProject",
                   "isBookmarked": false,
+                  "isMember": true,
                   "name": "Test Project",
                   "slug": "project-slug",
                   "teams": Array [

--- a/tests/js/spec/views/onboarding/configure/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/configure/index.spec.jsx
@@ -57,6 +57,7 @@ describe('Configure should render correctly', function() {
         slug: 'project-slug',
         id: 'testProject',
         hasAccess: true,
+        isMember: true,
         isBookmarked: false,
         teams: [
           {
@@ -157,6 +158,7 @@ describe('Configure should render correctly', function() {
                   id: 'testProject',
                   hasAccess: true,
                   isBookmarked: false,
+                  isMember: true,
                   teams: [
                     {
                       id: 'coolteam',

--- a/tests/js/spec/views/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/projectGeneralSettings.spec.jsx
@@ -219,15 +219,6 @@ describe('projectGeneralSettings', function() {
     expect(putMock).not.toHaveBeenCalled();
     wrapper.find('SaveButton').simulate('click');
 
-    await tick();
-    // :(
-    await tick();
-    wrapper.update();
-    // updates ProjectsStore
-    expect(ProjectsStore.itemsById['2'].slug).toBe('new-project');
-    expect(browserHistory.replace).toHaveBeenCalled();
-    expect(wrapper.find('Input[name="slug"]').prop('value')).toBe('new-project');
-
     // fetches new slug
     let newProjectGet = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/new-project/`,
@@ -245,9 +236,20 @@ describe('projectGeneralSettings', function() {
       body: [],
     });
 
+    await tick();
+    // :(
+    await tick();
+    wrapper.update();
+    // updates ProjectsStore
+    expect(ProjectsStore.itemsById['2'].slug).toBe('new-project');
+    expect(browserHistory.replace).toHaveBeenCalled();
+    expect(wrapper.find('Input[name="slug"]').prop('value')).toBe('new-project');
+
     wrapper.setProps({
       projectId: 'new-project',
     });
+    await tick();
+    wrapper.update();
     expect(newProjectGet).toHaveBeenCalled();
     expect(newProjectEnv).toHaveBeenCalled();
     expect(newProjectMembers).toHaveBeenCalled();

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -5,6 +5,7 @@ import {Client} from 'app/api';
 import ProjectTeams from 'app/views/settings/project/projectTeams';
 import {openCreateTeamModal} from 'app/actionCreators/modal';
 
+jest.unmock('app/actionCreators/modal');
 jest.mock('app/actionCreators/modal', () => ({
   openCreateTeamModal: jest.fn(),
 }));

--- a/tests/js/spec/views/projects/projectContext.spec.jsx
+++ b/tests/js/spec/views/projects/projectContext.spec.jsx
@@ -16,12 +16,27 @@ describe('projectContext component', function() {
     {name: 'Projects', path: ':projectId/', childRoutes: []},
   ];
 
-  const location = {};
+  const location = {query: {}};
 
   const project = TestStubs.Project();
   const org = TestStubs.Organization();
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    [project.slug, 'new-slug'].forEach(slug => {
+      MockApiClient.addMockResponse({
+        url: `/projects/${org.slug}/${slug}/members/`,
+        method: 'GET',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${org.slug}/${slug}/environments/`,
+        method: 'GET',
+        body: [],
+      });
+    });
+  });
 
-  it('displays error on 404s', function() {
+  it('displays error on 404s', async function() {
     const router = TestStubs.router();
 
     MockApiClient.addMockResponse({
@@ -46,6 +61,9 @@ describe('projectContext component', function() {
       context: {organization: org},
       childContextTypes: {organization: SentryTypes.Organization},
     });
+
+    await tick();
+    wrapper.update();
 
     expect(wrapper.state('error')).toBe(true);
     expect(wrapper.state('loading')).toBe(false);

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -78,7 +78,7 @@ class ProjectDetailsTest(APITestCase):
 
         response = self.client.get(url)
         assert response.status_code == 302
-        assert response.data['detail']['slug'] == 'foobar'
+        assert response.data['detail']['extra']['slug'] == 'foobar'
 
 
 class ProjectUpdateTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -77,7 +77,9 @@ class ProjectDetailsTest(APITestCase):
         self.client.put(url, data={'slug': 'foobar'})
 
         response = self.client.get(url)
-        assert response.status_code == 307
+        assert response.status_code == 302
+        assert response.data['slug'] == 'foobar'
+        assert response.data['detail']['extra']['url'] == '/api/0/projects/%s/%s/' % (project.organization.slug, 'foobar')
         assert response['Location'] == 'http://testserver/api/0/projects/%s/%s/' % (project.organization.slug, 'foobar')
 
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -77,8 +77,8 @@ class ProjectDetailsTest(APITestCase):
         self.client.put(url, data={'slug': 'foobar'})
 
         response = self.client.get(url)
-        assert response.status_code == 302
-        assert response.data['detail']['extra']['slug'] == 'foobar'
+        assert response.status_code == 307
+        assert response['Location'] == 'http://testserver/api/0/projects/%s/%s/' % (project.organization.slug, 'foobar')
 
 
 class ProjectUpdateTest(APITestCase):


### PR DESCRIPTION
~~Previously we would only be handling API responses with a 302 in
 `ProjectContext`, which is only a subset of requests that can return a 302.
 Move the handling up to the API client.~~

 ~~Also changes the 302 response body to be an object more consistent with our
 error response objects.~~

Previously the API would return an object with a new slug, this changes it to return a proper redirect response using the `Location` response header.

Currently undecided how to handle this on the frontend because the user can be at an old URL in the browser while the API requests will transparently query the updated project (since the XHR requests will follow the redirects).

There doesn't seem to be an easy way to intercept 302s using our API client.


Fixes JAVASCRIPT-3JM