### PR TITLE
fix(integrations): Ensure that only one subscription is created per VSTS integration

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -6,6 +6,7 @@ from django import forms
 from django.utils.translation import ugettext as _
 
 from sentry import http
+from sentry.models import Integration as IntegrationModel
 from sentry.integrations import Integration, IntegrationFeatures, IntegrationProvider, IntegrationMetadata
 from sentry.integrations.exceptions import ApiError
 from sentry.integrations.vsts.issues import VstsIssueSync
@@ -167,8 +168,11 @@ class VstsIntegrationProvider(IntegrationProvider):
         account = state['account']
         instance = state['instance']
         user = get_user_info(data['access_token'])
-        subscription_id, subscription_secret = self.create_subscription(
-            instance, account['AccountId'], oauth_data)
+        try:
+            IntegrationModel.objects.get(provider='vsts', external_id=account['AccountId'])
+        except IntegrationModel.DoesNotExist:
+            subscription_id, subscription_secret = self.create_subscription(
+                instance, account['AccountId'], oauth_data)
         scopes = sorted(VSTSIdentityProvider.oauth_scopes)
 
         return {

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -38,7 +38,7 @@ class WorkItemWebhook(Endpoint):
         return self.respond()
 
     def check_webhook_secret(self, request, integration):
-        assert integration.metadata['subscription_secret'] == request.META['HTTP_SHARED_SECRET']
+        assert integration.metadata['subscription']['secret'] == request.META['HTTP_SHARED_SECRET']
 
     def handle_updated_workitem(self, data, integration):
         external_issue_key = data['resource']['workItemId']

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -28,7 +28,10 @@ class VstsWebhookWorkItemTest(APITestCase):
             name='vsts_name',
             metadata={
                  'domain_name': 'instance.visualstudio.com',
-                 'subscription_secret': self.shared_secret,
+                 'subscription': {
+                     'id': 1234,
+                     'secret': self.shared_secret,
+                 }
             }
         )
         self.identity_provider = IdentityProvider.objects.create(type='vsts')


### PR DESCRIPTION
Before we did not check that subscriptions (vsts webhooks) were created only once per integration. Two different organizations can integrate with the same integration causing two different subscriptions to be produced. Now checking if the integration already exists, that we not create a new webhook.