### PR TITLE
feat: Show register values in event details

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ sqlparse>=0.1.16,<0.2.0
 statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
-symbolic>=5.0.0,<6.0.0
+symbolic>=5.1.0,<6.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 # for bitbucket client

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -204,6 +204,7 @@ def merge_minidump_event(data, minidump):
                 'function': '<unknown>',  # Required by interface
                 'package': frame.module.name if frame.module else None,
             } for frame in reversed(list(thread.frames()))],
+            'registers': thread.get_frame(0).registers if thread.frame_count else None,
         },
     } for thread in state.threads()]
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -13,6 +13,7 @@ import {defined, objectIsEmpty, isUrl} from 'app/utils';
 
 import ContextLine from 'app/components/events/interfaces/contextLine';
 import FrameVariables from 'app/components/events/interfaces/frameVariables';
+import FrameRegisters from 'app/components/events/interfaces/frameRegisters';
 
 export function trimPackage(pkg) {
   let pieces = pkg.split(/^[a-z]:\\/i.test(pkg) ? '\\' : '/');
@@ -32,6 +33,7 @@ const Frame = createReactClass({
     emptySourceNotation: PropTypes.bool,
     isOnlyFrame: PropTypes.bool,
     timesRepeated: PropTypes.number,
+    registers: PropTypes.objectOf(PropTypes.string.isRequired),
   },
 
   getDefaultProps() {
@@ -66,11 +68,16 @@ const Frame = createReactClass({
     return !objectIsEmpty(this.props.data.vars);
   },
 
+  hasContextRegisters() {
+    return !objectIsEmpty(this.props.registers);
+  },
+
   isExpandable() {
     return (
       (!this.props.isOnlyFrame && this.props.emptySourceNotation) ||
       this.hasContextSource() ||
-      this.hasContextVars()
+      this.hasContextVars() ||
+      this.hasContextRegisters()
     );
   },
 
@@ -235,13 +242,14 @@ const Frame = createReactClass({
 
     let hasContextSource = this.hasContextSource();
     let hasContextVars = this.hasContextVars();
+    let hasContextRegisters = this.hasContextRegisters();
     let expandable = this.isExpandable();
 
     let contextLines = isExpanded
       ? data.context
       : data.context && data.context.filter(l => l[0] === data.lineNo);
 
-    if (hasContextSource || hasContextVars) {
+    if (hasContextSource || hasContextVars || hasContextRegisters) {
       let startLineNo = hasContextSource ? data.context[0][0] : '';
       context = (
         <ol start={startLineNo} className={outerClassName}>
@@ -257,6 +265,12 @@ const Frame = createReactClass({
                 <ContextLine key={index} line={line} isActive={data.lineNo === line[0]} />
               );
             })}
+
+          {hasContextRegisters && (
+            <ClippedBox clipHeight={100}>
+              <FrameRegisters data={this.props.registers} key="registers" />
+            </ClippedBox>
+          )}
 
           {hasContextVars && (
             <ClippedBox clipHeight={100}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -266,15 +266,12 @@ const Frame = createReactClass({
               );
             })}
 
-          {hasContextRegisters && (
+          {(hasContextRegisters || hasContextVars) && (
             <ClippedBox clipHeight={100}>
-              <FrameRegisters data={this.props.registers} key="registers" />
-            </ClippedBox>
-          )}
-
-          {hasContextVars && (
-            <ClippedBox clipHeight={100}>
-              <FrameVariables data={data.vars} key="vars" />
+              {hasContextRegisters && (
+                <FrameRegisters data={this.props.registers} key="registers" />
+              )}
+              {hasContextVars && <FrameVariables data={data.vars} key="vars" />}
             </ClippedBox>
           )}
         </ol>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
@@ -73,8 +73,8 @@ class FrameRegisters extends React.Component {
     );
 
     return (
-      <div>
-        <RegistersHeading>{t('Register Values')}</RegistersHeading>
+      <div className="registers">
+        <RegistersHeading>{t('registers')}</RegistersHeading>
         <Registers>
           {registers.map(register => (
             <Register key={register[0]} onClick={this.preventToggling}>
@@ -90,24 +90,31 @@ class FrameRegisters extends React.Component {
 
 const Registers = styled(Flex)`
   flex-wrap: wrap;
-  padding: 8px 10px;
+  margin-left: 125px;
+  padding: 2px 0px;
 `;
 
 const Register = styled(Box)`
-  padding: 6px 10px;
+  padding: 4px 5px;
 `;
 
 const RegistersHeading = styled.strong`
-  font-size: 90%;
+  font-weight: 600;
+  font-size: 13px;
+  width: 125px;
+  max-width: 125px;
+  word-wrap: break-word;
+  padding: 10px 15px 10px 0 !important;
+  line-height: 1.4 !important;
+  float: left;
 `;
 
 const RegisterName = styled.span`
   display: inline-block;
   font-size: 13px;
   font-weight: 600;
-  padding-right: 1em;
   text-align: right;
-  width: 5em;
+  width: 4em;
 `;
 
 const InlinePre = styled.pre`

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
@@ -4,9 +4,10 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import Tooltip from 'app/components/tooltip';
+import {t} from 'app/locale';
 import {defined, objectToArray} from 'app/utils';
 
-const REGISTER_VIEWS = ['Hexadecimal', 'Numeric'];
+const REGISTER_VIEWS = [t('Hexadecimal'), t('Numeric')];
 
 export class RegisterValue extends React.Component {
   static propTypes = {
@@ -73,7 +74,7 @@ class FrameRegisters extends React.Component {
 
     return (
       <div>
-        <RegistersHeading>Register Values</RegistersHeading>
+        <RegistersHeading>{t('Register Values')}</RegistersHeading>
         <Registers>
           {registers.map(register => (
             <Register key={register[0]} onClick={this.preventToggling}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
@@ -4,11 +4,11 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import Tooltip from 'app/components/tooltip';
-import {objectToArray} from 'app/utils';
+import {defined, objectToArray} from 'app/utils';
 
-const REGISTER_VIEWS = ['Hexadecimal', 'Big Endian', 'Little Endian'];
+const REGISTER_VIEWS = ['Hexadecimal', 'Numeric'];
 
-class RegisterValue extends React.Component {
+export class RegisterValue extends React.Component {
   static propTypes = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   };
@@ -28,23 +28,15 @@ class RegisterValue extends React.Component {
 
   formatValue = value => {
     try {
+      let parsed = typeof value === 'string' ? parseInt(value, 16) : value;
+      if (isNaN(parsed)) return value;
+
       switch (this.state.view) {
-        case 0:
-          return value;
         case 1:
-          return parseInt(value, 16);
-        case 2:
-          return parseInt(
-            '0x' +
-              value
-                .slice(2)
-                .match(/../g)
-                .reverse()
-                .join(''),
-            16
-          );
+          return String(parsed);
+        case 0:
         default:
-          return value;
+          return '0x' + ('0000000000000000' + parsed.toString(16)).substr(-16);
       }
     } catch (e) {
       return value;
@@ -75,7 +67,9 @@ class FrameRegisters extends React.Component {
   };
 
   render() {
-    let registers = objectToArray(this.props.data);
+    let registers = objectToArray(this.props.data).filter(register =>
+      defined(register[1])
+    );
 
     return (
       <div>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
@@ -1,0 +1,137 @@
+import {Flex, Box} from 'grid-emotion';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import Tooltip from 'app/components/tooltip';
+import {objectToArray} from 'app/utils';
+
+const REGISTER_VIEWS = [
+  'Hexadecimal',
+  'Big Endian',
+  'Little Endian'
+]
+
+class RegisterValue extends React.Component {
+  static propTypes = {
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]).isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      view: 0,
+    };
+  }
+
+  toggleView = () => {
+    this.setState({
+      view: (this.state.view + 1) % REGISTER_VIEWS.length,
+    });
+  };
+
+  formatValue = (value) => {
+    try {
+      switch (this.state.view) {
+        case 0:
+          return value;
+        case 1:
+          return parseInt(value);
+        case 2:
+          return parseInt('0x' + value.slice(2).match(/../g).reverse().join(''));
+        default:
+          return value;
+      }
+    } catch (e) {
+      return value;
+    }
+  }
+
+  render() {
+    return (
+      <InlinePre>
+        <FixedWidth>{this.formatValue(this.props.value)}</FixedWidth>
+        <Tooltip title={REGISTER_VIEWS[this.state.view]} onClick={this.toggleView}>
+          <Toggle className="icon-filter" />
+        </Tooltip>
+      </InlinePre>
+    )
+  }
+}
+
+class FrameRegisters extends React.Component {
+  static propTypes = {
+    data: PropTypes.object.isRequired,
+  };
+
+  // make sure that clicking on the registers does not actually do
+  // anything on the containing element.
+  preventToggling = evt => {
+    evt.stopPropagation();
+  };
+
+  render() {
+    let registers = objectToArray(this.props.data);
+
+    return (
+      <div>
+        <RegistersHeading>Register Values</RegistersHeading>
+        <Registers>
+          {registers.map(register => (
+            <Register key={register[0]} onClick={this.preventToggling}>
+              <RegisterName>{register[0]}</RegisterName>
+              {' '}
+              <RegisterValue value={register[1]} />
+            </Register>
+          ))}
+        </Registers>
+      </div>
+    );
+  }
+}
+
+const Registers = styled(Flex)`
+  flex-wrap: wrap;
+  padding: 8px 10px;
+`;
+
+const Register = styled(Box)`
+  padding: 6px 10px;
+`;
+
+const RegistersHeading = styled.strong`
+  font-size: 90%;
+`;
+
+const RegisterName = styled.span`
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 600;
+  padding-right: 1em;
+  text-align: right;
+  width: 5em;
+`;
+
+const InlinePre = styled.pre`
+  display: inline;
+`;
+
+const FixedWidth = styled.span`
+  width: 12em;
+  text-align: right;
+`;
+
+const Toggle = styled.span`
+  opacity: 0.33;
+  margin-left: 1ex;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+export default FrameRegisters;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
@@ -6,19 +6,12 @@ import styled from 'react-emotion';
 import Tooltip from 'app/components/tooltip';
 import {objectToArray} from 'app/utils';
 
-const REGISTER_VIEWS = [
-  'Hexadecimal',
-  'Big Endian',
-  'Little Endian'
-]
+const REGISTER_VIEWS = ['Hexadecimal', 'Big Endian', 'Little Endian'];
 
 class RegisterValue extends React.Component {
   static propTypes = {
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]).isRequired,
-  }
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  };
 
   constructor(props) {
     super(props);
@@ -33,22 +26,30 @@ class RegisterValue extends React.Component {
     });
   };
 
-  formatValue = (value) => {
+  formatValue = value => {
     try {
       switch (this.state.view) {
         case 0:
           return value;
         case 1:
-          return parseInt(value);
+          return parseInt(value, 16);
         case 2:
-          return parseInt('0x' + value.slice(2).match(/../g).reverse().join(''));
+          return parseInt(
+            '0x' +
+              value
+                .slice(2)
+                .match(/../g)
+                .reverse()
+                .join(''),
+            16
+          );
         default:
           return value;
       }
     } catch (e) {
       return value;
     }
-  }
+  };
 
   render() {
     return (
@@ -58,7 +59,7 @@ class RegisterValue extends React.Component {
           <Toggle className="icon-filter" />
         </Tooltip>
       </InlinePre>
-    )
+    );
   }
 }
 
@@ -82,8 +83,7 @@ class FrameRegisters extends React.Component {
         <Registers>
           {registers.map(register => (
             <Register key={register[0]} onClick={this.preventToggling}>
-              <RegisterName>{register[0]}</RegisterName>
-              {' '}
+              <RegisterName>{register[0]}</RegisterName>{' '}
               <RegisterValue value={register[1]} />
             </Register>
           ))}

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
@@ -22,9 +22,7 @@ export class RegisterValue extends React.Component {
   }
 
   toggleView = () => {
-    this.setState({
-      view: (this.state.view + 1) % REGISTER_VIEWS.length,
-    });
+    this.setState(state => ({view: (state.view + 1) % REGISTER_VIEWS.length}));
   };
 
   formatValue = value => {
@@ -34,10 +32,10 @@ export class RegisterValue extends React.Component {
 
       switch (this.state.view) {
         case 1:
-          return String(parsed);
+          return `${parsed}`;
         case 0:
         default:
-          return '0x' + ('0000000000000000' + parsed.toString(16)).substr(-16);
+          return `0x${('0000000000000000' + parsed.toString(16)).substr(-16)}`;
       }
     } catch (e) {
       return value;
@@ -73,7 +71,7 @@ class FrameRegisters extends React.Component {
     );
 
     return (
-      <div className="registers">
+      <RegistersWrapper>
         <RegistersHeading>{t('registers')}</RegistersHeading>
         <Registers>
           {registers.map(register => (
@@ -83,10 +81,20 @@ class FrameRegisters extends React.Component {
             </Register>
           ))}
         </Registers>
-      </div>
+      </RegistersWrapper>
     );
   }
 }
+
+const RegistersWrapper = styled.div`
+  border-top: 1px solid @trim;
+  padding-top: 10px;
+
+  .traceback .frame .box-clippable:first-child > & {
+    border-top: none;
+    padding-top: 0;
+  }
+`;
 
 const Registers = styled(Flex)`
   flex-wrap: wrap;
@@ -104,8 +112,8 @@ const RegistersHeading = styled.strong`
   width: 125px;
   max-width: 125px;
   word-wrap: break-word;
-  padding: 10px 15px 10px 0 !important;
-  line-height: 1.4 !important;
+  padding: 10px 15px 10px 0;
+  line-height: 1.4;
   float: left;
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -107,6 +107,14 @@ const StacktraceContent = createReactClass({
         frames.push(this.renderOmittedFrames(firstFrameOmitted, lastFrameOmitted));
       }
     });
+
+    if (frames.length > 0 && data.registers) {
+      let lastFrame = frames.length - 1;
+      frames[lastFrame] = React.cloneElement(frames[lastFrame], {
+        registers: data.registers
+      });
+    }
+
     if (this.props.newestFirst) {
       frames.reverse();
     }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1503,6 +1503,11 @@ div.traceback > ul {
       }
     }
 
+    .registers {
+      padding: 16px 10px;
+      flex-wrap: wrap;
+    }
+
     .box-clippable {
       margin-left: 0;
       margin-right: 0;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1509,6 +1509,19 @@ div.traceback > ul {
       &:first-of-type {
         margin-top: 0;
       }
+      &:first-child {
+        margin-top: -20px;
+      }
+    }
+
+    .registers {
+      border-top: 1px solid @trim;
+      padding-top: 10px;
+    }
+
+    .box-clippable:first-child > .registers {
+      border-top: none;
+      padding-top: 0;
     }
 
     .tag-app {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1503,11 +1503,6 @@ div.traceback > ul {
       }
     }
 
-    .registers {
-      padding: 16px 10px;
-      flex-wrap: wrap;
-    }
-
     .box-clippable {
       margin-left: 0;
       margin-right: 0;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1514,16 +1514,6 @@ div.traceback > ul {
       }
     }
 
-    .registers {
-      border-top: 1px solid @trim;
-      padding-top: 10px;
-    }
-
-    .box-clippable:first-child > .registers {
-      border-top: none;
-      padding-top: 0;
-    }
-
     .tag-app {
       color: #aaa;
       font-size: 0.9em;

--- a/tests/js/spec/components/events/interfaces/__snapshots__/frame.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/frame.spec.jsx.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Frame renderContext() should render context lines 1`] = `
+Array [
+  <ContextLine
+    isActive={false}
+    key="0"
+    line={
+      Array [
+        211,
+        "    # Mark the crashed thread and add its stacktrace to the exception",
+      ]
+    }
+  />,
+  <ContextLine
+    isActive={false}
+    key="1"
+    line={
+      Array [
+        212,
+        "    crashed_thread = data['threads'][state.requesting_thread]",
+      ]
+    }
+  />,
+  <ContextLine
+    isActive={false}
+    key="2"
+    line={
+      Array [
+        213,
+        "    crashed_thread['crashed'] = True",
+      ]
+    }
+  />,
+]
+`;
+
 exports[`Frame renderOriginalSourceInfo() should render the source map information as a HTML string 1`] = `
 "
     <div>

--- a/tests/js/spec/components/events/interfaces/__snapshots__/frameRegisters.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/frameRegisters.spec.jsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FrameRegisters should render registers 1`] = `
+Array [
+  <RegisterValue
+    value="0x00007fff9300bf70"
+  />,
+  <RegisterValue
+    value="0xffffffffffffffff"
+  />,
+  <RegisterValue
+    value="0x0000000000000000"
+  />,
+]
+`;
+
+exports[`FrameRegisters should skip registers without a value 1`] = `
+Array [
+  <RegisterValue
+    value="0x00007fff9300bf70"
+  />,
+  <RegisterValue
+    value="0x0000000000000000"
+  />,
+]
+`;

--- a/tests/js/spec/components/events/interfaces/frame.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame.spec.jsx
@@ -25,4 +25,71 @@ describe('Frame', function() {
       expect(frame.find('Tooltip').prop('title')).toMatchSnapshot();
     });
   });
+
+  describe('renderContext()', () => {
+    it('should render context lines', () => {
+      data = {
+        context: [
+          [211, '    # Mark the crashed thread and add its stacktrace to the exception'],
+          [212, "    crashed_thread = data['threads'][state.requesting_thread]"],
+          [213, "    crashed_thread['crashed'] = True"],
+        ],
+      };
+
+      let frame = shallow(<Frame data={data} isExpanded />);
+      expect(frame.find('ContextLine')).toMatchSnapshot();
+    });
+
+    it('should render register values', () => {
+      data = {};
+      let registers = {
+        r10: '0x00007fff9300bf70',
+        r11: '0xffffffffffffffff',
+        r12: '0x0000000000000000',
+        r13: '0x0000000000000000',
+        r14: '0x000000000000000a',
+        r15: '0x0000000000000000',
+        r8: '0x00007fff9300bf78',
+        r9: '0x0000000000000040',
+        rax: '0x00007fff9291e660',
+        rbp: '0x00007ffedfdff7e0',
+        rbx: '0x00007fff9291e660',
+        rcx: '0x0000000000000008',
+        rdi: '0x00007ffedfdff790',
+        rdx: '0x0000020000000303',
+        rip: '0x000000010fe00a59',
+        rsi: '0x0000000000000300',
+        rsp: '0x00007ffedfdff7c0',
+      };
+
+      let frame = shallow(<Frame data={data} registers={registers} isExpanded />);
+      expect(frame.find('FrameRegisters').prop('data')).toEqual(registers);
+    });
+
+    it('should not render empty registers', () => {
+      data = {};
+      let registers = {};
+
+      let frame = shallow(<Frame data={data} registers={registers} isExpanded />);
+      expect(frame.find('FrameRegisters')).toHaveLength(0);
+    });
+
+    it('should render context vars', () => {
+      data = {
+        vars: {
+          origin: null,
+          helper: '<sentry.coreapi.MinidumpApiHelper object at 0x10e157ed0>',
+          self: '<sentry.web.api.MinidumpView object at 0x10e157250>',
+          args: [],
+          request: '<WSGIRequest at 0x4531253712>',
+          content: '[Filtered]',
+          kwargs: {},
+          project_id: "u'3'",
+        },
+      };
+
+      let frame = shallow(<Frame data={data} isExpanded />);
+      expect(frame.find('FrameVariables').prop('data')).toEqual(data.vars);
+    });
+  });
 });

--- a/tests/js/spec/components/events/interfaces/frameRegisters.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frameRegisters.spec.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+
+import FrameRegisters, {
+  RegisterValue,
+} from 'app/components/events/interfaces/frameRegisters';
+
+describe('FrameRegisters', () => {
+  it('should render registers', () => {
+    let registers = {
+      r10: '0x00007fff9300bf70',
+      r11: '0xffffffffffffffff',
+      r12: '0x0000000000000000',
+    };
+
+    let wrapper = shallow(<FrameRegisters data={registers} />);
+    expect(wrapper.find('RegisterValue')).toMatchSnapshot();
+  });
+
+  it('should skip registers without a value', () => {
+    let registers = {
+      r10: '0x00007fff9300bf70',
+      r11: null,
+      r12: '0x0000000000000000',
+    };
+
+    let wrapper = shallow(<FrameRegisters data={registers} />);
+    expect(wrapper.find('RegisterValue')).toMatchSnapshot();
+  });
+});
+
+describe('RegisterValue', () => {
+  let wrapper;
+  describe('with string value', () => {
+    beforeEach(() => {
+      wrapper = mount(<RegisterValue value="0x000000000000000a" />);
+    });
+
+    it('should display the hexadecimal value', () => {
+      expect(wrapper.text()).toBe('0x000000000000000a');
+    });
+
+    it('should display the numeric value', () => {
+      wrapper.find('Toggle').simulate('click');
+      expect(wrapper.text()).toBe('10');
+    });
+  });
+
+  describe('with numeric value', () => {
+    beforeEach(() => {
+      wrapper = mount(<RegisterValue value={10} />);
+    });
+
+    it('should display the hexadecimal value', () => {
+      expect(wrapper.text()).toBe('0x000000000000000a');
+    });
+
+    it('should display the numeric value', () => {
+      wrapper.find('Toggle').simulate('click');
+      expect(wrapper.text()).toBe('10');
+    });
+  });
+
+  describe('with unknown value', () => {
+    beforeEach(() => {
+      wrapper = mount(<RegisterValue value="xyz" />);
+    });
+
+    it('should display the hexadecimal value', () => {
+      expect(wrapper.text()).toBe('xyz');
+    });
+
+    it('should display the numeric value', () => {
+      wrapper.find('Toggle').simulate('click');
+      expect(wrapper.text()).toBe('xyz');
+    });
+  });
+});

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -285,7 +285,26 @@ def test_minidump_linux():
                         'instruction_addr': '0x401d72',
                         'package': u'/work/linux/build/crash'
                     }
-                ]
+                ],
+                'registers': {
+                    u'r10': u'0x0000000000000131',
+                    u'r11': u'0x00007f5140aca4c0',
+                    u'r12': u'0x0000000000401dc0',
+                    u'r13': u'0x00007fff5ae4ac90',
+                    u'r14': u'0x00007fff5ae4aab0',
+                    u'r15': u'0x0000000000000000',
+                    u'r8': u'0x0000000000000000',
+                    u'r9': u'0x0000000000000000',
+                    u'rax': u'0xffffffffffffffff',
+                    u'rbp': u'0x00007fff5ae4abb0',
+                    u'rbx': u'0x00007fff5ae4aa20',
+                    u'rcx': u'0x00007f5140521b20',
+                    u'rdi': u'0x00007fff5ae4aab0',
+                    u'rdx': u'0x00007f5140efc000',
+                    u'rip': u'0x0000000000401d72',
+                    u'rsi': u'0x0000000000000000',
+                    u'rsp': u'0x00007fff5ae4aa20'
+                }
             },
             'thread_id': 1304,
             'type': u'SIGSEGV',
@@ -367,7 +386,26 @@ def test_minidump_macos():
                         'instruction_addr': '0x109ba8c15',
                         'package': u'/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash'
                     }
-                ]
+                ],
+                'registers': {
+                    u'r10': u'0x000000000000002e',
+                    u'r11': u'0x00007fffe8105171',
+                    u'r12': u'0x0000000000000000',
+                    u'r13': u'0x0000000000000000',
+                    u'r14': u'0x0000000000000000',
+                    u'r15': u'0x0000000000000000',
+                    u'r8': u'0x000000000c0008ff',
+                    u'r9': u'0x0000000000000000',
+                    u'rax': u'0x0000000000000001',
+                    u'rbp': u'0x00007fff56064258',
+                    u'rbx': u'0x00007fff56064120',
+                    u'rcx': u'0x0000000000000000',
+                    u'rdi': u'0x00007fff56064120',
+                    u'rdx': u'0x0000000000000000',
+                    u'rip': u'0x0000000109ba8c15',
+                    u'rsi': u'0x00007fff56064140',
+                    u'rsp': u'0x00007fff56064110'
+                }
             },
             'thread_id': 775,
             'type': u'EXC_BAD_ACCESS / KERN_INVALID_ADDRESS',
@@ -510,7 +548,19 @@ def test_minidump_windows():
                         'instruction_addr': '0x2a2a3d',
                         'package': u'C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe'
                     }
-                ]
+                ],
+                'registers': {
+                    u'eax': u'0x00000000',
+                    u'ebp': u'0x010ff670',
+                    u'ebx': u'0x00fe5000',
+                    u'ecx': u'0x010ff670',
+                    u'edi': u'0x013bfd78',
+                    u'edx': u'0x00000007',
+                    u'eflags': u'0x00010246',
+                    u'eip': u'0x002a2a3d',
+                    u'esi': u'0x759c6314',
+                    u'esp': u'0x010ff644'
+                }
             },
             'thread_id': 1636,
             'type': u'EXCEPTION_ACCESS_VIOLATION_WRITE',
@@ -548,7 +598,19 @@ def test_minidump_windows():
                         'function': '<unknown>',
                         'instruction_addr': '0x771e016c',
                         'package': u'C:\\Windows\\System32\\ntdll.dll'
-                    }]
+                    }],
+                    'registers': {
+                        u'eax': u'0x00000000',
+                        u'ebp': u'0x0159faa4',
+                        u'ebx': u'0x013b0990',
+                        u'ecx': u'0x00000000',
+                        u'edi': u'0x013b4af0',
+                        u'edx': u'0x00000000',
+                        u'eflags': u'0x00000216',
+                        u'eip': u'0x771e016c',
+                        u'esi': u'0x013b4930',
+                        u'esp': u'0x0159f900'
+                    }
                 }
             },
             {
@@ -574,7 +636,19 @@ def test_minidump_windows():
                         'function': '<unknown>',
                         'instruction_addr': '0x771e016c',
                         'package': u'C:\\Windows\\System32\\ntdll.dll'
-                    }]
+                    }],
+                    'registers': {
+                        u'eax': u'0x00000000',
+                        u'ebp': u'0x0169fb98',
+                        u'ebx': u'0x013b0990',
+                        u'ecx': u'0x00000000',
+                        u'edi': u'0x013b7c28',
+                        u'edx': u'0x00000000',
+                        u'eflags': u'0x00000202',
+                        u'eip': u'0x771e016c',
+                        u'esi': u'0x013b7a68',
+                        u'esp': u'0x0169f9f4'
+                    }
                 }
             },
             {
@@ -585,7 +659,19 @@ def test_minidump_windows():
                         'function': '<unknown>',
                         'instruction_addr': '0x771df3dc',
                         'package': u'C:\\Windows\\System32\\ntdll.dll'
-                    }]
+                    }],
+                    'registers': {
+                        u'eax': u'0x00000000',
+                        u'ebp': u'0x0179f2b8',
+                        u'ebx': u'0x017b1aa0',
+                        u'ecx': u'0x00000000',
+                        u'edi': u'0x017b1a90',
+                        u'edx': u'0x00000000',
+                        u'eflags': u'0x00000206',
+                        u'eip': u'0x771df3dc',
+                        u'esi': u'0x000002cc',
+                        u'esp': u'0x0179f2ac'
+                    }
                 }
             }
         ],


### PR DESCRIPTION
Displays register values with the top frame, if available. By default, the values are collapsed and can be extended. Their usual view is binary, but there are LE and BE available by clicking through.

<img width="1191" alt="screen shot 2018-07-30 at 16 28 52" src="https://user-images.githubusercontent.com/1433023/43403810-5facf83e-9416-11e8-9cd8-59e2bff2bc24.png">

**Edit:** Updated screenshot in comments.