### PR TITLE
fix(api): Release models need default counts

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -77,10 +77,10 @@ class Release(Model):
     owner = FlexibleForeignKey('sentry.User', null=True, blank=True)
 
     # materialized stats
-    commit_count = BoundedPositiveIntegerField(null=True)
+    commit_count = BoundedPositiveIntegerField(null=True, default=0)
     last_commit_id = BoundedPositiveIntegerField(null=True)
     authors = ArrayField(null=True)
-    total_deploys = BoundedPositiveIntegerField(null=True)
+    total_deploys = BoundedPositiveIntegerField(null=True, default=0)
     last_deploy_id = BoundedPositiveIntegerField(null=True)
 
     class Meta:


### PR DESCRIPTION
Without this, since the default value is NULL, you can't increment NULL.
This means if the instance is created without explicitly setting
`commit_count=0` or `total_deploys=0`, in the future doing
`total_deploys=F('total_deploys')+1` doesn't do anything, since `NULL+1`
is still NULL.

This does not require a database migration, since this value is simply
used by Django.