### PR TITLE
fix(settings): Correctly pass in project to getConfiguration

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectSettingsNavigation.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectSettingsNavigation.jsx
@@ -32,7 +32,7 @@ const ProjectSettingsNavigation = createReactClass({
 
     return (
       <SettingsNavigation
-        navigationObjects={getConfiguration(project)}
+        navigationObjects={getConfiguration({project})}
         access={access}
         features={features}
         organization={org}


### PR DESCRIPTION
This expected an object

https://github.com/getsentry/sentry/blob/318525c78ea3033ff7af985175140544e073fb67/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx#L5-L6

Now plugins are correctly listed.

![image](https://user-images.githubusercontent.com/1421724/42789614-1f945fe0-891b-11e8-9a26-c72cc6af6a32.png)
