### PR TITLE
feat(integrations): Add Project Integrations list

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -425,6 +425,13 @@ function routes() {
         component={errorHandler(LazyLoad)}
       />
       <Route
+        path="integrations/:providerKey/:integrationId/"
+        name="Integration Configuration"
+        componentPromise={() =>
+          import(/* webpackChunkName: "ProjectIntegration" */ './views/settings/project/projectIntegration')}
+        component={errorHandler(LazyLoad)}
+      />
+      <Route
         path="install/"
         name="Configuration"
         component={errorHandler(ProjectDocsContext)}

--- a/src/sentry/static/sentry/app/views/projectPlugins/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectPlugins/index.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import {t} from 'app/locale';
 import {fetchPlugins, enablePlugin, disablePlugin} from 'app/actionCreators/plugins';
-import withPlugins from 'app/utils/withPlugins';
+import {t} from 'app/locale';
+import ProjectIntegrations from 'app/views/settings/project/projectIntegrations';
 import ProjectPlugins from 'app/views/projectPlugins/projectPlugins';
-import OrganizationIntegrations from 'app/views/organizationIntegrations';
 import SentryTypes from 'app/proptypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import withPlugins from 'app/utils/withPlugins';
 
 class ProjectPluginsContainer extends React.Component {
   static propTypes = {
@@ -29,17 +29,12 @@ class ProjectPluginsContainer extends React.Component {
 
   render() {
     let {loading, error, plugins} = this.props.plugins || {};
-    let {projectId, orgId} = this.props.params;
 
     return (
       <React.Fragment>
         <SettingsPageHeader title={t('Integrations')} />
 
-        <OrganizationIntegrations
-          {...this.props}
-          hideHeader={true}
-          linkPrefix={`/settings/${orgId}/${projectId}/integrations/`}
-        />
+        <ProjectIntegrations {...this.props} />
 
         <ProjectPlugins
           {...this.props}

--- a/src/sentry/static/sentry/app/views/projectPlugins/projectPlugins.jsx
+++ b/src/sentry/static/sentry/app/views/projectPlugins/projectPlugins.jsx
@@ -1,9 +1,15 @@
 import PropTypes from 'prop-types';
-import React, {Fragment, Component} from 'react';
+import React, {Component} from 'react';
 
+import {
+  Panel,
+  PanelAlert,
+  PanelBody,
+  PanelHeader,
+  PanelItem,
+} from 'app/components/panels';
 import {t} from 'app/locale';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import {Panel, PanelItem} from 'app/components/panels';
 import ProjectPluginRow from 'app/views/projectPlugins/projectPluginRow';
 import RouteError from 'app/views/routeError';
 import SentryTypes from 'app/proptypes';
@@ -32,28 +38,30 @@ class ProjectPlugins extends Component {
     }
 
     return (
-      <Panel
-        title={
-          <React.Fragment>
-            <div>{t('Legacy Integration')}</div>
-            <div>{t('Enabled')}</div>
-          </React.Fragment>
-        }
-        body={
-          <Fragment>
-            {plugins.map(plugin => (
-              <PanelItem key={plugin.id}>
-                <ProjectPluginRow
-                  params={params}
-                  routes={routes}
-                  {...plugin}
-                  onChange={onChange}
-                />
-              </PanelItem>
-            ))}
-          </Fragment>
-        }
-      />
+      <Panel>
+        <PanelHeader>
+          <div>{t('Legacy Integration')}</div>
+          <div>{t('Enabled')}</div>
+        </PanelHeader>
+        <PanelBody>
+          <PanelAlert type="warning">
+            {t(
+              "Legacy Integrations must be configured per-project. It's recommended to prefer organization-integrations over the legacy project integrations when available, as features will be more robust and flexible."
+            )}
+          </PanelAlert>
+
+          {plugins.map(plugin => (
+            <PanelItem key={plugin.id}>
+              <ProjectPluginRow
+                params={params}
+                routes={routes}
+                {...plugin}
+                onChange={onChange}
+              />
+            </PanelItem>
+          ))}
+        </PanelBody>
+      </Panel>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/project/projectIntegrations.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectIntegrations.jsx
@@ -1,0 +1,112 @@
+import {Box} from 'grid-emotion';
+import React from 'react';
+
+import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import {
+  addIntegrationToProject,
+  removeIntegrationFromProject,
+} from 'app/actionCreators/integrations';
+import {t, tct} from 'app/locale';
+import AsyncComponent from 'app/components/asyncComponent';
+import Button from 'app/components/buttons/button';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
+import Link from 'app/components/link';
+import Switch from 'app/components/switch';
+import TextBlock from 'app/views/settings/components/text/textBlock';
+import space from 'app/styles/space';
+
+export default class ProjectIntegrations extends AsyncComponent {
+  getEndpoints() {
+    let {orgId} = this.props.params;
+    return [['integrations', `/organizations/${orgId}/integrations/`]];
+  }
+
+  onToggleEnabled(enabled, integration) {
+    const {orgId, projectId} = this.props.params;
+
+    const promise = enabled
+      ? addIntegrationToProject(orgId, projectId, integration)
+      : removeIntegrationFromProject(orgId, projectId, integration);
+
+    promise.then(() => {
+      const integrations = [...this.state.integrations];
+      const integRef = integrations.find(i => i.id === integration.id);
+
+      if (enabled) {
+        integRef.projects.push(projectId);
+      } else {
+        integRef.projects = integRef.projects.filter(p => p !== projectId);
+      }
+
+      this.setState({integrations});
+    });
+  }
+
+  renderBody() {
+    const {orgId, projectId} = this.props.params;
+
+    const integrations = this.state.integrations
+      .filter(integration => integration.provider.canAddProject)
+      .map(integration => {
+        const enabled = integration.projects.includes(projectId);
+
+        return (
+          <PanelItem key={integration.id} align="center">
+            <Box flex={1}>
+              <IntegrationItem integration={integration} />
+            </Box>
+            <Box px={2}>
+              <Button
+                size="small"
+                disabled={!enabled}
+                to={`/settings/${orgId}/${projectId}/integrations/${integration.provider
+                  .key}/${integration.id}/`}
+              >
+                {t('Configure')}
+              </Button>
+            </Box>
+            <Switch
+              size="lg"
+              isActive={enabled}
+              toggle={() => this.onToggleEnabled(!enabled, integration)}
+            />
+          </PanelItem>
+        );
+      });
+
+    return (
+      <Panel>
+        <PanelHeader disablePadding hasButtons>
+          <Box px={2} flex="1">
+            {t('Project Integrations')}
+          </Box>
+          <Box pr={1}>
+            <Button size="xsmall" to={`/settings/${orgId}/integrations/`}>
+              {t('Manage Integrations')}
+            </Button>
+          </Box>
+        </PanelHeader>
+        <PanelBody>
+          {integrations.length === 0 && (
+            <EmptyMessage
+              size="large"
+              title={t('No Integrations Enabled')}
+              description={tct(
+                'Project Integrations can be enabled here for this project. Currently no organization integrations are enabled with project-specific integration capabilities. Visit the [link] to configure integrations.',
+                {
+                  link: (
+                    <Link to={`/settings/${orgId}/integrations`}>
+                      Organization Integration Settings
+                    </Link>
+                  ),
+                }
+              )}
+            />
+          )}
+          {integrations}
+        </PanelBody>
+      </Panel>
+    );
+  }
+}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -529,6 +529,34 @@ window.TestStubs = {
     };
   },
 
+  JiraIntegrationProvider: params => {
+    return {
+      key: 'jira',
+      name: 'Jira',
+      canAdd: false,
+      canAddProject: true,
+      config: [],
+      features: [],
+      metadata: {
+        description: '*markdown* formatted Jira _description_',
+        author: 'Rick',
+        noun: 'Instance',
+        issue_url: 'http://example.com/jira_integration_issue_url',
+        source_url: 'http://example.com/jira_integration_source_url',
+        aspects: {
+          externalInstall: [
+            {
+              url: 'http://jira.com',
+              buttonText: 'Visit Jira',
+              noticeText: 'You must visit jira to install the integration',
+            },
+          ],
+        },
+      },
+      ...params,
+    };
+  },
+
   GitHubIntegration: params => {
     return {
       domainName: 'gtithub.com/test-integration',
@@ -542,10 +570,31 @@ window.TestStubs = {
         canAddProject: false,
         features: [],
       },
+      projects: [],
       configOrganization: [],
       configProject: [],
       configData: {},
-      configDataProjects: {},
+      ...params,
+    };
+  },
+
+  JiraIntegration: params => {
+    return {
+      domainName: 'jira.com/test-integration',
+      icon: 'http://jira.example.com/integration_icon.png',
+      id: '1',
+      name: 'Jira Test Integration',
+      provider: {
+        name: 'Jira',
+        key: 'jira',
+        canAdd: true,
+        canAddProject: true,
+        features: [],
+      },
+      projects: [],
+      configOrganization: [],
+      configProject: [],
+      configData: {},
       ...params,
     };
   },

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
@@ -1,75 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProjectPlugins renders 1`] = `
-<Panel
-  body={
-    <UNDEFINED>
-      <PanelItem
-        p={2}
-      >
-        <ProjectPluginRow
-          assets={Array []}
-          author={
-            Object {
-              "name": "Sentry Team",
-              "url": "https://github.com/getsentry/sentry",
-            }
+<Panel>
+  <PanelHeader>
+    <div>
+      Legacy Integration
+    </div>
+    <div>
+      Enabled
+    </div>
+  </PanelHeader>
+  <PanelBody
+    direction="column"
+    disablePadding={true}
+    flex={false}
+  >
+    <PanelAlert
+      m={0}
+      mb={0}
+      type="warning"
+    >
+      Legacy Integrations must be configured per-project. It's recommended to prefer organization-integrations over the legacy project integrations when available, as features will be more robust and flexible.
+    </PanelAlert>
+    <PanelItem
+      key="amazon-sqs"
+      p={2}
+    >
+      <ProjectPluginRow
+        assets={Array []}
+        author={
+          Object {
+            "name": "Sentry Team",
+            "url": "https://github.com/getsentry/sentry",
           }
-          canDisable={true}
-          enabled={false}
-          hasConfiguration={true}
-          id="amazon-sqs"
-          name="Amazon SQS"
-          onChange={undefined}
-          params={
-            Object {
-              "orgId": "org-slug",
-              "projectId": "project-slug",
-            }
+        }
+        canDisable={true}
+        enabled={false}
+        hasConfiguration={true}
+        id="amazon-sqs"
+        name="Amazon SQS"
+        params={
+          Object {
+            "orgId": "org-slug",
+            "projectId": "project-slug",
           }
-          routes={undefined}
-          slug="amazon-sqs"
-          version="8.23.0.dev0"
-        />
-      </PanelItem>
-      <PanelItem
-        p={2}
-      >
-        <ProjectPluginRow
-          assets={Array []}
-          author={
-            Object {
-              "name": "Sentry Team",
-              "url": "https://github.com/getsentry/sentry",
-            }
+        }
+        slug="amazon-sqs"
+        version="8.23.0.dev0"
+      />
+    </PanelItem>
+    <PanelItem
+      key="github"
+      p={2}
+    >
+      <ProjectPluginRow
+        assets={Array []}
+        author={
+          Object {
+            "name": "Sentry Team",
+            "url": "https://github.com/getsentry/sentry",
           }
-          canDisable={false}
-          enabled={true}
-          id="github"
-          name="GitHub"
-          onChange={undefined}
-          params={
-            Object {
-              "orgId": "org-slug",
-              "projectId": "project-slug",
-            }
+        }
+        canDisable={false}
+        enabled={true}
+        id="github"
+        name="GitHub"
+        params={
+          Object {
+            "orgId": "org-slug",
+            "projectId": "project-slug",
           }
-          routes={undefined}
-          slug="github"
-          version="8.23.0.dev0"
-        />
-      </PanelItem>
-    </UNDEFINED>
-  }
-  title={
-    <UNDEFINED>
-      <div>
-        Legacy Integration
-      </div>
-      <div>
-        Enabled
-      </div>
-    </UNDEFINED>
-  }
-/>
+        }
+        slug="github"
+        version="8.23.0.dev0"
+      />
+    </PanelItem>
+  </PanelBody>
+</Panel>
 `;

--- a/tests/js/spec/views/projectPlugins/index.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/index.spec.jsx
@@ -29,9 +29,9 @@ describe('ProjectPluginsContainer', function() {
       body: org,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/config/integrations/`,
+      url: `/organizations/${org.slug}/integrations/`,
       method: 'GET',
-      body: {providers: [TestStubs.GitHubIntegrationProvider()]},
+      body: [],
     });
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/plugins/`,

--- a/tests/js/spec/views/projectPlugins/pluginNavigation.integration.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/pluginNavigation.integration.spec.jsx
@@ -14,9 +14,9 @@ describe('PluginNavigation Integration', function() {
 
   beforeEach(function() {
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/config/integrations/`,
+      url: `/organizations/${org.slug}/integrations/`,
       method: 'GET',
-      body: {providers: [TestStubs.GitHubIntegrationProvider()]},
+      body: [],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/`,

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -73,13 +73,13 @@ exports[`Integration render() with one integration renders 1`] = `
           integration={
             Object {
               "configData": Object {},
-              "configDataProjects": Object {},
               "configOrganization": Array [],
               "configProject": Array [],
               "domainName": "gtithub.com/test-integration",
               "icon": "http://example.com/integration_icon.png",
               "id": "1",
               "name": "Test Integration",
+              "projects": Array [],
               "provider": Object {
                 "canAdd": true,
                 "canAddProject": false,

--- a/tests/js/spec/views/settings/project/__snapshots__/projectIntegrations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/project/__snapshots__/projectIntegrations.spec.jsx.snap
@@ -1,0 +1,698 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectIntegrations Renders emptystate with access 1`] = `
+<ProjectIntegrations
+  params={
+    Object {
+      "orgId": "org-slug",
+      "projectId": "project-slug",
+    }
+  }
+>
+  <Panel>
+    <Component
+      className="css-10qfvek-Panel e1laxa7d0"
+    >
+      <div
+        className="css-10qfvek-Panel e1laxa7d0"
+      >
+        <PanelHeader
+          disablePadding={true}
+          hasButtons={true}
+        >
+          <Component
+            className="css-30ccsi-PanelHeader-getPadding e1p8v8nv0"
+            disablePadding={true}
+            hasButtons={true}
+          >
+            <Flex
+              align="center"
+              className="css-30ccsi-PanelHeader-getPadding e1p8v8nv0"
+              justify="space-between"
+            >
+              <Base
+                align="center"
+                className="e1p8v8nv0 css-1uiswd5-PanelHeader-getPadding"
+                justify="space-between"
+              >
+                <div
+                  className="e1p8v8nv0 css-1uiswd5-PanelHeader-getPadding"
+                  is={null}
+                >
+                  <Box
+                    flex="1"
+                    px={2}
+                  >
+                    <Base
+                      className="css-pcjga5"
+                      flex="1"
+                      px={2}
+                    >
+                      <div
+                        className="css-pcjga5"
+                        is={null}
+                      >
+                        Project Integrations
+                      </div>
+                    </Base>
+                  </Box>
+                  <Box
+                    pr={1}
+                  >
+                    <Base
+                      className="css-ioegso"
+                      pr={1}
+                    >
+                      <div
+                        className="css-ioegso"
+                        is={null}
+                      >
+                        <FeatureContainer
+                          access={
+                            Array [
+                              "org:integrations",
+                            ]
+                          }
+                        >
+                          <Feature
+                            access={
+                              Array [
+                                "org:integrations",
+                              ]
+                            }
+                            config={Array []}
+                            organization={
+                              Object {
+                                "access": Array [
+                                  "org:read",
+                                  "org:write",
+                                  "org:admin",
+                                  "project:read",
+                                  "project:write",
+                                  "project:admin",
+                                  "team:read",
+                                  "team:write",
+                                  "team:admin",
+                                  "org:integrations",
+                                ],
+                                "features": Array [],
+                                "id": "3",
+                                "name": "Organization Name",
+                                "onboardingTasks": Array [],
+                                "projects": Array [],
+                                "scrapeJavaScript": true,
+                                "slug": "org-slug",
+                                "status": Object {
+                                  "id": "active",
+                                  "name": "active",
+                                },
+                                "teams": Array [],
+                              }
+                            }
+                            project={
+                              Object {
+                                "hasAccess": true,
+                                "id": "2",
+                                "isBookmarked": false,
+                                "isMember": true,
+                                "name": "Project Name",
+                                "slug": "project-slug",
+                                "teams": Array [],
+                              }
+                            }
+                          >
+                            <Tooltip
+                              disabled={true}
+                              title="You don't have permission to manage organization integrations"
+                            >
+                              <span>
+                                <Button
+                                  disabled={false}
+                                  size="xsmall"
+                                  to="/settings/org-slug/integrations/"
+                                >
+                                  <StyledButton
+                                    aria-label="Manage Integrations"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    role="button"
+                                    size="xsmall"
+                                    to="/settings/org-slug/integrations/"
+                                  >
+                                    <Component
+                                      aria-label="Manage Integrations"
+                                      className="css-dkprmi-StyledButton-getColors e17811v30"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      role="button"
+                                      size="xsmall"
+                                      to="/settings/org-slug/integrations/"
+                                    >
+                                      <Link
+                                        aria-label="Manage Integrations"
+                                        className="css-dkprmi-StyledButton-getColors e17811v30"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        onlyActiveOnIndex={false}
+                                        role="button"
+                                        size="xsmall"
+                                        style={Object {}}
+                                        to="/settings/org-slug/integrations/"
+                                      >
+                                        <a
+                                          aria-label="Manage Integrations"
+                                          className="css-dkprmi-StyledButton-getColors e17811v30"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          role="button"
+                                          size="xsmall"
+                                          style={Object {}}
+                                        >
+                                          <ButtonLabel
+                                            size="xsmall"
+                                          >
+                                            <Component
+                                              className="css-6q5v1w-ButtonLabel e17811v31"
+                                              size="xsmall"
+                                            >
+                                              <Flex
+                                                align="center"
+                                                className="css-6q5v1w-ButtonLabel e17811v31"
+                                                size="xsmall"
+                                              >
+                                                <Base
+                                                  align="center"
+                                                  className="e17811v31 css-dqr4rq-ButtonLabel"
+                                                  size="xsmall"
+                                                >
+                                                  <div
+                                                    className="e17811v31 css-dqr4rq-ButtonLabel"
+                                                    is={null}
+                                                    size="xsmall"
+                                                  >
+                                                    Manage Integrations
+                                                  </div>
+                                                </Base>
+                                              </Flex>
+                                            </Component>
+                                          </ButtonLabel>
+                                        </a>
+                                      </Link>
+                                    </Component>
+                                  </StyledButton>
+                                </Button>
+                              </span>
+                            </Tooltip>
+                          </Feature>
+                        </FeatureContainer>
+                      </div>
+                    </Base>
+                  </Box>
+                </div>
+              </Base>
+            </Flex>
+          </Component>
+        </PanelHeader>
+        <PanelBody
+          direction="column"
+          disablePadding={true}
+          flex={false}
+        >
+          <div
+            className="css-9vq8an-textStyles"
+          >
+            <EmptyMessage
+              description={
+                <FeatureContainer
+                  access={
+                    Array [
+                      "org:integrations",
+                    ]
+                  }
+                >
+                  [Function]
+                </FeatureContainer>
+              }
+              size="large"
+              title="No Integrations Enabled"
+            >
+              <Wrapper
+                size="large"
+              >
+                <div
+                  className="css-1ykemxy-Wrapper eh488yo0"
+                  size="large"
+                >
+                  <div
+                    className="ref-message"
+                  >
+                    <EmptyHeader>
+                      <div
+                        className="css-y01aqt-EmptyHeader eh488yo3"
+                      >
+                        No Integrations Enabled
+                      </div>
+                    </EmptyHeader>
+                    <EmptyDescription
+                      noMargin={true}
+                    >
+                      <Component
+                        className="css-1szwf0j-TextBlock-EmptyDescription eh488yo4"
+                        noMargin={true}
+                      >
+                        <div
+                          className="css-1szwf0j-TextBlock-EmptyDescription eh488yo4"
+                        >
+                          <FeatureContainer
+                            access={
+                              Array [
+                                "org:integrations",
+                              ]
+                            }
+                          >
+                            <Feature
+                              access={
+                                Array [
+                                  "org:integrations",
+                                ]
+                              }
+                              config={Array []}
+                              organization={
+                                Object {
+                                  "access": Array [
+                                    "org:read",
+                                    "org:write",
+                                    "org:admin",
+                                    "project:read",
+                                    "project:write",
+                                    "project:admin",
+                                    "team:read",
+                                    "team:write",
+                                    "team:admin",
+                                    "org:integrations",
+                                  ],
+                                  "features": Array [],
+                                  "id": "3",
+                                  "name": "Organization Name",
+                                  "onboardingTasks": Array [],
+                                  "projects": Array [],
+                                  "scrapeJavaScript": true,
+                                  "slug": "org-slug",
+                                  "status": Object {
+                                    "id": "active",
+                                    "name": "active",
+                                  },
+                                  "teams": Array [],
+                                }
+                              }
+                              project={
+                                Object {
+                                  "hasAccess": true,
+                                  "id": "2",
+                                  "isBookmarked": false,
+                                  "isMember": true,
+                                  "name": "Project Name",
+                                  "slug": "project-slug",
+                                  "teams": Array [],
+                                }
+                              }
+                            >
+                              <span
+                                key="6"
+                              >
+                                <span
+                                  key="1"
+                                >
+                                  Project Integrations can be enabled here for this project. Currently no organization integrations are enabled with project-specific integration capabilities.
+                                </span>
+                                <span
+                                  key="2"
+                                >
+                                   Visit the 
+                                </span>
+                                <Link
+                                  key="3"
+                                  to="/settings/org-slug/integrations"
+                                >
+                                  <Link
+                                    onlyActiveOnIndex={false}
+                                    style={Object {}}
+                                    to="/settings/org-slug/integrations"
+                                  >
+                                    <a
+                                      onClick={[Function]}
+                                      style={Object {}}
+                                    >
+                                      Organization Integration Settings
+                                    </a>
+                                  </Link>
+                                </Link>
+                                <span
+                                  key="4"
+                                >
+                                   to configure integrations.
+                                </span>
+                              </span>
+                            </Feature>
+                          </FeatureContainer>
+                        </div>
+                      </Component>
+                    </EmptyDescription>
+                  </div>
+                </div>
+              </Wrapper>
+            </EmptyMessage>
+          </div>
+        </PanelBody>
+      </div>
+    </Component>
+  </Panel>
+</ProjectIntegrations>
+`;
+
+exports[`ProjectIntegrations Renders emptystate with no permissions 1`] = `
+<ProjectIntegrations
+  params={
+    Object {
+      "orgId": "org-slug",
+      "projectId": "project-slug",
+    }
+  }
+>
+  <Panel>
+    <Component
+      className="css-10qfvek-Panel e1laxa7d0"
+    >
+      <div
+        className="css-10qfvek-Panel e1laxa7d0"
+      >
+        <PanelHeader
+          disablePadding={true}
+          hasButtons={true}
+        >
+          <Component
+            className="css-30ccsi-PanelHeader-getPadding e1p8v8nv0"
+            disablePadding={true}
+            hasButtons={true}
+          >
+            <Flex
+              align="center"
+              className="css-30ccsi-PanelHeader-getPadding e1p8v8nv0"
+              justify="space-between"
+            >
+              <Base
+                align="center"
+                className="e1p8v8nv0 css-1uiswd5-PanelHeader-getPadding"
+                justify="space-between"
+              >
+                <div
+                  className="e1p8v8nv0 css-1uiswd5-PanelHeader-getPadding"
+                  is={null}
+                >
+                  <Box
+                    flex="1"
+                    px={2}
+                  >
+                    <Base
+                      className="css-pcjga5"
+                      flex="1"
+                      px={2}
+                    >
+                      <div
+                        className="css-pcjga5"
+                        is={null}
+                      >
+                        Project Integrations
+                      </div>
+                    </Base>
+                  </Box>
+                  <Box
+                    pr={1}
+                  >
+                    <Base
+                      className="css-ioegso"
+                      pr={1}
+                    >
+                      <div
+                        className="css-ioegso"
+                        is={null}
+                      >
+                        <FeatureContainer
+                          access={
+                            Array [
+                              "org:integrations",
+                            ]
+                          }
+                        >
+                          <Feature
+                            access={
+                              Array [
+                                "org:integrations",
+                              ]
+                            }
+                            config={Array []}
+                            organization={
+                              Object {
+                                "access": Array [
+                                  "org:read",
+                                  "org:write",
+                                  "org:admin",
+                                  "project:read",
+                                  "project:write",
+                                  "project:admin",
+                                  "team:read",
+                                  "team:write",
+                                  "team:admin",
+                                ],
+                                "features": Array [],
+                                "id": "3",
+                                "name": "Organization Name",
+                                "onboardingTasks": Array [],
+                                "projects": Array [],
+                                "scrapeJavaScript": true,
+                                "slug": "org-slug",
+                                "status": Object {
+                                  "id": "active",
+                                  "name": "active",
+                                },
+                                "teams": Array [],
+                              }
+                            }
+                            project={
+                              Object {
+                                "hasAccess": true,
+                                "id": "2",
+                                "isBookmarked": false,
+                                "isMember": true,
+                                "name": "Project Name",
+                                "slug": "project-slug",
+                                "teams": Array [],
+                              }
+                            }
+                          >
+                            <Tooltip
+                              disabled={false}
+                              title="You don't have permission to manage organization integrations"
+                            >
+                              <span
+                                className="tip"
+                                title="You don't have permission to manage organization integrations"
+                              >
+                                <Button
+                                  disabled={true}
+                                  size="xsmall"
+                                  to="/settings/org-slug/integrations/"
+                                >
+                                  <StyledButton
+                                    aria-label="Manage Integrations"
+                                    disabled={true}
+                                    href={null}
+                                    onClick={[Function]}
+                                    role="button"
+                                    size="xsmall"
+                                    to={null}
+                                  >
+                                    <Component
+                                      aria-label="Manage Integrations"
+                                      className="css-1rcxqx1-StyledButton-getColors e17811v30"
+                                      disabled={true}
+                                      href={null}
+                                      onClick={[Function]}
+                                      role="button"
+                                      size="xsmall"
+                                      to={null}
+                                    >
+                                      <button
+                                        aria-label="Manage Integrations"
+                                        className="css-1rcxqx1-StyledButton-getColors e17811v30"
+                                        disabled={true}
+                                        href={null}
+                                        onClick={[Function]}
+                                        role="button"
+                                        size="xsmall"
+                                        to={null}
+                                      >
+                                        <ButtonLabel
+                                          size="xsmall"
+                                        >
+                                          <Component
+                                            className="css-6q5v1w-ButtonLabel e17811v31"
+                                            size="xsmall"
+                                          >
+                                            <Flex
+                                              align="center"
+                                              className="css-6q5v1w-ButtonLabel e17811v31"
+                                              size="xsmall"
+                                            >
+                                              <Base
+                                                align="center"
+                                                className="e17811v31 css-dqr4rq-ButtonLabel"
+                                                size="xsmall"
+                                              >
+                                                <div
+                                                  className="e17811v31 css-dqr4rq-ButtonLabel"
+                                                  is={null}
+                                                  size="xsmall"
+                                                >
+                                                  Manage Integrations
+                                                </div>
+                                              </Base>
+                                            </Flex>
+                                          </Component>
+                                        </ButtonLabel>
+                                      </button>
+                                    </Component>
+                                  </StyledButton>
+                                </Button>
+                              </span>
+                            </Tooltip>
+                          </Feature>
+                        </FeatureContainer>
+                      </div>
+                    </Base>
+                  </Box>
+                </div>
+              </Base>
+            </Flex>
+          </Component>
+        </PanelHeader>
+        <PanelBody
+          direction="column"
+          disablePadding={true}
+          flex={false}
+        >
+          <div
+            className="css-9vq8an-textStyles"
+          >
+            <EmptyMessage
+              description={
+                <FeatureContainer
+                  access={
+                    Array [
+                      "org:integrations",
+                    ]
+                  }
+                >
+                  [Function]
+                </FeatureContainer>
+              }
+              size="large"
+              title="No Integrations Enabled"
+            >
+              <Wrapper
+                size="large"
+              >
+                <div
+                  className="css-1ykemxy-Wrapper eh488yo0"
+                  size="large"
+                >
+                  <div
+                    className="ref-message"
+                  >
+                    <EmptyHeader>
+                      <div
+                        className="css-y01aqt-EmptyHeader eh488yo3"
+                      >
+                        No Integrations Enabled
+                      </div>
+                    </EmptyHeader>
+                    <EmptyDescription
+                      noMargin={true}
+                    >
+                      <Component
+                        className="css-1szwf0j-TextBlock-EmptyDescription eh488yo4"
+                        noMargin={true}
+                      >
+                        <div
+                          className="css-1szwf0j-TextBlock-EmptyDescription eh488yo4"
+                        >
+                          <FeatureContainer
+                            access={
+                              Array [
+                                "org:integrations",
+                              ]
+                            }
+                          >
+                            <Feature
+                              access={
+                                Array [
+                                  "org:integrations",
+                                ]
+                              }
+                              config={Array []}
+                              organization={
+                                Object {
+                                  "access": Array [
+                                    "org:read",
+                                    "org:write",
+                                    "org:admin",
+                                    "project:read",
+                                    "project:write",
+                                    "project:admin",
+                                    "team:read",
+                                    "team:write",
+                                    "team:admin",
+                                  ],
+                                  "features": Array [],
+                                  "id": "3",
+                                  "name": "Organization Name",
+                                  "onboardingTasks": Array [],
+                                  "projects": Array [],
+                                  "scrapeJavaScript": true,
+                                  "slug": "org-slug",
+                                  "status": Object {
+                                    "id": "active",
+                                    "name": "active",
+                                  },
+                                  "teams": Array [],
+                                }
+                              }
+                              project={
+                                Object {
+                                  "hasAccess": true,
+                                  "id": "2",
+                                  "isBookmarked": false,
+                                  "isMember": true,
+                                  "name": "Project Name",
+                                  "slug": "project-slug",
+                                  "teams": Array [],
+                                }
+                              }
+                            >
+                              Project Integrations can be enabled here for this project. Currently no organization integrations are enabled with project-specific integration capabilities.
+                            </Feature>
+                          </FeatureContainer>
+                        </div>
+                      </Component>
+                    </EmptyDescription>
+                  </div>
+                </div>
+              </Wrapper>
+            </EmptyMessage>
+          </div>
+        </PanelBody>
+      </div>
+    </Component>
+  </Panel>
+</ProjectIntegrations>
+`;

--- a/tests/js/spec/views/settings/project/projectIntegrations.spec.jsx
+++ b/tests/js/spec/views/settings/project/projectIntegrations.spec.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+
+import {mount} from 'enzyme';
+import {
+  removeIntegrationFromProject,
+  addIntegrationToProject,
+} from 'app/actionCreators/integrations';
+import ProjectIntegrations from 'app/views/settings/project/projectIntegrations';
+
+jest.mock('app/actionCreators/integrations');
+
+describe('ProjectIntegrations', function() {
+  let org, project, params, organization, routerContext;
+
+  beforeEach(function() {
+    project = TestStubs.Project();
+    org = TestStubs.Organization();
+    organization = org;
+    params = {
+      orgId: org.slug,
+      projectId: project.slug,
+    };
+    routerContext = TestStubs.routerContext([{organization, project}]);
+
+    removeIntegrationFromProject.mockReturnValue(new Promise(resolve => resolve()));
+    addIntegrationToProject.mockReturnValue(new Promise(resolve => resolve()));
+  });
+
+  it('Renders emptystate with no permissions', function() {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/`,
+      method: 'GET',
+      body: [],
+    });
+
+    const wrapper = mount(<ProjectIntegrations params={params} />, routerContext);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('Renders emptystate with access', function() {
+    organization.access.push('org:integrations');
+
+    const wrapper = mount(<ProjectIntegrations params={params} />, routerContext);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('Renders integration without access', function() {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/`,
+      method: 'GET',
+      body: [TestStubs.JiraIntegration()],
+    });
+
+    const wrapper = mount(<ProjectIntegrations params={params} />, routerContext);
+
+    expect(wrapper.find('Switch').prop('isDisabled')).toBe(true);
+  });
+
+  it('Renders integration with access', function() {
+    organization.access.push('project:integrations');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/`,
+      method: 'GET',
+      body: [TestStubs.JiraIntegration()],
+    });
+
+    const wrapper = mount(<ProjectIntegrations params={params} />, routerContext);
+    const integration = wrapper.find('IntegrationItem');
+
+    expect(integration.exists()).toBe(true);
+    expect(wrapper.find('Switch').prop('isDisabled')).toBe(false);
+  });
+
+  it('can enable and disable an integration', async function() {
+    organization.access.push('project:integrations');
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/`,
+      method: 'GET',
+      body: [TestStubs.JiraIntegration()],
+    });
+
+    const wrapper = mount(<ProjectIntegrations params={params} />, routerContext);
+
+    wrapper.find('Switch').simulate('click');
+    expect(addIntegrationToProject).toHaveBeenCalled();
+
+    await tick();
+    expect(wrapper.state('integrations')[0].projects).toEqual([project.slug]);
+
+    wrapper.find('Switch').simulate('click');
+    expect(removeIntegrationFromProject).toHaveBeenCalled();
+
+    await tick();
+    expect(wrapper.state('integrations')[0].projects).toEqual([]);
+  });
+});


### PR DESCRIPTION
Instaed of rendering the integrations managment panel in the project integrations page, we now instead render integrations that are project-capable.

This also adds some nice notices about legacy vs organization / project integrations.

![image](https://user-images.githubusercontent.com/1421724/41946347-e341cd48-7966-11e8-9218-74a4c18df0ac.png)
![image](https://user-images.githubusercontent.com/1421724/41946353-eb674354-7966-11e8-8906-d158a5df9923.png)
![image](https://user-images.githubusercontent.com/1421724/41946373-10b65a1e-7967-11e8-9413-f880a46416f8.png)
