### PR TITLE
lint: bring back sentry.lint.sentry_check:SentryCheck

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ autopep8>=1.3.5,<1.4.0
 Babel
 flake8>=3.5.0<3.6.0
 isort>=4.2.2,<4.3.0
-pycodestyle>=2.3,<2.4.0
+pycodestyle>=2.3.1,<2.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,10 @@ ignore = F999,E501,E128,E124,E402,W503,E731,C901
 max-line-length = 100
 exclude = .git,*/south_migrations/*,node_modules/*,src/sentry/static/sentry/vendor/*,docs/*,src/south/*,examples/*
 
+[flake8:local-plugins]
+extension =
+    B = sentry.lint.sentry_check:SentryCheck
+
 [bdist_wheel]
 python-tag = py27
 

--- a/setup.py
+++ b/setup.py
@@ -143,8 +143,6 @@ setup(
         'console_scripts': [
             'sentry = sentry.runner:main',
         ],
-        'flake8.extension': [
-        ],
     },
     classifiers=[
         'Framework :: Django',

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -23,14 +23,6 @@ from subprocess import check_output, Popen
 os.environ['PYFLAKES_NODOCTEST'] = '1'
 
 
-def register_pycodestyle_checks():
-    import pycodestyle
-
-    from sentry.lint.sentry_check import SentryCheck
-
-    pycodestyle.register_check(SentryCheck)
-
-
 def get_project_root():
     return os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
 
@@ -111,7 +103,6 @@ def get_python_files(file_list=None):
 # parseable is a no-op
 def py_lint(file_list, parseable=False):
     from flake8.api.legacy import get_style_guide
-    register_pycodestyle_checks()
 
     file_list = get_python_files(file_list)
     flake8_style = get_style_guide(parse_argv=True)

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -118,7 +118,7 @@ def js_lint(file_list=None, parseable=False, format=False):
     eslint_wrapper_path = get_sentry_bin('eslint-travis-wrapper')
 
     if not os.path.exists(eslint_path):
-        print('!! Skipping JavaScript linting because eslint is not installed.')
+        print('!! Skipping JavaScript linting because eslint is not installed.')  # noqa: B314
         return False
 
     js_file_list = get_js_files(file_list, snapshots=True)
@@ -148,7 +148,7 @@ def js_stylelint(file_list=None, parseable=False, format=False):
     stylelint_path = get_node_modules_bin('stylelint')
 
     if not os.path.exists(stylelint_path):
-        print('!! Skipping JavaScript styled-components linting because "stylelint" is not installed.')
+        print('!! Skipping JavaScript styled-components linting because "stylelint" is not installed.')  # noqa: B314
         return False
 
     js_file_list = get_js_files(file_list, snapshots=False)
@@ -175,7 +175,8 @@ def yarn_check(file_list):
         return False
 
     if 'package.json' in file_list and 'yarn.lock' not in file_list:
-        print('\033[33m' + """Warning: package.json modified without accompanying yarn.lock modifications.
+        print(    # noqa: B314
+            '\033[33m' + """Warning: package.json modified without accompanying yarn.lock modifications.
 
 If you updated a dependency/devDependency in package.json, you must run `yarn install` to update the lockfile.
 
@@ -187,7 +188,7 @@ To skip this check, run `SKIP_YARN_CHECK=1 git commit [options]`""" + '\033[0m')
 
 def is_prettier_valid(project_root, prettier_path):
     if not os.path.exists(prettier_path):
-        print('[sentry.lint] Skipping JavaScript formatting because prettier is not installed.', file=sys.stderr)
+        print('[sentry.lint] Skipping JavaScript formatting because prettier is not installed.', file=sys.stderr)  # noqa: B314
         return False
 
     # Get Prettier version from package.json
@@ -198,13 +199,13 @@ def is_prettier_valid(project_root, prettier_path):
             package_version = json.load(package_json)[
                 'devDependencies']['prettier']
         except KeyError:
-            print('!! Prettier missing from package.json', file=sys.stderr)
+            print('!! Prettier missing from package.json', file=sys.stderr)  # noqa: B314
             return False
 
     prettier_version = subprocess.check_output(
         [prettier_path, '--version']).rstrip()
     if prettier_version != package_version:
-        print(
+        print(  # noqa: B314
             '[sentry.lint] Prettier is out of date: {} (expected {}). Please run `yarn install`.'.format(
                 prettier_version,
                 package_version),
@@ -222,7 +223,7 @@ def js_lint_format(file_list=None):
     eslint_path = get_node_modules_bin('eslint')
 
     if not os.path.exists(eslint_path):
-        print('!! Skipping JavaScript linting and formatting because eslint is not installed.')
+        print('!! Skipping JavaScript linting and formatting because eslint is not installed.')  # noqa: B314
         return False
 
     js_file_list = get_js_files(file_list)
@@ -263,7 +264,7 @@ def js_test(file_list=None):
     jest_path = get_node_modules_bin('jest')
 
     if not os.path.exists(jest_path):
-        print('[sentry.test] Skipping JavaScript testing because jest is not installed.')
+        print('[sentry.test] Skipping JavaScript testing because jest is not installed.')  # noqa: B314
         return False
 
     js_file_list = get_js_files(file_list)
@@ -300,7 +301,7 @@ def py_format(file_list=None):
     try:
         __import__('autopep8')
     except ImportError:
-        print('[sentry.lint] Skipping Python autoformat because autopep8 is not installed.', err=True)
+        print('[sentry.lint] Skipping Python autoformat because autopep8 is not installed.', err=True)  # noqa: B314
         return False
 
     py_file_list = get_python_files(file_list)
@@ -322,19 +323,19 @@ def run_formatter(cmd, file_list, prompt_on_changes=True):
     # this is not quite correct, but it at least represents what would be staged
     output = subprocess.check_output(['git', 'diff'] + file_list)
     if output:
-        print('[sentry.lint] applied changes from autoformatting')
+        print('[sentry.lint] applied changes from autoformatting')  # noqa: B314
         for line in output.splitlines():
             if line.startswith('-'):
-                print('\033[41m' + line + '\033[0m')  # red fg
+                print('\033[41m' + line + '\033[0m')  # noqa: B314
             elif line.startswith('+'):
-                print('\033[42m' + line + '\033[0m')  # green fg
+                print('\033[42m' + line + '\033[0m')  # noqa: B314
             else:
-                print(line)
+                print(line)  # noqa: B314
         if prompt_on_changes:
             with open('/dev/tty') as fp:
-                print('\033[1m' + 'Stage this patch and continue? [Y/n] ' + '\033[0m')
+                print('\033[1m' + 'Stage this patch and continue? [Y/n] ' + '\033[0m')  # noqa: B314
                 if fp.readline().strip().lower() != 'y':
-                    print(
+                    print(  # noqa: B314
                         '[sentry.lint] Aborted! Changes have been applied but not staged.', file=sys.stderr)
                     if not os.environ.get('SENTRY_SKIP_FORCE_PATCH'):
                         sys.exit(1)

--- a/src/sentry/lint/sentry_check.py
+++ b/src/sentry/lint/sentry_check.py
@@ -156,6 +156,7 @@ class SentryVisitor(ast.NodeVisitor):
 
 class SentryCheck(object):
     name = 'sentry-checker'
+    version = '0.0.1'
 
     def __init__(self, tree, filename=None, lines=None):
         self.tree = tree


### PR DESCRIPTION
Upgrading to flake8 3.5.0 caused `pycodestyle`'s `register_check` to silently ignore our custom checker, so we're missing out on some linting. Fortunately, flake8 3.5.0 lets us use local plugins via `setup.cfg` as documented [here](http://flake8.pycqa.org/en/latest/user/configuration.html#using-local-plugins).