### PR TITLE
Do not override type function

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -31,7 +31,7 @@ def gettext_noop(s):
 socket.setdefaulttimeout(5)
 
 
-def env(key, default='', type=None):
+def env(key, default='', cast_type=None):
     "Extract an environment variable for use in configuration"
 
     # First check an internal cache, so we can `pop` multiple times
@@ -53,10 +53,10 @@ def env(key, default='', type=None):
         except KeyError:
             rv = default
 
-    if type is None:
-        type = type_from_value(default)
+    if cast_type is None:
+        cast_type = type_from_value(default)
 
-    return type(rv)
+    return cast_type(rv)
 
 
 env._cache = {}


### PR DESCRIPTION
The `env` function used `type` as a variable name. `type` is a built-in type.  
This causes confusion. For example, [`return type(rv)`](https://github.com/getsentry/sentry/blob/2ea999f948e88bf6fb606753ddaf79af8cf5085e/src/sentry/conf/server.py#L59) does not return the type of `rv`. This PR resolves that confusion.