### PR TITLE
feat(identity): Don't relink identity if login depends on it

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import, print_function
 
 __all__ = ['IntegrationPipeline']
 
-import six
-
 from django.db import IntegrityError
 from django.http import HttpResponse
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 
 from sentry.api.serializers import serialize
 from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration
@@ -123,12 +121,10 @@ class IntegrationPipeline(Pipeline):
                         # have a password, we don't delete the link as it may lock them out.
                         if not other_identity.user.has_usable_password():
                             return self._dialog_response({
-                                # Force text_type conversion because translation objects are not
-                                # JSON-serializable by default.
-                                'error': six.text_type(_(
+                                'error': _(
                                     'The provided Github account is linked to a different user. '
                                     'Please try again with a different Github account.'
-                                ))},
+                                )},
                                 False,
                             )
                 identity_model = Identity.reattach(

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -128,7 +128,7 @@ class IntegrationPipeline(Pipeline):
                                 False,
                             )
                 identity_model = Identity.reattach(
-                    idp, identity['external_id'], self.request.user, **identity_data)
+                    idp, identity['external_id'], self.request.user, identity_data)
 
         org_integration_args = {}
 

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -84,7 +84,7 @@ class SlackLinkIdentitiyView(BaseView):
             if not created:
                 identity.update(**defaults)
         except IntegrityError:
-            Identity.reattach(idp, params['slack_id'], request.user, **defaults)
+            Identity.reattach(idp, params['slack_id'], request.user, defaults)
 
         payload = {
             'replace_original': False,

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -66,7 +66,7 @@ class Identity(Model):
         return get(self.idp.type)
 
     @classmethod
-    def reattach(cls, idp, external_id, user, **kwargs):
+    def reattach(cls, idp, external_id, user, defaults):
         """
         Removes identities under `idp` associated with either `external_id` or `user`
         and creates a new identity linking them.
@@ -78,5 +78,5 @@ class Identity(Model):
             idp=idp,
             user=user,
             external_id=external_id,
-            **kwargs
+            **defaults
         )

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
@@ -75,7 +75,7 @@ export default class AddIntegrationButton extends React.Component {
     const {success, data} = message.data;
 
     if (!success) {
-      IndicatorStore.addError(t('Unable to add Integration'));
+      IndicatorStore.addError(data['error']);
       return;
     }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
@@ -75,7 +75,7 @@ export default class AddIntegrationButton extends React.Component {
     const {success, data} = message.data;
 
     if (!success) {
-      IndicatorStore.addError(data['error']);
+      IndicatorStore.addError(data.error);
       return;
     }
 

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -85,13 +85,13 @@ class SlackIntegrationLinkIdentityTest(TestCase):
     @responses.activate
     @patch('sentry.integrations.slack.link_identity.unsign')
     def test_overwrites_existing_identities(self, unsign):
-        existing_id1 = Identity.objects.create(
+        Identity.objects.create(
             user=self.user1,
             idp=self.idp,
             external_id='slack-id1',
             status=IdentityStatus.VALID,
         )
-        existing_id2 = Identity.objects.create(
+        Identity.objects.create(
             user=self.user2,
             idp=self.idp,
             external_id='slack-id2',
@@ -123,10 +123,6 @@ class SlackIntegrationLinkIdentityTest(TestCase):
 
         self.client.post(linking_url)
 
-        assert Identity.objects.filter(
-            id=existing_id1.id,
-            external_id='slack-id2',
-            user=self.user1,
-        ).exists()
-
-        assert not Identity.objects.filter(id=existing_id2.id).exists()
+        Identity.objects.get(external_id='slack-id2', user=self.user1)
+        assert not Identity.objects.filter(external_id='slack-id1', user=self.user1).exists()
+        assert not Identity.objects.filter(external_id='slack-id2', user=self.user2).exists()


### PR DESCRIPTION
When a user sets up an integration, if their identity is linked to a different user or user is linked to a different identity, we delete those before creating a new link. Now that we're using identity for login, we restrict this deletion to users that have a password so that they don't get locked out if we delete an identity they use for login.