### PR TITLE
ref(native): Update wording for symbolication error message

### DIFF
--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -93,7 +93,7 @@ class EventError(object):
         NATIVE_MISSING_OPTIONALLY_BUNDLED_DSYM: u'An optional debug information file was missing.',
         NATIVE_MISSING_DSYM: u'A required debug information file was missing.',
         NATIVE_MISSING_SYSTEM_DSYM: u'A system debug information file was missing.',
-        NATIVE_MISSING_SYMBOL: u'Unable to resolve a symbol.',
+        NATIVE_MISSING_SYMBOL: u'Could not resolve one or more frames in debug information file.',
         NATIVE_SIMULATOR_FRAME: u'Encountered an unprocessable simulator frame.',
         NATIVE_UNKNOWN_IMAGE: u'A binary image is referenced that is unknown.',
         PROGUARD_MISSING_MAPPING: u'A proguard mapping file was missing.',

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -25,7 +25,7 @@ const MESSAGES = {
   ),
   native_missing_dsym: t('A required debug information file was missing.'),
   native_missing_system_dsym: t('A system debug information file was missing.'),
-  native_missing_symbol: t('Unable to resolve a symbol.'),
+  native_missing_symbol: t('Could not resolve one or more frames in debug information file.'),
   native_simulator_frame: t('Encountered an unprocessable simulator frame.'),
   native_unknown_image: t('A binary image is referenced that is unknown.'),
   proguard_missing_mapping: t('A proguard mapping file was missing.'),


### PR DESCRIPTION
Uses have repeatedly been confused about the _"Unable to resolve a symbol."_ error message. It in fact does not mean that a debug symbol (read: debug information file) wasn't found. Instead, it means that we couldn'nt look up an address in the DIF.

Changing this message now to resolve the confusion.