### PR TITLE
feat(discover): Codesplit discover

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -25,7 +25,6 @@ import MyIssuesBookmarked from 'app/views/myIssues/bookmarked';
 import MyIssuesViewed from 'app/views/myIssues/viewed';
 import NewProject from 'app/views/projectInstall/newProject';
 import OnboardingConfigure from 'app/views/onboarding/configure/index';
-import OrganizationDiscover from 'app/views/organizationDiscover';
 import OnboardingWizard from 'app/views/onboarding/index';
 import OrganizationActivity from 'app/views/organizationActivity';
 import OrganizationContext from 'app/views/organizationContext';
@@ -761,7 +760,9 @@ function routes() {
 
           <Route
             path="/organizations/:orgId/discover/"
-            component={errorHandler(OrganizationDiscover)}
+            componentPromise={() =>
+              import(/*webpackChunkName:"OrganizationDiscover"*/ './views/organizationDiscover/index')}
+            component={errorHandler(LazyLoad)}
           />
           <Route
             path="/organizations/:orgId/activity/"


### PR DESCRIPTION
Do not load discover unless it's required, since it won't be used by the majority of users