### PR TITLE
fix(ui): Clean up disabled reason spacing

### DIFF
--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -113,6 +113,13 @@ storiesOf('Forms/Fields/New', module)
           required
           flexibleControlStateSize
         />
+        <TextField
+          name="textfielddisabled"
+          label="Text field with disabled reason"
+          placeholder="I am disabled"
+          disabled
+          disabledReason="This is the reason this field is disabled"
+        />
       </Form>
     ))
   )

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.jsx
@@ -73,11 +73,11 @@ class FieldControl extends React.Component {
 
           {disabled &&
             disabledReason && (
-              <Tooltip title={disabledReason}>
-                <span className="disabled-indicator m-a-0">
+              <Flex align="center" ml={1} className="disabled-indicator">
+                <Tooltip title={disabledReason}>
                   <StyledInlineSvg src="icon-circle-question" size="18px" />
-                </span>
-              </Tooltip>
+                </Tooltip>
+              </Flex>
             )}
 
           <FieldControlState flexibleControlStateSize={flexibleControlStateSize}>


### PR DESCRIPTION
Not sure why it had the margin removed, but this looks good. Added a story book item.