### PR TITLE
fix(tagstore): Add `order_by` parameter to `get_group_tag_value_paginator` API

### DIFF
--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -309,7 +309,7 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_tag_value_paginator(self, project_id, group_id, environment_id, key):
+    def get_group_tag_value_paginator(self, project_id, group_id, environment_id, key, order_by='-id'):
         """
         >>> get_group_tag_value_paginator(1, 2, 3, 'environment')
         """


### PR DESCRIPTION
Fixes SENTRY-6WV, SENTRY-6WW