### PR TITLE
fix(dashboard): Truncate long time ago text

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/deploys.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/deploys.jsx
@@ -72,7 +72,7 @@ class Deploy extends React.Component {
           </StyledLink>
         </Version>
         <Flex w={90} justify="flex-end">
-          <DynamicWrapper
+          <StyledDynamicWrapper
             value={moment(deploy.dateFinished).fromNow()}
             fixed="3 hours ago"
           />
@@ -108,6 +108,12 @@ const Version = styled(TextOverflow)`
 const StyledLink = styled(Link)`
   text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
+`;
+
+const StyledDynamicWrapper = styled(DynamicWrapper)`
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 `;
 

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -658,11 +658,11 @@ exports[`ProjectCard renders 1`] = `
                   p={2}
                 >
                   <Base
-                    className="css-1y6xtyw-DeployBox eltxe6c4"
+                    className="css-1y6xtyw-DeployBox eltxe6c5"
                     p={2}
                   >
                     <div
-                      className="css-1y6xtyw-DeployBox eltxe6c4"
+                      className="css-1y6xtyw-DeployBox eltxe6c5"
                       is={null}
                     >
                       <Background
@@ -671,11 +671,11 @@ exports[`ProjectCard renders 1`] = `
                       >
                         <Base
                           align="center"
-                          className="css-itelel-Background eltxe6c5"
+                          className="css-itelel-Background eltxe6c6"
                           justify="center"
                         >
                           <div
-                            className="css-itelel-Background eltxe6c5"
+                            className="css-itelel-Background eltxe6c6"
                             is={null}
                           >
                             <Button


### PR DESCRIPTION
This prevents the line breaking and the dashboard alignment looking
weird in the case where the time reads "a few seconds ago".

Closes APP-406