### PR TITLE
fix(deletions): Missing project_id in events

### DIFF
--- a/src/sentry/deletions/defaults/event.py
+++ b/src/sentry/deletions/defaults/event.py
@@ -19,10 +19,11 @@ class EventDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry import models
         relations = super(EventDeletionTask, self).get_child_relations(instance)
+        key = {'project_id': instance.project_id, 'event_id': instance.event_id}
         relations.extend([
-            ModelRelation(models.EventAttachment, {'event_id': instance.event_id}),
-            ModelRelation(models.EventMapping, {'event_id': instance.event_id}),
-            ModelRelation(models.UserReport, {'event_id': instance.event_id}),
+            ModelRelation(models.EventAttachment, key),
+            ModelRelation(models.EventMapping, key),
+            ModelRelation(models.UserReport, key),
         ])
         return relations
 


### PR DESCRIPTION
With 44c69f25b9c5b8d149bff21bc235c4a4a31e4e96, introduced deleting
UserReport and EventMapping as well as the new model.

But with just specifying event_id, we have introduced two issues:

1, deletions now slowed down drastically since there is no index for
just event_id
2. this is potentially deleting incorrect data, since event_id is not
globally unique, it's only safely unique within a single project. So
we're potentially deleting data from other projects unrelated.

cc @getsentry/ops 