### PR TITLE
ref(ui): svg-based bar charts

### DIFF
--- a/src/sentry/static/sentry/app/components/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/barChart.jsx
@@ -33,7 +33,7 @@ class BarChart extends React.Component {
       return {x: point.x, y: [point.y]};
     });
     let props = Object.assign({}, this.props, {points});
-    return <StackedBarChart gap={4} {...props} />;
+    return <StackedBarChart {...props} />;
   }
 }
 

--- a/src/sentry/static/sentry/app/components/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/barChart.jsx
@@ -33,7 +33,7 @@ class BarChart extends React.Component {
       return {x: point.x, y: [point.y]};
     });
     let props = Object.assign({}, this.props, {points});
-    return <StackedBarChart {...props} />;
+    return <StackedBarChart gap={4} {...props} />;
   }
 }
 

--- a/src/sentry/static/sentry/app/components/group/releaseChart.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseChart.jsx
@@ -149,7 +149,8 @@ const GroupReleaseChart = createReactClass({
           markers={markers}
           barClasses={['release', 'environment', 'inactive']}
           tooltip={this.renderTooltip}
-          minHeights={[0, 0, 4]}
+          gap={0.75}
+          minHeights={[0, 0, 5]}
         />
       </div>
     );

--- a/src/sentry/static/sentry/app/components/group/releaseChart.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseChart.jsx
@@ -6,6 +6,7 @@ import StackedBarChart from 'app/components/stackedBarChart';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import {escape, intcomma} from 'app/utils';
+import theme from 'app/utils/theme';
 
 const GroupReleaseChart = createReactClass({
   displayName: 'GroupReleaseChart',
@@ -118,6 +119,8 @@ const GroupReleaseChart = createReactClass({
           label: t('First seen'),
           x: firstSeenX,
           className: 'first-seen',
+          offset: -7.5,
+          fill: theme.pink,
         });
       }
     }
@@ -129,6 +132,7 @@ const GroupReleaseChart = createReactClass({
           label: t('Last seen'),
           x: lastSeenX,
           className: 'last-seen',
+          fill: theme.green,
         });
       }
     }

--- a/src/sentry/static/sentry/app/components/group/releaseChart.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseChart.jsx
@@ -149,6 +149,7 @@ const GroupReleaseChart = createReactClass({
           markers={markers}
           barClasses={['release', 'environment', 'inactive']}
           tooltip={this.renderTooltip}
+          minHeights={[0, 0, 4]}
         />
       </div>
     );

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -257,10 +257,11 @@ const StackedBarChart = createReactClass({
       let pt = (
         <rect
           x={index * pointWidth}
-          y={100 - pct}
+          y={100 - pct - prevPct}
           width={pointWidth - space}
           height={pct}
-          fill="#aab"
+          fill={this.state.series[i].color}
+          className={this.props.barClasses[i]}
         />
       );
       prevPct += pct;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -228,7 +228,7 @@ class StackedBarChart extends React.Component {
         <circle
           data-test-id="chart-column"
           cx={index * pointWidth + '%'}
-          transform={`translate(${markerOffset}, 0)`}
+          transform={`translate(${markerOffset || 0}, 0)`}
           cy="100%"
           r="4"
           fill={marker.fill || theme.gray2}
@@ -266,7 +266,7 @@ class StackedBarChart extends React.Component {
     let {minHeights} = this.props;
     return minHeights && (minHeights[index] || minHeights[index] == 0)
       ? this.props.minHeights[index]
-      : index == pointLength - 1 ? 4 : 0;
+      : 1;
   }
 
   renderChartColumn(point, maxval, pointWidth, index, totalPoints) {
@@ -283,7 +283,7 @@ class StackedBarChart extends React.Component {
         <rect
           key={i}
           x={index * pointWidth + '%'}
-          y={98.5 - pct - prevPct + '%'}
+          y={100.0 - pct - prevPct + '%'}
           width={pointWidth + '%'}
           height={pct + '%'}
           fill={this.state.series[i].color}
@@ -311,7 +311,7 @@ class StackedBarChart extends React.Component {
             <rect
               x={index * pointWidth + '%'}
               width={pointWidth + '%'}
-              height="98.5%"
+              height="100%"
               transform={`translate(-${this.props.gap}, 0)`}
             />
           </clipPath>
@@ -391,7 +391,7 @@ class StackedBarChart extends React.Component {
 }
 
 const StyledSvg = styled('svg')`
-  width: calc(100% + ${p => p.gap + 0.5}px);
+  width: calc(100% + ${p => p.gap}px);
   height: 100%;
   overflow: visible !important; /* overrides global declaration */
 `;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
 import _ from 'lodash';
 import styled from 'react-emotion';
+import cx from 'classnames';
 
 import Tooltip from 'app/components/tooltip';
 import Count from 'app/components/count';
@@ -248,12 +249,14 @@ class StackedBarChart extends React.Component {
     let totalY = point.y.reduce((a, b) => a + b);
     let totalPct = totalY / maxval;
     let prevPct = 0;
-    let space = 36 / totalPoints;
+    let space = 36 / (totalPoints - 1); // were alloting 36% of the viewport to white space.
     let pts = point.y.map((y, i) => {
+      let minHeight = i == 0 ? 1.5 : 0; // min-heights are only useful on the first bar
       let pct = Math.max(
         totalY && this.floatFormat(y / totalY * totalPct * 99, 2),
-        i == 0 ? 1.5 : 0
+        minHeight
       );
+
       let pt = (
         <rect
           key={i}
@@ -262,7 +265,7 @@ class StackedBarChart extends React.Component {
           width={pointWidth - space}
           height={pct}
           fill={this.state.series[i].color}
-          className={this.props.barClasses[i]}
+          className={cx(this.props.barClasses[i], 'barchart-rect')}
         >
           {y}
         </rect>
@@ -288,7 +291,7 @@ class StackedBarChart extends React.Component {
   renderChart() {
     let {pointIndex, series} = this.state;
     let totalPoints = Math.max(...series.map(s => s.data.length));
-    let pointWidth = this.floatFormat(101.0 / totalPoints, 2);
+    let pointWidth = this.floatFormat(100.0 / totalPoints, 2);
 
     let maxval = this.maxPointValue();
     let markers = this.props.markers.slice();

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -251,15 +251,14 @@ const StackedBarChart = createReactClass({
     let totalY = point.y.reduce((a, b) => a + b);
     let totalPct = totalY / maxval;
     let prevPct = 0;
-    let gap = index == 0 ? 0 : 1;
     let pts = point.y.map((y, i) => {
       let pct = totalY && this.floatFormat(y / totalY * totalPct * 99, 2);
       let height = Math.random() * 100;
       let pt = (
         <rect
-          x={index * pointWidth + '%'}
-          y={100 - height + '%'}
-          width={pointWidth - 1 + '%'}
+          x={index * pointWidth}
+          y={100 - height}
+          width={pointWidth - 1}
           height={height}
           fill="#aab"
         />
@@ -335,7 +334,7 @@ const StackedBarChart = createReactClass({
         <span className="min-y">0</span>
         <svg
           shapeRendering="geometricPrecision"
-          viewBox={'0 0 100 99'}
+          viewBox={'0 0 99.9 99.9'}
           preserveAspectRatio="none"
           style={{width: '100%', height: '100%'}}
         >

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -42,7 +42,7 @@ class StackedBarChart extends React.Component {
     tooltip: PropTypes.func,
     barClasses: PropTypes.array,
     /* Some bars need to be visible and interactable even if they are
-    empty. Each min height will be a single point within the view box */
+    empty. Use minHeights for that. Units are in svg points */
     minHeights: PropTypes.arrayOf(PropTypes.number),
     /* the amount of space between bars. Also represents an svg point */
     gap: PropTypes.number,

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -209,7 +209,7 @@ class StackedBarChart extends React.Component {
     );
   }
 
-  renderMarker(marker) {
+  renderMarker(marker, index, pointWidth) {
     let timeLabel = moment(marker.x * 1000).format('lll');
     let title =
       '<div style="width:130px">' + marker.label + '<br/>' + timeLabel + '</div>';
@@ -220,7 +220,11 @@ class StackedBarChart extends React.Component {
 
     return (
       <Tooltip title={title} key={key} tooltipOptions={{html: true, placement: 'bottom'}}>
-        <a data-test-id="chart-column" className={className} style={{height: '100%'}}>
+        <a
+          data-test-id="chart-column"
+          className={className}
+          style={{height: '100%', left: index * pointWidth + '%'}}
+        >
           <span>{marker.label}</span>
         </a>
       </Tooltip>
@@ -304,6 +308,7 @@ class StackedBarChart extends React.Component {
 
     let maxval = this.maxPointValue();
     let markers = this.props.markers.slice();
+    let markerChildren = [];
 
     // group points, then resort
     let points = Object.keys(pointIndex)
@@ -322,7 +327,7 @@ class StackedBarChart extends React.Component {
     let children = [];
     points.forEach((point, index) => {
       while (markers.length && markers[0].x <= point.x) {
-        children.push(this.renderMarker(markers.shift()));
+        markerChildren.push(this.renderMarker(markers.shift(), index, pointWidth));
       }
 
       children.push(
@@ -333,10 +338,23 @@ class StackedBarChart extends React.Component {
     // in bizarre case where markers never got rendered, render them last
     // NOTE: should this ever happen?
     markers.forEach(marker => {
-      children.push(this.renderMarker(marker));
+      markerChildren.push(this.renderMarker(marker));
     });
 
-    return children;
+    return (
+      <React.Fragment>
+        <StyledSvg
+          shapeRendering="geometricPrecision"
+          viewBox={'0 0 99.9 99.9'}
+          preserveAspectRatio="none"
+        >
+          {children}
+        </StyledSvg>
+        <div style={{position: 'absolute', bottom: 0, left: 0, height: 0, width: '100%'}}>
+          {markerChildren}
+        </div>
+      </React.Fragment>
+    );
   }
 
   render() {
@@ -350,13 +368,7 @@ class StackedBarChart extends React.Component {
           <Count value={maxval} />
         </span>
         <span className="min-y">0</span>
-        <StyledSvg
-          shapeRendering="geometricPrecision"
-          viewBox={'0 0 99.9 99.9'}
-          preserveAspectRatio="none"
-        >
-          {this.renderChart()}
-        </StyledSvg>
+        {this.renderChart()}
       </figure>
     );
   }

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -41,6 +41,8 @@ class StackedBarChart extends React.Component {
     ),
     tooltip: PropTypes.func,
     barClasses: PropTypes.array,
+    minHeights: PropTypes.arrayOf(PropTypes.number),
+    allottedGapSpace: PropTypes.number,
   };
 
   static defaultProps = {
@@ -52,6 +54,7 @@ class StackedBarChart extends React.Component {
     markers: [],
     width: null,
     barClasses: ['chart-bar'],
+    allottedGapSpace: 20,
   };
 
   constructor(props) {
@@ -245,16 +248,22 @@ class StackedBarChart extends React.Component {
     return title;
   };
 
+  getMinHeight(index, pointLength) {
+    let {minHeights} = this.props;
+    return minHeights && (minHeights[index] || minHeights[index] == 0)
+      ? this.props.minHeights[index]
+      : index == pointLength - 1 ? 4 : 0;
+  }
+
   renderChartColumn(point, maxval, pointWidth, index, totalPoints) {
     let totalY = point.y.reduce((a, b) => a + b);
     let totalPct = totalY / maxval;
     let prevPct = 0;
-    let space = 36 / (totalPoints - 1); // were alloting 36% of the viewport to white space.
+    let space = this.props.allottedGapSpace / (totalPoints - 1); // were alloting 20% of the viewport to white space.
     let pts = point.y.map((y, i) => {
-      let minHeight = i == 0 ? 1.5 : 0; // min-heights are only useful on the first bar
       let pct = Math.max(
         totalY && this.floatFormat(y / totalY * totalPct * 99, 2),
-        minHeight
+        this.getMinHeight(i, point.y.length)
       );
 
       let pt = (

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -312,6 +312,7 @@ class StackedBarChart extends React.Component {
             width={pointWidth + '%'}
             height="100%"
             opacity="0"
+            transform={`translate(-${this.props.gap}, 0)`}
           />
           <clipPath id={maskId}>
             <rect

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -247,24 +247,15 @@ const StackedBarChart = createReactClass({
     return title;
   },
 
-  renderChartColumn(point, maxval, pointWidth) {
+  renderChartColumn(point, maxval, pointWidth, index) {
     let totalY = point.y.reduce((a, b) => a + b);
     let totalPct = totalY / maxval;
     let prevPct = 0;
     let pts = point.y.map((y, i) => {
       let pct = totalY && this.floatFormat(y / totalY * totalPct * 99, 2);
+      let height = Math.random() * 200;
       let pt = (
-        <span
-          key={i}
-          className={this.props.barClasses[i]}
-          style={{
-            height: pct + '%',
-            bottom: prevPct + '%',
-            backgroundColor: this.state.series[i].color || null,
-          }}
-        >
-          {y}
-        </span>
+        <rect x={index * 100} y={100 - height} width="80" height={height} fill="#aab"/>
       );
       prevPct += pct;
       return pt;
@@ -279,9 +270,9 @@ const StackedBarChart = createReactClass({
         key={point.x}
         tooltipOptions={{html: true, placement: 'bottom'}}
       >
-        <a className="chart-column" style={{width: pointWidth, height: '100%'}}>
+        <g>
           {pts}
-        </a>
+        </g>
       </Tooltip>
     );
   },
@@ -309,12 +300,12 @@ const StackedBarChart = createReactClass({
     });
 
     let children = [];
-    points.forEach(point => {
+    points.forEach((point, index) => {
       while (markers.length && markers[0].x <= point.x) {
         children.push(this.renderMarker(markers.shift()));
       }
 
-      children.push(this.renderChartColumn(point, maxval, pointWidth));
+      children.push(this.renderChartColumn(point, maxval, pointWidth, index));
     });
 
     // in bizarre case where markers never got rendered, render them last
@@ -337,7 +328,7 @@ const StackedBarChart = createReactClass({
           <Count value={maxval} />
         </span>
         <span className="min-y">0</span>
-        <span>{this.renderChart()}</span>
+        <svg shape-rendering="geometricPrecision" viewBox={`0 0 ${Object.keys(this.state.pointIndex).length * 100} 100`} style={{width: '100%', height: '100%'}}>{this.renderChart()}</svg>
       </figure>
     );
   },

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -253,7 +253,10 @@ const StackedBarChart = createReactClass({
     let prevPct = 0;
     let space = 36 / totalPoints;
     let pts = point.y.map((y, i) => {
-      let pct = Math.max(totalY && this.floatFormat(y / totalY * totalPct * 99, 2), 1.5);
+      let pct = Math.max(
+        totalY && this.floatFormat(y / totalY * totalPct * 99, 2),
+        i == 0 ? 1.5 : 0
+      );
       let pt = (
         <rect
           x={index * pointWidth}

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -247,19 +247,19 @@ const StackedBarChart = createReactClass({
     return title;
   },
 
-  renderChartColumn(point, maxval, pointWidth, index) {
+  renderChartColumn(point, maxval, pointWidth, index, totalPoints) {
     let totalY = point.y.reduce((a, b) => a + b);
     let totalPct = totalY / maxval;
     let prevPct = 0;
+    let space = 36 / totalPoints;
     let pts = point.y.map((y, i) => {
-      let pct = totalY && this.floatFormat(y / totalY * totalPct * 99, 2);
-      let height = Math.random() * 100;
+      let pct = Math.max(totalY && this.floatFormat(y / totalY * totalPct * 99, 2), 1.5);
       let pt = (
         <rect
           x={index * pointWidth}
-          y={100 - height}
-          width={pointWidth - 1}
-          height={height}
+          y={100 - pct}
+          width={pointWidth - space}
+          height={pct}
           fill="#aab"
         />
       );
@@ -309,7 +309,9 @@ const StackedBarChart = createReactClass({
         children.push(this.renderMarker(markers.shift()));
       }
 
-      children.push(this.renderChartColumn(point, maxval, pointWidth, index));
+      children.push(
+        this.renderChartColumn(point, maxval, pointWidth, index, totalPoints)
+      );
     });
 
     // in bizarre case where markers never got rendered, render them last

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -251,11 +251,18 @@ const StackedBarChart = createReactClass({
     let totalY = point.y.reduce((a, b) => a + b);
     let totalPct = totalY / maxval;
     let prevPct = 0;
+    let gap = index == 0 ? 0 : 1;
     let pts = point.y.map((y, i) => {
       let pct = totalY && this.floatFormat(y / totalY * totalPct * 99, 2);
-      let height = Math.random() * 200;
+      let height = Math.random() * 100;
       let pt = (
-        <rect x={index * 100} y={100 - height} width="80" height={height} fill="#aab"/>
+        <rect
+          x={index * pointWidth + '%'}
+          y={100 - height + '%'}
+          width={pointWidth - 1 + '%'}
+          height={height}
+          fill="#aab"
+        />
       );
       prevPct += pct;
       return pt;
@@ -270,9 +277,7 @@ const StackedBarChart = createReactClass({
         key={point.x}
         tooltipOptions={{html: true, placement: 'bottom'}}
       >
-        <g>
-          {pts}
-        </g>
+        <g>{pts}</g>
       </Tooltip>
     );
   },
@@ -280,7 +285,7 @@ const StackedBarChart = createReactClass({
   renderChart() {
     let {pointIndex, series} = this.state;
     let totalPoints = Math.max(...series.map(s => s.data.length));
-    let pointWidth = this.floatFormat(100.0 / totalPoints, 2) + '%';
+    let pointWidth = this.floatFormat(101.0 / totalPoints, 2);
 
     let maxval = this.maxPointValue();
     let markers = this.props.markers.slice();
@@ -328,7 +333,14 @@ const StackedBarChart = createReactClass({
           <Count value={maxval} />
         </span>
         <span className="min-y">0</span>
-        <svg shape-rendering="geometricPrecision" viewBox={`0 0 ${Object.keys(this.state.pointIndex).length * 100} 100`} style={{width: '100%', height: '100%'}}>{this.renderChart()}</svg>
+        <svg
+          shapeRendering="geometricPrecision"
+          viewBox={'0 0 100 99'}
+          preserveAspectRatio="none"
+          style={{width: '100%', height: '100%'}}
+        >
+          {this.renderChart()}
+        </svg>
       </figure>
     );
   },

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -367,7 +367,7 @@ class StackedBarChart extends React.Component {
     // in bizarre case where markers never got rendered, render them last
     // NOTE: should this ever happen?
     markers.forEach(marker => {
-      markerChildren.push(this.renderMarker(marker));
+      markerChildren.push(this.renderMarker(marker, points.length, pointWidth));
     });
 
     return (

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -55,7 +55,7 @@ class StackedBarChart extends React.Component {
     markers: [],
     width: null,
     barClasses: ['chart-bar'],
-    gap: 2,
+    gap: 0.5,
   };
 
   constructor(props) {
@@ -229,7 +229,7 @@ class StackedBarChart extends React.Component {
           left={index * pointWidth}
           offset={markerOffset || 0}
           viewBox="0 0 10 10"
-          size={12}
+          size={10}
         >
           <circle
             data-test-id="chart-column"
@@ -290,7 +290,8 @@ class StackedBarChart extends React.Component {
           key={i}
           x={index * pointWidth + '%'}
           y={100.0 - pct - prevPct + '%'}
-          width={pointWidth + '%'}
+          width={pointWidth - this.props.gap + '%'}
+          data-test-id="chart-column"
           height={pct + '%'}
           fill={this.state.series[i].color}
           className={cx(this.props.barClasses[i], 'barchart-rect')}
@@ -304,7 +305,6 @@ class StackedBarChart extends React.Component {
 
     let pointIdx = point.x;
     let tooltipFunc = this.props.tooltip || this.renderTooltip;
-    let maskId = `path-${pointWidth}-${index}`; /* an ID in SVG is global just like html. */
 
     return (
       <Tooltip
@@ -314,24 +314,12 @@ class StackedBarChart extends React.Component {
       >
         <g>
           <rect
-            x={index * pointWidth + '%'}
-            width={pointWidth + '%'}
+            x={index * pointWidth - this.props.gap + '%'}
+            width={pointWidth + this.props.gap + '%'}
             height="100%"
             opacity="0"
-            transform={`translate(-${this.props.gap}, 0)`}
           />
-          <clipPath id={maskId}>
-            <rect
-              x={index * pointWidth + '%'}
-              width={pointWidth + '%'}
-              height="105%"
-              y="-5%"
-              transform={`translate(-${this.props.gap}, 0)`}
-            />
-          </clipPath>
-          <g data-test-id="chart-column" clipPath={`url(#${maskId})`}>
-            {pts}
-          </g>
+          {pts}
         </g>
       </Tooltip>
     );
@@ -340,7 +328,7 @@ class StackedBarChart extends React.Component {
   renderChart() {
     let {pointIndex, series} = this.state;
     let totalPoints = Math.max(...series.map(s => s.data.length));
-    let pointWidth = this.floatFormat(100.0 / totalPoints, 2);
+    let pointWidth = this.floatFormat((100.0 + this.props.gap + 0.1) / totalPoints, 2);
 
     let maxval = this.maxPointValue();
     let markers = this.props.markers.slice();
@@ -379,9 +367,7 @@ class StackedBarChart extends React.Component {
 
     return (
       <SvgContainer>
-        <StyledSvg gap={this.props.gap} overflow="visible">
-          {children}
-        </StyledSvg>
+        <StyledSvg overflow="visible">{children}</StyledSvg>
         {markerChildren.length ? markerChildren : null}
       </SvgContainer>
     );
@@ -405,7 +391,7 @@ class StackedBarChart extends React.Component {
 }
 
 const StyledSvg = styled('svg')`
-  width: calc(100% + ${p => p.gap}px);
+  width: 100%;
   height: 100%;
   overflow: visible !important; /* overrides global declaration */
 `;
@@ -430,6 +416,10 @@ const CircleSvg = styled('svg')`
   bottom: -${p => p.size / 2}px;
   transform: translate(${p => (p.offset || 0) - p.size / 2}px, 0);
   left: ${p => p.left}%;
+
+  &:hover circle {
+    fill: ${p => p.theme.purple};
+  }
 `;
 
 export default StackedBarChart;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -225,18 +225,24 @@ class StackedBarChart extends React.Component {
         key={key}
         tooltipOptions={{html: true, placement: 'bottom', container: 'body'}}
       >
-        <circle
-          data-test-id="chart-column"
-          cx={index * pointWidth + '%'}
-          transform={`translate(${markerOffset || 0}, 0)`}
-          cy="100%"
-          r="4"
-          fill={marker.fill || theme.gray2}
-          stroke="#fff"
-          strokeWidth={2}
+        <CircleSvg
+          left={index * pointWidth}
+          offset={markerOffset || 0}
+          viewBox="0 0 10 10"
+          size={12}
         >
-          {marker.label}
-        </circle>
+          <circle
+            data-test-id="chart-column"
+            r="4"
+            cx="50%"
+            cy="50%"
+            fill={marker.fill || theme.gray2}
+            stroke="#fff"
+            strokeWidth="2"
+          >
+            {marker.label}
+          </circle>
+        </CircleSvg>
       </Tooltip>
     );
   }
@@ -372,12 +378,12 @@ class StackedBarChart extends React.Component {
     });
 
     return (
-      <React.Fragment>
+      <SvgContainer>
         <StyledSvg gap={this.props.gap} overflow="visible">
           {children}
-          {markerChildren.length ? markerChildren : null}
         </StyledSvg>
-      </React.Fragment>
+        {markerChildren.length ? markerChildren : null}
+      </SvgContainer>
     );
   }
 
@@ -387,13 +393,13 @@ class StackedBarChart extends React.Component {
     let maxval = this.maxPointValue();
 
     return (
-      <SvgContainer className={figureClass} style={{height, width, ...style}}>
+      <StyledFigure className={figureClass} style={{height, width, ...style}}>
         <span className="max-y">
           <Count value={maxval} />
         </span>
         <span className="min-y">0</span>
         {this.renderChart()}
-      </SvgContainer>
+      </StyledFigure>
     );
   }
 }
@@ -404,11 +410,26 @@ const StyledSvg = styled('svg')`
   overflow: visible !important; /* overrides global declaration */
 `;
 
-const SvgContainer = styled('figure')`
+const StyledFigure = styled('figure')`
   display: block;
   position: relative;
   width: 100%;
   height: 100%;
+`;
+
+const SvgContainer = styled('div')`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const CircleSvg = styled('svg')`
+  width: ${p => p.size}px;
+  height: ${p => p.size}px;
+  position: absolute;
+  bottom: -${p => p.size / 2}px;
+  transform: translate(${p => (p.offset || 0) - p.size / 2}px, 0);
+  left: ${p => p.left}%;
 `;
 
 export default StackedBarChart;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -317,7 +317,8 @@ class StackedBarChart extends React.Component {
             <rect
               x={index * pointWidth + '%'}
               width={pointWidth + '%'}
-              height="100%"
+              height="105%"
+              y="-5%"
               transform={`translate(-${this.props.gap}, 0)`}
             />
           </clipPath>

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
 import _ from 'lodash';
+import styled from 'react-emotion';
 
 import Tooltip from 'app/components/tooltip';
 import Count from 'app/components/count';
@@ -53,41 +53,6 @@ class StackedBarChart extends React.Component {
     barClasses: ['chart-bar'],
   };
 
-  getInterval = series => {
-    // TODO(dcramer): not guaranteed correct
-    return series.length && series[0].data.length > 1
-      ? series[0].data[1].x - series[0].data[0].x
-      : null;
-  };
-
-  pointsToSeries = points => {
-    let series = [];
-    points.forEach((p, pIdx) => {
-      p.y.forEach((y, yIdx) => {
-        if (!series[yIdx]) {
-          series[yIdx] = {data: []};
-        }
-        series[yIdx].data.push({x: p.x, y});
-      });
-    });
-    return series;
-  };
-
-  pointIndex = series => {
-    let points = {};
-    series.forEach(s => {
-      s.data.forEach(p => {
-        if (!points[p.x]) {
-          points[p.x] = {y: [], x: p.x};
-        }
-        points[p.x].y.push(p.y);
-      });
-    });
-    return points;
-  };
-
-  funTime = () => console.log('hi');
-
   constructor(props) {
     super(props);
 
@@ -131,6 +96,39 @@ class StackedBarChart extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     return !_.isEqual(this.props, nextProps);
   }
+
+  getInterval = series => {
+    // TODO(dcramer): not guaranteed correct
+    return series.length && series[0].data.length > 1
+      ? series[0].data[1].x - series[0].data[0].x
+      : null;
+  };
+
+  pointsToSeries = points => {
+    let series = [];
+    points.forEach((p, pIdx) => {
+      p.y.forEach((y, yIdx) => {
+        if (!series[yIdx]) {
+          series[yIdx] = {data: []};
+        }
+        series[yIdx].data.push({x: p.x, y});
+      });
+    });
+    return series;
+  };
+
+  pointIndex = series => {
+    let points = {};
+    series.forEach(s => {
+      s.data.forEach(p => {
+        if (!points[p.x]) {
+          points[p.x] = {y: [], x: p.x};
+        }
+        points[p.x].y.push(p.y);
+      });
+    });
+    return points;
+  };
 
   use24Hours() {
     let user = ConfigStore.get('user');
@@ -218,14 +216,14 @@ class StackedBarChart extends React.Component {
 
     return (
       <Tooltip title={title} key={key} tooltipOptions={{html: true, placement: 'bottom'}}>
-        <a className={className} style={{height: '100%'}}>
+        <a data-test-id="chart-column" className={className} style={{height: '100%'}}>
           <span>{marker.label}</span>
         </a>
       </Tooltip>
     );
   }
 
-  renderTooltip(point, pointIdx) {
+  renderTooltip = (point, pointIdx) => {
     let timeLabel = this.getTimeLabel(point);
     let totalY = point.y.reduce((a, b) => a + b);
     let title =
@@ -244,7 +242,7 @@ class StackedBarChart extends React.Component {
       }
     });
     return title;
-  }
+  };
 
   renderChartColumn(point, maxval, pointWidth, index, totalPoints) {
     let totalY = point.y.reduce((a, b) => a + b);
@@ -258,13 +256,16 @@ class StackedBarChart extends React.Component {
       );
       let pt = (
         <rect
+          key={i}
           x={index * pointWidth}
           y={100 - pct - prevPct}
           width={pointWidth - space}
           height={pct}
           fill={this.state.series[i].color}
           className={this.props.barClasses[i]}
-        />
+        >
+          {y}
+        </rect>
       );
       prevPct += pct;
       return pt;
@@ -279,7 +280,7 @@ class StackedBarChart extends React.Component {
         key={point.x}
         tooltipOptions={{html: true, placement: 'bottom', container: 'body'}}
       >
-        <g onHover={this.funTime}>{pts}</g>
+        <g data-test-id="chart-column">{pts}</g>
       </Tooltip>
     );
   }
@@ -337,17 +338,21 @@ class StackedBarChart extends React.Component {
           <Count value={maxval} />
         </span>
         <span className="min-y">0</span>
-        <svg
+        <StyledSvg
           shapeRendering="geometricPrecision"
           viewBox={'0 0 99.9 99.9'}
           preserveAspectRatio="none"
-          style={{width: '100%', height: '100%'}}
         >
           {this.renderChart()}
-        </svg>
+        </StyledSvg>
       </figure>
     );
   }
 }
+
+const StyledSvg = styled('svg')`
+  width: 100%;
+  height: 100%;
+`;
 
 export default StackedBarChart;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -307,6 +307,12 @@ class StackedBarChart extends React.Component {
         key={point.x}
       >
         <g>
+          <rect
+            x={index * pointWidth + '%'}
+            width={pointWidth + '%'}
+            height="100%"
+            opacity="0"
+          />
           <clipPath id={maskId}>
             <rect
               x={index * pointWidth + '%'}

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -277,7 +277,7 @@ class StackedBarChart extends React.Component {
       <Tooltip
         title={tooltipFunc(this.state.pointIndex[pointIdx], pointIdx, this)}
         key={point.x}
-        tooltipOptions={{html: true, placement: 'bottom'}}
+        tooltipOptions={{html: true, placement: 'bottom', container: 'body'}}
       >
         <g onHover={this.funTime}>{pts}</g>
       </Tooltip>

--- a/src/sentry/static/sentry/app/components/stream/groupChart.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.jsx
@@ -35,7 +35,7 @@ class GroupChart extends React.Component {
 
     return (
       <LazyLoad debounce={50} height={24}>
-        <StyledBarChart points={chartData} label="events" />
+        <StyledBarChart points={chartData} label="events" gap={2} />
       </LazyLoad>
     );
   }

--- a/src/sentry/static/sentry/app/components/stream/groupChart.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.jsx
@@ -35,7 +35,7 @@ class GroupChart extends React.Component {
 
     return (
       <LazyLoad debounce={50} height={24}>
-        <StyledBarChart points={chartData} label="events" minHeights={[3]} />
+        <StyledBarChart points={chartData} label="events" minHeights={[3]} gap={1} />
       </LazyLoad>
     );
   }

--- a/src/sentry/static/sentry/app/components/stream/groupChart.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.jsx
@@ -35,7 +35,7 @@ class GroupChart extends React.Component {
 
     return (
       <LazyLoad debounce={50} height={24}>
-        <StyledBarChart points={chartData} label="events" gap={2} minHeights={[3]} />
+        <StyledBarChart points={chartData} label="events" minHeights={[3]} />
       </LazyLoad>
     );
   }

--- a/src/sentry/static/sentry/app/components/stream/groupChart.jsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.jsx
@@ -35,7 +35,7 @@ class GroupChart extends React.Component {
 
     return (
       <LazyLoad debounce={50} height={24}>
-        <StyledBarChart points={chartData} label="events" gap={2} />
+        <StyledBarChart points={chartData} label="events" gap={2} minHeights={[3]} />
       </LazyLoad>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/chart.jsx
@@ -18,7 +18,7 @@ export default class Chart extends React.Component {
 
     return (
       <div>
-        <StyledBarChart points={data} label="events" height={60} />
+        <StyledBarChart points={data} label="events" height={60} gap={1.5} />
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -99,6 +99,8 @@ class OrganizationStats extends React.Component {
                 label="events"
                 className="standard-barchart b-a-0 m-b-0"
                 barClasses={['accepted', 'rate-limited', 'black-listed']}
+                minHeights={[2, 0, 0]}
+                allottedGapSpace={36}
                 tooltip={this.renderTooltip}
               />
             </Panel>

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -100,6 +100,7 @@ class OrganizationStats extends React.Component {
                 className="standard-barchart b-a-0 m-b-0"
                 barClasses={['accepted', 'rate-limited', 'black-listed']}
                 minHeights={[2, 0, 0]}
+                gap={0.25}
                 tooltip={this.renderTooltip}
               />
             </Panel>

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -100,7 +100,6 @@ class OrganizationStats extends React.Component {
                 className="standard-barchart b-a-0 m-b-0"
                 barClasses={['accepted', 'rate-limited', 'black-listed']}
                 minHeights={[2, 0, 0]}
-                allottedGapSpace={36}
                 tooltip={this.renderTooltip}
               />
             </Panel>

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -128,7 +128,6 @@ const ProjectChart = createReactClass({
           markers={markers}
           label="events"
           height={150}
-          gap={2}
           className="standard-barchart"
         />
         <small className="date-legend">

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -128,6 +128,7 @@ const ProjectChart = createReactClass({
           markers={markers}
           label="events"
           height={150}
+          gap={0.2}
           className="standard-barchart"
         />
         <small className="date-legend">

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -128,6 +128,7 @@ const ProjectChart = createReactClass({
           markers={markers}
           label="events"
           height={150}
+          gap={2}
           className="standard-barchart"
         />
         <small className="date-legend">

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
@@ -28,7 +28,13 @@ const ProjectStatsGraph = createReactClass({
       <div>
         {chartData && (
           <LazyLoad height={25} debounce={50}>
-            <BarChart height={25} minHeights={[3]} points={chartData} label="events" />
+            <BarChart
+              height={25}
+              minHeights={[3]}
+              gap={1}
+              points={chartData}
+              label="events"
+            />
           </LazyLoad>
         )}
       </div>

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
@@ -28,7 +28,13 @@ const ProjectStatsGraph = createReactClass({
       <div>
         {chartData && (
           <LazyLoad height={25} debounce={50}>
-            <BarChart height={25} points={chartData} label="events" />
+            <BarChart
+              height={25}
+              minHeights={[3]}
+              gap={2}
+              points={chartData}
+              label="events"
+            />
           </LazyLoad>
         )}
       </div>

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
@@ -28,13 +28,7 @@ const ProjectStatsGraph = createReactClass({
       <div>
         {chartData && (
           <LazyLoad height={25} debounce={50}>
-            <BarChart
-              height={25}
-              minHeights={[3]}
-              gap={2}
-              points={chartData}
-              label="events"
-            />
+            <BarChart height={25} minHeights={[3]} points={chartData} label="events" />
           </LazyLoad>
         )}
       </div>

--- a/src/sentry/static/sentry/less/components/charts.less
+++ b/src/sentry/static/sentry/less/components/charts.less
@@ -43,42 +43,6 @@
       fill: @gray-lighter;
     }
   }
-
-  .chart-marker {
-    display: block;
-    position: relative;
-    float: left;
-    width: 0;
-    bottom: -5px;
-    transform: translateX(-5px);
-
-    &:hover {
-      > span {
-        background-color: gray;
-        border-color: #fff;
-      }
-    }
-
-    &.first-seen {
-      transform: translateX(-13px);
-      > span {
-        background: @pink;
-      }
-    }
-
-    &.last-seen > span {
-      background: @green;
-    }
-
-    > span {
-      z-index: 2;
-      position: absolute;
-      border: 2px solid #fff;
-      .square(10px);
-      background: gray;
-      border-radius: 8px;
-    }
-  }
 }
 
 .standard-barchart {

--- a/src/sentry/static/sentry/less/components/charts.less
+++ b/src/sentry/static/sentry/less/components/charts.less
@@ -50,7 +50,7 @@
     float: left;
     width: 0;
     bottom: -5px;
-    left: -5px;
+    transform: translateX(-5px);
 
     &:hover {
       > span {
@@ -60,7 +60,7 @@
     }
 
     &.first-seen {
-      left: -13px;
+      transform: translateX(-13px);
       > span {
         background: @pink;
       }

--- a/src/sentry/static/sentry/less/components/charts.less
+++ b/src/sentry/static/sentry/less/components/charts.less
@@ -15,13 +15,16 @@
     cursor: default;
 
     &:hover {
-      > span {
+      > span,
+      > rect {
         background: @purple;
+        fill: @purple;
         border-color: transparent;
       }
     }
 
-    > span {
+    > span,
+    > rect {
       display: block;
       position: absolute;
       bottom: 0;
@@ -35,6 +38,7 @@
       min-height: 1px;
 
       background: @gray-lighter;
+      fill: @gray-lighter;
     }
   }
 

--- a/src/sentry/static/sentry/less/components/charts.less
+++ b/src/sentry/static/sentry/less/components/charts.less
@@ -24,20 +24,21 @@
       }
     }
 
-    > span,
-    > .barchart-rect {
+    > span {
       display: block;
       position: absolute;
       bottom: 0;
       left: 1px;
       right: 1px;
-      min-width: 1px;
       height: 0;
       overflow: hidden;
       text-indent: -9999px;
       text-align: left;
       min-height: 1px;
+    }
 
+    > span,
+    > .barchart-rect {
       background: @gray-lighter;
       fill: @gray-lighter;
     }

--- a/src/sentry/static/sentry/less/components/charts.less
+++ b/src/sentry/static/sentry/less/components/charts.less
@@ -7,7 +7,8 @@
     display: none;
   }
 
-  a {
+  a,
+  g {
     position: relative;
     float: left;
     height: 20px;
@@ -16,7 +17,7 @@
 
     &:hover {
       > span,
-      > rect {
+      > .barchart-rect {
         background: @purple;
         fill: @purple;
         border-color: transparent;
@@ -24,7 +25,7 @@
     }
 
     > span,
-    > rect {
+    > .barchart-rect {
       display: block;
       position: absolute;
       bottom: 0;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -345,10 +345,12 @@
     border-bottom: 1px dotted @trim;
   }
 
-  .bar-chart figure a {
+  .bar-chart figure a,
+  .bar-chart figure g {
     height: 50px;
 
-    span {
+    span,
+    .barchart-rect {
       background: @purple;
       #gradient > .vertical(@purple-light, @purple);
 
@@ -363,7 +365,8 @@
       }
     }
 
-    &:hover span {
+    &:hover span,
+    &:hover .barchart-rect {
       background: @purple-dark;
       #gradient > .vertical(@purple, @purple-dark);
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -352,32 +352,32 @@
     span,
     .barchart-rect {
       background: @purple;
-      #gradient > .vertical(@purple-light, @purple);
+      fill: @purple;
 
       &.inactive {
         background: @gray-lightest;
-        #gradient > .vertical(@gray-lightest, @gray-lightest);
+        fill: @gray-lightest;
       }
 
       &.environment {
         background: @purple-lightest;
-        #gradient > .vertical(@purple-lightest, @purple-lightest);
+        fill: @purple-lightest;
       }
     }
 
     &:hover span,
     &:hover .barchart-rect {
       background: @purple-dark;
-      #gradient > .vertical(@purple, @purple-dark);
+      fill: @purple-dark;
 
       &.inactive {
         background: @gray-lighter;
-        #gradient > .vertical(@gray-lighter, @gray-lighter);
+        fill: @purple-dark;
       }
 
       &.environment {
         background: @purple;
-        #gradient > .vertical(@purple, @purple);
+        fill: @purple;
       }
     }
   }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -372,7 +372,7 @@
 
       &.inactive {
         background: @gray-lighter;
-        fill: @purple-dark;
+        fill: @gray-lighter;
       }
 
       &.environment {

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -22,38 +22,47 @@
 
       &.ip-address {
         background: @red-light;
+        fill: @red-light;
       }
 
       &.release-version {
         background: @purple-light;
+        fill: @purple-light;
       }
 
       &.error-message {
         background: @purple;
+        fill: @purple;
       }
 
       &.browser-extensions {
         background: @gray;
+        fill: @gray;
       }
 
       &.legacy-browsers {
         background: @gray-light;
+        fill: @gray-light;
       }
 
       &.localhost {
         background: @blue;
+        fill: @blue;
       }
 
       &.web-crawlers {
         background: @red;
+        fill: @red;
       }
 
       &.invalid-csp {
         background: @blue-light;
+        fill: @blue-light;
       }
 
       &.cors {
         background: @orange;
+        fill: @orange;
       }
     }
   }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1178,19 +1178,23 @@ table.integrations {
         }
       }
 
-      &:hover span {
+      &:hover span,
+      &:hover rect {
         &.accepted {
           background: @gray-light;
+          fill: @gray-light;
         }
 
         &.rate-limited,
         &.dropped {
           background: @red-dark;
+          fill: @red-dark;
         }
 
         &.black-listed,
         &.filtered {
           background: @orange-dark;
+          fill: @orange-dark;
         }
       }
     }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1147,28 +1147,33 @@ table.integrations {
     margin-bottom: 20px;
     position: relative;
 
-    a {
+    a,
+    g {
       height: 90px;
       position: relative;
       cursor: default;
 
-      span {
+      span,
+      rect {
         display: block;
         min-height: 2px;
 
         &.accepted {
           background: @gray-lightest;
+          fill: @gray-lightest;
         }
 
         &.rate-limited,
         &.dropped {
           background: @red;
+          fill: @red;
           min-height: 0;
         }
 
         &.black-listed,
         &.filtered {
           background: @orange-light;
+          fill: @orange-light;
           min-height: 0;
         }
       }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -882,16 +882,19 @@ table.integrations {
 * ============================================================================
 */
 .inbound-filters-stats {
-  .bar-chart figure a {
+  .bar-chart figure a,
+  .bar-chart figure g {
     height: 50px;
 
-    span {
+    span,
+    .barchart-rect {
       &.filtered {
         background: @gray-lightest;
       }
     }
 
-    &:hover span {
+    &:hover span,
+    &:hover .barchart-rect {
       &.filtered {
         background: @gray-light;
       }

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -160,6 +160,7 @@ exports[`GroupReleaseStats renders 1`] = `
               </span>
             </h6>
             <StackedBarChart
+              allottedGapSpace={20}
               barClasses={
                 Array [
                   "release",
@@ -249,11 +250,11 @@ exports[`GroupReleaseStats renders 1`] = `
                       >
                         <rect
                           className="release barchart-rect"
-                          height={1.5}
+                          height={0}
                           key="0"
-                          width={14}
+                          width={30}
                           x={0}
-                          y={98.5}
+                          y={100}
                         >
                           0
                         </rect>
@@ -261,19 +262,19 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="environment barchart-rect"
                           height={19.8}
                           key="1"
-                          width={14}
+                          width={30}
                           x={0}
-                          y={78.7}
+                          y={80.2}
                         >
                           2
                         </rect>
                         <rect
                           className="inactive barchart-rect"
-                          height={0}
+                          height={4}
                           key="2"
-                          width={14}
+                          width={30}
                           x={0}
-                          y={78.7}
+                          y={76.2}
                         >
                           0
                         </rect>
@@ -297,11 +298,11 @@ exports[`GroupReleaseStats renders 1`] = `
                       >
                         <rect
                           className="release barchart-rect"
-                          height={1.5}
+                          height={0}
                           key="0"
-                          width={14}
+                          width={30}
                           x={50}
-                          y={98.5}
+                          y={100}
                         >
                           0
                         </rect>
@@ -309,19 +310,19 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="environment barchart-rect"
                           height={9.9}
                           key="1"
-                          width={14}
+                          width={30}
                           x={50}
-                          y={88.6}
+                          y={90.1}
                         >
                           1
                         </rect>
                         <rect
                           className="inactive barchart-rect"
-                          height={0}
+                          height={4}
                           key="2"
-                          width={14}
+                          width={30}
                           x={50}
-                          y={88.6}
+                          y={86.1}
                         >
                           0
                         </rect>
@@ -407,6 +408,7 @@ exports[`GroupReleaseStats renders 1`] = `
               </span>
             </h6>
             <StackedBarChart
+              allottedGapSpace={20}
               barClasses={
                 Array [
                   "release",
@@ -496,11 +498,11 @@ exports[`GroupReleaseStats renders 1`] = `
                       >
                         <rect
                           className="release barchart-rect"
-                          height={1.5}
+                          height={0}
                           key="0"
-                          width={14}
+                          width={30}
                           x={0}
-                          y={98.5}
+                          y={100}
                         >
                           0
                         </rect>
@@ -508,19 +510,19 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="environment barchart-rect"
                           height={0.81}
                           key="1"
-                          width={14}
+                          width={30}
                           x={0}
-                          y={97.69}
+                          y={99.19}
                         >
                           1
                         </rect>
                         <rect
                           className="inactive barchart-rect"
-                          height={0}
+                          height={4}
                           key="2"
-                          width={14}
+                          width={30}
                           x={0}
-                          y={97.69}
+                          y={95.19}
                         >
                           0
                         </rect>
@@ -544,11 +546,11 @@ exports[`GroupReleaseStats renders 1`] = `
                       >
                         <rect
                           className="release barchart-rect"
-                          height={1.5}
+                          height={0}
                           key="0"
-                          width={14}
+                          width={30}
                           x={50}
-                          y={98.5}
+                          y={100}
                         >
                           0
                         </rect>
@@ -556,19 +558,19 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="environment barchart-rect"
                           height={99}
                           key="1"
-                          width={14}
+                          width={30}
                           x={50}
-                          y={-0.5}
+                          y={1}
                         >
                           122
                         </rect>
                         <rect
                           className="inactive barchart-rect"
-                          height={0}
+                          height={4}
                           key="2"
-                          width={14}
+                          width={30}
                           x={50}
-                          y={-0.5}
+                          y={-3}
                         >
                           0
                         </rect>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -248,30 +248,30 @@ exports[`GroupReleaseStats renders 1`] = `
                         title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
                       >
                         <rect
-                          className="release"
+                          className="release barchart-rect"
                           height={1.5}
                           key="0"
-                          width={32.5}
+                          width={14}
                           x={0}
                           y={98.5}
                         >
                           0
                         </rect>
                         <rect
-                          className="environment"
+                          className="environment barchart-rect"
                           height={19.8}
                           key="1"
-                          width={32.5}
+                          width={14}
                           x={0}
                           y={78.7}
                         >
                           2
                         </rect>
                         <rect
-                          className="inactive"
+                          className="inactive barchart-rect"
                           height={0}
                           key="2"
-                          width={32.5}
+                          width={14}
                           x={0}
                           y={78.7}
                         >
@@ -296,31 +296,31 @@ exports[`GroupReleaseStats renders 1`] = `
                         title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                       >
                         <rect
-                          className="release"
+                          className="release barchart-rect"
                           height={1.5}
                           key="0"
-                          width={32.5}
-                          x={50.5}
+                          width={14}
+                          x={50}
                           y={98.5}
                         >
                           0
                         </rect>
                         <rect
-                          className="environment"
+                          className="environment barchart-rect"
                           height={9.9}
                           key="1"
-                          width={32.5}
-                          x={50.5}
+                          width={14}
+                          x={50}
                           y={88.6}
                         >
                           1
                         </rect>
                         <rect
-                          className="inactive"
+                          className="inactive barchart-rect"
                           height={0}
                           key="2"
-                          width={32.5}
-                          x={50.5}
+                          width={14}
+                          x={50}
                           y={88.6}
                         >
                           0
@@ -495,30 +495,30 @@ exports[`GroupReleaseStats renders 1`] = `
                         title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                       >
                         <rect
-                          className="release"
+                          className="release barchart-rect"
                           height={1.5}
                           key="0"
-                          width={32.5}
+                          width={14}
                           x={0}
                           y={98.5}
                         >
                           0
                         </rect>
                         <rect
-                          className="environment"
+                          className="environment barchart-rect"
                           height={0.81}
                           key="1"
-                          width={32.5}
+                          width={14}
                           x={0}
                           y={97.69}
                         >
                           1
                         </rect>
                         <rect
-                          className="inactive"
+                          className="inactive barchart-rect"
                           height={0}
                           key="2"
-                          width={32.5}
+                          width={14}
                           x={0}
                           y={97.69}
                         >
@@ -543,31 +543,31 @@ exports[`GroupReleaseStats renders 1`] = `
                         title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
                       >
                         <rect
-                          className="release"
+                          className="release barchart-rect"
                           height={1.5}
                           key="0"
-                          width={32.5}
-                          x={50.5}
+                          width={14}
+                          x={50}
                           y={98.5}
                         >
                           0
                         </rect>
                         <rect
-                          className="environment"
+                          className="environment barchart-rect"
                           height={99}
                           key="1"
-                          width={32.5}
-                          x={50.5}
+                          width={14}
+                          x={50}
                           y={-0.5}
                         >
                           122
                         </rect>
                         <rect
-                          className="inactive"
+                          className="inactive barchart-rect"
                           height={0}
                           key="2"
-                          width={32.5}
-                          x={50.5}
+                          width={14}
+                          x={50}
                           y={-0.5}
                         >
                           0

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -235,7 +235,7 @@ exports[`GroupReleaseStats renders 1`] = `
                     overflow="visible"
                   >
                     <svg
-                      className="css-spxnbk-StyledSvg e5t71580"
+                      className="css-v8214s-StyledSvg e5t71580"
                       overflow="visible"
                     >
                       <Tooltip
@@ -257,7 +257,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-0"
                           >
                             <rect
-                              height="98.5%"
+                              height="100%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="0%"
@@ -269,11 +269,11 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="0%"
+                              height="1%"
                               key="0"
                               width="50%"
                               x="0%"
-                              y="98.5%"
+                              y="99%"
                             >
                               0
                             </rect>
@@ -283,17 +283,17 @@ exports[`GroupReleaseStats renders 1`] = `
                               key="1"
                               width="50%"
                               x="0%"
-                              y="78.7%"
+                              y="79.2%"
                             >
                               2
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="4%"
+                              height="1%"
                               key="2"
                               width="50%"
                               x="0%"
-                              y="74.7%"
+                              y="78.2%"
                             >
                               0
                             </rect>
@@ -319,7 +319,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-1"
                           >
                             <rect
-                              height="98.5%"
+                              height="100%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="50%"
@@ -331,11 +331,11 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="0%"
+                              height="1%"
                               key="0"
                               width="50%"
                               x="50%"
-                              y="98.5%"
+                              y="99%"
                             >
                               0
                             </rect>
@@ -345,17 +345,17 @@ exports[`GroupReleaseStats renders 1`] = `
                               key="1"
                               width="50%"
                               x="50%"
-                              y="88.6%"
+                              y="89.1%"
                             >
                               1
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="4%"
+                              height="1%"
                               key="2"
                               width="50%"
                               x="50%"
-                              y="84.6%"
+                              y="88.1%"
                             >
                               0
                             </rect>
@@ -518,7 +518,7 @@ exports[`GroupReleaseStats renders 1`] = `
                     overflow="visible"
                   >
                     <svg
-                      className="css-spxnbk-StyledSvg e5t71580"
+                      className="css-v8214s-StyledSvg e5t71580"
                       overflow="visible"
                     >
                       <Tooltip
@@ -540,7 +540,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-0"
                           >
                             <rect
-                              height="98.5%"
+                              height="100%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="0%"
@@ -552,31 +552,31 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="0%"
+                              height="1%"
                               key="0"
                               width="50%"
                               x="0%"
-                              y="98.5%"
+                              y="99%"
                             >
                               0
                             </rect>
                             <rect
                               className="environment barchart-rect"
-                              height="0.81%"
+                              height="1%"
                               key="1"
                               width="50%"
                               x="0%"
-                              y="97.69%"
+                              y="98%"
                             >
                               1
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="4%"
+                              height="1%"
                               key="2"
                               width="50%"
                               x="0%"
-                              y="93.69%"
+                              y="97%"
                             >
                               0
                             </rect>
@@ -602,7 +602,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-1"
                           >
                             <rect
-                              height="98.5%"
+                              height="100%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="50%"
@@ -614,11 +614,11 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="0%"
+                              height="1%"
                               key="0"
                               width="50%"
                               x="50%"
-                              y="98.5%"
+                              y="99%"
                             >
                               0
                             </rect>
@@ -628,17 +628,17 @@ exports[`GroupReleaseStats renders 1`] = `
                               key="1"
                               width="50%"
                               x="50%"
-                              y="-0.5%"
+                              y="0%"
                             >
                               122
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="4%"
+                              height="1%"
                               key="2"
                               width="50%"
                               x="50%"
-                              y="-4.5%"
+                              y="-1%"
                             >
                               0
                             </rect>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -172,6 +172,13 @@ exports[`GroupReleaseStats renders 1`] = `
               height={40}
               label="events"
               markers={Array []}
+              minHeights={
+                Array [
+                  0,
+                  0,
+                  4,
+                ]
+              }
               points={
                 Array [
                   Object {
@@ -263,10 +270,11 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-0"
                           >
                             <rect
-                              height="100%"
+                              height="105%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="0%"
+                              y="-5%"
                             />
                           </clipPath>
                           <g
@@ -275,11 +283,11 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="1%"
+                              height="0%"
                               key="0"
                               width="50%"
                               x="0%"
-                              y="99%"
+                              y="100%"
                             >
                               0
                             </rect>
@@ -289,17 +297,17 @@ exports[`GroupReleaseStats renders 1`] = `
                               key="1"
                               width="50%"
                               x="0%"
-                              y="79.2%"
+                              y="80.2%"
                             >
                               2
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="1%"
+                              height="4%"
                               key="2"
                               width="50%"
                               x="0%"
-                              y="78.2%"
+                              y="76.2%"
                             >
                               0
                             </rect>
@@ -331,10 +339,11 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-1"
                           >
                             <rect
-                              height="100%"
+                              height="105%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="50%"
+                              y="-5%"
                             />
                           </clipPath>
                           <g
@@ -343,11 +352,11 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="1%"
+                              height="0%"
                               key="0"
                               width="50%"
                               x="50%"
-                              y="99%"
+                              y="100%"
                             >
                               0
                             </rect>
@@ -357,17 +366,17 @@ exports[`GroupReleaseStats renders 1`] = `
                               key="1"
                               width="50%"
                               x="50%"
-                              y="89.1%"
+                              y="90.1%"
                             >
                               1
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="1%"
+                              height="4%"
                               key="2"
                               width="50%"
                               x="50%"
-                              y="88.1%"
+                              y="86.1%"
                             >
                               0
                             </rect>
@@ -467,6 +476,13 @@ exports[`GroupReleaseStats renders 1`] = `
               height={40}
               label="events"
               markers={Array []}
+              minHeights={
+                Array [
+                  0,
+                  0,
+                  4,
+                ]
+              }
               points={
                 Array [
                   Object {
@@ -558,10 +574,11 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-0"
                           >
                             <rect
-                              height="100%"
+                              height="105%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="0%"
+                              y="-5%"
                             />
                           </clipPath>
                           <g
@@ -570,31 +587,31 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="1%"
+                              height="0%"
                               key="0"
                               width="50%"
                               x="0%"
-                              y="99%"
+                              y="100%"
                             >
                               0
                             </rect>
                             <rect
                               className="environment barchart-rect"
-                              height="1%"
+                              height="0.81%"
                               key="1"
                               width="50%"
                               x="0%"
-                              y="98%"
+                              y="99.19%"
                             >
                               1
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="1%"
+                              height="4%"
                               key="2"
                               width="50%"
                               x="0%"
-                              y="97%"
+                              y="95.19%"
                             >
                               0
                             </rect>
@@ -626,10 +643,11 @@ exports[`GroupReleaseStats renders 1`] = `
                             id="path-50-1"
                           >
                             <rect
-                              height="100%"
+                              height="105%"
                               transform="translate(-2, 0)"
                               width="50%"
                               x="50%"
+                              y="-5%"
                             />
                           </clipPath>
                           <g
@@ -638,11 +656,11 @@ exports[`GroupReleaseStats renders 1`] = `
                           >
                             <rect
                               className="release barchart-rect"
-                              height="1%"
+                              height="0%"
                               key="0"
                               width="50%"
                               x="50%"
-                              y="99%"
+                              y="100%"
                             >
                               0
                             </rect>
@@ -652,17 +670,17 @@ exports[`GroupReleaseStats renders 1`] = `
                               key="1"
                               width="50%"
                               x="50%"
-                              y="0%"
+                              y="1%"
                             >
                               122
                             </rect>
                             <rect
                               className="inactive barchart-rect"
-                              height="1%"
+                              height="4%"
                               key="2"
                               width="50%"
                               x="50%"
-                              y="-1%"
+                              y="-3%"
                             >
                               0
                             </rect>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -160,7 +160,6 @@ exports[`GroupReleaseStats renders 1`] = `
               </span>
             </h6>
             <StackedBarChart
-              allottedGapSpace={20}
               barClasses={
                 Array [
                   "release",
@@ -169,6 +168,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 ]
               }
               className="sparkline"
+              gap={2}
               height={40}
               label="events"
               markers={Array []}
@@ -196,7 +196,7 @@ exports[`GroupReleaseStats renders 1`] = `
               tooltip={[Function]}
               width={null}
             >
-              <figure
+              <SvgContainer
                 className="sparkline barchart"
                 style={
                   Object {
@@ -205,143 +205,167 @@ exports[`GroupReleaseStats renders 1`] = `
                   }
                 }
               >
-                <span
-                  className="max-y"
-                >
-                  <count
-                    value={10}
-                  >
-                    <span>
-                      10
-                    </span>
-                  </count>
-                </span>
-                <span
-                  className="min-y"
-                >
-                  0
-                </span>
-                <StyledSvg
-                  preserveAspectRatio="none"
-                  shapeRendering="geometricPrecision"
-                  viewBox="0 0 99.9 99.9"
-                >
-                  <svg
-                    className="css-znv93x-StyledSvg e5t71580"
-                    preserveAspectRatio="none"
-                    shapeRendering="geometricPrecision"
-                    viewBox="0 0 99.9 99.9"
-                  >
-                    <Tooltip
-                      key="1517281200"
-                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
-                      tooltipOptions={
-                        Object {
-                          "container": "body",
-                          "html": true,
-                          "placement": "bottom",
-                        }
-                      }
-                    >
-                      <g
-                        className="tip"
-                        data-test-id="chart-column"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
-                      >
-                        <rect
-                          className="release barchart-rect"
-                          height={0}
-                          key="0"
-                          width={30}
-                          x={0}
-                          y={100}
-                        >
-                          0
-                        </rect>
-                        <rect
-                          className="environment barchart-rect"
-                          height={19.8}
-                          key="1"
-                          width={30}
-                          x={0}
-                          y={80.2}
-                        >
-                          2
-                        </rect>
-                        <rect
-                          className="inactive barchart-rect"
-                          height={4}
-                          key="2"
-                          width={30}
-                          x={0}
-                          y={76.2}
-                        >
-                          0
-                        </rect>
-                      </g>
-                    </Tooltip>
-                    <Tooltip
-                      key="1517310000"
-                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                      tooltipOptions={
-                        Object {
-                          "container": "body",
-                          "html": true,
-                          "placement": "bottom",
-                        }
-                      }
-                    >
-                      <g
-                        className="tip"
-                        data-test-id="chart-column"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                      >
-                        <rect
-                          className="release barchart-rect"
-                          height={0}
-                          key="0"
-                          width={30}
-                          x={50}
-                          y={100}
-                        >
-                          0
-                        </rect>
-                        <rect
-                          className="environment barchart-rect"
-                          height={9.9}
-                          key="1"
-                          width={30}
-                          x={50}
-                          y={90.1}
-                        >
-                          1
-                        </rect>
-                        <rect
-                          className="inactive barchart-rect"
-                          height={4}
-                          key="2"
-                          width={30}
-                          x={50}
-                          y={86.1}
-                        >
-                          0
-                        </rect>
-                      </g>
-                    </Tooltip>
-                  </svg>
-                </StyledSvg>
-                <div
+                <figure
+                  className="sparkline barchart css-14dnxoy-SvgContainer e5t71581"
                   style={
                     Object {
-                      "bottom": 0,
-                      "height": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "width": "100%",
+                      "height": 40,
+                      "width": null,
                     }
                   }
-                />
-              </figure>
+                >
+                  <span
+                    className="max-y"
+                  >
+                    <count
+                      value={10}
+                    >
+                      <span>
+                        10
+                      </span>
+                    </count>
+                  </span>
+                  <span
+                    className="min-y"
+                  >
+                    0
+                  </span>
+                  <StyledSvg
+                    gap={2}
+                    overflow="visible"
+                  >
+                    <svg
+                      className="css-spxnbk-StyledSvg e5t71580"
+                      overflow="visible"
+                    >
+                      <Tooltip
+                        key="1517281200"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
+                        tooltipOptions={
+                          Object {
+                            "container": "body",
+                            "html": true,
+                            "placement": "bottom",
+                          }
+                        }
+                      >
+                        <g
+                          className="tip"
+                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
+                        >
+                          <clipPath
+                            id="path-50-0"
+                          >
+                            <rect
+                              height="98.5%"
+                              transform="translate(-2, 0)"
+                              width="50%"
+                              x="0%"
+                            />
+                          </clipPath>
+                          <g
+                            clipPath="url(#path-50-0)"
+                            data-test-id="chart-column"
+                          >
+                            <rect
+                              className="release barchart-rect"
+                              height="0%"
+                              key="0"
+                              width="50%"
+                              x="0%"
+                              y="98.5%"
+                            >
+                              0
+                            </rect>
+                            <rect
+                              className="environment barchart-rect"
+                              height="19.8%"
+                              key="1"
+                              width="50%"
+                              x="0%"
+                              y="78.7%"
+                            >
+                              2
+                            </rect>
+                            <rect
+                              className="inactive barchart-rect"
+                              height="4%"
+                              key="2"
+                              width="50%"
+                              x="0%"
+                              y="74.7%"
+                            >
+                              0
+                            </rect>
+                          </g>
+                        </g>
+                      </Tooltip>
+                      <Tooltip
+                        key="1517310000"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                        tooltipOptions={
+                          Object {
+                            "container": "body",
+                            "html": true,
+                            "placement": "bottom",
+                          }
+                        }
+                      >
+                        <g
+                          className="tip"
+                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                        >
+                          <clipPath
+                            id="path-50-1"
+                          >
+                            <rect
+                              height="98.5%"
+                              transform="translate(-2, 0)"
+                              width="50%"
+                              x="50%"
+                            />
+                          </clipPath>
+                          <g
+                            clipPath="url(#path-50-1)"
+                            data-test-id="chart-column"
+                          >
+                            <rect
+                              className="release barchart-rect"
+                              height="0%"
+                              key="0"
+                              width="50%"
+                              x="50%"
+                              y="98.5%"
+                            >
+                              0
+                            </rect>
+                            <rect
+                              className="environment barchart-rect"
+                              height="9.9%"
+                              key="1"
+                              width="50%"
+                              x="50%"
+                              y="88.6%"
+                            >
+                              1
+                            </rect>
+                            <rect
+                              className="inactive barchart-rect"
+                              height="4%"
+                              key="2"
+                              width="50%"
+                              x="50%"
+                              y="84.6%"
+                            >
+                              0
+                            </rect>
+                          </g>
+                        </g>
+                      </Tooltip>
+                    </svg>
+                  </StyledSvg>
+                </figure>
+              </SvgContainer>
             </StackedBarChart>
           </div>
         </GroupReleaseChart>
@@ -419,7 +443,6 @@ exports[`GroupReleaseStats renders 1`] = `
               </span>
             </h6>
             <StackedBarChart
-              allottedGapSpace={20}
               barClasses={
                 Array [
                   "release",
@@ -428,6 +451,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 ]
               }
               className="sparkline"
+              gap={2}
               height={40}
               label="events"
               markers={Array []}
@@ -455,7 +479,7 @@ exports[`GroupReleaseStats renders 1`] = `
               tooltip={[Function]}
               width={null}
             >
-              <figure
+              <SvgContainer
                 className="sparkline barchart"
                 style={
                   Object {
@@ -464,143 +488,167 @@ exports[`GroupReleaseStats renders 1`] = `
                   }
                 }
               >
-                <span
-                  className="max-y"
-                >
-                  <count
-                    value={122}
-                  >
-                    <span>
-                      122
-                    </span>
-                  </count>
-                </span>
-                <span
-                  className="min-y"
-                >
-                  0
-                </span>
-                <StyledSvg
-                  preserveAspectRatio="none"
-                  shapeRendering="geometricPrecision"
-                  viewBox="0 0 99.9 99.9"
-                >
-                  <svg
-                    className="css-znv93x-StyledSvg e5t71580"
-                    preserveAspectRatio="none"
-                    shapeRendering="geometricPrecision"
-                    viewBox="0 0 99.9 99.9"
-                  >
-                    <Tooltip
-                      key="1514764800"
-                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                      tooltipOptions={
-                        Object {
-                          "container": "body",
-                          "html": true,
-                          "placement": "bottom",
-                        }
-                      }
-                    >
-                      <g
-                        className="tip"
-                        data-test-id="chart-column"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                      >
-                        <rect
-                          className="release barchart-rect"
-                          height={0}
-                          key="0"
-                          width={30}
-                          x={0}
-                          y={100}
-                        >
-                          0
-                        </rect>
-                        <rect
-                          className="environment barchart-rect"
-                          height={0.81}
-                          key="1"
-                          width={30}
-                          x={0}
-                          y={99.19}
-                        >
-                          1
-                        </rect>
-                        <rect
-                          className="inactive barchart-rect"
-                          height={4}
-                          key="2"
-                          width={30}
-                          x={0}
-                          y={95.19}
-                        >
-                          0
-                        </rect>
-                      </g>
-                    </Tooltip>
-                    <Tooltip
-                      key="1515024000"
-                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
-                      tooltipOptions={
-                        Object {
-                          "container": "body",
-                          "html": true,
-                          "placement": "bottom",
-                        }
-                      }
-                    >
-                      <g
-                        className="tip"
-                        data-test-id="chart-column"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
-                      >
-                        <rect
-                          className="release barchart-rect"
-                          height={0}
-                          key="0"
-                          width={30}
-                          x={50}
-                          y={100}
-                        >
-                          0
-                        </rect>
-                        <rect
-                          className="environment barchart-rect"
-                          height={99}
-                          key="1"
-                          width={30}
-                          x={50}
-                          y={1}
-                        >
-                          122
-                        </rect>
-                        <rect
-                          className="inactive barchart-rect"
-                          height={4}
-                          key="2"
-                          width={30}
-                          x={50}
-                          y={-3}
-                        >
-                          0
-                        </rect>
-                      </g>
-                    </Tooltip>
-                  </svg>
-                </StyledSvg>
-                <div
+                <figure
+                  className="sparkline barchart css-14dnxoy-SvgContainer e5t71581"
                   style={
                     Object {
-                      "bottom": 0,
-                      "height": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "width": "100%",
+                      "height": 40,
+                      "width": null,
                     }
                   }
-                />
-              </figure>
+                >
+                  <span
+                    className="max-y"
+                  >
+                    <count
+                      value={122}
+                    >
+                      <span>
+                        122
+                      </span>
+                    </count>
+                  </span>
+                  <span
+                    className="min-y"
+                  >
+                    0
+                  </span>
+                  <StyledSvg
+                    gap={2}
+                    overflow="visible"
+                  >
+                    <svg
+                      className="css-spxnbk-StyledSvg e5t71580"
+                      overflow="visible"
+                    >
+                      <Tooltip
+                        key="1514764800"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                        tooltipOptions={
+                          Object {
+                            "container": "body",
+                            "html": true,
+                            "placement": "bottom",
+                          }
+                        }
+                      >
+                        <g
+                          className="tip"
+                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                        >
+                          <clipPath
+                            id="path-50-0"
+                          >
+                            <rect
+                              height="98.5%"
+                              transform="translate(-2, 0)"
+                              width="50%"
+                              x="0%"
+                            />
+                          </clipPath>
+                          <g
+                            clipPath="url(#path-50-0)"
+                            data-test-id="chart-column"
+                          >
+                            <rect
+                              className="release barchart-rect"
+                              height="0%"
+                              key="0"
+                              width="50%"
+                              x="0%"
+                              y="98.5%"
+                            >
+                              0
+                            </rect>
+                            <rect
+                              className="environment barchart-rect"
+                              height="0.81%"
+                              key="1"
+                              width="50%"
+                              x="0%"
+                              y="97.69%"
+                            >
+                              1
+                            </rect>
+                            <rect
+                              className="inactive barchart-rect"
+                              height="4%"
+                              key="2"
+                              width="50%"
+                              x="0%"
+                              y="93.69%"
+                            >
+                              0
+                            </rect>
+                          </g>
+                        </g>
+                      </Tooltip>
+                      <Tooltip
+                        key="1515024000"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
+                        tooltipOptions={
+                          Object {
+                            "container": "body",
+                            "html": true,
+                            "placement": "bottom",
+                          }
+                        }
+                      >
+                        <g
+                          className="tip"
+                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
+                        >
+                          <clipPath
+                            id="path-50-1"
+                          >
+                            <rect
+                              height="98.5%"
+                              transform="translate(-2, 0)"
+                              width="50%"
+                              x="50%"
+                            />
+                          </clipPath>
+                          <g
+                            clipPath="url(#path-50-1)"
+                            data-test-id="chart-column"
+                          >
+                            <rect
+                              className="release barchart-rect"
+                              height="0%"
+                              key="0"
+                              width="50%"
+                              x="50%"
+                              y="98.5%"
+                            >
+                              0
+                            </rect>
+                            <rect
+                              className="environment barchart-rect"
+                              height="99%"
+                              key="1"
+                              width="50%"
+                              x="50%"
+                              y="-0.5%"
+                            >
+                              122
+                            </rect>
+                            <rect
+                              className="inactive barchart-rect"
+                              height="4%"
+                              key="2"
+                              width="50%"
+                              x="50%"
+                              y="-4.5%"
+                            >
+                              0
+                            </rect>
+                          </g>
+                        </g>
+                      </Tooltip>
+                    </svg>
+                  </StyledSvg>
+                </figure>
+              </SvgContainer>
             </StackedBarChart>
           </div>
         </GroupReleaseChart>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -168,7 +168,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 ]
               }
               className="sparkline"
-              gap={2}
+              gap={0.75}
               height={40}
               label="events"
               markers={Array []}
@@ -176,7 +176,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 Array [
                   0,
                   0,
-                  4,
+                  5,
                 ]
               }
               points={
@@ -242,11 +242,10 @@ exports[`GroupReleaseStats renders 1`] = `
                       className="css-1jg1opr-SvgContainer e5t71582"
                     >
                       <StyledSvg
-                        gap={2}
                         overflow="visible"
                       >
                         <svg
-                          className="css-v8214s-StyledSvg e5t71580"
+                          className="css-1ob8vbo-StyledSvg e5t71580"
                           overflow="visible"
                         >
                           <Tooltip
@@ -267,56 +266,42 @@ exports[`GroupReleaseStats renders 1`] = `
                               <rect
                                 height="100%"
                                 opacity="0"
-                                transform="translate(-2, 0)"
-                                width="50%"
-                                x="0%"
+                                width="51.17%"
+                                x="-0.75%"
                               />
-                              <clipPath
-                                id="path-50-0"
-                              >
-                                <rect
-                                  height="105%"
-                                  transform="translate(-2, 0)"
-                                  width="50%"
-                                  x="0%"
-                                  y="-5%"
-                                />
-                              </clipPath>
-                              <g
-                                clipPath="url(#path-50-0)"
+                              <rect
+                                className="release barchart-rect"
                                 data-test-id="chart-column"
+                                height="0%"
+                                key="0"
+                                width="49.67%"
+                                x="0%"
+                                y="100%"
                               >
-                                <rect
-                                  className="release barchart-rect"
-                                  height="0%"
-                                  key="0"
-                                  width="50%"
-                                  x="0%"
-                                  y="100%"
-                                >
-                                  0
-                                </rect>
-                                <rect
-                                  className="environment barchart-rect"
-                                  height="19.8%"
-                                  key="1"
-                                  width="50%"
-                                  x="0%"
-                                  y="80.2%"
-                                >
-                                  2
-                                </rect>
-                                <rect
-                                  className="inactive barchart-rect"
-                                  height="4%"
-                                  key="2"
-                                  width="50%"
-                                  x="0%"
-                                  y="76.2%"
-                                >
-                                  0
-                                </rect>
-                              </g>
+                                0
+                              </rect>
+                              <rect
+                                className="environment barchart-rect"
+                                data-test-id="chart-column"
+                                height="19.8%"
+                                key="1"
+                                width="49.67%"
+                                x="0%"
+                                y="80.2%"
+                              >
+                                2
+                              </rect>
+                              <rect
+                                className="inactive barchart-rect"
+                                data-test-id="chart-column"
+                                height="5%"
+                                key="2"
+                                width="49.67%"
+                                x="0%"
+                                y="75.2%"
+                              >
+                                0
+                              </rect>
                             </g>
                           </Tooltip>
                           <Tooltip
@@ -337,56 +322,42 @@ exports[`GroupReleaseStats renders 1`] = `
                               <rect
                                 height="100%"
                                 opacity="0"
-                                transform="translate(-2, 0)"
-                                width="50%"
-                                x="50%"
+                                width="51.17%"
+                                x="49.67%"
                               />
-                              <clipPath
-                                id="path-50-1"
-                              >
-                                <rect
-                                  height="105%"
-                                  transform="translate(-2, 0)"
-                                  width="50%"
-                                  x="50%"
-                                  y="-5%"
-                                />
-                              </clipPath>
-                              <g
-                                clipPath="url(#path-50-1)"
+                              <rect
+                                className="release barchart-rect"
                                 data-test-id="chart-column"
+                                height="0%"
+                                key="0"
+                                width="49.67%"
+                                x="50.42%"
+                                y="100%"
                               >
-                                <rect
-                                  className="release barchart-rect"
-                                  height="0%"
-                                  key="0"
-                                  width="50%"
-                                  x="50%"
-                                  y="100%"
-                                >
-                                  0
-                                </rect>
-                                <rect
-                                  className="environment barchart-rect"
-                                  height="9.9%"
-                                  key="1"
-                                  width="50%"
-                                  x="50%"
-                                  y="90.1%"
-                                >
-                                  1
-                                </rect>
-                                <rect
-                                  className="inactive barchart-rect"
-                                  height="4%"
-                                  key="2"
-                                  width="50%"
-                                  x="50%"
-                                  y="86.1%"
-                                >
-                                  0
-                                </rect>
-                              </g>
+                                0
+                              </rect>
+                              <rect
+                                className="environment barchart-rect"
+                                data-test-id="chart-column"
+                                height="9.9%"
+                                key="1"
+                                width="49.67%"
+                                x="50.42%"
+                                y="90.1%"
+                              >
+                                1
+                              </rect>
+                              <rect
+                                className="inactive barchart-rect"
+                                data-test-id="chart-column"
+                                height="5%"
+                                key="2"
+                                width="49.67%"
+                                x="50.42%"
+                                y="85.1%"
+                              >
+                                0
+                              </rect>
                             </g>
                           </Tooltip>
                         </svg>
@@ -480,7 +451,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 ]
               }
               className="sparkline"
-              gap={2}
+              gap={0.75}
               height={40}
               label="events"
               markers={Array []}
@@ -488,7 +459,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 Array [
                   0,
                   0,
-                  4,
+                  5,
                 ]
               }
               points={
@@ -554,11 +525,10 @@ exports[`GroupReleaseStats renders 1`] = `
                       className="css-1jg1opr-SvgContainer e5t71582"
                     >
                       <StyledSvg
-                        gap={2}
                         overflow="visible"
                       >
                         <svg
-                          className="css-v8214s-StyledSvg e5t71580"
+                          className="css-1ob8vbo-StyledSvg e5t71580"
                           overflow="visible"
                         >
                           <Tooltip
@@ -579,56 +549,42 @@ exports[`GroupReleaseStats renders 1`] = `
                               <rect
                                 height="100%"
                                 opacity="0"
-                                transform="translate(-2, 0)"
-                                width="50%"
-                                x="0%"
+                                width="51.17%"
+                                x="-0.75%"
                               />
-                              <clipPath
-                                id="path-50-0"
-                              >
-                                <rect
-                                  height="105%"
-                                  transform="translate(-2, 0)"
-                                  width="50%"
-                                  x="0%"
-                                  y="-5%"
-                                />
-                              </clipPath>
-                              <g
-                                clipPath="url(#path-50-0)"
+                              <rect
+                                className="release barchart-rect"
                                 data-test-id="chart-column"
+                                height="0%"
+                                key="0"
+                                width="49.67%"
+                                x="0%"
+                                y="100%"
                               >
-                                <rect
-                                  className="release barchart-rect"
-                                  height="0%"
-                                  key="0"
-                                  width="50%"
-                                  x="0%"
-                                  y="100%"
-                                >
-                                  0
-                                </rect>
-                                <rect
-                                  className="environment barchart-rect"
-                                  height="0.81%"
-                                  key="1"
-                                  width="50%"
-                                  x="0%"
-                                  y="99.19%"
-                                >
-                                  1
-                                </rect>
-                                <rect
-                                  className="inactive barchart-rect"
-                                  height="4%"
-                                  key="2"
-                                  width="50%"
-                                  x="0%"
-                                  y="95.19%"
-                                >
-                                  0
-                                </rect>
-                              </g>
+                                0
+                              </rect>
+                              <rect
+                                className="environment barchart-rect"
+                                data-test-id="chart-column"
+                                height="0.81%"
+                                key="1"
+                                width="49.67%"
+                                x="0%"
+                                y="99.19%"
+                              >
+                                1
+                              </rect>
+                              <rect
+                                className="inactive barchart-rect"
+                                data-test-id="chart-column"
+                                height="5%"
+                                key="2"
+                                width="49.67%"
+                                x="0%"
+                                y="94.19%"
+                              >
+                                0
+                              </rect>
                             </g>
                           </Tooltip>
                           <Tooltip
@@ -649,56 +605,42 @@ exports[`GroupReleaseStats renders 1`] = `
                               <rect
                                 height="100%"
                                 opacity="0"
-                                transform="translate(-2, 0)"
-                                width="50%"
-                                x="50%"
+                                width="51.17%"
+                                x="49.67%"
                               />
-                              <clipPath
-                                id="path-50-1"
-                              >
-                                <rect
-                                  height="105%"
-                                  transform="translate(-2, 0)"
-                                  width="50%"
-                                  x="50%"
-                                  y="-5%"
-                                />
-                              </clipPath>
-                              <g
-                                clipPath="url(#path-50-1)"
+                              <rect
+                                className="release barchart-rect"
                                 data-test-id="chart-column"
+                                height="0%"
+                                key="0"
+                                width="49.67%"
+                                x="50.42%"
+                                y="100%"
                               >
-                                <rect
-                                  className="release barchart-rect"
-                                  height="0%"
-                                  key="0"
-                                  width="50%"
-                                  x="50%"
-                                  y="100%"
-                                >
-                                  0
-                                </rect>
-                                <rect
-                                  className="environment barchart-rect"
-                                  height="99%"
-                                  key="1"
-                                  width="50%"
-                                  x="50%"
-                                  y="1%"
-                                >
-                                  122
-                                </rect>
-                                <rect
-                                  className="inactive barchart-rect"
-                                  height="4%"
-                                  key="2"
-                                  width="50%"
-                                  x="50%"
-                                  y="-3%"
-                                >
-                                  0
-                                </rect>
-                              </g>
+                                0
+                              </rect>
+                              <rect
+                                className="environment barchart-rect"
+                                data-test-id="chart-column"
+                                height="99%"
+                                key="1"
+                                width="49.67%"
+                                x="50.42%"
+                                y="1%"
+                              >
+                                122
+                              </rect>
+                              <rect
+                                className="inactive barchart-rect"
+                                data-test-id="chart-column"
+                                height="5%"
+                                key="2"
+                                width="49.67%"
+                                x="50.42%"
+                                y="-4%"
+                              >
+                                0
+                              </rect>
                             </g>
                           </Tooltip>
                         </svg>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -330,6 +330,17 @@ exports[`GroupReleaseStats renders 1`] = `
                     </Tooltip>
                   </svg>
                 </StyledSvg>
+                <div
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "width": "100%",
+                    }
+                  }
+                />
               </figure>
             </StackedBarChart>
           </div>
@@ -578,6 +589,17 @@ exports[`GroupReleaseStats renders 1`] = `
                     </Tooltip>
                   </svg>
                 </StyledSvg>
+                <div
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "width": "100%",
+                    }
+                  }
+                />
               </figure>
             </StackedBarChart>
           </div>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -253,6 +253,12 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="tip"
                           title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
                         >
+                          <rect
+                            height="100%"
+                            opacity="0"
+                            width="50%"
+                            x="0%"
+                          />
                           <clipPath
                             id="path-50-0"
                           >
@@ -315,6 +321,12 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="tip"
                           title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                         >
+                          <rect
+                            height="100%"
+                            opacity="0"
+                            width="50%"
+                            x="50%"
+                          />
                           <clipPath
                             id="path-50-1"
                           >
@@ -536,6 +548,12 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="tip"
                           title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                         >
+                          <rect
+                            height="100%"
+                            opacity="0"
+                            width="50%"
+                            x="0%"
+                          />
                           <clipPath
                             id="path-50-0"
                           >
@@ -598,6 +616,12 @@ exports[`GroupReleaseStats renders 1`] = `
                           className="tip"
                           title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
                         >
+                          <rect
+                            height="100%"
+                            opacity="0"
+                            width="50%"
+                            x="50%"
+                          />
                           <clipPath
                             id="path-50-1"
                           >

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -263,6 +263,7 @@ exports[`GroupReleaseStats renders 1`] = `
                           <rect
                             height="100%"
                             opacity="0"
+                            transform="translate(-2, 0)"
                             width="50%"
                             x="0%"
                           />
@@ -332,6 +333,7 @@ exports[`GroupReleaseStats renders 1`] = `
                           <rect
                             height="100%"
                             opacity="0"
+                            transform="translate(-2, 0)"
                             width="50%"
                             x="50%"
                           />
@@ -567,6 +569,7 @@ exports[`GroupReleaseStats renders 1`] = `
                           <rect
                             height="100%"
                             opacity="0"
+                            transform="translate(-2, 0)"
                             width="50%"
                             x="0%"
                           />
@@ -636,6 +639,7 @@ exports[`GroupReleaseStats renders 1`] = `
                           <rect
                             height="100%"
                             opacity="0"
+                            transform="translate(-2, 0)"
                             width="50%"
                             x="50%"
                           />

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -203,7 +203,7 @@ exports[`GroupReleaseStats renders 1`] = `
               tooltip={[Function]}
               width={null}
             >
-              <SvgContainer
+              <StyledFigure
                 className="sparkline barchart"
                 style={
                   Object {
@@ -213,7 +213,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 }
               >
                 <figure
-                  className="sparkline barchart css-14dnxoy-SvgContainer e5t71581"
+                  className="sparkline barchart css-na17se-StyledFigure e5t71581"
                   style={
                     Object {
                       "height": 40,
@@ -237,158 +237,164 @@ exports[`GroupReleaseStats renders 1`] = `
                   >
                     0
                   </span>
-                  <StyledSvg
-                    gap={2}
-                    overflow="visible"
-                  >
-                    <svg
-                      className="css-v8214s-StyledSvg e5t71580"
-                      overflow="visible"
+                  <SvgContainer>
+                    <div
+                      className="css-1jg1opr-SvgContainer e5t71582"
                     >
-                      <Tooltip
-                        key="1517281200"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
+                      <StyledSvg
+                        gap={2}
+                        overflow="visible"
                       >
-                        <g
-                          className="tip"
-                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
+                        <svg
+                          className="css-v8214s-StyledSvg e5t71580"
+                          overflow="visible"
                         >
-                          <rect
-                            height="100%"
-                            opacity="0"
-                            transform="translate(-2, 0)"
-                            width="50%"
-                            x="0%"
-                          />
-                          <clipPath
-                            id="path-50-0"
+                          <Tooltip
+                            key="1517281200"
+                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
+                            tooltipOptions={
+                              Object {
+                                "container": "body",
+                                "html": true,
+                                "placement": "bottom",
+                              }
+                            }
                           >
-                            <rect
-                              height="105%"
-                              transform="translate(-2, 0)"
-                              width="50%"
-                              x="0%"
-                              y="-5%"
-                            />
-                          </clipPath>
-                          <g
-                            clipPath="url(#path-50-0)"
-                            data-test-id="chart-column"
+                            <g
+                              className="tip"
+                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
+                            >
+                              <rect
+                                height="100%"
+                                opacity="0"
+                                transform="translate(-2, 0)"
+                                width="50%"
+                                x="0%"
+                              />
+                              <clipPath
+                                id="path-50-0"
+                              >
+                                <rect
+                                  height="105%"
+                                  transform="translate(-2, 0)"
+                                  width="50%"
+                                  x="0%"
+                                  y="-5%"
+                                />
+                              </clipPath>
+                              <g
+                                clipPath="url(#path-50-0)"
+                                data-test-id="chart-column"
+                              >
+                                <rect
+                                  className="release barchart-rect"
+                                  height="0%"
+                                  key="0"
+                                  width="50%"
+                                  x="0%"
+                                  y="100%"
+                                >
+                                  0
+                                </rect>
+                                <rect
+                                  className="environment barchart-rect"
+                                  height="19.8%"
+                                  key="1"
+                                  width="50%"
+                                  x="0%"
+                                  y="80.2%"
+                                >
+                                  2
+                                </rect>
+                                <rect
+                                  className="inactive barchart-rect"
+                                  height="4%"
+                                  key="2"
+                                  width="50%"
+                                  x="0%"
+                                  y="76.2%"
+                                >
+                                  0
+                                </rect>
+                              </g>
+                            </g>
+                          </Tooltip>
+                          <Tooltip
+                            key="1517310000"
+                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                            tooltipOptions={
+                              Object {
+                                "container": "body",
+                                "html": true,
+                                "placement": "bottom",
+                              }
+                            }
                           >
-                            <rect
-                              className="release barchart-rect"
-                              height="0%"
-                              key="0"
-                              width="50%"
-                              x="0%"
-                              y="100%"
+                            <g
+                              className="tip"
+                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                             >
-                              0
-                            </rect>
-                            <rect
-                              className="environment barchart-rect"
-                              height="19.8%"
-                              key="1"
-                              width="50%"
-                              x="0%"
-                              y="80.2%"
-                            >
-                              2
-                            </rect>
-                            <rect
-                              className="inactive barchart-rect"
-                              height="4%"
-                              key="2"
-                              width="50%"
-                              x="0%"
-                              y="76.2%"
-                            >
-                              0
-                            </rect>
-                          </g>
-                        </g>
-                      </Tooltip>
-                      <Tooltip
-                        key="1517310000"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
-                      >
-                        <g
-                          className="tip"
-                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                        >
-                          <rect
-                            height="100%"
-                            opacity="0"
-                            transform="translate(-2, 0)"
-                            width="50%"
-                            x="50%"
-                          />
-                          <clipPath
-                            id="path-50-1"
-                          >
-                            <rect
-                              height="105%"
-                              transform="translate(-2, 0)"
-                              width="50%"
-                              x="50%"
-                              y="-5%"
-                            />
-                          </clipPath>
-                          <g
-                            clipPath="url(#path-50-1)"
-                            data-test-id="chart-column"
-                          >
-                            <rect
-                              className="release barchart-rect"
-                              height="0%"
-                              key="0"
-                              width="50%"
-                              x="50%"
-                              y="100%"
-                            >
-                              0
-                            </rect>
-                            <rect
-                              className="environment barchart-rect"
-                              height="9.9%"
-                              key="1"
-                              width="50%"
-                              x="50%"
-                              y="90.1%"
-                            >
-                              1
-                            </rect>
-                            <rect
-                              className="inactive barchart-rect"
-                              height="4%"
-                              key="2"
-                              width="50%"
-                              x="50%"
-                              y="86.1%"
-                            >
-                              0
-                            </rect>
-                          </g>
-                        </g>
-                      </Tooltip>
-                    </svg>
-                  </StyledSvg>
+                              <rect
+                                height="100%"
+                                opacity="0"
+                                transform="translate(-2, 0)"
+                                width="50%"
+                                x="50%"
+                              />
+                              <clipPath
+                                id="path-50-1"
+                              >
+                                <rect
+                                  height="105%"
+                                  transform="translate(-2, 0)"
+                                  width="50%"
+                                  x="50%"
+                                  y="-5%"
+                                />
+                              </clipPath>
+                              <g
+                                clipPath="url(#path-50-1)"
+                                data-test-id="chart-column"
+                              >
+                                <rect
+                                  className="release barchart-rect"
+                                  height="0%"
+                                  key="0"
+                                  width="50%"
+                                  x="50%"
+                                  y="100%"
+                                >
+                                  0
+                                </rect>
+                                <rect
+                                  className="environment barchart-rect"
+                                  height="9.9%"
+                                  key="1"
+                                  width="50%"
+                                  x="50%"
+                                  y="90.1%"
+                                >
+                                  1
+                                </rect>
+                                <rect
+                                  className="inactive barchart-rect"
+                                  height="4%"
+                                  key="2"
+                                  width="50%"
+                                  x="50%"
+                                  y="86.1%"
+                                >
+                                  0
+                                </rect>
+                              </g>
+                            </g>
+                          </Tooltip>
+                        </svg>
+                      </StyledSvg>
+                    </div>
+                  </SvgContainer>
                 </figure>
-              </SvgContainer>
+              </StyledFigure>
             </StackedBarChart>
           </div>
         </GroupReleaseChart>
@@ -509,7 +515,7 @@ exports[`GroupReleaseStats renders 1`] = `
               tooltip={[Function]}
               width={null}
             >
-              <SvgContainer
+              <StyledFigure
                 className="sparkline barchart"
                 style={
                   Object {
@@ -519,7 +525,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 }
               >
                 <figure
-                  className="sparkline barchart css-14dnxoy-SvgContainer e5t71581"
+                  className="sparkline barchart css-na17se-StyledFigure e5t71581"
                   style={
                     Object {
                       "height": 40,
@@ -543,158 +549,164 @@ exports[`GroupReleaseStats renders 1`] = `
                   >
                     0
                   </span>
-                  <StyledSvg
-                    gap={2}
-                    overflow="visible"
-                  >
-                    <svg
-                      className="css-v8214s-StyledSvg e5t71580"
-                      overflow="visible"
+                  <SvgContainer>
+                    <div
+                      className="css-1jg1opr-SvgContainer e5t71582"
                     >
-                      <Tooltip
-                        key="1514764800"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
+                      <StyledSvg
+                        gap={2}
+                        overflow="visible"
                       >
-                        <g
-                          className="tip"
-                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                        <svg
+                          className="css-v8214s-StyledSvg e5t71580"
+                          overflow="visible"
                         >
-                          <rect
-                            height="100%"
-                            opacity="0"
-                            transform="translate(-2, 0)"
-                            width="50%"
-                            x="0%"
-                          />
-                          <clipPath
-                            id="path-50-0"
+                          <Tooltip
+                            key="1514764800"
+                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                            tooltipOptions={
+                              Object {
+                                "container": "body",
+                                "html": true,
+                                "placement": "bottom",
+                              }
+                            }
                           >
-                            <rect
-                              height="105%"
-                              transform="translate(-2, 0)"
-                              width="50%"
-                              x="0%"
-                              y="-5%"
-                            />
-                          </clipPath>
-                          <g
-                            clipPath="url(#path-50-0)"
-                            data-test-id="chart-column"
+                            <g
+                              className="tip"
+                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                            >
+                              <rect
+                                height="100%"
+                                opacity="0"
+                                transform="translate(-2, 0)"
+                                width="50%"
+                                x="0%"
+                              />
+                              <clipPath
+                                id="path-50-0"
+                              >
+                                <rect
+                                  height="105%"
+                                  transform="translate(-2, 0)"
+                                  width="50%"
+                                  x="0%"
+                                  y="-5%"
+                                />
+                              </clipPath>
+                              <g
+                                clipPath="url(#path-50-0)"
+                                data-test-id="chart-column"
+                              >
+                                <rect
+                                  className="release barchart-rect"
+                                  height="0%"
+                                  key="0"
+                                  width="50%"
+                                  x="0%"
+                                  y="100%"
+                                >
+                                  0
+                                </rect>
+                                <rect
+                                  className="environment barchart-rect"
+                                  height="0.81%"
+                                  key="1"
+                                  width="50%"
+                                  x="0%"
+                                  y="99.19%"
+                                >
+                                  1
+                                </rect>
+                                <rect
+                                  className="inactive barchart-rect"
+                                  height="4%"
+                                  key="2"
+                                  width="50%"
+                                  x="0%"
+                                  y="95.19%"
+                                >
+                                  0
+                                </rect>
+                              </g>
+                            </g>
+                          </Tooltip>
+                          <Tooltip
+                            key="1515024000"
+                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
+                            tooltipOptions={
+                              Object {
+                                "container": "body",
+                                "html": true,
+                                "placement": "bottom",
+                              }
+                            }
                           >
-                            <rect
-                              className="release barchart-rect"
-                              height="0%"
-                              key="0"
-                              width="50%"
-                              x="0%"
-                              y="100%"
+                            <g
+                              className="tip"
+                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
                             >
-                              0
-                            </rect>
-                            <rect
-                              className="environment barchart-rect"
-                              height="0.81%"
-                              key="1"
-                              width="50%"
-                              x="0%"
-                              y="99.19%"
-                            >
-                              1
-                            </rect>
-                            <rect
-                              className="inactive barchart-rect"
-                              height="4%"
-                              key="2"
-                              width="50%"
-                              x="0%"
-                              y="95.19%"
-                            >
-                              0
-                            </rect>
-                          </g>
-                        </g>
-                      </Tooltip>
-                      <Tooltip
-                        key="1515024000"
-                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
-                      >
-                        <g
-                          className="tip"
-                          title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
-                        >
-                          <rect
-                            height="100%"
-                            opacity="0"
-                            transform="translate(-2, 0)"
-                            width="50%"
-                            x="50%"
-                          />
-                          <clipPath
-                            id="path-50-1"
-                          >
-                            <rect
-                              height="105%"
-                              transform="translate(-2, 0)"
-                              width="50%"
-                              x="50%"
-                              y="-5%"
-                            />
-                          </clipPath>
-                          <g
-                            clipPath="url(#path-50-1)"
-                            data-test-id="chart-column"
-                          >
-                            <rect
-                              className="release barchart-rect"
-                              height="0%"
-                              key="0"
-                              width="50%"
-                              x="50%"
-                              y="100%"
-                            >
-                              0
-                            </rect>
-                            <rect
-                              className="environment barchart-rect"
-                              height="99%"
-                              key="1"
-                              width="50%"
-                              x="50%"
-                              y="1%"
-                            >
-                              122
-                            </rect>
-                            <rect
-                              className="inactive barchart-rect"
-                              height="4%"
-                              key="2"
-                              width="50%"
-                              x="50%"
-                              y="-3%"
-                            >
-                              0
-                            </rect>
-                          </g>
-                        </g>
-                      </Tooltip>
-                    </svg>
-                  </StyledSvg>
+                              <rect
+                                height="100%"
+                                opacity="0"
+                                transform="translate(-2, 0)"
+                                width="50%"
+                                x="50%"
+                              />
+                              <clipPath
+                                id="path-50-1"
+                              >
+                                <rect
+                                  height="105%"
+                                  transform="translate(-2, 0)"
+                                  width="50%"
+                                  x="50%"
+                                  y="-5%"
+                                />
+                              </clipPath>
+                              <g
+                                clipPath="url(#path-50-1)"
+                                data-test-id="chart-column"
+                              >
+                                <rect
+                                  className="release barchart-rect"
+                                  height="0%"
+                                  key="0"
+                                  width="50%"
+                                  x="50%"
+                                  y="100%"
+                                >
+                                  0
+                                </rect>
+                                <rect
+                                  className="environment barchart-rect"
+                                  height="99%"
+                                  key="1"
+                                  width="50%"
+                                  x="50%"
+                                  y="1%"
+                                >
+                                  122
+                                </rect>
+                                <rect
+                                  className="inactive barchart-rect"
+                                  height="4%"
+                                  key="2"
+                                  width="50%"
+                                  x="50%"
+                                  y="-3%"
+                                >
+                                  0
+                                </rect>
+                              </g>
+                            </g>
+                          </Tooltip>
+                        </svg>
+                      </StyledSvg>
+                    </div>
+                  </SvgContainer>
                 </figure>
-              </SvgContainer>
+              </StyledFigure>
             </StackedBarChart>
           </div>
         </GroupReleaseChart>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -243,10 +243,14 @@ exports[`GroupReleaseStats renders 1`] = `
                     >
                       <StyledSvg
                         overflow="visible"
+                        preserveAspectRatio="none"
+                        viewBox="0 0 100 400"
                       >
                         <svg
-                          className="css-1ob8vbo-StyledSvg e5t71580"
+                          className="css-1vaz76z-StyledSvg e5t71580"
                           overflow="visible"
+                          preserveAspectRatio="none"
+                          viewBox="0 0 100 400"
                         >
                           <Tooltip
                             key="1517281200"
@@ -526,10 +530,14 @@ exports[`GroupReleaseStats renders 1`] = `
                     >
                       <StyledSvg
                         overflow="visible"
+                        preserveAspectRatio="none"
+                        viewBox="0 0 100 400"
                       >
                         <svg
-                          className="css-1ob8vbo-StyledSvg e5t71580"
+                          className="css-1vaz76z-StyledSvg e5t71580"
                           overflow="visible"
+                          preserveAspectRatio="none"
+                          viewBox="0 0 100 400"
                         >
                           <Tooltip
                             key="1514764800"

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -220,130 +220,115 @@ exports[`GroupReleaseStats renders 1`] = `
                 >
                   0
                 </span>
-                <span>
-                  <Tooltip
-                    key="1517281200"
-                    title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
-                    tooltipOptions={
-                      Object {
-                        "html": true,
-                        "placement": "bottom",
-                      }
-                    }
+                <StyledSvg
+                  preserveAspectRatio="none"
+                  shapeRendering="geometricPrecision"
+                  viewBox="0 0 99.9 99.9"
+                >
+                  <svg
+                    className="css-znv93x-StyledSvg e5t71580"
+                    preserveAspectRatio="none"
+                    shapeRendering="geometricPrecision"
+                    viewBox="0 0 99.9 99.9"
                   >
-                    <a
-                      className="tip chart-column"
-                      style={
-                        Object {
-                          "height": "100%",
-                          "width": "50%",
-                        }
-                      }
+                    <Tooltip
+                      key="1517281200"
                       title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
-                    >
-                      <span
-                        className="release"
-                        key="0"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "0%",
-                          }
-                        }
-                      >
-                        0
-                      </span>
-                      <span
-                        className="environment"
-                        key="1"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "19.8%",
-                          }
-                        }
-                      >
-                        2
-                      </span>
-                      <span
-                        className="inactive"
-                        key="2"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "19.8%",
-                            "height": "0%",
-                          }
-                        }
-                      >
-                        0
-                      </span>
-                    </a>
-                  </Tooltip>
-                  <Tooltip
-                    key="1517310000"
-                    title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                    tooltipOptions={
-                      Object {
-                        "html": true,
-                        "placement": "bottom",
-                      }
-                    }
-                  >
-                    <a
-                      className="tip chart-column"
-                      style={
+                      tooltipOptions={
                         Object {
-                          "height": "100%",
-                          "width": "50%",
+                          "container": "body",
+                          "html": true,
+                          "placement": "bottom",
                         }
                       }
-                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                     >
-                      <span
-                        className="release"
-                        key="0"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "0%",
-                          }
-                        }
+                      <g
+                        className="tip"
+                        data-test-id="chart-column"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
                       >
-                        0
-                      </span>
-                      <span
-                        className="environment"
-                        key="1"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "9.9%",
-                          }
+                        <rect
+                          className="release"
+                          height={1.5}
+                          key="0"
+                          width={32.5}
+                          x={0}
+                          y={98.5}
+                        >
+                          0
+                        </rect>
+                        <rect
+                          className="environment"
+                          height={19.8}
+                          key="1"
+                          width={32.5}
+                          x={0}
+                          y={78.7}
+                        >
+                          2
+                        </rect>
+                        <rect
+                          className="inactive"
+                          height={0}
+                          key="2"
+                          width={32.5}
+                          x={0}
+                          y={78.7}
+                        >
+                          0
+                        </rect>
+                      </g>
+                    </Tooltip>
+                    <Tooltip
+                      key="1517310000"
+                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
+                      tooltipOptions={
+                        Object {
+                          "container": "body",
+                          "html": true,
+                          "placement": "bottom",
                         }
+                      }
+                    >
+                      <g
+                        className="tip"
+                        data-test-id="chart-column"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                       >
-                        1
-                      </span>
-                      <span
-                        className="inactive"
-                        key="2"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "9.9%",
-                            "height": "0%",
-                          }
-                        }
-                      >
-                        0
-                      </span>
-                    </a>
-                  </Tooltip>
-                </span>
+                        <rect
+                          className="release"
+                          height={1.5}
+                          key="0"
+                          width={32.5}
+                          x={50.5}
+                          y={98.5}
+                        >
+                          0
+                        </rect>
+                        <rect
+                          className="environment"
+                          height={9.9}
+                          key="1"
+                          width={32.5}
+                          x={50.5}
+                          y={88.6}
+                        >
+                          1
+                        </rect>
+                        <rect
+                          className="inactive"
+                          height={0}
+                          key="2"
+                          width={32.5}
+                          x={50.5}
+                          y={88.6}
+                        >
+                          0
+                        </rect>
+                      </g>
+                    </Tooltip>
+                  </svg>
+                </StyledSvg>
               </figure>
             </StackedBarChart>
           </div>
@@ -482,130 +467,115 @@ exports[`GroupReleaseStats renders 1`] = `
                 >
                   0
                 </span>
-                <span>
-                  <Tooltip
-                    key="1514764800"
-                    title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                    tooltipOptions={
-                      Object {
-                        "html": true,
-                        "placement": "bottom",
-                      }
-                    }
+                <StyledSvg
+                  preserveAspectRatio="none"
+                  shapeRendering="geometricPrecision"
+                  viewBox="0 0 99.9 99.9"
+                >
+                  <svg
+                    className="css-znv93x-StyledSvg e5t71580"
+                    preserveAspectRatio="none"
+                    shapeRendering="geometricPrecision"
+                    viewBox="0 0 99.9 99.9"
                   >
-                    <a
-                      className="tip chart-column"
-                      style={
-                        Object {
-                          "height": "100%",
-                          "width": "50%",
-                        }
-                      }
+                    <Tooltip
+                      key="1514764800"
                       title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                    >
-                      <span
-                        className="release"
-                        key="0"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "0%",
-                          }
-                        }
-                      >
-                        0
-                      </span>
-                      <span
-                        className="environment"
-                        key="1"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "0.81%",
-                          }
-                        }
-                      >
-                        1
-                      </span>
-                      <span
-                        className="inactive"
-                        key="2"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0.81%",
-                            "height": "0%",
-                          }
-                        }
-                      >
-                        0
-                      </span>
-                    </a>
-                  </Tooltip>
-                  <Tooltip
-                    key="1515024000"
-                    title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
-                    tooltipOptions={
-                      Object {
-                        "html": true,
-                        "placement": "bottom",
-                      }
-                    }
-                  >
-                    <a
-                      className="tip chart-column"
-                      style={
+                      tooltipOptions={
                         Object {
-                          "height": "100%",
-                          "width": "50%",
+                          "container": "body",
+                          "html": true,
+                          "placement": "bottom",
                         }
                       }
-                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
                     >
-                      <span
-                        className="release"
-                        key="0"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "0%",
-                          }
-                        }
+                      <g
+                        className="tip"
+                        data-test-id="chart-column"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
                       >
-                        0
-                      </span>
-                      <span
-                        className="environment"
-                        key="1"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "0%",
-                            "height": "99%",
-                          }
+                        <rect
+                          className="release"
+                          height={1.5}
+                          key="0"
+                          width={32.5}
+                          x={0}
+                          y={98.5}
+                        >
+                          0
+                        </rect>
+                        <rect
+                          className="environment"
+                          height={0.81}
+                          key="1"
+                          width={32.5}
+                          x={0}
+                          y={97.69}
+                        >
+                          1
+                        </rect>
+                        <rect
+                          className="inactive"
+                          height={0}
+                          key="2"
+                          width={32.5}
+                          x={0}
+                          y={97.69}
+                        >
+                          0
+                        </rect>
+                      </g>
+                    </Tooltip>
+                    <Tooltip
+                      key="1515024000"
+                      title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
+                      tooltipOptions={
+                        Object {
+                          "container": "body",
+                          "html": true,
+                          "placement": "bottom",
                         }
+                      }
+                    >
+                      <g
+                        className="tip"
+                        data-test-id="chart-column"
+                        title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
                       >
-                        122
-                      </span>
-                      <span
-                        className="inactive"
-                        key="2"
-                        style={
-                          Object {
-                            "backgroundColor": null,
-                            "bottom": "99%",
-                            "height": "0%",
-                          }
-                        }
-                      >
-                        0
-                      </span>
-                    </a>
-                  </Tooltip>
-                </span>
+                        <rect
+                          className="release"
+                          height={1.5}
+                          key="0"
+                          width={32.5}
+                          x={50.5}
+                          y={98.5}
+                        >
+                          0
+                        </rect>
+                        <rect
+                          className="environment"
+                          height={99}
+                          key="1"
+                          width={32.5}
+                          x={50.5}
+                          y={-0.5}
+                        >
+                          122
+                        </rect>
+                        <rect
+                          className="inactive"
+                          height={0}
+                          key="2"
+                          width={32.5}
+                          x={50.5}
+                          y={-0.5}
+                        >
+                          0
+                        </rect>
+                      </g>
+                    </Tooltip>
+                  </svg>
+                </StyledSvg>
               </figure>
             </StackedBarChart>
           </div>

--- a/tests/js/spec/components/stackedBarChart.spec.jsx
+++ b/tests/js/spec/components/stackedBarChart.spec.jsx
@@ -37,12 +37,11 @@ describe('StackedBarChart', function() {
 
       expect(columns).toHaveProperty('length', 5);
 
-      // NOTE: markers are placed *before* corresponding chart column
-      expect(columns.at(0).text()).toEqual('first seen');
-      expect(columns.at(1).text()).toEqual('10');
-      expect(columns.at(2).text()).toEqual('20');
-      expect(columns.at(3).text()).toEqual('last seen');
-      expect(columns.at(4).text()).toEqual('30');
+      expect(columns.at(0).text()).toEqual('10');
+      expect(columns.at(1).text()).toEqual('20');
+      expect(columns.at(2).text()).toEqual('30');
+      expect(columns.at(3).text()).toEqual('first seen');
+      expect(columns.at(4).text()).toEqual('last seen');
     });
 
     it('renders with points and markers, when first and last seen are same data point', function() {
@@ -57,10 +56,9 @@ describe('StackedBarChart', function() {
 
       expect(columns).toHaveProperty('length', 3);
 
-      // NOTE: markers are placed *before* corresponding chart column
-      expect(columns.at(0).text()).toEqual('first seen');
-      expect(columns.at(1).text()).toEqual('last seen');
-      expect(columns.at(2).text()).toEqual('30');
+      expect(columns.at(0).text()).toEqual('30');
+      expect(columns.at(1).text()).toEqual('first seen');
+      expect(columns.at(2).text()).toEqual('last seen');
     });
   });
 });

--- a/tests/js/spec/components/stackedBarChart.spec.jsx
+++ b/tests/js/spec/components/stackedBarChart.spec.jsx
@@ -13,7 +13,7 @@ describe('StackedBarChart', function() {
       ];
 
       let wrapper = shallow(<StackedBarChart points={points} />);
-      let columns = wrapper.find('.chart-column');
+      let columns = wrapper.find('[data-test-id="chart-column"]');
 
       expect(columns).toHaveProperty('length', 3);
       expect(columns.at(0).text()).toEqual('10'); // check y values
@@ -33,7 +33,7 @@ describe('StackedBarChart', function() {
       ];
 
       let wrapper = shallow(<StackedBarChart points={points} markers={markers} />);
-      let columns = wrapper.find('a');
+      let columns = wrapper.find('[data-test-id="chart-column"]');
 
       expect(columns).toHaveProperty('length', 5);
 
@@ -53,7 +53,7 @@ describe('StackedBarChart', function() {
       ];
 
       let wrapper = shallow(<StackedBarChart points={points} markers={markers} />);
-      let columns = wrapper.find('a');
+      let columns = wrapper.find('[data-test-id="chart-column"]');
 
       expect(columns).toHaveProperty('length', 3);
 

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -497,7 +497,7 @@ exports[`ProjectCard renders 1`] = `
                           series={Array []}
                           width={null}
                         >
-                          <SvgContainer
+                          <StyledFigure
                             className="css-h6aoq0-StyledBarChart e1wib7610 barchart"
                             style={
                               Object {
@@ -507,7 +507,7 @@ exports[`ProjectCard renders 1`] = `
                             }
                           >
                             <figure
-                              className="e1wib7610 barchart css-12vrsos-SvgContainer-StyledBarChart e5t71581"
+                              className="e1wib7610 barchart css-1563gow-StyledFigure-StyledBarChart e5t71581"
                               style={
                                 Object {
                                   "height": 60,
@@ -531,118 +531,124 @@ exports[`ProjectCard renders 1`] = `
                               >
                                 0
                               </span>
-                              <StyledSvg
-                                gap={4}
-                                overflow="visible"
-                              >
-                                <svg
-                                  className="css-j6bjhn-StyledSvg e5t71580"
-                                  overflow="visible"
+                              <SvgContainer>
+                                <div
+                                  className="css-1jg1opr-SvgContainer e5t71582"
                                 >
-                                  <Tooltip
-                                    key="1525042800"
-                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
-                                    tooltipOptions={
-                                      Object {
-                                        "container": "body",
-                                        "html": true,
-                                        "placement": "bottom",
-                                      }
-                                    }
+                                  <StyledSvg
+                                    gap={4}
+                                    overflow="visible"
                                   >
-                                    <g
-                                      className="tip"
-                                      title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
+                                    <svg
+                                      className="css-j6bjhn-StyledSvg e5t71580"
+                                      overflow="visible"
                                     >
-                                      <rect
-                                        height="100%"
-                                        opacity="0"
-                                        transform="translate(-4, 0)"
-                                        width="50%"
-                                        x="0%"
-                                      />
-                                      <clipPath
-                                        id="path-50-0"
+                                      <Tooltip
+                                        key="1525042800"
+                                        title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
+                                        tooltipOptions={
+                                          Object {
+                                            "container": "body",
+                                            "html": true,
+                                            "placement": "bottom",
+                                          }
+                                        }
                                       >
-                                        <rect
-                                          height="105%"
-                                          transform="translate(-4, 0)"
-                                          width="50%"
-                                          x="0%"
-                                          y="-5%"
-                                        />
-                                      </clipPath>
-                                      <g
-                                        clipPath="url(#path-50-0)"
-                                        data-test-id="chart-column"
-                                      >
-                                        <rect
-                                          className="chart-bar barchart-rect"
-                                          height="9.9%"
-                                          key="0"
-                                          width="50%"
-                                          x="0%"
-                                          y="90.1%"
+                                        <g
+                                          className="tip"
+                                          title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
                                         >
-                                          1
-                                        </rect>
-                                      </g>
-                                    </g>
-                                  </Tooltip>
-                                  <Tooltip
-                                    key="1525046400"
-                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
-                                    tooltipOptions={
-                                      Object {
-                                        "container": "body",
-                                        "html": true,
-                                        "placement": "bottom",
-                                      }
-                                    }
-                                  >
-                                    <g
-                                      className="tip"
-                                      title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
-                                    >
-                                      <rect
-                                        height="100%"
-                                        opacity="0"
-                                        transform="translate(-4, 0)"
-                                        width="50%"
-                                        x="50%"
-                                      />
-                                      <clipPath
-                                        id="path-50-1"
+                                          <rect
+                                            height="100%"
+                                            opacity="0"
+                                            transform="translate(-4, 0)"
+                                            width="50%"
+                                            x="0%"
+                                          />
+                                          <clipPath
+                                            id="path-50-0"
+                                          >
+                                            <rect
+                                              height="105%"
+                                              transform="translate(-4, 0)"
+                                              width="50%"
+                                              x="0%"
+                                              y="-5%"
+                                            />
+                                          </clipPath>
+                                          <g
+                                            clipPath="url(#path-50-0)"
+                                            data-test-id="chart-column"
+                                          >
+                                            <rect
+                                              className="chart-bar barchart-rect"
+                                              height="9.9%"
+                                              key="0"
+                                              width="50%"
+                                              x="0%"
+                                              y="90.1%"
+                                            >
+                                              1
+                                            </rect>
+                                          </g>
+                                        </g>
+                                      </Tooltip>
+                                      <Tooltip
+                                        key="1525046400"
+                                        title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
+                                        tooltipOptions={
+                                          Object {
+                                            "container": "body",
+                                            "html": true,
+                                            "placement": "bottom",
+                                          }
+                                        }
                                       >
-                                        <rect
-                                          height="105%"
-                                          transform="translate(-4, 0)"
-                                          width="50%"
-                                          x="50%"
-                                          y="-5%"
-                                        />
-                                      </clipPath>
-                                      <g
-                                        clipPath="url(#path-50-1)"
-                                        data-test-id="chart-column"
-                                      >
-                                        <rect
-                                          className="chart-bar barchart-rect"
-                                          height="19.8%"
-                                          key="0"
-                                          width="50%"
-                                          x="50%"
-                                          y="80.2%"
+                                        <g
+                                          className="tip"
+                                          title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
                                         >
-                                          2
-                                        </rect>
-                                      </g>
-                                    </g>
-                                  </Tooltip>
-                                </svg>
-                              </StyledSvg>
+                                          <rect
+                                            height="100%"
+                                            opacity="0"
+                                            transform="translate(-4, 0)"
+                                            width="50%"
+                                            x="50%"
+                                          />
+                                          <clipPath
+                                            id="path-50-1"
+                                          >
+                                            <rect
+                                              height="105%"
+                                              transform="translate(-4, 0)"
+                                              width="50%"
+                                              x="50%"
+                                              y="-5%"
+                                            />
+                                          </clipPath>
+                                          <g
+                                            clipPath="url(#path-50-1)"
+                                            data-test-id="chart-column"
+                                          >
+                                            <rect
+                                              className="chart-bar barchart-rect"
+                                              height="19.8%"
+                                              key="0"
+                                              width="50%"
+                                              x="50%"
+                                              y="80.2%"
+                                            >
+                                              2
+                                            </rect>
+                                          </g>
+                                        </g>
+                                      </Tooltip>
+                                    </svg>
+                                  </StyledSvg>
+                                </div>
+                              </SvgContainer>
                             </figure>
-                          </SvgContainer>
+                          </StyledFigure>
                         </StackedBarChart>
                       </BarChart>
                     </StyledBarChart>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -435,6 +435,7 @@ exports[`ProjectCard renders 1`] = `
                 >
                   <div>
                     <StyledBarChart
+                      gap={1.5}
                       height={60}
                       label="events"
                       points={
@@ -452,6 +453,7 @@ exports[`ProjectCard renders 1`] = `
                     >
                       <BarChart
                         className="css-h6aoq0-StyledBarChart e1wib7610"
+                        gap={1.5}
                         height={60}
                         label="events"
                         points={
@@ -474,7 +476,7 @@ exports[`ProjectCard renders 1`] = `
                             ]
                           }
                           className="css-h6aoq0-StyledBarChart e1wib7610"
-                          gap={4}
+                          gap={1.5}
                           height={60}
                           label="events"
                           markers={Array []}
@@ -536,11 +538,10 @@ exports[`ProjectCard renders 1`] = `
                                   className="css-1jg1opr-SvgContainer e5t71582"
                                 >
                                   <StyledSvg
-                                    gap={4}
                                     overflow="visible"
                                   >
                                     <svg
-                                      className="css-j6bjhn-StyledSvg e5t71580"
+                                      className="css-1ob8vbo-StyledSvg e5t71580"
                                       overflow="visible"
                                     >
                                       <Tooltip
@@ -561,36 +562,20 @@ exports[`ProjectCard renders 1`] = `
                                           <rect
                                             height="100%"
                                             opacity="0"
-                                            transform="translate(-4, 0)"
-                                            width="50%"
-                                            x="0%"
+                                            width="52.3%"
+                                            x="-1.5%"
                                           />
-                                          <clipPath
-                                            id="path-50-0"
-                                          >
-                                            <rect
-                                              height="105%"
-                                              transform="translate(-4, 0)"
-                                              width="50%"
-                                              x="0%"
-                                              y="-5%"
-                                            />
-                                          </clipPath>
-                                          <g
-                                            clipPath="url(#path-50-0)"
+                                          <rect
+                                            className="chart-bar barchart-rect"
                                             data-test-id="chart-column"
+                                            height="9.9%"
+                                            key="0"
+                                            width="49.3%"
+                                            x="0%"
+                                            y="90.1%"
                                           >
-                                            <rect
-                                              className="chart-bar barchart-rect"
-                                              height="9.9%"
-                                              key="0"
-                                              width="50%"
-                                              x="0%"
-                                              y="90.1%"
-                                            >
-                                              1
-                                            </rect>
-                                          </g>
+                                            1
+                                          </rect>
                                         </g>
                                       </Tooltip>
                                       <Tooltip
@@ -611,36 +596,20 @@ exports[`ProjectCard renders 1`] = `
                                           <rect
                                             height="100%"
                                             opacity="0"
-                                            transform="translate(-4, 0)"
-                                            width="50%"
-                                            x="50%"
+                                            width="52.3%"
+                                            x="49.3%"
                                           />
-                                          <clipPath
-                                            id="path-50-1"
-                                          >
-                                            <rect
-                                              height="105%"
-                                              transform="translate(-4, 0)"
-                                              width="50%"
-                                              x="50%"
-                                              y="-5%"
-                                            />
-                                          </clipPath>
-                                          <g
-                                            clipPath="url(#path-50-1)"
+                                          <rect
+                                            className="chart-bar barchart-rect"
                                             data-test-id="chart-column"
+                                            height="19.8%"
+                                            key="0"
+                                            width="49.3%"
+                                            x="50.8%"
+                                            y="80.2%"
                                           >
-                                            <rect
-                                              className="chart-bar barchart-rect"
-                                              height="19.8%"
-                                              key="0"
-                                              width="50%"
-                                              x="50%"
-                                              y="80.2%"
-                                            >
-                                              2
-                                            </rect>
-                                          </g>
+                                            2
+                                          </rect>
                                         </g>
                                       </Tooltip>
                                     </svg>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -549,10 +549,10 @@ exports[`ProjectCard renders 1`] = `
                                     title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
                                   >
                                     <rect
-                                      className="chart-bar"
+                                      className="chart-bar barchart-rect"
                                       height={9.9}
                                       key="0"
-                                      width={32.5}
+                                      width={14}
                                       x={0}
                                       y={90.1}
                                     >
@@ -577,11 +577,11 @@ exports[`ProjectCard renders 1`] = `
                                     title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
                                   >
                                     <rect
-                                      className="chart-bar"
+                                      className="chart-bar barchart-rect"
                                       height={19.8}
                                       key="0"
-                                      width={32.5}
-                                      x={50.5}
+                                      width={14}
+                                      x={50}
                                       y={80.2}
                                     >
                                       2

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -468,13 +468,13 @@ exports[`ProjectCard renders 1`] = `
                         }
                       >
                         <StackedBarChart
-                          allottedGapSpace={20}
                           barClasses={
                             Array [
                               "chart-bar",
                             ]
                           }
                           className="css-h6aoq0-StyledBarChart e1wib7610"
+                          gap={4}
                           height={60}
                           label="events"
                           markers={Array []}
@@ -497,7 +497,7 @@ exports[`ProjectCard renders 1`] = `
                           series={Array []}
                           width={null}
                         >
-                          <figure
+                          <SvgContainer
                             className="css-h6aoq0-StyledBarChart e1wib7610 barchart"
                             style={
                               Object {
@@ -506,103 +506,127 @@ exports[`ProjectCard renders 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="max-y"
-                            >
-                              <count
-                                value={10}
-                              >
-                                <span>
-                                  10
-                                </span>
-                              </count>
-                            </span>
-                            <span
-                              className="min-y"
-                            >
-                              0
-                            </span>
-                            <StyledSvg
-                              preserveAspectRatio="none"
-                              shapeRendering="geometricPrecision"
-                              viewBox="0 0 99.9 99.9"
-                            >
-                              <svg
-                                className="css-znv93x-StyledSvg e5t71580"
-                                preserveAspectRatio="none"
-                                shapeRendering="geometricPrecision"
-                                viewBox="0 0 99.9 99.9"
-                              >
-                                <Tooltip
-                                  key="1525042800"
-                                  title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
-                                  tooltipOptions={
-                                    Object {
-                                      "container": "body",
-                                      "html": true,
-                                      "placement": "bottom",
-                                    }
-                                  }
-                                >
-                                  <g
-                                    className="tip"
-                                    data-test-id="chart-column"
-                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
-                                  >
-                                    <rect
-                                      className="chart-bar barchart-rect"
-                                      height={9.9}
-                                      key="0"
-                                      width={30}
-                                      x={0}
-                                      y={90.1}
-                                    >
-                                      1
-                                    </rect>
-                                  </g>
-                                </Tooltip>
-                                <Tooltip
-                                  key="1525046400"
-                                  title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
-                                  tooltipOptions={
-                                    Object {
-                                      "container": "body",
-                                      "html": true,
-                                      "placement": "bottom",
-                                    }
-                                  }
-                                >
-                                  <g
-                                    className="tip"
-                                    data-test-id="chart-column"
-                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
-                                  >
-                                    <rect
-                                      className="chart-bar barchart-rect"
-                                      height={19.8}
-                                      key="0"
-                                      width={30}
-                                      x={50}
-                                      y={80.2}
-                                    >
-                                      2
-                                    </rect>
-                                  </g>
-                                </Tooltip>
-                              </svg>
-                            </StyledSvg>
-                            <div
+                            <figure
+                              className="e1wib7610 barchart css-12vrsos-SvgContainer-StyledBarChart e5t71581"
                               style={
                                 Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "width": "100%",
+                                  "height": 60,
+                                  "width": null,
                                 }
                               }
-                            />
-                          </figure>
+                            >
+                              <span
+                                className="max-y"
+                              >
+                                <count
+                                  value={10}
+                                >
+                                  <span>
+                                    10
+                                  </span>
+                                </count>
+                              </span>
+                              <span
+                                className="min-y"
+                              >
+                                0
+                              </span>
+                              <StyledSvg
+                                gap={4}
+                                overflow="visible"
+                              >
+                                <svg
+                                  className="css-11agq87-StyledSvg e5t71580"
+                                  overflow="visible"
+                                >
+                                  <Tooltip
+                                    key="1525042800"
+                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
+                                    tooltipOptions={
+                                      Object {
+                                        "container": "body",
+                                        "html": true,
+                                        "placement": "bottom",
+                                      }
+                                    }
+                                  >
+                                    <g
+                                      className="tip"
+                                      title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
+                                    >
+                                      <clipPath
+                                        id="path-50-0"
+                                      >
+                                        <rect
+                                          height="98.5%"
+                                          transform="translate(-4, 0)"
+                                          width="50%"
+                                          x="0%"
+                                        />
+                                      </clipPath>
+                                      <g
+                                        clipPath="url(#path-50-0)"
+                                        data-test-id="chart-column"
+                                      >
+                                        <rect
+                                          className="chart-bar barchart-rect"
+                                          height="9.9%"
+                                          key="0"
+                                          width="50%"
+                                          x="0%"
+                                          y="88.6%"
+                                        >
+                                          1
+                                        </rect>
+                                      </g>
+                                    </g>
+                                  </Tooltip>
+                                  <Tooltip
+                                    key="1525046400"
+                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
+                                    tooltipOptions={
+                                      Object {
+                                        "container": "body",
+                                        "html": true,
+                                        "placement": "bottom",
+                                      }
+                                    }
+                                  >
+                                    <g
+                                      className="tip"
+                                      title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
+                                    >
+                                      <clipPath
+                                        id="path-50-1"
+                                      >
+                                        <rect
+                                          height="98.5%"
+                                          transform="translate(-4, 0)"
+                                          width="50%"
+                                          x="50%"
+                                        />
+                                      </clipPath>
+                                      <g
+                                        clipPath="url(#path-50-1)"
+                                        data-test-id="chart-column"
+                                      >
+                                        <rect
+                                          className="chart-bar barchart-rect"
+                                          height="19.8%"
+                                          key="0"
+                                          width="50%"
+                                          x="50%"
+                                          y="78.7%"
+                                        >
+                                          2
+                                        </rect>
+                                      </g>
+                                    </g>
+                                  </Tooltip>
+                                </svg>
+                              </StyledSvg>
+                            </figure>
+                          </SvgContainer>
                         </StackedBarChart>
                       </BarChart>
                     </StyledBarChart>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -536,7 +536,7 @@ exports[`ProjectCard renders 1`] = `
                                 overflow="visible"
                               >
                                 <svg
-                                  className="css-11agq87-StyledSvg e5t71580"
+                                  className="css-j6bjhn-StyledSvg e5t71580"
                                   overflow="visible"
                                 >
                                   <Tooltip
@@ -558,7 +558,7 @@ exports[`ProjectCard renders 1`] = `
                                         id="path-50-0"
                                       >
                                         <rect
-                                          height="98.5%"
+                                          height="100%"
                                           transform="translate(-4, 0)"
                                           width="50%"
                                           x="0%"
@@ -574,7 +574,7 @@ exports[`ProjectCard renders 1`] = `
                                           key="0"
                                           width="50%"
                                           x="0%"
-                                          y="88.6%"
+                                          y="90.1%"
                                         >
                                           1
                                         </rect>
@@ -600,7 +600,7 @@ exports[`ProjectCard renders 1`] = `
                                         id="path-50-1"
                                       >
                                         <rect
-                                          height="98.5%"
+                                          height="100%"
                                           transform="translate(-4, 0)"
                                           width="50%"
                                           x="50%"
@@ -616,7 +616,7 @@ exports[`ProjectCard renders 1`] = `
                                           key="0"
                                           width="50%"
                                           x="50%"
-                                          y="78.7%"
+                                          y="80.2%"
                                         >
                                           2
                                         </rect>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -468,6 +468,7 @@ exports[`ProjectCard renders 1`] = `
                         }
                       >
                         <StackedBarChart
+                          allottedGapSpace={20}
                           barClasses={
                             Array [
                               "chart-bar",
@@ -552,7 +553,7 @@ exports[`ProjectCard renders 1`] = `
                                       className="chart-bar barchart-rect"
                                       height={9.9}
                                       key="0"
-                                      width={14}
+                                      width={30}
                                       x={0}
                                       y={90.1}
                                     >
@@ -580,7 +581,7 @@ exports[`ProjectCard renders 1`] = `
                                       className="chart-bar barchart-rect"
                                       height={19.8}
                                       key="0"
-                                      width={14}
+                                      width={30}
                                       x={50}
                                       y={80.2}
                                     >

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -539,10 +539,14 @@ exports[`ProjectCard renders 1`] = `
                                 >
                                   <StyledSvg
                                     overflow="visible"
+                                    preserveAspectRatio="none"
+                                    viewBox="0 0 100 400"
                                   >
                                     <svg
-                                      className="css-1ob8vbo-StyledSvg e5t71580"
+                                      className="css-1vaz76z-StyledSvg e5t71580"
                                       overflow="visible"
+                                      preserveAspectRatio="none"
+                                      viewBox="0 0 100 400"
                                     >
                                       <Tooltip
                                         key="1525042800"

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -557,6 +557,7 @@ exports[`ProjectCard renders 1`] = `
                                       <rect
                                         height="100%"
                                         opacity="0"
+                                        transform="translate(-4, 0)"
                                         width="50%"
                                         x="0%"
                                       />
@@ -606,6 +607,7 @@ exports[`ProjectCard renders 1`] = `
                                       <rect
                                         height="100%"
                                         opacity="0"
+                                        transform="translate(-4, 0)"
                                         width="50%"
                                         x="50%"
                                       />

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -564,10 +564,11 @@ exports[`ProjectCard renders 1`] = `
                                         id="path-50-0"
                                       >
                                         <rect
-                                          height="100%"
+                                          height="105%"
                                           transform="translate(-4, 0)"
                                           width="50%"
                                           x="0%"
+                                          y="-5%"
                                         />
                                       </clipPath>
                                       <g
@@ -612,10 +613,11 @@ exports[`ProjectCard renders 1`] = `
                                         id="path-50-1"
                                       >
                                         <rect
-                                          height="100%"
+                                          height="105%"
                                           transform="translate(-4, 0)"
                                           width="50%"
                                           x="50%"
+                                          y="-5%"
                                         />
                                       </clipPath>
                                       <g

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -591,6 +591,17 @@ exports[`ProjectCard renders 1`] = `
                                 </Tooltip>
                               </svg>
                             </StyledSvg>
+                            <div
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "width": "100%",
+                                }
+                              }
+                            />
                           </figure>
                         </StackedBarChart>
                       </BarChart>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -554,6 +554,12 @@ exports[`ProjectCard renders 1`] = `
                                       className="tip"
                                       title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
                                     >
+                                      <rect
+                                        height="100%"
+                                        opacity="0"
+                                        width="50%"
+                                        x="0%"
+                                      />
                                       <clipPath
                                         id="path-50-0"
                                       >
@@ -596,6 +602,12 @@ exports[`ProjectCard renders 1`] = `
                                       className="tip"
                                       title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
                                     >
+                                      <rect
+                                        height="100%"
+                                        opacity="0"
+                                        width="50%"
+                                        x="50%"
+                                      />
                                       <clipPath
                                         id="path-50-1"
                                       >

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -521,78 +521,75 @@ exports[`ProjectCard renders 1`] = `
                             >
                               0
                             </span>
-                            <span>
-                              <Tooltip
-                                key="1525042800"
-                                title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
-                                tooltipOptions={
-                                  Object {
-                                    "html": true,
-                                    "placement": "bottom",
-                                  }
-                                }
+                            <StyledSvg
+                              preserveAspectRatio="none"
+                              shapeRendering="geometricPrecision"
+                              viewBox="0 0 99.9 99.9"
+                            >
+                              <svg
+                                className="css-znv93x-StyledSvg e5t71580"
+                                preserveAspectRatio="none"
+                                shapeRendering="geometricPrecision"
+                                viewBox="0 0 99.9 99.9"
                               >
-                                <a
-                                  className="tip chart-column"
-                                  style={
-                                    Object {
-                                      "height": "100%",
-                                      "width": "50%",
-                                    }
-                                  }
+                                <Tooltip
+                                  key="1525042800"
                                   title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
-                                >
-                                  <span
-                                    className="chart-bar"
-                                    key="0"
-                                    style={
-                                      Object {
-                                        "backgroundColor": null,
-                                        "bottom": "0%",
-                                        "height": "9.9%",
-                                      }
-                                    }
-                                  >
-                                    1
-                                  </span>
-                                </a>
-                              </Tooltip>
-                              <Tooltip
-                                key="1525046400"
-                                title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
-                                tooltipOptions={
-                                  Object {
-                                    "html": true,
-                                    "placement": "bottom",
-                                  }
-                                }
-                              >
-                                <a
-                                  className="tip chart-column"
-                                  style={
+                                  tooltipOptions={
                                     Object {
-                                      "height": "100%",
-                                      "width": "50%",
+                                      "container": "body",
+                                      "html": true,
+                                      "placement": "bottom",
                                     }
                                   }
-                                  title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
                                 >
-                                  <span
-                                    className="chart-bar"
-                                    key="0"
-                                    style={
-                                      Object {
-                                        "backgroundColor": null,
-                                        "bottom": "0%",
-                                        "height": "19.8%",
-                                      }
-                                    }
+                                  <g
+                                    className="tip"
+                                    data-test-id="chart-column"
+                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
                                   >
-                                    2
-                                  </span>
-                                </a>
-                              </Tooltip>
-                            </span>
+                                    <rect
+                                      className="chart-bar"
+                                      height={9.9}
+                                      key="0"
+                                      width={32.5}
+                                      x={0}
+                                      y={90.1}
+                                    >
+                                      1
+                                    </rect>
+                                  </g>
+                                </Tooltip>
+                                <Tooltip
+                                  key="1525046400"
+                                  title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
+                                  tooltipOptions={
+                                    Object {
+                                      "container": "body",
+                                      "html": true,
+                                      "placement": "bottom",
+                                    }
+                                  }
+                                >
+                                  <g
+                                    className="tip"
+                                    data-test-id="chart-column"
+                                    title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
+                                  >
+                                    <rect
+                                      className="chart-bar"
+                                      height={19.8}
+                                      key="0"
+                                      width={32.5}
+                                      x={50.5}
+                                      y={80.2}
+                                    >
+                                      2
+                                    </rect>
+                                  </g>
+                                </Tooltip>
+                              </svg>
+                            </StyledSvg>
                           </figure>
                         </StackedBarChart>
                       </BarChart>


### PR DESCRIPTION
# Updates:

* I'm gonna wait to move all of this to styled components until a follow-up. This pull is getting complicated.
* I tried not to add/refactor too much js other than general housekeeping, but I did need to add in a min-height functionality since we use that feature a lot and svg doesn't support it.
* I've found several bugs with our charts. One I fixed and the rest I will address in follow-up pulls. They are noted below.

# Changes:

Our current bar charts do all sorts of crazy things if odd numbers are involved. This is because divs aren't subject to sub-pixel aliasing (or rather, they *are* but the browser doesn't seem to couple the antialiasing process with the precise layout):

<img width="558" alt="2018-06-20_1720" src="https://user-images.githubusercontent.com/435981/41691204-394218aa-74ae-11e8-8761-4074bc03cb76.png">

SVGs are capable of sub-pixel aliasing and even have several different [options](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering) to fit different goals. Best of all, they take layout precision into account much better during the aliasing process

![image](https://user-images.githubusercontent.com/435981/41691090-a18bead6-74ad-11e8-93a5-88ff19184bd8.png)

Here is what a complex example looks like before and after:

![example3](https://user-images.githubusercontent.com/435981/45720312-c3b90980-bb58-11e8-984e-2c6f937fe135.gif)

Circles also don't scale very well in the current charts:

<img width="399" alt="square-circles" src="https://user-images.githubusercontent.com/435981/45984804-d1b6d080-c017-11e8-8f29-d6bef3641439.png">

This converts our circles to svg so it scales correctly:

<img width="401" alt="circle-circles" src="https://user-images.githubusercontent.com/435981/45984823-e6936400-c017-11e8-8b2a-228cd61ea76b.png">

Performance is equal at worst, and might be a little better based on a quick look at the performance tab. There is the opportunity to emphatically improve performance in tabular list views by converting bars to a sprite with `<use />`.

As the charts get smaller and we move into sub-pixel layouts the improvements become more obvious: 

![image](https://user-images.githubusercontent.com/435981/46052330-c2f11c00-c0f2-11e8-9386-40641fba46d3.png)

![image](https://user-images.githubusercontent.com/435981/46052335-c8e6fd00-c0f2-11e8-852b-bb2d539ec66e.png)

![image](https://user-images.githubusercontent.com/435981/46052994-aefae980-c0f5-11e8-9c71-23ffdf96b7ff.png)

![image](https://user-images.githubusercontent.com/435981/46053000-bae6ab80-c0f5-11e8-97a9-1b52861d1c88.png)


todo: 

- [x] Visually replicate old charts
- [x] Stacking functionality
- [x] Tooltip functionality
- [x] Test in different browsers
- [x] SVG Markers
- [x] Check performance
- [x] Check all views
- [x] Cleanup 

other (existing) chart bugs for follow ups:

- colors don't work on various settings charts anymore
- several colors are no longer in the sentry brand 
- min-height is not factored into maximum chart height

