### PR TITLE
fix(js): Update raven fingerprint for RouteErrors

### DIFF
--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -17,28 +17,31 @@ class RouteError extends React.Component {
   };
 
   componentWillMount() {
-    let {routes} = this.props;
+    let {routes, error} = this.props;
     let {organization, project} = this.context;
     // TODO(dcramer): show something in addition to embed (that contains it?)
     // throw this in a timeout so if it errors we dont fall over
-    this._timeout = window.setTimeout(
-      function() {
-        let route = getRouteStringFromRoutes(routes);
+    this._timeout = window.setTimeout(() => {
+      let route = getRouteStringFromRoutes(routes);
 
-        Raven.captureException(this.props.error, {
-          fingerprint: [this.props.error, route],
-          extra: {
-            route,
-            orgFeatures: (organization && organization.features) || [],
-            orgAccess: (organization && organization.access) || [],
-            projectFeatures: (project && project.features) || [],
-          },
-        });
-        // TODO(dcramer): we do not have errorId until send() is called which
-        // has latency in production so this will literally never fire
-        Raven.showReportDialog();
-      }.bind(this)
-    );
+      if (!error) return;
+
+      if (route) {
+        error.message += `: ${route}`;
+      }
+
+      Raven.captureException(error, {
+        extra: {
+          route,
+          orgFeatures: (organization && organization.features) || [],
+          orgAccess: (organization && organization.access) || [],
+          projectFeatures: (project && project.features) || [],
+        },
+      });
+      // TODO(dcramer): we do not have errorId until send() is called which
+      // has latency in production so this will literally never fire
+      Raven.showReportDialog();
+    });
   }
 
   componentWillUnmount() {

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -94,3 +94,4 @@ class RouteError extends React.Component {
 }
 
 export default withRouter(RouteError);
+export {RouteError};

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -82,6 +82,14 @@ window.TestStubs = {
     ...params,
   }),
 
+  routes: () => [
+    {path: '/'},
+    {path: '/:orgId/'},
+    {name: 'this should be skipped'},
+    {path: '/organizations/:orgId/'},
+    {path: 'api-keys/', name: 'API Key'},
+  ],
+
   routerProps: (params = {}) => ({
     location: TestStubs.location(),
     params: {},

--- a/tests/js/spec/views/routeError.spec.jsx
+++ b/tests/js/spec/views/routeError.spec.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Raven from 'raven-js';
+
+import {mount} from 'enzyme';
+import {RouteError} from 'app/views/routeError';
+
+jest.mock('jquery');
+
+describe('RouteError', function() {
+  beforeEach(function() {});
+
+  it('captures errors with raven', async function() {
+    let error = new Error('Big Bad Error');
+    let routes = TestStubs.routes();
+    mount(<RouteError routes={routes} error={error} />, TestStubs.routerContext());
+
+    await tick();
+
+    expect(Raven.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Big Bad Error: /:orgId/organizations/:orgId/api-keys/',
+      }),
+      expect.objectContaining({
+        extra: expect.objectContaining({
+          route: '/:orgId/organizations/:orgId/api-keys/',
+        }),
+      })
+    );
+
+    expect(Raven.showReportDialog).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Updates the exception message to include the stringified raw route (without url params). Remove the custom fingerprint since the new error messaage should group how we want.
Fixes issues like this: https://sentry.io/sentry/javascript/issues/551475061/events/22881432125/