### PR TITLE
feat(experiment): Add _experiment to blacklisted org names

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -87,7 +87,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         'security', 'terms', 'from', 'sponsorship', 'for', 'at', 'platforms', 'branding', 'vs',
         'answers', '_admin', 'support', 'contact', 'onboarding', 'ext', 'extension', 'extensions',
         'plugins', 'themonitor', 'settings', 'legal', 'avatar', 'organization-avatar',
-        'project-avatar', 'team-avatar', 'careers',
+        'project-avatar', 'team-avatar', 'careers', '_experiment',
     )
 )
 


### PR DESCRIPTION
We're adding APIs endpoints to sentry.io/_experiment