### PR TITLE
ref(search): Make Search component reusable

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/commandPalette.jsx
+++ b/src/sentry/static/sentry/app/components/modals/commandPalette.jsx
@@ -43,7 +43,7 @@ class CommandPaletteModal extends React.Component {
       <Body>
         <Search
           {...this.props}
-          source="command_palette"
+          entryPoint="command_palette"
           minSearch={1}
           maxResults={10}
           dropdownStyle={dropdownStyle}

--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -13,13 +13,19 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import SearchResult from 'app/components/search/searchResult';
 import SearchResultWrapper from 'app/components/search/searchResultWrapper';
 import SearchSources from 'app/components/search/sources';
+import ApiSource from 'app/components/search/sources/apiSource';
+import CommandSource from 'app/components/search/sources/commandSource';
+import FormSource from 'app/components/search/sources/formSource';
+import RouteSource from 'app/components/search/sources/routeSource';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
 
 // "Omni" search
 class Search extends React.Component {
   static propTypes = {
     // For analytics
-    source: PropTypes.oneOf(['settings_search', 'command_palette']).isRequired,
+    entryPoint: PropTypes.oneOf(['settings_search', 'command_palette']).isRequired,
+
+    sources: PropTypes.array.isRequired,
 
     router: PropTypes.object,
     /**
@@ -59,16 +65,17 @@ class Search extends React.Component {
         <SearchResult highlighted={highlighted} item={item} matches={matches} />
       </SearchResultWrapper>
     ),
+    sources: [ApiSource, FormSource, RouteSource, CommandSource],
   };
 
   componentDidMount() {
-    analytics(`${this.props.source}.open`);
+    analytics(`${this.props.entryPoint}.open`);
   }
 
   handleSelect = (item, state) => {
     if (!item) return;
 
-    analytics(`${this.props.source}.select`, {query: state && state.inputValue});
+    analytics(`${this.props.entryPoint}.select`, {query: state && state.inputValue});
 
     let {to, action} = item;
 
@@ -89,7 +96,7 @@ class Search extends React.Component {
 
   saveQueryMetrics = debounce(query => {
     if (!query) return;
-    analytics(`${this.props.source}.query`, {query});
+    analytics(`${this.props.entryPoint}.query`, {query});
   }, 200);
 
   renderItem = ({resultObj, index, highlightedIndex, getItemProps}) => {
@@ -130,6 +137,7 @@ class Search extends React.Component {
       minSearch,
       maxResults,
       renderInput,
+      sources,
     } = this.props;
 
     return (
@@ -163,6 +171,7 @@ class Search extends React.Component {
                   searchOptions={searchOptions}
                   query={searchQuery}
                   params={params}
+                  sources={sources}
                 >
                   {({isLoading, results, hasAnyResults}) => (
                     <DropdownBox css={dropdownStyle}>

--- a/src/sentry/static/sentry/app/components/search/sources/formSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/formSource.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
+import {loadSearchMap} from 'app/actionCreators/formSearch';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import FormSearchStore from 'app/stores/formSearchStore';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
@@ -87,6 +88,12 @@ const FormSourceContainer = withRouter(
   createReactClass({
     displayName: 'FormSourceContainer',
     mixins: [Reflux.connect(FormSearchStore, 'searchMap')],
+
+    componentDidMount() {
+      // Loads form fields
+      loadSearchMap();
+    },
+
     render() {
       return <FormSource searchMap={this.state.searchMap} {...this.props} />;
     },

--- a/src/sentry/static/sentry/app/components/search/sources/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/index.jsx
@@ -45,6 +45,9 @@ class SearchSources extends React.Component {
     return (
       <Source {...this.props}>
         {args => {
+          // Mutate the array instead of pushing because we don't know how often
+          // this child function will be called and pushing will cause duplicate
+          // results to be pushed for all calls down the chain.
           results[idx] = args;
           return this.renderSources(sources, results, idx + 1);
         }}

--- a/src/sentry/static/sentry/app/components/search/sources/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/index.jsx
@@ -2,14 +2,9 @@ import {flatten} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {loadSearchMap} from 'app/actionCreators/formSearch';
-import ApiSource from 'app/components/search/sources/apiSource';
-import CommandSource from 'app/components/search/sources/commandSource';
-import FormSource from 'app/components/search/sources/formSource';
-import RouteSource from 'app/components/search/sources/routeSource';
-
 class SearchSources extends React.Component {
   static propTypes = {
+    sources: PropTypes.array.isRequired,
     query: PropTypes.string,
     /**
      * Render function the passes:
@@ -21,13 +16,8 @@ class SearchSources extends React.Component {
     children: PropTypes.func,
   };
 
-  componentDidMount() {
-    // Loads form fields
-    loadSearchMap();
-  }
-
   // `allSources` will be an array of all result objects from each source
-  renderResults(...allSources) {
+  renderResults(allSources) {
     let {children} = this.props;
 
     // loading means if any result has `isLoading` OR any result is null
@@ -47,25 +37,24 @@ class SearchSources extends React.Component {
     });
   }
 
-  render() {
+  renderSources(sources, results, idx) {
+    if (idx >= sources.length) {
+      return this.renderResults(results);
+    }
+    let Source = sources[idx];
     return (
-      <ApiSource {...this.props}>
-        {apiArgs => (
-          <FormSource {...this.props}>
-            {formFieldArgs => (
-              <RouteSource {...this.props}>
-                {routeArgs => (
-                  <CommandSource {...this.props}>
-                    {commandArgs =>
-                      this.renderResults(apiArgs, formFieldArgs, routeArgs, commandArgs)}
-                  </CommandSource>
-                )}
-              </RouteSource>
-            )}
-          </FormSource>
-        )}
-      </ApiSource>
+      <Source {...this.props}>
+        {args => {
+          results[idx] = args;
+          return this.renderSources(sources, results, idx + 1);
+        }}
+      </Source>
     );
+  }
+
+  render() {
+    let {sources} = this.props;
+    return this.renderSources(sources, new Array(sources.length), 0);
   }
 }
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsSearch/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsSearch/index.jsx
@@ -23,7 +23,7 @@ class SettingsSearch extends React.Component {
     return (
       <Search
         {...this.props}
-        source="settings_search"
+        entryPoint="settings_search"
         minSearch={MIN_SEARCH_LENGTH}
         maxResults={MAX_RESULTS}
         renderInput={({getInputProps}) => (

--- a/tests/js/spec/components/search/sources/formSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/formSource.spec.jsx
@@ -3,6 +3,7 @@ import {mount} from 'enzyme';
 
 import FormSource from 'app/components/search/sources/formSource';
 import FormSearchActions from 'app/actions/formSearchActions';
+import * as ActionCreators from 'app/actionCreators/formSearch';
 
 describe('FormSource', function() {
   let wrapper;
@@ -24,9 +25,15 @@ describe('FormSource', function() {
       },
     },
   ];
+  let loadStub;
 
   beforeEach(function() {
+    loadStub = sinon.stub(ActionCreators, 'loadSearchMap');
     FormSearchActions.loadSearchMap(searchMap);
+  });
+
+  afterEach(function() {
+    loadStub.restore();
   });
 
   it('can find a form field', async function() {


### PR DESCRIPTION
This parametrizes the Search component with the sources to be used, whereas previously it was hard-coded. Will be used in a future PR.