### PR TITLE
fix(environments): Do not strip environment from query if feature is off

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -200,9 +200,14 @@ const Stream = createReactClass({
             }
 
             newState.searchId = defaultResult.id;
-            newState.query = queryString.getQueryStringWithoutEnvironment(
-              defaultResult.query
-            );
+
+            if (this.getFeatures().has('environments')) {
+              newState.query = queryString.getQueryStringWithoutEnvironment(
+                defaultResult.query
+              );
+            } else {
+              newState.query = defaultResult.query;
+            }
             newState.isDefaultSearch = true;
           }
         }


### PR DESCRIPTION
Do not strip the environment from the default saved search if the environment feature is turned off

Fixes ISSUE-53