### PR TITLE
feat: Add support for feature policy reports

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -43,6 +43,7 @@ export const INTERFACES = {
   expectct: GenericInterface,
   expectstaple: GenericInterface,
   hpkp: GenericInterface,
+  'policy-report': GenericInterface,
   breadcrumbs: BreadcrumbsInterface,
   threads: ThreadsInterface,
   debugmeta: DebugMetaInterface,

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -388,6 +388,13 @@ function routes() {
           component={errorHandler(LazyLoad)}
         />
         <Route
+          path="feature-policy/"
+          name="Feature Policy"
+          componentPromise={() =>
+            import(/*webpackChunkName: "ProjectFeaturePolicyReports"*/ './views/settings/projectSecurityHeaders/featurePolicy')}
+          component={errorHandler(LazyLoad)}
+        />
+        <Route
           path="hpkp/"
           name="HPKP"
           componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails.jsx
@@ -165,8 +165,8 @@ const GroupDetails = createReactClass({
         if (group.metadata.type && group.metadata.value)
           return `${group.metadata.type}: ${group.metadata.value}`;
         return group.metadata.type || group.metadata.value;
+      case 'policy-report':
       case 'csp':
-        return group.metadata.message;
       case 'expectct':
       case 'expectstaple':
       case 'hpkp':

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/featurePolicy.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/featurePolicy.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {t, tct} from 'app/locale';
+import AsyncView from 'app/views/asyncView';
+import ExternalLink from 'app/components/externalLink';
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import PreviewFeature from 'app/components/previewFeature';
+import ReportUri, {
+  getSecurityDsn,
+} from 'app/views/settings/projectSecurityHeaders/reportUri';
+import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+
+export default class ProjectFeaturePolicyReports extends AsyncView {
+  static propTypes = {
+    setProjectNavSection: PropTypes.func,
+  };
+
+  componentWillMount() {
+    super.componentWillMount();
+    this.props.setProjectNavSection('settings');
+  }
+
+  getEndpoints() {
+    let {orgId, projectId} = this.props.params;
+    return [['keyList', `/projects/${orgId}/${projectId}/keys/`]];
+  }
+
+  getInstructions() {
+    return `Report-To: {"url": "${getSecurityDsn(
+      this.state.keyList
+    )}", "max-age": 86400}`;
+  }
+
+  renderBody() {
+    return (
+      <div>
+        <SettingsPageHeader title={t('Feature Policy')} />
+
+        <PreviewFeature />
+
+        <ReportUri keyList={this.state.keyList} params={this.props.params} />
+
+        <Panel>
+          <PanelHeader>{'About'}</PanelHeader>
+          <PanelBody disablePadding={false}>
+            <p>
+              {tct(
+                `[link:Feature Policy]
+      is a security standard which gives a website the ability to allow and deny the use of browser features in its own frame, and in iframes that it embeds`,
+                {
+                  link: <ExternalLink href="https://github.com/WICG/feature-policy" />,
+                }
+              )}
+            </p>
+            <p>
+              {tct(
+                "To configure reports in Sentry, you'll need to configure the [header] a header from your server:",
+                {
+                  header: <code>Report-To</code>,
+                }
+              )}
+            </p>
+
+            <pre>{this.getInstructions()}</pre>
+
+            <p>
+              {tct('For more information, see [link:the documentation on GitHub].', {
+                link: (
+                  <a href="https://github.com/WICG/feature-policy/blob/master/reporting.md" />
+                ),
+              })}
+            </p>
+          </PanelBody>
+        </Panel>
+      </div>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/index.jsx
@@ -46,6 +46,10 @@ export default class ProjectSecurityHeaders extends AsyncView {
         name: 'HTTP Public Key Pinning (HPKP)',
         url: recreateRoute('hpkp/', this.props),
       },
+      {
+        name: 'Feature Policy',
+        url: recreateRoute('feature-policy/', this.props),
+      },
     ];
   }
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -756,6 +756,8 @@ class SecurityReportView(StoreView):
             'known-pins': 'hpkp',
         }
         if isinstance(body, dict):
+            if 'type' in body and 'body' in body:
+                return 'policy-report'
             for k in report_type_for_key:
                 if k in body:
                     return report_type_for_key[k]

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectFeaturePolicyReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectFeaturePolicyReports.spec.jsx.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectFeaturePolicyReports renders 1`] = `
+<SideEffect(DocumentTitle)
+  title="Sentry"
+>
+  <div>
+    <SettingsPageHeading
+      title="Feature Policy"
+    />
+    <PreviewFeature />
+    <ReportUri
+      keyList={Array []}
+      params={
+        Object {
+          "orgId": "org-slug",
+          "projectId": "project-slug",
+        }
+      }
+    />
+    <Panel>
+      <PanelHeader>
+        About
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={false}
+        flex={false}
+      >
+        <p>
+          <span
+            key="4"
+          >
+            <ExternalLink
+              href="https://github.com/WICG/feature-policy"
+              key="1"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              <span
+                key="0"
+              >
+                Feature Policy
+              </span>
+            </ExternalLink>
+            <span
+              key="2"
+            >
+              
+      is a security standard which gives a website the ability to allow and deny the use of browser features in its own frame, and in iframes that it embeds
+            </span>
+          </span>
+        </p>
+        <p>
+          <span
+            key="4"
+          >
+            <span
+              key="0"
+            >
+              To configure reports in Sentry, you'll need to configure the 
+            </span>
+            <code
+              key="1"
+            >
+              Report-To
+            </code>
+            <span
+              key="2"
+            >
+               a header from your server:
+            </span>
+          </span>
+        </p>
+        <pre>
+          Report-To: {"url": "https://sentry.example.com/api/security-report/", "max-age": 86400}
+        </pre>
+        <p>
+          <span
+            key="5"
+          >
+            <span
+              key="0"
+            >
+              For more information, see 
+            </span>
+            <a
+              href="https://github.com/WICG/feature-policy/blob/master/reporting.md"
+              key="2"
+            >
+              <span
+                key="1"
+              >
+                the documentation on GitHub
+              </span>
+            </a>
+            <span
+              key="3"
+            >
+              .
+            </span>
+          </span>
+        </p>
+      </PanelBody>
+    </Panel>
+  </div>
+</SideEffect(DocumentTitle)>
+`;

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
@@ -198,6 +198,32 @@ exports[`ProjectSecurityHeaders renders 1`] = `
             </Button>
           </Flex>
         </PanelItem>
+        <PanelItem
+          direction="column"
+          key="feature-policy/"
+          p={0}
+        >
+          <Flex
+            align="center"
+            flex="1"
+            p={2}
+          >
+            <Box
+              flex="1"
+            >
+              <HeaderName>
+                Feature Policy
+              </HeaderName>
+            </Box>
+            <Button
+              disabled={false}
+              priority="primary"
+              to="feature-policy/"
+            >
+              Instructions
+            </Button>
+          </Flex>
+        </PanelItem>
       </PanelBody>
     </Panel>
   </div>

--- a/tests/js/spec/views/projectSecurityHeaders/projectFeaturePolicyReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectFeaturePolicyReports.spec.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import ProjectFeaturePolicyReports from 'app/views/settings/projectSecurityHeaders/featurePolicy';
+
+describe('ProjectFeaturePolicyReports', function() {
+  let org = TestStubs.Organization();
+  let project = TestStubs.Project();
+  let url = `/projects/${org.slug}/${project.slug}/feature-policy/`;
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/keys/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('renders', function() {
+    let wrapper = shallow(
+      <ProjectFeaturePolicyReports
+        organization={org}
+        project={project}
+        setProjectNavSection={() => {}}
+        {...TestStubs.routerProps({
+          params: {orgId: org.slug, projectId: project.slug},
+          location: TestStubs.location({pathname: url}),
+        })}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This isn't yet functional, but hopefully will only require minor chnages once the reporting API is live.

When will the reporting API be live? Your guess is as good as mine...

https://developers.google.com/web/updates/2018/06/feature-policy