### PR TITLE
feat(ui): Hint long subtitle with title attr

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
@@ -41,7 +41,7 @@ class EventOrGroupTitle extends React.Component {
       return (
         <span style={this.props.style}>
           <span style={{marginRight: 10}}>{title}</span>
-          <em>{subtitle}</em>
+          <em title={subtitle}>{subtitle}</em>
           <br />
         </span>
       );

--- a/tests/js/spec/components/__snapshots__/eventOrGroupTitle.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/eventOrGroupTitle.spec.jsx.snap
@@ -17,7 +17,9 @@ exports[`EventOrGroupTitle renders with subtitle when \`type = csp\` 1`] = `
   >
     metadata directive
   </span>
-  <em>
+  <em
+    title="metadata uri"
+  >
     metadata uri
   </em>
   <br />
@@ -35,7 +37,9 @@ exports[`EventOrGroupTitle renders with subtitle when \`type = error\` 1`] = `
   >
     metadata type
   </span>
-  <em>
+  <em
+    title="culprit"
+  >
     culprit
   </em>
   <br />

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -781,7 +781,9 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                             >
                                               TypeError
                                             </span>
-                                            <em>
+                                            <em
+                                              title="length(app/views/groupSimilar/groupSimilarView)"
+                                            >
                                               length(app/views/groupSimilar/groupSimilarView)
                                             </em>
                                             <br />


### PR DESCRIPTION
Due to text-overflow a combination of long title and/or subtitle will be cut.
Using the title attribute the user can hover the subtitle and still see a hint of it.

**After this change:**

<img width="1157" alt="sentry-issue-with-title" src="https://user-images.githubusercontent.com/809707/43584408-9a89b34a-9662-11e8-89a6-c8da8772a674.png">
