### PR TITLE
fix(stream): Fix direct event search to include matched env

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -339,11 +339,18 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                     matching_group = None
 
             if matching_group is not None:
+                matching_event_environment = None
+
+                try:
+                    matching_event_environment = matching_event.get_environment().name if matching_event else None
+                except Environment.DoesNotExist:
+                    pass
+
                 response = Response(
                     serialize(
                         [matching_group], request.user, serializer(
                             matching_event_id=getattr(matching_event, 'id', None),
-                            matching_event_environment=matching_event.get_environment().name if matching_event else None,
+                            matching_event_environment=matching_event_environment,
                         )
                     )
                 )

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -323,6 +323,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                             event_id=query, project_id=project.id)
                     except Event.DoesNotExist:
                         pass
+                    else:
+                        Event.objects.bind_nodes([matching_event], 'data')
 
             # If the query looks like a short id, we want to provide some
             # information about where that is.  Note that this can return
@@ -341,6 +343,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                     serialize(
                         [matching_group], request.user, serializer(
                             matching_event_id=getattr(matching_event, 'id', None),
+                            matching_event_environment=matching_event.get_environment().name if matching_event else None,
                         )
                     )
                 )

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -371,7 +371,7 @@ class StreamGroupSerializer(GroupSerializer):
         '24h': StatsPeriod(24, timedelta(hours=1)),
     }
 
-    def __init__(self, environment_func=None, stats_period=None, matching_event_id=None):
+    def __init__(self, environment_func=None, stats_period=None, matching_event_id=None, matching_event_environment=None):
         super(StreamGroupSerializer, self).__init__(environment_func)
 
         if stats_period is not None:
@@ -379,6 +379,7 @@ class StreamGroupSerializer(GroupSerializer):
 
         self.stats_period = stats_period
         self.matching_event_id = matching_event_id
+        self.matching_event_environment = matching_event_environment
 
     def get_attrs(self, item_list, user):
         attrs = super(StreamGroupSerializer, self).get_attrs(item_list, user)
@@ -425,6 +426,9 @@ class StreamGroupSerializer(GroupSerializer):
 
         if self.matching_event_id:
             result['matchingEventId'] = self.matching_event_id
+
+        if self.matching_event_environment:
+            result['matchingEventEnvironment'] = self.matching_event_environment
 
         return result
 

--- a/src/sentry/static/sentry/app/actionCreators/environments.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/environments.jsx
@@ -1,7 +1,12 @@
 import EnvironmentActions from 'app/actions/environmentActions';
+import EnvironmentStore from 'app/stores/environmentStore';
 
 export function setActiveEnvironment(environment) {
   EnvironmentActions.setActive(environment);
+}
+
+export function setActiveEnvironmentName(name) {
+  setActiveEnvironment(EnvironmentStore.getByName(name));
 }
 
 export function clearActiveEnvironment() {

--- a/src/sentry/static/sentry/app/actionCreators/environments.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/environments.jsx
@@ -6,7 +6,10 @@ export function setActiveEnvironment(environment) {
 }
 
 export function setActiveEnvironmentName(name) {
-  setActiveEnvironment(EnvironmentStore.getByName(name));
+  let environment = EnvironmentStore.getByName(name);
+
+  if (!environment) return;
+  setActiveEnvironment(environment);
 }
 
 export function clearActiveEnvironment() {

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -387,7 +387,6 @@ const Stream = createReactClass({
         // the current props one as the shortIdLookup can return results for
         // different projects.
         if (jqXHR.getResponseHeader('X-Sentry-Direct-Hit') === '1') {
-          console.log('direct hit', data);
           if (data && data[0].matchingEventId) {
             let {project, id, matchingEventId, matchingEventEnvironment} = data[0];
             let redirect = `/${this.props.params

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -197,11 +197,29 @@ class GroupListTest(APITestCase):
         )
 
         self.login_as(user=self.user)
+
         response = self.client.get('{}?query={}'.format(self.path, 'c' * 32), format='json')
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]['id'] == six.text_type(group.id)
         assert response.data[0]['matchingEventId'] == event.id
+
+    def test_lookup_by_event_with_matching_environment(self):
+        project = self.project
+        project.update_option('sentry:resolve_age', 1)
+        self.create_environment(name="test", project=project)
+        group = self.create_group(checksum='a' * 32)
+        self.create_group(checksum='b' * 32)
+        event_id = 'c' * 32
+        event = self.create_event(project_id=self.project.id, group=group, event_id=event_id, tags={'environment': 'test'})
+        self.login_as(user=self.user)
+
+        response = self.client.get('{}?query={}&environment=test'.format(self.path, 'c' * 32), format='json')
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == six.text_type(group.id)
+        assert response.data[0]['matchingEventId'] == event.id
+        assert response.data[0]['matchingEventEnvironment'] == 'test'
 
     def test_lookup_by_event_id_with_whitespace(self):
         project = self.project


### PR DESCRIPTION
When using stream search to search for an eventId, if direct result was
found and the event matches as specific environment, set matched
environment as active environment before redirecting to found group