### PR TITLE
fix(relay): Use default sentry cache for relay auth

### DIFF
--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -7,8 +7,8 @@ from rest_framework import serializers, status
 
 from django.conf import settings
 from django.utils import timezone
-from django.core.cache import cache as default_cache
 
+from sentry.cache import default_cache
 from sentry.utils import json
 from sentry.models import Relay
 from sentry.api.base import Endpoint


### PR DESCRIPTION
Uses `sentry.cache` instead of `django.core.cache` for relay authorization. This allows to register relays with the default configuration generated by `sentry init`. Previously, we required to manually set up the django cache.

@mitsuhiko I also checked the chunk upload, but that already seems to use `sentry.cache`. I was able to verify that it works with default settings.