### PR TITLE
feat(eventstream): Add Snuba backend

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+
+from sentry.eventstream.base import EventStream
+from sentry.utils import snuba
+
+
+class SnubaEventStream(EventStream):
+    def publish(self, group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume=False):
+        snuba.insert_raw([{
+            'group_id': event.group_id,
+            'event_id': event.event_id,
+            'project_id': event.project_id,
+            'message': event.message,
+            'platform': event.platform,
+            'datetime': event.datetime,
+            'data': event.data.data,
+            'primary_hash': primary_hash,
+        }])
+        super(SnubaEventStream, self).publish(group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume)


### PR DESCRIPTION
This depends on #8879.

One thing to note here is the change from `json` to `sentry.utils.json` within `sentry.utils.json`. I don't anticipate any issues from that, but was needed to handle serializing our payload without errors.