### PR TITLE
fix(ui): Fix select field component

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectField.jsx
@@ -43,7 +43,11 @@ export default class SelectField extends FormField {
       //
       // This can happen when this is apart of a field, and it re-renders onChange for a different field,
       // there will be a mismatch between this component's state.value and `this.getValue` result above
-      if (!isEqual(newValue, coercedValue) && !!newValue !== !!coercedValue) {
+      if (!newValue && !coercedValue) {
+        return;
+      }
+
+      if (!isEqual(newValue, coercedValue)) {
         this.setValue(newValue);
       }
     }

--- a/src/sentry/static/sentry/app/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectField.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
+import {isEqual} from 'lodash';
 
 import {defined} from 'app/utils';
 
@@ -42,7 +43,7 @@ export default class SelectField extends FormField {
       //
       // This can happen when this is apart of a field, and it re-renders onChange for a different field,
       // there will be a mismatch between this component's state.value and `this.getValue` result above
-      if (newValue !== coercedValue && !!newValue !== !!coercedValue) {
+      if (!isEqual(newValue, coercedValue) && !!newValue !== !!coercedValue) {
         this.setValue(newValue);
       }
     }


### PR DESCRIPTION
Fixes a bug in the select field component where updated props values (i.e. for controlled components) were being ignored since we were comparing on the object instance rather than for object equality.