### PR TITLE
feat: Enable saml2 SSO by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -751,7 +751,7 @@ SENTRY_FEATURES = {
     'organizations:event-attachments': False,
     'organizations:repos': True,
     'organizations:sso': True,
-    'organizations:sso-saml2': False,
+    'organizations:sso-saml2': True,
     'organizations:sso-rippling': False,
     'organizations:group-unmerge': False,
     'organizations:github-apps': False,


### PR DESCRIPTION
Given this is now stable (and launched in production), this makes the feature available by default. This primarily will affect open source users of Sentry.