### PR TITLE
fix(ui): Fix SelectField to support "multiple" property directly...

### DIFF
--- a/docs-ui/components/multipleCheckbox.stories.js
+++ b/docs-ui/components/multipleCheckbox.stories.js
@@ -5,7 +5,7 @@ import {action} from '@storybook/addon-actions';
 
 import MultipleCheckbox from 'app/views/settings/components/forms/controls/multipleCheckbox';
 
-storiesOf('Forms/Fields', module).add(
+storiesOf('Forms/Controls', module).add(
   'MultipleCheckbox',
   withInfo('Multiple Checkbox Control (controlled only atm)')(() => (
     <MultipleCheckbox

--- a/docs-ui/components/selectFields.stories.js
+++ b/docs-ui/components/selectFields.stories.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+import {action} from '@storybook/addon-actions';
+
+import {Form as LegacyForm} from 'app/components/forms';
+import SelectField from 'app/components/forms/selectField';
+import SelectCreatableField from 'app/components/forms/selectCreatableField';
+
+// eslint-disable-next-line
+storiesOf('Forms/Fields/Old', module)
+  .add(
+    'SelectField',
+    withInfo({
+      text: 'Select Field',
+      propTablesExclude: [LegacyForm],
+    })(() => (
+      <LegacyForm onSubmit={action('onSubmit')}>
+        <SelectField
+          name="foos"
+          choices={[['foo', 'Foo'], ['bar', 'Bar'], ['baz', 'Baz']]}
+        />
+        <SelectField
+          name="multi_foos"
+          choices={[['foo', 'Foo'], ['bar', 'Bar'], ['baz', 'Baz']]}
+          multiple
+        />
+      </LegacyForm>
+    ))
+  )
+  .add(
+    'SelectCreatableField',
+    withInfo({
+      text: 'Select Creatable Field',
+      propTablesExclude: [LegacyForm],
+    })(() => (
+      <LegacyForm onSubmit={action('onSubmit')}>
+        <SelectCreatableField
+          label="Creatable"
+          name="creatable_foos"
+          choices={[['foo', 'Foo'], ['bar', 'Bar'], ['baz', 'Baz']]}
+        />
+        <SelectCreatableField
+          label="Creatable (and Multiple)"
+          name="creatable_multi_foos"
+          multiple
+          choices={[['foo', 'Foo'], ['bar', 'Bar'], ['baz', 'Baz']]}
+        />
+      </LegacyForm>
+    ))
+  );

--- a/src/sentry/static/sentry/app/components/forms/multiSelectField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/multiSelectField.jsx
@@ -1,47 +1,15 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
-import {defined} from 'app/utils';
-import FormField from 'app/components/forms/formField';
-import MultiSelectControl from 'app/components/forms/multiSelectControl';
+import SelectField from 'app/components/forms/selectField';
 
-export default class MultiSelectField extends FormField {
+export default class MultiSelectField extends SelectField {
   static propTypes = {
     options: PropTypes.array,
     onChange: PropTypes.func,
     value: PropTypes.any,
   };
 
-  // Overriding this for now so that we can set default value to `[]`
-  getValue(props, context) {
-    let form = (context || this.context || {}).form;
-    props = props || this.props;
-    if (defined(props.value)) {
-      return props.value;
-    }
-    if (form && form.data.hasOwnProperty(props.name)) {
-      return defined(form.data[props.name]) ? form.data[props.name] : [];
-    }
-    return defined(props.defaultValue) ? props.defaultValue : [];
-  }
-
-  getClassName() {
-    return '';
-  }
-
-  onChange = (opts = []) => {
-    const value = opts.map(opt => opt.value);
-    this.setValue(value);
-  };
-
-  getField() {
-    return (
-      <MultiSelectControl
-        id={this.getId()}
-        value={this.state.value}
-        {...this.props}
-        onChange={this.onChange}
-      />
-    );
+  isMultiple() {
+    return true;
   }
 }

--- a/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {defined} from 'app/utils';
-
 import SelectAsyncControl from './selectAsyncControl';
 import SelectField from './selectField';
 
@@ -36,46 +34,6 @@ class SelectAsyncField extends SelectField {
     placeholder: 'Start typing to search for an issue',
   };
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    // super.componentWillReceiveProps(nextProps, nextContext);
-    let newError = this.getError(nextProps, nextContext);
-    if (newError != this.state.error) {
-      this.setState({error: newError});
-    }
-    if (this.props.value !== nextProps.value || defined(nextContext.form)) {
-      let newValue = this.getValue(nextProps, nextContext);
-      // This is the only thing that is different from parent, we compare newValue against coerved value in state
-      // To remain compatible with react-select, we need to store the option object that
-      // includes `value` and `label`, but when we submit the format, we need to coerce it
-      // to just return `value`. Also when field changes, it propagates the coerced value up
-      let coercedValue = this.coerceValue(this.state.value);
-
-      // newValue can be empty string because of `getValue`, while coerceValue needs to return null (to differentiate
-      // empty string from cleared item). We could use `!=` to compare, but lets be a bit more explicit with strict equality
-      //
-      // This can happen when this is apart of a field, and it re-renders onChange for a different field,
-      // there will be a mismatch between this component's state.value and `this.getValue` result above
-      if (newValue !== coercedValue && !!newValue !== !!coercedValue) {
-        this.setValue(newValue);
-      }
-    }
-  }
-
-  // Not sure why, but we need this to get react-select's `Creatable` to work properly
-  // Otherwise, when you hit "enter" to create a new item, the "selected value" does
-  // not update with new value (and also new value is not displayed in dropdown)
-  coerceValue(value) {
-    if (!value) return '';
-
-    if (this.isMultiple()) {
-      return value.map(v => v.value);
-    } else if (value.hasOwnProperty('value')) {
-      return value.value;
-    }
-
-    return value;
-  }
-
   onResults = data => {
     let {name} = this.props;
     let results = data && data[name];
@@ -86,12 +44,6 @@ class SelectAsyncField extends SelectField {
   onQuery = query => {
     // Used by legacy integrations
     return {autocomplete_query: query, autocomplete_field: this.props.name};
-  };
-
-  onChange = opt => {
-    // Changing this will most likely break react-select (e.g. you won't be able to select
-    // a menu option that is from an async request).
-    this.setValue(opt);
   };
 
   getField() {

--- a/src/sentry/static/sentry/app/components/forms/selectCreatableField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectCreatableField.jsx
@@ -2,9 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
+import {StyledForm} from 'app/components/forms/form';
 import {defined} from 'app/utils';
-import FormField from 'app/components/forms/formField';
 import SelectControl from 'app/components/forms/selectControl';
+import SelectField from 'app/components/forms/selectField';
 import convertFromSelect2Choices from 'app/utils/convertFromSelect2Choices';
 
 /**
@@ -12,9 +13,9 @@ import convertFromSelect2Choices from 'app/utils/convertFromSelect2Choices';
  *
  * This is used in some integrations
  */
-export default class SelectCreatableField extends FormField {
+export default class SelectCreatableField extends SelectField {
   static propTypes = {
-    ...FormField.propTypes,
+    ...SelectField.propTypes,
     options: SelectControl.propTypes.options,
     clearable: SelectControl.propTypes.clearable,
     choices: SelectControl.propTypes.choices,
@@ -33,7 +34,6 @@ export default class SelectCreatableField extends FormField {
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
-    // super.componentWillReceiveProps(nextProps, nextContext);
     let newError = this.getError(nextProps, nextContext);
     if (newError != this.state.error) {
       this.setState({error: newError});
@@ -65,41 +65,34 @@ export default class SelectCreatableField extends FormField {
     return convertFromSelect2Choices(props.choices) || props.options;
   }
 
-  getClassName = () => '';
-
-  // Not sure why, but we need this to get react-select's `Creatable` to work properly
-  // Otherwise, when you hit "enter" to create a new item, the "selected value" does
-  // not update with new value (and also new value is not displayed in dropdown)
-  coerceValue(value) {
-    return value ? value.value : null;
-  }
-
-  onChange = opt => {
-    this.setValue(opt);
-  };
-
   getField() {
-    let {placeholder, disabled, required, clearable} = this.props;
+    let {placeholder, disabled, required, clearable, name} = this.props;
 
     return (
-      <FieldSeparator>
-        <SelectControl
-          creatable
-          id={this.getId()}
-          options={this.options}
-          placeholder={placeholder}
-          disabled={disabled}
-          required={required}
-          value={this.state.value}
-          onChange={this.onChange}
-          clearable={clearable}
-        />
-      </FieldSeparator>
+      <StyledSelectControl
+        creatable
+        id={this.getId()}
+        options={this.options}
+        placeholder={placeholder}
+        disabled={disabled}
+        required={required}
+        value={this.state.value}
+        onChange={this.onChange}
+        clearable={clearable}
+        multiple={this.isMultiple()}
+        name={name}
+      />
     );
   }
 }
 
 // This is because we are removing `control-group` class name which provides margin-bottom
-const FieldSeparator = styled('div')`
-  margin-bottom: 15px;
+const StyledSelectControl = styled(SelectControl)`
+  ${StyledForm} &, .form-stacked & {
+    .control-group & {
+      margin-bottom: 0;
+    }
+
+    margin-bottom: 15px;
+  }
 `;

--- a/tests/js/helpers/select.js
+++ b/tests/js/helpers/select.js
@@ -11,7 +11,7 @@ export function getSelector(options = {}) {
 
 export function openMenu(wrapper, options = {}) {
   let selector = getSelector(options);
-  wrapper.find(`${selector} input`).simulate('focus');
+  wrapper.find(`${selector} input[role="combobox"]`).simulate('focus');
   wrapper.find(`${selector} .Select-control`).simulate('mouseDown', {button: 0});
 
   return wrapper;

--- a/tests/js/spec/components/forms/__snapshots__/genericField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/genericField.spec.jsx.snap
@@ -17,12 +17,14 @@ exports[`GenericField renders text as TextInput 1`] = `
 exports[`GenericField renders text with choices as SelectCreatableField 1`] = `
 <SelectCreatableField
   choices={Array []}
+  clearable={true}
   disabled={false}
   formState="Ready"
   help={null}
   hideErrorMessage={false}
   key="field-name"
   label="field label*"
+  multiple={false}
   name="field-name"
   required={true}
   type="text"

--- a/tests/js/spec/components/forms/__snapshots__/multiSelectField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/multiSelectField.spec.jsx.snap
@@ -7,10 +7,11 @@ exports[`MultiSelectField render() renders without form context 1`] = `
   <div
     className="controls"
   >
-    <MultiSelectControl
+    <StyledSelectControl
+      clearable={true}
       disabled={false}
-      hideErrorMessage={false}
       id="id-fieldName"
+      multiple={true}
       name="fieldName"
       onChange={[Function]}
       options={

--- a/tests/js/spec/components/forms/__snapshots__/selectField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/selectField.spec.jsx.snap
@@ -19,6 +19,7 @@ exports[`SelectField renders with flat choices 1`] = `
       disabled={false}
       id="id-fieldName"
       multiple={false}
+      name="fieldName"
       onChange={[Function]}
       required={false}
       value="fieldValue"
@@ -55,6 +56,7 @@ exports[`SelectField renders with paired choices 1`] = `
       disabled={false}
       id="id-fieldName"
       multiple={false}
+      name="fieldName"
       onChange={[Function]}
       required={false}
       value="fieldValue"
@@ -96,6 +98,7 @@ exports[`SelectField renders without form context 1`] = `
         disabled={false}
         id="id-fieldName"
         multiple={false}
+        name="fieldName"
         onChange={[Function]}
         options={
           Array [
@@ -118,6 +121,7 @@ exports[`SelectField renders without form context 1`] = `
           disabled={false}
           id="id-fieldName"
           multiple={false}
+          name="fieldName"
           onChange={[Function]}
           options={
             Array [
@@ -143,6 +147,7 @@ exports[`SelectField renders without form context 1`] = `
             disabled={false}
             id="id-fieldName"
             multiple={false}
+            name="fieldName"
             onChange={[Function]}
             options={
               Array [
@@ -168,6 +173,7 @@ exports[`SelectField renders without form context 1`] = `
               disabled={false}
               id="id-fieldName"
               multiple={false}
+              name="fieldName"
               onChange={[Function]}
               options={
                 Array [
@@ -213,6 +219,7 @@ exports[`SelectField renders without form context 1`] = `
                 menuRenderer={[Function]}
                 multi={false}
                 multiple={false}
+                name="fieldName"
                 noResultsText="No results found"
                 onBlurResetsInput={true}
                 onChange={[Function]}
@@ -249,6 +256,13 @@ exports[`SelectField renders without form context 1`] = `
                 <div
                   className="Select e1qrhqd00 css-dxi9rm-StyledSelect-StyledSelectControl eho28m20 has-value is-clearable is-searchable Select--single"
                 >
+                  <input
+                    disabled={false}
+                    key="hidden.0"
+                    name="fieldName"
+                    type="hidden"
+                    value="a"
+                  />
                   <div
                     className="Select-control"
                     onKeyDown={[Function]}

--- a/tests/js/spec/components/forms/multiSelectField.spec.jsx
+++ b/tests/js/spec/components/forms/multiSelectField.spec.jsx
@@ -23,7 +23,7 @@ describe('MultiSelectField', function() {
           value={['a']}
         />
       );
-      expect(wrapper.find('MultiSelectControl').prop('value')).toEqual(['a']);
+      expect(wrapper.find('StyledSelectControl').prop('value')).toEqual(['a']);
     });
 
     it('renders with form context', function() {
@@ -44,7 +44,7 @@ describe('MultiSelectField', function() {
         }
       );
 
-      expect(wrapper.find('MultiSelectControl').prop('value')).toEqual(['a', 'b']);
+      expect(wrapper.find('StyledSelectControl').prop('value')).toEqual(['a', 'b']);
     });
   });
 });

--- a/tests/js/spec/components/forms/selectField.spec.jsx
+++ b/tests/js/spec/components/forms/selectField.spec.jsx
@@ -69,4 +69,26 @@ describe('SelectField', function() {
       expect.anything()
     );
   });
+
+  describe('Multiple', function() {
+    it('selects multiple values and submits', function() {
+      let mock = jest.fn();
+      let wrapper = mount(
+        <Form onSubmit={mock}>
+          <SelectField
+            multiple
+            options={[{label: 'a', value: 'a'}, {label: 'b', value: 'b'}]}
+            name="fieldName"
+          />
+        </Form>
+      );
+      selectByValue(wrapper, 'a', {name: 'fieldName'});
+      wrapper.find('Form').simulate('submit');
+      expect(mock).toHaveBeenCalledWith(
+        {fieldName: ['a']},
+        expect.anything(),
+        expect.anything()
+      );
+    });
+  });
 });

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -162,6 +162,7 @@ exports[`Project Ownership Input renders 1`] = `
                   disabled={false}
                   id="id-select-type"
                   multiple={false}
+                  name="select-type"
                   onChange={[Function]}
                   options={
                     Array [
@@ -184,6 +185,7 @@ exports[`Project Ownership Input renders 1`] = `
                     disabled={false}
                     id="id-select-type"
                     multiple={false}
+                    name="select-type"
                     onChange={[Function]}
                     options={
                       Array [
@@ -209,6 +211,7 @@ exports[`Project Ownership Input renders 1`] = `
                       disabled={false}
                       id="id-select-type"
                       multiple={false}
+                      name="select-type"
                       onChange={[Function]}
                       options={
                         Array [
@@ -234,6 +237,7 @@ exports[`Project Ownership Input renders 1`] = `
                         disabled={false}
                         id="id-select-type"
                         multiple={false}
+                        name="select-type"
                         onChange={[Function]}
                         options={
                           Array [
@@ -279,6 +283,7 @@ exports[`Project Ownership Input renders 1`] = `
                           menuRenderer={[Function]}
                           multi={false}
                           multiple={false}
+                          name="select-type"
                           noResultsText="No results found"
                           onBlurResetsInput={true}
                           onChange={[Function]}
@@ -315,6 +320,13 @@ exports[`Project Ownership Input renders 1`] = `
                           <div
                             className="Select e1qrhqd00 css-b6mfcr-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                           >
+                            <input
+                              disabled={false}
+                              key="hidden.0"
+                              name="select-type"
+                              type="hidden"
+                              value="path"
+                            />
                             <div
                               className="Select-control"
                               onKeyDown={[Function]}

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -338,6 +338,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 disabled={false}
                                 id="id-actionMatch"
                                 multiple={false}
+                                name="actionMatch"
                                 onChange={[Function]}
                                 required={true}
                                 value=""
@@ -364,6 +365,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   disabled={false}
                                   id="id-actionMatch"
                                   multiple={false}
+                                  name="actionMatch"
                                   onChange={[Function]}
                                   required={true}
                                   value=""
@@ -377,6 +379,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     disabled={false}
                                     id="id-actionMatch"
                                     multiple={false}
+                                    name="actionMatch"
                                     onChange={[Function]}
                                     options={
                                       Array [
@@ -406,6 +409,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       disabled={false}
                                       id="id-actionMatch"
                                       multiple={false}
+                                      name="actionMatch"
                                       onChange={[Function]}
                                       options={
                                         Array [
@@ -455,6 +459,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                         menuRenderer={[Function]}
                                         multi={false}
                                         multiple={false}
+                                        name="actionMatch"
                                         noResultsText="No results found"
                                         onBlurResetsInput={true}
                                         onChange={[Function]}
@@ -1072,6 +1077,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             disabled={false}
                             id="id-environment"
                             multiple={false}
+                            name="environment"
                             onChange={[Function]}
                             required={true}
                             value="staging"
@@ -1098,6 +1104,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               disabled={false}
                               id="id-environment"
                               multiple={false}
+                              name="environment"
                               onChange={[Function]}
                               required={true}
                               value="staging"
@@ -1111,6 +1118,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 disabled={false}
                                 id="id-environment"
                                 multiple={false}
+                                name="environment"
                                 onChange={[Function]}
                                 options={
                                   Array [
@@ -1140,6 +1148,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   disabled={false}
                                   id="id-environment"
                                   multiple={false}
+                                  name="environment"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -1189,6 +1198,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     menuRenderer={[Function]}
                                     multi={false}
                                     multiple={false}
+                                    name="environment"
                                     noResultsText="No results found"
                                     onBlurResetsInput={true}
                                     onChange={[Function]}
@@ -1229,6 +1239,13 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     <div
                                       className="Select e1qrhqd00 css-b6mfcr-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                     >
+                                      <input
+                                        disabled={false}
+                                        key="hidden.0"
+                                        name="environment"
+                                        type="hidden"
+                                        value="staging"
+                                      />
                                       <div
                                         className="Select-control"
                                         onKeyDown={[Function]}
@@ -1876,6 +1893,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 disabled={false}
                                 id="id-frequency"
                                 multiple={false}
+                                name="frequency"
                                 onChange={[Function]}
                                 required={true}
                                 value=""
@@ -1926,6 +1944,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   disabled={false}
                                   id="id-frequency"
                                   multiple={false}
+                                  name="frequency"
                                   onChange={[Function]}
                                   required={true}
                                   value=""
@@ -1939,6 +1958,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     disabled={false}
                                     id="id-frequency"
                                     multiple={false}
+                                    name="frequency"
                                     onChange={[Function]}
                                     options={
                                       Array [
@@ -1992,6 +2012,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       disabled={false}
                                       id="id-frequency"
                                       multiple={false}
+                                      name="frequency"
                                       onChange={[Function]}
                                       options={
                                         Array [
@@ -2065,6 +2086,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                         menuRenderer={[Function]}
                                         multi={false}
                                         multiple={false}
+                                        name="frequency"
                                         noResultsText="No results found"
                                         onBlurResetsInput={true}
                                         onChange={[Function]}
@@ -2704,6 +2726,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 disabled={false}
                                 id="id-actionMatch"
                                 multiple={false}
+                                name="actionMatch"
                                 onChange={[Function]}
                                 required={true}
                                 value="all"
@@ -2730,6 +2753,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                   disabled={false}
                                   id="id-actionMatch"
                                   multiple={false}
+                                  name="actionMatch"
                                   onChange={[Function]}
                                   required={true}
                                   value="all"
@@ -2743,6 +2767,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     disabled={false}
                                     id="id-actionMatch"
                                     multiple={false}
+                                    name="actionMatch"
                                     onChange={[Function]}
                                     options={
                                       Array [
@@ -2772,6 +2797,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       disabled={false}
                                       id="id-actionMatch"
                                       multiple={false}
+                                      name="actionMatch"
                                       onChange={[Function]}
                                       options={
                                         Array [
@@ -2821,6 +2847,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                         menuRenderer={[Function]}
                                         multi={false}
                                         multiple={false}
+                                        name="actionMatch"
                                         noResultsText="No results found"
                                         onBlurResetsInput={true}
                                         onChange={[Function]}
@@ -2861,6 +2888,13 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                         <div
                                           className="Select e1qrhqd00 css-b6mfcr-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                         >
+                                          <input
+                                            disabled={false}
+                                            key="hidden.0"
+                                            name="actionMatch"
+                                            type="hidden"
+                                            value="all"
+                                          />
                                           <div
                                             className="Select-control"
                                             onKeyDown={[Function]}
@@ -3287,6 +3321,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                             disabled={false}
                             id="id-environment"
                             multiple={false}
+                            name="environment"
                             onChange={[Function]}
                             required={true}
                             value="__all_environments__"
@@ -3313,6 +3348,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               disabled={false}
                               id="id-environment"
                               multiple={false}
+                              name="environment"
                               onChange={[Function]}
                               required={true}
                               value="__all_environments__"
@@ -3326,6 +3362,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 disabled={false}
                                 id="id-environment"
                                 multiple={false}
+                                name="environment"
                                 onChange={[Function]}
                                 options={
                                   Array [
@@ -3355,6 +3392,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                   disabled={false}
                                   id="id-environment"
                                   multiple={false}
+                                  name="environment"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -3404,6 +3442,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     menuRenderer={[Function]}
                                     multi={false}
                                     multiple={false}
+                                    name="environment"
                                     noResultsText="No results found"
                                     onBlurResetsInput={true}
                                     onChange={[Function]}
@@ -3444,6 +3483,13 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     <div
                                       className="Select e1qrhqd00 css-b6mfcr-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                     >
+                                      <input
+                                        disabled={false}
+                                        key="hidden.0"
+                                        name="environment"
+                                        type="hidden"
+                                        value="__all_environments__"
+                                      />
                                       <div
                                         className="Select-control"
                                         onKeyDown={[Function]}
@@ -3920,6 +3966,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 disabled={false}
                                 id="id-frequency"
                                 multiple={false}
+                                name="frequency"
                                 onChange={[Function]}
                                 required={true}
                                 value={30}
@@ -3970,6 +4017,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                   disabled={false}
                                   id="id-frequency"
                                   multiple={false}
+                                  name="frequency"
                                   onChange={[Function]}
                                   required={true}
                                   value={30}
@@ -3983,6 +4031,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     disabled={false}
                                     id="id-frequency"
                                     multiple={false}
+                                    name="frequency"
                                     onChange={[Function]}
                                     options={
                                       Array [
@@ -4036,6 +4085,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       disabled={false}
                                       id="id-frequency"
                                       multiple={false}
+                                      name="frequency"
                                       onChange={[Function]}
                                       options={
                                         Array [
@@ -4109,6 +4159,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                         menuRenderer={[Function]}
                                         multi={false}
                                         multiple={false}
+                                        name="frequency"
                                         noResultsText="No results found"
                                         onBlurResetsInput={true}
                                         onChange={[Function]}
@@ -4173,6 +4224,13 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                         <div
                                           className="Select e1qrhqd00 css-b6mfcr-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                         >
+                                          <input
+                                            disabled={false}
+                                            key="hidden.0"
+                                            name="frequency"
+                                            type="hidden"
+                                            value="30"
+                                          />
                                           <div
                                             className="Select-control"
                                             onKeyDown={[Function]}

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -136,6 +136,7 @@ exports[`RuleBuilder renders 1`] = `
                 disabled={false}
                 id="id-select-type"
                 multiple={false}
+                name="select-type"
                 onChange={[Function]}
                 options={
                   Array [
@@ -158,6 +159,7 @@ exports[`RuleBuilder renders 1`] = `
                   disabled={false}
                   id="id-select-type"
                   multiple={false}
+                  name="select-type"
                   onChange={[Function]}
                   options={
                     Array [
@@ -183,6 +185,7 @@ exports[`RuleBuilder renders 1`] = `
                     disabled={false}
                     id="id-select-type"
                     multiple={false}
+                    name="select-type"
                     onChange={[Function]}
                     options={
                       Array [
@@ -208,6 +211,7 @@ exports[`RuleBuilder renders 1`] = `
                       disabled={false}
                       id="id-select-type"
                       multiple={false}
+                      name="select-type"
                       onChange={[Function]}
                       options={
                         Array [
@@ -253,6 +257,7 @@ exports[`RuleBuilder renders 1`] = `
                         menuRenderer={[Function]}
                         multi={false}
                         multiple={false}
+                        name="select-type"
                         noResultsText="No results found"
                         onBlurResetsInput={true}
                         onChange={[Function]}
@@ -289,6 +294,13 @@ exports[`RuleBuilder renders 1`] = `
                         <div
                           className="Select e1qrhqd00 css-b6mfcr-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                         >
+                          <input
+                            disabled={false}
+                            key="hidden.0"
+                            name="select-type"
+                            type="hidden"
+                            value="path"
+                          />
                           <div
                             className="Select-control"
                             onKeyDown={[Function]}
@@ -1377,6 +1389,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                 disabled={false}
                 id="id-select-type"
                 multiple={false}
+                name="select-type"
                 onChange={[Function]}
                 options={
                   Array [
@@ -1399,6 +1412,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                   disabled={false}
                   id="id-select-type"
                   multiple={false}
+                  name="select-type"
                   onChange={[Function]}
                   options={
                     Array [
@@ -1424,6 +1438,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                     disabled={false}
                     id="id-select-type"
                     multiple={false}
+                    name="select-type"
                     onChange={[Function]}
                     options={
                       Array [
@@ -1449,6 +1464,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       disabled={false}
                       id="id-select-type"
                       multiple={false}
+                      name="select-type"
                       onChange={[Function]}
                       options={
                         Array [
@@ -1494,6 +1510,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         menuRenderer={[Function]}
                         multi={false}
                         multiple={false}
+                        name="select-type"
                         noResultsText="No results found"
                         onBlurResetsInput={true}
                         onChange={[Function]}
@@ -1530,6 +1547,13 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         <div
                           className="Select e1qrhqd00 css-b6mfcr-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                         >
+                          <input
+                            disabled={false}
+                            key="hidden.0"
+                            name="select-type"
+                            type="hidden"
+                            value="path"
+                          />
                           <div
                             className="Select-control"
                             onKeyDown={[Function]}

--- a/tests/js/spec/views/projectAlertRuleDetails.spec.jsx
+++ b/tests/js/spec/views/projectAlertRuleDetails.spec.jsx
@@ -156,9 +156,9 @@ describe('ProjectAlertRuleDetails', function() {
 
     it('sends correct environment value', function() {
       selectByValue(wrapper, 'production', {name: 'environment'});
-      expect(wrapper.find('SelectField[name="environment"] Select').prop('value')).toBe(
-        'production'
-      );
+      expect(
+        wrapper.find('SelectField[name="environment"] Select').prop('value')
+      ).toEqual(expect.objectContaining({value: 'production'}));
       wrapper.find('form').simulate('submit');
 
       expect(mock).toHaveBeenCalledWith(


### PR DESCRIPTION
Instead of using the `<MultiSelectField>` you can use `multiple` property directly with `<SelectField>`. (Maybe follow up to remove `<MultiSelectField>`).
Some integrations are passing `multi` to the field (i.e. JIRA) - it will be better if `<SelectField>` supports this type of field directly.

Moved a lot of logic from the different "Select" components into `<SelectField>` so that it can support different combinations of "Select" fields. Now you can have "multiple" behavior in all Select fields.

There was a disconnect between the value in local state (where `react-select` expects an object with `label` and `value` keys) and the value that our forms expect (just the raw value to be used).