### PR TITLE
feat: Always consult stored symbols from the application

### DIFF
--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -283,10 +283,10 @@ class Symbolizer(object):
         app_err = None
         try:
             match = self._symbolize_app_frame(instruction_addr, obj, sdk_info=sdk_info)
+            if match:
+                return match
         except SymbolicationFailed as err:
             app_err = err
-        if match:
-            return match
 
         # Then we check the symbolserver for a match.
         match = self._convert_symbolserver_match(instruction_addr, symbolserver_match, obj)

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -278,13 +278,29 @@ class Symbolizer(object):
         if obj is None:
             raise SymbolicationFailed(type=EventError.NATIVE_UNKNOWN_IMAGE)
 
-        # If we are dealing with a frame that is not bundled with the app
-        # we look at system symbols.  If that fails, we go to looking for
-        # app symbols explicitly.
-        if not self.is_image_from_app_bundle(obj, sdk_info=sdk_info):
-            return self._convert_symbolserver_match(instruction_addr, symbolserver_match, obj)
+        # Try to always prefer the images from the application storage.
+        # If the symbolication fails we keep the error for later
+        app_err = None
+        try:
+            match = self._symbolize_app_frame(instruction_addr, obj, sdk_info=sdk_info)
+        except SymbolicationFailed as err:
+            app_err = err
+        if match:
+            return match
 
-        return self._symbolize_app_frame(instruction_addr, obj, sdk_info=sdk_info)
+        # Then we check the symbolserver for a match.
+        match = self._convert_symbolserver_match(instruction_addr, symbolserver_match, obj)
+
+        # If we do not get a match and the image was from an app bundle
+        # and we got an error first, we now fail with the original error
+        # as we did indeed encounter a symbolication error.  If however
+        # the match was empty we just accept it as a valid symbolication
+        # that just did not return any results but without error.
+        if not match and self.is_image_from_app_bundle(obj, sdk_info=sdk_info) \
+           and app_err is not None:
+            raise app_err
+
+        return match
 
     def is_in_app(self, instruction_addr, sdk_info=None):
         obj = self.object_lookup.find_object(instruction_addr)

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -27,6 +27,8 @@ SDK_INFO = {"sdk_name": "iOS", "version_major": 9,
 
 
 def patched_symbolize_app_frame(self, instruction_addr, img, sdk_info=None):
+    if instruction_addr != 4295123756:
+        return []
     return [
         {
             'filename': 'Foo.swift',


### PR DESCRIPTION
This will always look up stored symbols even if we normally would only consult the symbol server. It means that users can themselves upload system symbols which previously was not possible.