### PR TITLE
fix(integrations): Make GHE provider name consistent

### DIFF
--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -73,7 +73,6 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
             }, status=403)
 
         provider_id = request.DATA.get('provider')
-
         if features.has('organizations:internal-catchall', organization, actor=request.user):
             if provider_id is not None and provider_id.startswith('integrations:'):
                 try:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1259,7 +1259,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
 SENTRY_INTERNAL_INTEGRATIONS = (
     'bitbucket',
     'github',
-    'github-enterprise',
+    'github_enterprise',
     'jira',
     'vsts',
 )

--- a/src/sentry/identity/github_enterprise/provider.py
+++ b/src/sentry/identity/github_enterprise/provider.py
@@ -19,7 +19,7 @@ def get_user_info(url, access_token):
 
 
 class GitHubEnterpriseIdentityProvider(OAuth2Provider):
-    key = 'github-enterprise'
+    key = 'github_enterprise'
     name = 'GitHub Enterprise'
 
     oauth_scopes = ()
@@ -30,7 +30,7 @@ class GitHubEnterpriseIdentityProvider(OAuth2Provider):
         user = get_user_info(data['access_token'])
 
         return {
-            'type': 'github-enterprise',
+            'type': 'github_enterprise',
             'id': user['id'],
             'email': user['email'],
             'scopes': [],  # GitHub apps do not have user scopes

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -50,9 +50,6 @@ class GitHubIntegration(Integration, GitHubIssueBasic, RepositoryMixin):
     def get_repositories(self):
         return self.get_client().get_repositories()
 
-    def make_external_key(self, data):
-        return '{}#{}'.format(data['repo'], data['key'])
-
     def message_from_error(self, exc):
         if isinstance(exc, ApiError):
             message = API_ERRORS.get(exc.code)

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -32,7 +32,6 @@ logger = logging.getLogger('sentry.webhooks')
 
 class Webhook(object):
     provider = 'github'
-    repo_provider = 'github'
 
     def _handle(self, event, organization, repo):
         raise NotImplementedError
@@ -52,7 +51,7 @@ class Webhook(object):
 
             repos = Repository.objects.filter(
                 organization_id__in=orgs.keys(),
-                provider='integrations:%s' % self.repo_provider,
+                provider='integrations:%s' % self.provider,
                 external_id=six.text_type(event['repository']['id']),
             )
             for repo in repos:
@@ -83,7 +82,7 @@ class InstallationEventWebhook(Webhook):
 
         Repository.objects.filter(
             organization_id__in=organizations.values_list('id', flat=True),
-            provider='integrations:%s' % self.repo_provider,
+            provider='integrations:%s' % self.provider,
             integration_id=integration.id,
         ).update(status=ObjectStatus.DISABLED)
 

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -12,7 +12,7 @@ WEBHOOK_EVENTS = ['push', 'pull_request']
 class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
     name = 'GitHub Enterprise'
     logger = logging.getLogger('sentry.plugins.github_enterprise')
-    repo_provider = 'github-enterprise'
+    repo_provider = 'github_enterprise'
 
     def create_repository(self, organization, data, actor=None):
         integration = Integration.objects.get(

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -25,20 +25,18 @@ def get_installation_metadata(event):
     try:
         integration = Integration.objects.get(
             external_id=event['installation']['id'],
-            provider='github-enterprise')
+            provider='github_enterprise')
     except Integration.DoesNotExist:
         return
     return integration.metadata['installation']
 
 
 class GitHubEnterpriseInstallationEventWebhook(InstallationEventWebhook):
-    provider = 'github-enterprise'
-    repo_provider = 'github_enterprise'
+    provider = 'github_enterprise'
 
 
 class GitHubEnterpriseInstallationRepositoryEventWebhook(InstallationRepositoryEventWebhook):
-    provider = 'github-enterprise'
-    repo_provider = 'github_enterprise'
+    provider = 'github_enterprise'
 
     # https://developer.github.com/v3/activity/events/types/#installationrepositoriesevent
     def _handle(self, event, organization, repo):
@@ -46,8 +44,7 @@ class GitHubEnterpriseInstallationRepositoryEventWebhook(InstallationRepositoryE
 
 
 class GitHubEnterprisePushEventWebhook(PushEventWebhook):
-    provider = 'github-enterprise'
-    repo_provider = 'github_enterprise'
+    provider = 'github_enterprise'
 
     # https://developer.github.com/v3/activity/events/types/#pushevent
     def is_anonymous_email(self, email):
@@ -72,8 +69,7 @@ class GitHubEnterprisePushEventWebhook(PushEventWebhook):
 
 
 class GitHubEnterprisePullRequestEventWebhook(PullRequestEventWebhook):
-    provider = 'github-enterprise'
-    repo_provider = 'github_enterprise'
+    provider = 'github_enterprise'
 
     # https://developer.github.com/v3/activity/events/types/#pullrequestevent
     def is_anonymous_email(self, email):

--- a/src/sentry/static/sentry/app/plugins/components/pluginIcon.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/pluginIcon.jsx
@@ -48,7 +48,7 @@ export const ICON_PATHS = {
   clubhouse,
   flowdock,
   github,
-  'github-enterprise': githubEnterprise,
+  github_enterprise: githubEnterprise,
   gitlab,
   heroku,
   hipchat,

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -25,7 +25,8 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
     }
 
     @patch('sentry.integrations.github_enterprise.integration.get_jwt', return_value='jwt_token_1')
-    def assert_setup_flow(self, get_jwt, installation_id='install_id_1', app_id='app_1', user_id='user_id_1'):
+    def assert_setup_flow(self, get_jwt, installation_id='install_id_1',
+                          app_id='app_1', user_id='user_id_1'):
         responses.reset()
         resp = self.client.get(self.init_path)
         assert resp.status_code == 200
@@ -143,7 +144,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         )
         assert oi.config == {}
 
-        idp = IdentityProvider.objects.get(type='github-enterprise')
+        idp = IdentityProvider.objects.get(type='github_enterprise')
         identity = Identity.objects.get(
             idp=idp,
             user=self.user,

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -89,7 +89,7 @@ class PushEventWebhookTest(APITestCase):
         )
         integration = Integration.objects.create(
             external_id="12345",
-            provider='github-enterprise',
+            provider='github_enterprise',
         )
         integration.add_organization(project.organization.id)
 
@@ -144,7 +144,7 @@ class PushEventWebhookTest(APITestCase):
         }
 
         integration = Integration.objects.create(
-            provider='github-enterprise',
+            provider='github_enterprise',
             external_id='12345',
             name='octocat',
         )
@@ -224,7 +224,7 @@ class PushEventWebhookTest(APITestCase):
         )
         integration = Integration.objects.create(
             external_id="12345",
-            provider='github-enterprise',
+            provider='github_enterprise',
         )
         integration.add_organization(project.organization.id)
 
@@ -239,7 +239,7 @@ class PushEventWebhookTest(APITestCase):
         )
         integration = Integration.objects.create(
             external_id="99",
-            provider='github-enterprise',
+            provider='github_enterprise',
         )
         integration.add_organization(org2.id)
 
@@ -285,7 +285,7 @@ class PullRequestEventWebhook(APITestCase):
         }
 
         integration = Integration.objects.create(
-            provider='github-enterprise',
+            provider='github_enterprise',
             external_id='234',
             name='octocat',
         )
@@ -337,7 +337,7 @@ class PullRequestEventWebhook(APITestCase):
         }
 
         integration = Integration.objects.create(
-            provider='github-enterprise',
+            provider='github_enterprise',
             external_id='234',
             name='octocat',
         )
@@ -388,7 +388,7 @@ class PullRequestEventWebhook(APITestCase):
         }
 
         integration = Integration.objects.create(
-            provider='github-enterprise',
+            provider='github_enterprise',
             external_id='234',
             name='octocat',
         )


### PR DESCRIPTION
Changes `github-enterprise` to be `github_enterprise` for consistency. This change fixes things so GHE can utilize the new flow for adding repositories (using the dropdown).

cc @getsentry/app 