### PR TITLE
feat(health): Add `interval` to health request action creator

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/health.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/health.jsx
@@ -11,12 +11,23 @@ const BASE_URL = org => `/organizations/${org.slug}/health/`;
  * @param {Boolean} options.timeseries Should we group results by time period
  * @param {String[]} options.environments List of environments to query for
  * @param {String} options.period Time period to query for, in the format: <integer><units> where units are "d" or "h"
+ * @param {String} options.interval Time interval to group results in, in the format: <integer><units> where units are "d", "h", "m", "s"
  * @param {Boolean} options.includePrevious Should request also return reqsults for previous period?
  * @param {Number} options.topk Include topk results
  */
 export const doHealthRequest = (
   api,
-  {organization, projects, tag, environments, period, timeseries, includePrevious, topk}
+  {
+    organization,
+    projects,
+    tag,
+    environments,
+    period,
+    interval,
+    timeseries,
+    includePrevious,
+    topk,
+  }
 ) => {
   if (!api) return Promise.reject(new Error('API client not available'));
 
@@ -24,6 +35,7 @@ export const doHealthRequest = (
   const query = {
     tag,
     includePrevious,
+    interval,
     statsPeriod: period,
     project: projects,
     environment: environments,

--- a/tests/js/spec/actionCreators/health.spec.jsx
+++ b/tests/js/spec/actionCreators/health.spec.jsx
@@ -7,7 +7,37 @@ describe('Health ActionCreator', function() {
   const project = TestStubs.Project();
   let mock;
 
-  it('requests timeseries', function() {
+  it('requests timeseries w/o tag', function() {
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/health/graph/',
+    });
+    doHealthRequest(api, {
+      timeseries: true,
+      organization,
+      projects: [project.id],
+      environments: [],
+      topk: 5,
+      includePrevious: true,
+      period: '7d',
+    });
+
+    expect(mock).toHaveBeenCalled();
+
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/health/graph/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [project.id],
+          environment: [],
+          topk: 5,
+          includePrevious: true,
+          statsPeriod: '7d',
+        }),
+      })
+    );
+  });
+
+  it('requests timeseries w/ tag', function() {
     mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/health/graph/',
     });


### PR DESCRIPTION
* Also adds another test for requests w/o `tag`