### PR TITLE
fix: Prevent asset urls from being generated with double slash

### DIFF
--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -14,5 +14,5 @@ def get_asset_url(module, path):
     return '{}/{}/{}'.format(
         settings.STATIC_URL.rstrip('/'),
         module,
-        path,
+        path.lstrip('/'),
     )


### PR DESCRIPTION
In a few places we are generating static urls with a // which is wrong
for some severs.