### PR TITLE
fix(ui): Change "merge success" to check for valid response

### DIFF
--- a/src/sentry/static/sentry/app/stores/groupStore.jsx
+++ b/src/sentry/static/sentry/app/stores/groupStore.jsx
@@ -316,7 +316,7 @@ const GroupStore = Reflux.createStore({
     // Remove all but parent id (items were merged into this one)
     let mergedIdSet = new Set(mergedIds);
 
-    // Looks like the `	PUT /api/0/projects/:orgId/:projectId/issues/` endpoint
+    // Looks like the `PUT /api/0/projects/:orgId/:projectId/issues/` endpoint
     // actually returns a 204, so there is no `response` body
     this.items = this.items.filter(
       item =>

--- a/src/sentry/static/sentry/app/stores/groupStore.jsx
+++ b/src/sentry/static/sentry/app/stores/groupStore.jsx
@@ -315,8 +315,13 @@ const GroupStore = Reflux.createStore({
 
     // Remove all but parent id (items were merged into this one)
     let mergedIdSet = new Set(mergedIds);
+
+    // Looks like the `	PUT /api/0/projects/:orgId/:projectId/issues/` endpoint
+    // actually returns a 204, so there is no `response` body
     this.items = this.items.filter(
-      item => !mergedIdSet.has(item.id) || item.id === response.merge.parent
+      item =>
+        !mergedIdSet.has(item.id) ||
+        (response && response.merge && item.id === response.merge.parent)
     );
 
     showAlert(t('The selected events have been scheduled for merge.'), 'success');


### PR DESCRIPTION
It looks the endpoint can (sometimes? always?) returns a 204, so check if response is valid.

Fixes JAVASCRIPT-2H1