### PR TITLE
fix(async-component): Don't reload when loading

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -101,7 +101,10 @@ class AsyncComponent extends React.Component {
   };
 
   visibilityReloader = () =>
-    this.shouldReloadOnVisible && !document.hidden && this.reloadData();
+    this.shouldReloadOnVisible &&
+    !this.state.loading &&
+    !document.hidden &&
+    this.reloadData();
 
   reloadData = () => this.fetchData({reloading: true});
 


### PR DESCRIPTION
This would occur if the user switches focus while their component is first loading.

Fixes: [JAVASCRIPT-430](https://sentry.io/share/issue/d350054cfaca4820af579536019eb145/)
Fixes: [JAVASCRIPT-42Q](https://sentry.io/share/issue/c75ba73fa0ad43529a8dfa2d240b3911/)