### PR TITLE
fix(dashboard): Fix "Member Invite" route

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
@@ -38,7 +38,7 @@ const ProjectNav = createReactClass({
       },
       {
         title: t('Member'),
-        to: `settings/${org.slug}/members/new/`,
+        to: `/settings/${org.slug}/members/new/`,
         disabled: !hasTeamWrite,
         tooltip: t('You do not have permission to manage teams'),
       },


### PR DESCRIPTION
This would work when using react-router to navigate (e.g. clicking on this menu
option would work, but if you refreshed, the URL would be invalid)