### PR TITLE
ref(integrations): Changed the exception message length to longer

### DIFF
--- a/src/sentry/integrations/exceptions.py
+++ b/src/sentry/integrations/exceptions.py
@@ -29,7 +29,7 @@ class ApiError(Exception):
                 self.json = None
         else:
             self.json = None
-        super(ApiError, self).__init__(text[:128])
+        super(ApiError, self).__init__(text[:1024])
 
     @classmethod
     def from_response(cls, response):


### PR DESCRIPTION
Not sure why it was limited but the previous length was too short for most error messages.