### PR TITLE
fix(ui): Add leading zero to stacktrace code block

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1652,6 +1652,7 @@ div.traceback > ul {
   ol.context {
     margin: 0;
     list-style-position: inside;
+    list-style-type: decimal-leading-zero;
     border-radius: 3px;
     padding-left: 0;
 


### PR DESCRIPTION
Before:
 <img width="257" alt="screen shot 2018-07-05 at 16 02 35" src="https://user-images.githubusercontent.com/363802/42329968-4d79099e-8072-11e8-9a75-e15e9a8435d2.png">

After:
<img width="210" alt="screen shot 2018-07-05 at 16 02 40" src="https://user-images.githubusercontent.com/363802/42329966-4b6024c6-8072-11e8-8f10-4dd1b05f196b.png">

