### PR TITLE
feat(discover): Add basic aggregation support

### DIFF
--- a/src/sentry/api/endpoints/organization_discover.py
+++ b/src/sentry/api/endpoints/organization_discover.py
@@ -36,7 +36,7 @@ class DiscoverSerializer(serializers.Serializer):
     )
     limit = serializers.IntegerField(min_value=0, max_value=1000, required=False)
     rollup = serializers.IntegerField(required=False)
-    orderby = serializers.CharField(required=False, default='-last_seen')
+    orderby = serializers.CharField(required=False)
     conditions = ListField(
         child=ListField(),
         required=False,
@@ -109,11 +109,17 @@ class OrganizationDiscoverEndpoint(OrganizationEndpoint):
 
         serialized = serializer.object
 
+        has_aggregations = len(serialized.get('aggregations')) > 0
+
+        selected_columns = [] if has_aggregations else serialized.get('fields')
+
+        groupby = serialized.get('fields') if has_aggregations else []
+
         results = self.do_query(
             serialized.get('start'),
             serialized.get('end'),
-            serialized.get('groupby'),
-            selected_columns=serialized.get('fields'),
+            groupby,
+            selected_columns=selected_columns,
             conditions=serialized.get('conditions'),
             orderby=serialized.get('orderby'),
             limit=serialized.get('limit'),

--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations.jsx
@@ -5,6 +5,7 @@ import {Flex, Box} from 'grid-emotion';
 
 import Link from 'app/components/link';
 import SelectControl from 'app/components/forms/selectControl';
+import InlineSvg from 'app/components/inlineSvg';
 import {t} from 'app/locale';
 
 import {COLUMNS} from './data';
@@ -225,11 +226,9 @@ export default class Aggregations extends React.Component {
               onChange={val => this.handleChange(val, idx)}
             />
             <Box ml={1}>
-              <a
-                className="icon-circle-cross"
-                style={{lineHeight: '37px'}}
-                onClick={() => this.removeRow(idx)}
-              />
+              <a onClick={() => this.removeRow(idx)}>
+                <InlineSvg src="icon-circle-close" height="38px" />
+              </a>
             </Box>
           </Flex>
         ))}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations.jsx
@@ -4,9 +4,183 @@ import styled from 'react-emotion';
 import {Flex, Box} from 'grid-emotion';
 
 import Link from 'app/components/link';
-import TextField from 'app/components/forms/textField';
-
+import SelectControl from 'app/components/forms/selectControl';
 import {t} from 'app/locale';
+
+import {COLUMNS} from './data';
+
+const COUNT_OPTION = {value: 'count', label: 'count'};
+
+const TOPK_COUNTS = [5, 10, 20, 50, 100];
+
+const TOP_LEVEL_OPTIONS = [
+  {value: 'uniq', label: 'uniq(...)'},
+  {value: 'topK', label: 'topK(...)'},
+];
+
+const UNIQ_OPTIONS = COLUMNS.map(({name}) => ({
+  value: `uniq_${name}`,
+  label: `uniq(${name})`,
+}));
+
+const TOPK_COUNT_OPTIONS = TOPK_COUNTS.map(num => ({
+  value: `topK_${num}`,
+  label: `topK(${num})(...)`,
+}));
+
+const TOPK_VALUE_OPTIONS = TOPK_COUNTS.reduce((acc, num) => {
+  return [
+    ...acc,
+    ...COLUMNS.map(({name}) => ({
+      value: `topK_${num}_${name}`,
+      label: `topK(${num})(${name})`,
+    })),
+  ];
+}, []);
+
+/*
+* Converts from external representation (array) to internal format (string)
+* for dropdown.
+*/
+export function getInternal(external) {
+  const [func, col] = external;
+
+  if (func === null) {
+    return '';
+  }
+
+  if (func === 'count()') {
+    return 'count';
+  }
+
+  if (func === 'uniq') {
+    return `uniq_${col}`;
+  }
+
+  if (func.startsWith('topK')) {
+    const count = func.match(/topK\((\d+)\)/)[1];
+    return `topK_${count}_${col}`;
+  }
+
+  return func;
+}
+
+/*
+* Converts from external representation (string value from dropdown) to external format (array)
+*/
+export function getExternal(internal) {
+  const uniqRegex = /^uniq_(.+)$/;
+  const topKRegex = /^topK_(\d+)_(.+)$/;
+
+  if (internal === 'count') {
+    return ['count()', null, 'count'];
+  }
+
+  if (internal.match(uniqRegex)) {
+    return ['uniq', internal.match(uniqRegex)[1], internal];
+  }
+
+  const topKMatch = internal.match(topKRegex);
+  if (topKMatch) {
+    return [`topK(${parseInt(topKMatch[1], 10)})`, topKMatch[2], internal];
+  }
+
+  return internal;
+}
+
+class Aggregation extends React.Component {
+  static propTypes = {
+    value: PropTypes.array,
+    onChange: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: getInternal(props.value),
+      displayedOptions: null,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      value: getInternal(nextProps.value),
+    });
+  }
+
+  getOptions() {
+    return [COUNT_OPTION, ...UNIQ_OPTIONS, ...TOPK_VALUE_OPTIONS];
+  }
+
+  getOptionList(options, input) {}
+
+  filterOptions = (options, input, value) => {
+    let optionList = [COUNT_OPTION, ...TOP_LEVEL_OPTIONS];
+
+    if (input.startsWith('uniq') || this.state.displayedOptions === 'uniq') {
+      optionList = UNIQ_OPTIONS;
+    }
+
+    if (input.match(/^topK_\d+/) || this.state.displayedOptions === 'topKValues') {
+      optionList = TOPK_VALUE_OPTIONS;
+    }
+
+    if (input.startsWith('topK') || this.state.displayedOptions === 'topK') {
+      optionList = TOPK_COUNT_OPTIONS;
+    }
+
+    return optionList.filter(({label}) => label.includes(input));
+  };
+
+  focus() {
+    this.select.focus();
+  }
+
+  handleChange = option => {
+    const topLevelValues = new Set(['uniq', 'topK']);
+    const topKValues = new Set([...TOPK_COUNTS.map(num => `topK_${num}`)]);
+
+    if (topLevelValues.has(option.value)) {
+      this.setState({displayedOptions: option.value}, this.focus);
+    } else if (topKValues.has(option.value)) {
+      this.setState(
+        {
+          displayedOptions: 'topKValues',
+        },
+        this.focus
+      );
+    } else {
+      this.setState({value: option.value, displayedOptions: null}, () => {
+        this.props.onChange(getExternal(option.value));
+      });
+    }
+  };
+
+  handleClose = () => {
+    this.setState({displayedOptions: null});
+  };
+
+  render() {
+    return (
+      <Box w={1}>
+        <SelectControl
+          forwardedRef={ref => (this.select = ref)}
+          value={this.state.value}
+          options={this.getOptions()}
+          filterOptions={this.filterOptions}
+          onChange={this.handleChange}
+          closeOnSelect={true}
+          openOnFocus={true}
+          autoBlur={true}
+          clearable={false}
+          backspaceRemoves={false}
+          deleteRemoves={false}
+          onClose={this.handleClose}
+        />
+      </Box>
+    );
+  }
+}
 
 export default class Aggregations extends React.Component {
   static propTypes = {
@@ -15,7 +189,7 @@ export default class Aggregations extends React.Component {
   };
 
   addRow() {
-    this.props.onChange([...this.props.value, ['', '', '']]);
+    this.props.onChange([...this.props.value, [null, null, null]]);
   }
 
   removeRow(idx) {
@@ -24,47 +198,12 @@ export default class Aggregations extends React.Component {
     this.props.onChange(aggregations);
   }
 
-  updateAggregation(idx, conditionIdx, val) {
-    const conditions = this.props.value.slice();
+  handleChange(val, idx) {
+    const aggregations = this.props.value.slice();
 
-    conditions[conditionIdx][idx] = val;
+    aggregations[idx] = val;
 
-    this.props.onChange(conditions);
-  }
-
-  renderAggregation(aggregation, idx) {
-    return (
-      <React.Fragment>
-        <Box w={1 / 3} pr={1}>
-          <TextField
-            name="aggregations-1"
-            value={aggregation[0]}
-            onChange={val => this.updateAggregation(0, idx, val)}
-          />
-        </Box>
-        <Box w={1 / 3} pr={1}>
-          <TextField
-            name="aggregations-2"
-            value={aggregation[1]}
-            onChange={val => this.updateAggregation(1, idx, val)}
-          />
-        </Box>
-        <Box w={1 / 3} pr={1}>
-          <TextField
-            name="aggregations-3"
-            value={aggregation[2]}
-            onChange={val => this.updateAggregation(2, idx, val)}
-          />
-        </Box>
-        <Box>
-          <a
-            className="icon-circle-cross"
-            style={{lineHeight: '37px'}}
-            onClick={() => this.removeRow(idx)}
-          />
-        </Box>
-      </React.Fragment>
-    );
+    this.props.onChange(aggregations);
   }
 
   render() {
@@ -73,14 +212,26 @@ export default class Aggregations extends React.Component {
     return (
       <div>
         <div>
-          <strong>{t('Aggregations')}</strong>
+          <strong>{t('Aggregation')}</strong>
           <Add>
             (<Link onClick={() => this.addRow()}>{t('Add')}</Link>)
           </Add>
         </div>
         {!value.length && 'None'}
         {value.map((aggregation, idx) => (
-          <Flex key={idx}>{this.renderAggregation(aggregation, idx)}</Flex>
+          <Flex key={idx}>
+            <Aggregation
+              value={aggregation}
+              onChange={val => this.handleChange(val, idx)}
+            />
+            <Box ml={1}>
+              <a
+                className="icon-circle-cross"
+                style={{lineHeight: '37px'}}
+                onClick={() => this.removeRow(idx)}
+              />
+            </Box>
+          </Flex>
         ))}
       </div>
     );

--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -15,7 +15,6 @@ import {addErrorMessage} from 'app/actionCreators/indicator';
 
 import {t} from 'app/locale';
 
-import {COLUMNS} from './data';
 import createQueryBuilder from './queryBuilder';
 import Result from './result';
 import Time from './time';
@@ -69,24 +68,16 @@ const OrganizationDiscover = createReactClass({
   },
 
   render: function() {
+    const {queryBuilder} = this.state;
     const hasFeature = this.getFeatures().has('internal-catchall');
 
     if (!hasFeature) return this.renderComingSoon();
 
-    const fieldOptions = COLUMNS.map(({name}) => ({
-      value: name,
-      label: name,
-    }));
+    const fieldOptions = queryBuilder.getFieldOptions();
 
-    const orderbyOptions = COLUMNS.reduce((acc, {name}) => {
-      return [
-        ...acc,
-        {value: name, label: `${name} asc`},
-        {value: `-${name}`, label: `${name} desc`},
-      ];
-    }, []);
+    const orderbyOptions = queryBuilder.getOrderByOptions();
 
-    const query = this.state.queryBuilder.getInternal();
+    const query = queryBuilder.getInternal();
 
     return (
       <div className="organization-home">
@@ -118,10 +109,14 @@ const OrganizationDiscover = createReactClass({
           <Box w={[1 / 3, 1 / 3, 1 / 3, 1 / 4]}>
             <MultiSelectField
               name="fields"
-              label={t('Select')}
+              label={t('Summarize')}
               options={fieldOptions}
               value={query.fields}
               onChange={val => this.updateField('fields', val)}
+            />
+            <Aggregations
+              value={query.aggregations}
+              onChange={val => this.updateField('aggregations', val)}
             />
             <SelectField
               name="orderby"
@@ -140,10 +135,6 @@ const OrganizationDiscover = createReactClass({
             <Conditions
               value={query.conditions}
               onChange={val => this.updateField('conditions', val)}
-            />
-            <Aggregations
-              value={query.aggregations}
-              onChange={val => this.updateField('aggregations', val)}
             />
             <Button onClick={this.runQuery} style={{marginTop: 8}} priority="primary">
               {t('Run Query')}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -1,5 +1,7 @@
 import moment from 'moment-timezone';
 
+import {COLUMNS} from './data';
+
 const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
 const DEFAULTS = {
@@ -36,20 +38,61 @@ export default function createQueryBuilder(initial = {}, projectList) {
   }
 
   function getExternal() {
-    if (!query.projects.length) {
-      return {...query, projects: projectList.map(project => parseInt(project.id, 10))};
-    } else {
-      return query;
+    // Default to all projects if none is selected
+    const projects = query.projects.length
+      ? query.projects
+      : projectList.map(project => parseInt(project.id, 10));
+
+    // Default to all fields if there are none selected, and no aggregation or groupby is specified
+    const useDefaultFields =
+      !query.fields.length && !query.aggregations.length && !query.groupby;
+
+    const fields = useDefaultFields ? COLUMNS.map(({name}) => name) : query.fields;
+
+    // Remove orderby property if it is not set
+    if (!query.orderby) {
+      delete query.orderby;
     }
+
+    return {
+      ...query,
+      projects,
+      fields,
+    };
   }
 
   function updateField(field, value) {
     query[field] = value;
+
+    // If an aggregation is added, we need to remove the orderby parameter if it's not in the selected fields
+    if (field === 'aggregations' && value.length > 0) {
+      query.orderby = null;
+      query.limit = null;
+    }
+  }
+
+  function getFieldOptions() {
+    return COLUMNS.map(({name}) => ({
+      value: name,
+      label: name,
+    }));
+  }
+
+  function getOrderByOptions() {
+    return COLUMNS.reduce((acc, {name}) => {
+      return [
+        ...acc,
+        {value: name, label: `${name} asc`},
+        {value: `-${name}`, label: `${name} desc`},
+      ];
+    }, []);
   }
 
   return {
     getInternal,
     getExternal,
     updateField,
+    getFieldOptions,
+    getOrderByOptions,
   };
 }

--- a/tests/js/spec/views/organizationDiscover/aggregations.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/aggregations.spec.jsx
@@ -1,0 +1,32 @@
+import {getInternal, getExternal} from 'app/views/organizationDiscover/aggregations';
+
+const aggregationList = [
+  {
+    internal: 'count',
+    external: ['count()', null, 'count'],
+  },
+  {
+    internal: 'uniq_message',
+    external: ['uniq', 'message', 'uniq_message'],
+  },
+  {
+    internal: 'topK_10_message',
+    external: ['topK(10)', 'message', 'topK_10_message'],
+  },
+];
+
+describe('Aggregations', function() {
+  describe('converts between internal and external format', function() {
+    it('getExternal()', function() {
+      aggregationList.forEach(({internal, external}) => {
+        expect(getExternal(internal)).toEqual(external);
+      });
+    });
+
+    it('getInternal()', function() {
+      aggregationList.forEach(({internal, external}) => {
+        expect(getInternal(external)).toEqual(internal);
+      });
+    });
+  });
+});

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -1,0 +1,15 @@
+import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
+
+describe('Query Builder', function() {
+  it('generates default query with all projects', function() {
+    const queryBuilder = createQueryBuilder({}, [TestStubs.Project()]);
+    const external = queryBuilder.getExternal();
+
+    expect(external.projects).toEqual([2]);
+    expect(external.fields).toEqual(['event_id', 'timestamp']);
+    expect(external.conditions).toHaveLength(0);
+    expect(external.aggregations).toHaveLength(0);
+    expect(external.orderby).toBe('-event_id');
+    expect(external.limit).toBe(1000);
+  });
+});


### PR DESCRIPTION
Adds a basic implementation of how aggregations could work in the UI.

Currently it supports topK, uniq and count aggregations

Also changes the behavior of the API endpoint to treat 'fields' as a 'select' if no aggregation is provided, or if there are aggregations for this to mean 'groupby'

Depends on https://github.com/getsentry/sentry/pull/8816