### PR TITLE
docs(dsn): Improving DSN Settings Message

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
@@ -62,7 +62,7 @@ class ProjectKeyCredentials extends React.Component {
           <Field
             label={t('DSN (Deprecated)')}
             help={t(
-              'This DSN includes the secret which is no longer required by Sentry or newer versions of SDKs.'
+              "This DSN includes the secret which is no longer required by Sentry' newer versions of SDKs. If you are unsure which to use, follow installation instructions for your language."
             )}
             inline={false}
             flexibleControlStateSize


### PR DESCRIPTION
Customer found this confusing as "newer versions" is vague and the latest version of many SDKs (like Python or Go) don't accept DSNs without secrets.