### PR TITLE
fix(discover): Convert aggregation aliases to underscores

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/utils.jsx
@@ -85,7 +85,10 @@ export function getExternal(internal) {
 
   if (internal.match(uniqRegex)) {
     const column = internal.match(uniqRegex)[1];
-    return ['uniq', column, `uniq_${column}`];
+    const tagMatch = column.match(/^tags\[(.+)]$/);
+    const alias = tagMatch ? `tags_${tagMatch[1]}` : column;
+
+    return ['uniq', column, `uniq_${alias}`];
   }
 
   if (internal.match(avgRegex)) {

--- a/tests/js/spec/views/organizationDiscover/aggregations/aggregation.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/aggregations/aggregation.spec.jsx
@@ -8,7 +8,7 @@ describe('Aggregation', function() {
     it('renders empty, count, topK, uniq and avg', function() {
       const data = [
         {value: [null, null, null], expectedTextValue: 'Add aggregation function...'},
-        {value: ['count', null, 'count'], expectedTextValue: 'count'},
+        {value: ['count()', null, 'count'], expectedTextValue: 'count'},
         {
           value: ['uniq', 'environment', 'uniq_environment'],
           expectedTextValue: 'uniq(environment)',
@@ -20,6 +20,10 @@ describe('Aggregation', function() {
         {
           value: ['topK(5)', 'environment', 'topK_5_environment'],
           expectedTextValue: 'topK(5)(environment)',
+        },
+        {
+          value: ['uniq', 'tags[message]', 'uniq_tags_message'],
+          expectedTextValue: 'uniq(tags[message])',
         },
       ];
 


### PR DESCRIPTION
Use an underscore character instead of square brackets for aggregation aliases as [] is not allowed in orderby validation