### PR TITLE
feat(integrations): Limit Upgrade button

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -36,6 +36,8 @@ export default class ProviderRow extends React.Component {
     enabledPlugins: [],
   };
 
+  static upgradableIntegrations = ['vsts', 'bitbucket', 'github', 'github_enterprise'];
+
   // State
 
   get integrations() {
@@ -50,6 +52,10 @@ export default class ProviderRow extends React.Component {
     return this.props.enabledPlugins.includes(this.props.provider.key);
   }
 
+  get isUpgradable() {
+    return ProviderRow.upgradableIntegrations.includes(this.props.provider.key);
+  }
+
   // Actions
 
   openModal = () => {
@@ -62,7 +68,8 @@ export default class ProviderRow extends React.Component {
 
   get buttonText() {
     let buttonText = this.isEnabled > 0 ? t('Add Another') : t('Install');
-    return this.isEnabledPlugin ? t('Upgrade') : buttonText;
+
+    return this.isEnabledPlugin && this.isUpgradable ? t('Upgrade') : buttonText;
   }
 
   renderButton() {

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -130,7 +130,7 @@ describe('OrganizationIntegrations', function() {
     describe('with matching plugins installed', function() {
       Client.addMockResponse({
         url: `/organizations/${org.slug}/integrations/`,
-        body: [githubIntegration, jiraIntegration],
+        body: [githubIntegration],
       });
       Client.addMockResponse({
         url: `/organizations/${org.slug}/config/integrations/`,
@@ -141,6 +141,10 @@ describe('OrganizationIntegrations', function() {
         body: [
           {
             slug: 'github',
+            enabled: true,
+          },
+          {
+            slug: 'jira',
             enabled: true,
           },
         ],
@@ -163,6 +167,28 @@ describe('OrganizationIntegrations', function() {
       it('fetches unmigratable repositories', function() {
         expect(wrapper.instance().state.unmigratableRepos).toHaveLength(1);
         expect(wrapper.instance().state.unmigratableRepos[0].name).toBe('Test-Org/foo');
+      });
+
+      it('displays an Upgrade button instead of Install', function() {
+        expect(
+          wrapper
+            .find('ProviderRow')
+            .filterWhere(n => n.key() === 'github')
+            .find('Button')
+            .first()
+            .text()
+        ).toBe('Upgrade');
+      });
+
+      it('display an Install button when its not an upgradable Integration', () => {
+        expect(
+          wrapper
+            .find('ProviderRow')
+            .filterWhere(n => n.key() === 'jira')
+            .find('Button')
+            .first()
+            .text()
+        ).toBe('Install');
       });
 
       it('displays a warning for each Org with unmigratable repos', () => {


### PR DESCRIPTION
This limits the "Upgrade" button on the Integration page to Repository-based integrations only (GitHub, VSTS, and Bitbucket).

All others will still say "Install" - even if they have the legacy plugin installed.