### PR TITLE
feat: Give plugins the same set of permissions as project settings

### DIFF
--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 
 from sentry.exceptions import InvalidIdentity, PluginError, PluginIdentityRequired
 from sentry.plugins import plugins
-from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.plugin import (
@@ -27,6 +27,8 @@ OK_UPDATED = 'Successfully updated configuration.'
 
 
 class ProjectPluginDetailsEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectSettingPermission, )
+
     def _get_plugin(self, plugin_id):
         try:
             return plugins.get(plugin_id)


### PR DESCRIPTION
This means, DELETE does not require `project:admin` anymore. Since
DELETE is simply used to disable a plugin, there's not any reason to not
allow it with `project:write` just like any other settings.