### PR TITLE
fix(integrations): Capture 401 in VSTS Webhook

### DIFF
--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -3,6 +3,7 @@ from .client import VstsApiClient
 
 from sentry.models import Identity, Integration, sync_group_assignee_inbound
 from sentry.api.base import Endpoint
+from sentry.app import raven
 from uuid import uuid4
 from django.views.decorators.csrf import csrf_exempt
 
@@ -33,6 +34,7 @@ class WorkItemWebhook(Endpoint):
             try:
                 self.check_webhook_secret(request, integration)
             except AssertionError:
+                raven.captureException(request=request)
                 return self.respond(status=401)
             self.handle_updated_workitem(data, integration)
         return self.respond()


### PR DESCRIPTION
Because I'm catching this error it was not being passed to sentry. 