### PR TITLE
xrange(3) --> range(3) for Python 3 compatibility

### DIFF
--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -11,7 +11,7 @@ from sentry.utils.concurrent import FutureSet, SynchronousExecutor, ThreadedExec
 
 
 def test_future_set_callback_success():
-    future_set = FutureSet([Future() for i in xrange(3)])
+    future_set = FutureSet([Future() for i in range(3)])
 
     callback = mock.Mock()
     future_set.add_done_callback(callback)
@@ -31,7 +31,7 @@ def test_future_set_callback_success():
 
 
 def test_future_set_callback_error():
-    future_set = FutureSet([Future() for i in xrange(3)])
+    future_set = FutureSet([Future() for i in range(3)])
 
     callback = mock.Mock()
     future_set.add_done_callback(callback)


### PR DESCRIPTION
In Python 2, there is no difference between __xrange(i)__ and __range(i)__ when __i__ is such a low value as 3.

In Python 3, __xrange()__ was removed in favor of __range()__.