### PR TITLE
perf: Remove 2 out of 4 snuba queries made by tagstore endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -46,24 +46,22 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise ResourceDoesNotExist
 
         try:
-            tag_key = tagstore.get_tag_key(group.project_id, environment_id, lookup_key)
-        except tagstore.TagKeyNotFound:
-            raise ResourceDoesNotExist
-
-        try:
             group_tag_key = tagstore.get_group_tag_key(
                 group.project_id, group.id, environment_id, lookup_key)
         except tagstore.GroupTagKeyNotFound:
             raise ResourceDoesNotExist
 
-        total_values = tagstore.get_group_tag_value_count(
-            group.project_id, group.id, environment_id, lookup_key)
+        if group_tag_key.count is None:
+            total_values = tagstore.get_group_tag_value_count(
+                group.project_id, group.id, environment_id, lookup_key)
+        else:
+            total_values = group_tag_key.count
         top_values = tagstore.get_top_group_tag_values(
             group.project_id, group.id, environment_id, lookup_key, limit=9)
 
         data = {
             'key': key,
-            'name': tagstore.get_tag_key_label(tag_key.key),
+            'name': tagstore.get_tag_key_label(group_tag_key.key),
             'uniqueValues': group_tag_key.values_seen,
             'totalValues': total_values,
             'topValues': serialize(top_values, request.user),

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -50,10 +50,11 @@ class TagValue(TagType):
 class GroupTagKey(TagType):
     __slots__ = ['group_id', 'key', 'values_seen']
 
-    def __init__(self, group_id, key, values_seen):
+    def __init__(self, group_id, key, values_seen, count=None):
         self.group_id = group_id
         self.key = key
         self.values_seen = values_seen
+        self.count = count
 
 
 class GroupTagValue(TagType):


### PR DESCRIPTION
- Remove separate call to get the (non-group) tag_key, as the only
  purpose of this is to use the `key` attribute (which is always the same
  as the GroupTagKey's key) or raise if the tag doesn't exist (in which
  case the GroupTagKey would also not exist, so it will raise there
  anyway)

- Modify the snuba version of get_tag_key to return the total count as
  well as the unique count, as these queries have the same
  filters/conditions, and both values can be retrieved with a single
  snuba query. In legacy/v2 tagstore land we continue to to the second
  query to get the count.