### PR TITLE
fix(health): Change default projects to require membership

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationHealth/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/index.jsx
@@ -21,9 +21,13 @@ class OrganizationHealth extends React.Component {
 
   constructor(props) {
     super(props);
+    let {organization} = props;
+    let projects = organization.projects
+      .filter(({isMember}) => isMember)
+      .map(({id}) => id);
     this.state = {
       params: {
-        projects: [],
+        projects,
         environments: [],
         period: '7d',
       },


### PR DESCRIPTION
By default, selected projects should be all org projects that the user is a member of.