### PR TITLE
feat(onboarding): Don't show project cards if first event not sent

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/index.jsx
@@ -47,6 +47,10 @@ class Dashboard extends React.Component {
 
     const hasTeamAdminAccess = access.has('team:admin');
 
+    if (projects.length === 1 && !projects[0].firstEvent) {
+      return <Resources org={organization} project={projects[0]} />;
+    }
+
     return (
       <React.Fragment>
         {favorites.length > 0 && (
@@ -88,10 +92,6 @@ class Dashboard extends React.Component {
         {teamSlugs.length === 0 &&
           favorites.length === 0 && (
             <EmptyState projects={projects} teams={teams} organization={organization} />
-          )}
-        {projects.length === 1 &&
-          !projects[0].firstEvent && (
-            <Resources org={organization} project={projects[0]} />
           )}
       </React.Fragment>
     );

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -61,7 +61,7 @@ class DashboardTest(AcceptanceTestCase):
         self.project.update(first_event=None)
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading-indicator')
-        self.browser.wait_until('[data-test-id] figure')
+        self.browser.wait_until('[data-test-id="awaiting-events"]')
         self.browser.snapshot('org dash no issues')
 
     def test_one_issue(self):

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -95,7 +95,10 @@ describe('OrganizationDashboard', function() {
     beforeEach(function() {});
 
     it('renders TeamSection', function() {
-      const projects = [TestStubs.Project({teams})];
+      const projects = [TestStubs.Project({
+        teams,
+        firstEvent: true,
+      })];
 
       const wrapper = shallow(
         <Dashboard
@@ -115,7 +118,11 @@ describe('OrganizationDashboard', function() {
     });
 
     it('renders favorited project in favorites section ', function() {
-      const projects = [TestStubs.Project({teams, isBookmarked: true})];
+      const projects = [TestStubs.Project({
+        teams,
+        isBookmarked: true,
+        firstEvent: true,
+      })];
 
       const wrapper = shallow(
         <Dashboard


### PR DESCRIPTION
We're showing projects/teams/favorites on the org dashboard before first event (not very useful IMO) causing the error robot + resources to get pushed out of view.