### PR TITLE
chore: Add odds and ends to jest ReactRouter

### DIFF
--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -19,7 +19,11 @@ jest.mock('scroll-to-element', () => {});
 jest.mock('react-router', () => {
   const ReactRouter = require.requireActual('react-router');
   return {
+    IndexRedirect: ReactRouter.IndexRedirect,
+    IndexRoute: ReactRouter.IndexRoute,
     Link: ReactRouter.Link,
+    Redirect: ReactRouter.Redirect,
+    Route: ReactRouter.Route,
     withRouter: ReactRouter.withRouter,
     browserHistory: {
       push: jest.fn(),


### PR DESCRIPTION
This makes extra bits of `ReactRouter` available to Jest which are needed in `getsentry`.