### PR TITLE
fix(roles): Fix admin role, "project:integrations" and "team:read"

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1139,7 +1139,7 @@ SENTRY_ROLES = (
                 'project:write',
                 'project:admin',
                 'project:releases',
-                'project:integrations'
+                'project:integrations',
                 'team:read',
                 'team:write',
                 'team:admin',


### PR DESCRIPTION
... missing comma caused this to concat into a single string.

Fixes JAVASCRIPT-415