### PR TITLE
fix: Revert "Temporarily disable cleanup for tagstore v2 #7505"

### DIFF
--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -83,8 +83,13 @@ class V2TagStorage(TagStorage):
         self.setup_receivers()
 
     def setup_cleanup(self):
-        # TODO: fix for sharded DB
-        pass
+        from sentry.runner.commands import cleanup
+
+        cleanup.EXTRA_BULK_QUERY_DELETES += [
+            (models.GroupTagValue, 'last_seen', None),
+            (models.TagValue, 'last_seen', None),
+            (models.EventTag, 'date_added', 'date_added', 50000),
+        ]
 
     def setup_deletions(self):
         from sentry.deletions import default_manager as deletion_manager

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import
 
-import pytest
-
 from django.conf import settings
 
 from sentry.models import Event, Group
@@ -31,10 +29,6 @@ class SentryCleanupTest(CliTestCase):
 
     command = cleanup
 
-    @pytest.mark.skipif(
-        settings.SENTRY_TAGSTORE == 'sentry.tagstore.v2.V2TagStorage',
-        reason='Cleanup is temporarily disabled for tagstore v2'
-    )
     def test_simple(self):
         rv = self.invoke('--days=1')
         assert rv.exit_code == 0, rv.output
@@ -42,10 +36,6 @@ class SentryCleanupTest(CliTestCase):
         for model in ALL_MODELS:
             assert model.objects.count() == 0
 
-    @pytest.mark.skipif(
-        settings.SENTRY_TAGSTORE == 'sentry.tagstore.v2.V2TagStorage',
-        reason='Cleanup is temporarily disabled for tagstore v2'
-    )
     def test_project(self):
         orig_counts = {}
         for model in ALL_MODELS:


### PR DESCRIPTION
This was disabled when we disallowed Citus "cross cluster queries" (not sure of the official term). They are apparently allowed now so these delete queries should work. We're approaching the 90 day v2 line in early August.