### PR TITLE
feat(forms): Add prettyValue function for form toasts

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/indicator.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/indicator.jsx
@@ -88,6 +88,8 @@ export function saveOnBlurUndoMessage(change, model, fieldName) {
   if (!label) return;
 
   let prettifyValue = val => prettyFormString(val, model, fieldName);
+
+  // Hide the change text when formatMessageValue is explicitly set to false
   let showChangeText = model.getDescriptor(fieldName, 'formatMessageValue') !== false;
 
   addSuccessMessage(

--- a/src/sentry/static/sentry/app/views/settings/components/forms/choiceMapper.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/choiceMapper.jsx
@@ -73,6 +73,10 @@ export default class ChoiceMapper extends React.Component {
     addButtonText: t('Add Item'),
     perItemMapping: false,
     allowEmpty: false,
+    // Since we're saving an object, there isn't a great way to render the
+    // change within the toast. Just turn off displaying the from/to portion of
+    // the message.
+    formatMessageValue: false,
   };
 
   hasValue = value => defined(value) && !objectIsEmpty(value);

--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.jsx
@@ -42,7 +42,7 @@ export default class FieldFromConfig extends React.Component {
        * Function to format the value displayed in the undo toast. May also be
        * specified as false to disable showing the changed fields in the toast.
        */
-      formatMessageValue: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+      formatMessageValue: PropTypes.oneOfType([PropTypes.func, PropTypes.oneOf([false])]),
       /**
        * Should show a "return key" icon in input?
        */

--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.jsx
@@ -39,6 +39,11 @@ export default class FieldFromConfig extends React.Component {
       visible: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
       disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
       /**
+       * Function to format the value displayed in the undo toast. May also be
+       * specified as false to disable showing the changed fields in the toast.
+       */
+      formatMessageValue: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+      /**
        * Should show a "return key" icon in input?
        */
       showReturnButton: PropTypes.bool,

--- a/src/sentry/static/sentry/app/views/settings/components/forms/rangeField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/rangeField.jsx
@@ -4,6 +4,11 @@ import InputField from 'app/views/settings/components/forms/inputField';
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
 
 export default class RangeField extends React.Component {
+  static defaultProps = {
+    prettyValue: (value, props) =>
+      (typeof props.formatLabel === 'function' && props.formatLabel(value)) || value,
+  };
+
   onChange = (onChange, onBlur, value, e) => {
     // We need to toggle current value because Switch is not an input
     onChange(value, e);

--- a/src/sentry/static/sentry/app/views/settings/components/forms/rangeField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/rangeField.jsx
@@ -5,7 +5,7 @@ import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlide
 
 export default class RangeField extends React.Component {
   static defaultProps = {
-    prettyValue: (value, props) =>
+    formatMessageValue: (value, props) =>
       (typeof props.formatLabel === 'function' && props.formatLabel(value)) || value,
   };
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -33,7 +33,7 @@ export default class SelectField extends React.Component {
     escapeMarkup: true,
     multiple: false,
     small: false,
-    prettyValue: (value, props) =>
+    formatMessageValue: (value, props) =>
       (getChoices(props).find(v => v[0] === value) || [null, value])[1],
   };
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -4,6 +4,16 @@ import React from 'react';
 import InputField from 'app/views/settings/components/forms/inputField';
 import SelectControl from 'app/components/forms/selectControl';
 
+const getChoices = props => {
+  let choices = props.choices || [];
+
+  if (typeof props.choices === 'function') {
+    choices = props.choices(props);
+  }
+
+  return choices;
+};
+
 export default class SelectField extends React.Component {
   static propTypes = {
     ...InputField.propTypes,
@@ -23,6 +33,8 @@ export default class SelectField extends React.Component {
     escapeMarkup: true,
     multiple: false,
     small: false,
+    prettyValue: (value, props) =>
+      (getChoices(props).find(v => v[0] === value) || [null, value])[1],
   };
 
   handleChange = (onBlur, onChange, optionObj) => {
@@ -49,11 +61,7 @@ export default class SelectField extends React.Component {
         {...otherProps}
         alignRight={this.props.small}
         field={({onChange, onBlur, disabled, ...props}) => {
-          let choices = props.choices || [];
-
-          if (typeof props.choices === 'function') {
-            choices = props.choices(props);
-          }
+          let choices = getChoices(props);
 
           return (
             <SelectControl

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -34,7 +34,7 @@ export default class SelectField extends React.Component {
     multiple: false,
     small: false,
     formatMessageValue: (value, props) =>
-      (getChoices(props).find(v => v[0] === value) || [null, value])[1],
+      (getChoices(props).find(choice => choice[0] === value) || [null, value])[1],
   };
 
   handleChange = (onBlur, onChange, optionObj) => {


### PR DESCRIPTION
Makes form toasts a decent bit better, and less "engineering" feeling.

- `true` and `false` are now displayed as "enabled" and "disabled"
- `null` renders as "<none>"
- `undefined` renders as "<unset>"

A `formatMessageValue` can now be specified on a fields properties (or through the field configuration) which can be declared as a function to format the message, or as false to just disable showing the changed values.

Adds formatters for:

 - Select dropdown, looksup the value from the choices
 - Range slider, uses the `formatLabel` function
 - Choice Mapper disables showing the changes.