### PR TITLE
feat(ui): Add ability for SelectAsyncField to send form values

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/genericField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/genericField.jsx
@@ -77,7 +77,7 @@ export default class GenericField extends React.Component {
         // it's required (with *) and rely on server validation
         delete props.required;
         if (props.has_autocomplete) {
-          return <SelectAsyncField {...props} />;
+          return <SelectAsyncField filterOption={() => true} {...props} />;
         }
         return <SelectField {...props} />;
       default:

--- a/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import fromPairs from 'lodash/fromPairs';
 
 import SelectAsyncControl from './selectAsyncControl';
 import SelectField from './selectField';
@@ -53,8 +54,8 @@ class SelectAsyncField extends SelectField {
 
   onQuery = query => {
     // Used by legacy integrations
-    let {depends} = this.props;
-    let {form} = this.context;
+    const {depends} = this.props;
+    const {form} = this.context;
     let dependentFields = {};
 
     if (form && form.data && depends) {

--- a/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
@@ -27,6 +27,16 @@ class SelectAsyncField extends SelectField {
      * Field ID
      */
     id: PropTypes.any,
+
+    /**
+     * A list of field names that we will try to retrieve current form values for
+     * in order to send with API request to fetch async results
+     */
+    depends: PropTypes.arrayOf(PropTypes.string),
+  };
+
+  static contextTypes = {
+    form: PropTypes.any,
   };
 
   static defaultProps = {
@@ -43,7 +53,19 @@ class SelectAsyncField extends SelectField {
 
   onQuery = query => {
     // Used by legacy integrations
-    return {autocomplete_query: query, autocomplete_field: this.props.name};
+    let {depends} = this.props;
+    let {form} = this.context;
+    let dependentFields = {};
+
+    if (form && form.data && depends) {
+      dependentFields = fromPairs(depends.map(key => [key, form.data[key]])) || {};
+    }
+
+    return {
+      autocomplete_query: query,
+      autocomplete_field: this.props.name,
+      ...dependentFields,
+    };
   };
 
   getField() {


### PR DESCRIPTION
e.g. if Foo depends on Bar, when you search in `Foo`, it will send the value of Bar in the search request


Used in 
https://github.com/getsentry/sentry-plugins/pull/382