### PR TITLE
feat(integrations): GitHub post-install migration

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -92,6 +92,9 @@ class IntegrationProvider(PipelineProvider):
     def get_logger(self):
         return logging.getLogger('sentry.integration.%s' % (self.key, ))
 
+    def post_install(self, integration, organization):
+        pass
+
     def get_pipeline_views(self):
         """
         Return a list of ``View`` instances describing this integration's

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -193,6 +193,9 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
                 # available from the installation config view.
                 lambda: self._make_identity_pipeline_view()]
 
+    def post_install(self, integration, organization):
+        pass
+
     def get_installation_info(self, installation_data, access_token, installation_id):
         session = http.build_session()
         resp = session.get(

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -52,25 +52,26 @@ class IntegrationPipeline(Pipeline):
     def finish_pipeline(self):
         data = self.provider.build_integration(self.state.data)
         response = self._finish_pipeline(data)
+        self.provider.post_install(self.integration, self.organization)
         self.clear_session()
         return response
 
     def _finish_pipeline(self, data):
         if 'reinstall_id' in data:
-            integration = Integration.objects.get(
+            self.integration = Integration.objects.get(
                 provider=self.provider.key,
                 id=data['reinstall_id'],
             )
-            integration.update(external_id=data['external_id'], status=ObjectStatus.VISIBLE)
-            integration.get_installation(self.organization.id).reinstall()
+            self.integration.update(external_id=data['external_id'], status=ObjectStatus.VISIBLE)
+            self.integration.get_installation(self.organization.id).reinstall()
 
         elif 'expect_exists' in data:
-            integration = Integration.objects.get(
+            self.integration = Integration.objects.get(
                 provider=self.provider.key,
                 external_id=data['external_id'],
             )
         else:
-            integration = ensure_integration(self.provider.key, data)
+            self.integration = ensure_integration(self.provider.key, data)
 
         # Does this integration provide a user identity for the user setting up
         # the integration?
@@ -146,7 +147,8 @@ class IntegrationPipeline(Pipeline):
                 raise NotImplementedError('Integration requires an identity')
             org_integration_args = {'default_auth_id': identity_model.id}
 
-        org_integration = integration.add_organization(self.organization.id, **org_integration_args)
+        org_integration = self.integration.add_organization(
+            self.organization.id, **org_integration_args)
 
         return self._dialog_response(serialize(org_integration, self.request.user), True)
 

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -2,13 +2,16 @@ from __future__ import absolute_import
 
 import responses
 import six
-from mock import patch
+import sentry
+
+from mock import MagicMock
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.github import GitHubIntegrationProvider
 from sentry.models import (
     Identity, IdentityProvider, IdentityStatus, Integration, OrganizationIntegration,
+    Repository,
 )
 from sentry.testutils import IntegrationTestCase
 
@@ -16,57 +19,77 @@ from sentry.testutils import IntegrationTestCase
 class GitHubIntegrationTest(IntegrationTestCase):
     provider = GitHubIntegrationProvider
 
-    @patch('sentry.integrations.github.integration.get_jwt', return_value='jwt_token_1')
-    def assert_setup_flow(self, get_jwt, installation_id='install_id_1',
-                          app_id='app_1', user_id='user_id_1'):
+    def setUp(self):
+        super(GitHubIntegrationTest, self).setUp()
+
+        self.installation_id = 'install_1'
+        self.user_id = 'user_1'
+        self.app_id = 'app_1'
+        self.access_token = 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
+        self.expires_at = '3000-01-01T00:00:00Z'
+
+        self._stub_github()
+
+    def _stub_github(self):
         responses.reset()
 
-        resp = self.client.get(self.init_path)
-        assert resp.status_code == 302
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.com'
-        assert redirect.path == '/apps/sentry-test-app'
-
-        # App installation ID is provided, mveo thr
-        resp = self.client.get('{}?{}'.format(
-            self.setup_path,
-            urlencode({'installation_id': installation_id})
-        ))
-
-        assert resp.status_code == 302
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.com'
-        assert redirect.path == '/login/oauth/authorize'
-
-        params = parse_qs(redirect.query)
-        assert params['state']
-        assert params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
-        assert params['response_type'] == ['code']
-        assert params['client_id'] == ['github-client-id']
-        # once we've asserted on it, switch to a singular values to make life
-        # easier
-        authorize_params = {k: v[0] for k, v in six.iteritems(params)}
-
-        access_token = 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
-
-        responses.add(
-            responses.POST, 'https://github.com/login/oauth/access_token',
-            json={'access_token': access_token}
+        sentry.integrations.github.integration.get_jwt = MagicMock(
+            return_value='jwt_token_1',
+        )
+        sentry.integrations.github.client.get_jwt = MagicMock(
+            return_value='jwt_token_1',
         )
 
         responses.add(
-            responses.GET, 'https://api.github.com/user',
-            json={'id': user_id}
+            responses.POST,
+            'https://github.com/login/oauth/access_token',
+            json={'access_token': self.access_token}
+        )
+
+        responses.add(
+            responses.POST,
+            'https://api.github.com/installations/{}/access_tokens'.format(
+                self.installation_id,
+            ),
+            json={
+                'token': self.access_token,
+                'expires_at': self.expires_at,
+            }
         )
 
         responses.add(
             responses.GET,
-            u'https://api.github.com/app/installations/{}'.format(installation_id),
+            'https://api.github.com/user',
+            json={'id': self.user_id}
+        )
+
+        responses.add(
+            responses.GET,
+            u'https://api.github.com/installation/repositories',
             json={
-                'id': installation_id,
-                'app_id': app_id,
+                'repositories': [
+                    {
+                        'id': 1296269,
+                        'name': 'foo',
+                        'full_name': 'Test-Organization/foo',
+                    },
+                    {
+                        'id': 9876574,
+                        'name': 'bar',
+                        'full_name': 'Test-Organization/bar',
+                    },
+                ],
+            }
+        )
+
+        responses.add(
+            responses.GET,
+            u'https://api.github.com/app/installations/{}'.format(
+                self.installation_id,
+            ),
+            json={
+                'id': self.installation_id,
+                'app_id': self.app_id,
                 'account': {
                     'login': 'Test Organization',
                     'avatar_url': 'http://example.com/avatar.png',
@@ -77,11 +100,43 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         responses.add(
-            responses.GET, u'https://api.github.com/user/installations',
+            responses.GET,
+            u'https://api.github.com/user/installations',
             json={
-                'installations': [{'id': installation_id}],
+                'installations': [{'id': self.installation_id}],
             }
         )
+
+    def assert_setup_flow(self):
+        resp = self.client.get(self.init_path)
+        assert resp.status_code == 302
+        redirect = urlparse(resp['Location'])
+        assert redirect.scheme == 'https'
+        assert redirect.netloc == 'github.com'
+        assert redirect.path == '/apps/sentry-test-app'
+
+        # App installation ID is provided
+        resp = self.client.get('{}?{}'.format(
+            self.setup_path,
+            urlencode({'installation_id': self.installation_id})
+        ))
+
+        redirect = urlparse(resp['Location'])
+
+        assert resp.status_code == 302
+        assert redirect.scheme == 'https'
+        assert redirect.netloc == 'github.com'
+        assert redirect.path == '/login/oauth/authorize'
+
+        params = parse_qs(redirect.query)
+
+        assert params['state']
+        assert params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
+        assert params['response_type'] == ['code']
+        assert params['client_id'] == ['github-client-id']
+
+        # Compact list values into singular values, since there's only ever one.
+        authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
         resp = self.client.get('{}?{}'.format(
             self.setup_path,
@@ -91,15 +146,16 @@ class GitHubIntegrationTest(IntegrationTestCase):
             })
         ))
 
-        mock_access_token_request = responses.calls[0].request
-        req_params = parse_qs(mock_access_token_request.body)
+        oauth_exchange = responses.calls[0]
+        req_params = parse_qs(oauth_exchange.request.body)
+
         assert req_params['grant_type'] == ['authorization_code']
         assert req_params['code'] == ['oauth-code']
         assert req_params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
         assert req_params['client_id'] == ['github-client-id']
         assert req_params['client_secret'] == ['github-client-secret']
 
-        assert resp.status_code == 200
+        assert oauth_exchange.response.status_code == 200
 
         auth_header = responses.calls[2].request.headers['Authorization']
         assert auth_header == 'Bearer jwt_token_1'
@@ -108,16 +164,49 @@ class GitHubIntegrationTest(IntegrationTestCase):
         return resp
 
     @responses.activate
+    def test_plugin_migration(self):
+        accessible_repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name='Test-Organization/foo',
+            url='https://github.com/Test-Organization/foo',
+            provider='github',
+            external_id=123,
+        )
+
+        inaccessible_repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name='Not-My-Org/other',
+            provider='github',
+            external_id=321,
+        )
+
+        self.assert_setup_flow()
+
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        # Updates the existing Repository to belong to the new Integration
+        assert Repository.objects.get(
+            id=accessible_repo.id,
+        ).integration_id == integration.id
+
+        # Doesn't touch Repositories not accessible by the new Integration
+        assert Repository.objects.get(
+            id=inaccessible_repo.id,
+        ).integration_id is None
+
+    @responses.activate
     def test_basic_flow(self):
         self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
 
-        assert integration.external_id == 'install_id_1'
+        assert integration.external_id == self.installation_id
         assert integration.name == 'Test Organization'
         assert integration.metadata == {
-            'access_token': None,
-            'expires_at': None,
+            'access_token': self.access_token,
+            # The metadata doesn't get saved with the timezone "Z" character
+            # for some reason, so just compare everything but that.
+            'expires_at': self.expires_at[:-1],
             'icon': 'http://example.com/avatar.png',
             'domain_name': 'github.com/Test-Organization',
             'account_type': 'Organization',
@@ -132,11 +221,11 @@ class GitHubIntegrationTest(IntegrationTestCase):
         identity = Identity.objects.get(
             idp=idp,
             user=self.user,
-            external_id='user_id_1',
+            external_id=self.user_id,
         )
         assert identity.status == IdentityStatus.VALID
         assert identity.data == {
-            'access_token': 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
+            'access_token': self.access_token,
         }
 
     @responses.activate
@@ -161,16 +250,14 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert 'The provided Github account is linked to a different user' in resp.content
 
     @responses.activate
-    @patch('sentry.integrations.github.integration.get_jwt', return_value='jwt_token_1')
-    def test_reinstall_flow(self, get_jwt, installation_id='install_id_2',
-                            app_id='app_1', user_id='user_id_1'):
+    def test_reinstall_flow(self):
+        self._stub_github()
         self.assert_setup_flow()
-        responses.reset()
 
         integration = Integration.objects.get(provider=self.provider.key)
         integration.update(status=ObjectStatus.DISABLED)
         assert integration.status == ObjectStatus.DISABLED
-        assert integration.external_id == 'install_id_1'
+        assert integration.external_id == self.installation_id
 
         resp = self.client.get('{}?{}'.format(
             self.init_path,
@@ -183,59 +270,32 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert redirect.netloc == 'github.com'
         assert redirect.path == '/apps/sentry-test-app'
 
+        # New Installation
+        self.installation_id = 'install_2'
+
         resp = self.client.get('{}?{}'.format(
             self.setup_path,
-            urlencode({'installation_id': installation_id})
+            urlencode({'installation_id': self.installation_id})
         ))
 
-        assert resp.status_code == 302
         redirect = urlparse(resp['Location'])
+
+        assert resp.status_code == 302
         assert redirect.scheme == 'https'
         assert redirect.netloc == 'github.com'
         assert redirect.path == '/login/oauth/authorize'
 
         params = parse_qs(redirect.query)
+
         assert params['state']
         assert params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
         assert params['response_type'] == ['code']
         assert params['client_id'] == ['github-client-id']
-        # once we've asserted on it, switch to a singular values to make life
-        # easier
+
+        # Compact list values to make the rest of this easier
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
-        access_token = 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
-
-        responses.add(
-            responses.POST, 'https://github.com/login/oauth/access_token',
-            json={'access_token': access_token}
-        )
-
-        responses.add(
-            responses.GET, 'https://api.github.com/user',
-            json={'id': user_id}
-        )
-
-        responses.add(
-            responses.GET,
-            u'https://api.github.com/app/installations/{}'.format(installation_id),
-            json={
-                'id': installation_id,
-                'app_id': app_id,
-                'account': {
-                    'login': 'Test Organization',
-                    'avatar_url': 'http://example.com/avatar.png',
-                    'html_url': 'https://github.com/Test-Organization',
-                    'type': 'Organization',
-                },
-            }
-        )
-
-        responses.add(
-            responses.GET, u'https://api.github.com/user/installations',
-            json={
-                'installations': [{'id': installation_id}],
-            }
-        )
+        self._stub_github()
 
         resp = self.client.get('{}?{}'.format(
             self.setup_path,
@@ -260,4 +320,4 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         integration = Integration.objects.get(provider=self.provider.key)
         assert integration.status == ObjectStatus.VISIBLE
-        assert integration.external_id == 'install_id_2'
+        assert integration.external_id == self.installation_id

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -25,7 +25,8 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
     }
 
     @patch('sentry.integrations.github_enterprise.integration.get_jwt', return_value='jwt_token_1')
-    def assert_setup_flow(self, get_jwt, installation_id='install_id_1',
+    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    def assert_setup_flow(self, get_jwt, _, installation_id='install_id_1',
                           app_id='app_1', user_id='user_id_1'):
         responses.reset()
         resp = self.client.get(self.init_path)
@@ -63,6 +64,16 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         responses.add(
             responses.POST, 'https://35.232.149.196/login/oauth/access_token',
             json={'access_token': access_token}
+        )
+
+        responses.add(
+            responses.POST, 'https://35.232.149.196/api/v3/installations/{}/access_tokens'.format(
+                installation_id,
+            ),
+            json={
+                'token': access_token,
+                'expires_at': '3000-01-01 00:00:00Z',
+            },
         )
 
         responses.add(


### PR DESCRIPTION
### IntegrationProvider Subclasses
Each `IntegrationProvider` subclass now has an optional `post_install` step that gets invoked via `_finish_pipeline`.

It's passed the resulting `Integration` and `Organization`. For this PR, it migrates any existing GitHub repositories the new `Integration` has access to.

### GitHubIntegrationProvider#post_install
We request all Repositories via the GitHub API and match the ones, by `name`, and update the `Repository` record of ours to be associated with the `Integration`.

Note: `name`, in this case, is the full repo name (eg. `getsentry/sentry`). It's unique across GitHub, so should be fine to match on.