### PR TITLE
feat(settings): Remove "team" field from Project Settings

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -63,17 +63,6 @@ export const fields = {
     saveMessageAlertType: 'info',
     saveMessage: t('You will be redirected to the new project slug after saving'),
   },
-  team: {
-    name: 'team',
-    type: 'array',
-    label: t('Team'),
-    visible: ({organization}) => {
-      return organization.teams.length > 1;
-    },
-    choices: ({organization}) =>
-      organization.teams.filter(o => o.isMember).map(o => [o.slug, o.slug]),
-    help: t('Update the team that owns this project'),
-  },
 
   subjectPrefix: {
     name: 'subjectPrefix',

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -250,7 +250,7 @@ class ProjectGeneralSettings extends AsyncView {
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
-            fields={[fields.slug, fields.name, fields.team]}
+            fields={[fields.slug, fields.name]}
           />
 
           <JsonForm


### PR DESCRIPTION
This is no longer valid because of team<->project is now many to many.

/cc @saragilford 