### PR TITLE
fix(discover): Fix order by for queries without aggregations

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -131,9 +131,8 @@ export default function createQueryBuilder(initial = {}, organization) {
     );
 
     const orderbyField = (query.orderby || '').replace(/^-/, '');
-    const hasOrderFieldInFields = getColumns()
-      .map(({name}) => name)
-      .includes(orderbyField);
+    const hasOrderFieldInFields =
+      getColumns().find(f => f.name === orderbyField) !== undefined;
     const hasOrderFieldInSelectedFields = query.fields.includes(orderbyField);
     const hasOrderFieldInAggregations = query.aggregations.some(
       agg => orderbyField === agg[2]

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -131,7 +131,9 @@ export default function createQueryBuilder(initial = {}, organization) {
     );
 
     const orderbyField = (query.orderby || '').replace(/^-/, '');
-    const hasOrderFieldInFields = getColumns().includes(orderbyField);
+    const hasOrderFieldInFields = getColumns()
+      .map(({name}) => name)
+      .includes(orderbyField);
     const hasOrderFieldInSelectedFields = query.fields.includes(orderbyField);
     const hasOrderFieldInAggregations = query.aggregations.some(
       agg => orderbyField === agg[2]
@@ -139,11 +141,15 @@ export default function createQueryBuilder(initial = {}, organization) {
 
     const hasInvalidOrderbyField = validAggregations.length
       ? !hasOrderFieldInSelectedFields && !hasOrderFieldInAggregations
-      : hasOrderFieldInFields;
+      : !hasOrderFieldInFields;
 
     // If orderby value becomes invalid, update it to the first valid aggregation
-    if (validAggregations.length > 0 && hasInvalidOrderbyField) {
-      query.orderby = validAggregations[0][2];
+    if (hasInvalidOrderbyField) {
+      if (validAggregations.length > 0) {
+        query.orderby = validAggregations[0][2];
+      } else {
+        query.orderby = '-timestamp';
+      }
     }
 
     // Snuba doesn't allow limit without orderby

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -109,7 +109,14 @@ describe('Query Builder', function() {
       queryBuilder.updateField('aggregations', [['count()', null, 'count']]);
 
       const query = queryBuilder.getInternal();
-      expect(query.orderby).toEqual('count');
+      expect(query.orderby).toBe('count');
+    });
+
+    it('updates orderby if there is no aggregation and value is not a valid field', function() {
+      queryBuilder.updateField('aggregations', [['count()', null, 'count']]);
+      expect(queryBuilder.getInternal().orderby).toBe('count');
+      queryBuilder.updateField('aggregations', []);
+      expect(queryBuilder.getInternal().orderby).toBe('-timestamp');
     });
   });
 });


### PR DESCRIPTION
Fixes a bug that was causing `hasInvalidOrderbyField` to always be
false. Also changes the ordering to `-timestamp` if there are no
aggregations and the current orderby value becomes invalid.