### PR TITLE
feat(integrations): Disable plugin if migrated

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from sentry.integrations import Integration, IntegrationFeatures, IntegrationProvider, IntegrationMetadata
 from sentry.integrations.atlassian_connect import AtlassianConnectValidationError, get_integration_from_request
+from sentry.integrations.migrate import PluginMigrator
 from sentry.integrations.repositories import RepositoryMixin
 from sentry.pipeline import NestedPipelineView, PipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
@@ -114,6 +115,8 @@ class BitbucketIntegrationProvider(IntegrationProvider):
 
         for repo in filter(lambda r: r not in unmigrateable_repos, repos):
             repo.update(integration_id=integration.id)
+
+        PluginMigrator(integration, organization).call()
 
     def build_integration(self, state):
         if state.get('publicKey'):

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -9,6 +9,7 @@ from sentry.integrations import Integration, IntegrationFeatures, IntegrationPro
 from sentry.integrations.exceptions import ApiError
 from sentry.integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.integrations.repositories import RepositoryMixin
+from sentry.integrations.migrate import PluginMigrator
 from sentry.models import Repository
 from sentry.pipeline import NestedPipelineView, PipelineView
 from sentry.utils.http import absolute_uri
@@ -153,6 +154,8 @@ class GitHubIntegrationProvider(IntegrationProvider):
 
         for repo in filter(lambda r: r not in unmigratable_repos, repos):
             repo.update(integration_id=integration.id)
+
+        PluginMigrator(integration, organization).call()
 
     def get_pipeline_views(self):
         identity_pipeline_config = {

--- a/src/sentry/integrations/migrate.py
+++ b/src/sentry/integrations/migrate.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+
+from sentry.models import Repository
+from sentry.plugins import plugins
+from sentry.utils.cache import memoize
+
+
+class PluginMigrator(object):
+    def __init__(self, integration, organization):
+        self.integration = integration
+        self.organization = organization
+
+    def call(self):
+        for project in self.projects:
+            for plugin in plugins.for_project(project):
+                if self.all_repos_migrated(plugin.slug):
+                    # Since repos are Org-level, if they're all migrated, we
+                    # can disable the Plugin for all Projects. There'd be no
+                    # Repos left, associated with the Plugin.
+                    self.disable_for_all_projects(plugin)
+
+    def all_repos_migrated(self, provider):
+        provider = 'visualstudio' if provider == 'vsts' else provider
+
+        return all(
+            r.integration_id is not None
+            for r in self.repos_for_provider(provider)
+        )
+
+    def disable_for_all_projects(self, plugin):
+        for project in self.projects:
+            try:
+                plugin.disable(project=project)
+            except NotImplementedError:
+                pass
+
+    def repos_for_provider(self, provider):
+        return filter(lambda r: r.provider == provider, self.repositories)
+
+    @property
+    def repositories(self):
+        return Repository.objects.filter(
+            organization_id=self.organization.id,
+        )
+
+    @memoize
+    def projects(self):
+        return list(self.organization.project_set.all())
+
+    @property
+    def plugins(self):
+        return [
+            plugins.configurable_for_project(project)
+            for project in self.projects
+        ]

--- a/tests/sentry/integrations/test_migrate.py
+++ b/tests/sentry/integrations/test_migrate.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from sentry.integrations.example import ExampleIntegrationProvider
+from sentry.integrations.migrate import PluginMigrator
+from sentry.models import Integration, Repository
+from sentry.plugins import plugins
+from sentry.plugins.bases.issue2 import IssuePlugin2
+from sentry.testutils import TestCase
+
+
+class ExamplePlugin(IssuePlugin2):
+    slug = 'example'
+
+
+plugins.register(ExamplePlugin)
+
+
+class PluginMigratorTest(TestCase):
+    def setUp(self):
+        super(PluginMigratorTest, self).setUp()
+
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+
+        self.integration = ExampleIntegrationProvider()
+
+        self.migrator = PluginMigrator(self.integration, self.organization)
+
+    def test_all_repos_migrated(self):
+        integration = Integration.objects.create(
+            provider=ExampleIntegrationProvider.key,
+        )
+
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            provider=self.integration.key,
+            integration_id=integration.id,
+        )
+
+        assert self.migrator.all_repos_migrated(self.integration.key)
+
+    def test_disable_for_all_projects(self):
+        plugin = plugins.get('example')
+        plugin.enable(self.project)
+
+        assert plugin in plugins.for_project(self.project)
+
+        self.migrator.disable_for_all_projects(plugin)
+
+        assert plugin not in plugins.for_project(self.project)
+
+    def test_call(self):
+        plugin = plugins.get('example')
+        plugin.enable(self.project)
+
+        self.migrator.call()
+        assert plugin not in plugins.for_project(self.project)

--- a/tests/sentry/plugins/testutils.py
+++ b/tests/sentry/plugins/testutils.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+
+from sentry.plugins import plugins, IssueTrackingPlugin2
+
+
+class VstsPlugin(IssueTrackingPlugin2):
+    slug = 'vsts'
+    conf_key = slug
+
+
+class GitHubPlugin(IssueTrackingPlugin2):
+    slug = 'github'
+    conf_key = slug
+
+
+class BitbucketPlugin(IssueTrackingPlugin2):
+    slug = 'bitbucket'
+    conf_key = slug
+
+
+plugins.register(VstsPlugin)
+plugins.register(GitHubPlugin)
+plugins.register(BitbucketPlugin)


### PR DESCRIPTION
For Integrations that have a corresponding, old, plugin and are repository based (VSTS, Bitbucket, GitHub), disable the plugin if all Repositories are migrated.

This means, if all the Repositories in the Org are accessible by the new Integration, they will all be automatically migrated and the plugin will be disabled.