### PR TITLE
fix(ui): Stop SettingsPageHeading from producing warnings

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.jsx
@@ -35,7 +35,7 @@ class SettingsPageHeading extends React.Component {
   }
 }
 
-const Title = styled(Flex)`
+const Title = styled(Flex, {shouldForwardProp: p => p !== 'styled'})`
   ${p =>
     !p.styled &&
     `


### PR DESCRIPTION
The styled prop was being passed to flex, which is used for something else than what we're using it for here.