### PR TITLE
fix(ui): add trailing space to search box before user clicks

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -15,6 +15,22 @@ import {t} from 'app/locale';
 import SearchDropdown from 'app/views/stream/searchDropdown';
 import OrganizationState from 'app/mixins/organizationState';
 
+export function addSpace(query = '') {
+  if (query.length !== 0 && query[query.length - 1] !== ' ') {
+    return query + ' ';
+  } else {
+    return query;
+  }
+}
+
+export function removeSpace(query = '') {
+  if (query[query.length - 1] === ' ') {
+    return query.slice(0, query.length - 1);
+  } else {
+    return query;
+  }
+}
+
 const SearchBar = createReactClass({
   displayName: 'SearchBar',
 
@@ -113,7 +129,8 @@ const SearchBar = createReactClass({
     const hasEnvironmentsFeature = this.getFeatures().has('environments');
 
     return {
-      query: this.props.query !== null ? this.props.query : this.props.defaultQuery,
+      query:
+        this.props.query !== null ? addSpace(this.props.query) : this.props.defaultQuery,
 
       searchTerm: '',
       searchItems: [],
@@ -132,7 +149,7 @@ const SearchBar = createReactClass({
     // query was updated by another source (e.g. sidebar filters)
     if (nextProps.query !== this.props.query) {
       this.setState({
-        query: nextProps.query,
+        query: addSpace(nextProps.query),
       });
     }
   },
@@ -146,7 +163,7 @@ const SearchBar = createReactClass({
   onSubmit(evt) {
     evt.preventDefault();
     this.blur();
-    this.props.onSearch(this.state.query);
+    this.props.onSearch(removeSpace(this.state.query));
   },
 
   clearSearch() {
@@ -246,24 +263,7 @@ const SearchBar = createReactClass({
   },
 
   onInputClick() {
-    let cursor = this.getCursorPosition();
-
-    if (
-      cursor === this.state.query.length &&
-      this.state.query.charAt(cursor - 1) !== ' '
-    ) {
-      // If the cursor lands at the end of the input value, and the preceding character
-      // is not whitespace, then add a space and move the cursor beyond that space.
-      this.setState({query: this.state.query + ' '}, () => {
-        ReactDOM.findDOMNode(this.refs.searchInput).setSelectionRange(
-          cursor + 1,
-          cursor + 1
-        );
-        this.updateAutoCompleteItems();
-      });
-    } else {
-      this.updateAutoCompleteItems();
-    }
+    this.updateAutoCompleteItems();
   },
 
   updateAutoCompleteItems() {

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -1,8 +1,36 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 
-import SearchBar from 'app/views/stream/searchBar';
+import SearchBar, {addSpace, removeSpace} from 'app/views/stream/searchBar';
 import TagStore from 'app/stores/tagStore';
+
+describe('addSpace()', function() {
+  it('should add a space when there is no trailing space', function() {
+    expect(addSpace('one')).toEqual('one ');
+  });
+
+  it('should not add another space when there is already one', function() {
+    expect(addSpace('one ')).toEqual('one ');
+  });
+
+  it('should leave the empty string alone', function() {
+    expect(addSpace('')).toEqual('');
+  });
+});
+
+describe('removeSpace()', function() {
+  it('should remove a trailing space', function() {
+    expect(removeSpace('one ')).toEqual('one');
+  });
+
+  it('should not remove the last character if it is not a space', function() {
+    expect(removeSpace('one')).toEqual('one');
+  });
+
+  it('should leave the empty string alone', function() {
+    expect(removeSpace('')).toEqual('');
+  });
+});
 
 describe('SearchBar', function() {
   let sandbox;
@@ -36,12 +64,18 @@ describe('SearchBar', function() {
   });
 
   describe('componentWillReceiveProps()', function() {
+    it('should add a space when setting state.query', function() {
+      let searchBar = shallow(<SearchBar query="one" />, options);
+
+      expect(searchBar.state().query).toEqual('one ');
+    });
+
     it('should update state.query if props.query is updated from outside', function() {
       let searchBar = shallow(<SearchBar query="one" />, options);
 
       searchBar.setProps({query: 'two'});
 
-      expect(searchBar.state().query).toEqual('two');
+      expect(searchBar.state().query).toEqual('two ');
     });
 
     it('should not reset user input if a noop props change happens', function() {
@@ -59,7 +93,7 @@ describe('SearchBar', function() {
 
       searchBar.setProps({query: 'three'});
 
-      expect(searchBar.state().query).toEqual('three');
+      expect(searchBar.state().query).toEqual('three ');
     });
   });
 
@@ -178,7 +212,12 @@ describe('SearchBar', function() {
     it('invokes onSearch() when submitting the form', function() {
       let stubbedOnSearch = sandbox.spy();
       let wrapper = mount(
-        <SearchBar onSearch={stubbedOnSearch} orgId="123" projectId="456" />,
+        <SearchBar
+          onSearch={stubbedOnSearch}
+          orgId="123"
+          projectId="456"
+          query="is:unresolved"
+        />,
         options
       );
 
@@ -186,7 +225,7 @@ describe('SearchBar', function() {
         preventDefault() {},
       });
 
-      expect(stubbedOnSearch.called).toBe(true);
+      expect(stubbedOnSearch.calledWith('is:unresolved')).toBe(true);
     });
 
     it('invokes onSearch() when search is cleared', function(done) {


### PR DESCRIPTION
Adds space to the end of props.query before saving it into state.query, and removes it again before calling props.onSearch.

This is to fix https://github.com/getsentry/sentry/issues/5871.

I have gone for a minimal patch again. I would like to refactor it to use getDerivedStateFromProps(), but we're blocked by https://github.com/airbnb/enzyme/issues/1600 again.

I've not looked around the codebase to see how you prefer to write pure helper functions, so I just dumped them at the top level in the component file. If you want anything moved around, I'll happily re-work it.