### PR TITLE
fix: Fix latest commit

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -330,7 +330,7 @@ class Release(Model):
         """
 
         # Sort commit list in reverse order
-        commit_list.sort(key=lambda commit: commit.get('date_added'), reverse=True)
+        commit_list.sort(key=lambda commit: commit.get('timestamp'), reverse=True)
 
         # TODO(dcramer): this function could use some cleanup/refactoring as its a bit unwieldly
         from sentry.models import (


### PR DESCRIPTION
Sort commits by `timestamp` not `date_added`, which isn't a valid attribute

This is a follow up to #8903 which introduced the incorrect change