### PR TITLE
fix(discover): Fix condition validation to support tags

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
@@ -73,7 +73,8 @@ export function getExternal(internal, columns) {
 
   // Validate value and convert to correct type
   if (external[0] && external[1] && !specialConditions.has(external[1])) {
-    const valuesMatch = internal.match(/^[a-zA-Z0-9_\.:-]+ [^\s]+ (.*)$/);
+    const valuesMatch = internal.match(/^[a-zA-Z0-9_\.:-\[\]]+ [^\s]+ (.*)$/);
+
     external[2] = valuesMatch ? valuesMatch[1] : null;
     const type = columns.find(({name}) => name === colValue).type;
 


### PR DESCRIPTION
Since we're using the proper column name for tags now, e.g. `tag[foo]` vs
`foo`, we need to update the condition validation to allow square
brackets.