### PR TITLE
feat: Add header to Confirm component

### DIFF
--- a/src/sentry/static/sentry/app/components/confirm.jsx
+++ b/src/sentry/static/sentry/app/components/confirm.jsx
@@ -26,6 +26,7 @@ class Confirm extends React.PureComponent {
     disableConfirmButton: PropTypes.bool,
     onConfirming: PropTypes.func,
     onCancel: PropTypes.func,
+    header: PropTypes.node,
   };
 
   static defaultProps = {
@@ -124,6 +125,7 @@ class Confirm extends React.PureComponent {
       confirmText,
       cancelText,
       children,
+      header,
     } = this.props;
 
     let confirmMessage;
@@ -154,6 +156,7 @@ class Confirm extends React.PureComponent {
               onClick: this.handleToggle,
             })}
         <Modal show={this.state.isModalOpen} animation={false} onHide={this.handleToggle}>
+          {header && <div className="modal-header">{header}</div>}
           <div className="modal-body">{confirmMessage}</div>
           <div className="modal-footer">
             <Button style={{marginRight: 10}} onClick={this.handleToggle}>


### PR DESCRIPTION
This is to support the component being used in _admin, and shouldn't affect anything which doesn’t pass this prop.