### PR TITLE
fix(ui): Fix SelectAsyncField

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
@@ -65,9 +65,15 @@ class SelectAsyncField extends SelectField {
   // Otherwise, when you hit "enter" to create a new item, the "selected value" does
   // not update with new value (and also new value is not displayed in dropdown)
   coerceValue(value) {
-    if (value && value.hasOwnProperty(value)) return value.value;
-    else if (value) return value;
-    return '';
+    if (!value) return '';
+
+    if (this.isMultiple()) {
+      return value.map(v => v.value);
+    } else if (value.hasOwnProperty('value')) {
+      return value.value;
+    }
+
+    return value;
   }
 
   onResults = data => {
@@ -83,13 +89,9 @@ class SelectAsyncField extends SelectField {
   };
 
   onChange = opt => {
-    let value;
-    if (this.isMultiple()) {
-      value = opt.map(v => v.value);
-    } else {
-      value = opt ? opt.value : null;
-    }
-    this.setValue(value);
+    // Changing this will most likely break react-select (e.g. you won't be able to select
+    // a menu option that is from an async request).
+    this.setValue(opt);
   };
 
   getField() {
@@ -101,7 +103,6 @@ class SelectAsyncField extends SelectField {
         onResults={this.onResults}
         onQuery={this.onQuery}
         {...this.props}
-        multiple={this.isMultiple()}
         value={this.state.value}
         onChange={this.onChange}
       />

--- a/tests/js/spec/components/customResolutionModal.spec.jsx
+++ b/tests/js/spec/components/customResolutionModal.spec.jsx
@@ -44,9 +44,10 @@ describe('CustomResolutionModal', function() {
 
     wrapper.find('input[id="version"]').simulate('keyDown', {keyCode: 13});
 
-    expect(wrapper.find('SelectControl').prop('value')).toEqual(
-      '92eccef279d966b2319f0802fa4b22b430a5f72b'
-    );
+    expect(wrapper.find('SelectControl').prop('value')).toEqual({
+      value: '92eccef279d966b2319f0802fa4b22b430a5f72b',
+      label: expect.anything(),
+    });
     wrapper.find('form').simulate('submit');
     expect(onSelected).toHaveBeenCalledWith({
       inRelease: '92eccef279d966b2319f0802fa4b22b430a5f72b',

--- a/tests/js/spec/components/forms/selectAsyncField.spec.jsx
+++ b/tests/js/spec/components/forms/selectAsyncField.spec.jsx
@@ -63,8 +63,13 @@ describe('SelectAsyncField', function() {
     // Select item
     wrapper.find('input[id="id-fieldName"]').simulate('keyDown', {keyCode: 13});
 
-    // SelectControl should have the value object, not just a simple value
-    expect(wrapper.find('SelectControl').prop('value')).toEqual('baz');
+    // SelectControl MUST have the value object, not just a simple value
+    // otherwise it means that selecting an item that has been populated in the menu by
+    // an async request will not work (nothing will appear selected).
+    expect(wrapper.find('SelectControl').prop('value')).toEqual({
+      value: 'baz',
+      label: expect.anything(),
+    });
 
     wrapper.find('Form').simulate('submit');
     expect(submitMock).toHaveBeenCalledWith(


### PR DESCRIPTION
Moved logic from `onChange` to `coerceValue` because we need to preserve the label/value object for react-select