### PR TITLE
fix(ownership): All unverified emails to be used

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -97,7 +97,8 @@ def resolve_actors(owners, project_id):
                     operator.or_,
                     [Q(emails__email__iexact=o.identifier) for o in users]
                 ),
-                emails__is_verified=True,
+                # We don't require verified emails
+                # emails__is_verified=True,
                 is_active=True,
                 sentry_orgmember_set__organizationmemberteam__team__projectteam__project_id=project_id,
             ).distinct().values_list('id', 'emails__email')

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -143,7 +143,9 @@ class ResolveActorsTestCase(TestCase):
         # Another secondary email, that isn't verified
         email2 = self.create_useremail(self.user, None, is_verified=False).email
         owner3 = Owner('user', email2)
-        actor3 = None
+        # Intentionally allow unverified emails
+        # actor3 = None
+        actor3 = actor1
 
         # An entirely unknown user
         owner4 = Owner('user', 'nope')


### PR DESCRIPTION
This restores the old behavior which didn't assert the email was
verified. The previous patch caused a regression then in this regard
while trying to add users without verified emails.