### PR TITLE
fix(auth): Style github button on org login page

### DIFF
--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -48,14 +48,26 @@
             </div>
           </form>
         </div>
-        {% if github_login_template or vsts_login_template %}
+        {% if github_login_template or github_login_link or vsts_login_link %}
           <div class="auth-provider-column">
             {% if github_login_template %}
               {% include github_login_template %}
             {% endif %}
 
-            {% if vsts_login_template %}
-              {% include vsts_login_template %}
+            {% if github_login_link %}
+              <p>
+                <a class="btn btn-default btn-login-github" href="{{ github_login_link }}" style="display: block">
+                  <span class="provider-logo github"></span> Sign in with GitHub
+                </a>
+              </p>
+            {% endif %}
+
+            {% if vsts_login_link %}
+              <p>
+                <a class="btn btn-default btn-login-vsts" href="{{ vsts_login_link }}" style="display: block">
+                  <span class="provider-logo vsts"></span> Sign in with VSTS
+                </a>
+              </p>
             {% endif %}
           </div>
         {% endif %}

--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -98,8 +98,20 @@
             {% include github_login_template %}
           {% endif %}
 
-          {% if vsts_login_template %}
-            {% include vsts_login_template %}
+          {% if github_login_link %}
+            <p style="text-align: center">
+              <a class="btn btn-default btn-login-github" href="{{ github_login_link }}" style="width: 50%">
+                <span class="provider-logo github"></span> Sign in with GitHub
+              </a>
+            </p>
+          {% endif %}
+
+          {% if vsts_login_link %}
+            <p style="text-align: center">
+              <a class="btn btn-default btn-login-vsts" href="{{ vsts_login_link }}" style="width: 50%">
+                <span class="provider-logo vsts"></span> Sign in with VSTS
+              </a>
+            </p>
           {% endif %}
 
           <p style="text-align: center">


### PR DESCRIPTION
Reduces the width of the "signup with github" button to match the login button on the org-login page (was missed in https://github.com/getsentry/sentry/pull/9064).

To support different styles on the login vs org-login page, we no longer inject the template from getsentry, we inject only the link.

Earlier:
<img width="702" alt="screenshot_2018-07-30_15 24 49" src="https://user-images.githubusercontent.com/693121/44131997-57885cd8-a00b-11e8-9960-58924adf95a1.png">
