### PR TITLE
lint(hotfix): prevent legacy precommit hook from choking on engine

### DIFF
--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -374,7 +374,7 @@ def run(file_list=None, format=True, lint=True, js=True, py=True,
 
         if lint:
             if py:
-                raise NotImplementedError('flake8 linting was moved to pre-commit hooks.')
+                pass  # flake8 linting was moved to pre-commit
             if js:
                 # stylelint `--fix` doesn't work well
                 results.append(js_stylelint(file_list, parseable=parseable, format=format))


### PR DESCRIPTION
legacy hook calls `return run(files_modified, test=True)`. The easy way to disable is just to pass, since there's a nested `if lint: if py:`.