### PR TITLE
fix(forms): Correct ref and prop passing for textareas

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.jsx
@@ -2,59 +2,29 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
 import styled from 'react-emotion';
+import isPropValid from '@emotion/is-prop-valid';
 
 import {inputStyles} from 'app/styles/input';
 
-class TextareaOrAutosize extends React.Component {
-  static propTypes = {
-    /**
-     * Enable autosizing of the textarea.
-     */
-    autosize: PropTypes.bool,
+const TextAreaControl = React.forwardRef(
+  ({autosize, ...p}, ref) =>
+    autosize ? (
+      <TextareaAutosize async innerRef={ref} rows={p.rows ? p.rows : 2} {...p} />
+    ) : (
+      <textarea ref={ref} {...p} />
+    )
+);
 
-    /**
-     * Number of rows to start with if autosize
-     */
-    rows: PropTypes.number,
+TextAreaControl.propTypes = {
+  /**
+   * Enable autosizing of the textarea.
+   */
+  autosize: PropTypes.bool,
+};
 
-    innerRef: PropTypes.func,
-  };
+const propFilter = p => ['autosize', 'rows', 'maxRows'].includes(p) || isPropValid(p);
 
-  render() {
-    let {
-      autosize,
-      rows,
-      innerRef,
-      highlighted, // eslint-disable-line
-      stacked, // eslint-disable-line
-      inline, // eslint-disable-line
-      field, // eslint-disable-line
-      multiline, // eslint-disable-line
-      getValue, // eslint-disable-line
-      setValue, // eslint-disable-line
-      error, // eslint-disable-line
-      initialData, // eslint-disable-line
-      getData, // eslint-disable-line
-      extraHelp, // eslint-disable-line
-      ...props
-    } = this.props;
-
-    if (autosize) {
-      return (
-        <TextareaAutosize
-          rows={rows ? rows : 2}
-          async={true}
-          innerRef={innerRef}
-          {...props}
-        />
-      );
-    }
-
-    return <textarea {...props} ref={innerRef} />;
-  }
-}
-
-const TextArea = styled(TextareaOrAutosize)`
+const TextArea = styled(TextAreaControl, {shouldForwardProp: propFilter})`
   ${inputStyles};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.jsx
@@ -7,9 +7,9 @@ import isPropValid from '@emotion/is-prop-valid';
 import {inputStyles} from 'app/styles/input';
 
 const TextAreaControl = React.forwardRef(
-  ({autosize, ...p}, ref) =>
+  ({autosize, rows, ...p}, ref) =>
     autosize ? (
-      <TextareaAutosize async innerRef={ref} rows={p.rows ? p.rows : 2} {...p} />
+      <TextareaAutosize async innerRef={ref} rows={rows ? rows : 2} {...p} />
     ) : (
       <textarea ref={ref} {...p} />
     )


### PR DESCRIPTION
This is going to fail tests. We need this: https://github.com/airbnb/enzyme/issues/1604.

https://github.com/airbnb/enzyme/issues/1604#issuecomment-398125609 unfortunately does not fix our issue (even though it says it does, https://github.com/airbnb/enzyme/pull/1513#issuecomment-403101948 it is backed up that it does not here)
