### PR TITLE
format: ignore some autopep8 fixes

### DIFF
--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -306,7 +306,13 @@ def py_format(file_list=None):
 
     py_file_list = get_python_files(file_list)
 
-    return run_formatter(['autopep8', '--in-place', '-j0'], py_file_list)
+    return run_formatter([
+        'autopep8',
+        '--in-place',
+        '-j0',
+        '--ignore',
+        'E721,E722,W690',
+    ], py_file_list)
 
 
 def run_formatter(cmd, file_list, prompt_on_changes=True):


### PR DESCRIPTION
From the [current autopep8 readme](https://github.com/hhatto/autopep8/blob/2e7e3ba985bfa7e090a10c6450454ff4b87f9475/README.rst):

```
E721 - Use "isinstance()" instead of comparing types directly.
E722 - Fix bare except.
W690 - Fix various deprecated code (via lib2to3).
```

> Correct deprecated or non-idiomatic Python code (via lib2to3). Use this for making Python 2.7 code more compatible with Python 3. (This is triggered if W690 is enabled.)
