### PR TITLE
fix(ui): Check `saveField` for null value

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -374,6 +374,7 @@ class FormModel {
   /**
    * Attempts to save field and show undo message if necessary.
    * Calls submit handlers.
+   * TODO(billy): This should return a promise that resolves (instead of null)
    */
   @action
   saveField(id, currentValue) {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -526,7 +526,11 @@ class FormModel {
    */
   @action
   handleSaveField(id, currentValue) {
-    return this.saveField(id, currentValue).then(() => {
+    const savePromise = this.saveField(id, currentValue);
+
+    if (!savePromise) return null;
+
+    return savePromise.then(() => {
       this.setFieldState(id, 'showSave', false);
     });
   }


### PR DESCRIPTION
This is a quick fix for when you try to save a field that does not auto save but instead has a button to save (e.g. slug change). It can return null if i.e. field does not pass validation. I think a real fix would involve always returning a promise.

Fixes JAVASCRIPT-3Z5