### PR TITLE
feat(integrations): VSTS Marketplace Extension

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1261,6 +1261,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
     'sentry.integrations.github_enterprise.GitHubEnterpriseIntegrationProvider',
     'sentry.integrations.jira.JiraIntegrationProvider',
     'sentry.integrations.vsts.VstsIntegrationProvider',
+    'sentry.integrations.vsts_extension.VstsExtensionIntegrationProvider',
 )
 
 SENTRY_INTERNAL_INTEGRATIONS = (
@@ -1269,6 +1270,7 @@ SENTRY_INTERNAL_INTEGRATIONS = (
     'github_enterprise',
     'jira',
     'vsts',
+    'vsts-extension',
 )
 
 

--- a/src/sentry/identity/__init__.py
+++ b/src/sentry/identity/__init__.py
@@ -8,6 +8,7 @@ from .slack import *  # NOQA
 from .github import *  # NOQA
 from .github_enterprise import *  # NOQA
 from .vsts import *  # NOQA
+from .vsts_extension import *  # NOQA
 from .bitbucket import *  # NOQA
 
 
@@ -24,4 +25,5 @@ register(SlackIdentityProvider)  # NOQA
 register(GitHubIdentityProvider)  # NOQA
 register(GitHubEnterpriseIdentityProvider)  # NOQA
 register(VSTSIdentityProvider)  # NOQA
+register(VstsExtensionIdentityProvider)  # NOQA
 register(BitbucketIdentityProvider)  # NOQA

--- a/src/sentry/identity/vsts_extension/__init__.py
+++ b/src/sentry/identity/vsts_extension/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from sentry.utils.imports import import_submodules
+
+import_submodules(globals(), __name__, __path__)

--- a/src/sentry/identity/vsts_extension/provider.py
+++ b/src/sentry/identity/vsts_extension/provider.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry.identity.vsts.provider import VSTSIdentityProvider
+
+
+class VstsExtensionIdentityProvider(VSTSIdentityProvider):
+    """
+    Functions exactly the same as ``VSTSIdentityProvider``.
+
+    This class is necessary because of how Integration Pipelines look up
+    sibling/dependent classes using ``key``.
+
+    The IntegrationProvider for the VSTS Extension is slightly different from
+    the VSTS version, so it requires a new class. Hence, the Identity portion
+    also requires a new class; this one.
+    """
+
+    key = 'vsts-extension'

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -51,8 +51,15 @@ class IntegrationProvider(PipelineProvider):
     it provides (such as extensions provided).
     """
 
-    # a unique identifier (e.g. 'slack')
+    # a unique identifier (e.g. 'slack').
+    # Used to lookup sibling classes and the ``key`` used when creating
+    # Integration objects.
     key = None
+
+    # a unique identifier to use when creating the ``Integration`` object.
+    # Only needed when you want to create the above object with something other
+    # than ``key``. See: VstsExtensionIntegrationProvider.
+    _integration_key = None
 
     # a human readable name (e.g. 'Slack')
     name = None
@@ -89,6 +96,10 @@ class IntegrationProvider(PipelineProvider):
             raise NotImplementedError
 
         return cls.integration_cls(model, organization_id, **kwargs)
+
+    @property
+    def integration_key(self):
+        return self._integration_key or self.key
 
     def get_logger(self):
         return logging.getLogger('sentry.integration.%s' % (self.key, ))

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -122,3 +122,13 @@ class ExampleIntegrationProvider(IntegrationProvider):
         >>> def setup(self):
         >>>     bindings.add('repository.provider', GitHubRepositoryProvider, key='github')
         """
+
+
+class AliasedIntegration(ExampleIntegration):
+    pass
+
+
+class AliasedIntegrationProvider(ExampleIntegrationProvider):
+    key = 'aliased'
+    integration_key = 'example'
+    name = 'Integration Key Example'

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -64,7 +64,7 @@ class IntegrationPipeline(Pipeline):
     def _finish_pipeline(self, data):
         if 'reinstall_id' in data:
             self.integration = Integration.objects.get(
-                provider=self.provider.key,
+                provider=self.provider.integration_key,
                 id=data['reinstall_id'],
             )
             self.integration.update(external_id=data['external_id'], status=ObjectStatus.VISIBLE)
@@ -72,11 +72,14 @@ class IntegrationPipeline(Pipeline):
 
         elif 'expect_exists' in data:
             self.integration = Integration.objects.get(
-                provider=self.provider.key,
+                provider=self.provider.integration_key,
                 external_id=data['external_id'],
             )
         else:
-            self.integration = ensure_integration(self.provider.key, data)
+            self.integration = ensure_integration(
+                self.provider.integration_key,
+                data,
+            )
 
         # Does this integration provide a user identity for the user setting up
         # the integration?

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -257,7 +257,7 @@ class VstsIntegrationProvider(IntegrationProvider):
 
         identity_pipeline_view = NestedPipelineView(
             bind_key='identity',
-            provider_key='vsts',
+            provider_key=self.key,
             pipeline_cls=IdentityProviderPipeline,
             config=identity_pipeline_config,
         )

--- a/src/sentry/integrations/vsts_extension/__init__.py
+++ b/src/sentry/integrations/vsts_extension/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from sentry.utils.imports import import_submodules
+
+import_submodules(globals(), __name__, __path__)

--- a/src/sentry/integrations/vsts_extension/integration.py
+++ b/src/sentry/integrations/vsts_extension/integration.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+
+from sentry.integrations.vsts.integration import (
+    VstsIntegrationProvider, AccountConfigView,
+)
+from sentry.pipeline import PipelineView
+from sentry.utils.http import absolute_uri
+
+
+class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
+    key = 'vsts-extension'
+    integration_key = 'vsts'
+
+    def get_pipeline_views(self):
+        views = super(VstsExtensionIntegrationProvider, self).get_pipeline_views()
+        views = [view for view in views if not isinstance(view, AccountConfigView)]
+        views.append(VstsExtensionFinishedView())
+        return views
+
+    def build_integration(self, state):
+        # Normally this is saved into the ``identity`` state, but for some
+        # reason it gets wiped out in the NestedPipeline. Instead, we'll store
+        # it in it's own key (``vsts``) to be used down the line in
+        # ``VSTSOrganizationSelectionView``.
+        state['account'] = {
+            'AccountId': state['vsts']['AccountId'],
+            'AccountName': state['vsts']['AccountName'],
+        }
+
+        state['instance'] = '{}.visualstudio.com'.format(
+            state['vsts']['AccountName']
+        )
+
+        return super(
+            VstsExtensionIntegrationProvider,
+            self
+        ).build_integration(state)
+
+
+class VstsExtensionFinishedView(PipelineView):
+    def dispatch(self, request, pipeline):
+        pipeline.finish_pipeline()
+
+        messages.add_message(request, messages.SUCCESS, 'VSTS Extension installed.')
+
+        # TODO: replace with whatever we decide the finish step is.
+        return HttpResponseRedirect(
+            absolute_uri('/settings/{}/integrations/vsts-extension/{}/'.format(
+                pipeline.organization.slug,
+                pipeline.integration.id,
+            ))
+        )

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -200,19 +200,22 @@ def register_extensions():
 
     from sentry import integrations
     from sentry.integrations.bitbucket import BitbucketIntegrationProvider
-    from sentry.integrations.example import ExampleIntegrationProvider
+    from sentry.integrations.example import ExampleIntegrationProvider, AliasedIntegrationProvider
     from sentry.integrations.github import GitHubIntegrationProvider
     from sentry.integrations.github_enterprise import GitHubEnterpriseIntegrationProvider
     from sentry.integrations.jira import JiraIntegrationProvider
     from sentry.integrations.slack import SlackIntegrationProvider
     from sentry.integrations.vsts import VstsIntegrationProvider
+    from sentry.integrations.vsts_extension import VstsExtensionIntegrationProvider
     integrations.register(BitbucketIntegrationProvider)
     integrations.register(ExampleIntegrationProvider)
+    integrations.register(AliasedIntegrationProvider)
     integrations.register(GitHubIntegrationProvider)
     integrations.register(GitHubEnterpriseIntegrationProvider)
     integrations.register(JiraIntegrationProvider)
     integrations.register(SlackIntegrationProvider)
     integrations.register(VstsIntegrationProvider)
+    integrations.register(VstsExtensionIntegrationProvider)
 
     from sentry.plugins import bindings
     from sentry.plugins.providers.dummy import DummyRepositoryProvider

--- a/tests/sentry/integrations/vsts_extension/test_provider.py
+++ b/tests/sentry/integrations/vsts_extension/test_provider.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+from mock import patch
+
+from sentry.integrations.vsts import VstsIntegrationProvider
+from sentry.integrations.vsts_extension import (
+    VstsExtensionIntegrationProvider,
+    VstsExtensionFinishedView,
+)
+from sentry.testutils import TestCase
+
+
+class VstsExtensionIntegrationProviderTest(TestCase):
+    def setUp(self):
+        self.provider = VstsExtensionIntegrationProvider()
+
+    def test_get_pipeline_views(self):
+        # Should be same as the VSTS integration, but with a different last
+        # step.
+        views = self.provider.get_pipeline_views()
+        vsts_views = VstsIntegrationProvider().get_pipeline_views()
+
+        assert isinstance(views[0], type(vsts_views[0]))
+        assert isinstance(views[-1], VstsExtensionFinishedView)
+
+    @patch('sentry.integrations.vsts.integration.get_user_info')
+    @patch('sentry.integrations.vsts.integration.VstsIntegrationProvider.create_subscription')
+    def test_build_integration(self, create_sub, get_user_info):
+        get_user_info.return_value = {'id': '987'}
+        create_sub.return_value = (1, 'sharedsecret')
+
+        integration = self.provider.build_integration({
+            'vsts': {
+                'AccountId': '123',
+                'AccountName': 'test',
+            },
+            'identity': {
+                'data': {
+                    'access_token': '123',
+                    'expires_in': '3600',
+                    'refresh_token': '321',
+                },
+            },
+        })
+
+        assert integration['external_id'] == '123'
+        assert integration['name'] == 'test'


### PR DESCRIPTION
This adds the underlying pieces necessary for our VSTS Markertplace Extension.

It has a slightly different setup process than the "normal" VSTS integration. Instead of choosing the VSTS Account, you choose the Sentry Organization. Other than that, it's the same process as installing the "normal" integration.