### PR TITLE
feat(integrations):  Introduce domain logic for SentryApp[Installation]s

### DIFF
--- a/src/sentry/mediators/__init__.py
+++ b/src/sentry/mediators/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import
+
+from .mediator import Mediator  # NOQA
+from .param import Param  # NOQA
+from .sentry_apps import *  # NOQA
+from .sentry_app_installations import *  # NOQA

--- a/src/sentry/mediators/mediator.py
+++ b/src/sentry/mediators/mediator.py
@@ -1,0 +1,226 @@
+from __future__ import absolute_import
+
+import datetime
+import logging
+import six
+import sentry
+
+from contextlib import contextmanager
+from django.db import transaction
+
+from sentry.utils.cache import memoize
+from .param import Param
+
+
+class Mediator(object):
+    """
+    Objects that encapsulte domain logic.
+
+    Mediators provide a layer between User accessible components like Endpoints
+    and the database. They encapsulate the logic necessary to create domain
+    objects, including all dependant objects, cross-object validations, etc.
+
+    Mediators are intended to be composable and make it obvious where a piece
+    of domain logic resides.
+
+    Invocation:
+        Invoke Mediators through their ``run`` class method. This essentially
+        just wraps ``__init__(**kwargs).call()`` with some useful stuff,
+        namely a DB transaction.
+
+        >>> Mediator.run(**kwargs)
+
+    Declaration:
+        Mediators should define two things - a set of ``Param``s and a ``call``
+        function.
+
+        >>> class Creator(Mediator):
+        >>>     name = Param(six.binary_type)
+        >>>
+        >>>     def call(self):
+        >>>         with self.log():
+        >>>             Thing.objects.create(name=self.name)
+        >>>
+        >>> Creator.run(name='thing')
+        >>>
+
+    Transactions
+        Mediators are automatically wrapped in a transaction. As long as you
+        invoke them via their ``run`` class method, you don't need to worry
+        about declaring one yourself.
+
+    Naming & Organization Conventions
+        Mediators are organized by domain object and describe some domain
+        process relevant to that object. For example:
+
+            sentry.mediators.sentry_apps.Creator
+            sentry.mediators.sentry_apps.Deactivator
+
+    Params:
+        Mediators declare the params they need similarly to Models. On
+        instantiation, the Mediator will validate using the ``**kwargs``
+        passed in.
+
+        >>> from sentry.mediators import Mediator, Param
+        >>>
+        >>> class Creator(Mediator):
+        >>>     name = Param(six.binary_type, default='example')
+        >>>     user = Param('sentry.models.user.User', none=True)
+
+        See ``sentry.mediators.param`` for more in-depth docs.
+
+    Interface:
+        Mediators have two main functions you should be aware of.
+
+        ``run``:
+            Convenience function for ``__init__(**kwargs).call()``
+
+        ``call``:
+            Instance method where you should implement your logic.
+
+        >>> class Creator(Mediator):
+        >>>     name = Param(six.binary_type, default='example')
+        >>>
+        >>>     def call(self):
+        >>>         Thing.objects.create(name=self.name)
+
+    Logging:
+        Mediators have a ``log`` function available to them that will write to
+        a logger with a standardized name. The name will be the full module
+        path and class of the Mediator.
+
+        When invoked via ``run``, the Mediator will automaticallyt log the
+        start and end of its run.
+
+        >>> class Creator(Mediator):
+        >>>     def call(self):
+        >>>         self.log(at='step')
+        >>>
+        >>> Creator.run()
+        18:14:26 [INFO] sentry.mediators.sentry_apps.creator.Creator:  (at=u'step')  # NOQA
+
+    Measuring:
+        Mediators will automatically log the start and finish time of
+        execution. If it ends via an Exception, it will log that instead of the
+        finish time.
+
+        The exception logging it just meant to augment what you get in Sentry
+        itself, not replace anything about it. It's sometimes useful to see the
+        progression of a request through many Mediators.
+
+        You can manually use ``log`` to either write a set of attributes to
+        stdout
+
+        >>> self.log(at='a-special-step')
+        18:14:26 [INFO] sentry.mediators.things.creator.Creator:  (at=u'a-special-step')  # NOQA
+
+        or as a generator do log the start and finish of a block of
+        code.
+
+        >>> with self.log():
+        >>>     do_a_thing()
+        18:14:26 [INFO] sentry.mediators.things.creator.Creator:  (at=u'start')  # NOQA
+        18:14:27 [INFO] sentry.mediators.things.creator.Creator:  (at=u'finish', elapsed=1634)  # NOQA
+    """
+
+    # Have we processed the Param declarations yet. Should happen once per
+    # class.
+    _params_prepared = False
+
+    def __new__(cls, *args, **kwargs):
+        """
+        When the Mediator type is created, we turn all of it's Param
+        declarations into actual properties.
+        """
+        if (
+            sentry.mediators.mediator.Mediator in cls.__bases__
+            and not cls._params_prepared
+        ):
+            cls._prepare_params()
+            cls._params_prepared = True
+
+        return super(Mediator, cls).__new__(cls, *args, **kwargs)
+
+    @classmethod
+    def _prepare_params(cls):
+        params = [
+            (k, v) for k, v in six.iteritems(cls.__dict__)
+            if isinstance(v, Param)
+        ]
+
+        for name, param in params:
+            param.setup(cls, name)
+
+    @classmethod
+    @transaction.atomic
+    def run(cls, *args, **kwargs):
+        obj = cls(*args, **kwargs)
+
+        with obj.log():
+            return obj.call()
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        self.logger = kwargs.get('logger',
+                                 logging.getLogger(self._logging_name))
+        self._validate_params(**kwargs)
+
+    def call(self):
+        raise NotImplementedError
+
+    def log(self, **kwargs):
+        if any(kwargs):
+            self.logger.info(None, extra=kwargs)
+        else:
+            return self._measured(self)
+
+    def _validate_params(self, **kwargs):
+        for name, param in six.iteritems(self._params):
+            if param.is_required:
+                param.validate(self, name, self.__getattr__(name))
+
+    def __getattr__(self, key):
+        if key in self.kwargs:
+            return self.kwargs.get(key)
+
+        param = self._params.get(key)
+
+        if param and param.has_default:
+            return param.default(self)
+
+        return self.__getattribute__(key)
+
+    @property
+    def _params(self):
+        # These will be named ``_<name>`` on the class, so remove the ``_`` so
+        # that it matches the name we'll be invoking on the Mediator instance.
+        return dict(
+            (k[1:], v) for k, v in six.iteritems(self.__class__.__dict__)
+            if isinstance(v, Param)
+        )
+
+    @memoize
+    def _logging_name(self):
+        return '.'.join([
+            self.__class__.__module__,
+            self.__class__.__name__
+        ])
+
+    @contextmanager
+    def _measured(self, context):
+        start = datetime.datetime.now()
+        context.log(at='start')
+
+        try:
+            yield
+        except Exception as e:
+            context.log(at='exception',
+                        elapsed=self._milliseconds_since(start))
+            raise e
+
+        context.log(at='finish', elapsed=self._milliseconds_since(start))
+
+    def _milliseconds_since(self, start):
+        now = datetime.datetime.now()
+        elapsed = now - start
+        return (elapsed.seconds * 1000) + (elapsed.microseconds / 1000)

--- a/src/sentry/mediators/param.py
+++ b/src/sentry/mediators/param.py
@@ -1,0 +1,154 @@
+from __future__ import absolute_import
+
+import six
+import types
+
+from sentry.utils.cache import memoize
+
+
+class Param(object):
+    """
+    Argument declarations for Mediators.
+
+    Params offer a way to validate the arguments passed to a Mediator as well
+    as set defaults.
+
+    Example Usage:
+        >>> class Creator(Mediator):
+        >>>     name = Param(six.binary_type, default='example')
+        >>>
+        >>> c = Creator(name='foo')
+        >>> c.name
+        'foo'
+
+        >>> c = Creator()
+        >>> c.name
+        'example'
+
+        >>> c = Creator(name=False)
+        Traceback (most recent call last):
+            ...
+        TypeError: `name` must be a <type 'six.binary_type'>
+
+    Type Validation:
+        When a Mediator is instantiated, it validates each of it's Params. This
+        mainly checks that the type of object passed in matches what we
+        expected.
+
+        >>> class Creator(Mediator):
+        >>>     name = Param(six.binary_type)
+        >>>
+        >>> c = Creator(name=False)
+        Traceback (most recent call last):
+            ...
+        TypeError: `name` must be a <type 'six.binary_type'>
+
+    Presence Validation:
+        Without specifying otherwise, Params are assumed to be required. If
+        it's okay for specific param to be None or not passed at all, you can
+        do so by declaring ``required=False``.
+
+        >>> class Creator(Mediator):
+        >>>     size = Param(int, required=False)
+        >>>
+        >>> c = Creator()
+        >>> c.size
+        None
+
+    Default Value:
+        You can set a default value using the ``default`` argument. Default
+        values can be static ones like an int, string, etc. that get evaluated
+        at import. Or they can be a ``lambda`` that gets evaluated when the
+        Mediator is instantiated.
+
+        Declaration order DOES matter.
+
+        >>> class Creator(Mediator):
+        >>>     name = Param(six.binary_type, default='Pete')
+        >>>
+        >>> c = Creator()
+        >>> c.name
+        'Pete'
+
+        >>> class Creator(Mediator):
+        >>>     user = Param(dict)
+        >>>     name = Param(six.binary_type, default=lambda self: self.user['name'])
+    """
+
+    def __init__(self, type, **kwargs):
+        self.type = type
+        self.kwargs = kwargs
+
+    def setup(self, target, name):
+        delattr(target, name)
+        setattr(target, '_{}'.format(name), self)
+
+    def validate(self, target, name, value):
+        """
+        Ensure the value evaluated is present (when required) and of the
+        correct type.
+        """
+        if value is None:
+            value = self.default(target)
+
+        if self._missing_value(value):
+            raise AttributeError('Missing required param: `{}`'.format(name))
+
+        if self.is_required and not self._type_match(value):
+            raise TypeError('`{}` must be a {}, received {}'.format(
+                name, self.type, self._value_type(value)))
+
+        return True
+
+    def default(self, target):
+        """
+        Evaluated default value, when given.
+        """
+        default = value = self.kwargs.get('default')
+
+        if self.is_lambda_default:
+            value = default(target)
+
+        return value
+
+    @memoize
+    def has_default(self):
+        return 'default' in self.kwargs
+
+    @memoize
+    def is_lambda_default(self):
+        return isinstance(self.kwargs.get('default'), types.LambdaType)
+
+    @memoize
+    def is_required(self):
+        if self.kwargs.get('required') is False:
+            return False
+        return True
+
+    def _type_match(self, value):
+        if isinstance(self.type, six.string_types):
+            return self._value_type(value) == self.type
+
+        return isinstance(value, self.type)
+
+    def _value_type(self, value):
+        module = type(value).__module__
+        klass = type(value).__name__
+
+        if module == '__builtin__':
+            return klass
+
+        return '.'.join([module, klass])
+
+    def _missing_value(self, value):
+        return self.is_required and value is None and not self.has_default
+
+
+def if_param(name):
+    def _if_param(func):
+        def wrapper(self, *args):
+            if not hasattr(self, name) or getattr(self, name) is None:
+                return
+            return func(self, *args)
+        return wrapper
+    return _if_param

--- a/src/sentry/mediators/sentry_app_installations/__init__.py
+++ b/src/sentry/mediators/sentry_app_installations/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+from .creator import Creator  # NOQA
+from .destroyer import Destroyer  # NOQA

--- a/src/sentry/mediators/sentry_app_installations/creator.py
+++ b/src/sentry/mediators/sentry_app_installations/creator.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.mediators import Mediator, Param
+from sentry.models import (
+    ApiAuthorization, ApiGrant, SentryApp, SentryAppInstallation
+)
+from sentry.utils.cache import memoize
+
+
+class Creator(Mediator):
+    organization = Param('sentry.models.organization.Organization')
+    slug = Param(six.string_types)
+
+    def call(self):
+        self._create_authorization()
+        self._create_api_grant()
+        self._create_install()
+        return (self.install, self.api_grant)
+
+    def _create_authorization(self):
+        self.authorization = ApiAuthorization.objects.create(
+            application=self.api_application,
+            user=self.sentry_app.proxy_user,
+            scope_list=self.sentry_app.scope_list,
+        )
+
+    def _create_install(self):
+        self.install = SentryAppInstallation.objects.create(
+            organization=self.organization,
+            sentry_app=self.sentry_app,
+            authorization=self.authorization,
+            api_grant=self.api_grant,
+        )
+
+    def _create_api_grant(self):
+        self.api_grant = ApiGrant.objects.create(
+            user=self.sentry_app.proxy_user,
+            application=self.api_application,
+        )
+
+    @memoize
+    def api_application(self):
+        return self.sentry_app.application
+
+    @memoize
+    def sentry_app(self):
+        return SentryApp.objects.get(slug=self.slug)

--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from sentry.mediators import Mediator, Param
+
+
+class Destroyer(Mediator):
+    install = Param(
+        'sentry.models.sentryappinstallation.SentryAppInstallation'
+    )
+
+    def call(self):
+        self._destroy_authorization()
+        self._destroy_grant()
+        self._destroy_installation()
+        return self.install
+
+    def _destroy_authorization(self):
+        self.install.authorization.delete()
+
+    def _destroy_grant(self):
+        self.install.api_grant.delete()
+
+    def _destroy_installation(self):
+        self.install.delete()

--- a/src/sentry/mediators/sentry_apps/__init__.py
+++ b/src/sentry/mediators/sentry_apps/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+from .creator import Creator  # NOQA
+from .updater import Updater  # NOQA

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import Iterable
+
+from sentry.mediators import Mediator, Param
+from sentry.models import (ApiApplication, SentryApp, User)
+
+
+class Creator(Mediator):
+    name = Param(six.string_types)
+    user = Param('sentry.models.user.User')
+    scopes = Param(Iterable)
+    webhook_url = Param(six.string_types)
+
+    def call(self):
+        self.proxy = self._create_proxy_user()
+        self.api_app = self._create_api_application()
+        self.app = self._create_sentry_app()
+        return self.app
+
+    def _create_proxy_user(self):
+        return User.objects.create(
+            username=self.name.lower(),
+            is_sentry_app=True,
+        )
+
+    def _create_api_application(self):
+        return ApiApplication.objects.create(
+            owner=self.proxy,
+        )
+
+    def _create_sentry_app(self):
+        return SentryApp.objects.create(
+            name=self.name,
+            application=self.api_app,
+            owner=self.user,
+            proxy_user=self.proxy,
+            scope_list=self.scopes,
+            webhook_url=self.webhook_url,
+        )

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import Iterable
+from rest_framework.serializers import ValidationError
+
+from sentry.mediators import Mediator, Param
+from sentry.mediators.param import if_param
+
+
+class Updater(Mediator):
+    sentry_app = Param('sentry.models.sentryapp.SentryApp')
+    name = Param(six.string_types, required=False)
+    scopes = Param(Iterable, required=False)
+    webhook_url = Param(six.string_types, required=False)
+
+    def call(self):
+        self._update_name()
+        self._update_scopes()
+        self._update_webhook_url()
+        self.sentry_app.save()
+        return self.sentry_app
+
+    @if_param('name')
+    def _update_name(self):
+        self.sentry_app.name = self.name
+
+    @if_param('scopes')
+    def _update_scopes(self):
+        self._validate_only_added_scopes()
+        self.sentry_app.scope_list = self.scopes
+
+    @if_param('webhook_url')
+    def _update_webhook_url(self):
+        self.sentry_app.webhook_url = self.webhook_url
+
+    def _validate_only_added_scopes(self):
+        if any(self._scopes_removed):
+            raise ValidationError('Cannot remove `scopes` already in use.')
+
+    @property
+    def _scopes_removed(self):
+        return [s for s in self.sentry_app.scope_list if s not in self.scopes]

--- a/src/sentry/models/apiscopes.py
+++ b/src/sentry/models/apiscopes.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 
+import six
+
+from bitfield import BitField
 from collections import Sequence
+from django.db import models
+
+from sentry.db.models import ArrayField
 
 
 class ApiScopes(Sequence):
@@ -53,3 +59,26 @@ class ApiScopes(Sequence):
 
     def __repr__(self):
         return self.scopes.__repr__()
+
+
+class HasApiScopes(models.Model):
+    """
+    Mixin for models that hold a list of OAuth Scopes.
+    """
+
+    class Meta:
+        abstract = True
+
+    # List of scopes in bit form
+    scopes = BitField(flags=ApiScopes().to_bitfield())
+
+    # Human readable list of scopes
+    scope_list = ArrayField(of=models.TextField)
+
+    def get_scopes(self):
+        if self.scope_list:
+            return self.scope_list
+        return [k for k, v in six.iteritems(self.scopes) if v]
+
+    def has_scope(self, scope):
+        return scope in self.get_scopes()

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -3,16 +3,15 @@ from __future__ import absolute_import
 import six
 import uuid
 
-from bitfield import BitField
 from django.db import models
 from django.utils import timezone
 from django.template.defaultfilters import slugify
 
-from sentry.db.models import (ArrayField, FlexibleForeignKey, ParanoidModel)
-from sentry.models import ApiScopes
+from sentry.db.models import FlexibleForeignKey, ParanoidModel
+from sentry.models.apiscopes import HasApiScopes
 
 
-class SentryApp(ParanoidModel):
+class SentryApp(ParanoidModel, HasApiScopes):
     __core__ = True
 
     application = models.OneToOneField('sentry.ApiApplication',
@@ -27,10 +26,6 @@ class SentryApp(ParanoidModel):
     # determine who can manage the SentryApp itself.
     owner = FlexibleForeignKey('sentry.User',
                                related_name='owned_sentry_apps')
-
-    # The set of OAuth scopes necessary for this integration to function.
-    scopes = BitField(flags=ApiScopes().to_bitfield())
-    scope_list = ArrayField(of=models.TextField())
 
     name = models.TextField()
     slug = models.CharField(max_length=64, unique=True)

--- a/tests/sentry/mediators/__init__.py
+++ b/tests/sentry/mediators/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/mediators/sentry_app_installations/__init__.py
+++ b/tests/sentry/mediators/sentry_app_installations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator
+from sentry.models import ApiAuthorization
+from sentry.testutils import TestCase
+
+
+class TestCreator(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization()
+
+        self.sentry_app = SentryAppCreator.run(
+            name='nulldb',
+            user=self.user,
+            scopes=('project:read',),
+            webhook_url='http://example.com',
+        )
+
+        self.creator = Creator(organization=self.org, slug='nulldb')
+
+    def test_creates_api_authorization(self):
+        install, grant = self.creator.call()
+
+        assert ApiAuthorization.objects.get(
+            application=self.sentry_app.application,
+            user=self.sentry_app.proxy_user,
+            scopes=self.sentry_app.scopes,
+        )
+
+    def test_creates_installation(self):
+        install, grant = self.creator.call()
+        assert install.pk
+
+    def test_creates_api_grant(self):
+        install, grant = self.creator.call()
+        assert grant.pk
+
+    def test_associations(self):
+        install, grant = self.creator.call()
+
+        assert install.api_grant == grant
+        assert install.authorization is not None

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from django.db import connection
+
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator, Destroyer
+from sentry.models import ApiAuthorization, ApiGrant, SentryAppInstallation
+from sentry.testutils import TestCase
+
+
+class TestDestroyer(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization()
+
+        self.sentry_app = SentryAppCreator.run(
+            name='nulldb',
+            user=self.user,
+            scopes=('project:read',),
+            webhook_url='https://example.com',
+        )
+
+        self.install, self.grant = Creator.run(
+            organization=self.org,
+            slug='nulldb',
+        )
+
+        self.destroyer = Destroyer(install=self.install)
+
+    def test_deletes_authorization(self):
+        auth = self.install.authorization
+
+        self.destroyer.call()
+
+        assert not ApiAuthorization.objects.filter(pk=auth.id).exists()
+
+    def test_deletes_grant(self):
+        grant = self.install.api_grant
+
+        self.destroyer.call()
+
+        assert not ApiGrant.objects.filter(pk=grant.id).exists()
+
+    def test_soft_deletes_installation(self):
+        self.destroyer.call()
+
+        with self.assertRaises(SentryAppInstallation.DoesNotExist):
+            SentryAppInstallation.objects.get(pk=self.install.id)
+
+        # The QuerySet will automatically NOT include deleted installs, so we
+        # use a raw sql query to ensure it still exists.
+        c = connection.cursor()
+        c.execute(
+            'SELECT COUNT(1) '
+            'FROM sentry_sentryappinstallation '
+            'WHERE id = %s AND date_deleted IS NOT NULL',
+            [self.install.id])
+
+        assert c.fetchone()[0] == 1

--- a/tests/sentry/mediators/sentry_apps/__init__.py
+++ b/tests/sentry/mediators/sentry_apps/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+from sentry.mediators.sentry_apps import Creator
+from sentry.models import ApiApplication, SentryApp, User
+from sentry.testutils import TestCase
+
+
+class TestCreator(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.creator = Creator(name='nulldb',
+                               user=self.user,
+                               scopes=('project:read',),
+                               webhook_url='http://example.com')
+
+    def test_creates_proxy_user(self):
+        self.creator.call()
+
+        assert User.objects.get(
+            username='nulldb',
+            is_sentry_app=True,
+        )
+
+    def test_creates_api_application(self):
+        self.creator.call()
+        proxy = User.objects.get(username='nulldb')
+
+        assert ApiApplication.objects.get(owner=proxy)
+
+    def test_creates_sentry_app(self):
+        self.creator.call()
+
+        proxy = User.objects.get(username='nulldb')
+        app = ApiApplication.objects.get(owner=proxy)
+
+        sentry_app = SentryApp.objects.get(
+            name='nulldb',
+            application=app,
+            owner=self.user,
+            proxy_user=proxy,
+        )
+
+        assert sentry_app
+        assert sentry_app.scope_list == ['project:read']

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+from rest_framework.serializers import ValidationError
+
+from sentry.mediators.sentry_apps import Creator, Updater
+from sentry.testutils import TestCase
+
+
+class TestUpdater(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.sentry_app = Creator.run(
+            name='nulldb',
+            user=self.user,
+            scopes=('project:read',),
+            webhook_url='http://example.com',
+        )
+
+        self.updater = Updater(sentry_app=self.sentry_app)
+
+    def test_updates_name(self):
+        self.updater.name = 'A New Thing'
+        self.updater.call()
+        assert self.sentry_app.name == 'A New Thing'
+
+    def test_updates_scopes(self):
+        self.updater.scopes = ('project:read', 'project:write', )
+        self.updater.call()
+        assert self.sentry_app.get_scopes() == \
+            ['project:read', 'project:write']
+
+    def test_rejects_scope_subtractions(self):
+        self.updater.scopes = (None, )
+
+        with self.assertRaises(ValidationError):
+            self.updater.call()
+
+    def test_updates_webhook_url(self):
+        self.updater.webhook_url = 'http://example.com/hooks'
+        self.updater.call()
+        assert self.sentry_app.webhook_url == 'http://example.com/hooks'

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import
+
+import logging
+import six
+import types
+
+from mock import patch
+
+from sentry.mediators import Mediator, Param
+from sentry.models import User
+from sentry.testutils import TestCase
+
+
+class MockMediator(Mediator):
+    user = Param(dict)
+    name = Param(six.string_types, default=lambda self: self.user['name'])
+    age = Param(int, required=False)
+
+    def call(self):
+        with self.log():
+            pass
+
+
+class TestMediator(TestCase):
+    def setUp(self):
+        super(TestCase, self).setUp()
+
+        self.logger = logging.getLogger('test-mediator')
+        self.mediator = MockMediator(
+            user={'name': 'Example'},
+            age=30,
+            logger=self.logger,
+        )
+
+    def test_must_implement_call(self):
+        del MockMediator.call
+
+        with self.assertRaises(NotImplementedError):
+            MockMediator.run(user={'name': 'Example'})
+
+    def test_validate_params(self):
+        with self.assertRaises(TypeError):
+            MockMediator.run(user=False)
+
+    def test_param_access(self):
+        assert self.mediator.user == {'name': 'Example'}
+        assert self.mediator.age == 30
+
+    def test_param_default_access(self):
+        assert self.mediator.name == 'Example'
+
+    def test_log(self):
+        with patch.object(self.logger, 'info') as mock:
+            self.mediator.log(at='test')
+
+        mock.assert_called_with(None, extra={'at': 'test'})
+
+    def test_log_start(self):
+        with patch.object(self.logger, 'info') as mock:
+            self.mediator.call()
+
+        mock.assert_any_call(None, extra={'at': 'start'})
+
+    def test_log_finish(self):
+        with patch.object(self.logger, 'info') as mock:
+            self.mediator.call()
+
+        mock.assert_any_call(None, extra={'at': 'finish', 'elapsed': 0})
+
+    def test_log_exception(self):
+        def call(self):
+            with self.log():
+                raise TypeError
+
+        setattr(self.mediator, 'call', types.MethodType(call, self.mediator))
+
+        with patch.object(self.logger, 'info') as mock:
+            try:
+                self.mediator.call()
+            except Exception:
+                pass
+
+        mock.assert_called_with(None, extra={'at': 'exception', 'elapsed': 0})
+
+    def test_automatic_transaction(self):
+        class TransactionMediator(Mediator):
+            def call(self):
+                User.objects.create(username='beep')
+                raise Exception
+
+        with self.assertRaises(Exception):
+            TransactionMediator.run()
+
+        assert not User.objects.filter(username='beep').exists()

--- a/tests/sentry/mediators/test_param.py
+++ b/tests/sentry/mediators/test_param.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.mediators import Param
+from sentry.models import User
+from sentry.testutils import TestCase
+
+
+class TestParam(TestCase):
+    def test_validate_type(self):
+        name = Param(six.string_types)
+
+        with self.assertRaises(TypeError):
+            name.validate(None, 'name', 1)
+
+    def test_validate_required(self):
+        name = Param(six.string_types)
+
+        with self.assertRaises(AttributeError):
+            name.validate(None, 'name', None)
+
+    def test_validate_default_type(self):
+        name = Param(six.string_types, default=1)
+
+        with self.assertRaises(TypeError):
+            name.validate(None, 'name', None)
+
+    def test_validate_user_defined_type(self):
+        user = Param('sentry.models.user.User')
+        assert user.validate(None, 'user', User())
+
+    def test_setup(self):
+        class Target(object):
+            name = 1
+
+        name = Param(six.string_types)
+        name.setup(Target, 'name')
+
+        assert not hasattr(Target, 'name')
+        assert hasattr(Target, '_name')
+        assert Target._name == name
+
+    def test_default(self):
+        name = Param(six.string_types, default='Pete')
+        assert name.default(None) == 'Pete'
+
+    def test_lambda_default(self):
+        _name = 'Steve'
+        name = Param(six.string_types, default=lambda self: _name)
+        assert name.default(None) == 'Steve'
+
+    def test_default_referencing_instance(self):
+        class Target(object):
+            user = {'name': 'Pete'}
+
+        target = Target()
+        name = Param(six.string_types, default=lambda self: self.user['name'])
+        assert name.default(target) == 'Pete'


### PR DESCRIPTION
Introduces logic to create, destroy, and update `SentryApp` and `SentryAppInstallation` objects (as well as the underlying code to support that).

## Mediators

The above is done through objects called Mediators. They're meant to be the layer between User-facing components (like endpoints) and the storage layer (the DB). They're meant to be composable. They provide a canonical place to look for domain logic related to the base primitives/models.

Mediators share a consistent interface, so using them becomes obvious and unsurprising. They also provide a place to encapsulate common things like transactions, logging, etc. You can don't have to care about that stuff when writing one – the base class does the right thing by default.

### Params

Mediators declare a set of `Param`s. These define the `**kwargs` the mediator expects to receive on instantiation. They work much like Model fields.

The allow us to do some simple input validation, set default values, and see what a process requires, at a glance.

### Example

```python
class Creator(Mediator):
    name = Param(six.binary_type)
    identity = Param('models.Identity')

    def call(self):
        user = User.objects.create(name=self.name)
        user.set_identity(self.identity)
        return user
```

I like this pattern a lot, personally, but I'm not tied to it if it doesn't fit into our broader ideas for this codebase. Feedback more than welcome.