### PR TITLE
feat: Add EventStream service abstraction

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -255,6 +255,7 @@ INSTALLED_APPS = (
     'sentry.lang.javascript', 'sentry.lang.native', 'sentry.plugins.sentry_interface_types',
     'sentry.plugins.sentry_mail', 'sentry.plugins.sentry_urls', 'sentry.plugins.sentry_useragents',
     'sentry.plugins.sentry_webhooks', 'social_auth', 'sudo', 'sentry.tagstore',
+    'sentry.eventstream',
 )
 
 import django
@@ -984,6 +985,9 @@ SENTRY_TSDB_OPTIONS = {}
 
 SENTRY_NEWSLETTER = 'sentry.newsletter.base.Newsletter'
 SENTRY_NEWSLETTER_OPTIONS = {}
+
+SENTRY_EVENTSTREAM = 'sentry.eventstream.base.EventStream'
+SENTRY_EVENTSTREAM_OPTIONS = {}
 
 # rollups must be ordered from highest granularity to lowest
 SENTRY_TSDB_ROLLUPS = (

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -931,17 +931,21 @@ class EventManager(object):
                 project.update(first_event=date)
                 first_event_received.send(project=project, group=group, sender=Project)
 
-            eventstream.publish(
-                group=group,
-                event=event,
-                is_new=is_new,
-                is_sample=is_sample,
-                is_regression=is_regression,
-                is_new_group_environment=is_new_group_environment,
-                primary_hash=hashes[0],
-            )
-        else:
-            self.logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
+        eventstream.publish(
+            group=group,
+            event=event,
+            is_new=is_new,
+            is_sample=is_sample,
+            is_regression=is_regression,
+            is_new_group_environment=is_new_group_environment,
+            primary_hash=hashes[0],
+            # We are choosing to skip consuming the event back
+            # in the eventstream if it's flagged as raw.
+            # This means that we want to publish the event
+            # through the event stream, but we don't care
+            # about post processing and handling the commit.
+            skip_consume=raw,
+        )
 
         metrics.timing(
             'events.latency',

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -20,7 +20,7 @@ from django.utils.encoding import force_bytes, force_text
 from hashlib import md5
 from uuid import uuid4
 
-from sentry import buffer, eventtypes, features, tsdb
+from sentry import buffer, eventtypes, eventstream, features, tsdb
 from sentry.constants import (
     CLIENT_RESERVED_ATTRS, LOG_LEVELS, LOG_LEVELS_MAP, DEFAULT_LOG_LEVEL,
     DEFAULT_LOGGER_NAME, MAX_CULPRIT_LENGTH, VALID_PLATFORMS
@@ -39,10 +39,10 @@ from sentry.plugins import plugins
 from sentry.signals import event_discarded, event_saved, first_event_received
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_group
+from sentry.tasks.post_process import post_process_group
 from sentry.utils import metrics
 from sentry.utils.cache import default_cache
 from sentry.utils.db import get_db_engine
-from sentry.utils.imports import import_string
 from sentry.utils.safe import safe_execute, trim, trim_dict, get_path
 from sentry.utils.strings import truncatechars
 from sentry.utils.validators import is_float
@@ -52,14 +52,6 @@ from sentry.stacktraces import normalize_in_app
 HASH_RE = re.compile(r'^[0-9a-f]{32}$')
 DEFAULT_FINGERPRINT_VALUES = frozenset(['{{ default }}', '{{default}}'])
 ALLOWED_FUTURE_DELTA = timedelta(minutes=1)
-
-
-post_process_callback = getattr(settings, 'SENTRY_POST_PROCESS_CALLBACK', None)
-if post_process_callback is None:
-    from sentry.tasks.post_process import post_process_group
-    post_process_callback = post_process_group.delay
-else:
-    post_process_callback = import_string(post_process_callback)
 
 
 def count_limit(count):
@@ -940,7 +932,7 @@ class EventManager(object):
                 project.update(first_event=date)
                 first_event_received.send(project=project, group=group, sender=Project)
 
-            post_process_callback(
+            post_process_group.delay(
                 group=group,
                 event=event,
                 is_new=is_new,
@@ -949,6 +941,7 @@ class EventManager(object):
                 is_new_group_environment=is_new_group_environment,
                 primary_hash=hashes[0],
             )
+            eventstream.publish(event=event, primary_hash=hashes[0])
         else:
             self.logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -39,7 +39,6 @@ from sentry.plugins import plugins
 from sentry.signals import event_discarded, event_saved, first_event_received
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_group
-from sentry.tasks.post_process import post_process_group
 from sentry.utils import metrics
 from sentry.utils.cache import default_cache
 from sentry.utils.db import get_db_engine
@@ -932,7 +931,7 @@ class EventManager(object):
                 project.update(first_event=date)
                 first_event_received.send(project=project, group=group, sender=Project)
 
-            post_process_group.delay(
+            eventstream.publish(
                 group=group,
                 event=event,
                 is_new=is_new,
@@ -941,7 +940,6 @@ class EventManager(object):
                 is_new_group_environment=is_new_group_environment,
                 primary_hash=hashes[0],
             )
-            eventstream.publish(event=event, primary_hash=hashes[0])
         else:
             self.logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
 

--- a/src/sentry/eventstream/__init__.py
+++ b/src/sentry/eventstream/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.conf import settings
+
+from sentry.utils.services import LazyServiceWrapper
+
+from .base import EventStream
+
+backend = LazyServiceWrapper(
+    EventStream,
+    settings.SENTRY_EVENTSTREAM,
+    settings.SENTRY_EVENTSTREAM_OPTIONS,
+)
+backend.expose(locals())

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from sentry.utils.services import Service
+
+
+class EventStream(Service):
+    __all__ = (
+        'publish',
+    )
+
+    def publish(self, event, primary_hash, **kwargs):
+        return

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -7,8 +7,11 @@ from sentry.tasks.post_process import post_process_group
 
 class EventStream(Service):
     __all__ = (
-        'publish',
+        'publish', 'consume',
     )
 
     def publish(self, event, primary_hash, **kwargs):
+        self.consume(event=event, primary_hash=primary_hash, **kwargs)
+
+    def consume(self, event, primary_hash, **kwargs):
         post_process_group.delay(event=event, primary_hash=primary_hash, **kwargs)

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from sentry.utils.services import Service
 
+from sentry.tasks.post_process import post_process_group
+
 
 class EventStream(Service):
     __all__ = (
@@ -9,4 +11,4 @@ class EventStream(Service):
     )
 
     def publish(self, event, primary_hash, **kwargs):
-        return
+        post_process_group.delay(event=event, primary_hash=primary_hash, **kwargs)

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import
 
-from sentry.utils.services import Service
+import logging
 
+from sentry.utils.services import Service
 from sentry.tasks.post_process import post_process_group
+
+
+logger = logging.getLogger(__name__)
 
 
 class EventStream(Service):
@@ -11,7 +15,9 @@ class EventStream(Service):
     )
 
     def publish(self, group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume=False):
-        if not skip_consume:
+        if skip_consume:
+            logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
+        else:
             post_process_group.delay(
                 group=group,
                 event=event,

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -7,11 +7,17 @@ from sentry.tasks.post_process import post_process_group
 
 class EventStream(Service):
     __all__ = (
-        'publish', 'consume',
+        'publish',
     )
 
-    def publish(self, event, primary_hash, **kwargs):
-        self.consume(event=event, primary_hash=primary_hash, **kwargs)
-
-    def consume(self, event, primary_hash, **kwargs):
-        post_process_group.delay(event=event, primary_hash=primary_hash, **kwargs)
+    def publish(self, group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume=False):
+        if not skip_consume:
+            post_process_group.delay(
+                group=group,
+                event=event,
+                is_new=is_new,
+                is_sample=is_sample,
+                is_regression=is_regression,
+                is_new_group_environment=is_new_group_environment,
+                primary_hash=primary_hash,
+            )

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -65,6 +65,6 @@ class KafkaEventStream(EventStream):
             logger.warning('Could not publish event: %s', error, exc_info=True)
             raise
 
-        def consume(self, event, primary_hash, **kwargs):
-            # TODO talk to Ted
-            pass
+    def consume(self, event, primary_hash, **kwargs):
+        # TODO talk to Ted
+        pass

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -64,3 +64,7 @@ class KafkaEventStream(EventStream):
         except Exception as error:
             logger.warning('Could not publish event: %s', error, exc_info=True)
             raise
+
+        def consume(self, event, primary_hash, **kwargs):
+            # TODO talk to Ted
+            pass

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -33,8 +33,8 @@ class KafkaPublisher(object):
 
 
 class KafkaEventStream(EventStream):
-    def __init__(self, topic='events', sync=False, connection=None, **options):
-        self.topic = topic
+    def __init__(self, publish_topic='events', sync=False, connection=None, **options):
+        self.publish_topic = publish_topic
         self.pubsub = KafkaPublisher(connection)
         if not sync:
             self.pubsub = QueuedPublisher(self.pubsub)
@@ -60,7 +60,7 @@ class KafkaEventStream(EventStream):
                 'retention_days': retention_days,
             })
 
-            self.pubsub.publish(self.topic, key=key.encode('utf-8'), value=json.dumps(value))
+            self.pubsub.publish(self.publish_topic, key=key.encode('utf-8'), value=json.dumps(value))
         except Exception as error:
             logger.warning('Could not publish event: %s', error, exc_info=True)
             raise

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+
+import logging
+
+from kafka import KafkaProducer
+from django.utils.functional import cached_property
+
+from sentry import quotas
+from sentry.models import Organization
+from sentry.eventstream.base import EventStream
+from sentry.utils import json
+from sentry.utils.pubsub import QueuedPublisher
+
+logger = logging.getLogger(__name__)
+
+
+# Beware! Changing this, or the message format/fields themselves requires
+# consideration of all downstream consumers.
+# Version 0 format: (0, '(insert|delete)', {..event json...})
+EVENT_PROTOCOL_VERSION = 0
+
+
+class KafkaPublisher(object):
+    def __init__(self, connection):
+        self.connection = connection or {}
+
+    @cached_property
+    def client(self):
+        return KafkaProducer(**self.connection)
+
+    def publish(self, topic, value, key=None):
+        return self.client.send(topic, key=key, value=value)
+
+
+class KafkaEventStream(EventStream):
+    def __init__(self, topic='events', sync=False, connection=None, **options):
+        self.topic = topic
+        self.pubsub = KafkaPublisher(connection)
+        if not sync:
+            self.pubsub = QueuedPublisher(self.pubsub)
+
+    def publish(self, event, primary_hash, **kwargs):
+        project = event.project
+        retention_days = quotas.get_event_retention(
+            organization=Organization(project.organization_id)
+        )
+
+        try:
+            key = '%s:%s' % (event.project_id, event.event_id)
+            value = (EVENT_PROTOCOL_VERSION, 'insert', {
+                'group_id': event.group_id,
+                'event_id': event.event_id,
+                'organization_id': project.organization_id,
+                'project_id': event.project_id,
+                'message': event.message,
+                'platform': event.platform,
+                'datetime': event.datetime,
+                'data': event.data.data,
+                'primary_hash': primary_hash,
+                'retention_days': retention_days,
+            })
+
+            self.pubsub.publish(self.topic, key=key.encode('utf-8'), value=json.dumps(value))
+        except Exception as error:
+            logger.warning('Could not publish event: %s', error, exc_info=True)
+            raise

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -39,7 +39,7 @@ class KafkaEventStream(EventStream):
         if not sync:
             self.pubsub = QueuedPublisher(self.pubsub)
 
-    def publish(self, event, primary_hash, **kwargs):
+    def publish(self, group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume=False):
         project = event.project
         retention_days = quotas.get_event_retention(
             organization=Organization(project.organization_id)
@@ -64,7 +64,3 @@ class KafkaEventStream(EventStream):
         except Exception as error:
             logger.warning('Could not publish event: %s', error, exc_info=True)
             raise
-
-    def consume(self, event, primary_hash, **kwargs):
-        # TODO talk to Ted
-        pass

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -921,8 +921,8 @@ class EventManagerTest(TransactionTestCase):
 
         assert dict(event.tags).get('environment') == 'beta'
 
-    @mock.patch('sentry.event_manager.post_process_callback')
-    def test_group_environment(self, mock_post_process_callback):
+    @mock.patch('sentry.event_manager.eventstream.publish')
+    def test_group_environment(self, eventstream_publish):
         release_version = '1.0'
 
         def save_event():
@@ -949,7 +949,7 @@ class EventManagerTest(TransactionTestCase):
 
         # Ensure that the first event in the (group, environment) pair is
         # marked as being part of a new environment.
-        mock_post_process_callback.assert_called_with(
+        eventstream_publish.assert_called_with(
             group=event.group,
             event=event,
             is_new=True,
@@ -963,7 +963,7 @@ class EventManagerTest(TransactionTestCase):
 
         # Ensure that the next event in the (group, environment) pair is *not*
         # marked as being part of a new environment.
-        mock_post_process_callback.assert_called_with(
+        eventstream_publish.assert_called_with(
             group=event.group,
             event=event,
             is_new=False,

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -957,6 +957,7 @@ class EventManagerTest(TransactionTestCase):
             is_regression=False,
             is_new_group_environment=True,
             primary_hash='acbd18db4cc2f85cedef654fccc4a4d8',
+            skip_consume=False,
         )
 
         event = save_event()
@@ -971,6 +972,7 @@ class EventManagerTest(TransactionTestCase):
             is_regression=None,  # XXX: wut
             is_new_group_environment=False,
             primary_hash='acbd18db4cc2f85cedef654fccc4a4d8',
+            skip_consume=False,
         )
 
     def test_default_fingerprint(self):


### PR DESCRIPTION
This is bringing in the code we had specific to getsentry into a configurable backend for our EventStream abstraction. This also will open up the doors for the kafka based consumer coming soon and a development/local version that sends data directly to Snuba bypassing kafka.

This needs to be coordinated with a PR on getsentry side before merging, otherwise we will break stuff.