### PR TITLE
fix(2fa): Update created_at date on code regeneration

### DIFF
--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -317,6 +317,7 @@ class RecoveryCodeInterface(AuthenticatorInterface):
         if not self.is_enrolled:
             raise RuntimeError('Interface is not enrolled')
         self.config.update(self.generate_new_config())
+        self.authenticator.reset_fields(save=False)
         if save:
             self.authenticator.save()
 
@@ -609,6 +610,12 @@ class Authenticator(BaseModel):
 
     def mark_used(self, save=True):
         self.last_used_at = timezone.now()
+        if save:
+            self.save()
+
+    def reset_fields(self, save=True):
+        self.created_at = timezone.now()
+        self.last_used_at = None
         if save:
             self.save()
 


### PR DESCRIPTION
Updates created_at and last_used_at fields when recovery codes are regenerated. Fix for issue [5569](https://github.com/getsentry/sentry/issues/5569)