### PR TITLE
fix(requirements): Peg redis-py-cluster to 1.3.4

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -50,7 +50,7 @@ qrcode>=5.2.2,<6.0.0
 querystring_parser>=1.2.3,<2.0.0
 raven>=6.0.0,<=6.4.0
 rb>=1.7.0,<2.0.0
-redis-py-cluster>=1.3.4,<1.4.0
+redis-py-cluster==1.3.4
 redis>=2.10.3,<2.10.6
 requests[security]>=2.18.4,<2.19.0
 selenium==3.11.0


### PR DESCRIPTION
The latest release 1.3.5 requires redis 2.10.6 which conflicts with the specified version.