### PR TITLE
ref(ui): Add position relative to PanelHeader

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelHeader.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panelHeader.jsx
@@ -19,6 +19,7 @@ const PanelHeader = styled(({disablePadding, hasButtons, ...props}) => (
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   background: ${p => p.theme.offWhite};
   line-height: 1;
+  position: relative;
   ${getPadding};
 `;
 

--- a/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
@@ -112,20 +112,20 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
               <div>
                 <PanelHeader>
                   <Component
-                    className="css-1ql25pv-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-1yyvx03-PanelHeader-getPadding e1p8v8nv0"
                   >
                     <Flex
                       align="center"
-                      className="css-1ql25pv-PanelHeader-getPadding e1p8v8nv0"
+                      className="css-1yyvx03-PanelHeader-getPadding e1p8v8nv0"
                       justify="space-between"
                     >
                       <Base
                         align="center"
-                        className="e1p8v8nv0 css-hc5qef-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-tinu0q-PanelHeader-getPadding"
                         justify="space-between"
                       >
                         <div
-                          className="e1p8v8nv0 css-hc5qef-PanelHeader-getPadding"
+                          className="e1p8v8nv0 css-tinu0q-PanelHeader-getPadding"
                           is={null}
                         >
                           Subscription

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -20,21 +20,21 @@ exports[`OrganizationTeamProjects Should render 1`] = `
           hasButtons={true}
         >
           <Component
-            className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+            className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
             hasButtons={true}
           >
             <Flex
               align="center"
-              className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+              className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
               justify="space-between"
             >
               <Base
                 align="center"
-                className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                 justify="space-between"
               >
                 <div
-                  className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                  className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                   is={null}
                 >
                   <div>

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -198,20 +198,20 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
               >
                 <PanelHeader>
                   <Component
-                    className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                   >
                     <Flex
                       align="center"
-                      className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                      className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                       justify="space-between"
                     >
                       <Base
                         align="center"
-                        className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                         justify="space-between"
                       >
                         <div
-                          className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                          className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                           is={null}
                         >
                           Edit Alert Rule
@@ -1408,20 +1408,20 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
               >
                 <PanelHeader>
                   <Component
-                    className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                   >
                     <Flex
                       align="center"
-                      className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                      className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                       justify="space-between"
                     >
                       <Base
                         align="center"
-                        className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                         justify="space-between"
                       >
                         <div
-                          className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                          className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                           is={null}
                         >
                           New Alert Rule

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -368,21 +368,21 @@ exports[`projectAlertRules renders 1`] = `
                 >
                   <Component
                     align="center"
-                    className="css-1kcywdb-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-10edylt-PanelHeader-getPadding e1p8v8nv0"
                     justify="space-between"
                   >
                     <Flex
                       align="center"
-                      className="css-1kcywdb-PanelHeader-getPadding e1p8v8nv0"
+                      className="css-10edylt-PanelHeader-getPadding e1p8v8nv0"
                       justify="space-between"
                     >
                       <Base
                         align="center"
-                        className="e1p8v8nv0 css-24tymz-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-51qtoa-PanelHeader-getPadding"
                         justify="space-between"
                       >
                         <div
-                          className="e1p8v8nv0 css-24tymz-PanelHeader-getPadding"
+                          className="e1p8v8nv0 css-51qtoa-PanelHeader-getPadding"
                           is={null}
                         >
                           <TextColorLink

--- a/tests/js/spec/views/__snapshots__/projectDebugSymbols.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugSymbols.spec.jsx.snap
@@ -89,20 +89,20 @@ exports[`ProjectDebugSymbols renders 1`] = `
         >
           <PanelHeader>
             <Component
-              className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+              className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
             >
               <Flex
                 align="center"
-                className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 justify="space-between"
               >
                 <Base
                   align="center"
-                  className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                  className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                   justify="space-between"
                 >
                   <div
-                    className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                    className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                     is={null}
                   >
                     <div>

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -173,20 +173,20 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
         >
           <PanelHeader>
             <Component
-              className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+              className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
             >
               <Flex
                 align="center"
-                className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 justify="space-between"
               >
                 <Base
                   align="center"
-                  className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                  className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                   justify="space-between"
                 >
                   <div
-                    className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                    className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                     is={null}
                   >
                     Active Environments
@@ -398,20 +398,20 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
         >
           <PanelHeader>
             <Component
-              className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+              className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
             >
               <Flex
                 align="center"
-                className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 justify="space-between"
               >
                 <Base
                   align="center"
-                  className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                  className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                   justify="space-between"
                 >
                   <div
-                    className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                    className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                     is={null}
                   >
                     Active Environments
@@ -1051,20 +1051,20 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
         >
           <PanelHeader>
             <Component
-              className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+              className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
             >
               <Flex
                 align="center"
-                className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 justify="space-between"
               >
                 <Base
                   align="center"
-                  className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                  className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                   justify="space-between"
                 >
                   <div
-                    className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                    className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                     is={null}
                   >
                     Hidden
@@ -1276,20 +1276,20 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
         >
           <PanelHeader>
             <Component
-              className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+              className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
             >
               <Flex
                 align="center"
-                className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 justify="space-between"
               >
                 <Base
                   align="center"
-                  className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                  className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                   justify="space-between"
                 >
                   <div
-                    className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                    className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                     is={null}
                   >
                     Hidden

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -403,21 +403,21 @@ exports[`ProjectPluginDetails renders 1`] = `
                         hasButtons={true}
                       >
                         <Component
-                          className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+                          className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
                           hasButtons={true}
                         >
                           <Flex
                             align="center"
-                            className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+                            className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
                             justify="space-between"
                           >
                             <Base
                               align="center"
-                              className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                              className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                               justify="space-between"
                             >
                               <div
-                                className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                                className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                                 is={null}
                               >
                                 <Flex

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -63,21 +63,21 @@ exports[`ProjectSavedSearches renders 1`] = `
                 disablePadding={true}
               >
                 <Component
-                  className="css-12b87zn-PanelHeader-getPadding e1p8v8nv0"
+                  className="css-1su43hb-PanelHeader-getPadding e1p8v8nv0"
                   disablePadding={true}
                 >
                   <Flex
                     align="center"
-                    className="css-12b87zn-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-1su43hb-PanelHeader-getPadding e1p8v8nv0"
                     justify="space-between"
                   >
                     <Base
                       align="center"
-                      className="e1p8v8nv0 css-1f5v8s8-PanelHeader-getPadding"
+                      className="e1p8v8nv0 css-1m84sz9-PanelHeader-getPadding"
                       justify="space-between"
                     >
                       <div
-                        className="e1p8v8nv0 css-1f5v8s8-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-1m84sz9-PanelHeader-getPadding"
                         is={null}
                       >
                         <Flex
@@ -935,21 +935,21 @@ exports[`ProjectSavedSearches renders empty 1`] = `
                 disablePadding={true}
               >
                 <Component
-                  className="css-12b87zn-PanelHeader-getPadding e1p8v8nv0"
+                  className="css-1su43hb-PanelHeader-getPadding e1p8v8nv0"
                   disablePadding={true}
                 >
                   <Flex
                     align="center"
-                    className="css-12b87zn-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-1su43hb-PanelHeader-getPadding e1p8v8nv0"
                     justify="space-between"
                   >
                     <Base
                       align="center"
-                      className="e1p8v8nv0 css-1f5v8s8-PanelHeader-getPadding"
+                      className="e1p8v8nv0 css-1m84sz9-PanelHeader-getPadding"
                       justify="space-between"
                     >
                       <div
-                        className="e1p8v8nv0 css-1f5v8s8-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-1m84sz9-PanelHeader-getPadding"
                         is={null}
                       >
                         <Flex

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -104,20 +104,20 @@ exports[`ProjectTags renders 1`] = `
             >
               <PanelHeader>
                 <Component
-                  className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                  className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 >
                   <Flex
                     align="center"
-                    className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                     justify="space-between"
                   >
                     <Base
                       align="center"
-                      className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                      className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                       justify="space-between"
                     >
                       <div
-                        className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                         is={null}
                       >
                         <Flex>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -147,20 +147,20 @@ exports[`CreateProject should render roles when available and allowed, and handl
             >
               <PanelHeader>
                 <Component
-                  className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                  className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 >
                   <Flex
                     align="center"
-                    className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                     justify="space-between"
                   >
                     <Base
                       align="center"
-                      className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                      className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                       justify="space-between"
                     >
                       <div
-                        className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                         is={null}
                       >
                         Role
@@ -372,20 +372,20 @@ exports[`CreateProject should render roles when available and allowed, and handl
             >
               <PanelHeader>
                 <Component
-                  className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                  className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                 >
                   <Flex
                     align="center"
-                    className="css-xib60i-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-gxu3mm-PanelHeader-getPadding e1p8v8nv0"
                     justify="space-between"
                   >
                     <Base
                       align="center"
-                      className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                      className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                       justify="space-between"
                     >
                       <div
-                        className="e1p8v8nv0 css-1x41mt1-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-18dn1ya-PanelHeader-getPadding"
                         is={null}
                       >
                         Team

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -220,21 +220,21 @@ exports[`Configure should render correctly render() should render platform docs 
                                 hasButtons={true}
                               >
                                 <Component
-                                  className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+                                  className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
                                   hasButtons={true}
                                 >
                                   <Flex
                                     align="center"
-                                    className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+                                    className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
                                     justify="space-between"
                                   >
                                     <Base
                                       align="center"
-                                      className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                                      className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                                       justify="space-between"
                                     >
                                       <div
-                                        className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                                        className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                                         is={null}
                                       >
                                         Configure node

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -309,21 +309,21 @@ exports[`OrganizationApiKeysList renders 1`] = `
           >
             <Component
               align="center"
-              className="css-12b87zn-PanelHeader-getPadding e1p8v8nv0"
+              className="css-1su43hb-PanelHeader-getPadding e1p8v8nv0"
               disablePadding={true}
             >
               <Flex
                 align="center"
-                className="css-12b87zn-PanelHeader-getPadding e1p8v8nv0"
+                className="css-1su43hb-PanelHeader-getPadding e1p8v8nv0"
                 justify="space-between"
               >
                 <Base
                   align="center"
-                  className="e1p8v8nv0 css-1f5v8s8-PanelHeader-getPadding"
+                  className="e1p8v8nv0 css-1m84sz9-PanelHeader-getPadding"
                   justify="space-between"
                 >
                   <div
-                    className="e1p8v8nv0 css-1f5v8s8-PanelHeader-getPadding"
+                    className="e1p8v8nv0 css-1m84sz9-PanelHeader-getPadding"
                     is={null}
                   >
                     <Flex

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -213,21 +213,21 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                 hasButtons={true}
               >
                 <Component
-                  className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+                  className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
                   hasButtons={true}
                 >
                   <Flex
                     align="center"
-                    className="css-x2bfp3-PanelHeader-getPadding e1p8v8nv0"
+                    className="css-xm0vov-PanelHeader-getPadding e1p8v8nv0"
                     justify="space-between"
                   >
                     <Base
                       align="center"
-                      className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                      className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                       justify="space-between"
                     >
                       <div
-                        className="e1p8v8nv0 css-1ticb9y-PanelHeader-getPadding"
+                        className="e1p8v8nv0 css-13rknte-PanelHeader-getPadding"
                         is={null}
                       >
                         Projects


### PR DESCRIPTION
This allows us to position things within a panel. Initially added to
support alignment of a loading indicator.