### PR TITLE
feat(discover): Improve validation of order by clause

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -46,6 +46,31 @@ export default class OrganizationDiscover extends React.Component {
     );
   };
 
+  getOrderbyOptions = () => {
+    const {queryBuilder} = this.props;
+    const columns = queryBuilder.getColumns();
+    const query = queryBuilder.getInternal();
+
+    // If there are aggregations, only allow summarized fields in orderby
+    const hasAggregations = query.aggregations.length > 0;
+    const hasFields = query.fields.length > 0;
+
+    return columns.reduce((acc, {name}) => {
+      if (hasAggregations) {
+        const isInvalidField = hasFields && !query.fields.includes(name);
+        if (!hasFields || isInvalidField) {
+          return acc;
+        }
+      }
+
+      return [
+        ...acc,
+        {value: name, label: `${name} asc`},
+        {value: `-${name}`, label: `${name} desc`},
+      ];
+    }, []);
+  };
+
   render() {
     const {result} = this.state;
     const {queryBuilder} = this.props;
@@ -57,14 +82,6 @@ export default class OrganizationDiscover extends React.Component {
       value: name,
       label: name,
     }));
-
-    const orderbyOptions = columns.reduce((acc, {name}) => {
-      return [
-        ...acc,
-        {value: name, label: `${name} asc`},
-        {value: `-${name}`, label: `${name} desc`},
-      ];
-    }, []);
 
     return (
       <div className="organization-home">
@@ -109,7 +126,7 @@ export default class OrganizationDiscover extends React.Component {
             <SelectField
               name="orderby"
               label={t('Order By')}
-              options={orderbyOptions}
+              options={this.getOrderbyOptions()}
               value={query.orderby}
               onChange={val => this.updateField('orderby', val)}
             />

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -12,7 +12,7 @@ describe('Query Builder', function() {
     expect(external.fields).toEqual(['event_id', 'timestamp']);
     expect(external.conditions).toHaveLength(0);
     expect(external.aggregations).toHaveLength(0);
-    expect(external.orderby).toBe('-event_id');
+    expect(external.orderby).toBe('-timestamp');
     expect(external.limit).toBe(1000);
   });
 
@@ -76,6 +76,41 @@ describe('Query Builder', function() {
         name: 'tag1',
         type: 'string',
       });
+    });
+  });
+
+  describe('updateField()', function() {
+    let queryBuilder;
+    beforeEach(function() {
+      queryBuilder = createQueryBuilder(
+        {},
+        TestStubs.Organization({projects: [TestStubs.Project()]})
+      );
+    });
+
+    it('updates field', function() {
+      queryBuilder.updateField('projects', [5]);
+      queryBuilder.updateField('conditions', [['event_id', '=', 'event1']]);
+
+      const query = queryBuilder.getInternal();
+      expect(query.conditions).toEqual([['event_id', '=', 'event1']]);
+    });
+
+    it('updates orderby if there is an aggregation and value is not a summarized field', function() {
+      queryBuilder.updateField('fields', ['environment']);
+      queryBuilder.updateField('aggregations', [['count', null, 'count']]);
+
+      const query = queryBuilder.getInternal();
+      expect(query.orderby).toEqual('environment');
+    });
+
+    it('removes orderby and limit if there is aggregation but no summarize', function() {
+      queryBuilder.updateField('fields', []);
+      queryBuilder.updateField('aggregations', [['count', null, 'count']]);
+
+      const query = queryBuilder.getInternal();
+      expect(query.orderby).toEqual(null);
+      expect(query.limit).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
Changes default orderby clause to `timestamp desc`

This attempts to better handle orderby validation when there is an aggregation present by showing only the valid orderby options in the dropdown as well as automatically updating the orderby field to something valid.