### PR TITLE
fix(discover): Fix converting to external condition format

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
@@ -72,7 +72,11 @@ export function getExternal(internal, columns) {
 
   // Validate value and convert to correct type
   if (external[0] && external[1] && !specialConditions.has(external[1])) {
-    external[2] = internal.replace(`${external[0]} ${external[1]} `, '');
+    const strStart = `${external[0]} ${external[1]} `;
+
+    if (internal.startsWith(strStart)) {
+      external[2] = internal.replace(strStart, '');
+    }
 
     const type = columns.find(({name}) => name === colValue).type;
 

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -31,6 +31,10 @@ const conditionList = [
     internal: 'message NOT LIKE something%',
     external: ['message', 'NOT LIKE', 'something%'],
   },
+  {
+    internal: 'message LIKE',
+    external: ['message', 'LIKE', null],
+  },
 ];
 
 describe('Conditions', function() {


### PR DESCRIPTION
Fixes a bug introduced in #9272 which incorrectly converted an internal condition with the format 'message LIKE' to the external format ['message', 'LIKE', 'message LIKE'] instead of ['message', 'LIKE', null].