### PR TITLE
ref(ui): Use a slightly saner fontsize for Autocompletes

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -295,6 +295,7 @@ const StyledInput = styled(Input)`
 `;
 
 const AutoCompleteItem = styled('div')`
+  font-size: 0.9em;
   background-color: ${p =>
     p.index == p.highlightedIndex ? p.theme.offWhite : 'transparent'};
   padding: ${space(1)};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/43108525-1e7ac7e4-8e97-11e8-9b59-1e53071af451.png)

vs the old one

![image](https://user-images.githubusercontent.com/1421724/43108541-2b2ec102-8e97-11e8-9f62-a268d45a0f21.png)

Doesn't seem to have affected anything else since most were using their own label