### PR TITLE
fix(integrations): Notify users of activity during inbound status sync

### DIFF
--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -185,11 +185,12 @@ class IssueSyncMixin(IssueBasicMixin):
         )
         if updated:
             for group in groups:
-                Activity.objects.create(
+                activity = Activity.objects.create(
                     project=group.project,
                     group=group,
                     type=activity_type,
                 )
+                activity.send_notification()
 
     def sync_status_inbound(self, issue_key, data):
         affected_groups = list(


### PR DESCRIPTION
wasn't sure if we actually wanted to do this, but confirmed with sara