### PR TITLE
build(brew): Add required lib geoip to brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,7 @@ brew 'python@2'
 brew 'pkgconfig'
 brew 'libxmlsec1'
 brew 'openssl'
+brew 'geoip'
 brew 'redis@3.2', restart_service: true
 brew 'postgresql@9.6', restart_service: true, link: true
 


### PR DESCRIPTION
I don't know when this was added, but without I cannot build Sentry anymore.