### PR TITLE
ref(integrations): Add sentry issue link to linked GH/GHE issue comments

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.integrations.issues import IssueBasicMixin
+from sentry.utils.http import absolute_uri
 
 
 class GitHubIssueBasic(IssueBasicMixin):
@@ -123,7 +124,10 @@ class GitHubIssueBasic(IssueBasicMixin):
             {
                 'name': 'comment',
                 'label': 'Comment',
-                'default': '',
+                'default': u'Sentry issue: [{issue_id}]({url})'.format(
+                    url=absolute_uri(group.get_absolute_url()),
+                    issue_id=group.qualified_short_id
+                ),
                 'type': 'textarea',
                 'required': False,
                 'help': ('Leave blank if you don\'t want to '

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -126,7 +126,7 @@ class GitHubIssueBasic(IssueBasicMixin):
                 'label': 'Comment',
                 'default': u'Sentry issue: [{issue_id}]({url})'.format(
                     url=absolute_uri(group.get_absolute_url()),
-                    issue_id=group.qualified_short_id
+                    issue_id=group.qualified_short_id,
                 ),
                 'type': 'textarea',
                 'required': False,


### PR DESCRIPTION
Add the default comment to be the Sentry Issue link: 

![screen shot 2018-07-23 at 12 58 05 pm](https://user-images.githubusercontent.com/15368179/43099793-2046f292-8e78-11e8-8ddb-7acc3e7d9f32.png)
