### PR TITLE
feat(ui): Change "Add team" from dashboard to use modal

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
@@ -1,3 +1,4 @@
+import {browserHistory} from 'react-router';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import {Flex, Box} from 'grid-emotion';
@@ -5,8 +6,9 @@ import styled from 'react-emotion';
 
 import space from 'app/styles/space';
 
+import {openCreateTeamModal} from 'app/actionCreators/modal';
+import ApiMixin from 'app/mixins/apiMixin';
 import OrganizationState from 'app/mixins/organizationState';
-
 import DropdownLink from 'app/components/dropdownLink';
 import MenuItem from 'app/components/menuItem';
 import {t} from 'app/locale';
@@ -15,7 +17,7 @@ import ProjectSelector from 'app/components/projectHeader/projectSelector';
 import Tooltip from 'app/components/tooltip';
 
 const ProjectNav = createReactClass({
-  mixins: [OrganizationState],
+  mixins: [ApiMixin, OrganizationState],
 
   render() {
     const org = this.getOrganization();
@@ -33,6 +35,16 @@ const ProjectNav = createReactClass({
       {
         title: t('Team'),
         to: `/organizations/${org.slug}/teams/new/`,
+        onSelect: () => {
+          openCreateTeamModal({
+            organization: org,
+            onClose: data => {
+              if (!data) return;
+
+              browserHistory.push(`/settings/${org.slug}/teams/${data.slug}/members/`);
+            },
+          });
+        },
         disabled: !hasTeamWrite,
         tooltip: t('You do not have permission to create new teams'),
       },
@@ -63,6 +75,7 @@ const ProjectNav = createReactClass({
             to={item.to}
             key={item.title}
             disabled={item.disabled}
+            onSelect={item.onSelect}
           >
             {item.title}
           </MenuItem>


### PR DESCRIPTION
This opens a modal to create a team when trying to add a team from the dashboard (redirects to team settings after)