### PR TITLE
fix: EventUser's tag_value was being calculated differently than it's hash

### DIFF
--- a/tests/sentry/models/test_eventuser.py
+++ b/tests/sentry/models/test_eventuser.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+from sentry.models import EventUser
+
+
+class EventUserTestCase(TestCase):
+    def test_build_hash(self):
+        cases = [
+            ({'ident': 'ident', 'username': 'username', 'email': 'email', 'ip_address': '127.0.0.1'}, '67217d8b401cf5e72bbf5103d60f3e97'),
+            ({'username': 'username', 'email': 'email', 'ip_address': '127.0.0.1'}, '14c4b06b824ec593239362517f538b29'),
+            ({'email': 'email', 'ip_address': '127.0.0.1'}, '0c83f57c786a0b4a39efab23731c7ebc'),
+            ({'ip_address': '127.0.0.1'}, 'f528764d624db129b32c21fbca0cb8d6'),
+            ({}, None),
+        ]
+        for kw, value in cases:
+            assert EventUser(**kw).build_hash() == value
+
+    def test_tag_value(self):
+        cases = [
+            ({'ident': 'ident', 'username': 'username', 'email': 'email', 'ip_address': '127.0.0.1'}, 'id:ident'),
+            ({'username': 'username', 'email': 'email', 'ip_address': '127.0.0.1'}, 'username:username'),
+            ({'email': 'email', 'ip_address': '127.0.0.1'}, 'email:email'),
+            ({'ip_address': '127.0.0.1'}, 'ip:127.0.0.1'),
+            ({}, None),
+        ]
+        for kw, value in cases:
+            assert EventUser(**kw).tag_value == value

--- a/tests/sentry/models/test_eventuser.py
+++ b/tests/sentry/models/test_eventuser.py
@@ -26,3 +26,13 @@ class EventUserTestCase(TestCase):
         ]
         for kw, value in cases:
             assert EventUser(**kw).tag_value == value
+
+    def test_attr_from_keyword(self):
+        cases = [
+            ('id', 'ident'),
+            ('username', 'username'),
+            ('email', 'email'),
+            ('ip', 'ip_address'),
+        ]
+        for keyword, attr in cases:
+            assert EventUser.attr_from_keyword(keyword) == attr


### PR DESCRIPTION
This unifies the priority and the behavor of both build_hash and
tag_value so they match.

Prior to this, EventUser.email was favored in a tag value over
EventUser.username. And the hash favored the opposite way.

This means if an EventUser row had both a email and an ident, it'd
generate a hash and tag_value that weren't compatible with each other.
From a given tag_value, you wouldn't be able to reverse it back into a
valid EventUser row since you couldn't reliably generate a hash given a
tag_value only.

This change in behavior breaks some existing tags, but the impact of
this is very low. Less than 0.1% of our real production data is impacted
by this, so I'm choosing to just write new tag values correctly moving
forward and ignoring repair (since this would require rewriting tag
values, if even possible).