### PR TITLE
fix(ui): Hide organization switcher in single org mode

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -119,9 +119,10 @@ class SidebarDropdown extends React.Component {
                         </SidebarMenuItem>
                       )}
 
-                      <SidebarMenuItem>
-                        <SwitchOrganization canCreateOrganization={hasOrgWrite} />
-                      </SidebarMenuItem>
+                      {!config.singleOrganization &&
+                        <SidebarMenuItem>
+                          <SwitchOrganization canCreateOrganization={hasOrgWrite} />
+                        </SidebarMenuItem>}
 
                       <Divider />
                     </React.Fragment>


### PR DESCRIPTION
Fixes getsentry/onpremise#103