### PR TITLE
feat: Add organization-wide scrapeJavaScript configuration

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -36,6 +36,7 @@ ORG_OPTIONS = (
     ('sensitiveFields', 'sentry:sensitive_fields', list),
     ('safeFields', 'sentry:safe_fields', list),
     ('scrubIPAddresses', 'sentry:require_scrub_ip_address', bool),
+    ('scrapeJavaScript', 'sentry:scrape_javascript', bool),
 )
 
 delete_logger = logging.getLogger('sentry.deletions.api')
@@ -84,6 +85,7 @@ class OrganizationSerializer(serializers.Serializer):
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
     scrubIPAddresses = serializers.BooleanField(required=False)
+    scrapeJavaScript = serializers.BooleanField(required=False)
     isEarlyAdopter = serializers.BooleanField(required=False)
     require2FA = serializers.BooleanField(required=False)
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -178,6 +178,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             'sensitiveFields': obj.get_option('sentry:sensitive_fields', None) or [],
             'safeFields': obj.get_option('sentry:safe_fields', None) or [],
             'scrubIPAddresses': bool(obj.get_option('sentry:require_scrub_ip_address', False)),
+            'scrapeJavaScript': bool(obj.get_option('sentry:scrape_javascript', True)),
         })
         context['teams'] = serialize(team_list, user, TeamSerializer())
         context['projects'] = serialize(project_list, user, ProjectSummarySerializer())

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -476,7 +476,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
     def __init__(self, *args, **kwargs):
         StacktraceProcessor.__init__(self, *args, **kwargs)
         self.max_fetches = MAX_RESOURCE_FETCHES
-        self.allow_scraping = self.project.get_option('sentry:scrape_javascript', True)
+        self.allow_scraping = (
+            self.project.organization.get_option('sentry:scrape_javascript', True) is not False
+            and self.project.get_option('sentry:scrape_javascript', True)
+        )
         self.fetch_count = 0
         self.sourcemaps_touched = set()
         self.cache = SourceCache()

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -183,6 +183,17 @@ const formGroups = [
           ),
         },
       },
+      {
+        name: 'scrapeJavaScript',
+        type: 'boolean',
+        confirm: {
+          false: t(
+            "Are you sure you want to disable sourcecode fetching for JavaScript events? This will affect Sentry's ability to aggregate issues if you're not already uploading sourcemaps as artifacts."
+          ),
+        },
+        label: t('Allow JavaScript source fetching'),
+        help: t('Allow Sentry to scrape missing JavaScript source context when possible'),
+      },
     ],
   },
 ];

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -195,6 +195,11 @@ export const fields = {
   scrapeJavaScript: {
     name: 'scrapeJavaScript',
     type: 'boolean',
+    // if this is off for the organization, it cannot be enabled for the project
+    disabled: ({organization, name}) => !organization[name],
+    disabledReason: ORG_DISABLED_REASON,
+    // `props` are the props given to FormField
+    setValue: (val, props) => props.organization && props.organization[props.name] && val,
     label: t('Enable JavaScript source fetching'),
     help: t('Allow Sentry to scrape missing JavaScript source context when possible'),
   },

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -667,6 +667,7 @@ window.TestStubs = {
         id: 'active',
         name: 'active',
       },
+      scrapeJavaScript: true,
       features: [],
       onboardingTasks: [],
       teams: [],

--- a/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
+++ b/tests/js/spec/components/projectHeader/__snapshots__/projectSelector.spec.jsx.snap
@@ -45,6 +45,7 @@ exports[`ProjectSelector render() can filter projects by project name 1`] = `
           ],
         },
       ],
+      "scrapeJavaScript": true,
       "slug": "org",
       "status": Object {
         "id": "active",
@@ -506,6 +507,7 @@ exports[`ProjectSelector render() can filter projects by team name/project name 
           ],
         },
       ],
+      "scrapeJavaScript": true,
       "slug": "org",
       "status": Object {
         "id": "active",
@@ -1196,6 +1198,7 @@ exports[`ProjectSelector render() shows empty filter message when filtering has 
           ],
         },
       ],
+      "scrapeJavaScript": true,
       "slug": "org",
       "status": Object {
         "id": "active",

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -157,6 +157,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
       "name": "Organization Name",
       "onboardingTasks": Array [],
       "projects": Array [],
+      "scrapeJavaScript": true,
       "slug": "org-slug",
       "status": Object {
         "id": "active",
@@ -191,6 +192,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
           "name": "Organization Name",
           "onboardingTasks": Array [],
           "projects": Array [],
+          "scrapeJavaScript": true,
           "slug": "org-slug",
           "status": Object {
             "id": "active",
@@ -225,6 +227,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                 "name": "Organization Name",
                 "onboardingTasks": Array [],
                 "projects": Array [],
+                "scrapeJavaScript": true,
                 "slug": "org-slug",
                 "status": Object {
                   "id": "active",
@@ -256,6 +259,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                   "name": "Organization Name",
                   "onboardingTasks": Array [],
                   "projects": Array [],
+                  "scrapeJavaScript": true,
                   "slug": "org-slug",
                   "status": Object {
                     "id": "active",
@@ -463,6 +467,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
           "name": "Organization Name",
           "onboardingTasks": Array [],
           "projects": Array [],
+          "scrapeJavaScript": true,
           "slug": "org-slug",
           "status": Object {
             "id": "active",

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -258,6 +258,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         "name": "Organization Name",
                         "onboardingTasks": Array [],
                         "projects": Array [],
+                        "scrapeJavaScript": true,
                         "slug": "org-slug",
                         "status": Object {
                           "id": "active",

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -21,6 +21,7 @@ exports[`Project Ownership Input renders 1`] = `
       "name": "Organization Name",
       "onboardingTasks": Array [],
       "projects": Array [],
+      "scrapeJavaScript": true,
       "slug": "org-slug",
       "status": Object {
         "id": "active",
@@ -67,6 +68,7 @@ exports[`Project Ownership Input renders 1`] = `
         "name": "Organization Name",
         "onboardingTasks": Array [],
         "projects": Array [],
+        "scrapeJavaScript": true,
         "slug": "org-slug",
         "status": Object {
           "id": "active",
@@ -471,6 +473,7 @@ exports[`Project Ownership Input renders 1`] = `
                     "name": "Organization Name",
                     "onboardingTasks": Array [],
                     "projects": Array [],
+                    "scrapeJavaScript": true,
                     "slug": "org-slug",
                     "status": Object {
                       "id": "active",

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -105,6 +105,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
             "name": "Organization Name",
             "onboardingTasks": Array [],
             "projects": Array [],
+            "scrapeJavaScript": true,
             "slug": "org-slug",
             "status": Object {
               "id": "active",
@@ -1316,6 +1317,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
             "name": "Organization Name",
             "onboardingTasks": Array [],
             "projects": Array [],
+            "scrapeJavaScript": true,
             "slug": "org-slug",
             "status": Object {
               "id": "active",

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -145,6 +145,7 @@ exports[`ProjectAlertSettings render() renders 1`] = `
           "name": "Organization Name",
           "onboardingTasks": Array [],
           "projects": Array [],
+          "scrapeJavaScript": true,
           "slug": "org-slug",
           "status": Object {
             "id": "active",

--- a/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
@@ -89,6 +89,7 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
               "name": "Organization Name",
               "onboardingTasks": Array [],
               "projects": Array [],
+              "scrapeJavaScript": true,
               "slug": "org-slug",
               "status": Object {
                 "id": "active",

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -26,6 +26,7 @@ exports[`ProjectPluginDetails renders 1`] = `
       "name": "Organization Name",
       "onboardingTasks": Array [],
       "projects": Array [],
+      "scrapeJavaScript": true,
       "slug": "org-slug",
       "status": Object {
         "id": "active",
@@ -78,6 +79,7 @@ exports[`ProjectPluginDetails renders 1`] = `
         "name": "Organization Name",
         "onboardingTasks": Array [],
         "projects": Array [],
+        "scrapeJavaScript": true,
         "slug": "org-slug",
         "status": Object {
           "id": "active",
@@ -370,6 +372,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                     "name": "Organization Name",
                     "onboardingTasks": Array [],
                     "projects": Array [],
+                    "scrapeJavaScript": true,
                     "slug": "org-slug",
                     "status": Object {
                       "id": "active",
@@ -526,6 +529,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                     "name": "Organization Name",
                                     "onboardingTasks": Array [],
                                     "projects": Array [],
+                                    "scrapeJavaScript": true,
                                     "slug": "org-slug",
                                     "status": Object {
                                       "id": "active",

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -29,6 +29,7 @@ exports[`RuleBuilder renders 1`] = `
       "name": "Organization Name",
       "onboardingTasks": Array [],
       "projects": Array [],
+      "scrapeJavaScript": true,
       "slug": "org-slug",
       "status": Object {
         "id": "active",
@@ -440,6 +441,7 @@ exports[`RuleBuilder renders 1`] = `
                   "name": "Organization Name",
                   "onboardingTasks": Array [],
                   "projects": Array [],
+                  "scrapeJavaScript": true,
                   "slug": "org-slug",
                   "status": Object {
                     "id": "active",
@@ -998,6 +1000,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
       "name": "Organization Name",
       "onboardingTasks": Array [],
       "projects": Array [],
+      "scrapeJavaScript": true,
       "slug": "org-slug",
       "status": Object {
         "id": "active",
@@ -1631,6 +1634,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                   "name": "Organization Name",
                   "onboardingTasks": Array [],
                   "projects": Array [],
+                  "scrapeJavaScript": true,
                   "slug": "org-slug",
                   "status": Object {
                     "id": "active",

--- a/tests/js/spec/views/__snapshots__/teamCreate.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamCreate.spec.jsx.snap
@@ -28,6 +28,7 @@ exports[`TeamCreate render() renders correctly 1`] = `
           "name": "Organization Name",
           "onboardingTasks": Array [],
           "projects": Array [],
+          "scrapeJavaScript": true,
           "slug": "org-slug",
           "status": Object {
             "id": "active",

--- a/tests/js/spec/views/groupDetails/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/actions.spec.jsx.snap
@@ -52,6 +52,7 @@ exports[`GroupActions render() renders correctly 1`] = `
         "name": "Organization Name",
         "onboardingTasks": Array [],
         "projects": Array [],
+        "scrapeJavaScript": true,
         "slug": "org",
         "status": Object {
           "id": "active",

--- a/tests/js/spec/views/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/projectGeneralSettings.spec.jsx
@@ -73,6 +73,9 @@ describe('projectGeneralSettings', function() {
     expect(wrapper.find('TextArea[name="allowedDomains"]').prop('value')).toBe(
       'example.com\nhttps://example.com'
     );
+    expect(wrapper.find('Switch[name="scrapeJavaScript"]').prop('isDisabled')).toBe(
+      false
+    );
     expect(wrapper.find('Switch[name="scrapeJavaScript"]').prop('isActive')).toBeTruthy();
     expect(wrapper.find('Input[name="securityToken"]').prop('value')).toBe(
       'security-token'
@@ -96,6 +99,16 @@ describe('projectGeneralSettings', function() {
     expect(wrapper.find('Switch[name="scrubIPAddresses"]').prop('isActive')).toBeFalsy();
     expect(wrapper.find('Switch[name="dataScrubber"]').prop('isDisabled')).toBe(true);
     expect(wrapper.find('Switch[name="dataScrubber"]').prop('isActive')).toBe(true);
+  });
+
+  it('disables scrapeJavaScript when equivalent org setting is false', function() {
+    routerContext.context.organization.scrapeJavaScript = false;
+    let wrapper = mount(
+      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />,
+      routerContext
+    );
+    expect(wrapper.find('Switch[name="scrapeJavaScript"]').prop('isDisabled')).toBe(true);
+    expect(wrapper.find('Switch[name="scrapeJavaScript"]').prop('isActive')).toBeFalsy();
   });
 
   it('project admins can remove project', function() {

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPluginsRow.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPluginsRow.spec.jsx.snap
@@ -43,6 +43,7 @@ exports[`ProjectPluginRow renders 1`] = `
           "name": "Organization Name",
           "onboardingTasks": Array [],
           "projects": Array [],
+          "scrapeJavaScript": true,
           "slug": "org-slug",
           "status": Object {
             "id": "active",

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -319,6 +319,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                     "name": "Organization Name",
                                     "onboardingTasks": Array [],
                                     "projects": Array [],
+                                    "scrapeJavaScript": true,
                                     "slug": "org-slug",
                                     "status": Object {
                                       "id": "active",

--- a/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
@@ -23,6 +23,7 @@ exports[`SettingsIndex renders 1`] = `
         "name": "Organization Name",
         "onboardingTasks": Array [],
         "projects": Array [],
+        "scrapeJavaScript": true,
         "slug": "org-slug",
         "status": Object {
           "id": "active",
@@ -132,6 +133,7 @@ exports[`SettingsIndex renders 1`] = `
                       "name": "Organization Name",
                       "onboardingTasks": Array [],
                       "projects": Array [],
+                      "scrapeJavaScript": true,
                       "slug": "org-slug",
                       "status": Object {
                         "id": "active",

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -188,6 +188,7 @@ class OrganizationUpdateTest(APITestCase):
                 'sensitiveFields': ['password'],
                 'safeFields': ['email'],
                 'scrubIPAddresses': True,
+                'scrapeJavaScript': False,
                 'defaultRole': 'owner',
             }
         )
@@ -210,6 +211,7 @@ class OrganizationUpdateTest(APITestCase):
         assert options.get('sentry:require_scrub_ip_address')
         assert options.get('sentry:sensitive_fields') == ['password']
         assert options.get('sentry:safe_fields') == ['email']
+        assert options.get('sentry:scrape_javascript') is False
 
     def test_setting_legacy_rate_limits(self):
         org = self.create_organization(owner=self.user)


### PR DESCRIPTION
This adds an override for scrapeJavaScript to the organization settings. Its inverted from the existing functions (like requireDataScrubbers), and when set to false will disable scrapeJavaScript on all projects.