### PR TITLE
fix(ui): Fix DropdownAutocomplete Actor warning

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
@@ -25,7 +25,7 @@ class DropdownAutoComplete extends React.Component {
             //eslint-disable-next-line no-unused-vars
             onClick,
             ...actorProps
-          } = renderProps.getActorProps();
+          } = renderProps.getActorProps({isStyled: true});
 
           return (
             <Actor

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -102,6 +102,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                   className="css-6v04yn-AutoCompleteRoot ejumqxq0"
                                 >
                                   <Actor
+                                    innerRef={[Function]}
                                     isOpen={false}
                                     onClick={[Function]}
                                     onMouseEnter={[Function]}


### PR DESCRIPTION
This fixes the DropdownAutocomplete Actor warning, this is related to React refs forwarding and styled-components.
In emotion 10 `ref` will be forwarded, but until then we need to pass `isStyled` for emotion actors and menus

Fixes JAVASCRIPT-47D