### PR TITLE
ref(integrations): Change VSTS display name.

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -151,6 +151,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             defaults={
                 'title': data.get('title'),
                 'description': data.get('description'),
+                'metadata': data.get('metadata'),
             }
         )
 

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -75,6 +75,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         defaults = {
             'title': data.get('title'),
             'description': data.get('description'),
+            'metadata': data.get('metadata'),
         }
 
         external_issue_key = installation.make_external_key(data)
@@ -117,6 +118,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             'key': external_issue.key,
             'url': url,
             'integrationId': external_issue.integration_id,
+            'display_name': installation.get_issue_display_name(external_issue),
         }
         return Response(context, status=201)
 
@@ -182,7 +184,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             'key': external_issue.key,
             'url': url,
             'integrationId': external_issue.integration_id,
-
+            'displayName': installation.get_issue_display_name(external_issue),
         }
         return Response(context, status=201)
 

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -118,7 +118,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             'key': external_issue.key,
             'url': url,
             'integrationId': external_issue.integration_id,
-            'display_name': installation.get_issue_display_name(external_issue),
+            'displayName': installation.get_issue_display_name(external_issue),
         }
         return Response(context, status=201)
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -152,12 +152,15 @@ class IntegrationIssueSerializer(IntegrationSerializer):
         ints_by_id = {i.id: i for i in item_list}
         for ei in external_issues:
             # TODO(jess): move into an external issue serializer?
+            installation = ints_by_id[ei.integration_id].get_installation(
+                self.group.organization.id)
             issues_by_integration[ei.integration_id].append({
                 'id': six.text_type(ei.id),
                 'key': ei.key,
-                'url': ints_by_id[ei.integration_id].get_installation(self.group.organization.id).get_issue_url(ei.key),
+                'url': installation.get_issue_url(ei.key),
                 'title': ei.title,
                 'description': ei.description,
+                'displayName': installation.get_issue_display_name(ei),
             })
 
         return {

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -84,6 +84,9 @@ class ExampleIntegration(Integration, IssueSyncMixin):
     def should_resolve(self, data):
         return data['status']['category'] == 'done'
 
+    def get_issue_display_name(self, external_issue):
+        return 'display name: %s' % external_issue.key
+
 
 class ExampleIntegrationProvider(IntegrationProvider):
     """

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -153,7 +153,7 @@ class IssueBasicMixin(object):
         This is not required but helpful for integrations whose external issue key
         does not match the disired display name.
         """
-        return None
+        return ''
 
 
 class IssueSyncMixin(IssueBasicMixin):

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -148,12 +148,10 @@ class IssueBasicMixin(object):
 
     def get_issue_display_name(self, external_issue_key):
         """
-
         Returns the display name of the issue.
 
         This is not required but helpful for integrations whose external issue key
         does not match the disired display name.
-
         """
         return None
 

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -146,6 +146,17 @@ class IssueBasicMixin(object):
         """
         return data['key']
 
+    def get_issue_display_name(self, external_issue_key):
+        """
+
+        Returns the display name of the issue.
+
+        This is not required but helpful for integrations whose external issue key
+        does not match the disired display name.
+
+        """
+        return None
+
 
 class IssueSyncMixin(IssueBasicMixin):
     comment_key = None

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -31,8 +31,9 @@ class VstsIssueSync(IssueSyncMixin):
         project_choices = []
         initial_project = ('', '')
         for project in projects:
-            project_choices.append(('%s#%s' % (project['id'], project['name']), project['name']))
-            if project['id'] == self.default_project:
+            project_id_and_name = '%s#%s' % (project['id'], project['name'])
+            project_choices.append((project_id_and_name, project['name']))
+            if project_id_and_name == self.default_project:
                 initial_project = project['name']
         return [
             {

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -33,6 +33,7 @@ class VstsIssueSync(IssueSyncMixin):
         for project in projects:
             project_id_and_name = '%s#%s' % (project['id'], project['name'])
             project_choices.append((project_id_and_name, project['name']))
+            # TODO(lb): Properly handle default project after it has been implemented.
             if project_id_and_name == self.default_project:
                 initial_project = project['name']
         return [

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -215,3 +215,6 @@ class VstsIssueSync(IssueSyncMixin):
             state['name'] for state in all_states if state['category'] in self.done_categories
         ]
         return done_states
+
+    def get_issue_display_name(self, external_issue):
+        pass

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
@@ -257,9 +257,9 @@ class ExternalIssueActions extends AsyncComponent {
         <IssueSyncListElement
           onOpen={this.openModal}
           externalIssueLink={issue ? issue.url : null}
-          externalIssueId={issue ? `${issue.id}` : null}
-          externalIssueKey={issue ? `${issue.key}` : null}
-          externalIssueDisplayName={issue ? issue.displayName : null }
+          externalIssueId={issue ? issue.id : null}
+          externalIssueKey={issue ? issue.key : null}
+          externalIssueDisplayName={issue ? issue.displayName : null}
           onClose={this.deleteIssue.bind(this)}
           integrationType={selectedIntegration.provider.key}
           integrationName={selectedIntegration.name}

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
@@ -258,7 +258,8 @@ class ExternalIssueActions extends AsyncComponent {
           onOpen={this.openModal}
           externalIssueLink={issue ? issue.url : null}
           externalIssueId={issue ? `${issue.id}` : null}
-          externalIssueKey={issue ? issue.displayName || `${issue.key}` : null}
+          externalIssueKey={issue ? `${issue.key}` : null}
+          externalIssueDisplayName={issue ? issue.displayName : null }
           onClose={this.deleteIssue.bind(this)}
           integrationType={selectedIntegration.provider.key}
           integrationName={selectedIntegration.name}

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
@@ -252,14 +252,13 @@ class ExternalIssueActions extends AsyncComponent {
 
   renderBody() {
     let {action, selectedIntegration, issue} = this.state;
-
     return (
       <React.Fragment>
         <IssueSyncListElement
           onOpen={this.openModal}
           externalIssueLink={issue ? issue.url : null}
-          externalIssueId={issue ? issue.id : null}
-          externalIssueKey={issue ? issue.key : null}
+          externalIssueId={issue ? `${issue.id}` : null}
+          externalIssueKey={issue ? issue.displayName || `${issue.key}` : null}
           onClose={this.deleteIssue.bind(this)}
           integrationType={selectedIntegration.provider.key}
           integrationName={selectedIntegration.name}

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
@@ -83,8 +83,8 @@ class IssueSyncElement extends React.Component {
     if (this.props.children) {
       return this.props.children;
     }
-    if (this.props.displayName) {
-      return this.props.displayName;
+    if (this.props.externalIssueDisplayName) {
+      return this.props.externalIssueDisplayName;
     }
     if (this.props.externalIssueKey) {
       return this.props.externalIssueKey;

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
@@ -21,6 +21,7 @@ class IssueSyncElement extends React.Component {
     externalIssueLink: PropTypes.string,
     externalIssueId: PropTypes.number,
     externalIssueKey: PropTypes.string,
+    externalIssueDisplayName: PropTypes.string,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     integrationType: PropTypes.string,
@@ -78,13 +79,14 @@ class IssueSyncElement extends React.Component {
   }
 
   getText() {
+    debugger;
     if (this.props.children) {
       return this.props.children;
     }
+    if (this.props.displayName) {
+      return this.props.displayName;
+    }
     if (this.props.externalIssueKey) {
-      if (this.props.integrationType === 'vsts' && this.props.integrationName) {
-        return `${this.props.integrationName}#${this.props.externalIssueKey}`;
-      }
       return this.props.externalIssueKey;
     }
 

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
@@ -79,7 +79,6 @@ class IssueSyncElement extends React.Component {
   }
 
   getText() {
-    debugger;
     if (this.props.children) {
       return this.props.children;
     }

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -215,6 +215,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
   }
 >
   <IssueSyncElement
+    externalIssueDisplayName={null}
     externalIssueId={null}
     externalIssueKey={null}
     externalIssueLink={null}

--- a/tests/sentry/api/endpoints/test_group_integrations.py
+++ b/tests/sentry/api/endpoints/test_group_integrations.py
@@ -56,6 +56,7 @@ class GroupIntegrationsTest(APITestCase):
                 'id': six.text_type(external_issue.id),
                 'url': 'https://example/issues/APP-123',
                 'key': 'APP-123',
-                'title': 'this is an example title'
+                'title': 'this is an example title',
+                'displayName': 'display name: APP-123',
             }],
         }

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -54,7 +54,7 @@ class VstsIssueSycnTest(TestCase):
             'sync_reverse_assignment': True,
         }
         self.integration = VstsIntegration(model, self.organization.id)
-        self.issue_id = 309
+        self.issue_id = '309'
 
     @responses.activate
     def test_create_issue(self):
@@ -70,11 +70,15 @@ class VstsIssueSycnTest(TestCase):
         form_data = {
             'title': 'Hello',
             'description': 'Fix this.',
+            'project': '0987654321#Fabrikam-Fiber-Git',
         }
         assert self.integration.create_issue(form_data) == {
             'key': self.issue_id,
             'description': 'Fix this.',
             'title': 'Hello',
+            'metadata': {
+                'display_name': u'Fabrikam-Fiber-Git#309'
+            }
         }
         request = responses.calls[-1].request
         assert request.headers['Content-Type'] == 'application/json-patch+json'
@@ -111,7 +115,7 @@ class VstsIssueSycnTest(TestCase):
     def test_get_issue(self):
         responses.add(
             responses.GET,
-            'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%d' % self.issue_id,
+            'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%s' % self.issue_id,
             body=WORK_ITEM_RESPONSE,
             content_type='application/json',
         )
@@ -119,6 +123,9 @@ class VstsIssueSycnTest(TestCase):
             'key': self.issue_id,
             'description': 'Fix this.',
             'title': 'Hello',
+            'metadata': {
+                'display_name': u'Fabrikam-Fiber-Git#309'
+            },
         }
         request = responses.calls[-1].request
         assert request.headers['Content-Type'] == 'application/json'


### PR DESCRIPTION
Dependent on #9433. We want to change VSTS issue names to display as `<project_name>#<issue_id>`, but this convention has no meaning in VSTS. This change uses a newly created field to store the `display_name` in the `ExternalIssue` model, and uses the frontend to display it to the user.

Does not currently handle default value changes.