### PR TITLE
feat(auth): Make sso message clearer

### DIFF
--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -52,7 +52,13 @@
       <input type="hidden" name="init" value="1" />
 
       <div class="align-center">
-        <p>Sign in with your {{ provider_name }} account to continue.</p>
+        <p>
+          {% if authenticated %}
+          <b>{{ organization.name }}</b> requires signing in with {{ provider_name }}.
+          {% else %}
+          Sign in with your {{ provider_name }} account to continue.
+          {% endif %}
+        </p>
 
         <p><button type="submit" class="btn btn-default btn-login-{{ provider_key }}">
           <span class="provider-logo {{ provider_name | lower}}"></span> Login with {{ provider_name }}

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -39,6 +39,7 @@ class AuthOrganizationLoginView(AuthLoginView):
             'organization': organization,
             'provider_key': provider.key,
             'provider_name': provider.name,
+            'authenticated': request.user.is_authenticated(),
         }
 
         return self.respond('sentry/organization-login.html', context)


### PR DESCRIPTION
If a user is already authenticated but brought to the SSO page for an org, make it clear that we're asking for re-login because the organization enforces SSO via that provider.