### PR TITLE
fix(docs): Use Bearer token examples in API docs

### DIFF
--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import os
 import re
 import json
-import base64
 import inspect
 import requests
 import mimetypes
@@ -445,8 +444,7 @@ class Runner(object):
 
         req_headers = dict(headers)
         req_headers['Host'] = 'sentry.io'
-        req_headers['Authorization'
-                    ] = 'Basic %s' % base64.b64encode('%s:' % (api_key.key.encode('utf-8')))
+        req_headers['Authorization'] = 'Bearer %s' % api_key.key.encode('utf-8')
 
         url = 'http://127.0.0.1:%s%s' % (settings.SENTRY_APIDOCS_WEB_PORT, path, )
 


### PR DESCRIPTION
This changes (what I think is) the code that controls the `Authorization` part of request examples in the API docs to use a `Bearer` format instead of Basic Auth.