### PR TITLE
fix: Gravatar fallback resulted in an invalid url

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/gravatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/gravatar.jsx
@@ -50,7 +50,7 @@ class Gravatar extends React.Component {
 
     let query = {
       s: remoteSize || undefined,
-      d: placeholder,
+      d: placeholder || 'blank',
     };
 
     url += '?' + qs.stringify(query);


### PR DESCRIPTION
Would end up getting `?d=undefined` which causes Gravatar to redirect
into a non-https url, and breaking out https from a Mixed Content
warning. The intended behavior is to just render the transparent "blank"
avatar.

I dunno what I'm doing, but the behavior seems to have changed in
https://github.com/getsentry/sentry/commit/a400a7b17e42b3b7e1dd0a0b8e9b6b9601f84eb7