### PR TITLE
fix: Cannot return None so return actual value

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -146,9 +146,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         # this is slightly gross but necessary until we have the get on the endpoint
         # to give the frontend a way to know when to log exposures
         sso_experiment = features.has('organizations:sso-paywall-experiment', obj, actor=user)
-        if sso_experiment:
+        if sso_experiment == 1:
             feature_list.append('sso-paywall-experiment-treatment')
-        elif sso_experiment is False:
+        elif sso_experiment == 0:
             feature_list.append('sso-paywall-experiment-control')
 
         context = super(DetailedOrganizationSerializer, self).serialize(obj, attrs, user)


### PR DESCRIPTION
Didn't realize the handler falls back to a default value `False` if `None` is returned which led to orgs not in the experiment bucketed as controls.
Counterpart PR GH-2047

Fixes JAVASCRIPT-43M

