### PR TITLE
ref(eventstream): Use confluent-kafka

### DIFF
--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -29,7 +29,7 @@ class KafkaEventStream(EventStream):
 
     @cached_property
     def producer(self):
-        return Producer(**self.producer_configuration)
+        return Producer(self.producer_configuration)
 
     def delivery_callback(self, error, message):
         logger.warning('Could not publish event (error: %s): %r', error, message)


### PR DESCRIPTION
- Uses the librdkafka-based Confluent Kafka producer for consistency moving forward
- Removes async/sync option

This will need to be synchronized with a dependency change and pin in getsentry/getsentry as well as a configuration update to use the librdkafka configuration mapping.