### PR TITLE
fix(discover): Querybuilder always rejects with an Error

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -175,7 +175,7 @@ export default function createQueryBuilder(initial = {}, organization) {
 
     // Reject immediately if no projects are available
     if (!data.projects.length) {
-      return Promise.reject(t('No projects selected'));
+      return Promise.reject(new Error(t('No projects selected')));
     }
 
     return api

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -121,7 +121,9 @@ describe('Query Builder', function() {
 
     it('handles no projects', async function() {
       const result = queryBuilder.fetch({projects: []});
-      await expect(result).rejects.toEqual('No projects selected');
+      await expect(result).rejects.toMatchObject({
+        message: 'No projects selected',
+      });
       expect(discoverMock).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Reject with an error if there are no projects selected