### PR TITLE
chore(js): Rename global Sentry variable to SentryApp

### DIFF
--- a/src/sentry/plugins/base/configuration.py
+++ b/src/sentry/plugins/base/configuration.py
@@ -35,7 +35,7 @@ def react_plugin_config(plugin, project, request):
     <div id="ref-plugin-config"></div>
     <script>
     $(function(){
-        ReactDOM.render(React.createFactory(Sentry.PluginConfig)({
+        ReactDOM.render(React.createFactory(SentryApp.PluginConfig)({
             project: %s,
             organization: %s,
             data: %s

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -78,7 +78,7 @@ export default {
 
   SentryRenderApp: () => render(Main),
 
-  Sentry: {
+  SentryApp: {
     api,
     forms: {
       // we dont yet export all form field classes as they're not

--- a/src/sentry/templates/sentry/account/avatar.html
+++ b/src/sentry/templates/sentry/account/avatar.html
@@ -10,7 +10,7 @@
   <div id="avatar-settings"></div>
   <script>
     $(function() {
-      ReactDOM.render(React.createFactory(Sentry.AvatarSettings)({
+      ReactDOM.render(React.createFactory(SentryApp.AvatarSettings)({
         userId: {{ request.user.id }}
       }), document.getElementById('avatar-settings'))
     });

--- a/src/sentry/templates/sentry/account/sudo.html
+++ b/src/sentry/templates/sentry/account/sudo.html
@@ -56,7 +56,7 @@
                 {% if u2f_challenge %}
                     <div id="u2f-challenge"></div>
                     <script>
-                      ReactDOM.render(React.createElement(Sentry.U2fSign, {
+                      ReactDOM.render(React.createElement(SentryApp.U2fSign, {
                         challengeData: {{ u2f_challenge|to_json|safe }},
                         displayMode: 'sudo'
                       }), document.getElementById('u2f-challenge'));

--- a/src/sentry/templates/sentry/account/twofactor/enroll_u2f.html
+++ b/src/sentry/templates/sentry/account/twofactor/enroll_u2f.html
@@ -20,7 +20,7 @@
     </fieldset>
   </form>
   <script>
-    ReactDOM.render(React.createElement(Sentry.U2fEnrollment, {
+    ReactDOM.render(React.createElement(SentryApp.U2fEnrollment, {
       enrollmentData: {{ enrollment_data|to_json|safe }}
     }), document.getElementById('u2f-enrollment'));
   </script>

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -54,7 +54,7 @@
     // if the ads.js file loads below it will mark this variable as false
     window.adblockSuspected = true;
 
-    Sentry.ConfigStore.loadInitialData({% get_react_config %}, {{ request.LANGUAGE_CODE|to_json|safe }});
+    SentryApp.ConfigStore.loadInitialData({% get_react_config %}, {{ request.LANGUAGE_CODE|to_json|safe }});
   </script>
   <script src="{% asset_url 'sentry' 'js/ads.js' %}"></script>
 
@@ -87,8 +87,8 @@
               }
             },
             render: function () {
-              return React.createElement(Sentry.OrganizationsLoader, {},
-                React.createElement(Sentry.Sidebar));
+              return React.createElement(SentryApp.OrganizationsLoader, {},
+                React.createElement(SentryApp.Sidebar));
             }
           });
           SidebarWrapper.childContextTypes = {
@@ -177,7 +177,7 @@
         {% block header_nav %}{% endblock %}
         <script>
         $(function(){
-          ReactDOM.render(React.createFactory(Sentry.ProjectSelector)({
+          ReactDOM.render(React.createFactory(SentryApp.ProjectSelector)({
             organization: {% serialize_detailed_org organization %},
             projectId: {% if project %}'{{ project.slug }}'{% else %}null{% endif %},
           }), document.getElementById('blk_projectselect'));

--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -2,7 +2,7 @@
 <div id="blk_alerts" class="messages-container"></div>
 <script>
 $(function(){
-  ReactDOM.render(React.createFactory(Sentry.Alerts)({
+  ReactDOM.render(React.createFactory(SentryApp.Alerts)({
      className: "alert-list"
   }), document.getElementById('blk_alerts'));
 });
@@ -10,7 +10,7 @@ $(function(){
 <div id="blk_indicators"></div>
 <script>
 $(function(){
-  ReactDOM.render(React.createFactory(Sentry.Indicators)({
+  ReactDOM.render(React.createFactory(SentryApp.Indicators)({
      className: "indicators-container"
   }), document.getElementById('blk_indicators'));
 });

--- a/src/sentry/templates/sentry/setup-wizard.html
+++ b/src/sentry/templates/sentry/setup-wizard.html
@@ -10,7 +10,7 @@
 {% block auth_main %}
   <div id="setup-wizard-container"></div>
   <script>
-    ReactDOM.render(React.createElement(Sentry.SetupWizard, {
+    ReactDOM.render(React.createElement(SentryApp.SetupWizard, {
       hash: {{ hash|to_json|safe }}
     }), document.getElementById('setup-wizard-container'));
   </script>

--- a/src/sentry/templates/sentry/twofactor_u2f.html
+++ b/src/sentry/templates/sentry/twofactor_u2f.html
@@ -3,7 +3,7 @@
 {% block twofactor_form_body %}
   <div id="u2f-container"></div>
   <script>
-    ReactDOM.render(React.createElement(Sentry.U2fSign, {
+    ReactDOM.render(React.createElement(SentryApp.U2fSign, {
       challengeData: {{ activation.challenge|to_json|safe }}
     }), document.getElementById('u2f-container'));
   </script>


### PR DESCRIPTION
In order for SDK name unification to work, we need to change the name of a globally exported `window.Sentry` variable. The best choice for this seems to be `SentryApp`.

Otherwise, we can get race conditions and errors thrown here - https://github.com/getsentry/sentry/blob/c5225316c23583840d4c5d346f66228e986150ea/src/sentry/templates/sentry/layout.html#L57 which we already caught few of.

Find regexp:
```
Sentry\.(api|forms|plugins|Alerts|AlertActions|AsyncComponent|AsyncView|AvatarSettings|Button|mixins|BarChart|i18n|ConfigStore|Count|DateTime|DropdownLink|DynamicWrapper|ErrorBoundary|Form|FormState|GuideAnchor|HookStore|Indicators|IndicatorStore|InviteMember|LoadingError|LoadingIndicator|ListLink|MenuItem|NarrowLayout|OrganizationHomeContainer|OrganizationsLoader|OrganizationMembersView|Panel|PanelHeader|PanelBody|PanelItem|Pagination|PluginConfig|ProjectIssueTracking|ProjectSelector|SettingsPageHeader|Sidebar|StackedBarChart|TextBlock|TimeSince|TodoList|Tooltip|U2fEnrollment|U2fSign|Badge|Switch|GlobalModal|SetupWizard|theme|utils)
```

Replace regexp:
```
SentryApp.$1
```