### PR TITLE
fix(js): Remove Raven from globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,6 @@
     "MockApiClient": true,
     "TestStubs": true,
     "tick": true,
-    "Raven": true,
     "jest": true
   },
   "plugins": [

--- a/src/sentry/static/sentry/app/actionCreators/group.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/group.jsx
@@ -1,3 +1,5 @@
+import Raven from 'raven-js';
+
 import {Client} from 'app/api';
 import GroupActions from 'app/actions/groupActions';
 import {buildUserId, buildTeamId} from 'app/utils';

--- a/src/sentry/static/sentry/app/components/actorAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/actorAvatar.jsx
@@ -1,3 +1,4 @@
+import Raven from 'raven-js';
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -1,5 +1,6 @@
 import {isEqual} from 'lodash';
 import PropTypes from 'prop-types';
+import Raven from 'raven-js';
 import React from 'react';
 
 import {Client} from 'app/api';

--- a/src/sentry/static/sentry/app/components/dropdownMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import Raven from 'raven-js';
 import React from 'react';
 
 import {MENU_CLOSE_DELAY} from 'app/constants';

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -1,4 +1,6 @@
 import {isString} from 'lodash';
+import Raven from 'raven-js';
+
 import {defined} from 'app/utils';
 
 export function escapeQuotes(v) {

--- a/src/sentry/static/sentry/app/components/onboardingWizard/toDoItem.jsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/toDoItem.jsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
+import Raven from 'raven-js';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import classNames from 'classnames';

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -1,5 +1,6 @@
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
+import Raven from 'raven-js';
 import React from 'react';
 import classNames from 'classnames';
 import createReactClass from 'create-react-class';

--- a/src/sentry/static/sentry/app/views/settings/project/projectUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectUserFeedback.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import Raven from 'raven-js';
 import styled from 'react-emotion';
 
 import {t} from 'app/locale';

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -31,6 +31,13 @@ jest.mock('react-lazyload', () => {
   return LazyLoadMock;
 });
 
+jest.mock('raven-js', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+  showReportDialog: jest.fn(),
+  lastEventId: jest.fn(),
+}));
+
 const constantDate = new Date(1508208080000); //National Pasta Day
 MockDate.set(constantDate);
 
@@ -45,7 +52,7 @@ window.tick = () => new Promise(resolve => setTimeout(resolve));
 
 window.$ = window.jQuery = jQuery;
 window.sinon = sinon;
-window.scrollTo = sinon.spy();
+window.scrollTo = jest.fn();
 
 // Instead of wrapping codeblocks in `setTimeout`
 window.tick = () => new Promise(res => setTimeout(res));
@@ -53,11 +60,6 @@ window.tick = () => new Promise(res => setTimeout(res));
 // emotion context broadcast
 const broadcast = createBroadcast(theme);
 
-window.Raven = {
-  captureMessage: sinon.spy(),
-  captureException: sinon.spy(),
-  lastEventId: sinon.spy(),
-};
 window.TestStubs = {
   // react-router's 'router' context
   router: (params = {}) => ({


### PR DESCRIPTION
Raven is no longer an accepted global in eslint. React components should now import Raven. Change tests to mock raven using jest mock fns (vs sinon spies) so that we can use jest matchers.