### PR TITLE
fix(ui): Consistent disabled state for switch

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -812,7 +812,6 @@ table.integrations {
   &.switch-disabled {
     cursor: not-allowed;
     pointer-events: none;
-    background: @white-darker;
 
     .switch-toggle {
       opacity: 0.4;


### PR DESCRIPTION
The disabled state didn't quite match the button disabled state, this removes the background, bringing it more inline with the buttons disabled state.
![image](https://user-images.githubusercontent.com/1421724/42187051-9646af58-7e03-11e8-8c43-6a64db570969.png)
