### PR TITLE
ref(charts): Move `grid` defaults to BaseChart

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/areaChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/areaChart.jsx
@@ -7,7 +7,6 @@ import theme from 'app/utils/theme';
 import AreaSeries from './series/areaSeries';
 import BaseChart from './baseChart';
 import LineSeries from './series/lineSeries';
-import Tooltip from './components/tooltip';
 import XAxis from './components/xAxis';
 import YAxis from './components/yAxis';
 
@@ -49,15 +48,6 @@ class AreaChart extends React.Component {
       <BaseChart
         {...props}
         options={{
-          tooltip: Tooltip(),
-          title: {},
-          legend: {},
-          grid: {
-            top: 24,
-            bottom: 40,
-            left: '10%',
-            right: '10%',
-          },
           xAxis: XAxis({
             type: 'category',
             data: DATES,

--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -1,10 +1,14 @@
+import 'zrender/lib/svg/svg';
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactEchartsCore from 'echarts-for-react/lib/core';
-import 'zrender/lib/svg/svg';
 import echarts from 'echarts/lib/echarts';
 
 import theme from 'app/utils/theme';
+
+import Grid from './components/grid';
+import Tooltip from './components/tooltip';
 
 // If dimension is a number conver it to pixels, otherwise use dimension without transform
 const getDimensionValue = dimension => {
@@ -88,6 +92,8 @@ class BaseChart extends React.Component {
         echarts={echarts}
         option={{
           color: colors,
+          grid: Grid(),
+          tooltip: Tooltip(),
           ...options,
         }}
         notMerge={notMerge}

--- a/src/sentry/static/sentry/app/components/charts/components/grid.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/grid.jsx
@@ -1,0 +1,18 @@
+/**
+ * Drawing grid in rectangular coordinates
+ *
+ * e.g. alignment of your chart?
+ */
+export default function Grid(props = {}) {
+  return {
+    top: 24,
+
+    // Is this a decent default for X-axis labels?
+    bottom: 40,
+
+    // This should allow for sufficient space for Y-axis labels
+    left: '10%',
+
+    right: '10%',
+  };
+}

--- a/src/sentry/static/sentry/app/components/charts/pieChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import PieSeries from './series/pieSeries';
 import BaseChart from './baseChart';
-import Tooltip from './components/tooltip';
 
 class PieChart extends React.Component {
   static propTypes = {
@@ -11,6 +10,7 @@ class PieChart extends React.Component {
     ...BaseChart.propTypes,
 
     name: PropTypes.string,
+
     data: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string,
@@ -27,15 +27,6 @@ class PieChart extends React.Component {
       <BaseChart
         {...props}
         options={{
-          tooltip: Tooltip(),
-          title: {},
-          legend: {},
-          grid: {
-            top: 24,
-            bottom: 40,
-            left: '10%',
-            right: '10%',
-          },
           series: [
             PieSeries({
               name,


### PR DESCRIPTION
Also add a `Grid` chart component with some defaults (TBD if these are good defaults).