### PR TITLE
feat(login): Add query string option on login page

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -99,10 +99,13 @@ class AuthLoginView(BaseView):
 
         op = request.POST.get('op')
 
-        # Detect that we are on the register page by url /register/ and
-        # then activate the register tab by default.
-        if not op and '/register' in request.path_info and can_register:
-            op = 'register'
+        if not op:
+            # Detect that we are on the register page by url /register/ and
+            # then activate the register tab by default.
+            if '/register' in request.path_info and can_register:
+                op = 'register'
+            elif request.GET.get('op') == 'sso':
+                op = 'sso'
 
         login_form = self.get_login_form(request)
         if can_register:


### PR DESCRIPTION
Currently a GET request to /auth/login always shows the basic authentication tab. Allow passing an "op" param that can be set to "sso" to activate the SSO tab instead. This is useful when we want to redirect someone to the SSO login page.