### PR TITLE
feat(minidump): Optionally add minidumps as event attachments

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -35,6 +35,7 @@ ORG_OPTIONS = (
     ('dataScrubberDefaults', 'sentry:require_scrub_defaults', bool),
     ('sensitiveFields', 'sentry:sensitive_fields', list),
     ('safeFields', 'sentry:safe_fields', list),
+    ('storeCrashReports', 'sentry:store_crash_reports', bool),
     ('scrubIPAddresses', 'sentry:require_scrub_ip_address', bool),
     ('scrapeJavaScript', 'sentry:scrape_javascript', bool),
 )
@@ -84,6 +85,7 @@ class OrganizationSerializer(serializers.Serializer):
     dataScrubberDefaults = serializers.BooleanField(required=False)
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
+    storeCrashReports = serializers.BooleanField(required=False)
     scrubIPAddresses = serializers.BooleanField(required=False)
     scrapeJavaScript = serializers.BooleanField(required=False)
     isEarlyAdopter = serializers.BooleanField(required=False)

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -93,6 +93,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     dataScrubberDefaults = serializers.BooleanField(required=False)
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
+    storeCrashReports = serializers.BooleanField(required=False)
     scrubIPAddresses = serializers.BooleanField(required=False)
     scrapeJavaScript = serializers.BooleanField(required=False)
     allowedDomains = ListField(child=OriginField(), required=False)
@@ -349,6 +350,9 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if result.get('safeFields') is not None:
             if project.update_option('sentry:safe_fields', result['safeFields']):
                 changed_proj_settings['sentry:safe_fields'] = result['safeFields']
+        if result.get('storeCrashReports') is not None:
+            if project.update_option('sentry:store_crash_reports', result['storeCrashReports']):
+                changed_proj_settings['sentry:store_crash_reports'] = result['storeCrashReports']
         if 'defaultEnvironment' in result:
             if result['defaultEnvironment'] is None:
                 project.delete_option('sentry:default_environment')
@@ -401,6 +405,9 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     'sentry:safe_fields',
                     [s.strip().lower() for s in options['sentry:safe_fields']]
                 )
+            if 'sentry:store_crash_reports' in options:
+                project.update_option('sentry:store_crash_reports', bool(
+                    options['sentry:store_crash_reports']))
             if 'sentry:sensitive_fields' in options:
                 project.update_option(
                     'sentry:sensitive_fields',

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -186,6 +186,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             'dataScrubberDefaults': bool(obj.get_option('sentry:require_scrub_defaults', False)),
             'sensitiveFields': obj.get_option('sentry:sensitive_fields', None) or [],
             'safeFields': obj.get_option('sentry:safe_fields', None) or [],
+            'storeCrashReports': bool(obj.get_option('sentry:store_crash_reports', False)),
             'scrubIPAddresses': bool(obj.get_option('sentry:require_scrub_ip_address', False)),
             'scrapeJavaScript': bool(obj.get_option('sentry:scrape_javascript', True)),
         })

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -322,6 +322,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             'sentry:scrub_data',
             'sentry:scrub_defaults',
             'sentry:safe_fields',
+            'sentry:store_crash_reports',
             'sentry:sensitive_fields',
             'sentry:csp_ignored_sources_defaults',
             'sentry:csp_ignored_sources',
@@ -465,6 +466,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 bool(attrs['options'].get('sentry:scrub_defaults', True)),
                 'safeFields':
                 attrs['options'].get('sentry:safe_fields', []),
+                'storeCrashReports': bool(attrs['options'].get('sentry:store_crash_reports', False)),
                 'sensitiveFields':
                 attrs['options'].get('sentry:sensitive_fields', []),
                 'subjectTemplate':

--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+
+__all__ = ['attachment_cache', 'CachedAttachment']
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from .base import AttachmentCache, CachedAttachment
+
+if settings.SENTRY_ATTACHMENTS:
+    cache_cls = settings.SENTRY_ATTACHMENTS
+    options = settings.SENTRY_ATTACHMENTS_OPTIONS
+elif settings.SENTRY_CACHE:
+    cache_cls = settings.SENTRY_CACHE
+    options = settings.SENTRY_CACHE_OPTIONS
+else:
+    raise ImproperlyConfigured('You must configure ``cache.backend``.')
+
+attachment_cache = AttachmentCache(cache_cls, **options)

--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -3,17 +3,10 @@ from __future__ import absolute_import
 __all__ = ['attachment_cache', 'CachedAttachment']
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 
-from .base import AttachmentCache, CachedAttachment
+from sentry.utils.imports import import_string
 
-if settings.SENTRY_ATTACHMENTS:
-    cache_cls = settings.SENTRY_ATTACHMENTS
-    options = settings.SENTRY_ATTACHMENTS_OPTIONS
-elif settings.SENTRY_CACHE:
-    cache_cls = settings.SENTRY_CACHE
-    options = settings.SENTRY_CACHE_OPTIONS
-else:
-    raise ImproperlyConfigured('You must configure ``cache.backend``.')
+from .base import CachedAttachment
 
-attachment_cache = AttachmentCache(cache_cls, **options)
+
+attachment_cache = import_string(settings.SENTRY_ATTACHMENTS)(**settings.SENTRY_ATTACHMENTS_OPTIONS)

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -8,10 +8,6 @@ sentry.attachments.base
 
 from __future__ import absolute_import
 
-from threading import local
-
-from sentry.utils.imports import import_string
-
 
 class CachedAttachment(object):
     def __init__(self, name=None, content_type=None, type=None, data=None, load=None):
@@ -49,11 +45,10 @@ class CachedAttachment(object):
         }
 
 
-class AttachmentCache(local):
-    appendix = 'a'
-
-    def __init__(self, cache_cls, **cache_options):
-        self.inner = import_string(cache_cls)(**cache_options)
+class BaseAttachmentCache(object):
+    def __init__(self, inner, appendix='a', **options):
+        self.appendix = appendix
+        self.inner = inner
 
     def make_key(self, key):
         return '{}:{}'.format(key, self.appendix)

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -1,0 +1,90 @@
+"""
+sentry.attachments.base
+~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from threading import local
+
+from sentry.utils.imports import import_string
+
+
+class CachedAttachment(object):
+    def __init__(self, name=None, content_type=None, type=None, data=None, load=None):
+        if data is None and load is None:
+            raise AttributeError('Missing attachment data')
+
+        self.name = name
+        self.content_type = content_type
+        self.type = type or 'event.attachment'
+
+        self._data = data
+        self._load = load
+
+    @classmethod
+    def from_upload(cls, file, **kwargs):
+        return CachedAttachment(
+            name=file.name,
+            content_type=file.content_type,
+            data=file.read(),
+            **kwargs
+        )
+
+    @property
+    def data(self):
+        if self._data is None and self._load is not None:
+            self._data = self._load()
+
+        return self._data
+
+    def meta(self):
+        return {
+            'name': self.name,
+            'content_type': self.content_type,
+            'type': self.type,
+        }
+
+
+class AttachmentCache(local):
+    appendix = 'a'
+
+    def __init__(self, cache_cls, **cache_options):
+        self.inner = import_string(cache_cls)(**cache_options)
+
+    def make_key(self, key):
+        return '{}:{}'.format(key, self.appendix)
+
+    def set(self, key, attachments, timeout=None):
+        key = self.make_key(key)
+        for index, attachment in enumerate(attachments):
+            self.inner.set('{}:{}'.format(key, index), attachment.data, timeout, raw=True)
+
+        meta = [attachment.meta() for attachment in attachments]
+        self.inner.set(key, meta, timeout, raw=False)
+
+    def get(self, key):
+        key = self.make_key(key)
+        result = self.inner.get(key, raw=False)
+        if result is not None:
+            result = [
+                CachedAttachment(
+                    load=lambda index=index: self.inner.get('{}:{}'.format(key, index), raw=True),
+                    **attachment
+                )
+                for index, attachment in enumerate(result)
+            ]
+        return result
+
+    def delete(self, key):
+        key = self.make_key(key)
+        attachments = self.inner.get(key, raw=False)
+        if attachments is None:
+            return
+
+        for index in range(0, len(attachments)):
+            self.inner.delete('{}:{}'.format(key, index))
+        self.inner.delete(key)

--- a/src/sentry/attachments/default.py
+++ b/src/sentry/attachments/default.py
@@ -1,0 +1,18 @@
+"""
+sentry.attachments.default
+~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from sentry.cache import default_cache
+
+from .base import BaseAttachmentCache
+
+
+class DefaultAttachmentCache(BaseAttachmentCache):
+    def __init__(self, **options):
+        super(DefaultAttachmentCache, self).__init__(default_cache, **options)

--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -8,11 +8,28 @@ sentry.attachments.redis
 
 from __future__ import absolute_import
 
+import logging
+
+from django.conf import settings
+
 from sentry.cache.redis import RedisCache
+from sentry.utils import redis
 
 from .base import BaseAttachmentCache
+
+logger = logging.getLogger(__name__)
 
 
 class RedisAttachmentCache(BaseAttachmentCache):
     def __init__(self, **options):
-        super(RedisAttachmentCache, self).__init__(RedisCache(**options), **options)
+        cluster_id = getattr(
+            settings,
+            'SENTRY_ATTACHMENTS_REDIS_CLUSTER',
+            'rc-short',
+        )
+        try:
+            cache = redis.redis_clusters.get(cluster_id)
+        except KeyError:
+            cache = RedisCache(**options)
+            logger.info('No redis cluster provided for attachments, using {!r}.'.format(cache))
+        super(RedisAttachmentCache, self).__init__(cache, **options)

--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -12,9 +12,7 @@ import logging
 
 from django.conf import settings
 
-from sentry.cache.redis import RedisCache
 from sentry.utils import redis
-
 from .base import BaseAttachmentCache
 
 logger = logging.getLogger(__name__)
@@ -25,11 +23,7 @@ class RedisAttachmentCache(BaseAttachmentCache):
         cluster_id = getattr(
             settings,
             'SENTRY_ATTACHMENTS_REDIS_CLUSTER',
-            'rc-short',
+            'rc-short'
         )
-        try:
-            cache = redis.redis_clusters.get(cluster_id)
-        except KeyError:
-            cache = RedisCache(**options)
-            logger.info('No redis cluster provided for attachments, using {!r}.'.format(cache))
+        cache = redis.redis_clusters.get(cluster_id)
         super(RedisAttachmentCache, self).__init__(cache, **options)

--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -1,0 +1,18 @@
+"""
+sentry.attachments.redis
+~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from sentry.cache.redis import RedisCache
+
+from .base import BaseAttachmentCache
+
+
+class RedisAttachmentCache(BaseAttachmentCache):
+    def __init__(self, **options):
+        super(RedisAttachmentCache, self).__init__(RedisCache(**options), **options)

--- a/src/sentry/cache/base.py
+++ b/src/sentry/cache/base.py
@@ -28,11 +28,11 @@ class BaseCache(local):
             key,
         )
 
-    def set(self, key, value, timeout, version=None):
+    def set(self, key, value, timeout, version=None, raw=False):
         raise NotImplementedError
 
     def delete(self, key, version=None):
         raise NotImplementedError
 
-    def get(self, key, version=None):
+    def get(self, key, version=None, raw=False):
         raise NotImplementedError

--- a/src/sentry/cache/django.py
+++ b/src/sentry/cache/django.py
@@ -14,11 +14,11 @@ from .base import BaseCache
 
 
 class DjangoCache(BaseCache):
-    def set(self, key, value, timeout, version=None):
+    def set(self, key, value, timeout, version=None, raw=False):
         cache.set(key, value, timeout, version=version or self.version)
 
     def delete(self, key, version=None):
         cache.delete(key, version=version or self.version)
 
-    def get(self, key, version=None):
+    def get(self, key, version=None, raw=False):
         return cache.get(key, version=version or self.version)

--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -28,9 +28,9 @@ class RedisCache(BaseCache):
 
         super(RedisCache, self).__init__(**options)
 
-    def set(self, key, value, timeout, version=None):
+    def set(self, key, value, timeout, version=None, raw=False):
         key = self.make_key(key, version=version)
-        v = json.dumps(value)
+        v = json.dumps(value) if not raw else value
         if len(v) > self.max_size:
             raise ValueTooLarge('Cache key too large: %r %r' % (key, len(v)))
         if timeout:
@@ -42,9 +42,9 @@ class RedisCache(BaseCache):
         key = self.make_key(key, version=version)
         self.client.delete(key)
 
-    def get(self, key, version=None):
+    def get(self, key, version=None, raw=False):
         key = self.make_key(key, version=version)
         result = self.client.get(key)
-        if result is not None:
+        if result is not None and not raw:
             result = json.loads(result)
         return result

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -925,7 +925,7 @@ SENTRY_CACHE = None
 SENTRY_CACHE_OPTIONS = {}
 
 # Attachment blob cache backend
-SENTRY_ATTACHMENTS = None
+SENTRY_ATTACHMENTS = 'sentry.attachments.default.DefaultAttachmentCache'
 SENTRY_ATTACHMENTS_OPTIONS = {}
 
 # The internal Django cache is still used in many places

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -924,6 +924,10 @@ SENTRY_BUFFER_OPTIONS = {}
 SENTRY_CACHE = None
 SENTRY_CACHE_OPTIONS = {}
 
+# Attachment blob cache backend
+SENTRY_ATTACHMENTS = None
+SENTRY_ATTACHMENTS_OPTIONS = {}
+
 # The internal Django cache is still used in many places
 # TODO(dcramer): convert uses over to Sentry's backend
 CACHES = {

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -25,6 +25,7 @@ from six import BytesIO
 from time import time
 
 from sentry import filters
+from sentry.attachments import attachment_cache
 from sentry.cache import default_cache
 from sentry.interfaces.base import get_interface
 from sentry.event_manager import EventManager
@@ -365,11 +366,7 @@ class ClientApiHelper(object):
         # is turned off. For native crash reports it will still contain the
         # crash dump (e.g. minidump) so we can load it during processing.
         if attachments is not None:
-            for index, attachment in enumerate(attachments):
-                attachment_data = attachment.pop('data')
-                attachment_key = '%s:a:%s'.format(cache_key, index)
-                default_cache.set(attachment_key, attachment_data, cache_timeout, raw=True)
-            default_cache.set(cache_key + ':a', attachments, cache_timeout)
+            attachment_cache.set(cache_key, attachments, cache_timeout)
 
         task = from_reprocessing and \
             preprocess_event_from_reprocessing or preprocess_event

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -198,6 +198,14 @@ const formGroups = [
         label: t('Allow JavaScript source fetching'),
         help: t('Allow Sentry to scrape missing JavaScript source context when possible'),
       },
+      {
+        name: 'storeCrashReports',
+        type: 'boolean',
+        label: t('Store Native Crash Reports'),
+        help: t(
+          'Store native crash reports such as Minidumps for improved processing and download in issue details'
+        ),
+      },
     ],
   },
 ];

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -205,6 +205,7 @@ const formGroups = [
         help: t(
           'Store native crash reports such as Minidumps for improved processing and download in issue details'
         ),
+        visible: ({features}) => features.has('event-attachments'),
       },
     ],
   },

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -181,7 +181,7 @@ export const fields = {
     help: t(
       'Store native crash reports such as Minidumps for improved processing and download in issue details'
     ),
-    visible: ({features}) => features.has('event-attachments'),
+    visible: ({features}) => features.includes('event-attachments'),
   },
 
   allowedDomains: {

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -181,6 +181,7 @@ export const fields = {
     help: t(
       'Store native crash reports such as Minidumps for improved processing and download in issue details'
     ),
+    visible: ({features}) => features.has('event-attachments'),
   },
 
   allowedDomains: {

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -174,6 +174,14 @@ export const fields = {
     getValue: val => extractMultilineFields(val),
     setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
   },
+  storeCrashReports: {
+    name: 'storeCrashReports',
+    type: 'boolean',
+    label: t('Store Native Crash Reports'),
+    help: t(
+      'Store native crash reports such as Minidumps for improved processing and download in issue details'
+    ),
+  },
 
   allowedDomains: {
     name: 'allowedDomains',

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -268,7 +268,7 @@ class ProjectGeneralSettings extends AsyncView {
           <JsonForm
             {...jsonFormProps}
             title={t('Data Privacy')}
-            features={new Set(organization.features)}
+            features={organization.features}
             fields={[
               fields.dataScrubber,
               fields.dataScrubberDefaults,

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -268,6 +268,7 @@ class ProjectGeneralSettings extends AsyncView {
           <JsonForm
             {...jsonFormProps}
             title={t('Data Privacy')}
+            features={new Set(organization.features)}
             fields={[
               fields.dataScrubber,
               fields.dataScrubberDefaults,

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -274,6 +274,7 @@ class ProjectGeneralSettings extends AsyncView {
               fields.scrubIPAddresses,
               fields.sensitiveFields,
               fields.safeFields,
+              fields.storeCrashReports,
             ]}
           />
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -10,12 +10,13 @@ from __future__ import absolute_import
 
 import logging
 from datetime import datetime
+import six
 
 from raven.contrib.django.models import client as Raven
 from time import time
 from django.utils import timezone
 
-from sentry import reprocessing
+from sentry import features, reprocessing
 from sentry.cache import default_cache
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -24,13 +25,16 @@ from sentry.stacktraces import process_stacktraces, \
     should_process_for_stacktraces
 from sentry.utils.canonical import CanonicalKeyDict, CANONICAL_TYPES
 from sentry.utils.dates import to_datetime
-from sentry.models import ProjectOption, Activity, Project
+from sentry.models import EventAttachment, File, ProjectOption, Activity, Project
 
 error_logger = logging.getLogger('sentry.errors.events')
 info_logger = logging.getLogger('sentry.store')
 
 # Is reprocessing on or off by default?
 REPROCESSING_DEFAULT = False
+
+# Attachment file types that are considered a crash report (PII relevant)
+CRASH_REPORT_TYPES = ('event.minidump', )
 
 
 class RetryProcessing(Exception):
@@ -294,6 +298,36 @@ def create_failed_event(cache_key, project_id, issues, event_id, start_time=None
     return True
 
 
+def save_attachment(event, data, name=None, type=None, content_type=None):
+    """
+    Saves an event attachment to blob storage.
+    """
+
+    # If the attachment is a crash report (e.g. minidump), we need to honor the
+    # store_crash_reports setting. Otherwise, we assume that the client has
+    # already verified PII and just store the attachment.
+    attachment_type = type or 'event.attachment'
+    if attachment_type in CRASH_REPORT_TYPES:
+        if not event.project.get_option('sentry:store_crash_reports') and \
+                not event.project.organization.get_option('sentry:store_crash_reports'):
+            return
+
+    file = File.objects.create(
+        name=name,
+        type=attachment_type,
+        headers={'Content-Type': content_type},
+    )
+    file.putfile(six.BytesIO(data))
+
+    EventAttachment.objects.create(
+        event_id=event.event_id,
+        group_id=event.group_id,
+        project_id=event.project_id,
+        name=name,
+        file=file,
+    )
+
+
 @instrumented_task(name='sentry.tasks.store.save_event', queue='events.save_event')
 def save_event(cache_key=None, data=None, start_time=None, event_id=None,
                project_id=None, **kwargs):
@@ -340,7 +374,17 @@ def save_event(cache_key=None, data=None, start_time=None, event_id=None,
 
     try:
         manager = EventManager(data)
-        manager.save(project_id)
+        event = manager.save(project_id)
+
+        # Always load attachments from the cache so we can later prune them.
+        # Only save them if the event-attachments feature is active, though.
+        attachments = default_cache.get(cache_key + ':a') or []
+        if features.has('organizations:event-attachments', event.project.organization, actor=None):
+            for index, attachment in enumerate(attachments):
+                attachment_key = '%s:a:%s'.format(cache_key, index)
+                attachment_data = default_cache.get(attachment_key, raw=True)
+                save_attachment(event, attachment_data, **attachment)
+
     except HashDiscarded:
         increment_list = [
             (tsdb.models.project_total_received_discarded, project_id),
@@ -379,6 +423,10 @@ def save_event(cache_key=None, data=None, start_time=None, event_id=None,
     finally:
         if cache_key:
             default_cache.delete(cache_key)
+            default_cache.delete(cache_key + ':a')
+            for i in range(0, len(attachments or []) - 1):
+                default_cache.delete('%s:a:%s'.format(cache_key, i))
+
         if start_time:
             metrics.timing(
                 'events.time-to-process',

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -489,7 +489,6 @@ class StoreView(APIView):
                     name=attachment.name,
                     type=kind,
                     headers={'Content-Type': attachment.content_type},
-                    size=attachment.size,
                 )
 
                 attachment.seek(0)

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -825,6 +825,7 @@ window.TestStubs = {
       resolveAge: 48,
       sensitiveFields: ['creditcard', 'ssn'],
       safeFields: ['business-email', 'company'],
+      storeCrashReports: false,
       allowedDomains: ['example.com', 'https://example.com'],
       scrapeJavaScript: true,
       securityToken: 'security-token',

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -185,6 +185,7 @@ exports[`ProjectAlertSettings render() renders 1`] = `
             "ssn",
           ],
           "slug": "project-slug",
+          "storeCrashReports": false,
           "subjectPrefix": "[my-org]",
           "subjectTemplate": "[$project] \${tag:level}: $title",
           "teams": Array [],

--- a/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
@@ -128,6 +128,7 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
                 "ssn",
               ],
               "slug": "project-slug",
+              "storeCrashReports": false,
               "subjectPrefix": "[my-org]",
               "subjectTemplate": "[$project] \${tag:level}: $title",
               "teams": Array [],

--- a/tests/js/spec/views/groupDetails/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/actions.spec.jsx.snap
@@ -91,6 +91,7 @@ exports[`GroupActions render() renders correctly 1`] = `
           "ssn",
         ],
         "slug": "project",
+        "storeCrashReports": false,
         "subjectPrefix": "[my-org]",
         "subjectTemplate": "[$project] \${tag:level}: $title",
         "teams": Array [],

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -193,6 +193,7 @@ class OrganizationUpdateTest(APITestCase):
             'dataScrubberDefaults': True,
             'sensitiveFields': [u'password'],
             'safeFields': [u'email'],
+            'storeCrashReports': True,
             'scrubIPAddresses': True,
             'scrapeJavaScript': False,
             'defaultRole': 'owner',
@@ -225,6 +226,7 @@ class OrganizationUpdateTest(APITestCase):
         assert options.get('sentry:require_scrub_ip_address')
         assert options.get('sentry:sensitive_fields') == ['password']
         assert options.get('sentry:safe_fields') == ['email']
+        assert options.get('sentry:store_crash_reports') is True
         assert options.get('sentry:scrape_javascript') is False
 
         # log created

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -79,8 +79,10 @@ class ProjectDetailsTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 302
         assert response.data['slug'] == 'foobar'
-        assert response.data['detail']['extra']['url'] == '/api/0/projects/%s/%s/' % (project.organization.slug, 'foobar')
-        assert response['Location'] == 'http://testserver/api/0/projects/%s/%s/' % (project.organization.slug, 'foobar')
+        assert response.data['detail']['extra']['url'] == '/api/0/projects/%s/%s/' % (
+            project.organization.slug, 'foobar')
+        assert response['Location'] == 'http://testserver/api/0/projects/%s/%s/' % (
+            project.organization.slug, 'foobar')
 
 
 class ProjectUpdateTest(APITestCase):
@@ -221,6 +223,7 @@ class ProjectUpdateTest(APITestCase):
             'sentry:scrub_defaults': False,
             'sentry:sensitive_fields': ['foo', 'bar'],
             'sentry:safe_fields': ['token'],
+            'sentry:store_crash_reports': False,
             'sentry:csp_ignored_sources_defaults': False,
             'sentry:csp_ignored_sources': 'foo\nbar',
             'filters:blacklisted_ips': '127.0.0.1\n198.51.100.0',
@@ -257,6 +260,9 @@ class ProjectUpdateTest(APITestCase):
             event=AuditLogEntryEvent.PROJECT_EDIT,
         ).exists()
         assert project.get_option('sentry:safe_fields', []) == options['sentry:safe_fields']
+        assert project.get_option(
+            'sentry:store_crash_reports',
+            False) == options['sentry:store_crash_reports']
         assert AuditLogEntry.objects.filter(
             organization=project.organization,
             event=AuditLogEntryEvent.PROJECT_EDIT,
@@ -472,6 +478,14 @@ class ProjectUpdateTest(APITestCase):
         assert self.project.get_option('sentry:safe_fields') == [
             'foobar.com', 'https://example.com']
         assert resp.data['safeFields'] == ['foobar.com', 'https://example.com']
+
+    def test_store_crash_reports(self):
+        resp = self.client.put(self.path, data={
+            'storeCrashReports': True,
+        })
+        assert resp.status_code == 200, resp.content
+        assert self.project.get_option('sentry:store_crash_reports') is True
+        assert resp.data['storeCrashReports'] is True
 
     def test_sensitive_fields(self):
         resp = self.client.put(self.path, data={

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -230,3 +230,14 @@ class OrganizationTest(TestCase):
             key='sentry:safe_fields')
         f.value = ['email']
         assert f.has_changed('value') is False
+
+        OrganizationOption.objects.create(
+            organization=org,
+            key='sentry:store_crash_reports',
+            value=False
+        )
+        p = OrganizationOption.objects.get(
+            organization=org,
+            key='sentry:store_crash_reports')
+        p.value = True
+        assert p.has_changed('value') is True


### PR DESCRIPTION
This PR adds a an organization and project setting to store native crash reports as event attachments:

<img width="1031" alt="screen shot 2018-08-01 at 11 28 07" src="https://user-images.githubusercontent.com/1433023/43513530-3dfc700c-957e-11e8-9bef-5e3b52bb8e26.png">

Minidumps will then appear as event attachments at the bottom of the issue details page:

<img width="1207" alt="screen shot 2018-08-01 at 11 28 22" src="https://user-images.githubusercontent.com/1433023/43513516-36f4ef32-957e-11e8-84be-6e3571cb4f98.png">

In addition to that, all files submitted as part of the minidump POST request will be added as attachment, too. This is independent of the above setting, as it's the developers responsibility to consider PII.

**Note:** All of this requires the `organizations:event-attachments` feature flag to be active.

All attachments (minidump + all other files) are first written to `sentry.cache.default_cache`, which is Redis in our case. In the `save_event` task, we then write them to the blob store.