### PR TITLE
fix(charts): Set notMerge default to true for all charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -60,7 +60,7 @@ class BaseChart extends React.Component {
     height: null,
     width: null,
     renderer: 'svg',
-    notMerge: false,
+    notMerge: true,
     lazyUpdate: false,
     colors: theme.charts.colors,
     options: {},


### PR DESCRIPTION
Having notMerge as false potentially causes charts to be incorrect, since echarts will try to merge previous options with new ones when props change. If props change and all the new series' received aren't the same as the previous ones, incorrect charts might be rendered with both the old and new data on them.