### PR TITLE
fix(discover): Fix conditions with the number 0

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
@@ -78,7 +78,8 @@ export function getExternal(internal, columns) {
     const type = columns.find(({name}) => name === colValue).type;
 
     if (type === 'number') {
-      external[2] = parseInt(external[2], 10) || null;
+      const num = parseInt(external[2], 10);
+      external[2] = !isNaN(num) ? num : null;
     }
   }
 

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -23,6 +23,10 @@ const conditionList = [
     internal: 'retention_days = 3',
     external: ['retention_days', '=', 3],
   },
+  {
+    internal: 'retention_days >= 0',
+    external: ['retention_days', '>=', 0],
+  },
 ];
 
 describe('Conditions', function() {


### PR DESCRIPTION
This fixes a bug that cast all falsy values in conditions to null so any condition with the number 0 wasn't working