### PR TITLE
feat: Add 'geo' (via GeoIP) to User interface if ip_address is present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     update: true
     packages:
       - libxmlsec1-dev
+      - libgeoip-dev
   chrome: stable
 
 env:

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,3 +2,4 @@ google-cloud-pubsub>=0.28.3,<0.29
 # See https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4001
 grpcio==1.4.0
 python3-saml>=1.4.0,<1.5
+GeoIP==1.3.2

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -534,7 +534,7 @@ class EventManager(object):
                 geo = None
 
             if geo:
-                data['sentry.interfaces.Geo'] = {
+                data['geo'] = {
                     'country_code': geo.get('country_code'),
                     'city': geo.get('city'),
                     'region': geo.get('region'),

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -528,7 +528,11 @@ class EventManager(object):
 
         ip_address = get_path(data, ['sentry.interfaces.User', 'ip_address'])
         if ip_address:
-            geo = geo_by_addr(ip_address)
+            try:
+                geo = geo_by_addr(ip_address)
+            except Exception:
+                geo = None
+
             if geo:
                 data['sentry.interfaces.User']['geo'] = {
                     'country_code': geo.get('country_code'),

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -42,7 +42,6 @@ from sentry.tasks.merge import merge_group
 from sentry.utils import metrics
 from sentry.utils.cache import default_cache
 from sentry.utils.db import get_db_engine
-from sentry.utils.geo import geo_by_addr
 from sentry.utils.imports import import_string
 from sentry.utils.safe import safe_execute, trim, trim_dict, get_path
 from sentry.utils.strings import truncatechars
@@ -525,20 +524,6 @@ class EventManager(object):
 
         if data['transaction']:
             data['transaction'] = trim(data['transaction'], MAX_CULPRIT_LENGTH)
-
-        ip_address = get_path(data, ['sentry.interfaces.User', 'ip_address'])
-        if ip_address:
-            try:
-                geo = geo_by_addr(ip_address)
-            except Exception:
-                geo = None
-
-            if geo:
-                data['geo'] = {
-                    'country_code': geo.get('country_code'),
-                    'city': geo.get('city'),
-                    'region': geo.get('region'),
-                }
 
         return data
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -534,12 +534,10 @@ class EventManager(object):
                 geo = None
 
             if geo:
-                data['sentry.interfaces.User']['geo'] = {
+                data['sentry.interfaces.Geo'] = {
                     'country_code': geo.get('country_code'),
                     'city': geo.get('city'),
                     'region': geo.get('region'),
-                    'latitude': geo.get('latitude'),
-                    'longitude': geo.get('longitude'),
                 }
 
         return data

--- a/src/sentry/interfaces/geo.py
+++ b/src/sentry/interfaces/geo.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 __all__ = ('Geo', )
 
 from sentry.interfaces.base import Interface
+from sentry.utils.geo import geo_by_addr
 
 
 class Geo(Interface):
@@ -16,6 +17,9 @@ class Geo(Interface):
     >>> }
     """
 
+    def get_path(self):
+        return 'geo'
+
     @classmethod
     def to_python(cls, data):
         kwargs = {
@@ -25,5 +29,19 @@ class Geo(Interface):
         }
         return cls(**kwargs)
 
-    def get_path(self):
-        return 'geo'
+    @classmethod
+    def from_ip_address(cls, ip_address):
+        try:
+            geo = geo_by_addr(ip_address)
+        except Exception:
+            geo = None
+
+        if not geo:
+            return None
+
+        kwargs = {
+            'country_code': geo.get('country_code'),
+            'city': geo.get('city'),
+            'region': geo.get('region'),
+        }
+        return cls(**kwargs)

--- a/src/sentry/interfaces/geo.py
+++ b/src/sentry/interfaces/geo.py
@@ -27,6 +27,7 @@ class Geo(Interface):
             'city': data.get('city'),
             'region': data.get('region'),
         }
+
         return cls(**kwargs)
 
     @classmethod
@@ -39,9 +40,9 @@ class Geo(Interface):
         if not geo:
             return None
 
-        kwargs = {
+        data = {
             'country_code': geo.get('country_code'),
             'city': geo.get('city'),
             'region': geo.get('region'),
         }
-        return cls(**kwargs)
+        return cls.to_python(data)

--- a/src/sentry/interfaces/geo.py
+++ b/src/sentry/interfaces/geo.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+
+__all__ = ('Geo', )
+
+from sentry.interfaces.base import Interface
+
+
+class Geo(Interface):
+    """
+    The (approximate) geographical location of the end user.
+
+    >>> {
+    >>>     'country_code': 'US',
+    >>>     'city': 'San Francisco',
+    >>>     'region': 'CA',
+    >>> }
+    """
+
+    @classmethod
+    def to_python(cls, data):
+        kwargs = {
+            'country_code': data.get('country_code'),
+            'city': data.get('city'),
+            'region': data.get('region'),
+        }
+        return cls(**kwargs)
+
+    def get_path(self):
+        return 'geo'

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -255,6 +255,16 @@ EXCEPTION_INTERFACE_SCHEMA = {
     'additionalProperties': True,
 }
 
+GEO_INTERFACE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'country_code': {'type': 'string'},
+        'city': {'type': 'string'},
+        'region': {'type': 'string'},
+    },
+    'additionalProperties': False,
+}
+
 DEVICE_INTERFACE_SCHEMA = {
     'type': 'object',
     'properties': {
@@ -438,15 +448,7 @@ EVENT_SCHEMA = {
         # Other interfaces
         'sentry.interfaces.User': {'type': 'object'},
         'sentry.interfaces.Http': {},
-        'sentry.interfaces.Geo': {
-            'type': 'object',
-            'properties': {
-                'country_code': {'type': 'string'},
-                'city': {'type': 'string'},
-                'region': {'type': 'string'},
-            },
-            'additionalProperties': False,
-        },
+        'geo': {},  # GEO_INTERFACE_SCHEMA
 
         # Other reserved keys. (some are added in processing)
         'project': {'type': ['number', 'string']},
@@ -714,6 +716,7 @@ INTERFACE_SCHEMAS = {
     'template': TEMPLATE_INTERFACE_SCHEMA,
     'sentry.interfaces.Template': TEMPLATE_INTERFACE_SCHEMA,
     'device': DEVICE_INTERFACE_SCHEMA,
+    'geo': GEO_INTERFACE_SCHEMA,
 
     # Security reports
     'sentry.interfaces.Csp': CSP_INTERFACE_SCHEMA,

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -438,6 +438,15 @@ EVENT_SCHEMA = {
         # Other interfaces
         'sentry.interfaces.User': {'type': 'object'},
         'sentry.interfaces.Http': {},
+        'sentry.interfaces.Geo': {
+            'type': 'object',
+            'properties': {
+                'country_code': {'type': 'string'},
+                'city': {'type': 'string'},
+                'region': {'type': 'string'},
+            },
+            'additionalProperties': False,
+        },
 
         # Other reserved keys. (some are added in processing)
         'project': {'type': ['number', 'string']},

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -82,7 +82,7 @@ class User(Interface):
         geo = data.pop('geo', None)
         if not geo and ip_address:
             geo = Geo.from_ip_address(ip_address)
-        elif geo and not isinstance(geo, Geo):
+        elif geo:
             geo = Geo.to_python(geo)
 
         # TODO(dcramer): patch in fix to deal w/ old data but not allow new
@@ -106,7 +106,7 @@ class User(Interface):
         geo = self._data.pop('geo') if 'geo' in self._data else {}
         json = super(User, self).to_json()
         if geo:
-            json['geo'] = geo
+            json['geo'] = geo.to_json()
         return json
 
     def get_api_context(self, is_public=False):

--- a/src/sentry/utils/geo.py
+++ b/src/sentry/utils/geo.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+import logging
+
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+# default is no-op
+geo_by_addr = lambda ip: None
+
+try:
+    import GeoIP
+except ImportError:
+    logger.warning("GeoIP module not available.")
+else:
+    geoip_path = getattr(settings, 'GEOIP_PATH', None)
+    if geoip_path:
+        try:
+            geo_db = GeoIP.open(geoip_path, GeoIP.GEOIP_STANDARD)
+        except BaseException:
+            logger.warning("Error opening GeoIP database: %s" % geoip_path)
+        else:
+            def geo_by_addr(ip):
+                try:
+                    return geo_db.record_by_addr(ip)
+                except BaseException:
+                    return None
+    else:
+        logger.warning("settings.GEOIP_PATH not configured.")

--- a/src/sentry/utils/geo.py
+++ b/src/sentry/utils/geo.py
@@ -23,6 +23,6 @@ else:
         except Exception:
             logger.warning("Error opening GeoIP database: %s" % geoip_path)
         else:
-            geo_by_addr = lambda ip: geo_db.record_by_addr(ip)
+            geo_by_addr = geo_db.record_by_addr
     else:
         logger.warning("settings.GEOIP_PATH not configured.")

--- a/src/sentry/utils/geo.py
+++ b/src/sentry/utils/geo.py
@@ -19,14 +19,10 @@ else:
     geoip_path = getattr(settings, 'GEOIP_PATH', None)
     if geoip_path:
         try:
-            geo_db = GeoIP.open(geoip_path, GeoIP.GEOIP_STANDARD)
-        except BaseException:
+            geo_db = GeoIP.open(geoip_path, GeoIP.GEOIP_MEMORY_CACHE)
+        except Exception:
             logger.warning("Error opening GeoIP database: %s" % geoip_path)
         else:
-            def geo_by_addr(ip):
-                try:
-                    return geo_db.record_by_addr(ip)
-                except BaseException:
-                    return None
+            geo_by_addr = lambda ip: geo_db.record_by_addr(ip)
     else:
         logger.warning("settings.GEOIP_PATH not configured.")

--- a/tests/sentry/interfaces/test_geo.py
+++ b/tests/sentry/interfaces/test_geo.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import mock
+
 from sentry.interfaces.geo import Geo
 from sentry.testutils import TestCase
 
@@ -11,6 +13,30 @@ class GeoTest(TestCase):
             'city': 'San Francisco',
             'region': 'CA',
         }).to_json() == {
+            'country_code': 'US',
+            'city': 'San Francisco',
+            'region': 'CA',
+        }
+
+    @mock.patch('sentry.interfaces.geo.geo_by_addr')
+    def test_from_ip_address(self, geo_by_addr_mock):
+        geo_by_addr_mock.return_value = {
+            'area_code': 415,
+            'city': 'San Francisco',
+            'country_code': 'US',
+            'country_code3': 'USA',
+            'country_name': 'United States',
+            'dma_code': 807,
+            'latitude': 37.79570007324219,
+            'longitude': -122.4208984375,
+            'metro_code': 807,
+            'postal_code': '94109',
+            'region': 'CA',
+            'region_name': 'California',
+            'time_zone': 'America/Los_Angeles'
+        }
+
+        assert Geo.from_ip_address('192.168.0.1').to_json() == {
             'country_code': 'US',
             'city': 'San Francisco',
             'region': 'CA',

--- a/tests/sentry/interfaces/test_geo.py
+++ b/tests/sentry/interfaces/test_geo.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+from sentry.interfaces.geo import Geo
+from sentry.testutils import TestCase
+
+
+class GeoTest(TestCase):
+    def test_serialize_behavior(self):
+        assert Geo.to_python({
+            'country_code': 'US',
+            'city': 'San Francisco',
+            'region': 'CA',
+        }).to_json() == {
+            'country_code': 'US',
+            'city': 'San Francisco',
+            'region': 'CA',
+        }
+
+    def test_path(self):
+        assert Geo().get_path() == 'geo'

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -155,12 +155,12 @@ class EventManagerTest(TransactionTestCase):
     def test_does_geo_from_ip(self, from_ip_address_mock):
         from sentry.interfaces.geo import Geo
 
-        geo = Geo.to_python({
+        geo = {
             'city': 'San Francisco',
             'country_code': 'US',
             'region': 'CA',
-        })
-        from_ip_address_mock.return_value = geo
+        }
+        from_ip_address_mock.return_value = Geo.to_python(geo)
 
         manager = EventManager(
             self.make_event(


### PR DESCRIPTION
Definitely have a few things to extra-review here:

1. I just added a `'geo'` object to the user interface. Maybe it belongs elsewhere, do we have precedent?
2. Added `GeoIP==1.3.2` to optional requirements and did everything I could to make this no-op. `getsentry` has `GeoIP==1.2.9` but ... doesn't use it. Even `orbital` (the only place I can find doing geo) uses the deprecated and archived `pygeoip` module instead... any idea why?
3. I warn when the user doesn't have the module and/or database file, I assume that's desired.
4. We'll need GeoIP C library and database on webs (or whatever we call the `normalize` endpoint) -- also, is `normalize` an OK place or should I move it?
5. I picked some fields that made sense. We don't have to make use of all of them but they seemed handy to have around. Here's the full object if we want to pick any others:

```python
geo_by_addr('162.217.75.90')
{'area_code': 415,
 'city': 'San Francisco',
 'country_code': 'US',
 'country_code3': 'USA',
 'country_name': 'United States',
 'dma_code': 807,
 'latitude': 37.79570007324219,
 'longitude': -122.4208984375,
 'metro_code': 807,
 'postal_code': '94109',
 'region': 'CA',
 'region_name': 'California',
 'time_zone': 'America/Los_Angeles'}
```