### PR TITLE
fix(ui): SharedGroupDetails breaks when there is no latest event

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -72,7 +72,7 @@ const EventEntries = createReactClass({
   componentDidMount() {
     let {event} = this.props;
 
-    if (!event.errors || !event.errors.length > 0) return;
+    if (!event || !event.errors || !event.errors.length > 0) return;
     let errors = event.errors;
     let errorTypes = errors.map(errorEntries => errorEntries.type);
     let errorMessages = errors.map(errorEntries => errorEntries.message);
@@ -99,11 +99,10 @@ const EventEntries = createReactClass({
 
   interfaces: INTERFACES,
 
-  render() {
-    let {group, isShare, project, event, orgId} = this.props;
-    let organization = this.getOrganization();
-    let features = organization ? new Set(organization.features) : new Set();
-    let entries = event.entries.map((entry, entryIdx) => {
+  renderEntries() {
+    let {event, group, isShare} = this.props;
+
+    return event.entries.map((entry, entryIdx) => {
       try {
         let Component = this.interfaces[entry.type];
         if (!Component) {
@@ -137,9 +136,24 @@ const EventEntries = createReactClass({
         );
       }
     });
+  },
+
+  render() {
+    let {group, isShare, project, event, orgId} = this.props;
+
+    let organization = this.getOrganization();
+    let features = organization ? new Set(organization.features) : new Set();
 
     let hasContext =
-      !utils.objectIsEmpty(event.user) || !utils.objectIsEmpty(event.contexts);
+      event && (!utils.objectIsEmpty(event.user) || !utils.objectIsEmpty(event.contexts));
+
+    if (!event) {
+      return (
+        <div style={{padding: '15px 30px'}}>
+          <h3>{t('Latest Event Not Available')}</h3>
+        </div>
+      );
+    }
 
     return (
       <div className="entries">
@@ -160,7 +174,7 @@ const EventEntries = createReactClass({
         )}
         {hasContext && <EventContextSummary group={group} event={event} />}
         <EventTags group={group} event={event} orgId={orgId} projectId={project.slug} />
-        {entries}
+        {this.renderEntries()}
         {hasContext && <EventContexts group={group} event={event} />}
         {!utils.objectIsEmpty(event.context) && (
           <EventExtraData group={group} event={event} />


### PR DESCRIPTION
This fixes <SharedGroupDetails> --> <EventEntries> when there is no latest event in a group. Not sure why latest event is null, but this will show an error message now

![image](https://user-images.githubusercontent.com/79684/43615397-59c92386-966c-11e8-89cc-a3e8768933c8.png)
