### PR TITLE
fix(ui): convert auth modal to new ui

### DIFF
--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -38,96 +38,105 @@
 
 {% block title %}{% trans "Login" %} | {{ block.super }}{% endblock %}
 
-{% block auth_main %}
+{% block auth_container %}
 <div style="padding-bottom: 10px">
-  <div class="align-center">
+  <div class="align-center m-t-2">
     <img src="{% asset_url "sentry" "images/default-organization-logo.png" %}" class="org-avatar">
-
-    <h3>{{ organization.name }}</h3>
+    {% if organization.name %}
+      <h3 class="m-b-0">{{ organization.name }}</h3>
+    {% endif %}
   </div>
 
   {% if provider_name %}
     <form class="form-stacked" action="" method="post" autocomplete="off">
       {% csrf_token %}
       <input type="hidden" name="init" value="1" />
+      <div class="auth-container p-t-1 border-bottom">
+        <div class="align-center">
+          <p>
+            {% if authenticated %}
+            <b>{{ organization.name }}</b> requires signing in with {{ provider_name }}.
+            {% else %}
+            Sign in with your {{ provider_name }} account to continue.
+            {% endif %}
+          </p>
 
-      <div class="align-center">
-        <p>
-          {% if authenticated %}
-          <b>{{ organization.name }}</b> requires signing in with {{ provider_name }}.
-          {% else %}
-          Sign in with your {{ provider_name }} account to continue.
-          {% endif %}
-        </p>
-
-        <p><button type="submit" class="btn btn-default btn-login-{{ provider_key }}">
-          <span class="provider-logo {{ provider_name | lower}}"></span> Login with {{ provider_name }}
-        </button></p>
+          <p><button type="submit" class="btn btn-default btn-login-{{ provider_key }}">
+            <span class="provider-logo {{ provider_name | lower}}"></span> Login with {{ provider_name }}
+          </button></p>
+        </div>
       </div>
     </form>
   {% else %}
-    <ul class="nav nav-tabs auth-toggle">
-      <li{% if op == "login" %} class="active"{% endif %}>
-        <a href="#login" data-toggle="tab">{% trans "Login" %}</a>
-      </li>
-      {% if CAN_REGISTER %}
-        <li{% if op == "register" %} class="active"{% endif %}>
-          <a href="#register" data-toggle="tab">{% trans "Register" %}</a>
+    <div class="auth-container p-t-0 border-bottom">
+      <ul class="nav nav-tabs auth-toggle">
+        <li{% if op == "login" %} class="active"{% endif %}>
+          <a href="#login" data-toggle="tab">{% trans "Login" %}</a>
         </li>
-      {% endif %}
-    </ul>
-
+        {% if CAN_REGISTER %}
+          <li{% if op == "register" %} class="active"{% endif %}>
+            <a href="#register" data-toggle="tab">{% trans "Register" %}</a>
+          </li>
+        {% endif %}
+      </ul>
+    </div>
     <div class="tab-content basic-login">
       <div class="tab-pane{% if op == "login" %} active{% endif %}" id="login">
-        <form class="form-stacked" action="" method="post" autocomplete="off">
-          {% csrf_token %}
+        <div class="auth-container">
+          <div class="auth-form-column">
+            <form class="form-stacked" action="" method="post" autocomplete="off">
+              {% csrf_token %}
 
-          <input type="hidden" name="op" value="login" />
+              <input type="hidden" name="op" value="login" />
 
-          {{ login_form|as_crispy_errors }}
+              {{ login_form|as_crispy_errors }}
 
-          {% for field in login_form %}
-            {{ field|as_crispy_field }}
-          {% endfor %}
+              {% for field in login_form %}
+                {{ field|as_crispy_field }}
+              {% endfor %}
 
-          <fieldset class="form-actions" style="text-align: center">
-            <button type="submit" class="btn btn-primary" style="width: 50%">{% trans "Login" %}</button>
-          </fieldset>
+              <div class="auth-footer m-t-1">
+                  <button type="submit" class="btn btn-primary">{% trans "Continue" %}</button>
+                  <a class="secondary" href="{% url 'sentry-account-recover' %}">{% trans "Lost your password?" %}</a>
+                </div>
+            </form>
+          </div>
+          {% if github_login_template or vsts_login_template %}
+          <div class="auth-provider-column">
+            {% if github_login_template %}
+              {% include github_login_template %}
+            {% endif %}
 
-          {% if github_login_template %}
-            {% include github_login_template %}
-          {% endif %}
-
-          {% if vsts_login_template %}
-            {% include vsts_login_template %}
-          {% endif %}
-
-          <p style="text-align: center">
-            <a style="margin-top: 9px; width: 50%; color: gray" href="{% url 'sentry-account-recover' %}">{% trans "Lost your password?" %}</a>
-          </p>
-        </form>
+            {% if vsts_login_template %}
+              {% include vsts_login_template %}
+            {% endif %}
+          </div>
+        {% endif %}
+        </div>
       </div>
       <div class="tab-pane{% if op == "register" %} active{% endif %}" id="register">
-        <form class="form-stacked" action="" method="post" autocomplete="off">
-          {% csrf_token %}
+        <div class="auth-container">
+          <form class="form-stacked" action="" method="post" autocomplete="off">
+            {% csrf_token %}
 
-          <input type="hidden" name="op" value="register" />
+            <input type="hidden" name="op" value="register" />
 
-          {{ register_form|as_crispy_errors }}
+            {{ register_form|as_crispy_errors }}
 
-          {% for field in register_form %}
-            {{ field|as_crispy_field }}
-          {% endfor %}
+            {% for field in register_form %}
+              {{ field|as_crispy_field }}
+            {% endfor %}
 
-          <div class="password-strength"></div>
+            <div class="password-strength"></div>
 
-          <fieldset class="form-actions">
-            <button type="submit" class="btn btn-primary">{% trans "Register" %}</button>
-            <a class="pull-right" style="margin-top: 9px" href="https://sentry.io/privacy/" target="_blank">
-              {% trans "Privacy Policy" %}
-            </a>
-          </fieldset>
-        </form>
+            <fieldset class="form-actions">
+              <button type="submit" class="btn btn-primary">{% trans "Register" %}</button>
+              <a class="pull-right" style="margin-top: 9px" href="https://sentry.io/privacy/" target="_blank">
+                {% trans "Privacy Policy" %}
+              </a>
+            </fieldset>
+          </form>
+        </div>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
What this looks like now:

<img width="790" alt="screen shot 2018-08-01 at 5 25 40 pm" src="https://user-images.githubusercontent.com/30713/43555713-c453b890-95b0-11e8-957f-e4dc7269100d.png">

We should:

- [ ] render org name
- [ ] use org's avatar and not our hardcoded avatar