### PR TITLE
chore(npm): No package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ coverage.xml
 junit.xml
 *.codestyle.xml
 .pytest_cache/
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Do not generate `package-lock.json` and add it to gitignore as well.