### PR TITLE
feat(2fa): Send additional security emails

### DIFF
--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -77,6 +77,16 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
         if interface.interface_id == 'recovery':
             interface.regenerate_codes()
 
+            capture_security_activity(
+                account=user,
+                type='recovery-codes-regenerated',
+                actor=request.user,
+                ip_address=request.META['REMOTE_ADDR'],
+                context={
+                    'authenticator': authenticator,
+                },
+                send_email=True
+            )
         return Response(serialize(interface))
 
     @sudo_required

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -127,7 +127,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                 context={
                     'authenticator': authenticator,
                 },
-                send_email=False
+                send_email=True
             )
             return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -119,6 +119,8 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                 return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
             interface.authenticator.save()
+            device_name = interface.get_device_name(interface_device_id)
+
             capture_security_activity(
                 account=user,
                 type='mfa-removed',
@@ -126,6 +128,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                 ip_address=request.META['REMOTE_ADDR'],
                 context={
                     'authenticator': authenticator,
+                    'device_name': device_name
                 },
                 send_email=True
             )

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -156,6 +156,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         except KeyError:
             pass
 
+        context = {}
         # Need to update interface with phone number before validating OTP
         if 'phone' in request.DATA:
             interface.phone_number = serializer.data['phone']
@@ -181,20 +182,24 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
                 serializer.data['response'],
                 serializer.data['deviceName']
             )
+            context.update({
+                'device_name': serializer.data['deviceName']
+            })
 
         try:
             interface.enroll(request.user)
         except Authenticator.AlreadyEnrolled:
             return Response(ALREADY_ENROLLED_ERR, status=status.HTTP_400_BAD_REQUEST)
         else:
+            context.update({
+                'authenticator': interface.authenticator
+            })
             capture_security_activity(
                 account=request.user,
                 type='mfa-added',
                 actor=request.user,
                 ip_address=request.META['REMOTE_ADDR'],
-                context={
-                    'authenticator': interface.authenticator,
-                },
+                context=context,
                 send_email=True,
             )
             request.user.clear_lost_passwords()

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -536,6 +536,11 @@ class U2fInterface(AuthenticatorInterface):
             return True
         return False
 
+    def get_device_name(self, key):
+        for device in self.config.get('devices') or ():
+            if device['binding']['keyHandle'] == key:
+                return device['binding']['name']
+
     def get_registered_devices(self):
         rv = []
         for device in self.config.get('devices') or ():

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -539,7 +539,7 @@ class U2fInterface(AuthenticatorInterface):
     def get_device_name(self, key):
         for device in self.config.get('devices') or ():
             if device['binding']['keyHandle'] == key:
-                return device['binding']['name']
+                return device['name']
 
     def get_registered_devices(self):
         rv = []

--- a/src/sentry/security/emails.py
+++ b/src/sentry/security/emails.py
@@ -21,6 +21,9 @@ def generate_security_email(account, type, actor, ip_address, context=None, curr
     elif type == 'password-changed':
         template = 'sentry/emails/password-changed.txt'
         html_template = 'sentry/emails/password-changed.html'
+    elif type == 'recovery-codes-regenerated':
+        template = 'sentry/emails/recovery-codes-regenerated.txt'
+        html_template = 'sentry/emails/recovery-codes-regenerated.html'
     else:
         raise ValueError('unknown type: {}'.format(type))
 

--- a/src/sentry/templates/sentry/emails/mfa-added.html
+++ b/src/sentry/templates/sentry/emails/mfa-added.html
@@ -5,8 +5,14 @@
 {% endblock %}
 
 {% block security_metadata %}
+  <tr>
+    <td></td>
+    <td style="padding-bottom: 0px"><strong>{{ authenticator.interface.name }}</strong></td>
+  </tr>
+  {% if device_name %}
     <tr>
       <td></td>
-      <td><strong>{{ authenticator.interface.name }}</strong></td>
+      <td style="padding-top: 0px"><strong>{{ device_name }}</strong></td>
     </tr>
+  {% endif %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/mfa-added.txt
+++ b/src/sentry/templates/sentry/emails/mfa-added.txt
@@ -6,4 +6,5 @@ An authenticator has been added to your Sentry account.
 
 {% block security_metadata %}
 Authenticator: {{ authenticator.interface.name }}
+{% if device_name %}Device: {{ device_name }}{% endif %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/mfa-removed.html
+++ b/src/sentry/templates/sentry/emails/mfa-removed.html
@@ -5,8 +5,14 @@
 {% endblock %}
 
 {% block security_metadata %}
+  <tr>
+    <td></td>
+    <td style="padding-bottom: 0px"><strong>{{ authenticator.interface.name }}</strong></td>
+  </tr>
+  {% if device_name %}
     <tr>
       <td></td>
-      <td><strong>{{ authenticator.interface.name }}</strong></td>
+      <td style="padding-top: 0px"><strong>{{ device_name }}</strong></td>
     </tr>
+  {% endif %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/mfa-removed.txt
+++ b/src/sentry/templates/sentry/emails/mfa-removed.txt
@@ -6,4 +6,5 @@ An authenticator has been removed from your Sentry account.
 
 {% block security_metadata %}
 Authenticator: {{ authenticator.interface.name }}
+{% if device_name %}Device: {{ device_name }}{% endif %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/recovery-codes-regenerated.html
+++ b/src/sentry/templates/sentry/emails/recovery-codes-regenerated.html
@@ -1,0 +1,5 @@
+{% extends "sentry/emails/security_base.html" %}
+
+{% block security_body %}
+  <p>Recovery codes have been regenerated for your Sentry account.</p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/recovery-codes-regenerated.txt
+++ b/src/sentry/templates/sentry/emails/recovery-codes-regenerated.txt
@@ -1,0 +1,5 @@
+{% extends "sentry/emails/security_base.txt" %}
+
+{% block security_body %}
+Recovery codes have been regenerated for your Sentry account.
+{% endblock %}

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -17,6 +17,7 @@ from sentry.web.frontend.debug.debug_new_release_email import (DebugNewReleaseEm
 from sentry.web.frontend.debug.debug_new_user_feedback_email import (DebugNewUserFeedbackEmailView)
 from sentry.web.frontend.debug.debug_note_email import DebugNoteEmailView
 from sentry.web.frontend.debug.debug_password_changed_email import (DebugPasswordChangedEmailView)
+from sentry.web.frontend.debug.debug_recovery_codes_regenerated_email import (DebugRecoveryCodesRegeneratedEmailView)
 from sentry.web.frontend.debug.debug_regression_email import (
     DebugRegressionEmailView, DebugRegressionReleaseEmailView
 )
@@ -74,6 +75,7 @@ urlpatterns = patterns(
     url(r'^debug/mail/org-delete-confirm/$', sentry.web.frontend.debug.mail.org_delete_confirm),
     url(r'^debug/mail/mfa-removed/$', DebugMfaRemovedEmailView.as_view()),
     url(r'^debug/mail/mfa-added/$', DebugMfaAddedEmailView.as_view()),
+    url(r'^debug/mail/recovery-codes-regenerated/$', DebugRecoveryCodesRegeneratedEmailView.as_view()),
     url(r'^debug/mail/password-changed/$', DebugPasswordChangedEmailView.as_view()),
     url(r'^debug/mail/new-processing-issues/$', DebugNewProcessingIssuesEmailView.as_view()),
     url(

--- a/src/sentry/web/frontend/accounts_twofactor.py
+++ b/src/sentry/web/frontend/accounts_twofactor.py
@@ -281,6 +281,16 @@ class U2fSettingsView(TwoFactorSettingsView):
         if key_handle and 'remove' in request.POST and \
            interface.remove_u2f_device(key_handle):
             interface.authenticator.save()
+            capture_security_activity(
+                account=request.user,
+                type='mfa-removed',
+                actor=request.user,
+                ip_address=request.META['REMOTE_ADDR'],
+                context={
+                    'authenticator': interface.authenticator,
+                },
+                send_email=True,
+            )
             return HttpResponseRedirect(request.path)
 
         return TwoFactorSettingsView.configure(self, request, interface)

--- a/src/sentry/web/frontend/accounts_twofactor.py
+++ b/src/sentry/web/frontend/accounts_twofactor.py
@@ -281,6 +281,8 @@ class U2fSettingsView(TwoFactorSettingsView):
         if key_handle and 'remove' in request.POST and \
            interface.remove_u2f_device(key_handle):
             interface.authenticator.save()
+            device_name = interface.get_device_name(key_handle)
+
             capture_security_activity(
                 account=request.user,
                 type='mfa-removed',
@@ -288,6 +290,7 @@ class U2fSettingsView(TwoFactorSettingsView):
                 ip_address=request.META['REMOTE_ADDR'],
                 context={
                     'authenticator': interface.authenticator,
+                    'device_name': device_name
                 },
                 send_email=True,
             )

--- a/src/sentry/web/frontend/accounts_twofactor.py
+++ b/src/sentry/web/frontend/accounts_twofactor.py
@@ -182,6 +182,16 @@ class RecoveryCodeSettingsView(TwoFactorSettingsView):
     def configure(self, request, interface):
         if 'regenerate' in request.POST:
             interface.regenerate_codes()
+            capture_security_activity(
+                account=request.user,
+                type='recovery-codes-regenerated',
+                actor=request.user,
+                ip_address=request.META['REMOTE_ADDR'],
+                context={
+                    'authenticator': interface.authenticator,
+                },
+                send_email=True,
+            )
             return HttpResponseRedirect(request.path)
         return TwoFactorSettingsView.configure(self, request, interface)
 

--- a/src/sentry/web/frontend/debug/debug_mfa_added_email.py
+++ b/src/sentry/web/frontend/debug/debug_mfa_added_email.py
@@ -25,6 +25,7 @@ class DebugMfaAddedEmailView(View):
             ip_address=request.META['REMOTE_ADDR'],
             context={
                 'authenticator': authenticator,
+                'device_name': 'Home computer'
             },
             # make this consistent for acceptance tests
             current_datetime=datetime.datetime(2017, 1, 20, 21, 39, 23, 30723)

--- a/src/sentry/web/frontend/debug/debug_mfa_removed_email.py
+++ b/src/sentry/web/frontend/debug/debug_mfa_removed_email.py
@@ -25,6 +25,7 @@ class DebugMfaRemovedEmailView(View):
             ip_address=request.META['REMOTE_ADDR'],
             context={
                 'authenticator': authenticator,
+                'device_name': 'Home computer'
             },
             # make this consistent for acceptance tests
             current_datetime=datetime.datetime(2017, 1, 20, 21, 39, 23, 30723)

--- a/src/sentry/web/frontend/debug/debug_recovery_codes_regenerated_email.py
+++ b/src/sentry/web/frontend/debug/debug_recovery_codes_regenerated_email.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, print_function
+
+import datetime
+
+from django.views.generic import View
+
+from sentry.models import Authenticator
+from sentry.security.emails import generate_security_email
+
+from .mail import MailPreview
+
+
+class DebugRecoveryCodesRegeneratedEmailView(View):
+    def get(self, request):
+        authenticator = Authenticator(
+            id=0,
+            type=3,  # u2f
+            user=request.user,
+        )
+
+        email = generate_security_email(
+            account=request.user,
+            actor=request.user,
+            type='recovery-codes-regenerated',
+            ip_address=request.META['REMOTE_ADDR'],
+            context={
+                'authenticator': authenticator,
+            },
+            # make this consistent for acceptance tests
+            current_datetime=datetime.datetime(2017, 1, 20, 21, 39, 23, 30723)
+        )
+        return MailPreview(
+            html_template=email.html_template,
+            text_template=email.template,
+            context=email.context,
+        ).render(request)

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -27,6 +27,7 @@ EMAILS = (
     ('/debug/mail/report/', 'report'),
     ('/debug/mail/mfa-added/', 'mfa added'),
     ('/debug/mail/mfa-removed/', 'mfa removed'),
+    ('/debug/mail/recovery-codes-regenerated/', 'recovery codes regenerated'),
     ('/debug/mail/password-changed/', 'password changed'),
     ('/debug/mail/sso-linked', 'sso linked'),
     ('/debug/mail/sso-unlinked', 'sso unlinked'),

--- a/tests/fixtures/emails/mfa_removed.txt
+++ b/tests/fixtures/emails/mfa_removed.txt
@@ -12,6 +12,7 @@ IP: 127.0.0.1
 When: Jan. 20, 2017, 9:39 p.m. UTC
 
 Authenticator: U2F (Universal 2nd Factor)
+Device: Home computer
 
 
 Don't recognize this activity?

--- a/tests/fixtures/emails/recovery_codes_regenerated.txt
+++ b/tests/fixtures/emails/recovery_codes_regenerated.txt
@@ -1,7 +1,7 @@
 Security Notice
 ---------------
 
-An authenticator has been added to your Sentry account.
+Recovery codes have been regenerated for your Sentry account.
 
 
 Details
@@ -10,9 +10,6 @@ Details
 Account: foo@example.com
 IP: 127.0.0.1
 When: Jan. 20, 2017, 9:39 p.m. UTC
-
-Authenticator: U2F (Universal 2nd Factor)
-Device: Home computer
 
 
 Don't recognize this activity?

--- a/tests/sentry/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_details.py
@@ -112,6 +112,34 @@ class UserAuthenticatorDetailsTest(APITestCase):
         assert 'challenge' not in resp.data
         assert 'response' not in resp.data
 
+    def test_get_device_name(self):
+        auth = Authenticator.objects.create(
+            type=3,  # u2f
+            user=self.user,
+            config={
+                'devices': [{
+                    'binding': {
+                        'publicKey': 'aowekroawker',
+                        'keyHandle': 'devicekeyhandle',
+                        'appId': 'https://dev.getsentry.net:8000/auth/2fa/u2fappid.json'
+                    },
+                    'name': 'Amused Beetle',
+                    'ts': 1512505334
+                }, {
+                    'binding': {
+                        'publicKey': 'publickey',
+                        'keyHandle': 'aowerkoweraowerkkro',
+                        'appId': 'https://dev.getsentry.net:8000/auth/2fa/u2fappid.json'
+                    },
+                    'name': 'Sentry',
+                    'ts': 1512505334
+                }]
+            }
+        )
+
+        assert auth.interface.get_device_name('devicekeyhandle') == 'Amused Beetle'
+        assert auth.interface.get_device_name('aowerkoweraowerkkro') == 'Sentry'
+
     @mock.patch('sentry.utils.email.logger')
     def test_u2f_remove_device(self, email_log):
         auth = Authenticator.objects.create(

--- a/tests/sentry/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_details.py
@@ -153,6 +153,8 @@ class UserAuthenticatorDetailsTest(APITestCase):
         authenticator = Authenticator.objects.get(id=auth.id)
         assert len(authenticator.interface.get_registered_devices()) == 1
 
+        self._assert_security_email_sent('mfa-removed', email_log)
+
         # Can't remove last device
         url = reverse(
             'sentry-api-0-user-authenticator-device-details',
@@ -165,7 +167,8 @@ class UserAuthenticatorDetailsTest(APITestCase):
         resp = self.client.delete(url)
         assert resp.status_code == 500
 
-        assert email_log.info.call_count == 0
+        # only one send
+        self._assert_security_email_sent('mfa-removed', email_log)
 
     def test_sms_get_phone(self):
         interface = SmsInterface()


### PR DESCRIPTION
- Send 'security settings changed' email for regenerating codes & removing 2FA devices
- Add device name to mfa added and removed emails

<img width="812" alt="screen shot 2018-06-21 at 10 21 44 pm" src="https://user-images.githubusercontent.com/16394317/41800026-9a04d7ce-7628-11e8-8a5b-a9a107a9548b.png">
<img width="774" alt="screen shot 2018-06-25 at 10 29 39 pm" src="https://user-images.githubusercontent.com/16394317/41891202-14d6dcbc-78c8-11e8-9294-03bd67d4e916.png">