### PR TITLE
fix(oauth2-identity): Ensure errors are handled on redirect

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -201,7 +201,7 @@ class OAuth2LoginView(PipelineView):
 
     @csrf_exempt
     def dispatch(self, request, pipeline):
-        if 'code' in request.GET:
+        if 'code' in request.GET or 'error' in request.GET:
             return pipeline.next_step()
 
         state = uuid4().hex


### PR DESCRIPTION
If the user was redirected with an error but without a code, they will be immediately redirected back to the authorization, but will get stuck in a redirect loop since they are never advanced to the callback step in the pipeline where the error is handled.

The fix is to move to the next step if they are redirect back with the code OR error key in the request query string.