### PR TITLE
fix(forms): Avoid remounting of form controls

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -392,23 +392,21 @@ class FormField extends React.Component {
 
                   return (
                     <React.Fragment>
-                      <this.props.children
-                        innerRef={this.handleInputMount}
-                        {...{
-                          ...props,
-                          name,
-                          id,
-                          onKeyDown: this.handleKeyDown,
-                          onChange: this.handleChange,
-                          onBlur: this.handleBlur,
-                          // Fixes react warnings about input switching from controlled to uncontrolled
-                          // So force to empty string for null values
-                          value: value === null ? '' : value,
-                          error,
-                          disabled,
-                        }}
-                        initialData={model.initialData}
-                      />
+                      {this.props.children({
+                        innerRef: this.handleInputMount,
+                        ...props,
+                        name,
+                        id,
+                        onKeyDown: this.handleKeyDown,
+                        onChange: this.handleChange,
+                        onBlur: this.handleBlur,
+                        // Fixes react warnings about input switching from controlled to uncontrolled
+                        // So force to empty string for null values
+                        value: value === null ? '' : value,
+                        error,
+                        disabled,
+                        initialData: model.initialData,
+                      })}
                       {showReturnButton && <ReturnButtonStyled />}
                     </React.Fragment>
                   );

--- a/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
@@ -195,7 +195,7 @@ exports[`FormField + model renders with Form 1`] = `
                                                         is={null}
                                                       >
                                                         <Observer>
-                                                          <Component
+                                                          <Input
                                                             disabled={false}
                                                             error={false}
                                                             field={[Function]}
@@ -209,33 +209,18 @@ exports[`FormField + model renders with Form 1`] = `
                                                             type="text"
                                                             value=""
                                                           >
-                                                            <Input
+                                                            <input
+                                                              className="css-1m7xmcf-Input-inputStyles e1xej46s0"
                                                               disabled={false}
-                                                              error={false}
-                                                              field={[Function]}
                                                               id="fieldName"
-                                                              initialData={Object {}}
-                                                              innerRef={[Function]}
                                                               name="fieldName"
                                                               onBlur={[Function]}
                                                               onChange={[Function]}
                                                               onKeyDown={[Function]}
                                                               type="text"
                                                               value=""
-                                                            >
-                                                              <input
-                                                                className="css-1m7xmcf-Input-inputStyles e1xej46s0"
-                                                                disabled={false}
-                                                                id="fieldName"
-                                                                name="fieldName"
-                                                                onBlur={[Function]}
-                                                                onChange={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                type="text"
-                                                                value=""
-                                                              />
-                                                            </Input>
-                                                          </Component>
+                                                            />
+                                                          </Input>
                                                         </Observer>
                                                       </div>
                                                     </Base>


### PR DESCRIPTION
There's a very subtle difference between calling our children function that renders the form control (as it's been changed to here), and declaring the function as a component using JSX.

#### React Reconciliation:

When rendering the children function as a component, we were adding it into reacts virtual DOM. Upon re-rendering, React will reconcile it's tree and look for differences. One of the things react compares is the node 'type'. such as a 'div', a component Class, or the component function. If the type differs of the node between the previous render and the next render, React will immediately assume that the entire browser DOM will need to be re-rendered because the node type has changed. What's important here, is that React does *instance comparison* of the type. If the type is a function, and that function differs, even if it is going to render the exact same thing *this node will be invalidated*.

#### What is happening here?

`this.props.children` typically comes from our various fields where the FormField is rendered with a function child. Many field types make use of the InputField component, specifying the `field` property with their own field to render. You can see here how the InputField renders the field property:

  https://github.com/getsentry/sentry/blob/0ac01ff8b4944ba38b9cc83213cab4777f44df52/src/sentry/static/sentry/app/views/settings/components/forms/inputField.jsx#L28-L34

  What's important to note here, is that *the children property, which is declared as a function, the same function being rendered in the FormField, is being DECLARED within our render*. Meaning, every time we re-render our field we are *redeclaring* our field rendering function.  When using that function as a component in the react tree, it will appear different to React *EVERY RENDER*, thus causing the entire control and it's subtree to be unmounted and remounted again, every render.

#### How does this fix that?

  Removing the field rendering function from the react tree (which you can see in the FormField test snapshot) Removes the unnamed function component which changes every render from the tree. This ensure that subtree will *not* re-render.