### PR TITLE
feat(discover): Add arrayjoin if a nested column is present

### DIFF
--- a/tests/snuba/test_organization_discover.py
+++ b/tests/snuba/test_organization_discover.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from datetime import datetime, timedelta
 import time
+import uuid
 
 from sentry.testutils import APITestCase
 from django.core.urlresolvers import reverse
@@ -24,21 +25,44 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
         )
 
         events = [{
-            'event_id': 'x' * 32,
-            'primary_hash': '1' * 32,
+            'event_id': uuid.uuid4().hex,
+            'primary_hash': uuid.uuid4().hex,
             'project_id': self.project.id,
             'message': 'message!',
             'platform': 'python',
             'datetime': now.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             'data': {
                 'received': time.mktime(now.timetuple()),
-            }
+                'exception': {
+                    'values': [
+                        {
+                            'type': 'ValidationError',
+                            'value': 'Bad request',
+                            'mechanism': {
+                                'type': '1',
+                                'value': '1',
+                            },
+                            'stacktrace': {
+                                'frames': [
+                                    {
+                                        'function': '?',
+                                        'filename': 'http://localhost:1337/error.js',
+                                        'lineno': 29,
+                                        'colno': 3,
+                                        'in_app': True
+                                    },
+                                ]
+                            },
+                        }
+                    ]
+                },
+            },
+
         }]
 
         self.snuba_insert(events)
 
     def test(self):
-
         url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
         response = self.client.post(url, {
             'projects': [self.project.id],
@@ -49,7 +73,19 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
         })
 
         assert response.status_code == 200, response.content
-
         assert len(response.data['data']) == 1
         assert response.data['data'][0]['message'] == 'message!'
         assert response.data['data'][0]['platform'] == 'python'
+
+    def test_array_join(self):
+        url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+        response = self.client.post(url, {
+            'projects': [self.project.id],
+            'fields': ['message', 'exception_stacks.type'],
+            'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
+            'end': datetime.now().strftime('%Y-%m-%dT%H:%M:%S'),
+            'orderby': '-timestamp',
+        })
+        assert response.status_code == 200, response.content
+        assert len(response.data['data']) == 1
+        assert response.data['data'][0]['exception_stacks.type'] == 'ValidationError'


### PR DESCRIPTION
If an exception_stacks.* or exception_frames.* column is selected, add
the corresponding arrayjoin property. Chooses the first match since we
can only have one.