### PR TITLE
feat: Add an experiment manager

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -143,7 +143,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         if features.has('organizations:event-attachments', obj, actor=user):
             feature_list.append('event-attachments')
 
-        experiment_assignments = experiments.all(org=obj, actor=user)
+        experiment_assignments = experiments.all(org=obj)
 
         context = super(DetailedOrganizationSerializer, self).serialize(obj, attrs, user)
         max_rate = quotas.get_maximum_quota(obj)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -69,7 +69,7 @@ class OnboardingTasksSerializer(Serializer):
 
 class DetailedOrganizationSerializer(OrganizationSerializer):
     def serialize(self, obj, attrs, user):
-        from sentry import features
+        from sentry import features, experiments
         from sentry.app import env
         from sentry.api.serializers.models.project import ProjectSummarySerializer
         from sentry.api.serializers.models.team import TeamSerializer
@@ -143,16 +143,11 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         if features.has('organizations:event-attachments', obj, actor=user):
             feature_list.append('event-attachments')
 
-        # this is slightly gross but necessary until we have the get on the endpoint
-        # to give the frontend a way to know when to log exposures
-        sso_experiment = features.has('organizations:sso-paywall-experiment', obj, actor=user)
-        if sso_experiment:
-            feature_list.append('sso-paywall-experiment-treatment')
-        elif sso_experiment is False:
-            feature_list.append('sso-paywall-experiment-control')
+        experiment_assignments = experiments.all(org=obj, actor=user)
 
         context = super(DetailedOrganizationSerializer, self).serialize(obj, attrs, user)
         max_rate = quotas.get_maximum_quota(obj)
+        context['experiments'] = experiment_assignments
         context['quota'] = {
             'maxRate': max_rate[0],
             'maxRateInterval': max_rate[1],

--- a/src/sentry/experiments/__init__.py
+++ b/src/sentry/experiments/__init__.py
@@ -3,3 +3,5 @@ from __future__ import absolute_import
 from .manager import ExperimentManager
 
 manager = ExperimentManager()
+
+all = manager.all

--- a/src/sentry/experiments/__init__.py
+++ b/src/sentry/experiments/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from .manager import ExperimentManager
+
+manager = ExperimentManager()

--- a/src/sentry/experiments/manager.py
+++ b/src/sentry/experiments/manager.py
@@ -18,12 +18,12 @@ class ExperimentManager(object):
         self._experiments[experiment.__name__] = {
             'experiment': experiment, 'param': param}
 
-    def all(self, org, actor):
-        """Returns an object with all the experiment assignments for the org, given this particular actor."""
+    def all(self, org):
+        """Returns an object with all the experiment assignments for the org."""
         assignments = {}
         for k, v in six.iteritems(self._experiments):
             cls = v['experiment']
             assignments[k] = cls(
-                org=org, actor=actor).get_variant(
+                org=org).get_variant(
                 v['param'], log_exposure=False)
         return assignments

--- a/src/sentry/experiments/manager.py
+++ b/src/sentry/experiments/manager.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+import six
+
+
+class ExperimentManager(object):
+    def __init__(self):
+        self._experiments = {}
+
+    def add(self, experiments):
+        for experiment in experiments:
+            self._experiments[experiment.__name__] = experiment
+
+    def all(self, org, actor):
+        assignments = {}
+        for k, v in six.iteritems(self._experiments):
+            assignments[k] = v(org=org, actor=actor).get_variant('exposed', log_exposure=False)
+            return assignments

--- a/src/sentry/experiments/manager.py
+++ b/src/sentry/experiments/manager.py
@@ -6,12 +6,15 @@ class ExperimentManager(object):
     def __init__(self):
         self._experiments = {}
 
-    def add(self, experiments):
-        for experiment in experiments:
-            self._experiments[experiment.__name__] = experiment
+    def add(self, experiment, param, log_exposure=True):
+        self._experiments[experiment.__name__] = {
+            'experiment': experiment, 'param': param, 'log_exposure': log_exposure}
 
     def all(self, org, actor):
         assignments = {}
         for k, v in six.iteritems(self._experiments):
-            assignments[k] = v(org=org, actor=actor).get_variant('exposed', log_exposure=False)
+            cls = v['experiment']
+            assignments[k] = cls(
+                org=org, actor=actor).get_variant(
+                v['param'], log_exposure=v['log_exposure'])
             return assignments

--- a/src/sentry/experiments/manager.py
+++ b/src/sentry/experiments/manager.py
@@ -3,18 +3,27 @@ import six
 
 
 class ExperimentManager(object):
+    """
+    Allows loading of experiment assignments (done in getsentry) on the frontend by
+    including them in the serialized org details via the org serializer which is in sentry.
+    """
+
     def __init__(self):
         self._experiments = {}
 
-    def add(self, experiment, param, log_exposure=True):
+    def add(self, experiment, param):
+        """
+        >>> ExperimentManager.add(ExperimentClass, param='name_of_param')
+        """
         self._experiments[experiment.__name__] = {
-            'experiment': experiment, 'param': param, 'log_exposure': log_exposure}
+            'experiment': experiment, 'param': param}
 
     def all(self, org, actor):
+        """Returns an object with all the experiment assignments for the org, given this particular actor."""
         assignments = {}
         for k, v in six.iteritems(self._experiments):
             cls = v['experiment']
             assignments[k] = cls(
                 org=org, actor=actor).get_variant(
-                v['param'], log_exposure=v['log_exposure'])
-            return assignments
+                v['param'], log_exposure=False)
+        return assignments


### PR DESCRIPTION
This is meant to make it easier to pull experiment assignments from `getsentry` that then get loaded elsewhere e.g. into org context.