### PR TITLE
fix(ui): pill descenders should not be clipped

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1608,7 +1608,6 @@ ul.faces {
       max-width: 100%;
       .truncate;
       display: inline-block;
-      line-height: 1;
       vertical-align: text-bottom;
     }
 
@@ -1618,6 +1617,7 @@ ul.faces {
       display: inline;
       margin: 0 0 0 8px;
       color: @gray-light;
+      line-height: 1.2;
 
       &:hover {
         color: @gray;


### PR DESCRIPTION
Fixes a small issue where pill text was getting clipped by a short line-height:

Before: 

<img width="300" alt="screen shot 2018-06-27 at 2 59 15 pm" src="https://user-images.githubusercontent.com/30713/42002040-bacde4a0-7a1a-11e8-95f9-c65a02d96cfd.png">

After:

<img width="300" alt="screen shot 2018-06-27 at 2 57 05 pm" src="https://user-images.githubusercontent.com/30713/42002059-c8023db0-7a1a-11e8-9a0c-953cdb4820e5.png">

cc @mattrobenolt 