### PR TITLE
Revert "fix: Revert "Temporarily disable cleanup for tagstore v2 #750…

### DIFF
--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -83,13 +83,8 @@ class V2TagStorage(TagStorage):
         self.setup_receivers()
 
     def setup_cleanup(self):
-        from sentry.runner.commands import cleanup
-
-        cleanup.EXTRA_BULK_QUERY_DELETES += [
-            (models.GroupTagValue, 'last_seen', None),
-            (models.TagValue, 'last_seen', None),
-            (models.EventTag, 'date_added', 'date_added', 50000),
-        ]
+        # TODO: fix for sharded DB
+        pass
 
     def setup_deletions(self):
         from sentry.deletions import default_manager as deletion_manager

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+import pytest
+
 from django.conf import settings
 
 from sentry.models import Event, Group
@@ -29,6 +31,10 @@ class SentryCleanupTest(CliTestCase):
 
     command = cleanup
 
+    @pytest.mark.skipif(
+        settings.SENTRY_TAGSTORE == 'sentry.tagstore.v2.V2TagStorage',
+        reason='Cleanup is temporarily disabled for tagstore v2'
+    )
     def test_simple(self):
         rv = self.invoke('--days=1')
         assert rv.exit_code == 0, rv.output
@@ -36,6 +42,10 @@ class SentryCleanupTest(CliTestCase):
         for model in ALL_MODELS:
             assert model.objects.count() == 0
 
+    @pytest.mark.skipif(
+        settings.SENTRY_TAGSTORE == 'sentry.tagstore.v2.V2TagStorage',
+        reason='Cleanup is temporarily disabled for tagstore v2'
+    )
     def test_project(self):
         orig_counts = {}
         for model in ALL_MODELS:


### PR DESCRIPTION
…5" (#9073)"

This reverts commit 46c4986a8bf7b66980a04e63b0f4742decc95ed6.

So we need another solution for this. For error see SENTRY-723.

Fixes SENTRY-723