### PR TITLE
chore(js): Upgrade "po-catalog-loader"

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "moment-timezone": "0.5.4",
     "node-libs-browser": "0.5.3",
     "platformicons": "2.0.3",
-    "po-catalog-loader": "^1.2.0",
+    "po-catalog-loader": "2.0.0",
     "prop-types": "^15.6.0",
     "query-string": "2.4.2",
     "raven-js": "3.23.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5927,7 +5927,15 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.5, loader-utils@^0.2.7:
+loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.0.3, loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
+loader-utils@^0.2.7:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -5935,14 +5943,6 @@ loader-utils@^0.2.5, loader-utils@^0.2.7:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
-
-loader-utils@^1.0.2, loader-utils@^1.0.3, loader-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -7126,11 +7126,11 @@ pn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
-po-catalog-loader@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/po-catalog-loader/-/po-catalog-loader-1.2.0.tgz#c8bad87e8366bd5fc071e12cc450c4290a87d362"
+po-catalog-loader@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/po-catalog-loader/-/po-catalog-loader-2.0.0.tgz#457baf768d34f144c75444e24daf8352cd052ccf"
   dependencies:
-    loader-utils "^0.2.5"
+    loader-utils "1.1.0"
 
 podda@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
Fixes deprecations for webpack4