### PR TITLE
fix(docs): Changed `sentry start` to `sentry run web`

### DIFF
--- a/docs/installation/python/index.rst
+++ b/docs/installation/python/index.rst
@@ -361,7 +361,7 @@ go.
   [program:sentry-web]
   directory=/www/sentry/
   environment=SENTRY_CONF="/etc/sentry"
-  command=/www/sentry/bin/sentry start
+  command=/www/sentry/bin/sentry run web
   autostart=true
   autorestart=true
   redirect_stderr=true


### PR DESCRIPTION
Because `sentry start` is deprecated I changed it's reference, in installation documentation, to `sentry run web`.