### PR TITLE
fix(ui): Fix `escape` on a null device name

### DIFF
--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -118,7 +118,7 @@ const TagDistributionMeter = createReactClass({
 
           const tooltipHtml =
             '<div class="truncate">' +
-            escape(deviceNameMapper(value.name || '', this.state.iOSDeviceList)) +
+            escape(deviceNameMapper(value.name || '', this.state.iOSDeviceList) || '') +
             '</div>' +
             pctLabel +
             '%';


### PR DESCRIPTION
This happens in <TagDistributionMeter> when API requests error with a status code 0.
Fixes JAVASCRIPT-44W