### PR TITLE
fix(integrations): Inbound issue sync should use done categories not mapping

### DIFF
--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -69,17 +69,11 @@ class ExampleIntegration(Integration, IssueSyncMixin):
     def sync_status_outbound(self, external_issue, is_resolved, project_id):
         pass
 
-    def get_external_project_id(self, data):
-        """
-        Given webhook data, pull out external project id
-        """
-        return data['project_id']
+    def should_unresolve(self, data):
+        return data['status']['category'] != 'done'
 
-    def get_external_issue_status(self, data):
-        """
-        Given webhook data, pull out external issue status
-        """
-        return data['status']
+    def should_resolve(self, data):
+        return data['status']['category'] == 'done'
 
 
 class ExampleIntegrationProvider(IntegrationProvider):

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.models import (
-    Group, GroupStatus, Integration, GroupLink, ExternalIssue,
-    IntegrationExternalProject, OrganizationIntegration
-)
+from sentry.models import Group, GroupStatus, Integration, GroupLink, ExternalIssue
 from sentry.testutils import TestCase
 
 
@@ -32,19 +29,14 @@ class IssueSyncIntegration(TestCase):
             relationship=GroupLink.Relationship.references,
         )
 
-        IntegrationExternalProject.objects.create(
-            organization_integration_id=OrganizationIntegration.objects.filter(
-                integration=integration,
-            ).values_list('id', flat=True).get(),
-            external_id='APP',
-            resolved_status='12345',
-        )
-
         installation = integration.get_installation(group.organization.id)
 
         installation.sync_status_inbound(external_issue.key, {
             'project_id': 'APP',
-            'status': '12345',
+            'status': {
+                'id': '12345',
+                'category': 'done',
+            },
         })
 
         assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
@@ -75,19 +67,14 @@ class IssueSyncIntegration(TestCase):
             relationship=GroupLink.Relationship.references,
         )
 
-        IntegrationExternalProject.objects.create(
-            organization_integration_id=OrganizationIntegration.objects.filter(
-                integration=integration,
-            ).values_list('id', flat=True).get(),
-            external_id='APP',
-            unresolved_status='12345',
-        )
-
         installation = integration.get_installation(group.organization.id)
 
         installation.sync_status_inbound(external_issue.key, {
             'project_id': 'APP',
-            'status': '12345',
+            'status': {
+                'id': '12345',
+                'category': 'in_progress',
+            },
         })
 
         assert Group.objects.get(id=group.id).status == GroupStatus.UNRESOLVED


### PR DESCRIPTION
realized i misinterpreted the spec for this. inbound should just depend on "done categories" not the specific mapping.