### PR TITLE
fix(ui): Better modal close button alignment

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2652,6 +2652,7 @@ ul.radio-inputs {
     background: none;
     border: 0;
     padding: 0;
+    margin: 0;
     font-size: 24px;
     position: absolute;
     top: 50%;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2654,8 +2654,9 @@ ul.radio-inputs {
     padding: 0;
     font-size: 24px;
     position: absolute;
-    top: 14px;
-    right: 15px;
+    top: 50%;
+    transform: translateY(-50%);
+    right: 24px;
     z-index: 100;
     color: lighten(@gray, 20);
     .transition(color 0.1s linear);
@@ -2678,6 +2679,7 @@ ul.radio-inputs {
     border-radius: 7px 7px 0 0;
     padding: 20px 30px;
     margin: -30px -30px 20px;
+    position: relative;
 
     h1,
     h2,

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2692,10 +2692,6 @@ ul.radio-inputs {
       margin-bottom: 0;
       line-height: 1.1;
     }
-
-    .close {
-      margin-top: 1px;
-    }
   }
 
   .modal-body {
@@ -2756,11 +2752,6 @@ ul.radio-inputs {
 .sudo-modal.modal {
   .modal-header {
     padding: 12px 30px;
-
-    .close {
-      margin-top: 0;
-      top: 12px;
-    }
   }
 
   .form-actions {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/43170264-359ef8ba-8f59-11e8-8840-3ae2ee56897b.png)

vs the old

![image](https://user-images.githubusercontent.com/1421724/43170296-48d3e292-8f59-11e8-86e0-57a63aae4186.png)
