### PR TITLE
fix(discover): Chart component gets the last run query

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -37,6 +37,7 @@ export default class OrganizationDiscover extends React.Component {
     this.state = {
       result: null,
       chartData: null,
+      chartQuery: null,
     };
   }
 
@@ -92,10 +93,10 @@ export default class OrganizationDiscover extends React.Component {
 
       queryBuilder.fetch(chartQuery).then(
         chartData => {
-          this.setState({chartData});
+          this.setState({chartData, chartQuery});
         },
         () => {
-          this.setState({chartData: null});
+          this.setState({chartData: null, chartQuery: null});
         }
       );
     }
@@ -163,7 +164,7 @@ export default class OrganizationDiscover extends React.Component {
     });
   };
   render() {
-    const {result, chartData} = this.state;
+    const {result, chartData, chartQuery} = this.state;
     const {queryBuilder} = this.props;
 
     const query = queryBuilder.getInternal();
@@ -259,7 +260,7 @@ export default class OrganizationDiscover extends React.Component {
             </Flex>
           </Box>
           <Box w={[2 / 3, 2 / 3, 2 / 3, 3 / 4]} pl={2}>
-            {chartData && <ResultChart data={chartData} />}
+            {chartData && <ResultChart data={chartData} query={chartQuery} />}
             {result && <ResultTable result={result} />}
           </Box>
         </Flex>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/chart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/chart.jsx
@@ -4,10 +4,15 @@ import PropTypes from 'prop-types';
 export default class Result extends React.Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
+    query: PropTypes.object.isRequired,
   };
 
   render() {
+    const {aggregations, fields} = this.props.query;
     // TODO: implement charts
-    return `data for charts: ${JSON.stringify(this.props.data)}`;
+    return (
+      `data for charts: ${JSON.stringify(this.props.data)} ` +
+      `chart query: ${fields} ${aggregations}`
+    );
   }
 }


### PR DESCRIPTION
Chart component needs the last run query that corresponds to data, not
the current querybuilder state