### PR TITLE
build(js): Remove "crypto-js" from vendor bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,6 @@ var appEntry = {
     'bootstrap/js/tooltip',
     'bootstrap/js/alert',
     'create-react-class',
-    'crypto-js/md5',
     'jed',
     'jquery',
     'marked',


### PR DESCRIPTION
This has been codesplit in Gravatar component.