### PR TITLE
feat(minidump): Support gzipped crashpad requests

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -211,6 +211,7 @@ TEMPLATE_LOADERS = (
 
 MIDDLEWARE_CLASSES = (
     'sentry.middleware.proxy.ChunkedMiddleware',
+    'sentry.middleware.proxy.DecompressBodyMiddleware',
     'sentry.middleware.proxy.ContentLengthHeaderMiddleware',
     'sentry.middleware.security.SecurityHeadersMiddleware',
     'sentry.middleware.maintenance.ServicesUnavailableMiddleware',

--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -96,6 +96,7 @@ class DecompressBodyMiddleware(object):
                 uncompressed = decompress(data, encoding)
                 request._stream = six.StringIO(uncompressed)
                 request.META['CONTENT_LENGTH'] = len(uncompressed)
+                request.META['HTTP_CONTENT_ENCODING'] = 'identity'
             except zlib.error:
                 logger.debug('Failed to decompress body payload', exc_info=True)
                 request._stream = six.StringIO(data)

--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -14,6 +14,7 @@ except ImportError:
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
+Z_CHUNK = 1024 * 8
 
 
 if has_uwsgi:
@@ -34,6 +35,74 @@ if has_uwsgi:
                 self._internal_buffer = self._internal_buffer[n:]
 
             return n
+
+
+class ZDecoder(io.RawIOBase):
+    """
+    Base class for HTTP content decoders based on zlib
+    See: https://github.com/eBay/wextracto/blob/9c789b1c98d95a1e87dbedfd1541a8688d128f5c/wex/http_decoder.py
+    """
+
+    def __init__(self, fp, z=None):
+        self.fp = fp
+        self.z = z
+        self.flushed = None
+
+    def readable(self):
+        return True
+
+    def readinto(self, buf):
+        if self.z is None:
+            self.z = zlib.decompressobj()
+            retry = True
+        else:
+            retry = False
+
+        n = 0
+        max_length = len(buf)
+
+        while max_length > 0:
+            if self.flushed is None:
+                chunk = self.fp.read(Z_CHUNK)
+                compressed = (self.z.unconsumed_tail + chunk)
+                try:
+                    decompressed = self.z.decompress(compressed, max_length)
+                except zlib.error:
+                    if not retry:
+                        raise
+                    self.z = zlib.decompressobj(-zlib.MAX_WBITS)
+                    retry = False
+                    decompressed = self.z.decompress(compressed, max_length)
+
+                if not chunk:
+                    self.flushed = self.z.flush()
+            else:
+                if not self.flushed:
+                    return n
+
+                decompressed = self.flushed[:max_length]
+                self.flushed = self.flushed[max_length:]
+
+            buf[n:n + len(decompressed)] = decompressed
+            n += len(decompressed)
+            max_length = len(buf) - n
+
+        return n
+
+
+class DeflateDecoder(ZDecoder):
+    """
+    Decoding for "content-encoding: deflate"
+    """
+
+
+class GzipDecoder(ZDecoder):
+    """
+    Decoding for "content-encoding: gzip"
+    """
+
+    def __init__(self, fp):
+        ZDecoder.__init__(self, fp, zlib.decompressobj(16 + zlib.MAX_WBITS))
 
 
 class SetRemoteAddrFromForwardedFor(object):
@@ -77,29 +146,22 @@ class ChunkedMiddleware(object):
             request.META['CONTENT_LENGTH'] = '4294967295'  # 0xffffffff
 
 
-COMPRESSED_ENCODINGS = ('gzip', 'deflate')
-
-
-def decompress(data, encoding):
-    if encoding == 'gzip':
-        return zlib.decompress(data, zlib.MAX_WBITS | 16)
-    if encoding == 'deflate':
-        return zlib.decompress(data, -zlib.MAX_WBITS)
-
-
 class DecompressBodyMiddleware(object):
     def process_request(self, request):
+        decode = False
         encoding = request.META.get('HTTP_CONTENT_ENCODING', '').lower()
-        if encoding in COMPRESSED_ENCODINGS:
-            data = request._stream.read()
-            try:
-                uncompressed = decompress(data, encoding)
-                request._stream = six.StringIO(uncompressed)
-                request.META['CONTENT_LENGTH'] = len(uncompressed)
-                request.META['HTTP_CONTENT_ENCODING'] = 'identity'
-            except zlib.error:
-                logger.debug('Failed to decompress body payload', exc_info=True)
-                request._stream = six.StringIO(data)
+
+        if encoding == 'gzip':
+            request._stream = GzipDecoder(request._stream)
+            decode = True
+
+        if encoding == 'deflate':
+            request._stream = DeflateDecoder(request._stream)
+            decode = True
+
+        if decode:
+            request.META['CONTENT_LENGTH'] = '4294967295'  # 0xffffffff
+            del request.META['HTTP_CONTENT_ENCODING']
 
 
 class ContentLengthHeaderMiddleware(object):

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -584,14 +584,6 @@ class MinidumpView(StoreView):
         except KeyError:
             raise APIError('Missing minidump upload')
 
-        if settings.SENTRY_MINIDUMP_CACHE:
-            if not os.path.exists(settings.SENTRY_MINIDUMP_PATH):
-                os.mkdir(settings.SENTRY_MINIDUMP_PATH, 0o744)
-
-            with open('%s/%s.dmp' % (settings.SENTRY_MINIDUMP_PATH, event_id), 'wb') as out:
-                for chunk in minidump.chunks():
-                    out.write(chunk)
-
         # Breakpad on linux sometimes stores the entire HTTP request body as
         # dump file instead of just the minidump. The Electron SDK then for
         # example uploads a multipart formdata body inside the minidump file.
@@ -623,6 +615,14 @@ class MinidumpView(StoreView):
                 minidump = files['upload_file_minidump']
             except KeyError:
                 raise APIError('Missing minidump upload')
+
+        if settings.SENTRY_MINIDUMP_CACHE:
+            if not os.path.exists(settings.SENTRY_MINIDUMP_PATH):
+                os.mkdir(settings.SENTRY_MINIDUMP_PATH, 0o744)
+
+            with open('%s/%s.dmp' % (settings.SENTRY_MINIDUMP_PATH, event_id), 'wb') as out:
+                for chunk in minidump.chunks():
+                    out.write(chunk)
 
         try:
             merge_minidump_event(data, minidump)


### PR DESCRIPTION
This adds a middleware that decompresses request payloads with a `Content-Encoding` of either `gzip` or `deflate`. We could theoretically also add brotli, in future.

Fixes SDK-296