### PR TITLE
feat(integrations): Prep for login-with-VSTS

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -169,7 +169,6 @@ class VstsIntegrationProvider(IntegrationProvider):
             'external_id': account['AccountId'],
             'metadata': {
                 'domain_name': instance,
-                'scopes': scopes,
             },
             'user_identity': {
                 'type': 'vsts',

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -1,14 +1,18 @@
 from __future__ import absolute_import
 from time import time
 
+from django import forms
 from django.utils.translation import ugettext as _
 
+from sentry import http
 from sentry.integrations import Integration, IntegrationFeatures, IntegrationProvider, IntegrationMetadata
 from sentry.integrations.exceptions import ApiError
 from sentry.integrations.vsts.issues import VstsIssueSync
 from sentry.pipeline import NestedPipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
-from sentry.identity.vsts import VSTSIdentityProvider
+from sentry.identity.vsts import VSTSIdentityProvider, get_user_info
+from sentry.pipeline import PipelineView
+from sentry.web.helpers import render_to_response
 from sentry.utils.http import absolute_uri
 from .client import VstsApiClient
 from .repository import VstsRepositoryProvider
@@ -150,14 +154,16 @@ class VstsIntegrationProvider(IntegrationProvider):
 
         return [
             identity_pipeline_view,
+            AccountConfigView(),
         ]
 
     def build_integration(self, state):
         data = state['identity']['data']
-        account = state['identity']['account']
-        instance = state['identity']['instance']
-
+        account = state['account']
+        instance = state['instance']
+        user = get_user_info(data['access_token'])
         scopes = sorted(VSTSIdentityProvider.oauth_scopes)
+
         return {
             'name': account['AccountName'],
             'external_id': account['AccountId'],
@@ -165,11 +171,10 @@ class VstsIntegrationProvider(IntegrationProvider):
                 'domain_name': instance,
                 'scopes': scopes,
             },
-            # TODO(LB): Change this to a Microsoft account as opposed to a VSTS workspace
             'user_identity': {
                 'type': 'vsts',
-                'external_id': account['AccountId'],
-                'scopes': [],
+                'external_id': user['id'],
+                'scopes': scopes,
                 'data': self.get_oauth_data(data),
             },
         }
@@ -192,4 +197,58 @@ class VstsIntegrationProvider(IntegrationProvider):
             'integration-repository.provider',
             VstsRepositoryProvider,
             id='integrations:vsts',
+        )
+
+
+class AccountConfigView(PipelineView):
+    def dispatch(self, request, pipeline):
+        if 'account' in request.POST:
+            account_id = request.POST.get('account')
+            accounts = pipeline.fetch_state(key='accounts')
+            account = self.get_account_from_id(account_id, accounts)
+            if account is not None:
+                pipeline.bind_state('account', account)
+                pipeline.bind_state('instance', account['AccountName'] + '.visualstudio.com')
+                return pipeline.next_step()
+
+        access_token = pipeline.fetch_state(key='data')['access_token']
+        accounts = self.get_accounts(access_token)
+        pipeline.bind_state('accounts', accounts)
+        account_form = AccountForm(accounts)
+        return render_to_response(
+            template='sentry/integrations/vsts-config.html',
+            context={
+                'form': account_form,
+            },
+            request=request,
+        )
+
+    def get_account_from_id(self, account_id, accounts):
+        for account in accounts:
+            if account['AccountId'] == account_id:
+                return account
+        return None
+
+    def get_accounts(self, access_token):
+        session = http.build_session()
+        url = 'https://app.vssps.visualstudio.com/_apis/accounts'
+        response = session.get(
+            url,
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer %s' % access_token,
+            },
+        )
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+
+class AccountForm(forms.Form):
+    def __init__(self, accounts, *args, **kwargs):
+        super(AccountForm, self).__init__(*args, **kwargs)
+        self.fields['account'] = forms.ChoiceField(
+            choices=[(acct['AccountId'], acct['AccountName']) for acct in accounts],
+            label='Account',
+            help_text='VS Team Services account (account.visualstudio.com).',
         )

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -40,7 +40,6 @@ class VstsIntegrationProviderTest(TestCase):
         integration_dict = self.integration.build_integration(state)
         assert integration_dict['name'] == 'sentry'
         assert integration_dict['external_id'] == '123435'
-        assert integration_dict['metadata']['scopes'] == sorted(VSTSIdentityProvider.oauth_scopes)
         assert integration_dict['metadata']['domain_name'] == 'sentry.visualstudio.com'
 
         assert integration_dict['user_identity']['type'] == 'vsts'

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 from mock import Mock
 import responses
 from django.http import HttpRequest
-from sentry.identity.vsts.provider import VSTSOAuth2CallbackView, AccountConfigView, AccountForm, VSTSIdentityProvider
+from sentry.identity.vsts.provider import VSTSOAuth2CallbackView, VSTSIdentityProvider
+from sentry.integrations.vsts.integration import AccountConfigView, AccountForm
 from sentry.testutils import TestCase
 from six.moves.urllib.parse import parse_qs
 from sentry.utils.http import absolute_uri


### PR DESCRIPTION
- Sets the identity's external id to the user ID
- Moves AccountConfigView() from the identity pipeline into the integrations pipeline
- Adds a build_identity method that will be used by the login flow