### PR TITLE
fix: Use sentry:release in results for get_release_tags

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -288,15 +288,16 @@ class SnubaTagStorage(TagStorage):
         # NB we add release as a condition rather than a filter because
         # this method is already dealing with version strings rather than
         # release ids which would need to be translated by the snuba util.
-        key = 'tags[sentry:release]'
-        conditions = [[key, 'IN', versions]]
+        tag = 'sentry:release'
+        col = 'tags[{}]'.format(tag)
+        conditions = [[col, 'IN', versions]]
         aggregations = [
             ['count()', '', 'times_seen'],
             ['min', SEEN_COLUMN, 'first_seen'],
             ['max', SEEN_COLUMN, 'last_seen'],
         ]
 
-        result = snuba.query(start, end, ['project_id', key],
+        result = snuba.query(start, end, ['project_id', col],
                              conditions, filters, aggregations,
                              referrer='tagstore.get_release_tags')
 
@@ -305,7 +306,7 @@ class SnubaTagStorage(TagStorage):
             for value, data in six.iteritems(project_data):
                 values.append(
                     TagValue(
-                        key=key,
+                        key=tag,
                         value=value,
                         **fix_tag_value_data(data)
                     )
@@ -383,7 +384,7 @@ class SnubaTagStorage(TagStorage):
         conditions = [[['tags[{}]'.format(k), '=', v] for (k, v) in tags.items()]]
 
         result = snuba.query(start, end, groupby=['event_id'], conditions=conditions,
-            filter_keys=filters, limit=1000, referrer='tagstore.get_group_event_filter')
+                             filter_keys=filters, limit=1000, referrer='tagstore.get_group_event_filter')
 
         if not result:
             return None

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -287,6 +287,7 @@ class TagStorageTest(SnubaTestCase):
         assert tags[0].last_seen == one_second_ago
         assert tags[0].first_seen == one_second_ago
         assert tags[0].times_seen == 1
+        assert tags[0].key == 'sentry:release'
 
     def test_get_group_event_filter(self):
         assert self.ts.get_group_event_filter(


### PR DESCRIPTION
The column we need to query snuba for is `tags[sentry:release]` but the
actual tag name is just `sentry_release` I think this is the only case
in here that needs this particular fix.