### PR TITLE
fix(ui): Fix <LazyLoad> using wrong fingerprint

### DIFF
--- a/src/sentry/static/sentry/app/components/lazyLoad.jsx
+++ b/src/sentry/static/sentry/app/components/lazyLoad.jsx
@@ -59,15 +59,20 @@ class LazyLoad extends React.Component {
   }
 
   componentDidCatch(error, info) {
-    this.handleFetchError(error);
+    sdk.captureException(error);
+    this.handleError(error);
   }
 
   getComponentGetter = () => this.props.component || this.props.route.componentPromise;
 
   handleFetchError = error => {
+    sdk.captureException(error, {fingerprint: ['webpack', 'error loading chunk']});
+    this.handleError(error);
+  };
+
+  handleError = error => {
     // eslint-disable-next-line no-console
     console.error(error);
-    sdk.captureException(error, {fingerprint: ['webpack', 'error loading chunk']});
     this.setState({
       error,
     });


### PR DESCRIPTION
Previously `componentDidCatch` was logging to Sentry with the same fingerprint as when the fetch component error handler. This would cause component exceptions to be unexpectedly grouped with webpack chunk loading errors.