### PR TITLE
feat(assistant): Fix hashtag assistant bugs

### DIFF
--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -34,10 +34,11 @@ const GuideStore = Reflux.createStore({
     this.listenTo(ProjectActions.setActive, this.onSetActiveProject);
     this.listenTo(OrganizationsActions.changeSlug, this.onChangeSlug);
 
-    window.addEventListener('hashchange', this.onHashChange, false);
+    window.addEventListener('hashchange', this.onURLChange, false);
+    window.addEventListener('load', this.onURLChange, false);
   },
 
-  onHashChange() {
+  onURLChange() {
     this.state.forceShow = window.location.hash === '#assistant';
     this.updateCurrentGuide();
   },
@@ -71,6 +72,8 @@ const GuideStore = Reflux.createStore({
         })
       ].seen = true;
     }
+    // Don't continue to force show if the user dismissed the guide.
+    this.state.forceShow = false;
     this.updateCurrentGuide();
   },
 

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -88,7 +88,11 @@ describe('GuideStore', function() {
     GuideStore.onRegisterAnchor(anchor2);
     GuideStore.state.forceShow = true;
     GuideStore.onFetchSucceeded(data);
-    expect(GuideStore.state.currentGuide).not.toEqual(null);
+    expect(GuideStore.state.currentGuide.id).toEqual(1);
+    GuideStore.onCloseGuideOrSupport();
+    expect(GuideStore.state.currentGuide.id).toEqual(2);
+    GuideStore.onCloseGuideOrSupport();
+    expect(GuideStore.state.currentGuide).toEqual(null);
   });
 
   it('should record analytics events when guide is cued', function() {


### PR DESCRIPTION
- #assistant works correctly on load now
- dismissing a guide while the hash is active also works correctly now