### PR TITLE
feat: Allow coupling superuser to an organizations SSO config

### DIFF
--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -21,6 +21,8 @@ from django.core.signing import BadSignature
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 
+from sentry.utils.auth import has_completed_sso
+
 logger = logging.getLogger('sentry.superuser')
 
 SESSION_KEY = '_su'
@@ -45,6 +47,8 @@ IDLE_MAX_AGE = getattr(settings, 'SUPERUSER_IDLE_MAX_AGE', timedelta(minutes=30)
 
 ALLOWED_IPS = frozenset(getattr(settings, 'SUPERUSER_ALLOWED_IPS', settings.INTERNAL_IPS) or ())
 
+ORG_ID = getattr(settings, 'SUPERUSER_ORG_ID', None)
+
 UNSET = object()
 
 
@@ -58,12 +62,16 @@ class Superuser(object):
         ipaddress.ip_network(six.text_type(v), strict=False) for v in ALLOWED_IPS
     ]
 
-    def __init__(self, request, allowed_ips=UNSET, current_datetime=None):
+    org_id = ORG_ID
+
+    def __init__(self, request, allowed_ips=UNSET, org_id=UNSET, current_datetime=None):
         self.request = request
         if allowed_ips is not UNSET:
             self.allowed_ips = frozenset(
                 ipaddress.ip_network(six.text_type(v), strict=False) for v in allowed_ips or ()
             )
+        if org_id is not UNSET:
+            self.org_id = org_id
         self._populate(current_datetime=current_datetime)
 
     @property
@@ -81,6 +89,10 @@ class Superuser(object):
 
     def is_privileged_request(self):
         allowed_ips = self.allowed_ips
+        # if we've bound superuser to an organization they must
+        # have completed SSO to gain status
+        if self.org_id and not has_completed_sso(self.request, self.org_id):
+            return False
         # if there's no IPs configured, we allow assume its the same as *
         if not allowed_ips:
             return True


### PR DESCRIPTION
First pass (quick and dirty) of requiring SSO authentication to activate superuser.