### PR TITLE
fix(discover): Make sure chart is cleared on non chart query

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -99,6 +99,8 @@ export default class OrganizationDiscover extends React.Component {
           this.setState({chartData: null, chartQuery: null});
         }
       );
+    } else {
+      this.setState({chartData: null, chartQuery: null});
     }
   };
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/chart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/chart.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default class Result extends React.Component {
+export default class ResultChart extends React.Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
     query: PropTypes.object.isRequired,

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
@@ -12,7 +12,7 @@ import {getDisplayValue} from './utils';
  * Renders results in a table as well as a query summary (timing, rows returned)
  * from any Snuba result
  */
-export default class Result extends React.Component {
+export default class ResultTable extends React.Component {
   static propTypes = {
     result: PropTypes.object.isRequired,
   };


### PR DESCRIPTION
Make sure previous chart is not still being rendered if a query without a
chart gets  executed.