### PR TITLE
build: upgrade to latest flake8 (3.5.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python: 2.7
 branches:
   only:
   - master
-  - build/upgrade-flake8
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python: 2.7
 branches:
   only:
   - master
+  - build/upgrade-flake8
 
 cache:
   yarn: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-autopep8
+autopep8>=1.3.5
 Babel
-flake8>=2.6,<2.7
+flake8>=3.5.0
 isort>=4.2.2,<4.3.0
-pycodestyle>=2.0,<2.1
+pycodestyle>=2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-autopep8>=1.3.5
+autopep8>=1.3.5,<1.4.0
 Babel
-flake8>=3.5.0
+flake8>=3.5.0<3.6.0
 isort>=4.2.2,<4.3.0
-pycodestyle>=2.3
+pycodestyle>=2.3,<2.4.0

--- a/src/bitfield/forms.py
+++ b/src/bitfield/forms.py
@@ -43,10 +43,11 @@ class BitFormField(IntegerField):
     def __init__(self, choices=(), widget=BitFieldCheckboxSelectMultiple, *args, **kwargs):
         if isinstance(kwargs['initial'], int):
             iv = kwargs['initial']
-            kwargs['initial'] = []
+            L = []
             for i in range(0, 63):
                 if (1 << i) & iv > 0:
-                    kwargs['initial'] += [choices[i][0]]
+                    L += [choices[i][0]]
+            kwargs['initial'] = L
         self.widget = widget
         super(BitFormField, self).__init__(widget=widget, *args, **kwargs)
         self.choices = self.widget.choices = choices

--- a/src/bitfield/forms.py
+++ b/src/bitfield/forms.py
@@ -43,11 +43,10 @@ class BitFormField(IntegerField):
     def __init__(self, choices=(), widget=BitFieldCheckboxSelectMultiple, *args, **kwargs):
         if isinstance(kwargs['initial'], int):
             iv = kwargs['initial']
-            l = []
+            kwargs['initial'] = []
             for i in range(0, 63):
                 if (1 << i) & iv > 0:
-                    l += [choices[i][0]]
-            kwargs['initial'] = l
+                    kwargs['initial'] += [choices[i][0]]
         self.widget = widget
         super(BitFormField, self).__init__(widget=widget, *args, **kwargs)
         self.choices = self.widget.choices = choices

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -55,6 +55,7 @@ class U2fRestSerializer(serializers.Serializer):
         required=True,
     )
 
+
 serializer_map = {
     'totp': TotpRestSerializer,
     'sms': SmsRestSerializer,

--- a/src/sentry/api/serializers/models/authenticator.py
+++ b/src/sentry/api/serializers/models/authenticator.py
@@ -38,5 +38,6 @@ class SmsInterfaceSerializer(AuthenticatorInterfaceSerializer):
         data['phone'] = obj.phone_number
         return data
 
+
 for interface in RecoveryCodeInterface, TotpInterface, U2fInterface:
     register(interface)(AuthenticatorInterfaceSerializer)

--- a/src/sentry/db/models/fields/citext.py
+++ b/src/sentry/db/models/fields/citext.py
@@ -64,4 +64,5 @@ def create_citext_extension(db, **kwargs):
         except Exception:
             pass
 
+
 pre_syncdb.connect(create_citext_extension)

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -21,6 +21,7 @@ from sentry.db.exceptions import CannotResolveExpression
 class _UnknownType(object):
     pass
 
+
 try:
     from django.db.models.expressions import ExpressionNode
     Value = _UnknownType

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -26,6 +26,7 @@ class ExampleSetupView(PipelineView):
 
         return HttpResponse(self.TEMPLATE)
 
+
 DESCRIPTION = """
 This is an example integration
 

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -34,6 +34,7 @@ def apierror(message="Invalid data"):
     from sentry.coreapi import APIForbidden
     raise APIForbidden(message)
 
+
 PAIRS = {
     'type': 'array',
     'items': {

--- a/src/sentry/lang/javascript/errorlocale.py
+++ b/src/sentry/lang/javascript/errorlocale.py
@@ -51,6 +51,7 @@ def find_translation(message):
 def format_message(message, data):
     return message.replace('%s', data)
 
+
 message_type_regexp = re.compile('^(?P<type>[a-zA-Z]*Error): (?P<message>.*)')
 
 

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -114,7 +114,7 @@ def get_python_files(file_list=None):
 
 # parseable is a no-op
 def py_lint(file_list, parseable=False):
-    from flake8.engine import get_style_guide
+    from flake8.api.legacy import get_style_guide
 
     file_list = get_python_files(file_list)
     flake8_style = get_style_guide(parse_argv=True)

--- a/src/sentry/models/groupenvironment.py
+++ b/src/sentry/models/groupenvironment.py
@@ -44,6 +44,7 @@ class GroupEnvironment(Model):
 
         return instance, created
 
+
 post_delete.connect(
     lambda instance, **kwargs: cache.delete(
         GroupEnvironment._get_cache_key(

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -305,5 +305,6 @@ class User(BaseModel, AbstractBaseUser):
     def clear_lost_passwords(self):
         LostPasswordHash.objects.filter(user=self).delete()
 
+
 # HACK(dcramer): last_login needs nullable for Django 1.8
 User._meta.get_field('last_login').null = True

--- a/src/sentry/receivers/auth.py
+++ b/src/sentry/receivers/auth.py
@@ -36,6 +36,7 @@ def remove_lost_password_hashes(sender, user, **kwargs):
     # Remove pending password recovery hashes; user was able to login
     user.clear_lost_passwords()
 
+
 user_logged_in.disconnect(update_last_login)
 user_logged_in.connect(
     safe_update_last_login,

--- a/src/sentry/utils/colors.py
+++ b/src/sentry/utils/colors.py
@@ -1,11 +1,10 @@
-# flake8: noqa
 from __future__ import absolute_import
 
 import hashlib
 import colorsys
 
 
-def get_hashed_color(string, l=0.5, s=0.5):
+def get_hashed_color(string, l=0.5, s=0.5):  # noqa: E741
     val = int(hashlib.md5(string.encode('utf-8')).hexdigest()[:3], 16)
     tup = colorsys.hls_to_rgb(val / 4096.0, l, s)
     return '#%02x%02x%02x' % (int(tup[0] * 255), int(tup[1] * 255), int(tup[2] * 255), )

--- a/src/sentry/utils/colors.py
+++ b/src/sentry/utils/colors.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from __future__ import absolute_import
 
 import hashlib

--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -28,6 +28,7 @@ class FilterStatKeys(object):
     CORS = 'cors'
     DISCARDED_HASH = 'discarded-hash'
 
+
 FILTER_STAT_KEYS_TO_VALUES = {
     FilterStatKeys.IP_ADDRESS: tsdb.models.project_total_received_ip_address,
     FilterStatKeys.RELEASE_VERSION: tsdb.models.project_total_received_release_version,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -35,6 +35,7 @@ def timer(name, prefix='snuba.client'):
     finally:
         metrics.timing('{}.{}'.format(prefix, name), time.time() - t)
 
+
 _snuba_pool = urllib3.connectionpool.connection_from_url(
     settings.SENTRY_SNUBA,
     retries=False,

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -227,13 +227,19 @@ def alert(request):
         make_group_generator(random, project),
     )
 
+    data = load_data(platform)
+    data['tags'] = [
+        ('logger', 'javascript'), ('environment', 'prod'), ('level', 'error'),
+        ('device', 'Other')
+    ]
+
     event = Event(
         id=1,
         event_id='44f1419e73884cd2b45c79918f4b6dc4',
         project=project,
         group=group,
         message=group.message,
-        data=load_data(platform),
+        data=data,
         datetime=to_datetime(
             random.randint(
                 to_timestamp(group.first_seen),
@@ -262,10 +268,6 @@ def alert(request):
             'interfaces': interface_list,
             'tags': event.get_tags(),
             'project_label': project.slug,
-            'tags': [
-                ('logger', 'javascript'), ('environment', 'prod'), ('level', 'error'),
-                ('device', 'Other')
-            ],
             'commits': [{
                 # TODO(dcramer): change to use serializer
                 "repository": {"status": "active", "name": "Example Repo", "url": "https://github.com/example/example", "dateCreated": "2018-02-28T23:39:22.402Z", "provider": {"id": "github", "name": "GitHub"}, "id": "1"},

--- a/tests/fixtures/emails/alert.txt
+++ b/tests/fixtures/emails/alert.txt
@@ -14,10 +14,10 @@ Suspect Commits
 Tags
 ----
 
-* logger = javascript
+* device = Other
 * environment = prod
 * level = error
-* device = Other
+* logger = javascript
 
 
 Stacktrace

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -214,7 +214,6 @@ class ProjectUpdateTest(APITestCase):
 
     def test_options(self):
         options = {
-            'sentry:origins': 'foo\nbar',
             'sentry:resolve_age': 1,
             'sentry:scrub_data': False,
             'sentry:scrub_defaults': False,

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -271,12 +271,6 @@ class BasicResolvingIntegrationTest(TestCase):
                     }
                 ]
             },
-            "contexts": {
-                "os": {
-                    "name": "iOS",
-                    "version": "9.3.0"
-                }
-            },
             "sentry.interfaces.Exception": {
                 "values": [
                     {
@@ -633,12 +627,6 @@ class InAppHonoringResolvingIntegrationTest(TestCase):
                     }
                 ]
             },
-            "contexts": {
-                "os": {
-                    "name": "iOS",
-                    "version": "9.3.0"
-                }
-            },
             "sentry.interfaces.Exception": {
                 "values": [
                     {
@@ -787,12 +775,6 @@ class InAppHonoringResolvingIntegrationTest(TestCase):
                         "name": object_name,
                     }
                 ]
-            },
-            "contexts": {
-                "os": {
-                    "name": "iOS",
-                    "version": "9.3.0"
-                }
             },
             "sentry.interfaces.Exception": {
                 "values": [


### PR DESCRIPTION
Bumping flake8 up a major version. Wasn't as bad as I thought it would be.

Also resolves this annoying warning (but does not impact functionality since I assume `pycodestyle` API doesn't differ that much between 2.0 and 2.4) that we've been having for a long time (`pip check`): `flake8 2.6.2 has requirement pycodestyle<2.1,>=2.0, but you'll have pycodestyle 2.4.0 which is incompatible.`