### PR TITLE
fix(discover): Only pass message to error indicator

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -81,8 +81,8 @@ export default class OrganizationDiscover extends React.Component {
           )}`,
         });
       },
-      errMessage => {
-        addErrorMessage(errMessage);
+      err => {
+        addErrorMessage(err.message);
         this.setState({result: null, isFetchingQuery: false});
       }
     );


### PR DESCRIPTION
Indicator now only accepts the message, not an error instance