### PR TITLE
fix(ui): Fix user language configuration

### DIFF
--- a/src/sentry/static/sentry/app/stores/configStore.jsx
+++ b/src/sentry/static/sentry/app/stores/configStore.jsx
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
 import Reflux from 'reflux';
+import qs from 'query-string';
 import {setLocale} from 'app/locale';
 
 const ConfigStore = Reflux.createStore({
@@ -30,7 +31,15 @@ const ConfigStore = Reflux.createStore({
     if (config.user) {
       config.user.permissions = new Set(config.user.permissions);
       moment.tz.setDefault(config.user.options.timezone);
-      setLocale(languageOverride || config.user.options.language || 'en');
+
+      // Parse query string for `lang`
+      let queryString = qs.parse(window.location.search) || {};
+
+      // Priority:
+      // "?lang=en" --> user configuration options --> django request.LANGUAGE_CODE --> "en"
+      setLocale(
+        queryString.lang || config.user.options.language || languageOverride || 'en'
+      );
     } else if (languageOverride) {
       setLocale(languageOverride);
     }


### PR DESCRIPTION
django seems to always supply a LANGUAGE_CODE, so user configuration was being overridden. Add client query string parsing for `lang` override in URL

Fixes https://github.com/getsentry/sentry/pull/9005