### PR TITLE
fix(identity): Advance view correctly in Identity oauth

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -201,8 +201,9 @@ class OAuth2LoginView(PipelineView):
 
     @csrf_exempt
     def dispatch(self, request, pipeline):
-        if 'code' in request.GET:
-            return pipeline.next_step()
+        for param in ('code', 'error', 'state'):
+            if param in request.GET:
+                return pipeline.next_step()
 
         state = uuid4().hex
 


### PR DESCRIPTION
When a provider does a callback, we need to check for the presence of several query params, not just 'code'.