### PR TITLE
feat(auth): Put github login button on org-login page

### DIFF
--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -93,6 +93,10 @@
           <fieldset class="form-actions">
             <button type="submit" class="btn btn-primary">{% trans "Login" %}</button> <a class="pull-right" style="margin-top: 9px" href="{% url 'sentry-account-recover' %}">{% trans "Lost your password?" %}</a>
           </fieldset>
+
+          {% if github_login_template %}
+            {% include github_login_template %}
+          {% endif %}
         </form>
       </div>
       <div class="tab-pane{% if op == "register" %} active{% endif %}" id="register">


### PR DESCRIPTION
We have the github login button on the main login page, this adds it to the org-specific login page too.