### PR TITLE
ref(ui): Remove webpack codesplit for sudo modal

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/modal.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.jsx
@@ -17,14 +17,13 @@ export function closeModal() {
 }
 
 export function openSudo({onClose, ...args} = {}) {
-  import(/* webpackChunkName: "SudoModal" */ '../components/modals/sudoModal')
-    .then(mod => mod.default)
-    .then(SudoModal =>
-      openModal(deps => <SudoModal {...deps} {...args} />, {
-        modalClassName: 'sudo-modal',
-        onClose,
-      })
-    );
+  // This is for getsentry, otherwise we get circular imports and
+  // getsentry can't dynamically import components
+  const SudoModal = require('app/components/modals/sudoModal').default;
+  openModal(deps => <SudoModal {...deps} {...args} />, {
+    modalClassName: 'sudo-modal',
+    onClose,
+  });
 }
 
 export function openDiffModal(options) {

--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -79,6 +79,7 @@ export class Client {
 
     if (isSudoRequired) {
       openSudo({
+        api: this,
         superuser: code === 'superuser-required',
         sudo: code === 'sudo-required',
         retryRequest: () => {

--- a/src/sentry/static/sentry/app/components/modals/sudoModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/sudoModal.jsx
@@ -1,11 +1,9 @@
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 import {t} from 'app/locale';
 import Alert from 'app/components/alert';
-import ApiMixin from 'app/mixins/apiMixin';
 import Button from 'app/components/buttons/button';
 import ConfigStore from 'app/stores/configStore';
 import Form from 'app/views/settings/components/forms/form';
@@ -164,15 +162,12 @@ class SudoModal extends React.Component {
   }
 }
 
-const SudoModalContainer = createReactClass({
-  displayName: 'SudoModalContainer',
-  mixins: [ApiMixin],
-
-  render() {
-    let user = ConfigStore.get('user');
-    return <SudoModal {...this.props} user={user} api={this.api} />;
-  },
-});
-
-export default withRouter(SudoModalContainer);
+export default withRouter(
+  class SudoModalWithUser extends React.Component {
+    render() {
+      let user = ConfigStore.get('user');
+      return <SudoModal {...this.props} user={user} />;
+    }
+  }
+);
 export {SudoModal};


### PR DESCRIPTION
This is so we can use the SudoModal inside of getsentry admin.

https://github.com/getsentry/getsentry/pull/1643