### PR TITLE
feat(integrations): settings list design touches

### DIFF
--- a/src/sentry/static/sentry/app/components/buttons/button.jsx
+++ b/src/sentry/static/sentry/app/components/buttons/button.jsx
@@ -78,7 +78,8 @@ class Button extends React.Component {
       icon,
       children,
       label,
-
+      borderless,
+      priority,
       // destructure from `buttonProps`
       // not necessary, but just in case someone re-orders props
       // eslint-disable-next-line no-unused-vars
@@ -98,11 +99,13 @@ class Button extends React.Component {
         to={this.getUrl(to)}
         href={this.getUrl(href)}
         size={size}
+        priority={priority}
+        borderless={borderless}
         {...buttonProps}
         onClick={this.handleClick}
         role="button"
       >
-        <ButtonLabel size={size}>
+        <ButtonLabel size={size} priority={priority} borderless={borderless}>
           {icon && (
             <Icon size={size} hasChildren={!!children}>
               <StyledInlineSvg
@@ -139,7 +142,8 @@ const getFontSize = ({size, theme}) => {
   }
 };
 
-const getFontWeight = ({priority}) => `font-weight: ${priority === 'link' ? 400 : 600};`;
+const getFontWeight = ({priority, borderless}) =>
+  `font-weight: ${priority === 'link' || borderless ? 400 : 600};`;
 
 const getBoxShadow = active => ({priority, borderless, disabled}) => {
   if (disabled || borderless || priority === 'link') {
@@ -225,7 +229,7 @@ const StyledButton = styled(({busy, external, borderless, ...props}) => {
 /**
  * Get label padding determined by size
  */
-const getLabelPadding = ({size, priority}) => {
+const getLabelPadding = ({size, priority, borderless}) => {
   if (priority === 'link') {
     return '0';
   }
@@ -234,18 +238,20 @@ const getLabelPadding = ({size, priority}) => {
     case 'zero':
       return '0';
     case 'xsmall':
-      return '6px 10px';
+      return borderless ? '4px 6px' : '6px 10px';
     case 'small':
-      return '8px 12px;';
+      return borderless ? '6px 8px' : '8px 12px';
     case 'large':
-      return '14px 20px';
+      return borderless ? '8px 10px' : '14px 20px';
 
     default:
-      return '12px 16px;';
+      return borderless ? '6px 10px' : '12px 16px';
   }
 };
 
-const ButtonLabel = styled(props => <Flex align="center" {...props} />)`
+const ButtonLabel = styled(({size, priority, borderless, ...props}) => (
+  <Flex align="center" {...props} />
+))`
   padding: ${getLabelPadding};
 `;
 
@@ -258,7 +264,7 @@ const getIconMargin = ({size, hasChildren}) => {
   return size === 'small' ? '6px' : '8px';
 };
 
-const Icon = styled(({hasChildren, ...props}) => <Box {...props} />)`
+const Icon = styled(Box)`
   margin-right: ${getIconMargin};
 `;
 

--- a/src/sentry/static/sentry/app/components/buttons/button.jsx
+++ b/src/sentry/static/sentry/app/components/buttons/button.jsx
@@ -264,7 +264,7 @@ const getIconMargin = ({size, hasChildren}) => {
   return size === 'small' ? '6px' : '8px';
 };
 
-const Icon = styled(Box)`
+const Icon = styled(({hasChildren, ...props}) => <Box {...props} />)`
   margin-right: ${getIconMargin};
 `;
 

--- a/src/sentry/static/sentry/app/styles/animations.jsx
+++ b/src/sentry/static/sentry/app/styles/animations.jsx
@@ -9,6 +9,15 @@ export const growIn = keyframes`
   }
 `;
 
+export const growDown = height => keyframes`
+  0% {
+    height: 0;
+  }
+  100% {
+    height: ${height};
+  }
+`;
+
 export const fadeOut = keyframes`
   0% {
     opacity: 1;
@@ -63,5 +72,16 @@ export const slideInUp = keyframes`
   100% {
     transform: translateY(0);
     opacity: 1;
+  }
+`;
+
+export const highlight = color => keyframes`
+  0%,
+  100% {
+    background: rgba(255, 255, 255, 0);
+  }
+
+  25% {
+    background: ${color};
   }
 `;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
@@ -1,4 +1,5 @@
 import {Box, Flex} from 'grid-emotion';
+import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -12,10 +13,14 @@ import Tooltip from 'app/components/tooltip';
 
 const CONFIGURABLE_FEATURES = ['commits'];
 
+const StyledButton = styled(Button)`
+  color: ${p => p.theme.gray2};
+`;
+
 const removeButton = (
-  <Button borderless size="xsmall" icon="icon-trash">
+  <StyledButton borderless icon="icon-trash">
     Remove
-  </Button>
+  </StyledButton>
 );
 
 export default class InstalledIntegration extends React.Component {
@@ -121,7 +126,7 @@ export default class InstalledIntegration extends React.Component {
         <Box flex={1}>
           <IntegrationItem compact integration={integration} />
         </Box>
-        <Box mr={1}>
+        <Box>
           {integration.status === 'disabled' && (
             <AddIntegrationButton
               size="xsmall"
@@ -139,15 +144,14 @@ export default class InstalledIntegration extends React.Component {
               title="Integration not configurable"
             >
               <span>
-                <Button
+                <StyledButton
                   borderless
-                  size="xsmall"
                   icon="icon-settings"
                   disabled={!this.hasConfiguration()}
                   to={`/settings/${orgId}/integrations/${provider.key}/${integration.id}/`}
                 >
                   Configure
-                </Button>
+                </StyledButton>
               </span>
             </Tooltip>
           )}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.jsx
@@ -20,7 +20,7 @@ export default class IntegrationItem extends React.Component {
     return (
       <Flex>
         <Box>
-          <IntegrationIcon size={compact ? 26 : 32} integration={integration} />
+          <IntegrationIcon size={compact ? 22 : 32} integration={integration} />
         </Box>
         <Labels compact={compact}>
           <IntegrationName>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -14,6 +14,7 @@ import Link from 'app/components/link';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
+import {growDown, highlight} from 'app/styles/animations';
 
 export default class ProviderRow extends React.Component {
   static contextTypes = {
@@ -95,7 +96,7 @@ export default class ProviderRow extends React.Component {
             <ProviderName>{this.props.provider.name}</ProviderName>
             <ProviderDetails>
               <Status enabled={this.isEnabled} />
-              <Link onClick={this.openModal}>Learn More</Link>
+              <StyledLink onClick={openModal}>Learn More</StyledLink>
             </ProviderDetails>
           </Box>
           <Box>{this.renderButton()}</Box>
@@ -106,30 +107,33 @@ export default class ProviderRow extends React.Component {
   }
 }
 
-const ProviderName = styled('div')`
-  font-weight: bold;
-`;
-
 const ProviderDetails = styled(Flex)`
   align-items: center;
   margin-top: 6px;
-  font-size: 0.8em;
+  font-size: 0.9em;
 `;
 
 const Status = styled(
   withTheme(props => {
     const {enabled, ...p} = props;
     return (
-      <React.Fragment>
-        <CircleIndicator size={6} color={enabled ? p.theme.success : p.theme.gray2} />
+      <Flex align="center">
+        <CircleIndicator size={7} color={enabled ? p.theme.success : p.theme.gray2} />
         <div {...p}>{enabled ? t('Installed') : t('Not Installed')}</div>
-      </React.Fragment>
+      </Flex>
     );
   })
 )`
   color: ${p => (p.enabled ? p.theme.success : p.theme.gray2)};
-  margin-left: 5px;
-  margin-right: 10px;
+  margin-left: ${space(1)};
+  &:after {
+    content: '|';
+    color: ${p => p.theme.gray1};
+    margin-left: ${space(0.75)};
+    font-weight: normal;
+  }
+  margin-right: ${space(0.75)};
+  font-weight: bold;
 `;
 
 const StyledInstalledIntegration = styled(
@@ -145,29 +149,20 @@ const StyledInstalledIntegration = styled(
   padding: ${space(2)};
   padding-left: 0;
   margin-left: 68px;
-  border-top: 1px dotted ${p => p.theme.borderLight};
+  border-top: 1px dashed ${p => p.theme.borderLight};
+`;
+
+const StyledLink = styled(Link)`
+  color: ${p => p.theme.gray2};
+`;
+
+const ProviderName = styled('div')`
+  font-size: 1.1em;
 `;
 
 const NewInstallation = styled('div')`
-  @keyframes slidein {
-    from {
-      height: 0;
-    }
-    to {
-      height: 59px;
-    }
-  }
-  @keyframes highlight {
-    0%,
-    100% {
-      height: rgba(255, 255, 255, 0);
-    }
-
-    25% {
-      background: ${p => p.theme.yellowLightest};
-    }
-  }
-
+  animation: ${growDown('59px')} 160ms 500ms ease-in-out forwards,
+    ${p => highlight(p.theme.yellowLightest)} 1000ms 500ms ease-in-out forwards;
   height: 0;
   overflow: hidden;
   animation: slidein 160ms 500ms ease-in-out forwards,

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -107,10 +107,15 @@ export default class ProviderRow extends React.Component {
   }
 }
 
+
+const ProviderName = styled('div')`
+  font-weight: bold;
+`;
+
 const ProviderDetails = styled(Flex)`
   align-items: center;
   margin-top: 6px;
-  font-size: 0.9em;
+  font-size: 0.8em;
 `;
 
 const Status = styled(
@@ -133,7 +138,13 @@ const Status = styled(
     font-weight: normal;
   }
   margin-right: ${space(0.75)};
-  font-weight: bold;
+`;
+
+const NewInstallation = styled('div')`
+  overflow: hidden;
+  transform-origin: 0 auto;
+  animation: ${growDown('59px')} 160ms 500ms ease-in-out forwards,
+    ${p => highlight(p.theme.yellowLightest)} 1000ms 500ms ease-in-out forwards;
 `;
 
 const StyledInstalledIntegration = styled(
@@ -154,17 +165,4 @@ const StyledInstalledIntegration = styled(
 
 const StyledLink = styled(Link)`
   color: ${p => p.theme.gray2};
-`;
-
-const ProviderName = styled('div')`
-  font-size: 1.1em;
-`;
-
-const NewInstallation = styled('div')`
-  animation: ${growDown('59px')} 160ms 500ms ease-in-out forwards,
-    ${p => highlight(p.theme.yellowLightest)} 1000ms 500ms ease-in-out forwards;
-  height: 0;
-  overflow: hidden;
-  animation: slidein 160ms 500ms ease-in-out forwards,
-    highlight 1000ms 500ms ease-in-out forwards;
 `;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -129,7 +129,7 @@ const Status = styled(
   })
 )`
   color: ${p => (p.enabled ? p.theme.success : p.theme.gray2)};
-  margin-left: ${space(1)};
+  margin-left: ${space(0.5)};
   &:after {
     content: '|';
     color: ${p => p.theme.gray1};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -107,7 +107,6 @@ export default class ProviderRow extends React.Component {
   }
 }
 
-
 const ProviderName = styled('div')`
   font-weight: bold;
 `;
@@ -123,7 +122,7 @@ const Status = styled(
     const {enabled, ...p} = props;
     return (
       <Flex align="center">
-        <CircleIndicator size={7} color={enabled ? p.theme.success : p.theme.gray2} />
+        <CircleIndicator size={6} color={enabled ? p.theme.success : p.theme.gray2} />
         <div {...p}>{enabled ? t('Installed') : t('Not Installed')}</div>
       </Flex>
     );

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -96,7 +96,7 @@ export default class ProviderRow extends React.Component {
             <ProviderName>{this.props.provider.name}</ProviderName>
             <ProviderDetails>
               <Status enabled={this.isEnabled} />
-              <StyledLink onClick={openModal}>Learn More</StyledLink>
+              <StyledLink onClick={this.openModal}>Learn More</StyledLink>
             </ProviderDetails>
           </Box>
           <Box>{this.renderButton()}</Box>

--- a/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
@@ -10,6 +10,7 @@ exports[`Button renders 1`] = `
   size="large"
 >
   <ButtonLabel
+    priority="primary"
     size="large"
   >
     Button

--- a/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
@@ -278,18 +278,18 @@ exports[`ConfirmDelete renders 1`] = `
                 >
                   <ButtonLabel>
                     <Component
-                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                      className="css-1emshjx-ButtonLabel e17811v31"
                     >
                       <Flex
                         align="center"
-                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                        className="css-1emshjx-ButtonLabel e17811v31"
                       >
                         <Base
                           align="center"
-                          className="e17811v31 css-mvnt76-ButtonLabel"
+                          className="e17811v31 css-1nhrbny-ButtonLabel"
                         >
                           <div
-                            className="e17811v31 css-mvnt76-ButtonLabel"
+                            className="e17811v31 css-1nhrbny-ButtonLabel"
                             is={null}
                           >
                             Cancel
@@ -344,20 +344,23 @@ exports[`ConfirmDelete renders 1`] = `
                   role="button"
                   to={null}
                 >
-                  <ButtonLabel>
+                  <ButtonLabel
+                    priority="primary"
+                  >
                     <Component
-                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                      className="css-1emshjx-ButtonLabel e17811v31"
+                      priority="primary"
                     >
                       <Flex
                         align="center"
-                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                        className="css-1emshjx-ButtonLabel e17811v31"
                       >
                         <Base
                           align="center"
-                          className="e17811v31 css-mvnt76-ButtonLabel"
+                          className="e17811v31 css-1nhrbny-ButtonLabel"
                         >
                           <div
-                            className="e17811v31 css-mvnt76-ButtonLabel"
+                            className="e17811v31 css-1nhrbny-ButtonLabel"
                             is={null}
                           >
                             Confirm

--- a/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
@@ -355,20 +355,23 @@ exports[`FormField + model renders with Form 1`] = `
                 role="button"
                 type="submit"
               >
-                <ButtonLabel>
+                <ButtonLabel
+                  priority="primary"
+                >
                   <Component
-                    className="css-1dxlw1i-ButtonLabel e17811v31"
+                    className="css-1emshjx-ButtonLabel e17811v31"
+                    priority="primary"
                   >
                     <Flex
                       align="center"
-                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                      className="css-1emshjx-ButtonLabel e17811v31"
                     >
                       <Base
                         align="center"
-                        className="e17811v31 css-mvnt76-ButtonLabel"
+                        className="e17811v31 css-1nhrbny-ButtonLabel"
                       >
                         <div
-                          className="e17811v31 css-mvnt76-ButtonLabel"
+                          className="e17811v31 css-1nhrbny-ButtonLabel"
                           is={null}
                         >
                           Save Changes

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1124,23 +1124,20 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                       size="small"
                     >
                       <Component
-                        className="css-19bmqb3-ButtonLabel e17811v31"
+                        className="css-o42ntg-ButtonLabel e17811v31"
                         size="small"
                       >
                         <Flex
                           align="center"
-                          className="css-19bmqb3-ButtonLabel e17811v31"
-                          size="small"
+                          className="css-o42ntg-ButtonLabel e17811v31"
                         >
                           <Base
                             align="center"
-                            className="e17811v31 css-1eblpyp-ButtonLabel"
-                            size="small"
+                            className="e17811v31 css-l5mlqc-ButtonLabel"
                           >
                             <div
-                              className="e17811v31 css-1eblpyp-ButtonLabel"
+                              className="e17811v31 css-l5mlqc-ButtonLabel"
                               is={null}
-                              size="small"
                             >
                               Learn more
                             </div>

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -449,23 +449,20 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                   size="small"
                                 >
                                   <Component
-                                    className="css-19bmqb3-ButtonLabel e17811v31"
+                                    className="css-o42ntg-ButtonLabel e17811v31"
                                     size="small"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
-                                      size="small"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                                        size="small"
+                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                           is={null}
-                                          size="small"
                                         >
                                           Compare
                                         </div>
@@ -522,23 +519,20 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                   size="small"
                                 >
                                   <Component
-                                    className="css-19bmqb3-ButtonLabel e17811v31"
+                                    className="css-o42ntg-ButtonLabel e17811v31"
                                     size="small"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
-                                      size="small"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                                        size="small"
+                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                           is={null}
-                                          size="small"
                                         >
                                           Collapse All
                                         </div>
@@ -1914,23 +1908,20 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                   size="small"
                                 >
                                   <Component
-                                    className="css-19bmqb3-ButtonLabel e17811v31"
+                                    className="css-o42ntg-ButtonLabel e17811v31"
                                     size="small"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
-                                      size="small"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                                        size="small"
+                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                           is={null}
-                                          size="small"
                                         >
                                           Compare
                                         </div>
@@ -1987,23 +1978,20 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                   size="small"
                                 >
                                   <Component
-                                    className="css-19bmqb3-ButtonLabel e17811v31"
+                                    className="css-o42ntg-ButtonLabel e17811v31"
                                     size="small"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
-                                      size="small"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                                        size="small"
+                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                           is={null}
-                                          size="small"
                                         >
                                           Collapse All
                                         </div>

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -164,17 +164,14 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                         <Flex
                                                           align="center"
                                                           className="css-6q5v1w-ButtonLabel e17811v31"
-                                                          size="xsmall"
                                                         >
                                                           <Base
                                                             align="center"
                                                             className="e17811v31 css-dqr4rq-ButtonLabel"
-                                                            size="xsmall"
                                                           >
                                                             <div
                                                               className="e17811v31 css-dqr4rq-ButtonLabel"
                                                               is={null}
-                                                              size="xsmall"
                                                             >
                                                               Add Project
                                                               <StyledChevronDown>
@@ -419,23 +416,20 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                               size="small"
                             >
                               <Component
-                                className="css-19bmqb3-ButtonLabel e17811v31"
+                                className="css-o42ntg-ButtonLabel e17811v31"
                                 size="small"
                               >
                                 <Flex
                                   align="center"
-                                  className="css-19bmqb3-ButtonLabel e17811v31"
-                                  size="small"
+                                  className="css-o42ntg-ButtonLabel e17811v31"
                                 >
                                   <Base
                                     align="center"
-                                    className="e17811v31 css-1eblpyp-ButtonLabel"
-                                    size="small"
+                                    className="e17811v31 css-l5mlqc-ButtonLabel"
                                   >
                                     <div
-                                      className="e17811v31 css-1eblpyp-ButtonLabel"
+                                      className="e17811v31 css-l5mlqc-ButtonLabel"
                                       is={null}
-                                      size="small"
                                     >
                                       <RemoveIcon>
                                         <Component

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -108,7 +108,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                 role="button"
               >
                 <div
-                  class="e17811v31 css-mvnt76-ButtonLabel"
+                  class="e17811v31 css-1nhrbny-ButtonLabel"
                 >
                   Restore Organization
                 </div>

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -848,26 +848,25 @@ exports[`Project Ownership Input renders 1`] = `
                   to={null}
                 >
                   <ButtonLabel
+                    priority="primary"
                     size="small"
                   >
                     <Component
-                      className="css-19bmqb3-ButtonLabel e17811v31"
+                      className="css-o42ntg-ButtonLabel e17811v31"
+                      priority="primary"
                       size="small"
                     >
                       <Flex
                         align="center"
-                        className="css-19bmqb3-ButtonLabel e17811v31"
-                        size="small"
+                        className="css-o42ntg-ButtonLabel e17811v31"
                       >
                         <Base
                           align="center"
-                          className="e17811v31 css-1eblpyp-ButtonLabel"
-                          size="small"
+                          className="e17811v31 css-l5mlqc-ButtonLabel"
                         >
                           <div
-                            className="e17811v31 css-1eblpyp-ButtonLabel"
+                            className="e17811v31 css-l5mlqc-ButtonLabel"
                             is={null}
-                            size="small"
                           >
                             <Icon
                               hasChildren={false}
@@ -1038,26 +1037,25 @@ url:http://example.com/settings/* #product"
                       size="small"
                     >
                       <ButtonLabel
+                        priority="primary"
                         size="small"
                       >
                         <Component
-                          className="css-19bmqb3-ButtonLabel e17811v31"
+                          className="css-o42ntg-ButtonLabel e17811v31"
+                          priority="primary"
                           size="small"
                         >
                           <Flex
                             align="center"
-                            className="css-19bmqb3-ButtonLabel e17811v31"
-                            size="small"
+                            className="css-o42ntg-ButtonLabel e17811v31"
                           >
                             <Base
                               align="center"
-                              className="e17811v31 css-1eblpyp-ButtonLabel"
-                              size="small"
+                              className="e17811v31 css-l5mlqc-ButtonLabel"
                             >
                               <div
-                                className="e17811v31 css-1eblpyp-ButtonLabel"
+                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                 is={null}
-                                size="small"
                               >
                                 Save Changes
                               </div>

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -707,23 +707,20 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                                 size="small"
                                               >
                                                 <Component
-                                                  className="css-19bmqb3-ButtonLabel e17811v31"
+                                                  className="css-o42ntg-ButtonLabel e17811v31"
                                                   size="small"
                                                 >
                                                   <Flex
                                                     align="center"
-                                                    className="css-19bmqb3-ButtonLabel e17811v31"
-                                                    size="small"
+                                                    className="css-o42ntg-ButtonLabel e17811v31"
                                                   >
                                                     <Base
                                                       align="center"
-                                                      className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                      size="small"
+                                                      className="e17811v31 css-l5mlqc-ButtonLabel"
                                                     >
                                                       <div
-                                                        className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                                         is={null}
-                                                        size="small"
                                                       >
                                                         <Icon
                                                           hasChildren={false}
@@ -1491,23 +1488,20 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                                 size="small"
                                               >
                                                 <Component
-                                                  className="css-19bmqb3-ButtonLabel e17811v31"
+                                                  className="css-o42ntg-ButtonLabel e17811v31"
                                                   size="small"
                                                 >
                                                   <Flex
                                                     align="center"
-                                                    className="css-19bmqb3-ButtonLabel e17811v31"
-                                                    size="small"
+                                                    className="css-o42ntg-ButtonLabel e17811v31"
                                                   >
                                                     <Base
                                                       align="center"
-                                                      className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                      size="small"
+                                                      className="e17811v31 css-l5mlqc-ButtonLabel"
                                                     >
                                                       <div
-                                                        className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                                         is={null}
-                                                        size="small"
                                                       >
                                                         <Icon
                                                           hasChildren={false}
@@ -2338,18 +2332,18 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   >
                                     <ButtonLabel>
                                       <Component
-                                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                                        className="css-1emshjx-ButtonLabel e17811v31"
                                       >
                                         <Flex
                                           align="center"
-                                          className="css-1dxlw1i-ButtonLabel e17811v31"
+                                          className="css-1emshjx-ButtonLabel e17811v31"
                                         >
                                           <Base
                                             align="center"
-                                            className="e17811v31 css-mvnt76-ButtonLabel"
+                                            className="e17811v31 css-1nhrbny-ButtonLabel"
                                           >
                                             <div
-                                              className="e17811v31 css-mvnt76-ButtonLabel"
+                                              className="e17811v31 css-1nhrbny-ButtonLabel"
                                               is={null}
                                             >
                                               Cancel
@@ -2391,20 +2385,23 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 priority="primary"
                                 role="button"
                               >
-                                <ButtonLabel>
+                                <ButtonLabel
+                                  priority="primary"
+                                >
                                   <Component
-                                    className="css-1dxlw1i-ButtonLabel e17811v31"
+                                    className="css-1emshjx-ButtonLabel e17811v31"
+                                    priority="primary"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                                      className="css-1emshjx-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-mvnt76-ButtonLabel"
+                                        className="e17811v31 css-1nhrbny-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-mvnt76-ButtonLabel"
+                                          className="e17811v31 css-1nhrbny-ButtonLabel"
                                           is={null}
                                         >
                                           Save Rule
@@ -4481,18 +4478,18 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                   >
                                     <ButtonLabel>
                                       <Component
-                                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                                        className="css-1emshjx-ButtonLabel e17811v31"
                                       >
                                         <Flex
                                           align="center"
-                                          className="css-1dxlw1i-ButtonLabel e17811v31"
+                                          className="css-1emshjx-ButtonLabel e17811v31"
                                         >
                                           <Base
                                             align="center"
-                                            className="e17811v31 css-mvnt76-ButtonLabel"
+                                            className="e17811v31 css-1nhrbny-ButtonLabel"
                                           >
                                             <div
-                                              className="e17811v31 css-mvnt76-ButtonLabel"
+                                              className="e17811v31 css-1nhrbny-ButtonLabel"
                                               is={null}
                                             >
                                               Cancel
@@ -4534,20 +4531,23 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 priority="primary"
                                 role="button"
                               >
-                                <ButtonLabel>
+                                <ButtonLabel
+                                  priority="primary"
+                                >
                                   <Component
-                                    className="css-1dxlw1i-ButtonLabel e17811v31"
+                                    className="css-1emshjx-ButtonLabel e17811v31"
+                                    priority="primary"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                                      className="css-1emshjx-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-mvnt76-ButtonLabel"
+                                        className="e17811v31 css-1nhrbny-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-mvnt76-ButtonLabel"
+                                          className="e17811v31 css-1nhrbny-ButtonLabel"
                                           is={null}
                                         >
                                           Save Rule

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -167,26 +167,25 @@ exports[`projectAlertRules renders 1`] = `
                                 style={Object {}}
                               >
                                 <ButtonLabel
+                                  priority="primary"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-19bmqb3-ButtonLabel e17811v31"
+                                    className="css-o42ntg-ButtonLabel e17811v31"
+                                    priority="primary"
                                     size="small"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
-                                      size="small"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                                        size="small"
+                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                           is={null}
-                                          size="small"
                                         >
                                           <Icon
                                             hasChildren={true}
@@ -484,23 +483,20 @@ exports[`projectAlertRules renders 1`] = `
                                           size="small"
                                         >
                                           <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                            className="css-o42ntg-ButtonLabel e17811v31"
                                             size="small"
                                           >
                                             <Flex
                                               align="center"
-                                              className="css-19bmqb3-ButtonLabel e17811v31"
-                                              size="small"
+                                              className="css-o42ntg-ButtonLabel e17811v31"
                                             >
                                               <Base
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                size="small"
+                                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                               >
                                                 <div
-                                                  className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                                   is={null}
-                                                  size="small"
                                                 >
                                                   Edit Rule
                                                 </div>
@@ -557,23 +553,20 @@ exports[`projectAlertRules renders 1`] = `
                                           size="small"
                                         >
                                           <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                            className="css-o42ntg-ButtonLabel e17811v31"
                                             size="small"
                                           >
                                             <Flex
                                               align="center"
-                                              className="css-19bmqb3-ButtonLabel e17811v31"
-                                              size="small"
+                                              className="css-o42ntg-ButtonLabel e17811v31"
                                             >
                                               <Base
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                size="small"
+                                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                               >
                                                 <div
-                                                  className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                                   is={null}
-                                                  size="small"
                                                 >
                                                   <Icon
                                                     hasChildren={false}

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -517,17 +517,14 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                       <Flex
                                         align="center"
                                         className="css-6q5v1w-ButtonLabel e17811v31"
-                                        size="xsmall"
                                       >
                                         <Base
                                           align="center"
                                           className="e17811v31 css-dqr4rq-ButtonLabel"
-                                          size="xsmall"
                                         >
                                           <div
                                             className="e17811v31 css-dqr4rq-ButtonLabel"
                                             is={null}
-                                            size="xsmall"
                                           >
                                             Set as default
                                           </div>
@@ -639,17 +636,14 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                       <Flex
                                         align="center"
                                         className="css-6q5v1w-ButtonLabel e17811v31"
-                                        size="xsmall"
                                       >
                                         <Base
                                           align="center"
                                           className="e17811v31 css-dqr4rq-ButtonLabel"
-                                          size="xsmall"
                                         >
                                           <div
                                             className="e17811v31 css-dqr4rq-ButtonLabel"
                                             is={null}
-                                            size="xsmall"
                                           >
                                             Set as default
                                           </div>
@@ -706,17 +700,14 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                       <Flex
                                         align="center"
                                         className="css-6q5v1w-ButtonLabel e17811v31"
-                                        size="xsmall"
                                       >
                                         <Base
                                           align="center"
                                           className="e17811v31 css-dqr4rq-ButtonLabel"
-                                          size="xsmall"
                                         >
                                           <div
                                             className="e17811v31 css-dqr4rq-ButtonLabel"
                                             is={null}
-                                            size="xsmall"
                                           >
                                             Hide
                                           </div>
@@ -860,17 +851,14 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                       <Flex
                                         align="center"
                                         className="css-6q5v1w-ButtonLabel e17811v31"
-                                        size="xsmall"
                                       >
                                         <Base
                                           align="center"
                                           className="e17811v31 css-dqr4rq-ButtonLabel"
-                                          size="xsmall"
                                         >
                                           <div
                                             className="e17811v31 css-dqr4rq-ButtonLabel"
                                             is={null}
-                                            size="xsmall"
                                           >
                                             Hide
                                           </div>
@@ -1419,17 +1407,14 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                       <Flex
                                         align="center"
                                         className="css-6q5v1w-ButtonLabel e17811v31"
-                                        size="xsmall"
                                       >
                                         <Base
                                           align="center"
                                           className="e17811v31 css-dqr4rq-ButtonLabel"
-                                          size="xsmall"
                                         >
                                           <div
                                             className="e17811v31 css-dqr4rq-ButtonLabel"
                                             is={null}
-                                            size="xsmall"
                                           >
                                             Show
                                           </div>

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -233,23 +233,20 @@ exports[`ProjectPluginDetails renders 1`] = `
                                     size="small"
                                   >
                                     <Component
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                       size="small"
                                     >
                                       <Flex
                                         align="center"
-                                        className="css-19bmqb3-ButtonLabel e17811v31"
-                                        size="small"
+                                        className="css-o42ntg-ButtonLabel e17811v31"
                                       >
                                         <Base
                                           align="center"
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
-                                          size="small"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                         >
                                           <div
-                                            className="e17811v31 css-1eblpyp-ButtonLabel"
+                                            className="e17811v31 css-l5mlqc-ButtonLabel"
                                             is={null}
-                                            size="small"
                                           >
                                             Enable Plugin
                                           </div>
@@ -293,23 +290,20 @@ exports[`ProjectPluginDetails renders 1`] = `
                                     size="small"
                                   >
                                     <Component
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                       size="small"
                                     >
                                       <Flex
                                         align="center"
-                                        className="css-19bmqb3-ButtonLabel e17811v31"
-                                        size="small"
+                                        className="css-o42ntg-ButtonLabel e17811v31"
                                       >
                                         <Base
                                           align="center"
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
-                                          size="small"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                         >
                                           <div
-                                            className="e17811v31 css-1eblpyp-ButtonLabel"
+                                            className="e17811v31 css-l5mlqc-ButtonLabel"
                                             is={null}
-                                            size="small"
                                           >
                                             Reset Configuration
                                           </div>

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -382,23 +382,20 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                     size="small"
                                                   >
                                                     <Component
-                                                      className="css-19bmqb3-ButtonLabel e17811v31"
+                                                      className="css-o42ntg-ButtonLabel e17811v31"
                                                       size="small"
                                                     >
                                                       <Flex
                                                         align="center"
-                                                        className="css-19bmqb3-ButtonLabel e17811v31"
-                                                        size="small"
+                                                        className="css-o42ntg-ButtonLabel e17811v31"
                                                       >
                                                         <Base
                                                           align="center"
-                                                          className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                          size="small"
+                                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                                         >
                                                           <div
-                                                            className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                            className="e17811v31 css-l5mlqc-ButtonLabel"
                                                             is={null}
-                                                            size="small"
                                                           >
                                                             <Icon
                                                               hasChildren={false}
@@ -716,23 +713,20 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                     size="small"
                                                   >
                                                     <Component
-                                                      className="css-19bmqb3-ButtonLabel e17811v31"
+                                                      className="css-o42ntg-ButtonLabel e17811v31"
                                                       size="small"
                                                     >
                                                       <Flex
                                                         align="center"
-                                                        className="css-19bmqb3-ButtonLabel e17811v31"
-                                                        size="small"
+                                                        className="css-o42ntg-ButtonLabel e17811v31"
                                                       >
                                                         <Base
                                                           align="center"
-                                                          className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                          size="small"
+                                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                                         >
                                                           <div
-                                                            className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                            className="e17811v31 css-l5mlqc-ButtonLabel"
                                                             is={null}
-                                                            size="small"
                                                           >
                                                             <Icon
                                                               hasChildren={false}

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -267,17 +267,14 @@ exports[`ProjectTags renders 1`] = `
                                                 <Flex
                                                   align="center"
                                                   className="css-6q5v1w-ButtonLabel e17811v31"
-                                                  size="xsmall"
                                                 >
                                                   <Base
                                                     align="center"
                                                     className="e17811v31 css-dqr4rq-ButtonLabel"
-                                                    size="xsmall"
                                                   >
                                                     <div
                                                       className="e17811v31 css-dqr4rq-ButtonLabel"
                                                       is={null}
-                                                      size="xsmall"
                                                     >
                                                       <Icon
                                                         hasChildren={false}
@@ -513,17 +510,14 @@ exports[`ProjectTags renders 1`] = `
                                                 <Flex
                                                   align="center"
                                                   className="css-6q5v1w-ButtonLabel e17811v31"
-                                                  size="xsmall"
                                                 >
                                                   <Base
                                                     align="center"
                                                     className="e17811v31 css-dqr4rq-ButtonLabel"
-                                                    size="xsmall"
                                                   >
                                                     <div
                                                       className="e17811v31 css-dqr4rq-ButtonLabel"
                                                       is={null}
-                                                      size="xsmall"
                                                     >
                                                       <Icon
                                                         hasChildren={false}
@@ -759,17 +753,14 @@ exports[`ProjectTags renders 1`] = `
                                                 <Flex
                                                   align="center"
                                                   className="css-6q5v1w-ButtonLabel e17811v31"
-                                                  size="xsmall"
                                                 >
                                                   <Base
                                                     align="center"
                                                     className="e17811v31 css-dqr4rq-ButtonLabel"
-                                                    size="xsmall"
                                                   >
                                                     <div
                                                       className="e17811v31 css-dqr4rq-ButtonLabel"
                                                       is={null}
-                                                      size="xsmall"
                                                     >
                                                       <Icon
                                                         hasChildren={false}
@@ -1013,17 +1004,14 @@ exports[`ProjectTags renders 1`] = `
                                                     <Flex
                                                       align="center"
                                                       className="css-6q5v1w-ButtonLabel e17811v31"
-                                                      size="xsmall"
                                                     >
                                                       <Base
                                                         align="center"
                                                         className="e17811v31 css-dqr4rq-ButtonLabel"
-                                                        size="xsmall"
                                                       >
                                                         <div
                                                           className="e17811v31 css-dqr4rq-ButtonLabel"
                                                           is={null}
-                                                          size="xsmall"
                                                         >
                                                           <Icon
                                                             hasChildren={false}

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -962,26 +962,25 @@ exports[`RuleBuilder renders 1`] = `
                 to={null}
               >
                 <ButtonLabel
+                  priority="primary"
                   size="small"
                 >
                   <Component
-                    className="css-19bmqb3-ButtonLabel e17811v31"
+                    className="css-o42ntg-ButtonLabel e17811v31"
+                    priority="primary"
                     size="small"
                   >
                     <Flex
                       align="center"
-                      className="css-19bmqb3-ButtonLabel e17811v31"
-                      size="small"
+                      className="css-o42ntg-ButtonLabel e17811v31"
                     >
                       <Base
                         align="center"
-                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                        size="small"
+                        className="e17811v31 css-l5mlqc-ButtonLabel"
                       >
                         <div
-                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                          className="e17811v31 css-l5mlqc-ButtonLabel"
                           is={null}
-                          size="small"
                         >
                           <Icon
                             hasChildren={false}
@@ -2699,26 +2698,25 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                 size="small"
               >
                 <ButtonLabel
+                  priority="primary"
                   size="small"
                 >
                   <Component
-                    className="css-19bmqb3-ButtonLabel e17811v31"
+                    className="css-o42ntg-ButtonLabel e17811v31"
+                    priority="primary"
                     size="small"
                   >
                     <Flex
                       align="center"
-                      className="css-19bmqb3-ButtonLabel e17811v31"
-                      size="small"
+                      className="css-o42ntg-ButtonLabel e17811v31"
                     >
                       <Base
                         align="center"
-                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                        size="small"
+                        className="e17811v31 css-l5mlqc-ButtonLabel"
                       >
                         <div
-                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                          className="e17811v31 css-l5mlqc-ButtonLabel"
                           is={null}
-                          size="small"
                         >
                           <Icon
                             hasChildren={false}

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -753,20 +753,23 @@ exports[`CreateProject should render roles when available and allowed, and handl
               priority="primary"
               role="button"
             >
-              <ButtonLabel>
+              <ButtonLabel
+                priority="primary"
+              >
                 <Component
-                  className="css-1dxlw1i-ButtonLabel e17811v31"
+                  className="css-1emshjx-ButtonLabel e17811v31"
+                  priority="primary"
                 >
                   <Flex
                     align="center"
-                    className="css-1dxlw1i-ButtonLabel e17811v31"
+                    className="css-1emshjx-ButtonLabel e17811v31"
                   >
                     <Base
                       align="center"
-                      className="e17811v31 css-mvnt76-ButtonLabel"
+                      className="e17811v31 css-1nhrbny-ButtonLabel"
                     >
                       <div
-                        className="e17811v31 css-mvnt76-ButtonLabel"
+                        className="e17811v31 css-1nhrbny-ButtonLabel"
                         is={null}
                       >
                         Add Member

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -301,23 +301,20 @@ exports[`Configure should render correctly render() should render platform docs 
                                                     size="small"
                                                   >
                                                     <Component
-                                                      className="css-19bmqb3-ButtonLabel e17811v31"
+                                                      className="css-o42ntg-ButtonLabel e17811v31"
                                                       size="small"
                                                     >
                                                       <Flex
                                                         align="center"
-                                                        className="css-19bmqb3-ButtonLabel e17811v31"
-                                                        size="small"
+                                                        className="css-o42ntg-ButtonLabel e17811v31"
                                                       >
                                                         <Base
                                                           align="center"
-                                                          className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                          size="small"
+                                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                                         >
                                                           <div
-                                                            className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                            className="e17811v31 css-l5mlqc-ButtonLabel"
                                                             is={null}
-                                                            size="small"
                                                           >
                                                             Full Documentation
                                                           </div>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -735,17 +735,14 @@ exports[`ProjectCard renders 1`] = `
                                           <Flex
                                             align="center"
                                             className="css-6q5v1w-ButtonLabel e17811v31"
-                                            size="xsmall"
                                           >
                                             <Base
                                               align="center"
                                               className="e17811v31 css-dqr4rq-ButtonLabel"
-                                              size="xsmall"
                                             >
                                               <div
                                                 className="e17811v31 css-dqr4rq-ButtonLabel"
                                                 is={null}
-                                                size="xsmall"
                                               >
                                                 Track deploys
                                               </div>

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -117,26 +117,25 @@ exports[`OrganizationApiKeysList renders 1`] = `
                           size="small"
                         >
                           <ButtonLabel
+                            priority="primary"
                             size="small"
                           >
                             <Component
-                              className="css-19bmqb3-ButtonLabel e17811v31"
+                              className="css-o42ntg-ButtonLabel e17811v31"
+                              priority="primary"
                               size="small"
                             >
                               <Flex
                                 align="center"
-                                className="css-19bmqb3-ButtonLabel e17811v31"
-                                size="small"
+                                className="css-o42ntg-ButtonLabel e17811v31"
                               >
                                 <Base
                                   align="center"
-                                  className="e17811v31 css-1eblpyp-ButtonLabel"
-                                  size="small"
+                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                 >
                                   <div
-                                    className="e17811v31 css-1eblpyp-ButtonLabel"
+                                    className="e17811v31 css-l5mlqc-ButtonLabel"
                                     is={null}
-                                    size="small"
                                   >
                                     <Icon
                                       hasChildren={true}

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -106,26 +106,25 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                 style={Object {}}
                               >
                                 <ButtonLabel
+                                  priority="primary"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-19bmqb3-ButtonLabel e17811v31"
+                                    className="css-o42ntg-ButtonLabel e17811v31"
+                                    priority="primary"
                                     size="small"
                                   >
                                     <Flex
                                       align="center"
-                                      className="css-19bmqb3-ButtonLabel e17811v31"
-                                      size="small"
+                                      className="css-o42ntg-ButtonLabel e17811v31"
                                     >
                                       <Base
                                         align="center"
-                                        className="e17811v31 css-1eblpyp-ButtonLabel"
-                                        size="small"
+                                        className="e17811v31 css-l5mlqc-ButtonLabel"
                                       >
                                         <div
-                                          className="e17811v31 css-1eblpyp-ButtonLabel"
+                                          className="e17811v31 css-l5mlqc-ButtonLabel"
                                           is={null}
-                                          size="small"
                                         >
                                           <Icon
                                             hasChildren={true}
@@ -507,23 +506,20 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                           size="small"
                                         >
                                           <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                            className="css-o42ntg-ButtonLabel e17811v31"
                                             size="small"
                                           >
                                             <Flex
                                               align="center"
-                                              className="css-19bmqb3-ButtonLabel e17811v31"
-                                              size="small"
+                                              className="css-o42ntg-ButtonLabel e17811v31"
                                             >
                                               <Base
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                size="small"
+                                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                               >
                                                 <div
-                                                  className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                                   is={null}
-                                                  size="small"
                                                 >
                                                   View Issues
                                                 </div>

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -293,11 +293,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                         enabled={false}
                                       >
                                         <WithTheme(Component)
-                                          className="css-lya23n-Status e1egfpwi2"
+                                          className="css-1xs0jyz-Status e1egfpwi2"
                                           enabled={false}
                                         >
                                           <Component
-                                            className="css-lya23n-Status e1egfpwi2"
+                                            className="css-1xs0jyz-Status e1egfpwi2"
                                             enabled={false}
                                             theme={
                                               Object {
@@ -499,239 +499,259 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                               }
                                             }
                                           >
-                                            <CircleIndicator
-                                              color="#9585A3"
-                                              enabled={true}
-                                              size={6}
+                                            <Flex
+                                              align="center"
                                             >
-                                              <Circle
-                                                color="#9585A3"
-                                                enabled={true}
-                                                size={6}
+                                              <Base
+                                                align="center"
+                                                className="css-5ipae5"
                                               >
                                                 <div
-                                                  className="css-xhz9xw-Circle eljqieg0"
-                                                  color="#9585A3"
-                                                  size={6}
-                                                />
-                                              </Circle>
-                                            </CircleIndicator>
-                                            <div
-                                              className="css-lya23n-Status e1egfpwi2"
-                                              theme={
-                                                Object {
-                                                  "alert": Object {
-                                                    "attention": Object {
-                                                      "background": "#F09E71",
-                                                      "backgroundLight": "#ECBFA6",
-                                                      "border": "#D0816D",
-                                                    },
-                                                    "error": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundLight": "#FDF6F5",
-                                                      "border": "#E7C0BC",
-                                                      "iconColor": "#C72516",
-                                                      "textDark": "#5d3e3b",
-                                                      "textLight": "#92635f",
-                                                    },
-                                                    "info": Object {
-                                                      "background": "#3B6ECC",
-                                                      "backgroundLight": "#F5FAFE",
-                                                      "border": "#B5D6ED",
-                                                      "iconColor": "#3B6ECC",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#57be8c",
-                                                      "backgroundLight": "#F8FCF7",
-                                                      "border": "#BBD6B3",
-                                                      "iconColor": "#3EA573",
-                                                    },
-                                                    "warn": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                    "warning": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                  },
-                                                  "background": "#fff",
-                                                  "blue": "#3B6ECC",
-                                                  "blueDark": "#2F58A3",
-                                                  "blueLight": "#628BD6",
-                                                  "borderDark": "#D1CAD8",
-                                                  "borderLight": "#E2DBE8",
-                                                  "borderLighter": "#f9f6fd",
-                                                  "borderRadius": "4px",
-                                                  "breakpoints": Array [
-                                                    "768px",
-                                                    "992px",
-                                                    "1200px",
-                                                  ],
-                                                  "button": Object {
-                                                    "borderRadius": "3px",
-                                                    "danger": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundActive": "#bf2a1d",
-                                                      "border": "#bf2a1d",
-                                                      "borderActive": "#7d1c13",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "default": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#d8d2de",
-                                                      "borderActive": "#c9c0d1",
-                                                      "color": "#2f2936",
-                                                      "colorActive": "#161319",
-                                                    },
-                                                    "disabled": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#e3e5e6",
-                                                      "borderActive": "#e3e5e6",
-                                                      "color": "#ced3d6",
-                                                    },
-                                                    "link": Object {
-                                                      "background": "transparent",
-                                                      "backgroundActive": "transparent",
-                                                      "color": "#3B6ECC",
-                                                    },
-                                                    "primary": Object {
-                                                      "background": "#6C5FC7",
-                                                      "backgroundActive": "#4e3fb4",
-                                                      "border": "#3d328e",
-                                                      "borderActive": "#352b7b",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#3fa372",
-                                                      "backgroundActive": "#57be8c",
-                                                      "border": "#7ccca5",
-                                                      "borderActive": "#7ccca5",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                  },
-                                                  "charts": Object {
-                                                    "colors": Array [
-                                                      "#4C416B",
-                                                      "#7A5195",
-                                                      "#BC5090",
-                                                      "#EF5675",
-                                                      "#FF764A",
-                                                      "#FFA600",
-                                                    ],
-                                                    "previousPeriod": "#BDB4C7",
-                                                  },
-                                                  "disabled": "#ced3d6",
-                                                  "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
-                                                  "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
-                                                  "error": "#e03e2f",
-                                                  "fontSizeExtraLarge": "18px",
-                                                  "fontSizeLarge": "16px",
-                                                  "fontSizeMedium": "14px",
-                                                  "fontSizeSmall": "12px",
-                                                  "gray1": "#BDB4C7",
-                                                  "gray2": "#9585A3",
-                                                  "gray3": "#645574",
-                                                  "gray4": "#4A3E56",
-                                                  "gray5": "#302839",
-                                                  "gray6": "#AFA3BB",
-                                                  "green": "#57be8c",
-                                                  "greenDark": "#3EA573",
-                                                  "greenLight": "#71D8A6",
-                                                  "greenTransparent": "rgba(87, 190, 140, 0.5)",
-                                                  "grid": 8,
-                                                  "offWhite": "#FAF9FB",
-                                                  "offWhite2": "#E7E1EC",
-                                                  "orange": "#ec5e44",
-                                                  "orangeDark": "#D3452B",
-                                                  "orangeLight": "#FF785E",
-                                                  "pink": "#F868BC",
-                                                  "pinkDark": "#DF4FA3",
-                                                  "pinkLight": "#FF82D6",
-                                                  "purple": "#6C5FC7",
-                                                  "purple2": "#6f617c",
-                                                  "purpleDark": "#5346AE",
-                                                  "purpleDarkest": "#392C94",
-                                                  "purpleLight": "#8679E1",
-                                                  "purpleLightest": "#9F92FA",
-                                                  "red": "#e03e2f",
-                                                  "redDark": "#C72516",
-                                                  "redLight": "#FA5849",
-                                                  "settings": Object {
-                                                    "containerWidth": "1140px",
-                                                    "headerHeight": "115px",
-                                                    "maxCrumbWidth": "240px",
-                                                    "sidebarWidth": "210px",
-                                                  },
-                                                  "sidebar": Object {
-                                                    "background": "#2f2936",
-                                                    "badgeSize": "22px",
-                                                    "collapsedWidth": "70px",
-                                                    "color": "#9586a5",
-                                                    "divider": "#493e54",
-                                                    "expandedWidth": "220px",
-                                                    "menuSpacing": "15px",
-                                                    "mobileHeight": "54px",
-                                                    "panel": Object {
-                                                      "headerHeight": "62px",
-                                                      "width": "320px",
-                                                    },
-                                                    "smallBadgeSize": "11px",
-                                                  },
-                                                  "success": "#57be8c",
-                                                  "text": Object {
-                                                    "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
-                                                    "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
-                                                    "lineHeightBody": "1.4",
-                                                    "lineHeightHeading": "1.15",
-                                                  },
-                                                  "textColor": "#302839",
-                                                  "white": "#FFFFFF",
-                                                  "whiteDark": "#fbfbfc",
-                                                  "yellow": "#ecc844",
-                                                  "yellowDark": "#e6bc23",
-                                                  "yellowLight": "#FFF15E",
-                                                  "yellowLightest": "#FFFDF7",
-                                                  "yellowOrange": "#f9a66d",
-                                                  "yellowOrangeDark": "#E08D54",
-                                                  "yellowOrangeLight": "#FFC087",
-                                                  "zIndex": Object {
-                                                    "dropdown": 1001,
-                                                    "dropdownAutocomplete": Object {
-                                                      "actor": 3,
-                                                      "menu": 2,
-                                                    },
-                                                    "header": 1000,
-                                                    "modal": 10000,
-                                                    "orgAndUserMenu": 1003,
-                                                    "sidebar": 1002,
-                                                    "toast": 10001,
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              Not Installed
-                                            </div>
+                                                  className="css-5ipae5"
+                                                  is={null}
+                                                >
+                                                  <CircleIndicator
+                                                    color="#9585A3"
+                                                    enabled={true}
+                                                    size={6}
+                                                  >
+                                                    <Circle
+                                                      color="#9585A3"
+                                                      enabled={true}
+                                                      size={6}
+                                                    >
+                                                      <div
+                                                        className="css-xhz9xw-Circle eljqieg0"
+                                                        color="#9585A3"
+                                                        size={6}
+                                                      />
+                                                    </Circle>
+                                                  </CircleIndicator>
+                                                  <div
+                                                    className="css-1xs0jyz-Status e1egfpwi2"
+                                                    theme={
+                                                      Object {
+                                                        "alert": Object {
+                                                          "attention": Object {
+                                                            "background": "#F09E71",
+                                                            "backgroundLight": "#ECBFA6",
+                                                            "border": "#D0816D",
+                                                          },
+                                                          "error": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundLight": "#FDF6F5",
+                                                            "border": "#E7C0BC",
+                                                            "iconColor": "#C72516",
+                                                            "textDark": "#5d3e3b",
+                                                            "textLight": "#92635f",
+                                                          },
+                                                          "info": Object {
+                                                            "background": "#3B6ECC",
+                                                            "backgroundLight": "#F5FAFE",
+                                                            "border": "#B5D6ED",
+                                                            "iconColor": "#3B6ECC",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#57be8c",
+                                                            "backgroundLight": "#F8FCF7",
+                                                            "border": "#BBD6B3",
+                                                            "iconColor": "#3EA573",
+                                                          },
+                                                          "warn": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                        },
+                                                        "background": "#fff",
+                                                        "blue": "#3B6ECC",
+                                                        "blueDark": "#2F58A3",
+                                                        "blueLight": "#628BD6",
+                                                        "borderDark": "#D1CAD8",
+                                                        "borderLight": "#E2DBE8",
+                                                        "borderLighter": "#f9f6fd",
+                                                        "borderRadius": "4px",
+                                                        "breakpoints": Array [
+                                                          "768px",
+                                                          "992px",
+                                                          "1200px",
+                                                        ],
+                                                        "button": Object {
+                                                          "borderRadius": "3px",
+                                                          "danger": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundActive": "#bf2a1d",
+                                                            "border": "#bf2a1d",
+                                                            "borderActive": "#7d1c13",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "default": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#d8d2de",
+                                                            "borderActive": "#c9c0d1",
+                                                            "color": "#2f2936",
+                                                            "colorActive": "#161319",
+                                                          },
+                                                          "disabled": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#e3e5e6",
+                                                            "borderActive": "#e3e5e6",
+                                                            "color": "#ced3d6",
+                                                          },
+                                                          "link": Object {
+                                                            "background": "transparent",
+                                                            "backgroundActive": "transparent",
+                                                            "color": "#3B6ECC",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#6C5FC7",
+                                                            "backgroundActive": "#4e3fb4",
+                                                            "border": "#3d328e",
+                                                            "borderActive": "#352b7b",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#3fa372",
+                                                            "backgroundActive": "#57be8c",
+                                                            "border": "#7ccca5",
+                                                            "borderActive": "#7ccca5",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                        },
+                                                        "charts": Object {
+                                                          "colors": Array [
+                                                            "#4C416B",
+                                                            "#7A5195",
+                                                            "#BC5090",
+                                                            "#EF5675",
+                                                            "#FF764A",
+                                                            "#FFA600",
+                                                          ],
+                                                          "previousPeriod": "#BDB4C7",
+                                                        },
+                                                        "disabled": "#ced3d6",
+                                                        "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
+                                                        "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
+                                                        "error": "#e03e2f",
+                                                        "fontSizeExtraLarge": "18px",
+                                                        "fontSizeLarge": "16px",
+                                                        "fontSizeMedium": "14px",
+                                                        "fontSizeSmall": "12px",
+                                                        "gray1": "#BDB4C7",
+                                                        "gray2": "#9585A3",
+                                                        "gray3": "#645574",
+                                                        "gray4": "#4A3E56",
+                                                        "gray5": "#302839",
+                                                        "gray6": "#AFA3BB",
+                                                        "green": "#57be8c",
+                                                        "greenDark": "#3EA573",
+                                                        "greenLight": "#71D8A6",
+                                                        "greenTransparent": "rgba(87, 190, 140, 0.5)",
+                                                        "grid": 8,
+                                                        "offWhite": "#FAF9FB",
+                                                        "offWhite2": "#E7E1EC",
+                                                        "orange": "#ec5e44",
+                                                        "orangeDark": "#D3452B",
+                                                        "orangeLight": "#FF785E",
+                                                        "pink": "#F868BC",
+                                                        "pinkDark": "#DF4FA3",
+                                                        "pinkLight": "#FF82D6",
+                                                        "purple": "#6C5FC7",
+                                                        "purple2": "#6f617c",
+                                                        "purpleDark": "#5346AE",
+                                                        "purpleDarkest": "#392C94",
+                                                        "purpleLight": "#8679E1",
+                                                        "purpleLightest": "#9F92FA",
+                                                        "red": "#e03e2f",
+                                                        "redDark": "#C72516",
+                                                        "redLight": "#FA5849",
+                                                        "settings": Object {
+                                                          "containerWidth": "1140px",
+                                                          "headerHeight": "115px",
+                                                          "maxCrumbWidth": "240px",
+                                                          "sidebarWidth": "210px",
+                                                        },
+                                                        "sidebar": Object {
+                                                          "background": "#2f2936",
+                                                          "badgeSize": "22px",
+                                                          "collapsedWidth": "70px",
+                                                          "color": "#9586a5",
+                                                          "divider": "#493e54",
+                                                          "expandedWidth": "220px",
+                                                          "menuSpacing": "15px",
+                                                          "mobileHeight": "54px",
+                                                          "panel": Object {
+                                                            "headerHeight": "62px",
+                                                            "width": "320px",
+                                                          },
+                                                          "smallBadgeSize": "11px",
+                                                        },
+                                                        "success": "#57be8c",
+                                                        "text": Object {
+                                                          "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
+                                                          "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
+                                                          "lineHeightBody": "1.4",
+                                                          "lineHeightHeading": "1.15",
+                                                        },
+                                                        "textColor": "#302839",
+                                                        "white": "#FFFFFF",
+                                                        "whiteDark": "#fbfbfc",
+                                                        "yellow": "#ecc844",
+                                                        "yellowDark": "#e6bc23",
+                                                        "yellowLight": "#FFF15E",
+                                                        "yellowLightest": "#FFFDF7",
+                                                        "yellowOrange": "#f9a66d",
+                                                        "yellowOrangeDark": "#E08D54",
+                                                        "yellowOrangeLight": "#FFC087",
+                                                        "zIndex": Object {
+                                                          "dropdown": 1001,
+                                                          "dropdownAutocomplete": Object {
+                                                            "actor": 3,
+                                                            "menu": 2,
+                                                          },
+                                                          "header": 1000,
+                                                          "modal": 10000,
+                                                          "orgAndUserMenu": 1003,
+                                                          "sidebar": 1002,
+                                                          "toast": 10001,
+                                                        },
+                                                      }
+                                                    }
+                                                  >
+                                                    Not Installed
+                                                  </div>
+                                                </div>
+                                              </Base>
+                                            </Flex>
                                           </Component>
                                         </WithTheme(Component)>
                                       </Status>
-                                      <Link
+                                      <StyledLink
                                         onClick={[Function]}
                                       >
-                                        <a
+                                        <Link
+                                          className="css-u3fgwp-StyledLink e1egfpwi5"
                                           onClick={[Function]}
                                         >
-                                          Learn More
-                                        </a>
-                                      </Link>
+                                          <a
+                                            className="css-u3fgwp-StyledLink e1egfpwi5"
+                                            onClick={[Function]}
+                                          >
+                                            Learn More
+                                          </a>
+                                        </Link>
+                                      </StyledLink>
                                     </div>
                                   </Base>
                                 </ProviderDetails>
@@ -779,23 +799,20 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                           size="small"
                                         >
                                           <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                            className="css-o42ntg-ButtonLabel e17811v31"
                                             size="small"
                                           >
                                             <Flex
                                               align="center"
-                                              className="css-19bmqb3-ButtonLabel e17811v31"
-                                              size="small"
+                                              className="css-o42ntg-ButtonLabel e17811v31"
                                             >
                                               <Base
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                size="small"
+                                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                               >
                                                 <div
-                                                  className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                                   is={null}
-                                                  size="small"
                                                 >
                                                   <Icon
                                                     hasChildren={true}
@@ -1014,11 +1031,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                         enabled={true}
                                       >
                                         <WithTheme(Component)
-                                          className="css-1mowpub-Status e1egfpwi2"
+                                          className="css-1rvre0-Status e1egfpwi2"
                                           enabled={true}
                                         >
                                           <Component
-                                            className="css-1mowpub-Status e1egfpwi2"
+                                            className="css-1rvre0-Status e1egfpwi2"
                                             enabled={true}
                                             theme={
                                               Object {
@@ -1220,239 +1237,259 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                               }
                                             }
                                           >
-                                            <CircleIndicator
-                                              color="#57be8c"
-                                              enabled={true}
-                                              size={6}
+                                            <Flex
+                                              align="center"
                                             >
-                                              <Circle
-                                                color="#57be8c"
-                                                enabled={true}
-                                                size={6}
+                                              <Base
+                                                align="center"
+                                                className="css-5ipae5"
                                               >
                                                 <div
-                                                  className="css-18at6gu-Circle eljqieg0"
-                                                  color="#57be8c"
-                                                  size={6}
-                                                />
-                                              </Circle>
-                                            </CircleIndicator>
-                                            <div
-                                              className="css-1mowpub-Status e1egfpwi2"
-                                              theme={
-                                                Object {
-                                                  "alert": Object {
-                                                    "attention": Object {
-                                                      "background": "#F09E71",
-                                                      "backgroundLight": "#ECBFA6",
-                                                      "border": "#D0816D",
-                                                    },
-                                                    "error": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundLight": "#FDF6F5",
-                                                      "border": "#E7C0BC",
-                                                      "iconColor": "#C72516",
-                                                      "textDark": "#5d3e3b",
-                                                      "textLight": "#92635f",
-                                                    },
-                                                    "info": Object {
-                                                      "background": "#3B6ECC",
-                                                      "backgroundLight": "#F5FAFE",
-                                                      "border": "#B5D6ED",
-                                                      "iconColor": "#3B6ECC",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#57be8c",
-                                                      "backgroundLight": "#F8FCF7",
-                                                      "border": "#BBD6B3",
-                                                      "iconColor": "#3EA573",
-                                                    },
-                                                    "warn": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                    "warning": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                  },
-                                                  "background": "#fff",
-                                                  "blue": "#3B6ECC",
-                                                  "blueDark": "#2F58A3",
-                                                  "blueLight": "#628BD6",
-                                                  "borderDark": "#D1CAD8",
-                                                  "borderLight": "#E2DBE8",
-                                                  "borderLighter": "#f9f6fd",
-                                                  "borderRadius": "4px",
-                                                  "breakpoints": Array [
-                                                    "768px",
-                                                    "992px",
-                                                    "1200px",
-                                                  ],
-                                                  "button": Object {
-                                                    "borderRadius": "3px",
-                                                    "danger": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundActive": "#bf2a1d",
-                                                      "border": "#bf2a1d",
-                                                      "borderActive": "#7d1c13",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "default": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#d8d2de",
-                                                      "borderActive": "#c9c0d1",
-                                                      "color": "#2f2936",
-                                                      "colorActive": "#161319",
-                                                    },
-                                                    "disabled": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#e3e5e6",
-                                                      "borderActive": "#e3e5e6",
-                                                      "color": "#ced3d6",
-                                                    },
-                                                    "link": Object {
-                                                      "background": "transparent",
-                                                      "backgroundActive": "transparent",
-                                                      "color": "#3B6ECC",
-                                                    },
-                                                    "primary": Object {
-                                                      "background": "#6C5FC7",
-                                                      "backgroundActive": "#4e3fb4",
-                                                      "border": "#3d328e",
-                                                      "borderActive": "#352b7b",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#3fa372",
-                                                      "backgroundActive": "#57be8c",
-                                                      "border": "#7ccca5",
-                                                      "borderActive": "#7ccca5",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                  },
-                                                  "charts": Object {
-                                                    "colors": Array [
-                                                      "#4C416B",
-                                                      "#7A5195",
-                                                      "#BC5090",
-                                                      "#EF5675",
-                                                      "#FF764A",
-                                                      "#FFA600",
-                                                    ],
-                                                    "previousPeriod": "#BDB4C7",
-                                                  },
-                                                  "disabled": "#ced3d6",
-                                                  "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
-                                                  "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
-                                                  "error": "#e03e2f",
-                                                  "fontSizeExtraLarge": "18px",
-                                                  "fontSizeLarge": "16px",
-                                                  "fontSizeMedium": "14px",
-                                                  "fontSizeSmall": "12px",
-                                                  "gray1": "#BDB4C7",
-                                                  "gray2": "#9585A3",
-                                                  "gray3": "#645574",
-                                                  "gray4": "#4A3E56",
-                                                  "gray5": "#302839",
-                                                  "gray6": "#AFA3BB",
-                                                  "green": "#57be8c",
-                                                  "greenDark": "#3EA573",
-                                                  "greenLight": "#71D8A6",
-                                                  "greenTransparent": "rgba(87, 190, 140, 0.5)",
-                                                  "grid": 8,
-                                                  "offWhite": "#FAF9FB",
-                                                  "offWhite2": "#E7E1EC",
-                                                  "orange": "#ec5e44",
-                                                  "orangeDark": "#D3452B",
-                                                  "orangeLight": "#FF785E",
-                                                  "pink": "#F868BC",
-                                                  "pinkDark": "#DF4FA3",
-                                                  "pinkLight": "#FF82D6",
-                                                  "purple": "#6C5FC7",
-                                                  "purple2": "#6f617c",
-                                                  "purpleDark": "#5346AE",
-                                                  "purpleDarkest": "#392C94",
-                                                  "purpleLight": "#8679E1",
-                                                  "purpleLightest": "#9F92FA",
-                                                  "red": "#e03e2f",
-                                                  "redDark": "#C72516",
-                                                  "redLight": "#FA5849",
-                                                  "settings": Object {
-                                                    "containerWidth": "1140px",
-                                                    "headerHeight": "115px",
-                                                    "maxCrumbWidth": "240px",
-                                                    "sidebarWidth": "210px",
-                                                  },
-                                                  "sidebar": Object {
-                                                    "background": "#2f2936",
-                                                    "badgeSize": "22px",
-                                                    "collapsedWidth": "70px",
-                                                    "color": "#9586a5",
-                                                    "divider": "#493e54",
-                                                    "expandedWidth": "220px",
-                                                    "menuSpacing": "15px",
-                                                    "mobileHeight": "54px",
-                                                    "panel": Object {
-                                                      "headerHeight": "62px",
-                                                      "width": "320px",
-                                                    },
-                                                    "smallBadgeSize": "11px",
-                                                  },
-                                                  "success": "#57be8c",
-                                                  "text": Object {
-                                                    "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
-                                                    "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
-                                                    "lineHeightBody": "1.4",
-                                                    "lineHeightHeading": "1.15",
-                                                  },
-                                                  "textColor": "#302839",
-                                                  "white": "#FFFFFF",
-                                                  "whiteDark": "#fbfbfc",
-                                                  "yellow": "#ecc844",
-                                                  "yellowDark": "#e6bc23",
-                                                  "yellowLight": "#FFF15E",
-                                                  "yellowLightest": "#FFFDF7",
-                                                  "yellowOrange": "#f9a66d",
-                                                  "yellowOrangeDark": "#E08D54",
-                                                  "yellowOrangeLight": "#FFC087",
-                                                  "zIndex": Object {
-                                                    "dropdown": 1001,
-                                                    "dropdownAutocomplete": Object {
-                                                      "actor": 3,
-                                                      "menu": 2,
-                                                    },
-                                                    "header": 1000,
-                                                    "modal": 10000,
-                                                    "orgAndUserMenu": 1003,
-                                                    "sidebar": 1002,
-                                                    "toast": 10001,
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              Installed
-                                            </div>
+                                                  className="css-5ipae5"
+                                                  is={null}
+                                                >
+                                                  <CircleIndicator
+                                                    color="#57be8c"
+                                                    enabled={true}
+                                                    size={6}
+                                                  >
+                                                    <Circle
+                                                      color="#57be8c"
+                                                      enabled={true}
+                                                      size={6}
+                                                    >
+                                                      <div
+                                                        className="css-18at6gu-Circle eljqieg0"
+                                                        color="#57be8c"
+                                                        size={6}
+                                                      />
+                                                    </Circle>
+                                                  </CircleIndicator>
+                                                  <div
+                                                    className="css-1rvre0-Status e1egfpwi2"
+                                                    theme={
+                                                      Object {
+                                                        "alert": Object {
+                                                          "attention": Object {
+                                                            "background": "#F09E71",
+                                                            "backgroundLight": "#ECBFA6",
+                                                            "border": "#D0816D",
+                                                          },
+                                                          "error": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundLight": "#FDF6F5",
+                                                            "border": "#E7C0BC",
+                                                            "iconColor": "#C72516",
+                                                            "textDark": "#5d3e3b",
+                                                            "textLight": "#92635f",
+                                                          },
+                                                          "info": Object {
+                                                            "background": "#3B6ECC",
+                                                            "backgroundLight": "#F5FAFE",
+                                                            "border": "#B5D6ED",
+                                                            "iconColor": "#3B6ECC",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#57be8c",
+                                                            "backgroundLight": "#F8FCF7",
+                                                            "border": "#BBD6B3",
+                                                            "iconColor": "#3EA573",
+                                                          },
+                                                          "warn": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                        },
+                                                        "background": "#fff",
+                                                        "blue": "#3B6ECC",
+                                                        "blueDark": "#2F58A3",
+                                                        "blueLight": "#628BD6",
+                                                        "borderDark": "#D1CAD8",
+                                                        "borderLight": "#E2DBE8",
+                                                        "borderLighter": "#f9f6fd",
+                                                        "borderRadius": "4px",
+                                                        "breakpoints": Array [
+                                                          "768px",
+                                                          "992px",
+                                                          "1200px",
+                                                        ],
+                                                        "button": Object {
+                                                          "borderRadius": "3px",
+                                                          "danger": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundActive": "#bf2a1d",
+                                                            "border": "#bf2a1d",
+                                                            "borderActive": "#7d1c13",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "default": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#d8d2de",
+                                                            "borderActive": "#c9c0d1",
+                                                            "color": "#2f2936",
+                                                            "colorActive": "#161319",
+                                                          },
+                                                          "disabled": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#e3e5e6",
+                                                            "borderActive": "#e3e5e6",
+                                                            "color": "#ced3d6",
+                                                          },
+                                                          "link": Object {
+                                                            "background": "transparent",
+                                                            "backgroundActive": "transparent",
+                                                            "color": "#3B6ECC",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#6C5FC7",
+                                                            "backgroundActive": "#4e3fb4",
+                                                            "border": "#3d328e",
+                                                            "borderActive": "#352b7b",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#3fa372",
+                                                            "backgroundActive": "#57be8c",
+                                                            "border": "#7ccca5",
+                                                            "borderActive": "#7ccca5",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                        },
+                                                        "charts": Object {
+                                                          "colors": Array [
+                                                            "#4C416B",
+                                                            "#7A5195",
+                                                            "#BC5090",
+                                                            "#EF5675",
+                                                            "#FF764A",
+                                                            "#FFA600",
+                                                          ],
+                                                          "previousPeriod": "#BDB4C7",
+                                                        },
+                                                        "disabled": "#ced3d6",
+                                                        "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
+                                                        "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
+                                                        "error": "#e03e2f",
+                                                        "fontSizeExtraLarge": "18px",
+                                                        "fontSizeLarge": "16px",
+                                                        "fontSizeMedium": "14px",
+                                                        "fontSizeSmall": "12px",
+                                                        "gray1": "#BDB4C7",
+                                                        "gray2": "#9585A3",
+                                                        "gray3": "#645574",
+                                                        "gray4": "#4A3E56",
+                                                        "gray5": "#302839",
+                                                        "gray6": "#AFA3BB",
+                                                        "green": "#57be8c",
+                                                        "greenDark": "#3EA573",
+                                                        "greenLight": "#71D8A6",
+                                                        "greenTransparent": "rgba(87, 190, 140, 0.5)",
+                                                        "grid": 8,
+                                                        "offWhite": "#FAF9FB",
+                                                        "offWhite2": "#E7E1EC",
+                                                        "orange": "#ec5e44",
+                                                        "orangeDark": "#D3452B",
+                                                        "orangeLight": "#FF785E",
+                                                        "pink": "#F868BC",
+                                                        "pinkDark": "#DF4FA3",
+                                                        "pinkLight": "#FF82D6",
+                                                        "purple": "#6C5FC7",
+                                                        "purple2": "#6f617c",
+                                                        "purpleDark": "#5346AE",
+                                                        "purpleDarkest": "#392C94",
+                                                        "purpleLight": "#8679E1",
+                                                        "purpleLightest": "#9F92FA",
+                                                        "red": "#e03e2f",
+                                                        "redDark": "#C72516",
+                                                        "redLight": "#FA5849",
+                                                        "settings": Object {
+                                                          "containerWidth": "1140px",
+                                                          "headerHeight": "115px",
+                                                          "maxCrumbWidth": "240px",
+                                                          "sidebarWidth": "210px",
+                                                        },
+                                                        "sidebar": Object {
+                                                          "background": "#2f2936",
+                                                          "badgeSize": "22px",
+                                                          "collapsedWidth": "70px",
+                                                          "color": "#9586a5",
+                                                          "divider": "#493e54",
+                                                          "expandedWidth": "220px",
+                                                          "menuSpacing": "15px",
+                                                          "mobileHeight": "54px",
+                                                          "panel": Object {
+                                                            "headerHeight": "62px",
+                                                            "width": "320px",
+                                                          },
+                                                          "smallBadgeSize": "11px",
+                                                        },
+                                                        "success": "#57be8c",
+                                                        "text": Object {
+                                                          "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
+                                                          "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
+                                                          "lineHeightBody": "1.4",
+                                                          "lineHeightHeading": "1.15",
+                                                        },
+                                                        "textColor": "#302839",
+                                                        "white": "#FFFFFF",
+                                                        "whiteDark": "#fbfbfc",
+                                                        "yellow": "#ecc844",
+                                                        "yellowDark": "#e6bc23",
+                                                        "yellowLight": "#FFF15E",
+                                                        "yellowLightest": "#FFFDF7",
+                                                        "yellowOrange": "#f9a66d",
+                                                        "yellowOrangeDark": "#E08D54",
+                                                        "yellowOrangeLight": "#FFC087",
+                                                        "zIndex": Object {
+                                                          "dropdown": 1001,
+                                                          "dropdownAutocomplete": Object {
+                                                            "actor": 3,
+                                                            "menu": 2,
+                                                          },
+                                                          "header": 1000,
+                                                          "modal": 10000,
+                                                          "orgAndUserMenu": 1003,
+                                                          "sidebar": 1002,
+                                                          "toast": 10001,
+                                                        },
+                                                      }
+                                                    }
+                                                  >
+                                                    Installed
+                                                  </div>
+                                                </div>
+                                              </Base>
+                                            </Flex>
                                           </Component>
                                         </WithTheme(Component)>
                                       </Status>
-                                      <Link
+                                      <StyledLink
                                         onClick={[Function]}
                                       >
-                                        <a
+                                        <Link
+                                          className="css-u3fgwp-StyledLink e1egfpwi5"
                                           onClick={[Function]}
                                         >
-                                          Learn More
-                                        </a>
-                                      </Link>
+                                          <a
+                                            className="css-u3fgwp-StyledLink e1egfpwi5"
+                                            onClick={[Function]}
+                                          >
+                                            Learn More
+                                          </a>
+                                        </Link>
+                                      </StyledLink>
                                     </div>
                                   </Base>
                                 </ProviderDetails>
@@ -1500,23 +1537,20 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                           size="small"
                                         >
                                           <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                            className="css-o42ntg-ButtonLabel e17811v31"
                                             size="small"
                                           >
                                             <Flex
                                               align="center"
-                                              className="css-19bmqb3-ButtonLabel e17811v31"
-                                              size="small"
+                                              className="css-o42ntg-ButtonLabel e17811v31"
                                             >
                                               <Base
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                size="small"
+                                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                               >
                                                 <div
-                                                  className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                                   is={null}
-                                                  size="small"
                                                 >
                                                   <Icon
                                                     hasChildren={true}
@@ -1656,7 +1690,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                       }
                     >
                       <Component
-                        className="css-aam648-StyledInstalledIntegration e1egfpwi3"
+                        className="css-1gojchp-StyledInstalledIntegration e1egfpwi4"
                         integration={
                           Object {
                             "configData": Object {},
@@ -1721,7 +1755,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                         }
                       >
                         <InstalledIntegration
-                          className="css-aam648-StyledInstalledIntegration e1egfpwi3"
+                          className="css-1gojchp-StyledInstalledIntegration e1egfpwi4"
                           integration={
                             Object {
                               "configData": Object {},
@@ -1787,15 +1821,15 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                         >
                           <Flex
                             align="center"
-                            className="css-aam648-StyledInstalledIntegration e1egfpwi3"
+                            className="css-1gojchp-StyledInstalledIntegration e1egfpwi4"
                             key="2"
                           >
                             <Base
                               align="center"
-                              className="e1egfpwi3 css-13bi3jz-StyledInstalledIntegration"
+                              className="e1egfpwi4 css-1r8fo78-StyledInstalledIntegration"
                             >
                               <div
-                                className="e1egfpwi3 css-13bi3jz-StyledInstalledIntegration"
+                                className="e1egfpwi4 css-1r8fo78-StyledInstalledIntegration"
                                 is={null}
                               >
                                 <Box
@@ -1863,15 +1897,15 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                           },
                                                         }
                                                       }
-                                                      size={26}
+                                                      size={22}
                                                     >
                                                       <Icon
-                                                        size={26}
+                                                        size={22}
                                                         src="http://jira.example.com/integration_icon.png"
                                                       >
                                                         <img
-                                                          className="css-b5iynx-Icon e17bf5d30"
-                                                          size={26}
+                                                          className="css-f8xrkt-Icon e17bf5d30"
+                                                          size={22}
                                                           src="http://jira.example.com/integration_icon.png"
                                                         />
                                                       </Icon>
@@ -1929,15 +1963,12 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                     </div>
                                   </Base>
                                 </Box>
-                                <Box
-                                  mr={1}
-                                >
+                                <Box>
                                   <Base
-                                    className="css-xgysgc"
-                                    mr={1}
+                                    className="css-roynbj"
                                   >
                                     <div
-                                      className="css-xgysgc"
+                                      className="css-roynbj"
                                       is={null}
                                     />
                                   </Base>
@@ -1968,126 +1999,122 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                         onConfirm={[Function]}
                                         priority="danger"
                                       >
-                                        <Button
+                                        <StyledButton
                                           borderless={true}
-                                          disabled={false}
                                           icon="icon-trash"
                                           onClick={[Function]}
-                                          size="xsmall"
                                         >
-                                          <StyledButton
-                                            aria-label="Remove"
+                                          <Button
                                             borderless={true}
+                                            className="css-1j0nrmm-StyledButton ejqw4f70"
                                             disabled={false}
+                                            icon="icon-trash"
                                             onClick={[Function]}
-                                            role="button"
-                                            size="xsmall"
                                           >
-                                            <Component
+                                            <StyledButton
                                               aria-label="Remove"
                                               borderless={true}
-                                              className="css-v5i7ge-StyledButton-getColors e17811v30"
+                                              className="css-1j0nrmm-StyledButton ejqw4f70"
                                               disabled={false}
                                               onClick={[Function]}
                                               role="button"
-                                              size="xsmall"
                                             >
-                                              <button
+                                              <Component
                                                 aria-label="Remove"
-                                                className="css-v5i7ge-StyledButton-getColors e17811v30"
+                                                borderless={true}
+                                                className="ejqw4f70 css-1rs3lxn-StyledButton-getColors-StyledButton e17811v30"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
-                                                size="xsmall"
                                               >
-                                                <ButtonLabel
-                                                  size="xsmall"
+                                                <button
+                                                  aria-label="Remove"
+                                                  className="ejqw4f70 css-1rs3lxn-StyledButton-getColors-StyledButton e17811v30"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  role="button"
                                                 >
-                                                  <Component
-                                                    className="css-6q5v1w-ButtonLabel e17811v31"
-                                                    size="xsmall"
+                                                  <ButtonLabel
+                                                    borderless={true}
                                                   >
-                                                    <Flex
-                                                      align="center"
+                                                    <Component
+                                                      borderless={true}
                                                       className="css-6q5v1w-ButtonLabel e17811v31"
-                                                      size="xsmall"
                                                     >
-                                                      <Base
+                                                      <Flex
                                                         align="center"
-                                                        className="e17811v31 css-dqr4rq-ButtonLabel"
-                                                        size="xsmall"
+                                                        className="css-6q5v1w-ButtonLabel e17811v31"
                                                       >
-                                                        <div
+                                                        <Base
+                                                          align="center"
                                                           className="e17811v31 css-dqr4rq-ButtonLabel"
-                                                          is={null}
-                                                          size="xsmall"
                                                         >
-                                                          <Icon
-                                                            hasChildren={true}
-                                                            size="xsmall"
+                                                          <div
+                                                            className="e17811v31 css-dqr4rq-ButtonLabel"
+                                                            is={null}
                                                           >
-                                                            <Component
-                                                              className="css-1jxtush-Icon e17811v32"
+                                                            <Icon
                                                               hasChildren={true}
-                                                              size="xsmall"
                                                             >
-                                                              <Box
+                                                              <Component
                                                                 className="css-1jxtush-Icon e17811v32"
-                                                                size="xsmall"
+                                                                hasChildren={true}
                                                               >
-                                                                <Base
-                                                                  className="e17811v32 css-md8goh-Icon"
-                                                                  size="xsmall"
+                                                                <Box
+                                                                  className="css-1jxtush-Icon e17811v32"
                                                                 >
-                                                                  <div
+                                                                  <Base
                                                                     className="e17811v32 css-md8goh-Icon"
-                                                                    is={null}
-                                                                    size="xsmall"
                                                                   >
-                                                                    <StyledInlineSvg
-                                                                      size="12px"
-                                                                      src="icon-trash"
+                                                                    <div
+                                                                      className="e17811v32 css-md8goh-Icon"
+                                                                      is={null}
                                                                     >
-                                                                      <InlineSvg
-                                                                        className="css-1ov3rcq-StyledInlineSvg e17811v33"
-                                                                        size="12px"
+                                                                      <StyledInlineSvg
+                                                                        size="16px"
                                                                         src="icon-trash"
                                                                       >
-                                                                        <StyledSvg
+                                                                        <InlineSvg
                                                                           className="css-1ov3rcq-StyledInlineSvg e17811v33"
-                                                                          height="12px"
-                                                                          viewBox={Object {}}
-                                                                          width="12px"
+                                                                          size="16px"
+                                                                          src="icon-trash"
                                                                         >
-                                                                          <svg
-                                                                            className="e17811v33 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                            height="12px"
+                                                                          <StyledSvg
+                                                                            className="css-1ov3rcq-StyledInlineSvg e17811v33"
+                                                                            height="16px"
                                                                             viewBox={Object {}}
-                                                                            width="12px"
+                                                                            width="16px"
                                                                           >
-                                                                            <use
-                                                                              href="#test"
-                                                                              xlinkHref="#test"
-                                                                            />
-                                                                          </svg>
-                                                                        </StyledSvg>
-                                                                      </InlineSvg>
-                                                                    </StyledInlineSvg>
-                                                                  </div>
-                                                                </Base>
-                                                              </Box>
-                                                            </Component>
-                                                          </Icon>
-                                                          Remove
-                                                        </div>
-                                                      </Base>
-                                                    </Flex>
-                                                  </Component>
-                                                </ButtonLabel>
-                                              </button>
-                                            </Component>
-                                          </StyledButton>
-                                        </Button>
+                                                                            <svg
+                                                                              className="e17811v33 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                              height="16px"
+                                                                              viewBox={Object {}}
+                                                                              width="16px"
+                                                                            >
+                                                                              <use
+                                                                                href="#test"
+                                                                                xlinkHref="#test"
+                                                                              />
+                                                                            </svg>
+                                                                          </StyledSvg>
+                                                                        </InlineSvg>
+                                                                      </StyledInlineSvg>
+                                                                    </div>
+                                                                  </Base>
+                                                                </Box>
+                                                              </Component>
+                                                            </Icon>
+                                                            Remove
+                                                          </div>
+                                                        </Base>
+                                                      </Flex>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </button>
+                                              </Component>
+                                            </StyledButton>
+                                          </Button>
+                                        </StyledButton>
                                         <Modal
                                           animation={false}
                                           autoFocus={true}
@@ -2439,11 +2466,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                         enabled={false}
                                       >
                                         <WithTheme(Component)
-                                          className="css-lya23n-Status e1egfpwi2"
+                                          className="css-1xs0jyz-Status e1egfpwi2"
                                           enabled={false}
                                         >
                                           <Component
-                                            className="css-lya23n-Status e1egfpwi2"
+                                            className="css-1xs0jyz-Status e1egfpwi2"
                                             enabled={false}
                                             theme={
                                               Object {
@@ -2645,239 +2672,259 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                               }
                                             }
                                           >
-                                            <CircleIndicator
-                                              color="#9585A3"
-                                              enabled={true}
-                                              size={6}
+                                            <Flex
+                                              align="center"
                                             >
-                                              <Circle
-                                                color="#9585A3"
-                                                enabled={true}
-                                                size={6}
+                                              <Base
+                                                align="center"
+                                                className="css-5ipae5"
                                               >
                                                 <div
-                                                  className="css-xhz9xw-Circle eljqieg0"
-                                                  color="#9585A3"
-                                                  size={6}
-                                                />
-                                              </Circle>
-                                            </CircleIndicator>
-                                            <div
-                                              className="css-lya23n-Status e1egfpwi2"
-                                              theme={
-                                                Object {
-                                                  "alert": Object {
-                                                    "attention": Object {
-                                                      "background": "#F09E71",
-                                                      "backgroundLight": "#ECBFA6",
-                                                      "border": "#D0816D",
-                                                    },
-                                                    "error": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundLight": "#FDF6F5",
-                                                      "border": "#E7C0BC",
-                                                      "iconColor": "#C72516",
-                                                      "textDark": "#5d3e3b",
-                                                      "textLight": "#92635f",
-                                                    },
-                                                    "info": Object {
-                                                      "background": "#3B6ECC",
-                                                      "backgroundLight": "#F5FAFE",
-                                                      "border": "#B5D6ED",
-                                                      "iconColor": "#3B6ECC",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#57be8c",
-                                                      "backgroundLight": "#F8FCF7",
-                                                      "border": "#BBD6B3",
-                                                      "iconColor": "#3EA573",
-                                                    },
-                                                    "warn": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                    "warning": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                  },
-                                                  "background": "#fff",
-                                                  "blue": "#3B6ECC",
-                                                  "blueDark": "#2F58A3",
-                                                  "blueLight": "#628BD6",
-                                                  "borderDark": "#D1CAD8",
-                                                  "borderLight": "#E2DBE8",
-                                                  "borderLighter": "#f9f6fd",
-                                                  "borderRadius": "4px",
-                                                  "breakpoints": Array [
-                                                    "768px",
-                                                    "992px",
-                                                    "1200px",
-                                                  ],
-                                                  "button": Object {
-                                                    "borderRadius": "3px",
-                                                    "danger": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundActive": "#bf2a1d",
-                                                      "border": "#bf2a1d",
-                                                      "borderActive": "#7d1c13",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "default": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#d8d2de",
-                                                      "borderActive": "#c9c0d1",
-                                                      "color": "#2f2936",
-                                                      "colorActive": "#161319",
-                                                    },
-                                                    "disabled": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#e3e5e6",
-                                                      "borderActive": "#e3e5e6",
-                                                      "color": "#ced3d6",
-                                                    },
-                                                    "link": Object {
-                                                      "background": "transparent",
-                                                      "backgroundActive": "transparent",
-                                                      "color": "#3B6ECC",
-                                                    },
-                                                    "primary": Object {
-                                                      "background": "#6C5FC7",
-                                                      "backgroundActive": "#4e3fb4",
-                                                      "border": "#3d328e",
-                                                      "borderActive": "#352b7b",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#3fa372",
-                                                      "backgroundActive": "#57be8c",
-                                                      "border": "#7ccca5",
-                                                      "borderActive": "#7ccca5",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                  },
-                                                  "charts": Object {
-                                                    "colors": Array [
-                                                      "#4C416B",
-                                                      "#7A5195",
-                                                      "#BC5090",
-                                                      "#EF5675",
-                                                      "#FF764A",
-                                                      "#FFA600",
-                                                    ],
-                                                    "previousPeriod": "#BDB4C7",
-                                                  },
-                                                  "disabled": "#ced3d6",
-                                                  "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
-                                                  "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
-                                                  "error": "#e03e2f",
-                                                  "fontSizeExtraLarge": "18px",
-                                                  "fontSizeLarge": "16px",
-                                                  "fontSizeMedium": "14px",
-                                                  "fontSizeSmall": "12px",
-                                                  "gray1": "#BDB4C7",
-                                                  "gray2": "#9585A3",
-                                                  "gray3": "#645574",
-                                                  "gray4": "#4A3E56",
-                                                  "gray5": "#302839",
-                                                  "gray6": "#AFA3BB",
-                                                  "green": "#57be8c",
-                                                  "greenDark": "#3EA573",
-                                                  "greenLight": "#71D8A6",
-                                                  "greenTransparent": "rgba(87, 190, 140, 0.5)",
-                                                  "grid": 8,
-                                                  "offWhite": "#FAF9FB",
-                                                  "offWhite2": "#E7E1EC",
-                                                  "orange": "#ec5e44",
-                                                  "orangeDark": "#D3452B",
-                                                  "orangeLight": "#FF785E",
-                                                  "pink": "#F868BC",
-                                                  "pinkDark": "#DF4FA3",
-                                                  "pinkLight": "#FF82D6",
-                                                  "purple": "#6C5FC7",
-                                                  "purple2": "#6f617c",
-                                                  "purpleDark": "#5346AE",
-                                                  "purpleDarkest": "#392C94",
-                                                  "purpleLight": "#8679E1",
-                                                  "purpleLightest": "#9F92FA",
-                                                  "red": "#e03e2f",
-                                                  "redDark": "#C72516",
-                                                  "redLight": "#FA5849",
-                                                  "settings": Object {
-                                                    "containerWidth": "1140px",
-                                                    "headerHeight": "115px",
-                                                    "maxCrumbWidth": "240px",
-                                                    "sidebarWidth": "210px",
-                                                  },
-                                                  "sidebar": Object {
-                                                    "background": "#2f2936",
-                                                    "badgeSize": "22px",
-                                                    "collapsedWidth": "70px",
-                                                    "color": "#9586a5",
-                                                    "divider": "#493e54",
-                                                    "expandedWidth": "220px",
-                                                    "menuSpacing": "15px",
-                                                    "mobileHeight": "54px",
-                                                    "panel": Object {
-                                                      "headerHeight": "62px",
-                                                      "width": "320px",
-                                                    },
-                                                    "smallBadgeSize": "11px",
-                                                  },
-                                                  "success": "#57be8c",
-                                                  "text": Object {
-                                                    "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
-                                                    "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
-                                                    "lineHeightBody": "1.4",
-                                                    "lineHeightHeading": "1.15",
-                                                  },
-                                                  "textColor": "#302839",
-                                                  "white": "#FFFFFF",
-                                                  "whiteDark": "#fbfbfc",
-                                                  "yellow": "#ecc844",
-                                                  "yellowDark": "#e6bc23",
-                                                  "yellowLight": "#FFF15E",
-                                                  "yellowLightest": "#FFFDF7",
-                                                  "yellowOrange": "#f9a66d",
-                                                  "yellowOrangeDark": "#E08D54",
-                                                  "yellowOrangeLight": "#FFC087",
-                                                  "zIndex": Object {
-                                                    "dropdown": 1001,
-                                                    "dropdownAutocomplete": Object {
-                                                      "actor": 3,
-                                                      "menu": 2,
-                                                    },
-                                                    "header": 1000,
-                                                    "modal": 10000,
-                                                    "orgAndUserMenu": 1003,
-                                                    "sidebar": 1002,
-                                                    "toast": 10001,
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              Not Installed
-                                            </div>
+                                                  className="css-5ipae5"
+                                                  is={null}
+                                                >
+                                                  <CircleIndicator
+                                                    color="#9585A3"
+                                                    enabled={true}
+                                                    size={6}
+                                                  >
+                                                    <Circle
+                                                      color="#9585A3"
+                                                      enabled={true}
+                                                      size={6}
+                                                    >
+                                                      <div
+                                                        className="css-xhz9xw-Circle eljqieg0"
+                                                        color="#9585A3"
+                                                        size={6}
+                                                      />
+                                                    </Circle>
+                                                  </CircleIndicator>
+                                                  <div
+                                                    className="css-1xs0jyz-Status e1egfpwi2"
+                                                    theme={
+                                                      Object {
+                                                        "alert": Object {
+                                                          "attention": Object {
+                                                            "background": "#F09E71",
+                                                            "backgroundLight": "#ECBFA6",
+                                                            "border": "#D0816D",
+                                                          },
+                                                          "error": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundLight": "#FDF6F5",
+                                                            "border": "#E7C0BC",
+                                                            "iconColor": "#C72516",
+                                                            "textDark": "#5d3e3b",
+                                                            "textLight": "#92635f",
+                                                          },
+                                                          "info": Object {
+                                                            "background": "#3B6ECC",
+                                                            "backgroundLight": "#F5FAFE",
+                                                            "border": "#B5D6ED",
+                                                            "iconColor": "#3B6ECC",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#57be8c",
+                                                            "backgroundLight": "#F8FCF7",
+                                                            "border": "#BBD6B3",
+                                                            "iconColor": "#3EA573",
+                                                          },
+                                                          "warn": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                        },
+                                                        "background": "#fff",
+                                                        "blue": "#3B6ECC",
+                                                        "blueDark": "#2F58A3",
+                                                        "blueLight": "#628BD6",
+                                                        "borderDark": "#D1CAD8",
+                                                        "borderLight": "#E2DBE8",
+                                                        "borderLighter": "#f9f6fd",
+                                                        "borderRadius": "4px",
+                                                        "breakpoints": Array [
+                                                          "768px",
+                                                          "992px",
+                                                          "1200px",
+                                                        ],
+                                                        "button": Object {
+                                                          "borderRadius": "3px",
+                                                          "danger": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundActive": "#bf2a1d",
+                                                            "border": "#bf2a1d",
+                                                            "borderActive": "#7d1c13",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "default": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#d8d2de",
+                                                            "borderActive": "#c9c0d1",
+                                                            "color": "#2f2936",
+                                                            "colorActive": "#161319",
+                                                          },
+                                                          "disabled": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#e3e5e6",
+                                                            "borderActive": "#e3e5e6",
+                                                            "color": "#ced3d6",
+                                                          },
+                                                          "link": Object {
+                                                            "background": "transparent",
+                                                            "backgroundActive": "transparent",
+                                                            "color": "#3B6ECC",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#6C5FC7",
+                                                            "backgroundActive": "#4e3fb4",
+                                                            "border": "#3d328e",
+                                                            "borderActive": "#352b7b",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#3fa372",
+                                                            "backgroundActive": "#57be8c",
+                                                            "border": "#7ccca5",
+                                                            "borderActive": "#7ccca5",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                        },
+                                                        "charts": Object {
+                                                          "colors": Array [
+                                                            "#4C416B",
+                                                            "#7A5195",
+                                                            "#BC5090",
+                                                            "#EF5675",
+                                                            "#FF764A",
+                                                            "#FFA600",
+                                                          ],
+                                                          "previousPeriod": "#BDB4C7",
+                                                        },
+                                                        "disabled": "#ced3d6",
+                                                        "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
+                                                        "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
+                                                        "error": "#e03e2f",
+                                                        "fontSizeExtraLarge": "18px",
+                                                        "fontSizeLarge": "16px",
+                                                        "fontSizeMedium": "14px",
+                                                        "fontSizeSmall": "12px",
+                                                        "gray1": "#BDB4C7",
+                                                        "gray2": "#9585A3",
+                                                        "gray3": "#645574",
+                                                        "gray4": "#4A3E56",
+                                                        "gray5": "#302839",
+                                                        "gray6": "#AFA3BB",
+                                                        "green": "#57be8c",
+                                                        "greenDark": "#3EA573",
+                                                        "greenLight": "#71D8A6",
+                                                        "greenTransparent": "rgba(87, 190, 140, 0.5)",
+                                                        "grid": 8,
+                                                        "offWhite": "#FAF9FB",
+                                                        "offWhite2": "#E7E1EC",
+                                                        "orange": "#ec5e44",
+                                                        "orangeDark": "#D3452B",
+                                                        "orangeLight": "#FF785E",
+                                                        "pink": "#F868BC",
+                                                        "pinkDark": "#DF4FA3",
+                                                        "pinkLight": "#FF82D6",
+                                                        "purple": "#6C5FC7",
+                                                        "purple2": "#6f617c",
+                                                        "purpleDark": "#5346AE",
+                                                        "purpleDarkest": "#392C94",
+                                                        "purpleLight": "#8679E1",
+                                                        "purpleLightest": "#9F92FA",
+                                                        "red": "#e03e2f",
+                                                        "redDark": "#C72516",
+                                                        "redLight": "#FA5849",
+                                                        "settings": Object {
+                                                          "containerWidth": "1140px",
+                                                          "headerHeight": "115px",
+                                                          "maxCrumbWidth": "240px",
+                                                          "sidebarWidth": "210px",
+                                                        },
+                                                        "sidebar": Object {
+                                                          "background": "#2f2936",
+                                                          "badgeSize": "22px",
+                                                          "collapsedWidth": "70px",
+                                                          "color": "#9586a5",
+                                                          "divider": "#493e54",
+                                                          "expandedWidth": "220px",
+                                                          "menuSpacing": "15px",
+                                                          "mobileHeight": "54px",
+                                                          "panel": Object {
+                                                            "headerHeight": "62px",
+                                                            "width": "320px",
+                                                          },
+                                                          "smallBadgeSize": "11px",
+                                                        },
+                                                        "success": "#57be8c",
+                                                        "text": Object {
+                                                          "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
+                                                          "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
+                                                          "lineHeightBody": "1.4",
+                                                          "lineHeightHeading": "1.15",
+                                                        },
+                                                        "textColor": "#302839",
+                                                        "white": "#FFFFFF",
+                                                        "whiteDark": "#fbfbfc",
+                                                        "yellow": "#ecc844",
+                                                        "yellowDark": "#e6bc23",
+                                                        "yellowLight": "#FFF15E",
+                                                        "yellowLightest": "#FFFDF7",
+                                                        "yellowOrange": "#f9a66d",
+                                                        "yellowOrangeDark": "#E08D54",
+                                                        "yellowOrangeLight": "#FFC087",
+                                                        "zIndex": Object {
+                                                          "dropdown": 1001,
+                                                          "dropdownAutocomplete": Object {
+                                                            "actor": 3,
+                                                            "menu": 2,
+                                                          },
+                                                          "header": 1000,
+                                                          "modal": 10000,
+                                                          "orgAndUserMenu": 1003,
+                                                          "sidebar": 1002,
+                                                          "toast": 10001,
+                                                        },
+                                                      }
+                                                    }
+                                                  >
+                                                    Not Installed
+                                                  </div>
+                                                </div>
+                                              </Base>
+                                            </Flex>
                                           </Component>
                                         </WithTheme(Component)>
                                       </Status>
-                                      <Link
+                                      <StyledLink
                                         onClick={[Function]}
                                       >
-                                        <a
+                                        <Link
+                                          className="css-u3fgwp-StyledLink e1egfpwi5"
                                           onClick={[Function]}
                                         >
-                                          Learn More
-                                        </a>
-                                      </Link>
+                                          <a
+                                            className="css-u3fgwp-StyledLink e1egfpwi5"
+                                            onClick={[Function]}
+                                          >
+                                            Learn More
+                                          </a>
+                                        </Link>
+                                      </StyledLink>
                                     </div>
                                   </Base>
                                 </ProviderDetails>
@@ -2925,23 +2972,20 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                           size="small"
                                         >
                                           <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                            className="css-o42ntg-ButtonLabel e17811v31"
                                             size="small"
                                           >
                                             <Flex
                                               align="center"
-                                              className="css-19bmqb3-ButtonLabel e17811v31"
-                                              size="small"
+                                              className="css-o42ntg-ButtonLabel e17811v31"
                                             >
                                               <Base
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                size="small"
+                                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                               >
                                                 <div
-                                                  className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                                   is={null}
-                                                  size="small"
                                                 >
                                                   <Icon
                                                     hasChildren={true}
@@ -3126,11 +3170,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                         enabled={false}
                                       >
                                         <WithTheme(Component)
-                                          className="css-lya23n-Status e1egfpwi2"
+                                          className="css-1xs0jyz-Status e1egfpwi2"
                                           enabled={false}
                                         >
                                           <Component
-                                            className="css-lya23n-Status e1egfpwi2"
+                                            className="css-1xs0jyz-Status e1egfpwi2"
                                             enabled={false}
                                             theme={
                                               Object {
@@ -3332,239 +3376,259 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                               }
                                             }
                                           >
-                                            <CircleIndicator
-                                              color="#9585A3"
-                                              enabled={true}
-                                              size={6}
+                                            <Flex
+                                              align="center"
                                             >
-                                              <Circle
-                                                color="#9585A3"
-                                                enabled={true}
-                                                size={6}
+                                              <Base
+                                                align="center"
+                                                className="css-5ipae5"
                                               >
                                                 <div
-                                                  className="css-xhz9xw-Circle eljqieg0"
-                                                  color="#9585A3"
-                                                  size={6}
-                                                />
-                                              </Circle>
-                                            </CircleIndicator>
-                                            <div
-                                              className="css-lya23n-Status e1egfpwi2"
-                                              theme={
-                                                Object {
-                                                  "alert": Object {
-                                                    "attention": Object {
-                                                      "background": "#F09E71",
-                                                      "backgroundLight": "#ECBFA6",
-                                                      "border": "#D0816D",
-                                                    },
-                                                    "error": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundLight": "#FDF6F5",
-                                                      "border": "#E7C0BC",
-                                                      "iconColor": "#C72516",
-                                                      "textDark": "#5d3e3b",
-                                                      "textLight": "#92635f",
-                                                    },
-                                                    "info": Object {
-                                                      "background": "#3B6ECC",
-                                                      "backgroundLight": "#F5FAFE",
-                                                      "border": "#B5D6ED",
-                                                      "iconColor": "#3B6ECC",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#57be8c",
-                                                      "backgroundLight": "#F8FCF7",
-                                                      "border": "#BBD6B3",
-                                                      "iconColor": "#3EA573",
-                                                    },
-                                                    "warn": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                    "warning": Object {
-                                                      "background": "#ecc844",
-                                                      "backgroundLight": "#FFFDF7",
-                                                      "border": "#E1D697",
-                                                      "iconColor": "#e6bc23",
-                                                      "textDark": "#D3BE2B",
-                                                    },
-                                                  },
-                                                  "background": "#fff",
-                                                  "blue": "#3B6ECC",
-                                                  "blueDark": "#2F58A3",
-                                                  "blueLight": "#628BD6",
-                                                  "borderDark": "#D1CAD8",
-                                                  "borderLight": "#E2DBE8",
-                                                  "borderLighter": "#f9f6fd",
-                                                  "borderRadius": "4px",
-                                                  "breakpoints": Array [
-                                                    "768px",
-                                                    "992px",
-                                                    "1200px",
-                                                  ],
-                                                  "button": Object {
-                                                    "borderRadius": "3px",
-                                                    "danger": Object {
-                                                      "background": "#e03e2f",
-                                                      "backgroundActive": "#bf2a1d",
-                                                      "border": "#bf2a1d",
-                                                      "borderActive": "#7d1c13",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "default": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#d8d2de",
-                                                      "borderActive": "#c9c0d1",
-                                                      "color": "#2f2936",
-                                                      "colorActive": "#161319",
-                                                    },
-                                                    "disabled": Object {
-                                                      "background": "#FFFFFF",
-                                                      "backgroundActive": "#FFFFFF",
-                                                      "border": "#e3e5e6",
-                                                      "borderActive": "#e3e5e6",
-                                                      "color": "#ced3d6",
-                                                    },
-                                                    "link": Object {
-                                                      "background": "transparent",
-                                                      "backgroundActive": "transparent",
-                                                      "color": "#3B6ECC",
-                                                    },
-                                                    "primary": Object {
-                                                      "background": "#6C5FC7",
-                                                      "backgroundActive": "#4e3fb4",
-                                                      "border": "#3d328e",
-                                                      "borderActive": "#352b7b",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                    "success": Object {
-                                                      "background": "#3fa372",
-                                                      "backgroundActive": "#57be8c",
-                                                      "border": "#7ccca5",
-                                                      "borderActive": "#7ccca5",
-                                                      "color": "#FFFFFF",
-                                                    },
-                                                  },
-                                                  "charts": Object {
-                                                    "colors": Array [
-                                                      "#4C416B",
-                                                      "#7A5195",
-                                                      "#BC5090",
-                                                      "#EF5675",
-                                                      "#FF764A",
-                                                      "#FFA600",
-                                                    ],
-                                                    "previousPeriod": "#BDB4C7",
-                                                  },
-                                                  "disabled": "#ced3d6",
-                                                  "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
-                                                  "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
-                                                  "error": "#e03e2f",
-                                                  "fontSizeExtraLarge": "18px",
-                                                  "fontSizeLarge": "16px",
-                                                  "fontSizeMedium": "14px",
-                                                  "fontSizeSmall": "12px",
-                                                  "gray1": "#BDB4C7",
-                                                  "gray2": "#9585A3",
-                                                  "gray3": "#645574",
-                                                  "gray4": "#4A3E56",
-                                                  "gray5": "#302839",
-                                                  "gray6": "#AFA3BB",
-                                                  "green": "#57be8c",
-                                                  "greenDark": "#3EA573",
-                                                  "greenLight": "#71D8A6",
-                                                  "greenTransparent": "rgba(87, 190, 140, 0.5)",
-                                                  "grid": 8,
-                                                  "offWhite": "#FAF9FB",
-                                                  "offWhite2": "#E7E1EC",
-                                                  "orange": "#ec5e44",
-                                                  "orangeDark": "#D3452B",
-                                                  "orangeLight": "#FF785E",
-                                                  "pink": "#F868BC",
-                                                  "pinkDark": "#DF4FA3",
-                                                  "pinkLight": "#FF82D6",
-                                                  "purple": "#6C5FC7",
-                                                  "purple2": "#6f617c",
-                                                  "purpleDark": "#5346AE",
-                                                  "purpleDarkest": "#392C94",
-                                                  "purpleLight": "#8679E1",
-                                                  "purpleLightest": "#9F92FA",
-                                                  "red": "#e03e2f",
-                                                  "redDark": "#C72516",
-                                                  "redLight": "#FA5849",
-                                                  "settings": Object {
-                                                    "containerWidth": "1140px",
-                                                    "headerHeight": "115px",
-                                                    "maxCrumbWidth": "240px",
-                                                    "sidebarWidth": "210px",
-                                                  },
-                                                  "sidebar": Object {
-                                                    "background": "#2f2936",
-                                                    "badgeSize": "22px",
-                                                    "collapsedWidth": "70px",
-                                                    "color": "#9586a5",
-                                                    "divider": "#493e54",
-                                                    "expandedWidth": "220px",
-                                                    "menuSpacing": "15px",
-                                                    "mobileHeight": "54px",
-                                                    "panel": Object {
-                                                      "headerHeight": "62px",
-                                                      "width": "320px",
-                                                    },
-                                                    "smallBadgeSize": "11px",
-                                                  },
-                                                  "success": "#57be8c",
-                                                  "text": Object {
-                                                    "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
-                                                    "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
-                                                    "lineHeightBody": "1.4",
-                                                    "lineHeightHeading": "1.15",
-                                                  },
-                                                  "textColor": "#302839",
-                                                  "white": "#FFFFFF",
-                                                  "whiteDark": "#fbfbfc",
-                                                  "yellow": "#ecc844",
-                                                  "yellowDark": "#e6bc23",
-                                                  "yellowLight": "#FFF15E",
-                                                  "yellowLightest": "#FFFDF7",
-                                                  "yellowOrange": "#f9a66d",
-                                                  "yellowOrangeDark": "#E08D54",
-                                                  "yellowOrangeLight": "#FFC087",
-                                                  "zIndex": Object {
-                                                    "dropdown": 1001,
-                                                    "dropdownAutocomplete": Object {
-                                                      "actor": 3,
-                                                      "menu": 2,
-                                                    },
-                                                    "header": 1000,
-                                                    "modal": 10000,
-                                                    "orgAndUserMenu": 1003,
-                                                    "sidebar": 1002,
-                                                    "toast": 10001,
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              Not Installed
-                                            </div>
+                                                  className="css-5ipae5"
+                                                  is={null}
+                                                >
+                                                  <CircleIndicator
+                                                    color="#9585A3"
+                                                    enabled={true}
+                                                    size={6}
+                                                  >
+                                                    <Circle
+                                                      color="#9585A3"
+                                                      enabled={true}
+                                                      size={6}
+                                                    >
+                                                      <div
+                                                        className="css-xhz9xw-Circle eljqieg0"
+                                                        color="#9585A3"
+                                                        size={6}
+                                                      />
+                                                    </Circle>
+                                                  </CircleIndicator>
+                                                  <div
+                                                    className="css-1xs0jyz-Status e1egfpwi2"
+                                                    theme={
+                                                      Object {
+                                                        "alert": Object {
+                                                          "attention": Object {
+                                                            "background": "#F09E71",
+                                                            "backgroundLight": "#ECBFA6",
+                                                            "border": "#D0816D",
+                                                          },
+                                                          "error": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundLight": "#FDF6F5",
+                                                            "border": "#E7C0BC",
+                                                            "iconColor": "#C72516",
+                                                            "textDark": "#5d3e3b",
+                                                            "textLight": "#92635f",
+                                                          },
+                                                          "info": Object {
+                                                            "background": "#3B6ECC",
+                                                            "backgroundLight": "#F5FAFE",
+                                                            "border": "#B5D6ED",
+                                                            "iconColor": "#3B6ECC",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#57be8c",
+                                                            "backgroundLight": "#F8FCF7",
+                                                            "border": "#BBD6B3",
+                                                            "iconColor": "#3EA573",
+                                                          },
+                                                          "warn": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ecc844",
+                                                            "backgroundLight": "#FFFDF7",
+                                                            "border": "#E1D697",
+                                                            "iconColor": "#e6bc23",
+                                                            "textDark": "#D3BE2B",
+                                                          },
+                                                        },
+                                                        "background": "#fff",
+                                                        "blue": "#3B6ECC",
+                                                        "blueDark": "#2F58A3",
+                                                        "blueLight": "#628BD6",
+                                                        "borderDark": "#D1CAD8",
+                                                        "borderLight": "#E2DBE8",
+                                                        "borderLighter": "#f9f6fd",
+                                                        "borderRadius": "4px",
+                                                        "breakpoints": Array [
+                                                          "768px",
+                                                          "992px",
+                                                          "1200px",
+                                                        ],
+                                                        "button": Object {
+                                                          "borderRadius": "3px",
+                                                          "danger": Object {
+                                                            "background": "#e03e2f",
+                                                            "backgroundActive": "#bf2a1d",
+                                                            "border": "#bf2a1d",
+                                                            "borderActive": "#7d1c13",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "default": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#d8d2de",
+                                                            "borderActive": "#c9c0d1",
+                                                            "color": "#2f2936",
+                                                            "colorActive": "#161319",
+                                                          },
+                                                          "disabled": Object {
+                                                            "background": "#FFFFFF",
+                                                            "backgroundActive": "#FFFFFF",
+                                                            "border": "#e3e5e6",
+                                                            "borderActive": "#e3e5e6",
+                                                            "color": "#ced3d6",
+                                                          },
+                                                          "link": Object {
+                                                            "background": "transparent",
+                                                            "backgroundActive": "transparent",
+                                                            "color": "#3B6ECC",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#6C5FC7",
+                                                            "backgroundActive": "#4e3fb4",
+                                                            "border": "#3d328e",
+                                                            "borderActive": "#352b7b",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#3fa372",
+                                                            "backgroundActive": "#57be8c",
+                                                            "border": "#7ccca5",
+                                                            "borderActive": "#7ccca5",
+                                                            "color": "#FFFFFF",
+                                                          },
+                                                        },
+                                                        "charts": Object {
+                                                          "colors": Array [
+                                                            "#4C416B",
+                                                            "#7A5195",
+                                                            "#BC5090",
+                                                            "#EF5675",
+                                                            "#FF764A",
+                                                            "#FFA600",
+                                                          ],
+                                                          "previousPeriod": "#BDB4C7",
+                                                        },
+                                                        "disabled": "#ced3d6",
+                                                        "dropShadowHeavy": "0 1px 4px 1px rgba(47,40,55,0.08), 0 4px 16px 0 rgba(47,40,55,0.12)",
+                                                        "dropShadowLight": "0 2px 0 rgba(37, 11, 54, 0.04)",
+                                                        "error": "#e03e2f",
+                                                        "fontSizeExtraLarge": "18px",
+                                                        "fontSizeLarge": "16px",
+                                                        "fontSizeMedium": "14px",
+                                                        "fontSizeSmall": "12px",
+                                                        "gray1": "#BDB4C7",
+                                                        "gray2": "#9585A3",
+                                                        "gray3": "#645574",
+                                                        "gray4": "#4A3E56",
+                                                        "gray5": "#302839",
+                                                        "gray6": "#AFA3BB",
+                                                        "green": "#57be8c",
+                                                        "greenDark": "#3EA573",
+                                                        "greenLight": "#71D8A6",
+                                                        "greenTransparent": "rgba(87, 190, 140, 0.5)",
+                                                        "grid": 8,
+                                                        "offWhite": "#FAF9FB",
+                                                        "offWhite2": "#E7E1EC",
+                                                        "orange": "#ec5e44",
+                                                        "orangeDark": "#D3452B",
+                                                        "orangeLight": "#FF785E",
+                                                        "pink": "#F868BC",
+                                                        "pinkDark": "#DF4FA3",
+                                                        "pinkLight": "#FF82D6",
+                                                        "purple": "#6C5FC7",
+                                                        "purple2": "#6f617c",
+                                                        "purpleDark": "#5346AE",
+                                                        "purpleDarkest": "#392C94",
+                                                        "purpleLight": "#8679E1",
+                                                        "purpleLightest": "#9F92FA",
+                                                        "red": "#e03e2f",
+                                                        "redDark": "#C72516",
+                                                        "redLight": "#FA5849",
+                                                        "settings": Object {
+                                                          "containerWidth": "1140px",
+                                                          "headerHeight": "115px",
+                                                          "maxCrumbWidth": "240px",
+                                                          "sidebarWidth": "210px",
+                                                        },
+                                                        "sidebar": Object {
+                                                          "background": "#2f2936",
+                                                          "badgeSize": "22px",
+                                                          "collapsedWidth": "70px",
+                                                          "color": "#9586a5",
+                                                          "divider": "#493e54",
+                                                          "expandedWidth": "220px",
+                                                          "menuSpacing": "15px",
+                                                          "mobileHeight": "54px",
+                                                          "panel": Object {
+                                                            "headerHeight": "62px",
+                                                            "width": "320px",
+                                                          },
+                                                          "smallBadgeSize": "11px",
+                                                        },
+                                                        "success": "#57be8c",
+                                                        "text": Object {
+                                                          "family": "\\"Rubik\\", \\"Avenir Next\\", sans-serif",
+                                                          "familyMono": "Monaco, Consolas, \\"Courier New\\", monospace",
+                                                          "lineHeightBody": "1.4",
+                                                          "lineHeightHeading": "1.15",
+                                                        },
+                                                        "textColor": "#302839",
+                                                        "white": "#FFFFFF",
+                                                        "whiteDark": "#fbfbfc",
+                                                        "yellow": "#ecc844",
+                                                        "yellowDark": "#e6bc23",
+                                                        "yellowLight": "#FFF15E",
+                                                        "yellowLightest": "#FFFDF7",
+                                                        "yellowOrange": "#f9a66d",
+                                                        "yellowOrangeDark": "#E08D54",
+                                                        "yellowOrangeLight": "#FFC087",
+                                                        "zIndex": Object {
+                                                          "dropdown": 1001,
+                                                          "dropdownAutocomplete": Object {
+                                                            "actor": 3,
+                                                            "menu": 2,
+                                                          },
+                                                          "header": 1000,
+                                                          "modal": 10000,
+                                                          "orgAndUserMenu": 1003,
+                                                          "sidebar": 1002,
+                                                          "toast": 10001,
+                                                        },
+                                                      }
+                                                    }
+                                                  >
+                                                    Not Installed
+                                                  </div>
+                                                </div>
+                                              </Base>
+                                            </Flex>
                                           </Component>
                                         </WithTheme(Component)>
                                       </Status>
-                                      <Link
+                                      <StyledLink
                                         onClick={[Function]}
                                       >
-                                        <a
+                                        <Link
+                                          className="css-u3fgwp-StyledLink e1egfpwi5"
                                           onClick={[Function]}
                                         >
-                                          Learn More
-                                        </a>
-                                      </Link>
+                                          <a
+                                            className="css-u3fgwp-StyledLink e1egfpwi5"
+                                            onClick={[Function]}
+                                          >
+                                            Learn More
+                                          </a>
+                                        </Link>
+                                      </StyledLink>
                                     </div>
                                   </Base>
                                 </ProviderDetails>
@@ -3612,23 +3676,20 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                           size="small"
                                         >
                                           <Component
-                                            className="css-19bmqb3-ButtonLabel e17811v31"
+                                            className="css-o42ntg-ButtonLabel e17811v31"
                                             size="small"
                                           >
                                             <Flex
                                               align="center"
-                                              className="css-19bmqb3-ButtonLabel e17811v31"
-                                              size="small"
+                                              className="css-o42ntg-ButtonLabel e17811v31"
                                             >
                                               <Base
                                                 align="center"
-                                                className="e17811v31 css-1eblpyp-ButtonLabel"
-                                                size="small"
+                                                className="e17811v31 css-l5mlqc-ButtonLabel"
                                               >
                                                 <div
-                                                  className="e17811v31 css-1eblpyp-ButtonLabel"
+                                                  className="e17811v31 css-l5mlqc-ButtonLabel"
                                                   is={null}
-                                                  size="small"
                                                 >
                                                   <Icon
                                                     hasChildren={true}

--- a/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
@@ -189,18 +189,18 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                 >
                   <ButtonLabel>
                     <Component
-                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                      className="css-1emshjx-ButtonLabel e17811v31"
                     >
                       <Flex
                         align="center"
-                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                        className="css-1emshjx-ButtonLabel e17811v31"
                       >
                         <Base
                           align="center"
-                          className="e17811v31 css-mvnt76-ButtonLabel"
+                          className="e17811v31 css-1nhrbny-ButtonLabel"
                         >
                           <div
-                            className="e17811v31 css-mvnt76-ButtonLabel"
+                            className="e17811v31 css-1nhrbny-ButtonLabel"
                             is={null}
                           >
                             Cancel
@@ -249,20 +249,23 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                   priority="primary"
                   role="button"
                 >
-                  <ButtonLabel>
+                  <ButtonLabel
+                    priority="primary"
+                  >
                     <Component
-                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                      className="css-1emshjx-ButtonLabel e17811v31"
+                      priority="primary"
                     >
                       <Flex
                         align="center"
-                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                        className="css-1emshjx-ButtonLabel e17811v31"
                       >
                         <Base
                           align="center"
-                          className="e17811v31 css-mvnt76-ButtonLabel"
+                          className="e17811v31 css-1nhrbny-ButtonLabel"
                         >
                           <div
-                            className="e17811v31 css-mvnt76-ButtonLabel"
+                            className="e17811v31 css-1nhrbny-ButtonLabel"
                             is={null}
                           >
                             Bulk resolve issues
@@ -503,18 +506,18 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                 >
                   <ButtonLabel>
                     <Component
-                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                      className="css-1emshjx-ButtonLabel e17811v31"
                     >
                       <Flex
                         align="center"
-                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                        className="css-1emshjx-ButtonLabel e17811v31"
                       >
                         <Base
                           align="center"
-                          className="e17811v31 css-mvnt76-ButtonLabel"
+                          className="e17811v31 css-1nhrbny-ButtonLabel"
                         >
                           <div
-                            className="e17811v31 css-mvnt76-ButtonLabel"
+                            className="e17811v31 css-1nhrbny-ButtonLabel"
                             is={null}
                           >
                             Cancel
@@ -563,20 +566,23 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                   priority="primary"
                   role="button"
                 >
-                  <ButtonLabel>
+                  <ButtonLabel
+                    priority="primary"
+                  >
                     <Component
-                      className="css-1dxlw1i-ButtonLabel e17811v31"
+                      className="css-1emshjx-ButtonLabel e17811v31"
+                      priority="primary"
                     >
                       <Flex
                         align="center"
-                        className="css-1dxlw1i-ButtonLabel e17811v31"
+                        className="css-1emshjx-ButtonLabel e17811v31"
                       >
                         <Base
                           align="center"
-                          className="e17811v31 css-mvnt76-ButtonLabel"
+                          className="e17811v31 css-1nhrbny-ButtonLabel"
                         >
                           <div
-                            className="e17811v31 css-mvnt76-ButtonLabel"
+                            className="e17811v31 css-1nhrbny-ButtonLabel"
                             is={null}
                           >
                             Bulk resolve issues


### PR DESCRIPTION
This adds in a couple things from the original designs that I thought were good and got left out, notably:

* User tests showed that folks struggled to read the icons. I improved the "borderless" visual state for  buttons and used it to bump up the size.
* Added Clearer parent -> child relationship with smaller child avatar icons
* Added a separator between installation indicator and "learn more"
* Gave the "learn more" button a super low visual importance level

before:
![image](https://user-images.githubusercontent.com/435981/44362695-994f3000-a476-11e8-9bdc-67204c3a4c8f.png)
after:
![image](https://user-images.githubusercontent.com/435981/44363839-3b244c00-a47a-11e8-8660-207463543545.png)

I also took this opportunity to tidy a few things up:

* moved animations into animations.jsx
* improved borderless styles in button to support text (all our current borderless buttons are icon-only)
* removed a ton of prop warnings from button (and generated x-million snapshot changes in the process)