### PR TITLE
fix(integrations): Make external IDs unique across GHE installations

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -95,7 +95,7 @@ class GitHubClientMixin(ApiClient):
     def create_token(self):
         return self.post(
             '/installations/{}/access_tokens'.format(
-                self.external_id,
+                self.installation_id,
             ),
             headers={
                 'Authorization': 'Bearer %s' % self.get_jwt(),
@@ -110,8 +110,8 @@ class GitHubClientMixin(ApiClient):
 
 class GitHubAppsClient(GitHubClientMixin):
 
-    def __init__(self, external_id):
-        self.external_id = external_id
+    def __init__(self, installation_id):
+        self.installation_id = installation_id
         self.token = None
         self.expires_at = None
         super(GitHubAppsClient, self).__init__()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -57,7 +57,7 @@ API_ERRORS = {
 class GitHubIntegration(Integration, GitHubIssueBasic, RepositoryMixin):
 
     def get_client(self):
-        return GitHubAppsClient(external_id=self.model.external_id)
+        return GitHubAppsClient(installation_id=self.model.external_id)
 
     def get_repositories(self):
         return self.get_client().get_repositories()

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -73,17 +73,13 @@ class InstallationEventWebhook(Webhook):
     def __call__(self, event, host=None):
         installation = event['installation']
         if installation and event['action'] == 'deleted':
+            external_id = event['installation']['id']
             if host:
                 external_id = '{}:{}'.format(host, event['installation']['id'])
-                integration = Integration.objects.get(
-                    external_id=external_id,
-                    provider=self.provider,
-                )
-            else:
-                integration = Integration.objects.get(
-                    external_id=event['installation']['id'],
-                    provider=self.provider,
-                )
+            integration = Integration.objects.get(
+                external_id=external_id,
+                provider=self.provider,
+            )
             self._handle_delete(event, integration)
 
     def _handle_delete(self, event, integration):
@@ -276,7 +272,7 @@ class PullRequestEventWebhook(Webhook):
 
     def get_idp_external_id(self, host=None):
         # todo(meredith): when we have the integration will return
-        # integration.external_id
+        # options.get(github-app.id)
         return
 
     def _handle(self, event, organization, repo, host=None):

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -110,9 +110,7 @@ class PushEventWebhook(Webhook):
         return 'github:%s' % username
 
     def get_idp_external_id(self, host=None):
-        # todo(meredith): when we have the integration will return
-        # integration.external_id
-        return
+        return options.get('github-app.id')
 
     def get_client(self, event, host=None):
         return GitHubAppsClient(event['installation']['id'])
@@ -172,7 +170,7 @@ class PushEventWebhook(Webhook):
                                 gh_username_cache[gh_username] = None
                                 try:
                                     identity = Identity.objects.get(
-                                        external_id=gh_user['id'], idp__external_id=self.get_idp_external_id(host))
+                                        external_id=gh_user['id'], idp__type=self.provider, idp__external_id=self.get_idp_external_id(host))
                                 except Identity.DoesNotExist:
                                     pass
                                 else:
@@ -271,9 +269,7 @@ class PullRequestEventWebhook(Webhook):
         return 'github:%s' % username
 
     def get_idp_external_id(self, host=None):
-        # todo(meredith): when we have the integration will return
-        # options.get(github-app.id)
-        return
+        return options.get('github-app.id')
 
     def _handle(self, event, organization, repo, host=None):
         pull_request = event['pull_request']
@@ -299,7 +295,7 @@ class PullRequestEventWebhook(Webhook):
         except CommitAuthor.DoesNotExist:
             try:
                 identity = Identity.objects.get(
-                    external_id=user['id'], idp__external_id=self.get_idp_external_id(host))
+                    external_id=user['id'], idp__type=self.provider, idp__external_id=self.get_idp_external_id(host))
             except Identity.DoesNotExist:
                 pass
             else:

--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -8,9 +8,9 @@ from sentry.integrations.github.client import GitHubClientMixin
 class GitHubEnterpriseAppsClient(GitHubClientMixin):
     base_url = None
 
-    def __init__(self, base_url, app_id, external_id, private_key):
+    def __init__(self, base_url, app_id, installation_id, private_key):
         self.base_url = "https://{}/api/v3".format(base_url)
-        self.external_id = external_id
+        self.installation_id = installation_id
         self.app_id = app_id
         self.private_key = private_key
         self.token = None

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -44,8 +44,9 @@ API_ERRORS = {
 
 class GitHubEnterpriseIntegration(Integration, GitHubIssueBasic, RepositoryMixin):
     def get_client(self):
+        base_url = urlparse(self.model.metadata['domain_name']).netloc
         return GitHubEnterpriseAppsClient(
-            base_url=self.model.metadata['domain_name'],
+            base_url=base_url,
             installation_id=self.model.metadata['installation_id'],
             private_key=self.model.metadata['installation']['private_key'],
             app_id=self.model.metadata['installation']['id'],
@@ -225,22 +226,21 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             identity['access_token'],
             state['installation_id'])
 
-        domain_name = installation['account']['html_url'].replace('https://', '').split("/")[0]
-
+        domain = urlparse(installation['account']['html_url']).netloc
         return {
             'name': installation['account']['login'],
             # installation id is not enough to be unique for self-hosted GH
-            'external_id': '{}:{}'.format(domain_name, installation['id']),
+            'external_id': '{}:{}'.format(domain, installation['id']),
             # GitHub identity is associated directly to the application, *not*
             # to the installation itself.
             # app id is not enough to be unique for self-hosted GH
-            'idp_external_id': '{}:{}'.format(domain_name, installation['app_id']),
+            'idp_external_id': '{}:{}'.format(domain, installation['app_id']),
             'metadata': {
                 # The access token will be populated upon API usage
                 'access_token': None,
                 'expires_at': None,
                 'icon': installation['account']['avatar_url'],
-                'domain_name': domain_name,
+                'domain_name': installation['account']['html_url'],
                 'installation_id': installation['id'],
                 'installation': installation_data
             },

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -246,8 +246,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             },
             'user_identity': {
                 'type': 'github_enterprise',
-                # used id is not enough to be unique for self-hosted GH
-                'external_id': '{}:{}'.format(domain_name, user['id']),
+                'external_id': user['id'],
                 'scopes': [],  # GitHub apps do not have user scopes
                 'data': {'access_token': identity['access_token']},
             },

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -55,8 +55,10 @@ class GitHubEnterprisePushEventWebhook(PushEventWebhook):
     def get_external_id(self, username):
         return 'github_enterprise:%s' % username
 
-    def get_user_external_id(self, gh_user_id, host=None):
-        return '{}:{}'.format(host, gh_user_id)
+    def get_idp_external_id(self, host):
+        # Todo(meredith): when we have integration will return
+        # host + integration.metadata['installation']['id']
+        return
 
     def get_client(self, event, host):
         metadata = get_installation_metadata(event, host)
@@ -83,8 +85,10 @@ class GitHubEnterprisePullRequestEventWebhook(PullRequestEventWebhook):
     def get_external_id(self, username):
         return 'github_enterprise:%s' % username
 
-    def get_user_external_id(self, user_id, host):
-        return '{}:{}'.format(host, user_id)
+    def get_idp_external_id(self, host):
+        # Todo(meredith): when we have integration will return
+        # host + integration.metadata['installation']['id']
+        return
 
 
 class GitHubEnterpriseWebhookBase(View):

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -21,10 +21,12 @@ from .client import GitHubEnterpriseAppsClient
 logger = logging.getLogger('sentry.webhooks')
 
 
-def get_installation_metadata(event):
+def get_installation_metadata(event, host):
+    if not host:
+        return
     try:
         integration = Integration.objects.get(
-            external_id=event['installation']['id'],
+            external_id='{}:{}'.format(host, event['installation']['id']),
             provider='github_enterprise')
     except Integration.DoesNotExist:
         return
@@ -53,8 +55,11 @@ class GitHubEnterprisePushEventWebhook(PushEventWebhook):
     def get_external_id(self, username):
         return 'github_enterprise:%s' % username
 
-    def get_client(self, event):
-        metadata = get_installation_metadata(event)
+    def get_user_external_id(self, gh_user_id, host=None):
+        return '{}:{}'.format(host, gh_user_id)
+
+    def get_client(self, event, host):
+        metadata = get_installation_metadata(event, host)
         if metadata is None:
             return None
 
@@ -77,6 +82,9 @@ class GitHubEnterprisePullRequestEventWebhook(PullRequestEventWebhook):
 
     def get_external_id(self, username):
         return 'github_enterprise:%s' % username
+
+    def get_user_external_id(self, user_id, host):
+        return '{}:{}'.format(host, user_id)
 
 
 class GitHubEnterpriseWebhookBase(View):
@@ -106,8 +114,8 @@ class GitHubEnterpriseWebhookBase(View):
     def get_logging_data(self):
         pass
 
-    def get_secret(self, event):
-        metadata = get_installation_metadata(event)
+    def get_secret(self, event, host):
+        metadata = get_installation_metadata(event, host)
         if metadata:
             return metadata.get('webhook_secret')
         else:
@@ -153,7 +161,12 @@ class GitHubEnterpriseWebhookBase(View):
             )
             return HttpResponse(status=400)
 
-        secret = self.get_secret(event)
+        try:
+            host = request.META['HTTP_X_GITHUB_ENTERPRISE_HOST']
+        except KeyError:
+            return HttpResponse(status=401)
+
+        secret = self.get_secret(event, host)
         if secret is None:
             logger.error(
                 'github_enterprise.webhook.missing-secret',
@@ -161,14 +174,14 @@ class GitHubEnterpriseWebhookBase(View):
             )
             return HttpResponse(status=401)
 
-        if not self.is_valid_signature(method, body, self.get_secret(event), signature):
+        if not self.is_valid_signature(method, body, self.get_secret(event, host), signature):
             logger.error(
                 'github_enterprise.webhook.invalid-signature',
                 extra=self.get_logging_data(),
             )
             return HttpResponse(status=401)
 
-        handler()(event)
+        handler()(event, host)
         return HttpResponse(status=204)
 
 

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -127,7 +127,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
             u'access_token': None,
             u'expires_at': None,
             u'icon': u'https://35.232.149.196/avatar.png',
-            u'domain_name': u'35.232.149.196',
+            u'domain_name': u'https://35.232.149.196/Test-Organization',
             u'installation_id': u'install_id_1',
             u'installation': {
                 u'client_id': u'client_id',

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -149,7 +149,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         identity = Identity.objects.get(
             idp=idp,
             user=self.user,
-            external_id='35.232.149.196:user_id_1',
+            external_id='user_id_1',
         )
         assert identity.status == IdentityStatus.VALID
         assert identity.data == {

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -121,13 +121,14 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
 
         integration = Integration.objects.get(provider=self.provider.key)
 
-        assert integration.external_id == 'install_id_1'
+        assert integration.external_id == '35.232.149.196:install_id_1'
         assert integration.name == 'Test Organization'
         assert integration.metadata == {
             u'access_token': None,
             u'expires_at': None,
             u'icon': u'https://35.232.149.196/avatar.png',
             u'domain_name': u'35.232.149.196',
+            u'installation_id': u'install_id_1',
             u'installation': {
                 u'client_id': u'client_id',
                 u'client_secret': u'client_secret',
@@ -148,7 +149,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         identity = Identity.objects.get(
             idp=idp,
             user=self.user,
-            external_id='user_id_1',
+            external_id='35.232.149.196:user_id_1',
         )
         assert identity.status == IdentityStatus.VALID
         assert identity.data == {

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -26,6 +26,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
             name='getsentry',
             metadata={
                 'domain_name': '35.232.149.196',
+                'installation_id': 'installation_id',
                 'installation': {
                     'id': 2,
                     'private_key': 'private_key'}}
@@ -38,7 +39,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
     def test_get_allowed_assignees(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/github_external_id/access_tokens',
+            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
             json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
         )
 
@@ -65,7 +66,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
     def test_create_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/github_external_id/access_tokens',
+            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
             json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
         )
 
@@ -100,7 +101,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
     def test_get_repo_issues(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/github_external_id/access_tokens',
+            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
             json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
         )
 
@@ -124,7 +125,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         issue_id = 321
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/github_external_id/access_tokens',
+            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
             json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
         )
 
@@ -157,7 +158,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
     def after_link_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/github_external_id/access_tokens',
+            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
             json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
         )
 

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -25,7 +25,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
             external_id='github_external_id',
             name='getsentry',
             metadata={
-                'domain_name': '35.232.149.196',
+                'domain_name': 'https://35.232.149.196',
                 'installation_id': 'installation_id',
                 'installation': {
                     'id': 2,

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -42,6 +42,7 @@ class WebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='UnregisteredEvent',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=56a3df597e02adbc17fb617502c70e19d96a6136',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
@@ -57,6 +58,7 @@ class WebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='push',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=33521abeaaf9a57c2abf486e0ccd54d23cf36fec',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
@@ -88,7 +90,7 @@ class PushEventWebhookTest(APITestCase):
             name='baxterthehacker/public-repo',
         )
         integration = Integration.objects.create(
-            external_id="12345",
+            external_id="35.232.149.196:12345",
             provider='github_enterprise',
         )
         integration.add_organization(project.organization.id)
@@ -98,6 +100,7 @@ class PushEventWebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='push',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
@@ -145,7 +148,7 @@ class PushEventWebhookTest(APITestCase):
 
         integration = Integration.objects.create(
             provider='github_enterprise',
-            external_id='12345',
+            external_id='35.232.149.196:12345',
             name='octocat',
         )
         integration.add_organization(project.organization.id)
@@ -169,6 +172,7 @@ class PushEventWebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='push',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
@@ -223,7 +227,7 @@ class PushEventWebhookTest(APITestCase):
             name='baxterthehacker/public-repo',
         )
         integration = Integration.objects.create(
-            external_id="12345",
+            external_id="35.232.149.196:12345",
             provider='github_enterprise',
         )
         integration.add_organization(project.organization.id)
@@ -238,7 +242,7 @@ class PushEventWebhookTest(APITestCase):
             name='another/repo',
         )
         integration = Integration.objects.create(
-            external_id="99",
+            external_id="35.232.149.196:99",
             provider='github_enterprise',
         )
         integration.add_organization(org2.id)
@@ -248,6 +252,7 @@ class PushEventWebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='push',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
@@ -286,7 +291,7 @@ class PullRequestEventWebhook(APITestCase):
 
         integration = Integration.objects.create(
             provider='github_enterprise',
-            external_id='234',
+            external_id='35.232.149.196:234',
             name='octocat',
         )
         integration.add_organization(project.organization.id)
@@ -303,6 +308,7 @@ class PullRequestEventWebhook(APITestCase):
             data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='pull_request',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=aa5b11bc52b9fac082cb59f9ee8667cb222c3aff',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
@@ -338,7 +344,7 @@ class PullRequestEventWebhook(APITestCase):
 
         integration = Integration.objects.create(
             provider='github_enterprise',
-            external_id='234',
+            external_id='35.232.149.196:234',
             name='octocat',
         )
         integration.add_organization(project.organization.id)
@@ -361,6 +367,7 @@ class PullRequestEventWebhook(APITestCase):
             data=PULL_REQUEST_EDITED_EVENT_EXAMPLE,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='pull_request',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=b50a13afd33b514e8e62e603827ea62530f0690e',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
@@ -389,7 +396,7 @@ class PullRequestEventWebhook(APITestCase):
 
         integration = Integration.objects.create(
             provider='github_enterprise',
-            external_id='234',
+            external_id='35.232.149.196:234',
             name='octocat',
         )
         integration.add_organization(project.organization.id)
@@ -406,6 +413,7 @@ class PullRequestEventWebhook(APITestCase):
             data=PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
             content_type='application/json',
             HTTP_X_GITHUB_EVENT='pull_request',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
             HTTP_X_HUB_SIGNATURE='sha1=dff1c803cf1e48c1b9aefe4a17952ea132758806',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )


### PR DESCRIPTION
This prefixes the following: 
* integration `external_id`
* integration `idp_external_id`
* user identity `external_id`

with the host for GHE installations so that they're now globally unique.

cc @adhiraj 