### PR TITLE
fix(ui): UI shifting with backdrop filter

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2631,7 +2631,7 @@ ul.radio-inputs {
 * ============================================================================
 */
 
-.modal-open .app {
+.modal-open .app > * {
   -webkit-filter: ~'blur(3px) grayscale(25%)';
 }
 


### PR DESCRIPTION
Fixes #8719

This fixes the issue where the page content shifts when modals are shown. 

The only obvious downside to this approach is that a slight amount of background colour bleeds in at the top and bottom of the left navigation. This is how it already looks on Safari Mac so not a great loss 🤷‍♂️ .

![image](https://user-images.githubusercontent.com/1150298/43270947-958ac45e-90f6-11e8-8ee5-3fd489450df9.png)
