### PR TITLE
feat: export orgauth component and register hookstore view

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -141,6 +141,7 @@ export default {
     ListLink: require('app/components/listLink').default,
     MenuItem: require('app/components/menuItem').default,
     NarrowLayout: require('app/components/narrowLayout').default,
+    OrganizationAuth: require('app/views/settings/organizationAuth').default,
     OrganizationHomeContainer: require('app/components/organizations/homeContainer')
       .default,
     OrganizationsLoader: require('app/components/organizations/organizationsLoader')

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -4,6 +4,7 @@ import _ from 'lodash';
 let validHookNames = new Set([
   'assistant:support-button',
   'component:org-members-view',
+  'component:org-auth-view',
   'footer',
   'settings:organization-navigation',
   'settings:organization-navigation-config',


### PR DESCRIPTION
This preps for the sso paywall- makes available the current orgauth component and registers the hook that will come from getsentry.

See spec[ here](https://paper.dropbox.com/doc/SSO-paywall-JRsESa4hYbdaf0bd9zJhY)