### PR TITLE
chore: Bump react-autosize-textarea to 4.00

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "raven-js": "^3.26.3",
     "react": "16.3.2",
     "react-addons-css-transition-group": "15.6.2",
-    "react-autosize-textarea": "3.0.2",
+    "react-autosize-textarea": "^4.0.0",
     "react-bootstrap": "^0.32.0",
     "react-document-title": "2.0.3",
     "react-dom": "16.3.2",

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -958,6 +958,7 @@ url:http://example.com/settings/* #product"
       value="new"
     >
       <TextareaAutosize
+        async={false}
         autoCapitalize="off"
         autoComplete="off"
         autoCorrect="off"
@@ -971,6 +972,7 @@ url:http://example.com/settings/* #product"
         value="new"
       >
         <textarea
+          async={false}
           autoCapitalize="off"
           autoComplete="off"
           autoCorrect="off"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8064,9 +8064,9 @@ react-addons-css-transition-group@15.6.2:
   dependencies:
     react-transition-group "^1.2.0"
 
-react-autosize-textarea@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-3.0.2.tgz#2b6840a69f7138719abcea5a429ecf7301768c07"
+react-autosize-textarea@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-4.0.0.tgz#893d43606b1efe820c71476f25d141c6b25deaab"
   dependencies:
     autosize "^4.0.0"
     line-height "^0.3.1"


### PR DESCRIPTION
Not necessarily needed, but we were passing async={true}, which was the default behavior in our version of autosize text, but wasn't actually configurable until 4.0.0

I also gave the version a caret.