### PR TITLE
fix(tests): Fix duplicate window.tick definition

### DIFF
--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -63,9 +63,6 @@ window.$ = window.jQuery = jQuery;
 window.sinon = sinon;
 window.scrollTo = jest.fn();
 
-// Instead of wrapping codeblocks in `setTimeout`
-window.tick = () => new Promise(res => setTimeout(res));
-
 // emotion context broadcast
 const broadcast = createBroadcast(theme);
 


### PR DESCRIPTION
Two is one too many - this code also exists 7 lines above.